### PR TITLE
Add the feature "Go to Moved Line" requested by #278.

### DIFF
--- a/Src/Merge.rc
+++ b/Src/Merge.rc
@@ -81,6 +81,8 @@ BEGIN
         MENUITEM "&Paste",                      ID_EDIT_PASTE
         MENUITEM SEPARATOR
         MENUITEM "&Goto...",                    ID_EDIT_WMGOTO
+        MENUITEM "Go to Moved Line Between Left and Middle\tCtrl+Shift+G", ID_GOTO_MOVED_LINE_LM
+        MENUITEM "Go to Moved Line Between Middle and Right\tCtrl+Alt+G",  ID_GOTO_MOVED_LINE_MR
         MENUITEM SEPARATOR
         POPUP "Op&en"
         BEGIN
@@ -869,6 +871,8 @@ BEGIN
     "C",            ID_EDIT_COPY_LINENUMBERS, VIRTKEY, SHIFT, CONTROL, NOINVERT
     "F",            ID_EDIT_FIND,           VIRTKEY, CONTROL, NOINVERT
     "G",            ID_EDIT_WMGOTO,         VIRTKEY, CONTROL, NOINVERT
+    "G",            ID_GOTO_MOVED_LINE_LM,  VIRTKEY, SHIFT, CONTROL, NOINVERT
+    "G",            ID_GOTO_MOVED_LINE_MR,  VIRTKEY, CONTROL, ALT, NOINVERT
     "H",            ID_EDIT_REPLACE,        VIRTKEY, CONTROL, NOINVERT
     "J",            ID_FILE_OPENPROJECT,    VIRTKEY, CONTROL, NOINVERT
     "M",            ID_EDIT_MARK,           VIRTKEY, SHIFT, CONTROL, NOINVERT
@@ -3289,6 +3293,12 @@ END
 STRINGTABLE
 BEGIN
     IDS_LOCBAR_GOTOLINE_FMT "G&oto Line %1"
+END
+
+// MERGEVIEW CONTEXT MENU
+STRINGTABLE
+BEGIN
+    IDS_GOTO_MOVED_LINE "Go to Moved Line\tCtrl+Shift+G"
 END
 
 // AUTOCOMPLETE COMBOBOX OPTIONS

--- a/Src/MergeEditView.cpp
+++ b/Src/MergeEditView.cpp
@@ -182,6 +182,10 @@ BEGIN_MESSAGE_MAP(CMergeEditView, CCrystalEditViewEx)
 	ON_COMMAND(ID_WINDOW_CHANGE_PANE, OnChangePane)
 	ON_COMMAND(ID_NEXT_PANE, OnChangePane)
 	ON_COMMAND(ID_EDIT_WMGOTO, OnWMGoto)
+	ON_COMMAND(ID_GOTO_MOVED_LINE_LM, OnGotoMovedLineLM)
+	ON_UPDATE_COMMAND_UI(ID_GOTO_MOVED_LINE_LM, OnUpdateGotoMovedLineLM)
+	ON_COMMAND(ID_GOTO_MOVED_LINE_MR, OnGotoMovedLineMR)
+	ON_UPDATE_COMMAND_UI(ID_GOTO_MOVED_LINE_MR, OnUpdateGotoMovedLineMR)
 	ON_COMMAND(ID_FILE_SHELLMENU, OnShellMenu)
 	ON_UPDATE_COMMAND_UI(ID_FILE_SHELLMENU, OnUpdateShellMenu)
 	ON_COMMAND_RANGE(ID_SCRIPT_FIRST, ID_SCRIPT_LAST, OnScripts)
@@ -2873,6 +2877,15 @@ void CMergeEditView::OnContextMenu(CWnd* pWnd, CPoint point)
 		menu.RemoveMenu(ID_COPY_FROM_RIGHT, MF_BYCOMMAND);
 	}
 
+	// Remove "Go to Moved Line Between Middle and Right" if in 2-way file comparison.
+	// Remove "Go to Moved Line Between Middle and Right" if the right pane is active in 3-way file comparison.
+	// Remove "Go to Moved Line Between Left and Middle" if the right pane is active in 3-way file comparison.
+	int nBuffers = GetDocument()->m_nBuffers;
+	if (nBuffers == 2 || (nBuffers == 3 && m_nThisPane == 0))
+		menu.RemoveMenu(ID_GOTO_MOVED_LINE_MR, MF_BYCOMMAND);
+	else if (nBuffers == 3 && m_nThisPane == 2)
+		menu.RemoveMenu(ID_GOTO_MOVED_LINE_LM, MF_BYCOMMAND);
+
 	VERIFY(menu.LoadToolbar(IDR_MAINFRAME));
 	theApp.TranslateMenu(menu.m_hMenu);
 
@@ -3103,6 +3116,139 @@ void CMergeEditView::OnWMGoto()
 
 			pCurrentView->SelectDiff(diff, true, false);
 		}
