### PR TITLE
Fixed the problem that the input to File1 or File2 comboboxes of the Patch Generator dialog is not applied when the Patch Generator dialog is opened by selecting multiple files.

### DIFF
--- a/Src/PatchDlg.cpp
+++ b/Src/PatchDlg.cpp
@@ -78,6 +78,10 @@ BEGIN_MESSAGE_MAP(CPatchDlg, CTrDialog)
 	ON_BN_CLICKED(IDC_DIFF_DEFAULTS, OnDefaultSettings)
 	ON_CBN_SELCHANGE(IDC_DIFF_STYLE, OnSelchangeDiffStyle)
 	ON_BN_CLICKED(IDC_DIFF_SWAPFILES, OnDiffSwapFiles)
+	ON_CBN_SELCHANGE(IDC_DIFF_FILE1, OnSelchangeFile1)
+	ON_CBN_SELCHANGE(IDC_DIFF_FILE2, OnSelchangeFile2)
+	ON_CBN_EDITCHANGE(IDC_DIFF_FILE1, OnEditchangeFile1)
+	ON_CBN_EDITCHANGE(IDC_DIFF_FILE2, OnEditchangeFile2)
 	//}}AFX_MSG_MAP
 END_MESSAGE_MAP()
 
@@ -262,7 +266,14 @@ void CPatchDlg::OnDiffBrowseFile1()
 
 	folder = m_file1;
 	if (SelectFileOrFolder(GetSafeHwnd(), s, folder.c_str()))
+	{
 		m_ctlFile1.SetWindowText(s.c_str());
+		if (m_fileList.size() > 1)
+		{
+			m_ctlFile2.SetWindowText(_T(""));
+			ClearItems();
+		}
+	}
 }
 
 /** 
@@ -275,7 +286,14 @@ void CPatchDlg::OnDiffBrowseFile2()
 
 	folder = m_file2;
 	if (SelectFileOrFolder(GetSafeHwnd(), s, folder.c_str()))
+	{
 		m_ctlFile2.SetWindowText(s.c_str());
+		if (m_fileList.size() > 1)
+		{
+			m_ctlFile1.SetWindowText(_T(""));
+			ClearItems();
+		}
+	}
 }
 
 /** 
@@ -428,6 +446,43 @@ void CPatchDlg::OnDefaultSettings()
 
 	UpdateSettings();
 }
+
+void CPatchDlg::OnSelchangeFile1()
+{
+	if (m_fileList.size() > 1)
+	{
+		m_ctlFile2.SetWindowText(_T(""));
+		ClearItems();
+	}
+}
+
+void CPatchDlg::OnSelchangeFile2()
+{
+	if (m_fileList.size() > 1)
+	{
+		m_ctlFile1.SetWindowText(_T(""));
+		ClearItems();
+	}
+}
+
+void CPatchDlg::OnEditchangeFile1()
+{
+	if (m_fileList.size() > 1)
+	{
+		m_ctlFile2.SetWindowText(_T(""));
+		ClearItems();
+	}
+}
+
+void CPatchDlg::OnEditchangeFile2()
+{
+	if (m_fileList.size() > 1)
+	{
+		m_ctlFile1.SetWindowText(_T(""));
+		ClearItems();
+	}
+}
+
 
 /**
  * @brief Swap sides.

--- a/Src/PatchDlg.h
+++ b/Src/PatchDlg.h
@@ -85,6 +85,10 @@ protected:
 	afx_msg void OnSelchangeDiffStyle();
 	afx_msg void OnDiffSwapFiles();
 	afx_msg void OnDefaultSettings();
+	afx_msg void OnSelchangeFile1();
+	afx_msg void OnSelchangeFile2();
+	afx_msg void OnEditchangeFile1();
+	afx_msg void OnEditchangeFile2();
 	//}}AFX_MSG
 	DECLARE_MESSAGE_MAP()
 };


### PR DESCRIPTION
In Current version, the input to File1 or File2 comboboxes of the Patch Generator dialog is not applied when the Patch Generator dialog is opened by selecting multiple files.

How to reproduce:
1. Select multiple files in the folder compare window and run "Generate Patch..." from the menu.
2. In the Patch Generator dialog, enter the files again in the File1 and File2 comboboxes and click the "OK" button.
3. The patch of the file selected in step 1 is generated instead of the file specified in step 2.

The cause is that the contents of the File1 and File2 comboboxes are read only if single files registered when the "OK" button is pressed in the Patch Generator dialog.

This PR fixes the problem by clearing the internal item list of the CPatchDlg class when multiple items are registered in the internal item list, and the File1 or File2 comboboxes of the Patch Generator dialog is changed.