### PR TITLE
Update manual

### DIFF
--- a/Docs/Manual/EN/About_Doc.xml
+++ b/Docs/Manual/EN/About_Doc.xml
@@ -204,7 +204,7 @@
     <title>Documentation conventions<indexterm>
         <primary>conventions, documentation</primary>
       </indexterm></title>
-
+    <para></para>
     <informaltable>
       <tgroup cols="2">
         <thead>
@@ -343,5 +343,6 @@
         </tbody>
       </tgroup>
     </informaltable>
+    <para></para>
   </section>
 </article>

--- a/Docs/Manual/EN/Command_line.xml
+++ b/Docs/Manual/EN/Command_line.xml
@@ -376,6 +376,7 @@
           class="directory">C:\Folder2</filename> does <emphasis>not</emphasis>
           contain a file named <filename>File.txt</filename>.</para>
         </tip>
+        <para></para>
       </listitem>
     </varlistentry>
 

--- a/Docs/Manual/EN/Compare_dirs.xml
+++ b/Docs/Manual/EN/Compare_dirs.xml
@@ -176,6 +176,7 @@ I get the partial list, but no Abort indicator.--></para>
                          fileref="screenshots/foldercomp1.png" format="PNG" />
             </imageobject>
           </mediaobject>
+          <para></para>
         </listitem>
       </varlistentry>
 
@@ -195,6 +196,7 @@ I get the partial list, but no Abort indicator.--></para>
                          fileref="screenshots/treeview-01.png" format="PNG" />
             </imageobject>
           </mediaobject>
+          <para></para>
 
           <itemizedlist>
             <listitem>
@@ -299,7 +301,7 @@ I get the partial list, but no Abort indicator.--></para>
 
       <para>In the Compare Folders window, files and folders are compared and
       divided into several categories. In each row, the category is clearly
-      identified in the left column with one of these icons :</para>
+      identified in the left column with one of these icons:</para>
 
       <simplelist>
         <member><inlinemediaobject>
@@ -630,7 +632,7 @@ I get the partial list, but no Abort indicator.--></para>
 
       <variablelist>
         <varlistentry>
-          <term><guimenuitem>with Registered Application</guimenuitem></term>
+          <term><guimenuitem>With Registered Application</guimenuitem></term>
 
           <listitem>
             <para>Opens the file with the application (if any) that is
@@ -640,11 +642,12 @@ I get the partial list, but no Abort indicator.--></para>
               <para>This shortcut usually opens a folder in a new Windows
               Explorer.</para>
             </tip>
+            <para></para>
           </listitem>
         </varlistentry>
 
         <varlistentry>
-          <term>with External Editor</term>
+          <term>With External Editor</term>
 
           <listitem>
             <para>Opens the file with an external editor. The default editor is
@@ -654,7 +657,7 @@ I get the partial list, but no Abort indicator.--></para>
         </varlistentry>
 
         <varlistentry>
-          <term><guimenuitem>with...</guimenuitem></term>
+          <term><guimenuitem>With...</guimenuitem></term>
 
           <listitem>
             <para>Opens the <guilabel>Open With</guilabel> dialog, where you can
@@ -953,6 +956,7 @@ added/deleted/copied. User can create a new archive file using above menuitems i
                 <phrase>Folder Compare window, two folders selected</phrase>
               </textobject>
             </mediaobject>
+            <para></para>
 
             <para>The order of selection is significant: the folder you select
             first is the left folder in the result; the second selected folder
@@ -1325,4 +1329,5 @@ added/deleted/copied. User can create a new archive file using above menuitems i
       see the change).</para>
     </caution>
   </section>
+  <para></para>
 </article>

--- a/Docs/Manual/EN/Compare_files.xml
+++ b/Docs/Manual/EN/Compare_files.xml
@@ -9,7 +9,7 @@
   <para>This topic describes how to use the WinMerge File Compare window to
   compare and merge text files. To understand the basic concepts about
   differences discussed here, we suggest you read <xref linkend="Intro_diffs" />
-  first. See <xref linkend="Intro_diffs" /> for related information about hex
+  first. See <xref linkend="Compare_bin" /> for related information about hex
   files. </para>
 
   <section id="Compare_files_starting">
@@ -166,6 +166,7 @@
                   <phrase>Difference block background colors</phrase>
                 </textobject>
               </mediaobject>
+              <para></para>
 
               <para>This comparison detects three difference blocks:</para>
 