+	}
+}
+
+/**
+* @brief Called when "Go to Moved Line Between Left and Middle" item is selected.
+* Go to moved line between the left and right panes when in 2-way file comparison.
+* Go to moved line between the left and middle panes when in 3-way file comparison.
+*/
+void CMergeEditView::OnGotoMovedLineLM()
+{
+	if (!GetOptionsMgr()->GetBool(OPT_CMP_MOVED_BLOCKS))
+		return;
+
+	CMergeDoc* pDoc = GetDocument();
+	CPoint pos = GetCursorPos();
+
+	ASSERT(m_nThisPane >= 0 && m_nThisPane < 3);
+	ASSERT(pDoc != nullptr);
+	ASSERT(pDoc->m_nBuffers == 2 || pDoc->m_nBuffers == 3);
+	ASSERT(pos.y >= 0);
+
+	if (m_nThisPane == 0)
+	{
+		int line = pDoc->RightLineInMovedBlock(m_nThisPane, pos.y);
+		if (line >= 0)
+			GotoLine(line, false, 1);
+	}
+	else if (m_nThisPane == 1)
+	{
+		int line = pDoc->LeftLineInMovedBlock(m_nThisPane, pos.y);
+		if (line >= 0)
+			GotoLine(line, false, 0);
+	}
+}
+
+/**
+ * @brief Called when "Go to Moved Line Between Left and Middle" item is updated.
+ * @param [in] pCmdUI UI component to update.
+ * @note The item label is changed to "Go to Moved Line" when 2-way file comparison.
+ */
+void CMergeEditView::OnUpdateGotoMovedLineLM(CCmdUI* pCmdUI)
+{
+	CMergeDoc* pDoc = GetDocument();
+	CPoint pos = GetCursorPos();
+
+	ASSERT(m_nThisPane >= 0 && m_nThisPane < 3);
+	ASSERT(pCmdUI != nullptr);
+	ASSERT(pDoc != nullptr);
+	ASSERT(pDoc->m_nBuffers == 2 || pDoc->m_nBuffers == 3);
+	ASSERT(pos.y >= 0);
+
+	if (pDoc->m_nBuffers == 2)
+		pCmdUI->SetText(_("Go to Moved Line\tCtrl+Shift+G").c_str());
+
+	if (!GetOptionsMgr()->GetBool(OPT_CMP_MOVED_BLOCKS) || m_nThisPane == 2)
+	{
+		pCmdUI->Enable(false);
+		return;
+	}
+
+	if (m_nThisPane == 0)
+	{
+		bool bOn = (pDoc->RightLineInMovedBlock(m_nThisPane, pos.y) >= 0);
+		pCmdUI->Enable(bOn);
+	}
+	else if (m_nThisPane == 1)
+	{
+		bool bOn = (pDoc->LeftLineInMovedBlock(m_nThisPane, pos.y) >= 0);
+		pCmdUI->Enable(bOn);
+	}
+}
+
+/**
+* @brief Called when "Go to Moved Line Between Middle and Right" item is selected.
+* Go to moved line between the middle and right panes when in 3-way file comparison.
+*/
+void CMergeEditView::OnGotoMovedLineMR()
+{
+	if (!GetOptionsMgr()->GetBool(OPT_CMP_MOVED_BLOCKS))
+		return;
+
+	CMergeDoc* pDoc = GetDocument();
+	CPoint pos = GetCursorPos();
+
+	ASSERT(m_nThisPane >= 0 && m_nThisPane < 3);
+	ASSERT(pDoc != nullptr);
+	ASSERT(pDoc->m_nBuffers == 2 || pDoc->m_nBuffers == 3);
+	ASSERT(pos.y >= 0);
+
+	if (m_nThisPane == 1)
+	{
+		int line = pDoc->RightLineInMovedBlock(m_nThisPane, pos.y);
+		if (line >= 0)
+			GotoLine(line, false, 2);
+	}
+	else if (m_nThisPane == 2)
+	{
+		int line = pDoc->LeftLineInMovedBlock(m_nThisPane, pos.y);
+		if (line >= 0)
+			GotoLine(line, false, 1);
+	}
+}
+
+/**
+ * @brief Called when "Go to Moved Line Between Middle and Right" item is updated.
+ * @param [in] pCmdUI UI component to update.
+ */
+void CMergeEditView::OnUpdateGotoMovedLineMR(CCmdUI* pCmdUI)
+{
+	CMergeDoc* pDoc = GetDocument();
+	CPoint pos = GetCursorPos();
+
+	ASSERT(m_nThisPane >= 0 && m_nThisPane < 3);
+	ASSERT(pCmdUI != nullptr);
+	ASSERT(pDoc != nullptr);
+	ASSERT(pDoc->m_nBuffers == 2 || pDoc->m_nBuffers == 3);
+	ASSERT(pos.y >= 0);
+
+	if (!GetOptionsMgr()->GetBool(OPT_CMP_MOVED_BLOCKS) || pDoc->m_nBuffers == 2 || m_nThisPane == 0)
+	{
+		pCmdUI->Enable(false);
+		return;
+	}
+
+	if (m_nThisPane == 1)
+	{
+		bool bOn = (pDoc->RightLineInMovedBlock(m_nThisPane, pos.y) >= 0);
+		pCmdUI->Enable(bOn);
+	}
+	else if (m_nThisPane == 2)
+	{
+		bool bOn = (pDoc->LeftLineInMovedBlock(m_nThisPane, pos.y) >= 0);
+		pCmdUI->Enable(bOn);
 	}
 }
 

--- a/Src/MergeEditView.h
+++ b/Src/MergeEditView.h
@@ -301,6 +301,10 @@ protected:
 	afx_msg void OnUpdateR2LNext(CCmdUI* pCmdUI);
 	afx_msg void OnChangePane();
 	afx_msg void OnWMGoto();
+	afx_msg void OnGotoMovedLineLM();
+	afx_msg void OnUpdateGotoMovedLineLM(CCmdUI* pCmdUI);
+	afx_msg void OnGotoMovedLineMR();
+	afx_msg void OnUpdateGotoMovedLineMR(CCmdUI* pCmdUI);
 	afx_msg void OnShellMenu();
 	afx_msg void OnUpdateShellMenu(CCmdUI* pCmdUI);
 	afx_msg void OnScripts(UINT nID );

