### PR TITLE
Limit the window flashing count.

### DIFF
--- a/Src/MainFrm.cpp
+++ b/Src/MainFrm.cpp
@@ -1904,7 +1904,7 @@ void CMainFrame::StartFlashing()
 {
 	CWnd * activeWindow = GetActiveWindow();
 	if (activeWindow != this)
-		FlashWindowEx(FLASHW_ALL | FLASHW_TIMERNOFG, 0, 0);
+		FlashWindowEx(FLASHW_ALL | FLASHW_TIMERNOFG, 3, 0);
 }
 
 #if _MFC_VER > 0x0600


### PR DESCRIPTION
After a lengthy comparison operation the window is flashing indicating the finished operation.
Current setting is to flash the window indefinitely, which is a distraction, as it demands to pay attention immediately.
Other applications are usually flash only few times, which is making sense.