### PR TITLE
Remove duplicate filename patterns without relying on WildcardDropList

### DIFF
--- a/Src/PluginsListDlg.cpp
+++ b/Src/PluginsListDlg.cpp
@@ -186,6 +186,7 @@ void PluginsListDlg::OnLVNItemChanging(NMHDR *pNMHDR, LRESULT *pResult)
 	if (plugin)
 	{
 		GetDlgItemText(IDC_PLUGIN_FILEFILTERS, plugin->m_filtersText);
+		WildcardRemoveDuplicatePatterns(plugin->m_filtersText);
 		plugin->LoadFilterString();
 	}
 }

--- a/Src/PropCompareBinary.cpp
+++ b/Src/PropCompareBinary.cpp
@@ -97,6 +97,7 @@ void PropCompareBinary::ReadOptions()
  */
 void PropCompareBinary::WriteOptions()
 {
+	WildcardRemoveDuplicatePatterns(m_sFilePatterns);
 	GetOptionsMgr()->SaveOption(OPT_CMP_BIN_FILEPATTERNS, m_sFilePatterns);
 }
 

--- a/Src/PropCompareImage.cpp
+++ b/Src/PropCompareImage.cpp
@@ -51,7 +51,7 @@ END_MESSAGE_MAP()
 void PropCompareImage::ReadOptions()
 {
 	m_sFilePatterns = GetOptionsMgr()->GetString(OPT_CMP_IMG_FILEPATTERNS);
-    m_bEnableImageCompare = GetOptionsMgr()->GetBool(OPT_CMP_ENABLE_IMGCMP_IN_DIRCMP);
+	m_bEnableImageCompare = GetOptionsMgr()->GetBool(OPT_CMP_ENABLE_IMGCMP_IN_DIRCMP);
 }
 
 /** 
@@ -61,8 +61,9 @@ void PropCompareImage::ReadOptions()
  */
 void PropCompareImage::WriteOptions()
 {
+	WildcardRemoveDuplicatePatterns(m_sFilePatterns);
 	GetOptionsMgr()->SaveOption(OPT_CMP_IMG_FILEPATTERNS, m_sFilePatterns);
-    GetOptionsMgr()->SaveOption(OPT_CMP_ENABLE_IMGCMP_IN_DIRCMP, m_bEnableImageCompare);
+	GetOptionsMgr()->SaveOption(OPT_CMP_ENABLE_IMGCMP_IN_DIRCMP, m_bEnableImageCompare);
 }
 
 /** 

--- a/Src/PropCompareTable.cpp
+++ b/Src/PropCompareTable.cpp
@@ -78,8 +78,11 @@ void PropCompareTable::ReadOptions()
  */
 void PropCompareTable::WriteOptions()
 {
+	WildcardRemoveDuplicatePatterns(m_sCSVFilePatterns);
 	GetOptionsMgr()->SaveOption(OPT_CMP_CSV_FILEPATTERNS, m_sCSVFilePatterns);
+	WildcardRemoveDuplicatePatterns(m_sTSVFilePatterns);
 	GetOptionsMgr()->SaveOption(OPT_CMP_TSV_FILEPATTERNS, m_sTSVFilePatterns);
+	WildcardRemoveDuplicatePatterns(m_sDSVFilePatterns);
 	GetOptionsMgr()->SaveOption(OPT_CMP_DSV_FILEPATTERNS, m_sDSVFilePatterns);
 	GetOptionsMgr()->SaveOption(OPT_CMP_DSV_DELIM_CHAR, m_sDSVDelimiterChar.substr(0, 1));
 	GetOptionsMgr()->SaveOption(OPT_CMP_TBL_ALLOW_NEWLINES_IN_QUOTES, m_bAllowNewlinesInQuotes);

--- a/Src/TrDialogs.cpp
+++ b/Src/TrDialogs.cpp
@@ -6,6 +6,26 @@ IMPLEMENT_DYNAMIC(CTrDialog, CDialog)
 IMPLEMENT_DYNAMIC(CTrPropertyPage, CPropertyPage)
 IMPLEMENT_DYNAMIC(CTrDialogBar, CDialogBar)
 
+void StaticDlgUtils::WildcardRemoveDuplicatePatterns(String& patterns)
+{
+	size_t i = 0, j = 0, k = 0;
+	while ((j = patterns.find_first_of(L"; ", i)) != String::npos &&
+		(k = patterns.find_last_of(L"; ", j) + 1) != patterns.length())
+	{
+		TCHAR const sep = patterns[j];
+		patterns[j] = L'\0';
+		if (PathMatchSpec(patterns.c_str() + i, patterns.c_str() + k))
+		{
+			patterns.erase(i, k - i);
+		}
+		else
+		{
+			patterns[j] = sep;
+			i = k;
+		}
+	}
+}
+
 BOOL CTrDialog::OnInitDialog()
 {
 	theApp.TranslateDialog(m_hWnd);

--- a/Src/TrDialogs.h
+++ b/Src/TrDialogs.h
@@ -5,8 +5,14 @@
 #undef GetDlgItemText
 #undef SetDlgItemText
 
+class StaticDlgUtils
+{
+protected:
+	static void WildcardRemoveDuplicatePatterns(String& patterns);
+};
+
 template<class T>
-class DlgUtils
+class DlgUtils : public StaticDlgUtils
 {
 	T *dlg() { return static_cast<T *>(this); }
 


### PR DESCRIPTION
This works also when user edits patterns without opening the drop list.