--- a/Src/resource.h
+++ b/Src/resource.h
@@ -979,6 +979,9 @@
 #define ID_REFRESH                      32787
 #define ID_EDIT_COPY_LINENUMBERS        32788
 #define ID_RESCAN                       32789
+#define ID_GOTO_MOVED_LINE_LM           32790
+#define ID_GOTO_MOVED_LINE_MR           32791
+#define IDS_GOTO_MOVED_LINE             32792
 #define ID_EDIT_FIND_PREVIOUS           32799
 #define ID_OPTIONS_SHOWIDENTICAL        32800
 #define ID_OPTIONS_SHOWDIFFERENT        32801

--- a/Translations/WinMerge/Arabic.po
+++ b/Translations/WinMerge/Arabic.po
@@ -60,6 +60,12 @@ msgstr "&لصق"
 msgid "&Goto..."
 msgstr "ال&ذهاب إلى..."
 
+msgid "Go to Moved Line Between Left and Middle\tCtrl+Shift+G"
+msgstr ""
+
+msgid "Go to Moved Line Between Middle and Right\tCtrl+Alt+G"
+msgstr ""
+
 msgid "Op&en"
 msgstr "&فتح"
 
@@ -3304,6 +3310,9 @@ msgstr "<تلقائي>"
 #, c-format
 msgid "G&oto Line %1"
 msgstr "إ&ذهب إلى السطر %1"
+
+msgid "Go to Moved Line\tCtrl+Shift+G"
+msgstr ""
 
 msgid "Disabled"
 msgstr "معطل"

--- a/Translations/WinMerge/Basque.po
+++ b/Translations/WinMerge/Basque.po
@@ -75,6 +75,12 @@ msgstr "&Itsatsi"
 msgid "&Goto..."
 msgstr "&Joan hona..."
 
+msgid "Go to Moved Line Between Left and Middle\tCtrl+Shift+G"
+msgstr ""
+
+msgid "Go to Moved Line Between Middle and Right\tCtrl+Alt+G"
+msgstr ""
+
 #, c-format
 msgid "Op&en"
 msgstr "Ire&ki"
@@ -3921,6 +3927,9 @@ msgstr "<Berezgaitasunez>"
 #, c-format
 msgid "G&oto Line %1"
 msgstr "&Joan lerro honetara: %1"
+
+msgid "Go to Moved Line\tCtrl+Shift+G"
+msgstr ""
 
 #, c-format
 msgid "Disabled"

--- a/Translations/WinMerge/Brazilian.po
+++ b/Translations/WinMerge/Brazilian.po
@@ -74,6 +74,12 @@ msgstr "&Colar"
 msgid "&Goto..."
 msgstr "&Ir para..."
 
+msgid "Go to Moved Line Between Left and Middle\tCtrl+Shift+G"
+msgstr ""
+
+msgid "Go to Moved Line Between Middle and Right\tCtrl+Alt+G"
+msgstr ""
+
 #, c-format
 msgid "Op&en"
 msgstr "Ab&rir"
@@ -4035,6 +4041,9 @@ msgstr "<Automático>"
 #, c-format
 msgid "G&oto Line %1"
 msgstr "I&r pra Linha %1"
+
+msgid "Go to Moved Line\tCtrl+Shift+G"
+msgstr ""
 
 #, c-format
 msgid "Disabled"

--- a/Translations/WinMerge/Bulgarian.po
+++ b/Translations/WinMerge/Bulgarian.po
@@ -56,6 +56,12 @@ msgstr "По&ставяне"
 msgid "&Goto..."
 msgstr "Отиване &към…"
 
+msgid "Go to Moved Line Between Left and Middle\tCtrl+Shift+G"
+msgstr ""
+
+msgid "Go to Moved Line Between Middle and Right\tCtrl+Alt+G"
+msgstr ""
+
 msgid "Op&en"
 msgstr "&Отваряне"
 
@@ -3278,6 +3284,9 @@ msgstr "<Автоматично>"
 #, c-format
 msgid "G&oto Line %1"
 msgstr "От&иване на ред %1"
+
+msgid "Go to Moved Line\tCtrl+Shift+G"
+msgstr ""
 
 msgid "Disabled"
 msgstr "Забранено"

--- a/Translations/WinMerge/Catalan.po
+++ b/Translations/WinMerge/Catalan.po
@@ -71,6 +71,12 @@ msgstr "Engan&xa"
 msgid "&Goto..."
 msgstr "&Vés a..."
 
+msgid "Go to Moved Line Between Left and Middle\tCtrl+Shift+G"
+msgstr ""
+
+msgid "Go to Moved Line Between Middle and Right\tCtrl+Alt+G"
+msgstr ""
+
 #, c-format
 msgid "Op&en"
 msgstr "O&bre"
@@ -3849,6 +3855,9 @@ msgstr "<Automàtic>"
 #, c-format
 msgid "G&oto Line %1"
 msgstr "Va fins a la línia %1"
+
+msgid "Go to Moved Line\tCtrl+Shift+G"
+msgstr ""
 
 #, c-format
 msgid "Disabled"

--- a/Translations/WinMerge/ChineseSimplified.po
+++ b/Translations/WinMerge/ChineseSimplified.po
@@ -62,6 +62,12 @@ msgstr "粘贴(&P)"
 msgid "&Goto..."
 msgstr "转到(&G)..."
 
