### PR TITLE
Update English.pot

### DIFF
--- a/Translations/WinMerge/English.pot
+++ b/Translations/WinMerge/English.pot
@@ -423,10 +423,10 @@ msgstr ""
 msgid "&Print..."
 msgstr ""
 
-msgid "Page Set&up"
+msgid "Page Set&up..."
 msgstr ""
 
-msgid "Print Previe&w"
+msgid "Print Previe&w..."
 msgstr ""
 
 msgid "&Convert Line Endings to"
@@ -615,10 +615,10 @@ msgstr ""
 msgid "Copy from Right\tAlt+Shift+Left"
 msgstr ""
 
-msgid "C&opy to Right and Advance\tAlt+Ctrl+Right"
+msgid "C&opy to Right and Advance\tCtrl+Alt+Right"
 msgstr ""
 
-msgid "Copy &to Left and Advance\tAlt+Ctrl+Left"
+msgid "Copy &to Left and Advance\tCtrl+Alt+Left"
 msgstr ""
 
 msgid "Copy &All to Right"
@@ -627,7 +627,7 @@ msgstr ""
 msgid "Cop&y All to Left"
 msgstr ""
 
-msgid "A&uto Merge\tAlt+Ctrl+M"
+msgid "A&uto Merge\tCtrl+Alt+M"
 msgstr ""
 
 msgid "Add &Synchronization Point\tAlt+S"
@@ -1343,7 +1343,7 @@ msgstr ""
 msgid "Filefilters"
 msgstr ""
 
-msgid "Test"
+msgid "Test..."
 msgstr ""
 
 msgid "Install..."
@@ -1580,7 +1580,7 @@ msgstr ""
 msgid "Test Filter"
 msgstr ""
 
-msgid "Testing filter ..."
+msgid "Testing filter..."
 msgstr ""
 
 msgid "&Enter text to test:"
@@ -1619,7 +1619,7 @@ msgstr ""
 msgid "Backup Files"
 msgstr ""
 
-msgid "Create backup files in:"
+msgid "Create backup files in"
 msgstr ""
 
 msgid "&Folder compare"
@@ -1628,7 +1628,7 @@ msgstr ""
 msgid "Fil&e compare"
 msgstr ""
 
-msgid "Create backup files into:"
+msgid "Create backup files into"
 msgstr ""
 
 msgid "&Original file's folder"
@@ -1637,7 +1637,7 @@ msgstr ""
 msgid "&Global backup folder:"
 msgstr ""
 
-msgid "Backup filename:"
+msgid "Backup filename"
 msgstr ""
 
 msgid "&Append .bak -extension"
@@ -1670,7 +1670,7 @@ msgstr ""
 msgid "&Enable plugins"
 msgstr ""
 
-msgid "File filters:"
+msgid "File filters"
 msgstr ""
 
 msgid "Shell Integration"
@@ -1722,7 +1722,7 @@ msgstr ""
 msgid "&Binary compare limit (MB):"
 msgstr ""
 
-msgid "&Number of compare threads (a negative value implies addition of the number of available CPU cores):"
+msgid "\n&Number of compare threads (a negative value implies addition of the number of available CPU cores):"
 msgstr ""
 
 msgctxt "Options dialog|Categories"
@@ -2108,7 +2108,7 @@ msgid "Unable to backup original file:\n%1\n\nContinue anyway?"
 msgstr ""
 
 #, c-format
-msgid "Saving file failed.\n%1\n%2\nDo you want to:\n\t-use a different filename (Press Ok)\n\t-abort the current operation (Press Cancel)?"
+msgid "Saving file failed.\n%1\n%2\nDo you want to:\n\t- use a different filename (Press Ok)\n\t- abort the current operation (Press Cancel)?"
 msgstr ""
 
 #, c-format
@@ -2621,7 +2621,7 @@ msgid "Do you want to move to the previous page?"
 msgstr ""
 
 #, c-format
-msgid "Different codepages found in left (cp%d) and right (cp%d) files. \nDisplaying each file in its codepage will give a better display but merging/copying will be dangerous.\nWould you like to treat both files as being in the default Windows codepage (recommended)?"
+msgid "Different codepages found in left (cp%d) and right (cp%d) files.\nDisplaying each file in its codepage will give a better display but merging/copying will be dangerous.\nWould you like to treat both files as being in the default Windows codepage (recommended)?"
 msgstr ""
 
 msgid "Information lost due to encoding errors: both files"


### PR DESCRIPTION
- missing ellipsis added
- superfluous colons removed
- superfluous space removed
- space added after \t-
- Alt+Ctrl uniformly changed to Ctrl+Alt
- \n added for better appearance