### PR TITLE
New branch

### DIFF
--- a/Src/DirFrame.cpp
+++ b/Src/DirFrame.cpp
@@ -88,13 +88,11 @@ CDirFrame::~CDirFrame()
 {
 }
 
-
 BEGIN_MESSAGE_MAP(CDirFrame, CMergeFrameCommon)
 	//{{AFX_MSG_MAP(CDirFrame)
 	ON_WM_CREATE()
 	ON_WM_CLOSE()
 	ON_WM_SIZE()
-	ON_WM_MDIACTIVATE()
 	//}}AFX_MSG_MAP
 END_MESSAGE_MAP()
 
@@ -212,4 +210,3 @@ void CDirFrame::OnSize(UINT nType, int cx, int cy)
 	
 	m_wndFilePathBar.Resize();
 }
-

--- a/Src/DirView.cpp
+++ b/Src/DirView.cpp
@@ -683,7 +683,7 @@ static void NTAPI CheckContextMenu(BCMenu *pPopup, UINT uIDItem, BOOL bCheck)
  */
 void CDirView::ListContextMenu(CPoint point, int /*i*/)
 {
-	CDirDoc *pDoc = GetDocument();
+	CDirDoc* pDoc = GetDocument();
 	BCMenu menu;
 	VERIFY(menu.LoadMenu(IDR_POPUP_DIRVIEW));
 	VERIFY(menu.LoadToolbar(IDR_MAINFRAME));
@@ -3694,7 +3694,6 @@ void CDirView::OnUpdateEditUndo(CCmdUI* pCmdUI)
 	CEdit *pEdit = m_pList->GetEditControl();
 	pCmdUI->Enable(pEdit && pEdit->CanUndo());
 }
-
 /**
  * @brief Returns CShellContextMenu object that owns given HMENU.
  *

--- a/Src/DirView.h
+++ b/Src/DirView.h
@@ -199,7 +199,7 @@ protected:
 	CSortHeaderCtrl m_ctlSortHeader;
 	CImageList m_imageList;
 	CImageList m_imageState;
-	CListCtrl *m_pList;
+	CListCtrl* m_pList;
 	std::unique_ptr<IListCtrl> m_pIList;
 	bool m_bEscCloses; /**< Cached value for option for ESC closing window */
 	bool m_bExpandSubdirs;

--- a/Src/ImgMergeFrm.cpp
+++ b/Src/ImgMergeFrm.cpp
@@ -215,7 +215,7 @@ bool CImgMergeFrame::OpenDocs(int nFiles, const FileLocation fileloc[], const bo
 	LPCTSTR lpszWndClass = AfxRegisterWndClass(CS_HREDRAW | CS_VREDRAW,
 			::LoadCursor(nullptr, IDC_ARROW), (HBRUSH)(COLOR_WINDOW+1), nullptr);
 
-	if (!CMDIChildWnd::Create(lpszWndClass, GetTitle(), WS_OVERLAPPEDWINDOW | WS_CHILD, rectDefault, pParent))
+	if (!CMergeFrameCommon::Create(lpszWndClass, GetTitle(), WS_OVERLAPPEDWINDOW | WS_CHILD, rectDefault, pParent))
 		return false;
 
 	int nCmdShow = SW_SHOW;
@@ -475,7 +475,7 @@ BOOL CImgMergeFrame::OnCreateClient( LPCREATESTRUCT /*lpcs*/,
 int CImgMergeFrame::OnCreate(LPCREATESTRUCT lpCreateStruct)
 {
 
-	if (CMDIChildWnd::OnCreate(lpCreateStruct) == -1)
+	if (CMergeFrameCommon::OnCreate(lpCreateStruct) == -1)
 		return -1;
 
 	EnableDocking(CBRS_ALIGN_TOP | CBRS_ALIGN_BOTTOM | CBRS_ALIGN_LEFT | CBRS_ALIGN_RIGHT);
@@ -553,7 +553,7 @@ BOOL CImgMergeFrame::DestroyWindow()
 	SaveActivePane();
 	SaveOptions();
 	SaveWindowState();
-	return CMDIChildWnd::DestroyWindow();
+	return CMergeFrameCommon::DestroyWindow();
 }
 
 void CImgMergeFrame::LoadOptions()
@@ -624,7 +624,9 @@ void CImgMergeFrame::OnMDIActivate(BOOL bActivate, CWnd* pActivateWnd, CWnd* pDe
 		// for the dimensions of the diff and location pane, use the CSizingControlBar loader
 		m_wndLocationBar.LoadState(_T("Settings-ImgMergeFrame"));
 	}
-	CMDIChildWnd::OnMDIActivate(bActivate, pActivateWnd, pDeactivateWnd);
+
+	CMergeFrameCommon::OnMDIActivate(bActivate, pActivateWnd, pDeactivateWnd);
+
 	if (bActivate)
 	{
 		GetMainFrame()->PostMessage(WM_USER + 1);
@@ -638,7 +640,7 @@ void CImgMergeFrame::OnClose()
 		return;
 
 	// clean up pointers.
-	CMDIChildWnd::OnClose();
+	CMergeFrameCommon::OnClose();
 
 	GetMainFrame()->ClearStatusbarItemCount();
 }
@@ -1013,7 +1015,7 @@ void CImgMergeFrame::SetTitle(LPCTSTR lpszTitle)
 		else
 			sTitle = strutils::join(&sFileName[0], &sFileName[0] + nBuffers, _T(" - "));
 	}
-	CMDIChildWnd::SetTitle(sTitle.c_str());
+	CMergeFrameCommon::SetTitle(sTitle.c_str());
 	if (m_hWnd != nullptr)
 		SetWindowText(sTitle.c_str());
 }
@@ -1255,12 +1257,12 @@ BOOL CImgMergeFrame::PreTranslateMessage(MSG* pMsg)
 			return true;
 		}
 	}
-	return CMDIChildWnd::PreTranslateMessage(pMsg);
+	return CMergeFrameCommon::PreTranslateMessage(pMsg);
 }
 
 void CImgMergeFrame::OnSize(UINT nType, int cx, int cy) 
 {
-	CMDIChildWnd::OnSize(nType, cx, cy);
+	CMergeFrameCommon::OnSize(nType, cx, cy);
 	UpdateHeaderSizes();
 }
 
@@ -1326,7 +1328,7 @@ void CImgMergeFrame::OnIdleUpdateCmdUI()
 			m_wndStatusBar[pane].SetPaneText(0, text.c_str());
 		}
 	}
-	CMDIChildWnd::OnIdleUpdateCmdUI();
+	CMergeFrameCommon::OnIdleUpdateCmdUI();
 }
 
 /**

--- a/Src/MainFrm.cpp
+++ b/Src/MainFrm.cpp
@@ -74,6 +74,8 @@
 #include "Bitmap.h"
 #include "CCrystalTextMarkers.h"
 
+#include "WindowsManagerDialog.h"
+
 using std::vector;
 using boost::begin;
 using boost::end;
@@ -232,7 +234,12 @@ BEGIN_MESSAGE_MAP(CMainFrame, CMDIFrameWnd)
 	ON_COMMAND_RANGE(ID_MRU_FIRST, ID_MRU_LAST, OnMRUs)
 	ON_UPDATE_COMMAND_UI(ID_MRU_FIRST, OnUpdateNoMRUs)
 	ON_UPDATE_COMMAND_UI(ID_NO_MRU, OnUpdateNoMRUs)
+	ON_COMMAND(ID_ACCEL_QUIT, &CMainFrame::OnAccelQuit)
 	//}}AFX_MSG_MAP
+	ON_MESSAGE(WMU_CHILDFRAMEADDED, &CMainFrame::OnChildFrameAdded)
+	ON_MESSAGE(WMU_CHILDFRAMEREMOVED, &CMainFrame::OnChildFrameRemoved)
+	ON_MESSAGE(WMU_CHILDFRAMEACTIVATE, &CMainFrame::OnChildFrameActivate)
+	ON_MESSAGE(WMU_CHILDFRAMEACTIVATED, &CMainFrame::OnChildFrameActivated)
 END_MESSAGE_MAP()
 
 /**
@@ -282,6 +289,8 @@ CMainFrame::~CMainFrame()
 {
 	GetOptionsMgr()->SaveOption(OPT_TABBAR_AUTO_MAXWIDTH, m_wndTabBar.GetAutoMaxWidth());
 	strdiff::Close();
+
+	m_arrChild.RemoveAll();
 }
 
 const TCHAR CMainFrame::szClassName[] = _T("WinMergeWindowClassW");
@@ -1681,12 +1690,21 @@ BOOL CMainFrame::PreTranslateMessage(MSG* pMsg)
 			AfxGetMainWnd()->SendMessage(WM_COMMAND, ID_APP_EXIT);
 			return TRUE;
 		}
-		else if (GetOptionsMgr()->GetBool(OPT_CLOSE_WITH_ESC) && m_wndTabBar.GetItemCount() == 0)
+/*		else if (GetOptionsMgr()->GetBool(OPT_CLOSE_WITH_ESC) && m_wndTabBar.GetItemCount() == 0)
 		{
 			AfxGetMainWnd()->PostMessage(WM_COMMAND, ID_APP_EXIT);
 			return FALSE;
-		}
+		}*/		// Don't close the app when user press escape and there is no tab opened, use Ctrl + Q instead like all editors do
 	}
+
+	if (WM_KEYDOWN == pMsg->message && VK_TAB == pMsg->wParam && GetAsyncKeyState(VK_CONTROL) < 0 && m_arrChild.GetSize() > 1)
+	{
+		CWindowsManagerDialog* pDlg = new CWindowsManagerDialog;
+		pDlg->Create(CWindowsManagerDialog::IDD, this);
+		pDlg->ShowWindow(SW_SHOW);
+		return TRUE;
+	}
+
 	return CMDIFrameWnd::PreTranslateMessage(pMsg);
 }
 
@@ -2520,4 +2538,73 @@ void CMainFrame::UpdateDocTitle()
 			((CFrameWnd*)AfxGetApp()->m_pMainWnd)->OnUpdateFrameTitle(TRUE);
 		}
 	}
+}
+
+void CMainFrame::OnAccelQuit()
+{
+	// TODO: Add your command handler code here
+
+	SendMessage(WM_CLOSE);
+}
+
+LRESULT CMainFrame::OnChildFrameAdded(WPARAM wParam, LPARAM lParam)
+{
+	for (int i = 0; i < m_arrChild.GetSize(); ++i)
+	{
+		if (reinterpret_cast<CMDIChildWnd*>(lParam) == m_arrChild.GetAt(i))
+		{
+			return 0;
+		}
+	}
+
+	m_arrChild.InsertAt(0, (CMDIChildWnd*)lParam);
+
+	return 1;
+}
+
+LRESULT CMainFrame::OnChildFrameRemoved(WPARAM wParam, LPARAM lParam)
+{
+	for (int i = 0; i < m_arrChild.GetSize(); ++i)
+	{
+		if (reinterpret_cast<CMDIChildWnd*>(lParam) == m_arrChild.GetAt(i))
+		{
+			m_arrChild.RemoveAt(i);
+			break;
+		}
+	}
+
+	return 1;
+}
+
+LRESULT CMainFrame::OnChildFrameActivate(WPARAM wParam, LPARAM lParam)
+{
+	for (int i = 0; i < m_arrChild.GetSize(); ++i)
+	{
+		if (reinterpret_cast<CMDIChildWnd*>(lParam) == m_arrChild.GetAt(i))
+		{
+			CMDIChildWnd* pMDIChild = m_arrChild.GetAt(i);
+			if (pMDIChild->IsIconic())
+				pMDIChild->ShowWindow(SW_RESTORE);
+			MDIActivate(pMDIChild);
+			break;
+		}
+	}
+
+	return 1;
+}
+// put lParam as index 0 in m_arrChild
+LRESULT CMainFrame::OnChildFrameActivated(WPARAM wParam, LPARAM lParam)
+{
+	for (int i = 0; i < m_arrChild.GetSize(); ++i)
+	{
+		if (reinterpret_cast<CMDIChildWnd*>(lParam) == m_arrChild.GetAt(i))
+		{
+			m_arrChild.RemoveAt(i);
+			break;
+		}
+	}
+
+	m_arrChild.InsertAt(0, (CMDIChildWnd*)lParam);
+
+	return 1;
 }

--- a/Src/MainFrm.h
+++ b/Src/MainFrm.h
@@ -85,6 +85,7 @@ public:
 	LOGFONT m_lfDiff; /**< MergeView user-selected font */
 	LOGFONT m_lfDir; /**< DirView user-selected font */
 	static const TCHAR szClassName[];