+msgid "Go to Moved Line Between Left and Middle\tCtrl+Shift+G"
+msgstr ""
+
+msgid "Go to Moved Line Between Middle and Right\tCtrl+Alt+G"
+msgstr ""
+
 msgid "Op&en"
 msgstr "打开(&E)"
 
@@ -3343,6 +3349,9 @@ msgstr "<自动>"
 #, c-format
 msgid "G&oto Line %1"
 msgstr "转到第 %1 行(&O)"
+
+msgid "Go to Moved Line\tCtrl+Shift+G"
+msgstr ""
 
 msgid "Disabled"
 msgstr "禁用"

--- a/Translations/WinMerge/ChineseTraditional.po
+++ b/Translations/WinMerge/ChineseTraditional.po
@@ -74,6 +74,12 @@ msgstr "貼上(&P)"
 msgid "&Goto..."
 msgstr "跳至(&G)..."
 
+msgid "Go to Moved Line Between Left and Middle\tCtrl+Shift+G"
+msgstr ""
+
+msgid "Go to Moved Line Between Middle and Right\tCtrl+Alt+G"
+msgstr ""
+
 #, c-format
 msgid "Op&en"
 msgstr "開啟(&E)"
@@ -3929,6 +3935,9 @@ msgstr "<自動>"
 #, c-format
 msgid "G&oto Line %1"
 msgstr "至第 %1 行(&O)"
+
+msgid "Go to Moved Line\tCtrl+Shift+G"
+msgstr ""
 
 #, c-format
 msgid "Disabled"

--- a/Translations/WinMerge/Croatian.po
+++ b/Translations/WinMerge/Croatian.po
@@ -72,6 +72,12 @@ msgstr "&Zalijepi"
 msgid "&Goto..."
 msgstr "Idi &na redak"
 
+msgid "Go to Moved Line Between Left and Middle\tCtrl+Shift+G"
+msgstr ""
+
+msgid "Go to Moved Line Between Middle and Right\tCtrl+Alt+G"
+msgstr ""
+
 #, c-format
 msgid "Op&en"
 msgstr "&Otvori"
@@ -3920,6 +3926,9 @@ msgstr "Automatski"
 #, c-format
 msgid "G&oto Line %1"
 msgstr "Idi &na redak"
+
+msgid "Go to Moved Line\tCtrl+Shift+G"
+msgstr ""
 
 #, c-format
 msgid "Disabled"

--- a/Translations/WinMerge/Czech.po
+++ b/Translations/WinMerge/Czech.po
@@ -72,6 +72,12 @@ msgstr "&Vložit"
 msgid "&Goto..."
 msgstr "Př&ejít na..."
 
+msgid "Go to Moved Line Between Left and Middle\tCtrl+Shift+G"
+msgstr ""
+
+msgid "Go to Moved Line Between Middle and Right\tCtrl+Alt+G"
+msgstr ""
+
 #, c-format
 msgid "Op&en"
 msgstr "&Otevřít"
@@ -3851,6 +3857,9 @@ msgstr "<automaticky>"
 #, c-format
 msgid "G&oto Line %1"
 msgstr "&Přejít na řádek %1"
+
+msgid "Go to Moved Line\tCtrl+Shift+G"
+msgstr ""
 
 #, c-format
 msgid "Disabled"

--- a/Translations/WinMerge/Danish.po
+++ b/Translations/WinMerge/Danish.po
@@ -73,6 +73,12 @@ msgstr "&Indsæt"
 msgid "&Goto..."
 msgstr "Gå &til..."
 
+msgid "Go to Moved Line Between Left and Middle\tCtrl+Shift+G"
+msgstr ""
+
+msgid "Go to Moved Line Between Middle and Right\tCtrl+Alt+G"
+msgstr ""
+
 #, c-format
 msgid "Op&en"
 msgstr "Åb&en"
@@ -3960,6 +3966,9 @@ msgstr "<Automatisk>"
 #, c-format
 msgid "G&oto Line %1"
 msgstr "G&å til linje %1"
+
+msgid "Go to Moved Line\tCtrl+Shift+G"
+msgstr ""
 
 #, c-format
 msgid "Disabled"

--- a/Translations/WinMerge/Dutch.po
+++ b/Translations/WinMerge/Dutch.po
@@ -60,6 +60,12 @@ msgstr "Plakken"
 msgid "&Goto..."
 msgstr "Ga naar..."
 
+msgid "Go to Moved Line Between Left and Middle\tCtrl+Shift+G"
+msgstr ""
+
+msgid "Go to Moved Line Between Middle and Right\tCtrl+Alt+G"
+msgstr ""
+
 msgid "Op&en"
 msgstr "Openen"
 
@@ -3351,6 +3357,9 @@ msgstr "<Automatic>"
 #, c-format
 msgid "G&oto Line %1"
 msgstr "Naar regel %1 gaan"
+
+msgid "Go to Moved Line\tCtrl+Shift+G"
+msgstr ""
 
 msgid "Disabled"
 msgstr "Uitgeschakeld"

--- a/Translations/WinMerge/English.pot
+++ b/Translations/WinMerge/English.pot
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: WinMerge\n"
 "Report-Msgid-Bugs-To: https://bugs.winmerge.org/\n"
-"POT-Creation-Date: 2020-11-21 13:50+0000\n"
+"POT-Creation-Date: 2020-11-21 22:58+0000\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: English <winmerge-translate@lists.sourceforge.net>\n"
@@ -51,6 +51,12 @@ msgid "&Paste"
 msgstr ""
 
 msgid "&Goto..."