@@ -228,6 +229,7 @@
                   <phrase>Difference block colors with ignored diff</phrase>
                 </textobject>
               </mediaobject>
+              <para></para>
             </listitem>
           </varlistentry>
 
@@ -254,6 +256,7 @@
                   detection</phrase>
                 </textobject>
               </mediaobject>
+              <para></para>
 
               <para>Notice that the two identical lines (containing
               <literal>a</literal> and <literal>c</literal>) that are in
@@ -463,6 +466,7 @@
                   whitespace</phrase>
                 </textobject>
               </mediaobject>
+              <para></para>
 
               <note>
                 <para>As with word-level line differences, character
@@ -780,6 +784,7 @@
             <simpara><keycap>Up</keycap> and <keycap>Down</keycap> keys for the
             <function>Previous Difference</function> and <function>Next
             Difference</function> functions.</simpara>
+            <para></para>
           </listitem>
 
           <listitem>
@@ -988,7 +993,7 @@
 
       <para>You can merge differences directly in the Diff pane by
       right-clicking in either the top or bottom side and choosing
-      <function><guimenuitem>Copy to Right</guimenuitem></function> or
+      <guimenuitem>Copy to Right</guimenuitem> or
       <guimenuitem>Copy to Left</guimenuitem>.</para>
     </section>
 
@@ -1160,6 +1165,7 @@
                 <phrase>Select Line Difference example</phrase>
               </textobject>
             </mediaobject>
+            <para></para>
 
             <para>If you want to select the difference block itself, use
             <command>Current Difference</command> instead.</para>
@@ -1387,6 +1393,7 @@
               <guimenuitem>Find</guimenuitem> to search text, or stepping
               through differences.</para>
             </tip>
+            <para></para>
 
             <para>Shortcuts: <menuchoice>
                 <guimenu>Edit</guimenu>
@@ -1644,7 +1651,7 @@
           <listitem>
             <para>Copies all differences from the left to the right File pane.
             Use to synchronize two files with one command. Similarly, you can
-            back out the entire merge by clicking the<inlinemediaobject>
+            back out the entire merge by clicking the <inlinemediaobject>
                 <imageobject>
                   <imagedata contentdepth="11"
                              fileref="screenshots/undo_btn.png" />

--- a/Docs/Manual/EN/Configuration.xml
+++ b/Docs/Manual/EN/Configuration.xml
@@ -138,31 +138,31 @@
     </section>
 
     <section>
-      <title>Close Windows with <keycap>ESC</keycap><indexterm>
+      <title>Close Windows with '<keycap>Esc</keycap>'<indexterm>
           <primary>closing windows using Esc key</primary>
         </indexterm></title>
 
       <itemizedlist>
         <listitem>
           <para><option>MDI child window or main window</option> (default): Lets you use the
-          <keycap>ESC</keycap> key to close WinMerge windows. Pressing
-          <keycap>ESC</keycap> once closes one window, so with one File Compare
+          <keycap>Esc</keycap> key to close WinMerge windows. Pressing
+          <keycap>Esc</keycap> once closes one window, so with one File Compare
           window open, it takes three key presses to close WinMerge: first the
           File Compare window, then the Folder Compare window, and finally the
           WinMerge window.</para>
 
           <para>Note that in the WinMerge command line, the
           <parameter>-e</parameter> parameter enables you to close WinMerge by
-          pressing <keycap>ESC</keycap> just once.</para>
+          pressing <keycap>Esc</keycap> just once.</para>
         </listitem>
 
         <listitem>
-          <para><option>MDI child window only</option>: Pressing <keycap>ESC</keycap>
+          <para><option>MDI child window only</option>: Pressing <keycap>Esc</keycap>
           closes a child window, but not the last remaining main window.</para>
         </listitem>
 
         <listitem>
-          <para><option>Disabled</option>: Pressing <keycap>ESC</keycap> does
+          <para><option>Disabled</option>: Pressing <keycap>Esc</keycap> does
           not close any WinMerge windows.</para>
         </listitem>
       </itemizedlist>
@@ -398,16 +398,16 @@
         </listitem>
 
         <listitem>
-          <para>Ignored differences cannot be merged</para>
+          <para>Ignored differences cannot be merged.</para>
         </listitem>
 
         <listitem>
-          <para>Ignored differences are not included in difference counts</para>
+          <para>Ignored differences are not included in difference counts.</para>
         </listitem>
 
         <listitem>
           <para>Files containing only ignored differences are marked as
