### PR TITLE
Fix the problem accessing the text buffer out of range if a sync point is added by selecting a ghost line that is after the last block.

### DIFF
--- a/Externals/crystaledit/editlib/ccrystaltextbuffer.cpp
+++ b/Externals/crystaledit/editlib/ccrystaltextbuffer.cpp
@@ -762,6 +762,12 @@ GetLineFlags (int nLine) const
   ASSERT (m_bInit);             //  Text buffer not yet initialized.
   //  You must call InitNew() or LoadFromFile() first!
 
+  if (nLine < 0 || nLine >= m_aLines.size())
+    {
+      ASSERT(false);      //  nLine is out of range.
+      return 0;
+    }
+
   return m_aLines[nLine].m_dwFlags;
 }
 
@@ -843,6 +849,12 @@ SetLineFlag (int nLine, DWORD dwFlag, bool bSet, bool bRemoveFromPreviousLine /*
       if (nLine == -1)
         return;
       bRemoveFromPreviousLine = false;
+    }
+
+  if (nLine < 0 || nLine >= m_aLines.size())
+    {
+      ASSERT(false);    //  nLine is out of range.
+      return;
     }
 
   DWORD dwNewFlags = m_aLines[nLine].m_dwFlags;

--- a/Src/Merge.rc
+++ b/Src/Merge.rc
@@ -3080,6 +3080,12 @@ BEGIN
     IDS_REPORT_SUCCESS      "The report has been created successfully."
 END
 
+// FILE COMPARE : SYNC POINT
+STRINGTABLE
+BEGIN
+    IDS_SYNCPOINT_LASTBLOCK "Cannot add a synchronization point after the last block."
+END
+
 // FILE COMPARISON RESULT : MESSAGES
 STRINGTABLE
 BEGIN

--- a/Src/MergeDoc.cpp
+++ b/Src/MergeDoc.cpp
@@ -3601,13 +3601,22 @@ void CMergeDoc::AddSyncPoint()
 	int nLine[3];
 	for (int nBuffer = 0; nBuffer < m_nBuffers; ++nBuffer)
 	{
-		 int tmp = m_pView[0][nBuffer]->GetCursorPos().y;
-		 nLine[nBuffer] = m_ptBuf[nBuffer]->ComputeApparentLine(m_ptBuf[nBuffer]->ComputeRealLine(tmp));
+		int tmp = m_pView[0][nBuffer]->GetCursorPos().y;
+		nLine[nBuffer] = m_ptBuf[nBuffer]->ComputeApparentLine(m_ptBuf[nBuffer]->ComputeRealLine(tmp));
+	}
 
+	// If adding a sync point by selecting a ghost line that is after the last block, Cancel the process adding a sync point.
+	for (int nBuffer = 0; nBuffer < m_nBuffers; ++nBuffer)
+		if (nLine[nBuffer] >= m_ptBuf[nBuffer]->GetLineCount())
+		{
+			LangMessageBox(IDS_SYNCPOINT_LASTBLOCK, MB_ICONSTOP);
+			return;
+		}
+
+	for (int nBuffer = 0; nBuffer < m_nBuffers; ++nBuffer)
 		if (m_ptBuf[nBuffer]->GetLineFlags(nLine[nBuffer]) & LF_INVALID_BREAKPOINT)
 			DeleteSyncPoint(nBuffer, nLine[nBuffer], false);
-	}
-	
+
 	for (int nBuffer = 0; nBuffer < m_nBuffers; ++nBuffer)
 		m_ptBuf[nBuffer]->SetLineFlag(nLine[nBuffer], LF_INVALID_BREAKPOINT, true, false);
 

--- a/Src/resource.h
+++ b/Src/resource.h
@@ -879,6 +879,7 @@
 #define IDS_REPORT_FILEOVERWRITE        17967
 #define IDS_REPORT_ERROR                17968
 #define IDS_REPORT_SUCCESS              17969
+#define IDS_SYNCPOINT_LASTBLOCK         17970
 #define IDS_FILE_TO_ITSELF              18100
 #define IDS_FILESSAME                   18101
 #define IDS_FILEERROR                   18103

--- a/Translations/WinMerge/Arabic.po
+++ b/Translations/WinMerge/Arabic.po
@@ -2899,6 +2899,9 @@ msgstr ""
 msgid "The report has been created successfully."
 msgstr "تم إنشاء التقرير بنجاح."
 
+msgid "Cannot add a synchronization point after the last block."
+msgstr ""
+
 msgid "The same file is opened in both panels."
 msgstr "تم فتح نفس الملف في كلا الخانتين."
 

--- a/Translations/WinMerge/Basque.po
+++ b/Translations/WinMerge/Basque.po
@@ -3533,6 +3533,9 @@ msgstr ""
 msgid "The report has been created successfully."
 msgstr "Jakinarazpena ongi sortu da."
 
+msgid "Cannot add a synchronization point after the last block."
+msgstr ""
+
 #, c-format
 msgid "The same file is opened in both panels."
 msgstr "Agiri berdina dago irekita bi paneletan."

--- a/Translations/WinMerge/Brazilian.po
+++ b/Translations/WinMerge/Brazilian.po
@@ -3568,6 +3568,9 @@ msgstr ""
 msgid "The report has been created successfully."
 msgstr "O relatório foi criado com sucesso."
 
+msgid "Cannot add a synchronization point after the last block."
+msgstr ""
+
 #, c-format
 msgid "The same file is opened in both panels."
 msgstr "O mesmo arquivo está aberto em ambos os painéis."

--- a/Translations/WinMerge/Bulgarian.po
+++ b/Translations/WinMerge/Bulgarian.po
@@ -2881,6 +2881,9 @@ msgstr ""
 msgid "The report has been created successfully."
 msgstr "Отчетът беше създаден успешно."
 
+msgid "Cannot add a synchronization point after the last block."
+msgstr ""
+
 msgid "The same file is opened in both panels."
 msgstr "Еднакви файлове са отворени в двата панела."
 

--- a/Translations/WinMerge/Catalan.po
+++ b/Translations/WinMerge/Catalan.po
@@ -3474,6 +3474,9 @@ msgstr ""
 msgid "The report has been created successfully."
 msgstr "L'informe s'ha creat satisfactòriament."
 
+msgid "Cannot add a synchronization point after the last block."
+msgstr ""
+
 #, c-format
 msgid "The same file is opened in both panels."
 msgstr "El mateix fitxer és obert a ambdues subfinestres."

--- a/Translations/WinMerge/ChineseSimplified.po
+++ b/Translations/WinMerge/ChineseSimplified.po
@@ -2904,6 +2904,9 @@ msgstr ""
 msgid "The report has been created successfully."
 msgstr "报告创建成功."
 
+msgid "Cannot add a synchronization point after the last block."
+msgstr ""
+
 msgid "The same file is opened in both panels."
 msgstr "两侧打开的是同一个文件。"
 

--- a/Translations/WinMerge/ChineseTraditional.po
+++ b/Translations/WinMerge/ChineseTraditional.po
@@ -3541,6 +3541,9 @@ msgstr ""
 msgid "The report has been created successfully."
 msgstr "成功產生報告。"
 
+msgid "Cannot add a synchronization point after the last block."
+msgstr ""
+
 #, c-format
 msgid "The same file is opened in both panels."
 msgstr "相同檔案開啟到兩邊。"

--- a/Translations/WinMerge/Croatian.po
+++ b/Translations/WinMerge/Croatian.po
@@ -3532,6 +3532,9 @@ msgstr ""
 msgid "The report has been created successfully."
 msgstr "Izvještaj je uspješno stvoren."
 
+msgid "Cannot add a synchronization point after the last block."
+msgstr ""
+
 #, c-format
 msgid "The same file is opened in both panels."
 msgstr "Ista datoteka je otvorena u oba panela."

--- a/Translations/WinMerge/Czech.po
+++ b/Translations/WinMerge/Czech.po
@@ -3477,6 +3477,9 @@ msgstr ""
 msgid "The report has been created successfully."
 msgstr "Protokol byl úspěšně vytvořen."
 
+msgid "Cannot add a synchronization point after the last block."
+msgstr ""
+
 #, c-format
 msgid "The same file is opened in both panels."
 msgstr "V obou panelech je otevřen stejný soubor."

--- a/Translations/WinMerge/Danish.po
+++ b/Translations/WinMerge/Danish.po
@@ -3560,6 +3560,9 @@ msgstr ""
 msgid "The report has been created successfully."
 msgstr "Rapporten blev oprettet succesfuldt."
 
+msgid "Cannot add a synchronization point after the last block."
+msgstr ""
+
 #, c-format
 msgid "The same file is opened in both panels."
 msgstr "Den samme fil er åbnet på begge sider."

--- a/Translations/WinMerge/Dutch.po
+++ b/Translations/WinMerge/Dutch.po
@@ -2903,6 +2903,9 @@ msgstr ""
 msgid "The report has been created successfully."
 msgstr "Het rapport is met succes aangemaakt."
 
+msgid "Cannot add a synchronization point after the last block."
+msgstr ""
+
 msgid "The same file is opened in both panels."
 msgstr "Hetzelfde bestand is in beide vensters geopend."
 

--- a/Translations/WinMerge/English.pot
+++ b/Translations/WinMerge/English.pot
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: WinMerge\n"
 "Report-Msgid-Bugs-To: https://bugs.winmerge.org/\n"
-"POT-Creation-Date: 2020-10-11 06:39+0000\n"
+"POT-Creation-Date: 2020-10-17 22:28+0000\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: English <winmerge-translate@lists.sourceforge.net>\n"
@@ -2651,6 +2651,9 @@ msgid "Error creating the report:\n%1"
 msgstr ""
 
 msgid "The report has been created successfully."
+msgstr ""
+
+msgid "Cannot add a synchronization point after the last block."
 msgstr ""
 
 msgid "The same file is opened in both panels."

--- a/Translations/WinMerge/Finnish.po
+++ b/Translations/WinMerge/Finnish.po
@@ -3553,6 +3553,9 @@ msgstr ""
 msgid "The report has been created successfully."
 msgstr "Raportin luominen onnistui."
 
+msgid "Cannot add a synchronization point after the last block."
+msgstr ""
+
 #, c-format
 msgid "The same file is opened in both panels."
 msgstr "Sama tiedosto on avatttu molemmissa paneeleissa."

--- a/Translations/WinMerge/French.po
+++ b/Translations/WinMerge/French.po
@@ -3607,6 +3607,9 @@ msgstr ""
 msgid "The report has been created successfully."
 msgstr "Le rapport a été créé avec succès."
 
+msgid "Cannot add a synchronization point after the last block."
+msgstr ""
+
 #, c-format
 msgid "The same file is opened in both panels."
 msgstr "Le même fichier est ouvert dans les deux volets."

--- a/Translations/WinMerge/Galician.po
+++ b/Translations/WinMerge/Galician.po
@@ -3568,6 +3568,9 @@ msgstr ""
 msgid "The report has been created successfully."
 msgstr "O informe creouse satisfactoriamente."
 
+msgid "Cannot add a synchronization point after the last block."
+msgstr ""
+
 #, c-format
 msgid "The same file is opened in both panels."
 msgstr "O mesmo arquivo está aberto en ambos paneis."

--- a/Translations/WinMerge/German.po
+++ b/Translations/WinMerge/German.po
@@ -3347,6 +3347,9 @@ msgstr "Fehler beim Erzeugen des Berichtes:\n%1"
 msgid "The report has been created successfully."
 msgstr "Der Bericht wurde erfolgreich geschrieben."
 
+msgid "Cannot add a synchronization point after the last block."
+msgstr ""
+
 #, c-format
 msgid "The same file is opened in both panels."
 msgstr "Die gleiche Datei ist in beiden Bereichen ausgewählt."

--- a/Translations/WinMerge/Greek.po
+++ b/Translations/WinMerge/Greek.po
@@ -3510,6 +3510,9 @@ msgstr ""
 msgid "The report has been created successfully."
 msgstr "Η αναφορά αποτελεσμάτων δημιουργήθηκε επιτυχώς."
 
+msgid "Cannot add a synchronization point after the last block."
+msgstr ""
+
 #, c-format
 msgid "The same file is opened in both panels."
 msgstr "Το ίδιο αρχείο ανοίχθηκε σε αμφότερα τα πεδία."

--- a/Translations/WinMerge/Hungarian.po
+++ b/Translations/WinMerge/Hungarian.po
@@ -3447,6 +3447,9 @@ msgstr ""
 msgid "The report has been created successfully."
 msgstr "A jelentés sikeresen elkészült."
 
+msgid "Cannot add a synchronization point after the last block."
+msgstr ""
+
 #, c-format
 msgid "The same file is opened in both panels."
 msgstr "Ugyanaz a fájl van megnyitva mindkét panelen."

--- a/Translations/WinMerge/Italian.po
+++ b/Translations/WinMerge/Italian.po
@@ -2908,6 +2908,9 @@ msgstr ""
 msgid "The report has been created successfully."
 msgstr "Craezione rapporto completata."
 
+msgid "Cannot add a synchronization point after the last block."
+msgstr ""
+
 msgid "The same file is opened in both panels."
 msgstr "Lo stesso file è aperto in entrambi i pannelli."
 

--- a/Translations/WinMerge/Japanese.po
+++ b/Translations/WinMerge/Japanese.po
@@ -2894,6 +2894,9 @@ msgstr ""
 msgid "The report has been created successfully."
 msgstr "レポートの生成に成功しました。"
 
+msgid "Cannot add a synchronization point after the last block."
+msgstr "最終ブロックの後ろには同期ポイントを追加できません。"
+
 msgid "The same file is opened in both panels."
 msgstr "同じファイルが両側のパネルで開かれています。"
 

--- a/Translations/WinMerge/Korean.po
+++ b/Translations/WinMerge/Korean.po
@@ -3557,6 +3557,9 @@ msgstr ""
 msgid "The report has been created successfully."
 msgstr "보고서를 성공적으로 만들었습니다."
 
+msgid "Cannot add a synchronization point after the last block."
+msgstr ""
+
 #, c-format
 msgid "The same file is opened in both panels."
 msgstr "같은 파일을 양쪽 창에 열었습니다."

--- a/Translations/WinMerge/Lithuanian.po
+++ b/Translations/WinMerge/Lithuanian.po
@@ -2662,6 +2662,9 @@ msgstr "Klaida kuriant ataskaitą:\n%1"
 msgid "The report has been created successfully."
 msgstr "Ataskaita sukurta sėkmingai."
 
+msgid "Cannot add a synchronization point after the last block."
+msgstr ""
+
 msgid "The same file is opened in both panels."
 msgstr "Tas pats failas pasirinktas abiejose pusėse."
 

--- a/Translations/WinMerge/Norwegian.po
+++ b/Translations/WinMerge/Norwegian.po
@@ -3532,6 +3532,9 @@ msgstr ""
 msgid "The report has been created successfully."
 msgstr "Rapporten er opprettet vellykket"
 
+msgid "Cannot add a synchronization point after the last block."
+msgstr ""
+
 #, c-format
 msgid "The same file is opened in both panels."
 msgstr "Samme filen er åpen i begge paneler."

--- a/Translations/WinMerge/Persian.po
+++ b/Translations/WinMerge/Persian.po
@@ -3563,6 +3563,9 @@ msgstr ""
 msgid "The report has been created successfully."
 msgstr " گزارش با موفقيت ايجاد شده است  "
 
+msgid "Cannot add a synchronization point after the last block."
+msgstr ""
+
 #, c-format
 msgid "The same file is opened in both panels."
 msgstr "  يک  پرونده در هر دو تابلو باز شده است"

--- a/Translations/WinMerge/Polish.po
+++ b/Translations/WinMerge/Polish.po
@@ -2660,6 +2660,9 @@ msgstr "Błąd przy tworzeniu raportu:\n%1"
 msgid "The report has been created successfully."
 msgstr "Raport został pomyślnie utworzony."
 
+msgid "Cannot add a synchronization point after the last block."
+msgstr ""
+
 msgid "The same file is opened in both panels."
 msgstr "Ten sam plik został otwarty w obu panelach."
 

--- a/Translations/WinMerge/Portuguese.po
+++ b/Translations/WinMerge/Portuguese.po
@@ -2933,6 +2933,9 @@ msgstr ""
 msgid "The report has been created successfully."
 msgstr "O relatório foi criado com sucesso."
 
+msgid "Cannot add a synchronization point after the last block."
+msgstr ""
+
 msgid "The same file is opened in both panels."
 msgstr "O mesmo ficheiro está aberto em ambas as janelas."
 

--- a/Translations/WinMerge/Romanian.po
+++ b/Translations/WinMerge/Romanian.po
@@ -3511,6 +3511,9 @@ msgstr ""
 msgid "The report has been created successfully."
 msgstr "Raportul a fost creat cu succes."
 
+msgid "Cannot add a synchronization point after the last block."
+msgstr ""
+
 #, c-format
 msgid "The same file is opened in both panels."
 msgstr "Acelaşi fişier este deschis în ambele panouri."

--- a/Translations/WinMerge/Russian.po
+++ b/Translations/WinMerge/Russian.po
@@ -2664,6 +2664,9 @@ msgstr "Ошибка создания отчета:\n%1"
 msgid "The report has been created successfully."
 msgstr "Отчет успешно создан."
 
+msgid "Cannot add a synchronization point after the last block."
+msgstr ""
+
 msgid "The same file is opened in both panels."
 msgstr "На обоих панелях открыт один и тот же файл"
 

--- a/Translations/WinMerge/Serbian.po
+++ b/Translations/WinMerge/Serbian.po
@@ -3507,6 +3507,9 @@ msgstr ""
 msgid "The report has been created successfully."
 msgstr "Извештај је успешно направљен"
 
+msgid "Cannot add a synchronization point after the last block."
+msgstr ""
+
 #, c-format
 msgid "The same file is opened in both panels."
 msgstr "Иста датотека је отворена у обе табле"

--- a/Translations/WinMerge/Sinhala.po
+++ b/Translations/WinMerge/Sinhala.po
@@ -3524,6 +3524,9 @@ msgstr ""
 msgid "The report has been created successfully."
 msgstr "The report has been created successfully."
 
+msgid "Cannot add a synchronization point after the last block."
+msgstr ""
+
 #, c-format
 msgid "The same file is opened in both panels."
 msgstr "The same file is opened in both panels."

--- a/Translations/WinMerge/Slovak.po
+++ b/Translations/WinMerge/Slovak.po
@@ -3532,6 +3532,9 @@ msgstr ""
 msgid "The report has been created successfully."
 msgstr "Správa bola úspešne vytvorená."
 
+msgid "Cannot add a synchronization point after the last block."
+msgstr ""
+
 #, c-format
 msgid "The same file is opened in both panels."
 msgstr "Rovnaký súbor je otvorený v boch paneloch."

--- a/Translations/WinMerge/Slovenian.po
+++ b/Translations/WinMerge/Slovenian.po
@@ -3567,6 +3567,9 @@ msgstr ""
 msgid "The report has been created successfully."
 msgstr "Poročilo je bilo uspešno izdelano."
 
+msgid "Cannot add a synchronization point after the last block."
+msgstr ""
+
 #, c-format
 msgid "The same file is opened in both panels."
 msgstr "Ista datoteka je odprta v obeh podoknih."

--- a/Translations/WinMerge/Spanish.po
+++ b/Translations/WinMerge/Spanish.po
@@ -2920,6 +2920,9 @@ msgstr ""
 msgid "The report has been created successfully."
 msgstr "El informe se ha creado correctamente."
 
+msgid "Cannot add a synchronization point after the last block."
+msgstr ""
+
 msgid "The same file is opened in both panels."
 msgstr "El mismo archivo está abierto en ambos paneles."
 

--- a/Translations/WinMerge/Swedish.po
+++ b/Translations/WinMerge/Swedish.po
@@ -3552,6 +3552,9 @@ msgstr ""
 msgid "The report has been created successfully."
 msgstr "Rapporten har skapats."
 
+msgid "Cannot add a synchronization point after the last block."
+msgstr ""
+
 #, c-format
 msgid "The same file is opened in both panels."
 msgstr "Samma fil är öppnad i båda paneler."

--- a/Translations/WinMerge/Turkish.po
+++ b/Translations/WinMerge/Turkish.po
@@ -2917,6 +2917,9 @@ msgstr ""
 msgid "The report has been created successfully."
 msgstr "Rapor hazırlandı."
 
+msgid "Cannot add a synchronization point after the last block."
+msgstr ""
+
 msgid "The same file is opened in both panels."
 msgstr "İki panoda da de aynı dosya açıldı."
 

--- a/Translations/WinMerge/Ukrainian.po
+++ b/Translations/WinMerge/Ukrainian.po
@@ -3531,6 +3531,9 @@ msgstr ""
 msgid "The report has been created successfully."
 msgstr "Звіт успішно створений"
 
+msgid "Cannot add a synchronization point after the last block."
+msgstr ""
+
 #, c-format
 msgid "The same file is opened in both panels."
 msgstr "На обох панелях відкритий той самий файл"


### PR DESCRIPTION
The current version of WinMerge accesses the text buffer out of range if a sync point is added by selecting a ghost line that is after the last block.
This PR fixes this problem by doing the following:
- Show an error message and cancel the process adding a sync point if a sync point is added by selecting a ghost line that is after the last block.
- Add some assertions.