+msgstr ""
+
+msgid "Go to Moved Line Between Left and Middle\tCtrl+Shift+G"
+msgstr ""
+
+msgid "Go to Moved Line Between Middle and Right\tCtrl+Alt+G"
 msgstr ""
 
 msgid "Op&en"
@@ -2940,6 +2946,9 @@ msgstr ""
 
 #, c-format
 msgid "G&oto Line %1"
+msgstr ""
+
+msgid "Go to Moved Line\tCtrl+Shift+G"
 msgstr ""
 
 msgid "Disabled"

--- a/Translations/WinMerge/Finnish.po
+++ b/Translations/WinMerge/Finnish.po
@@ -70,6 +70,12 @@ msgstr "Lii&tä"
 msgid "&Goto..."
 msgstr "&Siirry..."
 
+msgid "Go to Moved Line Between Left and Middle\tCtrl+Shift+G"
+msgstr ""
+
+msgid "Go to Moved Line Between Middle and Right\tCtrl+Alt+G"
+msgstr ""
+
 #, c-format
 msgid "Op&en"
 msgstr "Av&aa"
@@ -4016,6 +4022,9 @@ msgstr "<Automaattinen>"
 #, c-format
 msgid "G&oto Line %1"
 msgstr "Siirry riville %1"
+
+msgid "Go to Moved Line\tCtrl+Shift+G"
+msgstr ""
 
 #, c-format
 msgid "Disabled"

--- a/Translations/WinMerge/French.po
+++ b/Translations/WinMerge/French.po
@@ -77,6 +77,12 @@ msgstr "Co&ller"
 msgid "&Goto..."
 msgstr "&Atteindre..."
 
+msgid "Go to Moved Line Between Left and Middle\tCtrl+Shift+G"
+msgstr ""
+
+msgid "Go to Moved Line Between Middle and Right\tCtrl+Alt+G"
+msgstr ""
+
 #, c-format
 msgid "Op&en"
 msgstr "&Ouvrir"
@@ -4090,6 +4096,9 @@ msgstr "<Automatique>"
 #, c-format
 msgid "G&oto Line %1"
 msgstr "Atteindre la ligne %1"
+
+msgid "Go to Moved Line\tCtrl+Shift+G"
+msgstr ""
 
 #, c-format
 msgid "Disabled"

--- a/Translations/WinMerge/Galician.po
+++ b/Translations/WinMerge/Galician.po
@@ -72,6 +72,12 @@ msgstr "&Pegar"
 msgid "&Goto..."
 msgstr "Ir &a…"
 
+msgid "Go to Moved Line Between Left and Middle\tCtrl+Shift+G"
+msgstr ""
+
+msgid "Go to Moved Line Between Middle and Right\tCtrl+Alt+G"
+msgstr ""
+
 #, c-format
 msgid "Op&en"
 msgstr "A&brir"
@@ -4053,6 +4059,9 @@ msgstr "<Automático>"
 #, c-format
 msgid "G&oto Line %1"
 msgstr "I&r á liña %1"
+
+msgid "Go to Moved Line\tCtrl+Shift+G"
+msgstr ""
 
 #, c-format
 msgid "Disabled"

--- a/Translations/WinMerge/German.po
+++ b/Translations/WinMerge/German.po
@@ -72,6 +72,12 @@ msgstr "E&infügen"
 msgid "&Goto..."
 msgstr "&Gehe zu..."
 
+msgid "Go to Moved Line Between Left and Middle\tCtrl+Shift+G"
+msgstr ""
+
+msgid "Go to Moved Line Between Middle and Right\tCtrl+Alt+G"
+msgstr ""
+
 #, c-format
 msgid "Op&en"
 msgstr "Ö&ffnen"
@@ -3699,6 +3705,9 @@ msgstr "<Automatisch>"
 #, c-format
 msgid "G&oto Line %1"
 msgstr "Gehe zu &Zeile %1"
+
+msgid "Go to Moved Line\tCtrl+Shift+G"
+msgstr ""
 
 #, c-format
 msgid "Disabled"

--- a/Translations/WinMerge/Greek.po
+++ b/Translations/WinMerge/Greek.po
@@ -71,6 +71,12 @@ msgstr "Προ&σάρτηση"
 msgid "&Goto..."
 msgstr "Μετά&βαση..."
 
+msgid "Go to Moved Line Between Left and Middle\tCtrl+Shift+G"
+msgstr ""
+
+msgid "Go to Moved Line Between Middle and Right\tCtrl+Alt+G"
+msgstr ""
+
 #, c-format
 msgid "Op&en"
 msgstr "Άν&οιγμα"
@@ -3898,6 +3904,9 @@ msgstr "<Αυτόματο>"
 #, c-format
 msgid "G&oto Line %1"
 msgstr "Μετά&βαση στη Γραμμή %1"
+
+msgid "Go to Moved Line\tCtrl+Shift+G"
+msgstr ""
 
 #, c-format
 msgid "Disabled"

--- a/Translations/WinMerge/Hungarian.po
+++ b/Translations/WinMerge/Hungarian.po
@@ -72,6 +72,12 @@ msgstr "&Beillesztés"
 msgid "&Goto..."
 msgstr "&Ugrás..."
 
+msgid "Go to Moved Line Between Left and Middle\tCtrl+Shift+G"
+msgstr ""
+
+msgid "Go to Moved Line Between Middle and Right\tCtrl+Alt+G"
+msgstr ""
+
 #, c-format
 msgid "Op&en"
 msgstr "Meg&nyitás"