+
 // Operations
 public:
 	HMENU NewDirViewMenu();
@@ -120,6 +121,7 @@ public:
 	void UpdateDocTitle();
 	void ReloadMenu();
 	DropHandler *GetDropHandler() const { return m_pDropHandler; }
+	const CTypedPtrArray<CPtrArray, CMDIChildWnd*>* GetChildArray() const { return &m_arrChild; }
 
 // Overrides
 	virtual void GetMessageString(UINT nID, CString& rMessage) const;
@@ -136,20 +138,18 @@ public:
 protected:
 	virtual ~CMainFrame();
 
-
 // Public implementation data
 public:
 	bool m_bFirstTime; /**< If first time frame activated, get  pos from reg */
 
 // Implementation data
 protected:
-
-
 	// control bar embedded members
 	CStatusBar  m_wndStatusBar;
 	CReBar m_wndReBar;
 	CToolBar m_wndToolBar;
 	CMDITabBar m_wndTabBar;
+	CTypedPtrArray<CPtrArray, CMDIChildWnd*> m_arrChild;
 
 	// Tweak MDI client window behavior
 	class CMDIClient : public CWnd
@@ -297,7 +297,12 @@ protected:
 	afx_msg void OnMRUs(UINT nID);
 	afx_msg void OnUpdateNoMRUs(CCmdUI* pCmdUI);
 	afx_msg void OnDestroy();
+	afx_msg void OnAccelQuit();
 	//}}AFX_MSG
+	afx_msg LRESULT OnChildFrameAdded(WPARAM wParam, LPARAM lParam);
+	afx_msg LRESULT OnChildFrameRemoved(WPARAM wParam, LPARAM lParam);
+	afx_msg LRESULT OnChildFrameActivate(WPARAM wParam, LPARAM lParam);
+	afx_msg LRESULT OnChildFrameActivated(WPARAM wParam, LPARAM lParam);
 	DECLARE_MESSAGE_MAP()
 
 private:

--- a/Src/Merge.h
+++ b/Src/Merge.h
@@ -25,6 +25,11 @@
  */
 #pragma once
 
+#define WMU_CHILDFRAMEADDED						(WM_APP + 10)
+#define WMU_CHILDFRAMEREMOVED					(WM_APP + 11)
+#define WMU_CHILDFRAMEACTIVATE					(WM_APP + 12)
+#define WMU_CHILDFRAMEACTIVATED					(WM_APP + 13)
+
 #ifndef __AFXWIN_H__
 	#error include 'stdafx.h' before including this file for PCH
 #endif

--- a/Src/Merge.rc
+++ b/Src/Merge.rc
@@ -141,7 +141,7 @@ BEGIN
             MENUITEM "Zoom &In\tCtrl++",            ID_VIEW_ZOOMIN
             MENUITEM "Zoom &Out\tCtrl+-",           ID_VIEW_ZOOMOUT
             MENUITEM SEPARATOR
-            MENUITEM "&Normal\tCtrl+*",             ID_VIEW_ZOOMNORMAL //#. Zoom to normal
+            MENUITEM "&Normal\tCtrl+*",             ID_VIEW_ZOOMNORMAL
         END
         POPUP "&Overlay"
         BEGIN
@@ -481,7 +481,7 @@ BEGIN
             MENUITEM "Zoom &In\tCtrl++",            ID_VIEW_ZOOMIN
             MENUITEM "Zoom &Out\tCtrl+-",           ID_VIEW_ZOOMOUT
             MENUITEM SEPARATOR
-            MENUITEM "&Normal\tCtrl+*",             ID_VIEW_ZOOMNORMAL //#. Zoom to normal
+            MENUITEM "&Normal\tCtrl+*",             ID_VIEW_ZOOMNORMAL
         END
         POPUP "Syntax Highlight"
         BEGIN
@@ -637,14 +637,14 @@ BEGIN
     POPUP "_ITEM_POPUP_"
     BEGIN
         MENUITEM "Comp&are",                    ID_MERGE_COMPARE
-        MENUITEM "Compare Non-hor&izontally...",   ID_MERGE_COMPARE_NONHORIZONTALLY
+        MENUITEM "Compare Non-hor&izontally...", ID_MERGE_COMPARE_NONHORIZONTALLY
         POPUP "Compare Non-hor&izontally"
         BEGIN
             MENUITEM "First &left item with second left item", ID_MERGE_COMPARE_LEFT1_LEFT2
             MENUITEM "First &right item with second right item", ID_MERGE_COMPARE_RIGHT1_RIGHT2
             MENUITEM "&First left item with second right item", ID_MERGE_COMPARE_LEFT1_RIGHT2
             MENUITEM "&Second left item with first right item", ID_MERGE_COMPARE_LEFT2_RIGHT1
-            MENUITEM "Compare Non-hor&izontally...",   ID_MERGE_COMPARE_NONHORIZONTALLY
+            MENUITEM "Compare Non-hor&izontally...", ID_MERGE_COMPARE_NONHORIZONTALLY
         END
         POPUP "Co&mpare As"
         BEGIN
@@ -838,68 +838,69 @@ END
 
 IDR_MAINFRAME ACCELERATORS
 BEGIN
-    "A",            ID_EDIT_SELECT_ALL,     VIRTKEY, CONTROL, NOINVERT
-    "C",            ID_EDIT_COPY,           VIRTKEY, CONTROL, NOINVERT
-    "D",            ID_VIEW_DIFFCONTEXT_TOGGLE, VIRTKEY, CONTROL, NOINVERT
-    "E",            ID_FILE_OPEN_WITHEDITOR, VIRTKEY, CONTROL, ALT, NOINVERT
-    "C",            ID_EDIT_COPY_LINENUMBERS, VIRTKEY, SHIFT, CONTROL, NOINVERT
-    "F",            ID_EDIT_FIND,           VIRTKEY, CONTROL, NOINVERT
-    "G",            ID_EDIT_WMGOTO,         VIRTKEY, CONTROL, NOINVERT
-    "H",            ID_EDIT_REPLACE,        VIRTKEY, CONTROL, NOINVERT
-    "J",            ID_FILE_OPENPROJECT,    VIRTKEY, CONTROL, NOINVERT
-    "M",            ID_EDIT_MARK,           VIRTKEY, SHIFT, CONTROL, NOINVERT
     "M",            ID_AUTO_MERGE,          VIRTKEY, CONTROL, ALT, NOINVERT
-    "N",            ID_FILE_NEW,            VIRTKEY, CONTROL, NOINVERT
-    "O",            ID_FILE_OPEN,           VIRTKEY, CONTROL, NOINVERT
-    "P",            ID_FILE_PRINT,          VIRTKEY, CONTROL, NOINVERT
-    "S",            ID_FILE_SAVE,           VIRTKEY, CONTROL, NOINVERT
-    "U",            ID_EDIT_LOWERCASE,      VIRTKEY, CONTROL, NOINVERT
-    "U",            ID_EDIT_UPPERCASE,      VIRTKEY, SHIFT, CONTROL, NOINVERT
-    "V",            ID_EDIT_PASTE,          VIRTKEY, CONTROL, NOINVERT
-    "W",            ID_FILE_CLOSE,          VIRTKEY, CONTROL, NOINVERT
-    "X",            ID_EDIT_CUT,            VIRTKEY, CONTROL, NOINVERT
-    "Y",            ID_EDIT_REDO,           VIRTKEY, CONTROL, NOINVERT
-    "Z",            ID_EDIT_UNDO,           VIRTKEY, CONTROL, NOINVERT
-    "Z",            ID_EDIT_REDO,           VIRTKEY, SHIFT, CONTROL, NOINVERT
-    VK_BACK,        ID_EDIT_UNDO,           VIRTKEY, ALT, NOINVERT
-    VK_DELETE,      ID_EDIT_CUT,            VIRTKEY, SHIFT, NOINVERT
-    VK_DOWN,        ID_NEXTDIFF,            VIRTKEY, ALT, NOINVERT
-    VK_DOWN,        ID_NEXTCONFLICT,        VIRTKEY, SHIFT, ALT, NOINVERT
-    VK_F8,          ID_NEXTDIFF,            VIRTKEY, NOINVERT
-    VK_F8,          ID_NEXTCONFLICT,        VIRTKEY, SHIFT, NOINVERT
-    VK_F7,          ID_PREVDIFF,            VIRTKEY, NOINVERT
-    VK_F7,          ID_PREVCONFLICT,        VIRTKEY, SHIFT, NOINVERT
-    VK_END,         ID_LASTDIFF,            VIRTKEY, ALT, NOINVERT
-    VK_F2,          ID_DIR_ITEM_RENAME,     VIRTKEY, NOINVERT
-    VK_F3,          ID_EDIT_REPEAT,         VIRTKEY, SHIFT, NOINVERT
-    VK_F3,          ID_EDIT_REPEAT,         VIRTKEY, NOINVERT
-    VK_F3,          ID_EDIT_REPEAT,         VIRTKEY, SHIFT, CONTROL, NOINVERT
-    VK_F3,          ID_EDIT_REPEAT,         VIRTKEY, CONTROL, NOINVERT
-    VK_F4,          ID_SELECTLINEDIFF,      VIRTKEY, NOINVERT
-    VK_F4,          ID_SELECTPREVLINEDIFF,  VIRTKEY, SHIFT, NOINVERT
-    VK_F5,          ID_REFRESH,             VIRTKEY, NOINVERT
-    VK_F5,          ID_RESCAN,              VIRTKEY, CONTROL, NOINVERT
-    VK_F6,          ID_NEXT_PANE,           VIRTKEY, NOINVERT
-    VK_F6,          ID_PREV_PANE,           VIRTKEY, SHIFT, NOINVERT
-    VK_F9,          ID_FILE_MERGINGMODE,    VIRTKEY, NOINVERT
-    VK_HOME,        ID_FIRSTDIFF,           VIRTKEY, ALT, NOINVERT
-    VK_INSERT,      ID_EDIT_COPY,           VIRTKEY, CONTROL, NOINVERT
-    VK_INSERT,      ID_EDIT_PASTE,          VIRTKEY, SHIFT, NOINVERT
-    VK_LEFT,        ID_R2L,                 VIRTKEY, ALT, NOINVERT
-    VK_LEFT,        ID_R2LNEXT,             VIRTKEY, CONTROL, ALT, NOINVERT
+    VK_RIGHT,       ID_COPY_FROM_LEFT,      VIRTKEY, SHIFT, ALT, NOINVERT
     VK_LEFT,        ID_COPY_FROM_RIGHT,     VIRTKEY, SHIFT, ALT, NOINVERT
     VK_RETURN,      ID_CURDIFF,             VIRTKEY, ALT, NOINVERT
