### PR TITLE
Fix french translations for non-horizontal compare

### DIFF
--- a/Translations/WinMerge/French.po
+++ b/Translations/WinMerge/French.po
@@ -858,11 +858,11 @@ msgid "Comp&are"
 msgstr "Co&mparer"
 
 msgid "Compare Non-hor&izontally..."
-msgstr ""
+msgstr "Comparer non-hor&izontalement..."
 
 #, c-format
 msgid "Compare Non-hor&izontally"
-msgstr "Comparaison non-Hor & izontal"
+msgstr "Comparer non-hor&izontalement"
 
 #, c-format
 msgid "First &left item with second left item"


### PR DESCRIPTION
- Remove extra spaces around ampersand character
- Prefer "comparer" to "comparaison" for compare action
- Add translation for msgid "Compare Non-hor&izontally..."