@@ -3825,6 +3831,9 @@ msgstr "<Automatikus>"
 #, c-format
 msgid "G&oto Line %1"
 msgstr "&Ugrás a(z) %1. sorra"
+
+msgid "Go to Moved Line\tCtrl+Shift+G"
+msgstr ""
 
 #, c-format
 msgid "Disabled"

--- a/Translations/WinMerge/Italian.po
+++ b/Translations/WinMerge/Italian.po
@@ -59,6 +59,12 @@ msgstr "I&ncolla"
 msgid "&Goto..."
 msgstr "&Vai a..."
 
+msgid "Go to Moved Line Between Left and Middle\tCtrl+Shift+G"
+msgstr ""
+
+msgid "Go to Moved Line Between Middle and Right\tCtrl+Alt+G"
+msgstr ""
+
 msgid "Op&en"
 msgstr "&Apri"
 
@@ -3325,6 +3331,9 @@ msgstr "<Automatico>"
 #, c-format
 msgid "G&oto Line %1"
 msgstr "Vai alla &linea %1"
+
+msgid "Go to Moved Line\tCtrl+Shift+G"
+msgstr ""
 
 msgid "Disabled"
 msgstr "Disattivato"

--- a/Translations/WinMerge/Japanese.po
+++ b/Translations/WinMerge/Japanese.po
@@ -60,6 +60,12 @@ msgstr "貼り付け(&P)"
 msgid "&Goto..."
 msgstr "移動(&G)..."
 
+msgid "Go to Moved Line Between Left and Middle\tCtrl+Shift+G"
+msgstr "左側と中央の移動行に移動\tCtrl+Shift+G"
+
+msgid "Go to Moved Line Between Middle and Right\tCtrl+Alt+G"
+msgstr "中央と右側の移動行に移動\tCtrl+Alt+G"
+
 msgid "Op&en"
 msgstr "開く(&E)"
 
@@ -3305,6 +3311,9 @@ msgstr "<自動>"
 #, c-format
 msgid "G&oto Line %1"
 msgstr "行 %1 に移動(&O)"
+
+msgid "Go to Moved Line\tCtrl+Shift+G"
+msgstr "移動行に移動\tCtrl+Shift+G"
 
 msgid "Disabled"
 msgstr "無効"

--- a/Translations/WinMerge/Korean.po
+++ b/Translations/WinMerge/Korean.po
@@ -76,6 +76,12 @@ msgstr "붙여넣기(&P)"
 msgid "&Goto..."
 msgstr "이동(&G)"
 
+msgid "Go to Moved Line Between Left and Middle\tCtrl+Shift+G"
+msgstr ""
+
+msgid "Go to Moved Line Between Middle and Right\tCtrl+Alt+G"
+msgstr ""
+
 #, c-format
 msgid "Op&en"
 msgstr "열기(&E)"
@@ -4022,6 +4028,9 @@ msgstr "<자동>"
 #, c-format
 msgid "G&oto Line %1"
 msgstr "%1줄로 이동(&O)"
+
+msgid "Go to Moved Line\tCtrl+Shift+G"
+msgstr ""
 
 #, c-format
 msgid "Disabled"

--- a/Translations/WinMerge/Lithuanian.po
+++ b/Translations/WinMerge/Lithuanian.po
@@ -62,6 +62,12 @@ msgstr "Įter&pti"
 msgid "&Goto..."
 msgstr "&Eiti į..."
 
+msgid "Go to Moved Line Between Left and Middle\tCtrl+Shift+G"
+msgstr ""
+
+msgid "Go to Moved Line Between Middle and Right\tCtrl+Alt+G"
+msgstr ""
+
 msgid "Op&en"
 msgstr "Atv&erti"
 
@@ -2950,6 +2956,9 @@ msgstr "<Automatinis>"
 #, c-format
 msgid "G&oto Line %1"
 msgstr "E&iti į %1 eilutę"
+
+msgid "Go to Moved Line\tCtrl+Shift+G"
+msgstr ""
 
 msgid "Disabled"
 msgstr "Išjungta"

--- a/Translations/WinMerge/Norwegian.po
+++ b/Translations/WinMerge/Norwegian.po
@@ -72,6 +72,12 @@ msgstr "&Lim inn"
 msgid "&Goto..."
 msgstr "Gå &til..."
 
+msgid "Go to Moved Line Between Left and Middle\tCtrl+Shift+G"
+msgstr ""
+
+msgid "Go to Moved Line Between Middle and Right\tCtrl+Alt+G"
+msgstr ""
+
 #, c-format
 msgid "Op&en"
 msgstr "&Åpne"
@@ -3920,6 +3926,9 @@ msgstr "<Automatisk>"
 #, c-format
 msgid "G&oto Line %1"
 msgstr "G&å til linje %1"
+
+msgid "Go to Moved Line\tCtrl+Shift+G"
+msgstr ""
 
 #, c-format
 msgid "Disabled"

--- a/Translations/WinMerge/Persian.po
+++ b/Translations/WinMerge/Persian.po
@@ -73,6 +73,12 @@ msgstr "&P چسباندن "
 msgid "&Goto..."
 msgstr "&G برو به ... "
 
+msgid "Go to Moved Line Between Left and Middle\tCtrl+Shift+G"
+msgstr ""
+
+msgid "Go to Moved Line Between Middle and Right\tCtrl+Alt+G"
+msgstr ""
+
 #, c-format
 msgid "Op&en"
 msgstr "&e باز "