+    VK_F2,          ID_DIR_ITEM_RENAME,     VIRTKEY, NOINVERT
+    "C",            ID_EDIT_COPY,           VIRTKEY, CONTROL, NOINVERT
+    VK_INSERT,      ID_EDIT_COPY,           VIRTKEY, CONTROL, NOINVERT
+    "C",            ID_EDIT_COPY_LINENUMBERS, VIRTKEY, SHIFT, CONTROL, NOINVERT
+    VK_DELETE,      ID_EDIT_CUT,            VIRTKEY, SHIFT, NOINVERT
+    "X",            ID_EDIT_CUT,            VIRTKEY, CONTROL, NOINVERT
+    "F",            ID_EDIT_FIND,           VIRTKEY, CONTROL, NOINVERT
+    "U",            ID_EDIT_LOWERCASE,      VIRTKEY, CONTROL, NOINVERT
+    "M",            ID_EDIT_MARK,           VIRTKEY, SHIFT, CONTROL, NOINVERT
+    "V",            ID_EDIT_PASTE,          VIRTKEY, CONTROL, NOINVERT
+    VK_INSERT,      ID_EDIT_PASTE,          VIRTKEY, SHIFT, NOINVERT
+    "Y",            ID_EDIT_REDO,           VIRTKEY, CONTROL, NOINVERT
+    "Z",            ID_EDIT_REDO,           VIRTKEY, SHIFT, CONTROL, NOINVERT
+    VK_F3,          ID_EDIT_REPEAT,         VIRTKEY, NOINVERT
+    VK_F3,          ID_EDIT_REPEAT,         VIRTKEY, CONTROL, NOINVERT
+    VK_F3,          ID_EDIT_REPEAT,         VIRTKEY, SHIFT, NOINVERT
+    VK_F3,          ID_EDIT_REPEAT,         VIRTKEY, SHIFT, CONTROL, NOINVERT
+    "H",            ID_EDIT_REPLACE,        VIRTKEY, CONTROL, NOINVERT
+    "A",            ID_EDIT_SELECT_ALL,     VIRTKEY, CONTROL, NOINVERT
+    VK_BACK,        ID_EDIT_UNDO,           VIRTKEY, ALT, NOINVERT
+    "Z",            ID_EDIT_UNDO,           VIRTKEY, CONTROL, NOINVERT
+    "U",            ID_EDIT_UPPERCASE,      VIRTKEY, SHIFT, CONTROL, NOINVERT
+    "G",            ID_EDIT_WMGOTO,         VIRTKEY, CONTROL, NOINVERT
+    "W",            ID_FILE_CLOSE,          VIRTKEY, CONTROL, NOINVERT
+    VK_F9,          ID_FILE_MERGINGMODE,    VIRTKEY, NOINVERT
+    "N",            ID_FILE_NEW,            VIRTKEY, CONTROL, NOINVERT
+    "O",            ID_FILE_OPEN,           VIRTKEY, CONTROL, NOINVERT
+    "E",            ID_FILE_OPEN_WITHEDITOR, VIRTKEY, CONTROL, ALT, NOINVERT
+    "J",            ID_FILE_OPENPROJECT,    VIRTKEY, CONTROL, NOINVERT
+    "P",            ID_FILE_PRINT,          VIRTKEY, CONTROL, NOINVERT
+    "S",            ID_FILE_SAVE,           VIRTKEY, CONTROL, NOINVERT
+    VK_HOME,        ID_FIRSTDIFF,           VIRTKEY, ALT, NOINVERT
     VK_RIGHT,       ID_L2R,                 VIRTKEY, ALT, NOINVERT
     VK_RIGHT,       ID_L2RNEXT,             VIRTKEY, CONTROL, ALT, NOINVERT
-    VK_RIGHT,       ID_COPY_FROM_LEFT,      VIRTKEY, SHIFT, ALT, NOINVERT
-    VK_UP,          ID_PREVDIFF,            VIRTKEY, ALT, NOINVERT
+    VK_END,         ID_LASTDIFF,            VIRTKEY, ALT, NOINVERT
+    VK_F6,          ID_NEXT_PANE,           VIRTKEY, NOINVERT
+    VK_DOWN,        ID_NEXTCONFLICT,        VIRTKEY, SHIFT, ALT, NOINVERT
+    VK_F8,          ID_NEXTCONFLICT,        VIRTKEY, SHIFT, NOINVERT
+    VK_DOWN,        ID_NEXTDIFF,            VIRTKEY, ALT, NOINVERT
+    VK_F8,          ID_NEXTDIFF,            VIRTKEY, NOINVERT
+    VK_F6,          ID_PREV_PANE,           VIRTKEY, SHIFT, NOINVERT
+    VK_F7,          ID_PREVCONFLICT,        VIRTKEY, SHIFT, NOINVERT
     VK_UP,          ID_PREVCONFLICT,        VIRTKEY, SHIFT, ALT, NOINVERT
+    VK_F7,          ID_PREVDIFF,            VIRTKEY, NOINVERT
+    VK_UP,          ID_PREVDIFF,            VIRTKEY, ALT, NOINVERT
+    VK_LEFT,        ID_R2L,                 VIRTKEY, ALT, NOINVERT
+    VK_LEFT,        ID_R2LNEXT,             VIRTKEY, CONTROL, ALT, NOINVERT
+    VK_F5,          ID_REFRESH,             VIRTKEY, NOINVERT
+    VK_F5,          ID_RESCAN,              VIRTKEY, CONTROL, NOINVERT
+    VK_F4,          ID_SELECTLINEDIFF,      VIRTKEY, NOINVERT
+    VK_F4,          ID_SELECTPREVLINEDIFF,  VIRTKEY, SHIFT, NOINVERT
+    "D",            ID_VIEW_DIFFCONTEXT_TOGGLE, VIRTKEY, CONTROL, NOINVERT
     VK_ADD,         ID_VIEW_ZOOMIN,         VIRTKEY, CONTROL, NOINVERT
     VK_OEM_PLUS,    ID_VIEW_ZOOMIN,         VIRTKEY, CONTROL, NOINVERT
-    VK_SUBTRACT,    ID_VIEW_ZOOMOUT,        VIRTKEY, CONTROL, NOINVERT
-    VK_OEM_MINUS,   ID_VIEW_ZOOMOUT,        VIRTKEY, CONTROL, NOINVERT
-    VK_MULTIPLY,    ID_VIEW_ZOOMNORMAL,     VIRTKEY, CONTROL, NOINVERT
     "0",            ID_VIEW_ZOOMNORMAL,     VIRTKEY, CONTROL, NOINVERT
+    VK_MULTIPLY,    ID_VIEW_ZOOMNORMAL,     VIRTKEY, CONTROL, NOINVERT
+    VK_OEM_MINUS,   ID_VIEW_ZOOMOUT,        VIRTKEY, CONTROL, NOINVERT
+    VK_SUBTRACT,    ID_VIEW_ZOOMOUT,        VIRTKEY, CONTROL, NOINVERT
+    "Q",            ID_ACCEL_QUIT,          VIRTKEY, CONTROL, NOINVERT
 END
 
 
@@ -927,44 +928,37 @@ STYLE DS_SETFONT | DS_FIXEDSYS | DS_CENTER | WS_CHILD | WS_CAPTION
 CAPTION "Select Files or Folders"
 FONT 8, "MS Shell Dlg", 0, 0, 0x1
 BEGIN
-//	LOGO			res\\logo.jpg :: Height = 80px, Width=336px (extended fully to Right)
-    CONTROL         "&1st File or Folder",IDC_FILES_DIRS_GROUP0,"Button",BS_GROUPBOX,6,54,454,46,WS_EX_TRANSPARENT
+    GROUPBOX        "&1st File or Folder",IDC_FILES_DIRS_GROUP0,6,54,454,46,0,WS_EX_TRANSPARENT
     CONTROL         "",IDC_PATH0_COMBO,"ComboBoxEx32",CBS_DROPDOWN | CBS_AUTOHSCROLL | WS_VSCROLL | WS_TABSTOP,10,66,446,95
     CONTROL         "Re&ad-only",IDC_PATH0_READONLY,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,16,84,100,10
     PUSHBUTTON      "",IDC_SWAP01_BUTTON,120,82,15,14
     LTEXT           "Swap 1st | 2nd",IDC_SWAP01_STATIC,138,84,88,12
     PUSHBUTTON      "&Browse...",IDC_PATH0_BUTTON,383,82,73,14
-
-    CONTROL         "&2nd File or Folder",IDC_FILES_DIRS_GROUP1,"Button",BS_GROUPBOX,6,102,454,46,WS_EX_TRANSPARENT
+    GROUPBOX        "&2nd File or Folder",IDC_FILES_DIRS_GROUP1,6,102,454,46,0,WS_EX_TRANSPARENT
     CONTROL         "",IDC_PATH1_COMBO,"ComboBoxEx32",CBS_DROPDOWN | CBS_AUTOHSCROLL | WS_VSCROLL | WS_TABSTOP,10,114,446,95
     CONTROL         "Rea&d-only",IDC_PATH1_READONLY,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,16,132,100,10
     PUSHBUTTON      "",IDC_SWAP12_BUTTON,120,130,15,14
     LTEXT           "Swap 2nd | 3rd",IDC_SWAP12_STATIC,138,132,88,12
     PUSHBUTTON      "B&rowse...",IDC_PATH1_BUTTON,383,130,73,14
-
-    CONTROL         "&3rd File or Folder (Optional)",IDC_FILES_DIRS_GROUP2,"Button",BS_GROUPBOX,6,150,454,46,WS_EX_TRANSPARENT
+    GROUPBOX        "&3rd File or Folder (Optional)",IDC_FILES_DIRS_GROUP2,6,150,454,46,0,WS_EX_TRANSPARENT
     CONTROL         "",IDC_PATH2_COMBO,"ComboBoxEx32",CBS_DROPDOWN | CBS_AUTOHSCROLL | WS_VSCROLL | WS_TABSTOP,10,162,446,95
     CONTROL         "Read-o&nly",IDC_PATH2_READONLY,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,16,180,100,10
     PUSHBUTTON      "",IDC_SWAP02_BUTTON,120,178,15,14
     LTEXT           "Swap 1st | 3rd",IDC_SWAP02_STATIC,138,180,88,12
     PUSHBUTTON      "Browse...",IDC_PATH2_BUTTON,383,178,73,14
-
     GROUPBOX        "",IDC_FILES_DIRS_GROUP3X,6,197,224,42
     LTEXT           " Folder: Filter",IDC_FILES_DIRS_GROUP3,10,198,86,11
     COMBOBOX        IDC_EXT_COMBO,10,209,140,95,CBS_DROPDOWN | CBS_AUTOHSCROLL | WS_VSCROLL | WS_TABSTOP
     PUSHBUTTON      "&Select...",IDC_SELECT_FILTER,153,209,73,14
     CONTROL         "&Include Subfolders",IDC_RECURS_CHECK,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,16,227,143,10
-
     GROUPBOX        "",IDC_FILES_DIRS_GROUP4X,236,197,224,42
     LTEXT           " File: Unpacker Plugin",IDC_FILES_DIRS_GROUP4,240,198,86,11
     EDITTEXT        IDC_UNPACKER_EDIT,240,209,140,14,ES_AUTOHSCROLL | ES_READONLY
     PUSHBUTTON      "Se&lect...",IDC_SELECT_UNPACKER,383,209,73,14
-
     CONTROL         "Sa&ve Project...",ID_SAVE_PROJECT,"Button",BS_SPLITBUTTON | WS_TABSTOP,10,245,100,14
     DEFPUSHBUTTON   "Co&mpare",IDOK,316,245,70,20
     PUSHBUTTON      "Cancel",IDCANCEL,390,245,70,20
     LTEXT           "Status:",IDC_OPEN_STATUS,6,272,440,12
-
     PUSHBUTTON      "Help",ID_HELP,383,10,72,14
     CONTROL         "&Options...",IDC_OPTIONS,"Button",BS_SPLITBUTTON | WS_TABSTOP,383,29,72,14
 END
@@ -1149,7 +1143,8 @@ STYLE DS_SETFONT | DS_FIXEDSYS | WS_POPUP | WS_CAPTION
 CAPTION "Colors"
 FONT 8, "MS Shell Dlg", 0, 0, 0x1
 BEGIN
-    CONTROL         "&Use folder compare colors",IDC_USE_DIR_COMPARE_COLORS,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,4,15,152,10
+    CONTROL         "&Use folder compare colors",IDC_USE_DIR_COMPARE_COLORS,
+                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,4,15,152,10
     CTEXT           "Background",IDC_STATIC,154,29,50,10
     CTEXT           "Text",IDC_STATIC,207,29,29,10
     RTEXT           "Items equal:",IDC_STATIC,4,49,152,20
@@ -1742,7 +1737,7 @@ END
 
 IDD_PROPPAGE_COMPARE_FOLDER DIALOGEX 0, 0, 255, 205
 STYLE DS_SETFONT | DS_FIXEDSYS | WS_POPUP | WS_CAPTION
-CAPTION NC_("Options dialog|Categories", "Folder")
+CAPTION "\001""Options dialog|Categories""Folder"
 FONT 8, "MS Shell Dlg", 0, 0, 0x1
 BEGIN
     LTEXT           "&Compare method:",IDC_STATIC,7,6,100,10
@@ -1768,7 +1763,7 @@ END
 
 IDD_PROPPAGE_COMPARE_BINARY DIALOGEX 0, 0, 255, 205
 STYLE DS_SETFONT | DS_FIXEDSYS | WS_POPUP | WS_CAPTION
-CAPTION NC_("Options dialog|Categories", "Binary")
+CAPTION "\001""Options dialog|Categories""Binary"
 FONT 8, "MS Shell Dlg", 0, 0, 0x1
 BEGIN
     LTEXT           "Binary File &Patterns:",IDC_STATIC,7,6,200,10
@@ -1823,6 +1818,13 @@ BEGIN
     PUSHBUTTON      "Cancel",IDCANCEL,204,48,54,14
 END
 
