### PR TITLE
Typographical and encoding corrections to Galician and Spanish Shell Extension translations

### DIFF
--- a/Translations/ShellExtension/Galician.po
+++ b/Translations/ShellExtension/Galician.po
@@ -76,7 +76,7 @@ msgstr "Comparar con"
 #: ShellExtensionTemplate.rc:49
 #, c-format
 msgid "Save this path. Select another path to compare with this path."
-msgstr "Gardar esta ruta. Seleccionar outra ruta para comparar con esta."
+msgstr "Gardar esta ruta. Seleccionar outra ruta para comparar con ésta."
 
 #: ShellExtensionTemplate.rc:50
 #, c-format

--- a/Translations/ShellExtension/Spanish.po
+++ b/Translations/ShellExtension/Spanish.po
@@ -56,7 +56,7 @@ msgstr "Abrir con WinMerge"
 #: ShellExtensionTemplate.rc:45
 #, c-format
 msgid "Please select no more than 2 items"
-msgstr "Por favor, no selecciones más de 2 elementos"
+msgstr "Por favor, no selecciones mÃ¡s de 2 elementos"
 
 #: ShellExtensionTemplate.rc:46
 #, c-format
@@ -66,7 +66,7 @@ msgstr "Comparar"
 #: ShellExtensionTemplate.rc:47
 #, c-format
 msgid "Compare..."
-msgstr "Comparar…"
+msgstr "Compararâ€¦"
 
 #: ShellExtensionTemplate.rc:48
 #, c-format
@@ -76,7 +76,7 @@ msgstr "Comparar con"
 #: ShellExtensionTemplate.rc:49
 #, c-format
 msgid "Save this path. Select another path to compare with this path."
-msgstr "Guardar este ruta. Seleccionar otra ruta para compararla con esta."
+msgstr "Guardar esta ruta. Seleccionar otra ruta para compararla con Ã©sta."
 
 #: ShellExtensionTemplate.rc:50
 #, c-format


### PR DESCRIPTION
I made a couple of corrections to the Galician and Spanish Shell Extension translations. Everything should be OK now. Sorry for the noise.