@@ -3964,6 +3970,9 @@ msgstr "<خودکار>"
 #, c-format
 msgid "G&oto Line %1"
 msgstr "&G   برو به خط  %1 "
+
+msgid "Go to Moved Line\tCtrl+Shift+G"
+msgstr ""
 
 #, c-format
 msgid "Disabled"

--- a/Translations/WinMerge/Polish.po
+++ b/Translations/WinMerge/Polish.po
@@ -59,6 +59,12 @@ msgstr "Wklej"
 msgid "&Goto..."
 msgstr "Idź do..."
 
+msgid "Go to Moved Line Between Left and Middle\tCtrl+Shift+G"
+msgstr ""
+
+msgid "Go to Moved Line Between Middle and Right\tCtrl+Alt+G"
+msgstr ""
+
 msgid "Op&en"
 msgstr "Otwórz"
 
@@ -2948,6 +2954,9 @@ msgstr "<automatycznie>"
 #, c-format
 msgid "G&oto Line %1"
 msgstr "Idź do linii %1"
+
+msgid "Go to Moved Line\tCtrl+Shift+G"
+msgstr ""
 
 msgid "Disabled"
 msgstr "Wyłączone"

--- a/Translations/WinMerge/Portuguese.po
+++ b/Translations/WinMerge/Portuguese.po
@@ -62,6 +62,12 @@ msgstr "Co&lar"
 msgid "&Goto..."
 msgstr "&Ir para..."
 
+msgid "Go to Moved Line Between Left and Middle\tCtrl+Shift+G"
+msgstr ""
+
+msgid "Go to Moved Line Between Middle and Right\tCtrl+Alt+G"
+msgstr ""
+
 msgid "Op&en"
 msgstr "&Abrir"
 
@@ -3302,6 +3308,9 @@ msgstr "<Automático>"
 #, c-format
 msgid "G&oto Line %1"
 msgstr "I&r para a Linha %1"
+
+msgid "Go to Moved Line\tCtrl+Shift+G"
+msgstr ""
 
 msgid "Disabled"
 msgstr "Desativado"

--- a/Translations/WinMerge/Romanian.po
+++ b/Translations/WinMerge/Romanian.po
@@ -72,6 +72,12 @@ msgstr "Li&peşte"
 msgid "&Goto..."
 msgstr "&Mergi la..."
 
+msgid "Go to Moved Line Between Left and Middle\tCtrl+Shift+G"
+msgstr ""
+
+msgid "Go to Moved Line Between Middle and Right\tCtrl+Alt+G"
+msgstr ""
+
 #, c-format
 msgid "Op&en"
 msgstr "D&eschide"
@@ -3899,6 +3905,9 @@ msgstr "<Automat>"
 #, c-format
 msgid "G&oto Line %1"
 msgstr "&Mergi la linia %1"
+
+msgid "Go to Moved Line\tCtrl+Shift+G"
+msgstr ""
 
 #, c-format
 msgid "Disabled"

--- a/Translations/WinMerge/Russian.po
+++ b/Translations/WinMerge/Russian.po
@@ -64,6 +64,12 @@ msgstr "&Вставить"
 msgid "&Goto..."
 msgstr "Перейти к..."
 
+msgid "Go to Moved Line Between Left and Middle\tCtrl+Shift+G"
+msgstr ""
+
+msgid "Go to Moved Line Between Middle and Right\tCtrl+Alt+G"
+msgstr ""
+
 msgid "Op&en"
 msgstr "От&крыть"
 
@@ -2952,6 +2958,9 @@ msgstr "<Автоматически>"
 #, c-format
 msgid "G&oto Line %1"
 msgstr "Перейти к &строке %1"
+
+msgid "Go to Moved Line\tCtrl+Shift+G"
+msgstr ""
 
 msgid "Disabled"
 msgstr "Отключен"

--- a/Translations/WinMerge/Serbian.po
+++ b/Translations/WinMerge/Serbian.po
@@ -71,6 +71,12 @@ msgstr "&Налепи"
 msgid "&Goto..."
 msgstr "&Иди на..."
 
+msgid "Go to Moved Line Between Left and Middle\tCtrl+Shift+G"
+msgstr ""
+
+msgid "Go to Moved Line Between Middle and Right\tCtrl+Alt+G"
+msgstr ""
+
 #, c-format
 msgid "Op&en"
 msgstr "&Отвори"
@@ -3892,6 +3898,9 @@ msgstr "<Аутоматски>"
 #, c-format
 msgid "G&oto Line %1"
 msgstr "И&ди на ред %1"
+
+msgid "Go to Moved Line\tCtrl+Shift+G"
+msgstr ""
 
 #, c-format
 msgid "Disabled"

--- a/Translations/WinMerge/Sinhala.po
+++ b/Translations/WinMerge/Sinhala.po
@@ -69,6 +69,12 @@ msgstr "ඇලවීම"
 msgid "&Goto..."
 msgstr "යන්න"
 
+msgid "Go to Moved Line Between Left and Middle\tCtrl+Shift+G"
+msgstr ""
+
+msgid "Go to Moved Line Between Middle and Right\tCtrl+Alt+G"
+msgstr ""
+
 #, c-format
 msgid "Op&en"
 msgstr "විවෘත කිරීම"
@@ -3910,6 +3916,9 @@ msgstr "<Automatic>"
 #, c-format
 msgid "G&oto Line %1"
 msgstr "G&oto Line %1"
+
+msgid "Go to Moved Line\tCtrl+Shift+G"
+msgstr ""
 
 #, c-format
 msgid "Disabled"