+IDD_DIALOG_WINDOWSMANAGER DIALOGEX 0, 0, 309, 176
+STYLE DS_SETFONT | DS_FIXEDSYS | WS_POPUP | WS_SYSMENU
+FONT 8, "MS Shell Dlg", 400, 0, 0x1
+BEGIN
+    CONTROL         "",IDC_LIST_FILE,"SysListView32",LVS_REPORT | LVS_SINGLESEL | LVS_SHOWSELALWAYS | LVS_ALIGNLEFT | LVS_NOCOLUMNHEADER | WS_BORDER | WS_TABSTOP,0,0,309,176
+END
+
 
 /////////////////////////////////////////////////////////////////////////////
 //
@@ -1838,7 +1840,39 @@ BEGIN
         BOTTOMMARGIN, 264
     END
 
+    IDD_DIR_FILTER, DIALOG
+    BEGIN
+    END
+
+    IDD_EDIT_MARKER, DIALOG
+    BEGIN
+    END
+
+    IDD_PROPPAGE_SYSTEM, DIALOG
+    BEGIN
+    END
+
+    IDD_DIRCOLS, DIALOG
+    BEGIN
+    END
+
+    IDD_SELECTUNPACKER, DIALOG
+    BEGIN
+    END
+
     IDD_DIRCOMP_PROGRESS, DIALOG
+    BEGIN
+    END
+
+    IDD_WMGOTO, DIALOG
+    BEGIN
+    END
+
+    IDD_PROPPAGE_COMPARE, DIALOG
+    BEGIN
+    END
+
+    IDD_PROPPAGE_EDITOR, DIALOG
     BEGIN
     END
 
@@ -1846,11 +1880,63 @@ BEGIN
     BEGIN
     END
 
+    IDD_PROPPAGE_CODEPAGE, DIALOG
+    BEGIN
+    END
+
+    IDD_PREFERENCES, DIALOG
+    BEGIN
+    END
+
     IDD_PROPPAGE_COLORS_MARKER, DIALOG
     BEGIN
     END
 
+    IDD_DIRCMP_REPORT, DIALOG
+    BEGIN
+    END
+
+    IDD_SHARED_FILTER, DIALOG
+    BEGIN
+    END
+
+    IDD_PROP_ARCHIVE, DIALOG
+    BEGIN
+    END
+
+    IDD_COMPARE_STATISTICS, DIALOG
+    BEGIN
+    END
+
+    IDD_COMPARE_STATISTICS3, DIALOG
+    BEGIN
+    END
+
+    IDD_TEST_FILTER, DIALOG
+    BEGIN
+    END
+
+    IDD_PROPPAGE_BACKUPS, DIALOG
+    BEGIN
+    END
+
     IDD_CONFIRM_COPY, DIALOG
+    BEGIN
+    END
+
+    IDD_PLUGINS_LIST, DIALOG
+    BEGIN
+    END
+
+    IDD_PROPPAGE_COMPARE_FOLDER, DIALOG
+    BEGIN
+    END
+
+    IDD_SELECT_FILES_OR_FOLDERS, DIALOG
+    BEGIN
+    END
+
+    IDD_DIALOG_WINDOWSMANAGER, DIALOG
     BEGIN
     END
 END
@@ -1972,6 +2058,11 @@ BEGIN
     100, 0, 0, 0
 END
 
+IDD_DIALOG_WINDOWSMANAGER AFX_DIALOG_LAYOUT
+BEGIN
+    0
+END
+
 
 /////////////////////////////////////////////////////////////////////////////
 //
@@ -1983,7 +2074,6 @@ BEGIN
     AFX_IDS_APP_TITLE       "WinMerge"
 END
 
-// Generic status bar strings
 STRINGTABLE
 BEGIN
     ID_INDICATOR_EXT        "EXT"
@@ -1994,7 +2084,6 @@ BEGIN
     ID_INDICATOR_REC        "REC"
 END
 
-// Generic File menu commands
 STRINGTABLE
 BEGIN
     ID_FILE_NEW             "\nNew Documents (Ctrl+N)"
@@ -2002,7 +2091,6 @@ BEGIN
     ID_FILE_SAVE            "\nSave (Ctrl+S)"
 END
 
-// WinMerge Project Files
 STRINGTABLE
 BEGIN
     IDS_UNK_ERROR_READING_PROJECT 
@@ -2017,14 +2105,12 @@ BEGIN
     IDS_PROJFILE_SAVE_SUCCESS "Project file successfully saved."
 END
 
-// Generic Edit commands
 STRINGTABLE
 BEGIN
     ID_EDIT_UNDO            "\nUndo (Ctrl+Z)"
     ID_EDIT_REDO            "\nRedo (Ctrl+Y)"
 END
 
-// WINMERGE INFORMATION
 STRINGTABLE
 BEGIN
     IDR_MAINFRAME           "WinMerge"
@@ -2032,14 +2118,12 @@ BEGIN
     IDR_DIRDOCTYPE          "\nFolderCompare\n\n\n\nWinMerge.FolderCompare\nWinMerge Folder Compare"
 END
 
-// SPLASH SCREEN TEXTS
 STRINGTABLE
 BEGIN
     IDS_SPLASH_DEVELOPERS   "Developers:\nDean Grimm, Christian List, Kimmo Varis, Jochen Tucht, Tim Gerundt, Takashi Sawanaka, Gal Hammer, Alexander Skinner"
     IDS_SPLASH_GPLTEXT      "WinMerge comes with ABSOLUTELY NO WARRANTY. This is free software and you are welcome to redistribute it under certain circumstances; see the GNU General Public License in the Help menu for details."
 END
 
-// "DO NOT SHOW AGAIN" MESSAGEBOXES
 STRINGTABLE
 BEGIN
     IDS_MESSAGEBOX_OK       "&Ok"
@@ -2051,7 +2135,6 @@ BEGIN
     IDS_MESSAGEBOX_YES      "&Yes"
 END
 
-// "DO NOT SHOW AGAIN" MESSAGEBOXES (2)
 STRINGTABLE
 BEGIN
     IDS_MESSAGEBOX_YES_TO_ALL "Yes to &all"
@@ -2061,15 +2144,12 @@ BEGIN
     IDS_MESSAGEBOX_SKIP     "&Skip"
     IDS_MESSAGEBOX_SKIPALL  "Skip &all"
     IDS_MESSAGEBOX_HELP     "&Help"
-    IDS_MESSAGEBOX_DONT_DISPLAY_AGAIN 
-                            "Don't display this &message again."
-    IDS_MESSAGEBOX_DONT_ASK_AGAIN 
-                            "Don't ask this &question again."
+    IDS_MESSAGEBOX_DONT_DISPLAY_AGAIN "Don't display this &message again."
+    IDS_MESSAGEBOX_DONT_ASK_AGAIN "Don't ask this &question again."
     IDS_MESSAGEBOX_CHECKBOX_TOOLTIP 
                             "To make this messagebox visible again, press the Reset button on the General page of the Options dialog."
 END
 
-// Options-dialog page captions
 STRINGTABLE
 BEGIN
     IDS_OPTIONSPG_GENERAL   "General"
@@ -2079,7 +2159,6 @@ BEGIN
     IDS_OPTIONSPG_TEXTCOLORS "Text"
     IDS_OPTIONSPG_SYNTAXCOLORS "Syntax"
     IDS_OPTIONSPG_MARKERCOLORS "Markers"
-    IDS_OPTIONSPG_DIRCOLORS "Folder Compare"
     IDS_OPTIONSPG_SYSTEM    "System"
     IDS_OPTIONSPG_CODEPAGE  "Codepage"
     IDS_OPTIONSPG_ARCHIVE   "Archive Support"
@@ -2091,12 +2170,12 @@ END
 
 STRINGTABLE
 BEGIN
-    IDS_OPTIONSPG_FOLDERCOMPARE NC_("Options dialog|Categories", "Folder")
+    IDS_OPTIONSPG_FOLDERCOMPARE "\001""Options dialog|Categories""Folder"
     IDS_OPTIONSPG_IMAGECOMPARE "Image"
-    IDS_OPTIONSPG_BINARYCOMPARE NC_("Options dialog|Categories", "Binary")
+    IDS_OPTIONSPG_BINARYCOMPARE "\001""Options dialog|Categories""Binary"
+    IDS_OPTIONSPG_DIRCOLORS "Folder Compare"
 END
 
-// WINMERGE CUSTOM STRINGS
 STRINGTABLE
 BEGIN
     IDS_TO                  "To:"
@@ -2106,14 +2185,12 @@ BEGIN
     IDS_TO_RIGHT            "To right:"
 END
 
-// WINMERGE INFORMATION
 STRINGTABLE
 BEGIN
     IDS_VERSION_FMT         "Version %1"
     IDS_WINX64              "X64"
 END
 
-// VARIOUS OPTIONS
 STRINGTABLE
 BEGIN
     IDS_OPTIONS_TITLE       "Options (%1)"
@@ -2122,7 +2199,6 @@ BEGIN
                             "Value in Tab size -field is not in range WinMerge accepts.\n\nPlease use values 1 - %1."
 END
 
-// BROWSE FILE
 STRINGTABLE
 BEGIN
     IDS_OPEN_TITLE          "Open"
@@ -2133,7 +2209,6 @@ BEGIN
     IDS_INIFILES            "Options files (*.ini)|*.ini|All Files (*.*)|*.*||"
 END
 
-// REPORT FILES
 STRINGTABLE
 BEGIN
     IDS_TEXT_REPORT_FILES   "Text Files (*.csv;*.asc;*.rpt;*.txt)|*.csv;*.asc;*.rpt;*.txt|All Files (*.*)|*.*||"
@@ -2141,18 +2216,24 @@ BEGIN
     IDS_XML_REPORT_FILES    "XML Files (*.xml)|*.xml|All Files (*.*)|*.*||"
 END
 
-// COMPARE OPTIONS
 STRINGTABLE
 BEGIN
     IDS_COMPMETHOD_FULL_CONTENTS "Full Contents"
     IDS_COMPMETHOD_QUICK_CONTENTS "Quick Contents"
     IDS_COMPMETHOD_BINARY_CONTENTS "Binary Contents"
+END
+
+STRINGTABLE
+BEGIN
     IDS_COMPMETHOD_MODDATE  "Modified Date"
     IDS_COMPMETHOD_DATESIZE "Modified Date and Size"
     IDS_COMPMETHOD_SIZE     "Size"
+    IDS_UNPACK_AUTO         "The adapted unpacker is applied to both files (one file only needs the extension)"
+    IDS_NO_PREDIFFER        "No prediffer (normal)"
+    IDS_SUGGESTED_PLUGINS   "Suggested plugins"
+    IDS_NOT_SUGGESTED_PLUGINS "Other plugins"
 END
 
-// FILTER OPTIONS
 STRINGTABLE
 BEGIN
     IDS_FILTERFILE_NAMETITLE "Name"
@@ -2177,19 +2258,16 @@ BEGIN
                             "Filter file already exists. Overwrite existing filter?"
 END
 
-// LINEFILTER STRINGS
 STRINGTABLE
 BEGIN
     IDS_FILTERLINE_REGEXP   "Regular expression"
 END
 
-// GENERAL FILTER STRINGS
 STRINGTABLE
 BEGIN
     IDS_FILTERCHANGED       "Filters were updated. Do you want to refresh all open folder compares?\n\nIf you do not want to refresh all compares now you can select No and refresh compares later."
 END
 
-// WINDOWS TITLES
 STRINGTABLE
 BEGIN
     IDS_DIRECTORY_WINDOW_TITLE "Folder Comparison Results"
@@ -2201,28 +2279,20 @@ BEGIN
     IDS_CONFLICT_MINE_FILE  "Mine File"
 END
 
-// STATUS BAR : OTHER PANES (MOSTLY FOR EDITOR)
 STRINGTABLE
 BEGIN
-    IDS_LINE_STATUS_INFO_EOL 
-                            "Ln: %s  Col: %d/%d  Ch: %d/%d  EOL: %s"
+    IDS_LINE_STATUS_INFO_EOL "Ln: %s  Col: %d/%d  Ch: %d/%d  EOL: %s"
     IDS_EMPTY_LINE_STATUS_INFO "Line: %s"
     IDS_LINE_STATUS_INFO    "Ln: %s  Col: %d/%d  Ch: %d/%d"
     IDS_MERGEMODE_MERGING   "Merge"
     IDS_DIFF_NUMBER_STATUS_FMT "Difference %1 of %2"
     IDS_NO_DIFF_SEL_FMT     "%1 Differences Found"
     IDS_1_DIFF_FOUND        "1 Difference Found"
-    IDS_STATUSBAR_READONLY  "RO" //#. Abbreviation from "Read Only"
-END
-
-// MORE STATUS PANES
-STRINGTABLE
-BEGIN
+    IDS_STATUSBAR_READONLY  "RO"
     IDS_DIRVIEW_STATUS_FMT_FOCUS "Item %1 of %2"
     IDS_DIRVIEW_STATUS_FMT_NOFOCUS "Items: %1"
 END
 