-          identical in a folder comparison</para>
+          identical in a folder comparison.</para>
         </listitem>
       </itemizedlist>
     </section>
@@ -693,7 +693,7 @@
         </listitem>
 
         <listitem>
-          <para><option>Disabled</option> Disable the heuristic.</para>
+          <para><option>Disabled</option>: Disable the heuristic.</para>
         </listitem>
       </itemizedlist>
     </section>
@@ -951,7 +951,7 @@
 
           <para>This option sets the limit when WinMerge should stop comparing.
 		  If the limit is set to for instance 4 MB, then WinMerge will only read 
-		  the first 4 MB of a file. If no differences are founf before the 
+		  the first 4 MB of a file. If no differences are found before the 
 		  Quick Compare limit is reached, then the files will be marked as identical.
 		  </para>
 
@@ -1195,7 +1195,7 @@
 
           <listitem>
             <para>Width of a tab space. Specify a value
-            <replaceable>n</replaceable> : the resulting width is equivalent to
+            <replaceable>n</replaceable>: the resulting width is equivalent to
             that of <replaceable>n</replaceable> characters. Default: 4. The
             maximum value is 64.</para>
           </listitem>
@@ -1257,7 +1257,7 @@
             </listitem>
 
             <listitem>
-              <para><guilabel>simiWord-level</guilabel> (default): Highlights
+              <para><guilabel>Word-level</guilabel> (default): Highlights
               entire words that are different.</para>
 
               <itemizedlist>
@@ -1351,7 +1351,7 @@
   </section>
 
   <section id="Configuration_markercolors">
-    <title>Maker Colors page<indexterm>
+    <title>Marker Colors page<indexterm>
         <primary>marker colors</primary>
 
         <secondary>options</secondary>
@@ -1459,6 +1459,7 @@
             deactivated, this option does not work, and deleted files are
             lost!</para>
           </important>
+          <para></para>
         </listitem>
 
         <listitem>
@@ -1496,11 +1497,11 @@
       Folder Compare window and choose <menuchoice>
           <guimenuitem>Open Left</guimenuitem>
 
-          <guimenuitem>with External Editor</guimenuitem>
+          <guimenuitem>With External Editor</guimenuitem>
         </menuchoice> or <menuchoice>
           <guimenuitem>Open Right</guimenuitem>
 
-          <guimenuitem>with External Editor</guimenuitem>
+          <guimenuitem>With External Editor</guimenuitem>
         </menuchoice>.</para>
     </section>
 
@@ -1528,12 +1529,12 @@
 
       <itemizedlist>
         <listitem>
-          <para>System's temp folder (default): For example, this might be
+          <para><guilabel>System's temp folder</guilabel> (default): For example, this might be
           <filename>C:\Windows\Temp</filename> on your system.</para>
         </listitem>
 
         <listitem>
-          <para>Custom folder: Click <guibutton>Browse</guibutton> and select a
+          <para><guilabel>Custom folder</guilabel>: Click <guibutton>Browse</guibutton> and select a
           different folder where you have write access.</para>
         </listitem>
       </itemizedlist>
@@ -1601,13 +1602,13 @@
 
       <itemizedlist>
         <listitem>