--- a/Translations/WinMerge/Slovak.po
+++ b/Translations/WinMerge/Slovak.po
@@ -62,6 +62,12 @@ msgstr "&Prilepiť"
 msgid "&Goto..."
 msgstr "&Prejsť na..."
 
+msgid "Go to Moved Line Between Left and Middle\tCtrl+Shift+G"
+msgstr ""
+
+msgid "Go to Moved Line Between Middle and Right\tCtrl+Alt+G"
+msgstr ""
+
 msgid "Op&en"
 msgstr "&Otvoriť"
 
@@ -3366,6 +3372,9 @@ msgstr "<Automatické>"
 #, c-format
 msgid "G&oto Line %1"
 msgstr "Ch&oď na riadok %1"
+
+msgid "Go to Moved Line\tCtrl+Shift+G"
+msgstr ""
 
 msgid "Disabled"
 msgstr "Zakázané"

--- a/Translations/WinMerge/Slovenian.po
+++ b/Translations/WinMerge/Slovenian.po
@@ -73,6 +73,12 @@ msgstr "&Prilepi"
 msgid "&Goto..."
 msgstr "Pojdi &na..."
 
+msgid "Go to Moved Line Between Left and Middle\tCtrl+Shift+G"
+msgstr ""
+
+msgid "Go to Moved Line Between Middle and Right\tCtrl+Alt+G"
+msgstr ""
+
 #, c-format
 msgid "Op&en"
 msgstr "&Odpri"
@@ -4034,6 +4040,9 @@ msgstr "<Samodejno>"
 #, c-format
 msgid "G&oto Line %1"
 msgstr "Pojdi &na vrstico %1"
+
+msgid "Go to Moved Line\tCtrl+Shift+G"
+msgstr ""
 
 #, c-format
 msgid "Disabled"

--- a/Translations/WinMerge/Spanish.po
+++ b/Translations/WinMerge/Spanish.po
@@ -63,6 +63,12 @@ msgstr "&Pegar"
 msgid "&Goto..."
 msgstr "Ir &a..."
 
+msgid "Go to Moved Line Between Left and Middle\tCtrl+Shift+G"
+msgstr ""
+
+msgid "Go to Moved Line Between Middle and Right\tCtrl+Alt+G"
+msgstr ""
+
 msgid "Op&en"
 msgstr "A&brir"
 
@@ -3342,6 +3348,9 @@ msgstr "<Automático>"
 #, c-format
 msgid "G&oto Line %1"
 msgstr "Ir a &línea %1"
+
+msgid "Go to Moved Line\tCtrl+Shift+G"
+msgstr ""
 
 msgid "Disabled"
 msgstr "Deshabilitado"

--- a/Translations/WinMerge/Swedish.po
+++ b/Translations/WinMerge/Swedish.po
@@ -74,6 +74,12 @@ msgstr "Klistra in"
 msgid "&Goto..."
 msgstr "Gå till ..."
 
+msgid "Go to Moved Line Between Left and Middle\tCtrl+Shift+G"
+msgstr ""
+
+msgid "Go to Moved Line Between Middle and Right\tCtrl+Alt+G"
+msgstr ""
+
 #, c-format
 msgid "Op&en"
 msgstr "Öppna"
@@ -3999,6 +4005,9 @@ msgstr "<Automatisk>"
 #, c-format
 msgid "G&oto Line %1"
 msgstr "Gå till rad %1"
+
+msgid "Go to Moved Line\tCtrl+Shift+G"
+msgstr ""
 
 #, c-format
 msgid "Disabled"

--- a/Translations/WinMerge/Turkish.po
+++ b/Translations/WinMerge/Turkish.po
@@ -59,6 +59,12 @@ msgstr "Ya&pıştır"
 msgid "&Goto..."
 msgstr "&Git..."
 
+msgid "Go to Moved Line Between Left and Middle\tCtrl+Shift+G"
+msgstr ""
+
+msgid "Go to Moved Line Between Middle and Right\tCtrl+Alt+G"
+msgstr ""
+
 msgid "Op&en"
 msgstr "&Aç"
 
@@ -3337,6 +3343,9 @@ msgstr "<Otomatik>"
 #, c-format
 msgid "G&oto Line %1"
 msgstr "%1. &Satıra Git"
+
+msgid "Go to Moved Line\tCtrl+Shift+G"
+msgstr ""
 
 msgid "Disabled"
 msgstr "Etkisizleştirildi"

--- a/Translations/WinMerge/Ukrainian.po
+++ b/Translations/WinMerge/Ukrainian.po
@@ -73,6 +73,12 @@ msgstr "&Вставити"
 msgid "&Goto..."
 msgstr "Перейти до рядка..."
 
+msgid "Go to Moved Line Between Left and Middle\tCtrl+Shift+G"
+msgstr ""
+
+msgid "Go to Moved Line Between Middle and Right\tCtrl+Alt+G"
+msgstr ""
+
 #, c-format
 msgid "Op&en"
 msgstr "&Відкрити"
@@ -3920,6 +3926,9 @@ msgstr "<Автоматично>"
 #, c-format
 msgid "G&oto Line %1"
 msgstr "Перейти до &рядка %1"
+
+msgid "Go to Moved Line\tCtrl+Shift+G"
+msgstr ""
 
 #, c-format
 msgid "Disabled"


### PR DESCRIPTION
Add the feature "Go to Moved Line".
This feature can be performed in the file compare window in the following ways:
- The Context menu of the File pane or the Diff pane
- Shortcut key "Ctrl + Alt + G" or "Ctrl + Shift + G"