-// OPEN DIALOG
 STRINGTABLE
 BEGIN
     IDS_ERROR_INCOMPARABLE  "Select two existing folders or files to compare"
@@ -2231,7 +2301,6 @@ BEGIN
     IDS_OPEN_LEFTINVALID    "Left (1st) path is invalid!"
     IDS_OPEN_MIDDLEINVALID  "Middle (2nd) path is invalid!"
     IDS_OPEN_RIGHTINVALID2  "Right (2nd) path is invalid!"
-    IDS_OPEN_RIGHTINVALID3  "Right (3rd) path is invalid!"
     IDS_OPEN_BOTHINVALID    "Both paths are invalid!"
     IDS_OPEN_LEFTMIDDLEINVALID 
                             "Left (1st) and Middle (2nd) paths are invalid!"
@@ -2239,12 +2308,11 @@ BEGIN
     IDS_OPEN_MIDDLERIGHTINVALID 
                             "Middle (2nd) and Right (3rd) paths are invalid!"
     IDS_OPEN_ALLINVALID     "All paths are invalid!"
-    IDS_OPEN_UNPACKERDISABLED 
-                            "Only enabled for File comparisons"
+    IDS_OPEN_UNPACKERDISABLED "Only enabled for File comparisons"
     IDS_OPEN_MISMATCH       "Cannot compare file and folder!"
+    IDS_OPEN_RIGHTINVALID3  "Right (3rd) path is invalid!"
 END
 
-// LOADING FILE
 STRINGTABLE
 BEGIN
     IDS_ERROR_FILE_NOT_FOUND "File not found: %1"
@@ -2254,7 +2322,6 @@ BEGIN
     IDS_NOT_CONFLICT_FILE   "The file\n%1\nis not a conflict file."
 END
 
-// SAVING FILE
 STRINGTABLE
 BEGIN
     IDS_SAVE_AS_TITLE       "Save As"
@@ -2281,7 +2348,6 @@ BEGIN
     IDS_FILE_DISAPPEARED    "The file\n%1\nhas disappeared. Please save a copy of the file to continue."
 END
 
-// Editing/Merging file
 STRINGTABLE
 BEGIN
     IDS_VIEWS_OUTOFSYNC     "Cannot merge differences when documents are not in synch.\n\nRefresh documents before continuing."
@@ -2293,7 +2359,6 @@ BEGIN
     IDS_BREAK_ON_PUNCTUATION "Break at whitespace or punctuation"
 END
 
-// DIRECTORY DIFFING : FILE COPY/DELETE (WITHOUT/WITH NUMBER MARK)
 STRINGTABLE
 BEGIN
     IDS_COPY_RIGHT_TO_LEFT  "Right to Left (%1)"
@@ -2326,7 +2391,6 @@ BEGIN
     IDS_COPY_DIFFERENCES_TO2 "Differences to... (%1 of %2)"
 END
 
-// DIRECTORY DIFFING : FILE COPY/DELETE (WITHOUT/WITH NUMBER MARK)  (2)
 STRINGTABLE
 BEGIN
     IDS_DEL_LEFT_FMT        "Left (%1)"
@@ -2354,11 +2418,6 @@ BEGIN
     IDS_SELECT_DEST_RIGHT   "Right side - select destination folder:"
     IDS_FILES_AFFECTED_FMT  "(%1 Files Affected)"
     IDS_FILES_AFFECTED_FMT2 "(%1 of %2 Files Affected)"
-END
-
-// DIRECTORY DIFFING : FILE COPY/DELETE CONFIRMATION
-STRINGTABLE
-BEGIN
     IDS_CONFIRM_DELETE_SINGLE "Are you sure you want to delete\n\n%1 ?"
     IDS_CONFIRM_SINGLE_COPY "Are you sure you want to copy:"
     IDS_CONFIRM_MULTIPLE_COPY "Are you sure you want to copy %d items:"
@@ -2375,23 +2434,20 @@ BEGIN
                             "You are about to close the window that is comparing folders. Are you sure you want to close the window?"
 END
 
-// DIRECTORY DIFFING : OPEN FILE
 STRINGTABLE
 BEGIN
     IDS_ERROR_EXECUTE_FILE  "Failed to execute external editor: %1"
 END
 
-// DIRECTORY DIFFING : 7ZIP
 STRINGTABLE
 BEGIN
     IDS_UNKNOWN_ARCHIVE_FORMAT "Unknown archive format"
 END
 
-// DIRECTORY DIFFING : COLUMN TITLES #1
 STRINGTABLE
 BEGIN
     IDS_COLHDR_FILENAME     "Filename"
-    IDS_COLHDR_DIR          NC_("DirView|ColumnHeader", "Folder")
+    IDS_COLHDR_DIR          "\001""DirView|ColumnHeader""Folder"
     IDS_COLHDR_RESULT       "Comparison result"
     IDS_COLHDR_LTIMEM       "Left Date"
     IDS_COLHDR_RTIMEM       "Right Date"
@@ -2409,7 +2465,6 @@ BEGIN
     IDS_COLHDR_MSIZE_SHORT  "Middle Size (Short)"
 END
 
-// DIRECTORY DIFFING : COLUMN TITLES #2
 STRINGTABLE
 BEGIN
     IDS_COLHDR_LTIMEC       "Left Creation Time"
@@ -2432,7 +2487,6 @@ BEGIN
     IDS_COLHDR_REOL_TYPE    "Right EOL"
 END
 
-// DIRECTORY DIFFING : COLUMN TITLES #3
 STRINGTABLE
 BEGIN
     IDS_COLHDR_LENCODING    "Left Encoding"
@@ -2440,10 +2494,9 @@ BEGIN
     IDS_COLHDR_MENCODING    "Middle Encoding"
     IDS_COLHDR_NIDIFFS      "Ignored Diff"
     IDS_COLHDR_NSDIFFS      "Differences"
-    IDS_COLHDR_BINARY       NC_("DirView|ColumnHeader", "Binary")
+    IDS_COLHDR_BINARY       "\001""DirView|ColumnHeader""Binary"
 END
 
-// DIRECTORY DIFFING : FILE COMPARISON RESULT, FULL & SHORTENED FORMS
 STRINGTABLE
 BEGIN
     IDS_CANT_COMPARE_FILES  "Unable to compare files"
@@ -2472,13 +2525,16 @@ BEGIN
     IDS_DIFFERENT           "Different"
     IDS_CMPRES_ERROR        "Error"
     IDS_TEXT_FILES_SAME     "Text files are identical"
+END
+
+STRINGTABLE
+BEGIN
+    IDS_TEXT_FILES_DIFF     "Text files are different"
     IDS_LEFTONLY_DIFF       "(Middle and right are identical)"
     IDS_MIDDLEONLY_DIFF     "(Left and right are identical)"
     IDS_RIGHTONLY_DIFF      "(Left and middle are identical)"
-    IDS_TEXT_FILES_DIFF     "Text files are different"
 END
 
-// DIRECTORY DIFFING : SUMMARY BAR
 STRINGTABLE
 BEGIN
     IDS_ELAPSED_TIME        "Elapsed time: %ld ms"
@@ -2486,7 +2542,6 @@ BEGIN
     IDS_STATUS_SELITEMS     "%1 items selected"
 END
 
-// DIRECTORY DIFFING : COLUMN DESCRIPTIONS#1
 STRINGTABLE
 BEGIN
     IDS_COLDESC_FILENAME    "Filename or folder name."
@@ -2506,11 +2561,6 @@ BEGIN
     IDS_COLDESC_LSIZE_SHORT "Left file size abbreviated."
     IDS_COLDESC_RSIZE_SHORT "Right file size abbreviated."
     IDS_COLDESC_MSIZE_SHORT "Middle file size abbreviated."
-END
-
-// DIRECTORY DIFFING : COLUMN DESCRIPTIONS#2
-STRINGTABLE
-BEGIN
     IDS_COLDESC_LTIMEC      "Left side creation time."
     IDS_COLDESC_RTIMEC      "Right side creation time."
     IDS_COLDESC_MTIMEC      "Middle side creation time."
@@ -2531,7 +2581,6 @@ BEGIN
     IDS_COLDESC_MEOL_TYPE   "Middle side file EOL type."
 END
 
-// DIRECTORY DIFFING : COLUMN DESCRIPTIONS (2)
 STRINGTABLE
 BEGIN
     IDS_COLDESC_LENCODING   "Left side encoding."
@@ -2542,7 +2591,6 @@ BEGIN
     IDS_COLDESC_BINARY      "Shows an asterisk (*) if the file is binary."
 END
 
-// DIRECTORY DIFFING : GENERATE REPORT
 STRINGTABLE
 BEGIN
     IDS_DIRECTORY_REPORT_TITLE "Compare %1 with %2"
@@ -2560,7 +2608,6 @@ BEGIN
     IDS_REPORT_SUCCESS      "The report has been created successfully."
 END
 
-// FILE COMPARISON RESULT : MESSAGES
 STRINGTABLE
 BEGIN
     IDS_FILE_TO_ITSELF      "The same file is opened in both panels."
@@ -2581,42 +2628,37 @@ BEGIN
     IDS_MOVE_TO_PREVPAGE    "Do you want to move to the previous page?"
 END
 
-// Encoding issues
 STRINGTABLE
 BEGIN
     IDS_SUGGEST_IGNORECODEPAGE 
                             "Different codepages found in left (cp%d) and right (cp%d) files.\nDisplaying each file in its codepage will give a better display but merging/copying will be dangerous.\nWould you like to treat both files as being in the default Windows codepage (recommended)?"
-    IDS_LOSSY_TRANSCODING_BOTH 
-                            "Information lost due to encoding errors: both files"
     IDS_LOSSY_TRANSCODING_FIRST 
                             "Information lost due to encoding errors: first file"
     IDS_LOSSY_TRANSCODING_SECOND 
                             "Information lost due to encoding errors: second file"
     IDS_LOSSY_TRANSCODING_THIRD 
                             "Information lost due to encoding errors: third file"
+    IDS_LOSSY_TRANSCODING_BOTH 
+                            "Information lost due to encoding errors: both files"
 END
 
-// EDITOR : SHOW LINE DIFF
 STRINGTABLE
 BEGIN
     IDS_LINEDIFF_NODIFF     "No difference"
     IDS_LINEDIFF_NODIFF_CAPTION "Line difference"
 END
 
-// EDITOR : SEARCH/REPLACE DIALOGS
 STRINGTABLE
 BEGIN
     IDS_NUM_REPLACED        "Replaced %1 string(s)."
     IDS_EDIT_TEXT_NOT_FOUND "Cannot find string ""%s"""
 END
 
-// EDITOR : MERGE MODE
 STRINGTABLE
 BEGIN
     IDS_MERGE_MODE          "You are now entering Merge Mode. If you want to turn off Merge Mode, press F9 key"
 END
 
-// EDITOR : AUTO MERGE
 STRINGTABLE
 BEGIN
     IDS_AUTO_MERGE          "The number of automatically merged changes: %1\nThe number of unresolved conflicts: %2"
@@ -2626,14 +2668,12 @@ BEGIN
     IDS_EOL_CONFLICT        "The changes of EOL are conflicting"
 END
 
-// FILE COMPARE: PANE CAPTIONS
 STRINGTABLE
 BEGIN
     IDS_LOCBAR_CAPTION      "Location Pane"
     IDS_DIFFBAR_CAPTION     "Diff Pane"
 END
 
-// CREATE PATCH
 STRINGTABLE
 BEGIN
     IDS_DIFF_SUCCEEDED      "Patch file successfully written."
@@ -2667,14 +2707,13 @@ BEGIN
     IDS_CLOSEALL_WINDOWS    "You are about to close several compare windows.\n\nDo you want to continue?"
 END
 
-// EOL types shown in folder compare EOL type column and in file compare statusbar
 STRINGTABLE
 BEGIN
     IDS_EOL_DOS             "Win"
     IDS_EOL_MAC             "Mac"
     IDS_EOL_UNIX            "Unix"
     IDS_EOL_MIXED           "Mixed"
-    IDS_EOL_BIN             NC_("EOL Type", "Binary")
+    IDS_EOL_BIN             "\001""EOL Type""Binary"
     IDS_EOL_LF              "LF"
     IDS_EOL_CR              "CR"
     IDS_EOL_CRLF            "CRLF"
