### PR TITLE
Fix typo in GhostTextBuffer.cpp

### DIFF
--- a/Src/GhostTextBuffer.cpp
+++ b/Src/GhostTextBuffer.cpp
@@ -109,7 +109,7 @@ bool CGhostTextBuffer::InternalDeleteGhostLine (CCrystalTextView * pSource,
 		if (nLine == GetLineCount())
 			nLine--;
 		// The last parameter is optimization  
-		//   - don't recompute lines preceeding the removed line.
+		//   - don't recompute lines preceding the removed line.
 		UpdateViews (pSource, &context, UPDATE_HORZRANGE | UPDATE_VERTRANGE,
 				nLine);
 	}


### PR DESCRIPTION
preceeding -> preceding