### PR TITLE
Prevent silent abort with File Comparison of files whose size is an exact multiple of 2^32 bytes

### DIFF
--- a/Src/Common/UniFile.cpp
+++ b/Src/Common/UniFile.cpp
@@ -241,10 +241,10 @@ bool UniMemFile::DoOpen(const String& filename, AccessMode mode)
 		return false;
 	m_lineno = -1;
 
+#ifndef _WIN64
 	unsigned sizehi = (unsigned)(m_filesize >> 32);
 	unsigned sizelo = (unsigned)(m_filesize & 0xFFFFFFFF);
 
-#ifndef _WIN64
 	if (sizehi || sizelo > 0x7FFFFFFF)
 	{
 		LastErrorCustom(_T("UniMemFile cannot handle files over 2 gigabytes"));
@@ -252,7 +252,7 @@ bool UniMemFile::DoOpen(const String& filename, AccessMode mode)
 	}
 #endif
 
-	if (sizelo == 0)
+	if (m_filesize == 0)
 	{
 		// Allow opening empty file, but memory mapping doesn't work on such
 		// m_base and m_current are 0 from the Close call above


### PR DESCRIPTION
Prevent silent abort with File Comparison of files whose size is an exact multiple of 2^32 bytes

* File size values that were all zero in the low 32 bits were assumed to be empty,
   and thus did not have some critical pointers initialized.  This resulted in WinMerge
   silently aborting with no message.

* WinMerge will now properly continue, but will likely display an "Out of memory" error
   message box.

* I discovered this when attempting to compare two files that are exactly 0x3700000000
   (236,223,201,280‬) bytes long.  A pointless exercise of course... Memory eventually fills up
   and an "Out of memory" error is displayed.  After clicking "OK", WinMerge terminates the
   comparison, and returns to the "Select Files or Folders" dialog, but does not actually
   release the memory until the program has completely terminated !!

* Folder Comparison with files of this extreme size does not exhibit this problem.