@@ -2691,7 +2730,6 @@ BEGIN
     IDS_PLUGINS_TYPE_EDITSCRIPT "Editor script"
 END
 
-// EDIT MENU
 STRINGTABLE
 BEGIN
     ID_SELECTLINEDIFF       "\nDifference in the Current Line"
@@ -2699,7 +2737,6 @@ BEGIN
     ID_REFRESH              "\nRefresh (F5)"
 END
 
-// MERGE MENU
 STRINGTABLE
 BEGIN
     ID_PREVDIFF             "\nPrevious Difference (Alt+Up)"
@@ -2722,46 +2759,35 @@ BEGIN
     ID_AUTO_MERGE           "\nAuto Merge (Ctrl+Alt+M)"
 END
 
-// PLUGINS MENU
-STRINGTABLE
-BEGIN
-    IDS_UNPACK_AUTO         "The adapted unpacker is applied to both files (one file only needs the extension)"
-    IDS_NO_PREDIFFER        "No prediffer (normal)"
-    IDS_SUGGESTED_PLUGINS   "Suggested plugins"
-    IDS_NOT_SUGGESTED_PLUGINS "Other plugins"
-END
-
-// HELP MENU
 STRINGTABLE
 BEGIN
     IDS_PRIVATEBUILD_FMT    "Private Build: %1"
+END
+
+STRINGTABLE
+BEGIN
     IDS_CHECKFORUPDATES_UPTODATE "Your software is up to date"
     IDS_CHECKFORUPDATES_NEWVERSION 
                             "A new version of WinMerge is available.\n%1 is now available (you have %2). Would you like to download it now?"
-END
-
-STRINGTABLE
-BEGIN
     IDS_CHECKFORUPDATES_FAILED "Failed to download latest version information"
-END
-
-// PLUGINS DIALOGS AND DYNAMIC MENUS
-STRINGTABLE
-BEGIN
     IDS_TITLE_PLUGINS_SETTINGS "Plugin Settings"
     IDS_NO_EDIT_SCRIPTS     "< Empty >"
+END
+
+STRINGTABLE
+BEGIN
     IDS_NO_SCT_SCRIPTS      "WSH not found - .sct scripts disabled"
     IDS_USERCHOICE_NONE     "<None>"
     IDS_USERCHOICE_AUTOMATIC "<Automatic>"
+    IDS_CLOSE_LEFT_TABS     "Close &Left Tabs"
+    IDS_CLOSE_RIGHT_TABS    "Close R&ight Tabs"
 END
 
-// LOCATIONBAR CONTEXT MENU
 STRINGTABLE
 BEGIN
     IDS_LOCBAR_GOTOLINE_FMT "G&oto Line %1"
 END
 
-// AUTOCOMPLETE COMBOBOX OPTIONS
 STRINGTABLE
 BEGIN
     IDS_AUTOCOMPLETE_DISABLED "Disabled"
@@ -2769,7 +2795,6 @@ BEGIN
     IDS_AUTOCOMPLETE_MRU    "From MRU list"
 END
 
-// COLOR SCHEMES
 STRINGTABLE
 BEGIN
     IDS_COLORSCHEME_PLAIN   "No Highlighting"
@@ -2788,11 +2813,11 @@ BEGIN
     IDS_COLORSCHEME_INSTALLSHIELD "InstallShield"
     IDS_COLORSCHEME_JAVA    "Java"
     IDS_COLORSCHEME_LISP    "AutoLISP"
-    IDS_COLORSCHEME_LUA     "Lua"
 END
 
 STRINGTABLE
 BEGIN
+    IDS_COLORSCHEME_LUA     "Lua"
     IDS_COLORSCHEME_NSIS    "NSIS"
     IDS_COLORSCHEME_PASCAL  "Pascal"
     IDS_COLORSCHEME_PERL    "Perl"
@@ -2808,11 +2833,11 @@ BEGIN
     IDS_COLORSCHEME_SH      "Shell"
     IDS_COLORSCHEME_SIOD    "SIOD"
     IDS_COLORSCHEME_SQL     "SQL"
-    IDS_COLORSCHEME_TCL     "TCL"
 END
 
 STRINGTABLE
 BEGIN
+    IDS_COLORSCHEME_TCL     "TCL"
     IDS_COLORSCHEME_TEX     "TEX"
     IDS_COLORSCHEME_VERILOG "Verilog"
     IDS_COLORSCHEME_VHDL    "VHDL"
@@ -2821,8 +2846,6 @@ END
 
 STRINGTABLE
 BEGIN
-    IDS_CLOSE_LEFT_TABS     "Close &Left Tabs"
-    IDS_CLOSE_RIGHT_TABS    "Close R&ight Tabs"
     IDS_CLOSE_OTHER_TABS    "Close &Other Tabs"
     IDS_TABBAR_AUTO_MAXWIDTH "Enable &Auto Max Width"
 END
@@ -2850,21 +2873,22 @@ END
 
 STRINGTABLE
 BEGIN
-    IDS_DIFF_ALGORITHM_DEFAULT   "default"
-    IDS_DIFF_ALGORITHM_MINIMAL   "minimal"
-    IDS_DIFF_ALGORITHM_PATIENCE  "patience"
+    IDS_DIFF_ALGORITHM_DEFAULT "default"
+    IDS_DIFF_ALGORITHM_MINIMAL "minimal"
+    IDS_DIFF_ALGORITHM_PATIENCE "patience"
     IDS_DIFF_ALGORITHM_HISTOGRAM "histogram"
+    IDS_RENDERING_MODE_GDI  "GDI"
+    IDS_RENDERING_MODE_DIRECTWRITE_DEFAULT "DirectWrite Default"
 END
 
 STRINGTABLE
 BEGIN
-    IDS_RENDERING_MODE_GDI                           "GDI"
-    IDS_RENDERING_MODE_DIRECTWRITE_DEFAULT           "DirectWrite Default"
-    IDS_RENDERING_MODE_DIRECTWRITE_ALIASED           "DirectWrite Aliased"
-    IDS_RENDERING_MODE_DIRECTWRITE_GDI_CLASSIC       "DirectWrite GDI Classic"
-    IDS_RENDERING_MODE_DIRECTWRITE_GDI_NATURAL       "DirectWrite GDI Natural"
-    IDS_RENDERING_MODE_DIRECTWRITE_NATURAL           "DirectWrite Natural"
-    IDS_RENDERING_MODE_DIRECTWRITE_NATURAL_SYMMETRIC "DirectWrite Natural Symmetric"
+    IDS_RENDERING_MODE_DIRECTWRITE_ALIASED "DirectWrite Aliased"
+    IDS_RENDERING_MODE_DIRECTWRITE_GDI_CLASSIC "DirectWrite GDI Classic"
+    IDS_RENDERING_MODE_DIRECTWRITE_GDI_NATURAL "DirectWrite GDI Natural"
+    IDS_RENDERING_MODE_DIRECTWRITE_NATURAL "DirectWrite Natural"
+    IDS_RENDERING_MODE_DIRECTWRITE_NATURAL_SYMMETRIC 
+                            "DirectWrite Natural Symmetric"
 END
 
 #endif    // English (United States) resources

--- a/Src/MergeEditFrm.cpp
+++ b/Src/MergeEditFrm.cpp
@@ -279,7 +279,7 @@ BOOL CMergeEditFrame::DestroyWindow()
 	SavePosition();
 	SaveActivePane();
 	SaveWindowState();
-	return CMDIChildWnd::DestroyWindow();
+	return CMergeFrameCommon::DestroyWindow();
 }
 
 /**
@@ -315,7 +315,7 @@ void CMergeEditFrame::SaveActivePane()
 void CMergeEditFrame::OnClose() 
 {
 	// clean up pointers.
-	CMDIChildWnd::OnClose();
+	CMergeFrameCommon::OnClose();
 
 	GetMainFrame()->ClearStatusbarItemCount();
 }
@@ -388,7 +388,7 @@ void CMergeEditFrame::UpdateSplitter()
 void CMergeEditFrame::OnIdleUpdateCmdUI()
 {
 	UpdateHeaderSizes();
-	CMDIChildWnd::OnIdleUpdateCmdUI();
+	CMergeFrameCommon::OnIdleUpdateCmdUI();
 }
 
 void CMergeEditFrame::OnTimer(UINT_PTR nIDEvent) 
@@ -402,12 +402,12 @@ void CMergeEditFrame::OnTimer(UINT_PTR nIDEvent)
 	{
 		UpdateHeaderSizes();
 	}
-	CMDIChildWnd::OnTimer(nIDEvent);
+	CMergeFrameCommon::OnTimer(nIDEvent);
 }
 
 void CMergeEditFrame::OnMDIActivate(BOOL bActivate, CWnd* pActivateWnd, CWnd* pDeactivateWnd)
 {
-	CMDIChildWnd::OnMDIActivate(bActivate, pActivateWnd, pDeactivateWnd);
+	CMergeFrameCommon::OnMDIActivate(bActivate, pActivateWnd, pDeactivateWnd);
 
 	CMergeDoc *pDoc = GetMergeDoc();
 	if (bActivate && pDoc != nullptr)

--- a/Src/MergeFrameCommon.cpp
+++ b/Src/MergeFrameCommon.cpp
@@ -16,6 +16,7 @@ BEGIN_MESSAGE_MAP(CMergeFrameCommon, CMDIChildWnd)
 	//{{AFX_MSG_MAP(CMergeFrameCommon)
 	ON_WM_GETMINMAXINFO()
 	ON_WM_DESTROY()
+	ON_WM_MDIACTIVATE()
 	//}}AFX_MSG_MAP
 END_MESSAGE_MAP()
 
@@ -25,6 +26,12 @@ CMergeFrameCommon::CMergeFrameCommon(int nIdenticalIcon, int nDifferentIcon)
 	, m_bActivated(false)
 	, m_nLastSplitPos{0}
 {
+	::PostMessage(AfxGetMainWnd()->GetSafeHwnd(), WMU_CHILDFRAMEADDED, 0, reinterpret_cast<LPARAM>(this));
+}
+
+CMergeFrameCommon::~CMergeFrameCommon()
+{
+	::PostMessage(AfxGetMainWnd()->GetSafeHwnd(), WMU_CHILDFRAMEREMOVED, 0, reinterpret_cast<LPARAM>(this));
 }
 
 void CMergeFrameCommon::ActivateFrame(int nCmdShow)
@@ -106,3 +113,12 @@ void CMergeFrameCommon::OnDestroy()
 	CFrameWnd::OnDestroy();
 }
 
+void CMergeFrameCommon::OnMDIActivate(BOOL bActivate, CWnd* pActivateWnd, CWnd* pDeactivateWnd)
+{
+	// call the base class to let standard processing switch to
+	// the top-level menu associated with this window
+	CMDIChildWnd::OnMDIActivate(bActivate, pActivateWnd, pDeactivateWnd);
+
+	if (bActivate)
+		::PostMessage(AfxGetMainWnd()->GetSafeHwnd(), WMU_CHILDFRAMEACTIVATED, 0, reinterpret_cast<LPARAM>(this));
+}

--- a/Src/MergeFrameCommon.h
+++ b/Src/MergeFrameCommon.h
@@ -10,13 +10,14 @@ class CMergeFrameCommon: public CMDIChildWnd
 {
 	DECLARE_DYNCREATE(CMergeFrameCommon)
 public:
-	CMergeFrameCommon::CMergeFrameCommon(int nIdenticalIcon  = -1, int nDifferentIcon = -1);
+	CMergeFrameCommon(int nIdenticalIcon  = -1, int nDifferentIcon = -1);
 	bool IsActivated() const { return m_bActivated; }
 	void ActivateFrame(int nCmdShow);
 	void SetLastCompareResult(int nResult);
 	void SaveWindowState();
-	void SetSharedMenu(HMENU hMenu) { m_hMenuShared = hMenu; };
-	virtual BOOL IsTabbedMDIChild() {
+	void SetSharedMenu(HMENU hMenu) { m_hMenuShared = hMenu; }
+	virtual BOOL IsTabbedMDIChild()
+	{
 		return TRUE; // https://stackoverflow.com/questions/35553955/getting-rid-of-3d-look-of-mdi-frame-window
 	}
 protected:
@@ -26,9 +27,14 @@ private:
 	HICON m_hIdentical;
 	HICON m_hDifferent;
 
+protected:
+	virtual ~CMergeFrameCommon();
+
+protected:
 	//{{AFX_MSG(CMergeFrameCommon)
 	afx_msg void OnGetMinMaxInfo(MINMAXINFO* lpMMI);
 	afx_msg void OnDestroy();
+	afx_msg void OnMDIActivate(BOOL bActivate, CWnd* pActivateWnd, CWnd* pDeactivateWnd);
 	//}}AFX_MSG
 	DECLARE_MESSAGE_MAP()
 };

--- a/Src/OpenView.cpp
+++ b/Src/OpenView.cpp
@@ -308,7 +308,6 @@ COpenDoc* COpenView::GetDocument() const // non-debug version is inline
 }
 #endif //_DEBUG
 
-
 /////////////////////////////////////////////////////////////////////////////
 // COpenView message handlers
 

--- a/Src/PropGeneral.cpp
+++ b/Src/PropGeneral.cpp
@@ -41,17 +41,17 @@
  * @brief Constructor initialising members.
  */
 PropGeneral::PropGeneral(COptionsMgr *optionsMgr) 
