### PR TITLE
Include Excel Addin files (*.xlam)

### DIFF
--- a/Plugins/src_VB/CompareMSExcelFiles/WinMergeScript.cls
+++ b/Plugins/src_VB/CompareMSExcelFiles/WinMergeScript.cls
@@ -59,7 +59,7 @@ Public Property Get PluginDescription() As String
 End Property
 
 Public Property Get PluginFileFilters() As String
-    PluginFileFilters = "\.xls(\..*)?$;\.xlsx(\..*)?$;\.xlsm(\..*)?$;\.xlsb(\..*)?;\.xla(\..*)?$;\.xlax(\..*)?$"
+    PluginFileFilters = "\.xls(\..*)?$;\.xlsx(\..*)?$;\.xlsm(\..*)?$;\.xlsb(\..*)?;\.xla(\..*)?$;\.xlam(\..*)?$"
 End Property
 
 Public Property Get PluginIsAutomatic() As Boolean


### PR DESCRIPTION
The current CompareMSExcelFiles plugin does not identify Excel addin files (*.xlam) as an allowed extension. While the user can manually specify the unpacker plugin when `Manual Unpacking` is enabled, this is not possible with `Automatic Unpacking`. This pull request adds the *.xlam extension to the CompareMSExcelFiles and removes *.xlax (which I am assuming was a typo).