-          <para><guilabel>Append .bak -extension</guilabel> (enabled by
+          <para><guilabel>Append .bak extension</guilabel> (enabled by
           default): For example, the <filename>file.txt</filename> is backed up
           to <filename>file.txt.bak</filename>.</para>
         </listitem>
 
         <listitem>
-          <para><guilabel>File compare</guilabel> (enabled by default):
+          <para><guilabel>Append timestamp</guilabel> (enabled by default):
           Timestamps are almost always unique, so this option usually avoids
           duplicating backup file names when the source files have the same
           names.</para>
@@ -1681,7 +1682,7 @@
     </section>
 
     <section>
-      <title>Detect codepage info for these files: .html .rc .xml</title>
+      <title>Detect codepage info for these files: .html, .rc, .xml</title>
 
       <important>
         <para>Uncheck this option in <filename>WinMerge.exe</filename>.
@@ -1701,7 +1702,7 @@ or is this understood?--></para>
 
         <listitem>
           <para><option>Enabled</option>: WinMerge detects the codepage for
-          these extensions : <filename class="extension">html</filename>,
+          these extensions: <filename class="extension">html</filename>,
           <filename class="extension">rc</filename> (resource files for VC++)
           and <filename class="extension">xml</filename>. The detected codepage
           overrides the setting for the default codepage option.</para>

--- a/Docs/Manual/EN/Faq.xml
+++ b/Docs/Manual/EN/Faq.xml
@@ -43,7 +43,7 @@
             has none of the limitations of the ANSI executable.</para>
           <para><filename>WinMergeU.exe</filename> has been installed by default
             for some time, and since few ANSI-based Windows systems remain, the
-            value of maintaining <filename>WinMerge.exe</filename> is miminal.
+            value of maintaining <filename>WinMerge.exe</filename> is minimal.
             As of Version 2.14, WinMerge no longer includes
               <filename>WinMerge.exe</filename> in the installer.  </para>
         </answer>
@@ -283,7 +283,7 @@
     <qandaset>
       <qandaentry>
         <question>
-          <para>I want WinMerge to close with a single <keycap>ESC</keycap>
+          <para>I want WinMerge to close with a single <keycap>Esc</keycap>
           press after I'm done?</para>
         </question>
 
@@ -484,5 +484,6 @@
         </answer>
       </qandaentry>
     </qandaset>
+    <para></para>
   </section>
 </article>

--- a/Docs/Manual/EN/Filters.xml
+++ b/Docs/Manual/EN/Filters.xml
@@ -268,6 +268,7 @@
                 filter is already loaded in the <guilabel>Filter</guilabel>
                 field.</para>
               </note>
+              <para></para>
             </listitem>
 
             <listitem>
@@ -545,6 +546,7 @@ f: ^[h,k,m] ## <filename>h*.*</filename>, <filename>k*.*</filename>, and <filena
                 <para>The <guilabel>Filter</guilabel> field does not indicate
                 what line filters are enabled.</para>
               </note>
+              <para></para>
             </listitem>
 
             <listitem>
@@ -933,7 +935,7 @@ Pekka Himanen</screen></para>
             </note>
 
             <para>WinMerge initializes the new file with the contents of the
-            <filename>FileFilter.tmpl</filename> tempate, and opens it in your
+            <filename>FileFilter.tmpl</filename> template, and opens it in your
             default text editor.</para>
           </listitem>
 
@@ -948,6 +950,7 @@ Pekka Himanen</screen></para>
               try clicking Test in the Filters dialog. See <xref
               linkend="Filters_TestingDlg" /> for details.</para>
             </tip>
+            <para></para>
           </listitem>
 
           <listitem>
@@ -1006,7 +1009,7 @@ Pekka Himanen</screen></para>
           </listitem>
 
           <listitem>
-            <para>If you want to see the rules you will be testing,click
+            <para>If you want to see the rules you will be testing, click
             <guibutton>Edit</guibutton> now to open the file so that you can
             view it during the next steps.</para>
           </listitem>

--- a/Docs/Manual/EN/Install.xml
+++ b/Docs/Manual/EN/Install.xml
@@ -51,7 +51,7 @@
   
   <section id="Installing_usinginstaller">
     <title>Using the installer (recommended)</title>
-
+    <para></para>
     <note>
       <para>The installer requires Administrator user privileges. If you don't have admin user privileges, you can install
       WinMerge by unzipping from an archive file (see <xref
@@ -295,6 +295,7 @@
         If necessary, click <guibutton>Back</guibutton> to change anything in a
         previous page. When you are sure that you are ready to proceed, click
         <guibutton>Install</guibutton>.</simpara>
+      <para></para>
       </listitem>
 
       <listitem>

--- a/Docs/Manual/EN/Intro_diffs.xml
+++ b/Docs/Manual/EN/Intro_diffs.xml
@@ -4,7 +4,7 @@
 
   <para>This topic describes how WinMerge detects and displays differences
   within text files, and demonstrates simple file comparing and merging
-  operations. See <xref linkend="Intro_diffs" /> for related information about
+  operations. See <xref linkend="Compare_bin" /> for related information about
   hex files. </para>
 
   <section id="Intro_diffs_comparing">
@@ -217,6 +217,7 @@ Believe it or not.</screen></para>
               <phrase>Compare Files Diff Pane</phrase>
             </textobject>
           </mediaobject>
+          <para></para>
         </listitem>
 
         <listitem>
@@ -377,6 +378,7 @@ Believe it or not.</screen></para>
                          fileref="screenshots/filemerged1.png" format="PNG" />
             </imageobject>
           </mediaobject>
+          <para></para>
         </listitem>
 
         <listitem>

--- a/Docs/Manual/EN/Introduction.xml
+++ b/Docs/Manual/EN/Introduction.xml
@@ -110,7 +110,7 @@
       experimental and beta development versions. At the appropriate points we
       create new branches for stable releases. In the diagram, the arrows for
       2.4.x and 2.6.x versions are two current stable branches. (The diagram is
-      a snapshot; it is not updated to show the current stable branch).</para>
+      a snapshot; it is not updated to show the current stable branch.)</para>
 
       <important>
         <para>A branch always indicates a separate development effort. There is

--- a/Docs/Manual/EN/Plugins.xml
+++ b/Docs/Manual/EN/Plugins.xml
@@ -81,7 +81,7 @@
           </note>
 
           <para>Example plugin: <xref linkend="CompareMSExcelFiles" />
-          Displays the text contents of a 
+          displays the text contents of a 
           <trademark class="registered">Microsoft</trademark>
           <application>Excel</application> file.</para>
         </listitem>
@@ -285,7 +285,7 @@
       <title>Applying prediffer plugins in the Folder Compare window</title>
 
       <para>With prediffer plugins, you set the mode (<firstterm>Auto
-      prediiffer</firstterm> or <firstterm>No prediffer</firstterm>) for
+      prediffer</firstterm> or <firstterm>No prediffer</firstterm>) for
       individual files. (Contrast this with unpacker plugins, where you set the
       mode for all files.) That is, some files in the same folder have different
       prediffer modes.</para>