-: OptionsPanel(optionsMgr, PropGeneral::IDD)
-, m_bScroll(false)
-, m_bSingleInstance(false)
-, m_bVerifyPaths(false)
-, m_bCloseWindowWithEsc(true)
-, m_bAskMultiWindowClose(false)
-, m_nAutoCompleteSource(0)
-, m_bPreserveFiletime(false)
-, m_bShowSelectFolderOnStartup(false)
-, m_bCloseWithOK(true)
-, m_pLoadLanguagesThread(nullptr)
+	: OptionsPanel(optionsMgr, PropGeneral::IDD)
+	, m_bScroll(false)
+	, m_bSingleInstance(false)
+	, m_bVerifyPaths(false)
+	, m_bCloseWindowWithEsc(false)	// default is false !
+	, m_bAskMultiWindowClose(false)
+	, m_nAutoCompleteSource(0)
+	, m_bPreserveFiletime(false)
+	, m_bShowSelectFolderOnStartup(false)
+	, m_bCloseWithOK(true)
+	, m_pLoadLanguagesThread(nullptr)
 {
 }
 

--- a/Src/WindowsManagerDialog.cpp
+++ b/Src/WindowsManagerDialog.cpp
@@ -1,0 +1,307 @@
+// WindowsManagerDialog.cpp : implementation file
+//
+
+#include "stdafx.h"
+#include "Merge.h"
+#include "WindowsManagerDialog.h"
+
+#ifdef _DEBUG
+#define new DEBUG_NEW
+#undef THIS_FILE
+static char THIS_FILE[] = __FILE__;
+#endif
+
+/////////////////////////////////////////////////////////////////////////////
+// CWindowsManagerDialog dialog
+
+CWindowsManagerDialog::CWindowsManagerDialog(CWnd* pParent/* = NULL*/)
+	: CDialog(CWindowsManagerDialog::IDD, pParent)
+	,m_bAutoCleanup(FALSE)
+	,m_pFrame(NULL)
+	,m_pIL(NULL)
+{
+	//{{AFX_DATA_INIT(CWindowsManagerDialog)
+		// NOTE: the ClassWizard will add member initialization here
+	//}}AFX_DATA_INIT
+}
+
+CWindowsManagerDialog::~CWindowsManagerDialog()
+{
+	if (NULL != m_pIL->GetSafeHandle())
+		m_pIL->DeleteImageList();
+	if (NULL != m_pIL)
+		delete m_pIL;
+}
+
+void CWindowsManagerDialog::DoDataExchange(CDataExchange* pDX)
+{
+	CDialog::DoDataExchange(pDX);
+	//{{AFX_DATA_MAP(CWindowsManagerDialog)
+	// NOTE: the ClassWizard will add DDX and DDV calls here
+	//}}AFX_DATA_MAP
+	DDX_Control(pDX, IDC_LIST_FILE, m_List);
+}
+
+BEGIN_MESSAGE_MAP(CWindowsManagerDialog, CDialog)
+	//{{AFX_MSG_MAP(CWindowsManagerDialog)
+	ON_WM_SIZE()
+	ON_WM_CLOSE()
+	ON_WM_ACTIVATE()
+	ON_WM_DESTROY()
+	ON_NOTIFY(NM_CUSTOMDRAW, IDC_LIST_FILE, &CWindowsManagerDialog::OnNMCustomdrawListFile)
+	ON_NOTIFY(NM_DBLCLK, IDC_LIST_FILE, &CWindowsManagerDialog::OnNMDblclkListFile)
+	//}}AFX_MSG_MAP
+	ON_MESSAGE(WMU_ISOPEN, &CWindowsManagerDialog::OnIsOpen)
+	ON_MESSAGE(WMU_SELECTNEXT, &CWindowsManagerDialog::OnSelectNext)
+END_MESSAGE_MAP()
+
+/////////////////////////////////////////////////////////////////////////////
+// CWindowsManagerDialog message handlers
+
+BOOL CWindowsManagerDialog::PreTranslateMessage(MSG* pMsg)
+{
+	// TODO: Add your specialized code here and/or call the base class
+
+	if ((WM_KEYUP == pMsg->message && VK_CONTROL == pMsg->wParam) || 
+		(WM_KEYDOWN == pMsg->message && VK_ESCAPE == pMsg->wParam))
+	{
+		PostMessage(WM_CLOSE);
+	}
+
+	if (WM_KEYDOWN == pMsg->message && VK_TAB == pMsg->wParam)
+	{
+		PostMessage(WMU_SELECTNEXT, (GetAsyncKeyState(VK_SHIFT) < 0) ? 1 : 0, 0);
+	}
+
+	return CDialog::PreTranslateMessage(pMsg);
+}
+
+BOOL CWindowsManagerDialog::OnInitDialog()
+{
+	CDialog::OnInitDialog();
+
+	// TODO: Add extra initialization here
+
+	m_List.SetExtendedStyle(LVS_EX_INFOTIP | LVS_EX_FULLROWSELECT);
+
+	if (NULL == m_pIL)
+		m_pIL = new CImageList();
+
+	m_pIL->DeleteImageList();
+	m_pIL->Create(16, 16, ILC_COLOR32 | ILC_MASK, 0, 1);
+	m_List.SetImageList(m_pIL, LVSIL_SMALL);
+	m_List.SetBkColor(WMD_LISTCOLOR_BKG);
+	m_List.SetTextBkColor(WMD_LISTCOLOR_BKG);
+
+	PopulateList();
+
+	if(m_List.GetItemCount() > 0)
+		m_List.SetItemState((1 == m_List.GetItemCount()) ? 0 : 1, LVIS_SELECTED | LVIS_FOCUSED, LVIS_SELECTED | LVIS_FOCUSED);
+
+	AdjustSize();
+	CenterWindow(m_pFrame);	// please initialize the parent window before creating dialog
+
+	return TRUE;  // return TRUE unless you set the focus to a control
+				  // EXCEPTION: OCX Property Pages should return FALSE
+}
+
+void CWindowsManagerDialog::PopulateList()
+{
+	if (m_List.GetItemCount() <= 0)
+	{
+		CRect rect;
+		m_List.GetWindowRect(rect);
+		m_List.InsertColumn(0, _T("Files"), LVCFMT_LEFT, rect.Width());
+	}
+
+	m_List.DeleteAllItems();
+
+	CString sText;
+	const CTypedPtrArray<CPtrArray, CMDIChildWnd*>* pArrChild = m_pFrame->GetChildArray();
+	for (int i = 0; i < pArrChild->GetSize(); ++i)
+	{
+		HICON hIcon = pArrChild->GetAt(i)->GetIcon(TRUE);
+		if (NULL == hIcon)
+			hIcon = AfxGetApp()->LoadIcon(IDR_MAINFRAME);
+		m_pIL->Add(hIcon);
+		sText = pArrChild->GetAt(i)->GetActiveDocument()->GetPathName();
+		if(sText.IsEmpty())
+			pArrChild->GetAt(i)->GetWindowText(sText);
+		m_List.InsertItem(i, sText, m_pIL->GetImageCount() - 1);
+		m_List.SetItemData(i, (DWORD_PTR)pArrChild->GetAt(i));
+	}
+}
+// adjust size to listctrl column and dialog
+void CWindowsManagerDialog::AdjustSize()
+{
+	CRect rect;
+	m_List.GetItemRect(0, rect, LVIR_ICON);
+
+	const int nImgWidth = rect.right - rect.left;
+	const int nSpaceWidth = m_List.GetStringWidth(_T(" "));
+	const int nLeftMargin = ::GetSystemMetrics(SM_CXFRAME) * 2 + nSpaceWidth * 4;
+
+	int nMaxWidth = -1;
+
+	CString sText;
+	CRect _rc(0, 0, 0, 0);
+	for (int i = 0; i < m_List.GetItemCount(); ++i)
+	{
+		sText = m_List.GetItemText(i, 0);
+		int nWidth = m_List.GetStringWidth(sText);
+		if (nWidth > nMaxWidth)
+			nMaxWidth = nWidth;
+		_rc.bottom += rect.bottom - rect.top;
+	}
+
+	_rc.right = nMaxWidth + nImgWidth + nLeftMargin + 2 * ::GetSystemMetrics(SM_CYVSCROLL);
+	m_List.SetColumnWidth(0, _rc.right - ::GetSystemMetrics(SM_CYFRAME));
+
+	//if the tasklist exceeds the height of the display, leave some space at the bottom
+	if (_rc.bottom > ::GetSystemMetrics(SM_CYSCREEN) - 50)
+	{
+		_rc.bottom = ::GetSystemMetrics(SM_CYSCREEN) - 50;
+		m_List.SetColumnWidth(0, _rc.right - ::GetSystemMetrics(SM_CYFRAME) - ::GetSystemMetrics(SM_CYVSCROLL));
+	}
+	// Task List's border is 1px smaller than ::GetSystemMetrics(SM_CYFRAME) returns
+	_rc.bottom += ::GetSystemMetrics(SM_CYFRAME);
+	MoveWindow(_rc, FALSE);
+}
+
+void CWindowsManagerDialog::SetParentWnd(CWnd* pWnd)
+{
+	ASSERT(NULL != pWnd);
+	m_pFrame = DYNAMIC_DOWNCAST(CMainFrame, pWnd);
+}
+
+void CWindowsManagerDialog::OnSize(UINT nType, int cx, int cy)
+{
+	CDialog::OnSize(nType, cx, cy);
+
+	// TODO: Add your message handler code here
+
+	if(NULL != m_List.GetSafeHwnd() && cx > 0 && cy > 0)
+		m_List.MoveWindow(0, 0, cx, cy);
+}
+
+void CWindowsManagerDialog::OnActivate(UINT nState, CWnd* pWndOther, BOOL bMinimized)
+{
+	CDialog::OnActivate(nState, pWndOther, bMinimized);
+
+	if (WA_INACTIVE == nState)
+		PostMessage(WM_CLOSE);
+}
+
+void CWindowsManagerDialog::OnClose()
+{
+	// TODO: Add your message handler code here and/or call default
+
+	if (m_bAutoCleanup)
+		DestroyWindow();
+	else
+		CDialog::OnClose();
+}
+
+void CWindowsManagerDialog::OnOK()
+{
+	// TODO: Add extra validation here
+
+	if (m_bAutoCleanup)
+		DestroyWindow();
+	else
+		CDialog::OnOK();
+}
+
+void CWindowsManagerDialog::OnCancel()
+{
+	// TODO: Add extra cleanup here
+
+	if (m_bAutoCleanup)
+		DestroyWindow();
+	else
+		CDialog::OnCancel();
+}
+
+void CWindowsManagerDialog::PostNcDestroy()
+{
+	// TODO: Add your specialized code here and/or call the base class
+
+	if (m_bAutoCleanup)
+		delete this;
+
+	CDialog::PostNcDestroy();
+}
+
+void CWindowsManagerDialog::OnDestroy()
+{
+	CDialog::OnDestroy();
+
+	// TODO: Add your message handler code here
+
+	const int nIndex = m_List.GetNextItem(-1, LVNI_SELECTED);
+	if (nIndex >= 0 && nIndex < m_List.GetItemCount())
+		::PostMessage(AfxGetMainWnd()->GetSafeHwnd(), WMU_CHILDFRAMEACTIVATE, 0, (LPARAM)m_List.GetItemData(nIndex));
+}
+
+LRESULT CWindowsManagerDialog::OnIsOpen(WPARAM wParam, LPARAM lParam)
+{
+	return 1;
+}
+
+LRESULT CWindowsManagerDialog::OnSelectNext(WPARAM wParam, LPARAM lParam)
+{
+	int nIndex = m_List.GetNextItem(-1, LVNI_SELECTED);
+	if (wParam)		// reverse order
+	{
+		if (0 == nIndex)
+			nIndex = m_List.GetItemCount() - 1;
+		else
+			nIndex--;
+	}
+	else
+	{
+		if (nIndex == m_List.GetItemCount() - 1)
+			nIndex = 0;
+		else
+			nIndex++;
+	}
+
+	m_List.SetItemState(nIndex, LVIS_SELECTED | LVIS_FOCUSED, LVIS_SELECTED | LVIS_FOCUSED);
+	m_List.EnsureVisible(nIndex, FALSE);
+
+	return 1;
+}
+
+void CWindowsManagerDialog::OnNMCustomdrawListFile(NMHDR* pNMHDR, LRESULT* pResult)
+{
+//	LPNMCUSTOMDRAW pNMCD = reinterpret_cast<LPNMCUSTOMDRAW>(pNMHDR);
+	NMLVCUSTOMDRAW* pLVCD = reinterpret_cast<NMLVCUSTOMDRAW*>(pNMHDR);
+	// TODO: Add your control notification handler code here
+
+	switch (pLVCD->nmcd.dwDrawStage)
+	{
+	case CDDS_PREPAINT:
+		*pResult = CDRF_NOTIFYITEMDRAW;
+		break;
+	case CDDS_ITEMPREPAINT:
+		if (CDIS_FOCUS == (pLVCD->nmcd.uItemState & CDIS_FOCUS))
+		{
+			pLVCD->nmcd.uItemState = CDIS_DEFAULT;
+			pLVCD->clrTextBk = WMD_LISTCOLOR_BKGSEL;
+		}
+		*pResult = CDRF_DODEFAULT;
+		break;
+	default:
+		*pResult = CDRF_DODEFAULT;
+		break;
+	}
+}
+
+void CWindowsManagerDialog::OnNMDblclkListFile(NMHDR* pNMHDR, LRESULT* pResult)
+{
+	LPNMITEMACTIVATE pNMItemActivate = reinterpret_cast<LPNMITEMACTIVATE>(pNMHDR);
+	// TODO: Add your control notification handler code here
+	*pResult = 0;
+
+	PostMessage(WM_CLOSE);
+}

--- a/Src/WindowsManagerDialog.h
+++ b/Src/WindowsManagerDialog.h
@@ -1,0 +1,92 @@
+#if !defined(AFX_WINDOWSMANAGERDIALOG_H__9417C3AF_FE30_4749_A058_3461CD0BDCC6__INCLUDED_)
+#define AFX_WINDOWSMANAGERDIALOG_H__9417C3AF_FE30_4749_A058_3461CD0BDCC6__INCLUDED_
+
+#include "MainFrm.h"
+
+#if _MSC_VER > 1000
+#pragma once
+#endif // _MSC_VER > 1000
+// WindowsManagerDialog.h : header file
+//
+
+#define WMD_LISTCOLOR_BKG					RGB(255, 255, 213)
+#define WMD_LISTCOLOR_BKGSEL				RGB(255, 165, 0)
+
+#ifndef WMU_ISOPEN
+#define WMU_ISOPEN							(WM_APP + 33)
+#endif
+#ifndef WMU_SELECTNEXT
+#define WMU_SELECTNEXT						(WM_APP + 34)
+#endif
+/////////////////////////////////////////////////////////////////////////////
+// CWindowsManagerDialog dialog
+
+class CWindowsManagerDialog : public CDialog
+{
+// Construction
+public:
+	CWindowsManagerDialog(CWnd* pParent = NULL);   // standard constructor
+	BOOL Create(UINT nID, CWnd* pWnd = NULL, BOOL bAutoCleanup = TRUE)
+	{
+		m_bAutoCleanup = bAutoCleanup;
+		m_pFrame = DYNAMIC_DOWNCAST(CMainFrame, pWnd);
+
+		return CDialog::Create(nID, pWnd);
+	}
+
+// Dialog Data
+	//{{AFX_DATA(CWindowsManagerDialog)
+	enum { IDD = IDD_DIALOG_WINDOWSMANAGER };
+		// NOTE: the ClassWizard will add data members here
+	//}}AFX_DATA
+
+public:
+	void PopulateList();
+	void SetParentWnd(CWnd* pWnd);
+	CWnd* GetParentWnd() { return DYNAMIC_DOWNCAST(CWnd, m_pFrame); }
+	BOOL GetAutoCleanup() const { return m_bAutoCleanup; }
+	void SetAutoCleanup(const BOOL bSet) { m_bAutoCleanup = bSet; }
+
+protected:
+	CListCtrl m_List;
+	CImageList* m_pIL;
+	BOOL m_bAutoCleanup;
+	CMainFrame* m_pFrame;
+
+protected:
+	void AdjustSize();
+
+// Overrides
+	// ClassWizard generated virtual function overrides
+	//{{AFX_VIRTUAL(CWindowsManagerDialog)
+public:
+	virtual void OnOK();
+	virtual void OnCancel();
+	virtual BOOL PreTranslateMessage(MSG* pMsg);
+protected:
+	virtual BOOL OnInitDialog();
+	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void PostNcDestroy();
+	virtual ~CWindowsManagerDialog();
+	//}}AFX_VIRTUAL
+
+// Implementation
+protected:
+	// Generated message map functions
+	//{{AFX_MSG(CWindowsManagerDialog)
+	afx_msg void OnClose();
+	afx_msg void OnSize(UINT nType, int cx, int cy);
+	afx_msg void OnActivate(UINT nState, CWnd* pWndOther, BOOL bMinimized);
+	afx_msg void OnDestroy();
+	afx_msg void OnNMCustomdrawListFile(NMHDR* pNMHDR, LRESULT* pResult);
+	afx_msg void OnNMDblclkListFile(NMHDR *pNMHDR, LRESULT *pResult);
+	//}}AFX_MSG
+	afx_msg LRESULT OnIsOpen(WPARAM wParam, LPARAM lParam);
+	afx_msg LRESULT OnSelectNext(WPARAM wParam, LPARAM lParam);
+	DECLARE_MESSAGE_MAP()
+};
+
+//{{AFX_INSERT_LOCATION}}
+// Microsoft Visual C++ will insert additional declarations immediately before the previous line.
+
+#endif // !defined(AFX_WINDOWSMANAGERDIALOG_H__9417C3AF_FE30_4749_A058_3461CD0BDCC6__INCLUDED_)

--- a/Src/resource.h
+++ b/Src/resource.h
@@ -3,7 +3,7 @@
 // Used by Merge.rc
 //
 #define IDR_MAINFRAME                   100
-#define IDB_TOOLBAR_ENABLED8BIT         100  // = IDR_MAINFRAME
+#define IDB_TOOLBAR_ENABLED8BIT         100
 #define IDR_MERGEPROJECT                101
 #define IDR_POPUP_EDITOR_HEADERBAR      102
 #define IDR_POPUP_PLUGINS_SETTINGS      103
@@ -58,6 +58,7 @@
 #define IDD_EDIT_MARKER                 245
 #define IDD_PROPPAGE_COLORS_DIR         246
 #define IDD_SELECT_FILES_OR_FOLDERS     247
+#define IDD_DIALOG_WINDOWSMANAGER       251
 #define IDI_ROTATE2                     302
 #define IDR_LOGO                        307
 #define IDR_SPLASH                      308
@@ -551,6 +552,7 @@
 #define IDC_SWAP02_STATIC               8827
 #define IDC_DIFF_ALGORITHM              8828
 #define IDC_INDENT_HEURISTIC            8829
+#define IDC_LIST_FILE                   8830
 #define IDS_SPLASH_DEVELOPERS           8976
 #define IDS_SPLASH_GPLTEXT              8977
 #define IDS_MESSAGEBOX_OK               9001
@@ -935,7 +937,7 @@
 #define IDS_TEXT_REPORT_FILES           18540
 #define IDS_HTML_REPORT_FILES           18541
 #define IDS_XML_REPORT_FILES            18542
-#define ID_EDIT_MARK                    21406 // editcmd.h
+#define ID_EDIT_MARK                    21406
 #define IDS_EOL_DOS                     30400
 #define IDS_EOL_MAC                     30401
 #define IDS_EOL_UNIX                    30402
@@ -1119,7 +1121,7 @@
 #define ID_VIEW_FILEMARGIN              33150
 #define ID_VIEW_CHANGESCHEME            33151
 #define ID_COLORSCHEME_FIRST            33152
-#define IDS_COLORSCHEME_PLAIN           33152 // = ID_COLORSCHEME_FIRST
+#define IDS_COLORSCHEME_PLAIN           33152
 #define IDS_COLORSCHEME_ASP             33153
 #define IDS_COLORSCHEME_BASIC           33154
 #define IDS_COLORSCHEME_BATCH           33155
@@ -1156,7 +1158,7 @@
 #define IDS_COLORSCHEME_VERILOG         33186
 #define IDS_COLORSCHEME_VHDL            33187
 #define IDS_COLORSCHEME_XML             33188
-#define ID_COLORSCHEME_LAST             33188 // = IDS_COLORSCHEME_XML
+#define ID_COLORSCHEME_LAST             33188
 #define ID_TOOLBAR_NONE                 33194
 #define ID_TOOLBAR_SMALL                33195
 #define ID_TOOLBAR_BIG                  33196
@@ -1273,16 +1275,19 @@
 #define IDS_CREATE_FOLDER_ERROR         33658
 #define ID_FILE_SHELLMENU               33659
 #define ID_MERGE_COMPARE_NONHORIZONTALLY 33660
+#define ID_ACCEL_QUIT                   33661
+#define ID__OPENCONTAININGFOLDER        33662
+#define ID_OPENCONTAININGFOLDER         33663
 #define IDS_DIFF_ALGORITHM_DEFAULT      33700
-#define IDS_DIFF_ALGORITHM_MINIMAL      33701 
-#define IDS_DIFF_ALGORITHM_PATIENCE     33702 
-#define IDS_DIFF_ALGORITHM_HISTOGRAM    33703 
+#define IDS_DIFF_ALGORITHM_MINIMAL      33701
+#define IDS_DIFF_ALGORITHM_PATIENCE     33702
+#define IDS_DIFF_ALGORITHM_HISTOGRAM    33703
 #define IDS_RENDERING_MODE_GDI          33710
 #define IDS_RENDERING_MODE_DIRECTWRITE_DEFAULT 33711
 #define IDS_RENDERING_MODE_DIRECTWRITE_ALIASED 33712
 #define IDS_RENDERING_MODE_DIRECTWRITE_GDI_CLASSIC 33713
 #define IDS_RENDERING_MODE_DIRECTWRITE_GDI_NATURAL 33714
-#define IDS_RENDERING_MODE_DIRECTWRITE_NATURAL     33715
+#define IDS_RENDERING_MODE_DIRECTWRITE_NATURAL 33715
 #define IDS_RENDERING_MODE_DIRECTWRITE_NATURAL_SYMMETRIC 33716
 
 // Next default values for new objects
@@ -1290,9 +1295,9 @@
 #ifdef APSTUDIO_INVOKED
 #ifndef APSTUDIO_READONLY_SYMBOLS
 #define _APS_3D_CONTROLS                     1
-#define _APS_NEXT_RESOURCE_VALUE        251
-#define _APS_NEXT_COMMAND_VALUE         33661
-#define _APS_NEXT_CONTROL_VALUE         8830
+#define _APS_NEXT_RESOURCE_VALUE        253
+#define _APS_NEXT_COMMAND_VALUE         33664
+#define _APS_NEXT_CONTROL_VALUE         8831
 #define _APS_NEXT_SYMED_VALUE           116
 #endif
 #endif


### PR DESCRIPTION
I have made few modifications:
1. Added CWindowsManagerDialog class for handling open tabs with Ctrl+Tab, now the application is behave just like professional editors (Visual Studio, Notepad++, etc.) to switch and activate the open tabs.
2. m_bCloseWindowWithEsc from PropGeneral I put it **false** as default, not **true**.
3. The mainframe could be closed with Ctrl+Q (like others editors do). Also, I deactivated closing app by a simple Esc key.

The reason is that there is some modal dialog that is closing by Esc key, and if you keep Esc key a little bit longer, you close tabs and the entire app, which is not good (from my point of view). Still, the OpenView form is closing with Esc key, I cannot make it into get rid of this feature.
4. I have tried (but I didn't make it) to avoid flickering the OpenView dialog by set as TRUE the "Clipping childs" properties from this dialog, even if the flickering has disappeared, not all the controls inside of this dialog is not drawn correctly, so I give up. But I am sure this issue could be solved :)