@@ -324,7 +324,7 @@
     <section>
       <title>Applying prediffer plugins in the File Compare window</title>
 
-      <para>In the File Compare winodw, you can apply a prediffer plugin by
+      <para>In the File Compare window, you can apply a prediffer plugin by
       clicking <menuchoice>
           <guimenu>Plugins</guimenu>
 
@@ -367,13 +367,13 @@
           <seglistitem>
             <seg>Unpacker</seg>
 
-            <seg><filename class="extension">*.xls</filename><filename
-            class="extension">*.xlsx</filename><filename
-            class="extension">*.xlsm</filename><filename
-            class="extension">*.xlsb</filename><filename
-            class="extension">*.xla</filename><filename
-            class="extension">*.xlax</filename><filename
-            class="extension">*.xltx</filename><filename
+            <seg><filename class="extension">*.xls</filename>, <filename
+            class="extension">*.xlsx</filename>, <filename
+            class="extension">*.xlsm</filename>, <filename
+            class="extension">*.xlsb</filename>, <filename
+            class="extension">*.xla</filename>, <filename
+            class="extension">*.xlax</filename>, <filename
+            class="extension">*.xltx</filename>, <filename
             class="extension">*.xltm</filename></seg>
 
             <seg>No</seg>
@@ -566,7 +566,7 @@
         </indexterm></filename></title>
 
       <para>This plugin ignores characters at specified columns. The first
-      column is number 1</para>
+      column is number 1.</para>
 
       <para>Note that this plugin does not support files with tabs: the plugin
       does not fail, but all tabs are be treated as normal characters.</para>
@@ -662,7 +662,7 @@
             class="extension">*.php</filename>, <filename
             class="extension">*.js</filename>, <filename
             class="extension">*.cs</filename>, <filename
-            class="extension">*.ts</filename>,</seg>
+            class="extension">*.ts</filename></seg>
 
             <seg>No</seg>
           </seglistitem>
@@ -705,7 +705,7 @@
         </indexterm></filename></title>
 
       <para>This plugin is for files that use fields and tabs as delimiters
-      (<application>for examle, Excel</application> files saved in the <filename
+      (<application>for example, Excel</application> files saved in the <filename
       class="extension">*.txt</filename> format). It ignores the delimiter
       characters. The first field is number 1.</para>
 

--- a/Docs/Manual/EN/Quick_start.xml
+++ b/Docs/Manual/EN/Quick_start.xml
@@ -138,6 +138,7 @@
                 shows a list of paths available as you type in the fields. See
                 <xref linkend="Configuration" /> for details.</para>
               </tip>
+              <para></para>
             </listitem>
 
             <listitem>


### PR DESCRIPTION
- Spelling mistakes corrected.
- Wrong links corrected.
- Added missing blank lines behind boxes and pictures (for WinMerge.chm).
