### PR TITLE
Update manual

### DIFF
--- a/Docs/Manual/EN/Compare_dirs.xml
+++ b/Docs/Manual/EN/Compare_dirs.xml
@@ -973,7 +973,7 @@ added/deleted/copied. User can create a new archive file using above menuitems i
               <para>Again, the <guimenuitem>Compare</guimenuitem> operation is
               available only when the current left and right folder paths are
               identical in the Folder Compare window, as shown in the preceding
-              screen shot. For example, it is not available if the current
+              screenshot. For example, it is not available if the current
               window compares two different folders.</para>
             </tip>
           </listitem>

--- a/Docs/Manual/EN/Install.xml
+++ b/Docs/Manual/EN/Install.xml
@@ -24,11 +24,11 @@
 	
 	<itemizedlist>
 	  <listitem>
-	    <para><ulink url="https://sourceforge.net/projects/winmerge/files/stable/2.16.4/">WinMerge 2.16.4(64 bit)</ulink> 
+	    <para><ulink url="https://sourceforge.net/projects/winmerge/files/stable/2.16.4/">WinMerge 2.16.4 (64 bit)</ulink> 
 		supports Windows 7 and later. It runs on 64 bit Windows.</para>
 	  </listitem>
 	  <listitem>
-	    <para><ulink url="https://sourceforge.net/projects/winmerge/files/stable/2.16.4/">WinMerge 2.16.4(32 bit)</ulink> 
+	    <para><ulink url="https://sourceforge.net/projects/winmerge/files/stable/2.16.4/">WinMerge 2.16.4 (32 bit)</ulink> 
 		supports Windows XP and later. It runs on both 32 bit and 64 bit Windows.</para>
 	  </listitem>
 	  <listitem>
@@ -70,11 +70,6 @@
       </listitem>
 
       <listitem>
-        <simpara>Click <guibutton>Next</guibutton> in the Welcome
-        screen.</simpara>
-      </listitem>
-
-      <listitem>
         <simpara>Click <guibutton>Next</guibutton> in the License Agreement
         screen.</simpara>
       </listitem>
@@ -108,6 +103,16 @@
           </varlistentry>
 
           <varlistentry>
+            <term>32-bit WinMerge ShellExtension<indexterm>
+                <primary>Shellextension</primary>
+              </indexterm></term>
+
+            <listitem>
+              <para>The option enables you to launch WinMerge directly from Windows Explorer, comparing items that you have selected there.</para>
+            </listitem>
+          </varlistentry>
+
+          <varlistentry>
             <term>Filters</term>
 
             <listitem>
@@ -127,7 +132,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term>Frhed</term>
+            <term>Frhed (Free hex editor)</term>
 
             <listitem>
               <para>Frhed enable you to show files in hex format.</para>
@@ -135,7 +140,7 @@
           </varlistentry>
 
           <varlistentry>
-            <term>WinIMerge</term>
+            <term>WinIMerge (Image Diff/Merge)</term>
 
             <listitem>
               <para>WinIMerge enables you to show the differences between image files.</para>
@@ -188,7 +193,7 @@
           </listitem>
 
           <listitem>
-            <para>Optionally, check the option, <guilabel>Don't create a Start
+            <para>Optionally, check the option <guilabel>Don't create a Start
             Menu folder</guilabel>.</para>
           </listitem>
         </itemizedlist>
@@ -270,19 +275,64 @@
           </varlistentry>
 
           <varlistentry>
-            <term>Create a Desktop shortcut</term>
+            <term>Create a desktop shortcut</term>
 
             <listitem>
               <para>Adds the WinMerge shortcut to your Windows Desktop.</para>
             </listitem>
           </varlistentry>
+        </variablelist>
 
+        <para>Click <guibutton>Next</guibutton>.</para>
+      </listitem>
+
+      <listitem>
+        <simpara>In the 3-way merge wizard page, register WinMerge
+        as 3-way merge tool for TortoiseSVN/Git.</simpara>
+
+        <variablelist>
           <varlistentry>
-            <term>Create a Quick Launch shortcut</term>
+            <term>Register WinMerge as a 3-way merge tool<indexterm>
+                <primary>3-way merge tool</primary>
+              </indexterm></term>
 
             <listitem>
-              <para>Adds the WinMerge shortcut to the Windows Quick Launch
-              bar.</para>
+              <para>Register WinMerge as 3-way merge tool for
+              TortoiseSVN/Git.</para>
+            </listitem>
+          </varlistentry>
+
+          <varlistentry>
+            <term>Merge at right pane</term>
+
+            <listitem>
+              <para>Merge at right pane.</para>
+            </listitem>
+          </varlistentry>
+
+
+          <varlistentry>
+            <term>Merge at center pane</term>
+
+            <listitem>
+              <para>Merge at center pane.</para>
+            </listitem>
+          </varlistentry>
+
+          <varlistentry>
+            <term>Merge at left pane</term>
+
+            <listitem>
+              <para>Merge at left pane.</para>
+            </listitem>
+          </varlistentry>
+
+          <varlistentry>
+            <term>Auto-merge at startup time</term>
+
+            <listitem>
+              <para>Optionally, disable the option <guilabel>Auto-merge at
+            startup time</guilabel>.</para>
             </listitem>
           </varlistentry>
         </variablelist>

--- a/Docs/Manual/EN/Plugins.xml
+++ b/Docs/Manual/EN/Plugins.xml
@@ -386,46 +386,6 @@
         </segmentedlist></para>
     </section>
 
-    <section id="Plugins_msword">
-      <title><filename>CompareMSWordFiles.sct<indexterm>
-          <primary>CompareMSWordFiles.sct plugin file</primary>
-        </indexterm></filename></title>
-
-      <para>Displays the text content of a <trademark
-      class="registered">Microsoft</trademark> <application>Word</application>
-      file, stripping away all formatting and embedded objects.</para>
-
-      <para><segmentedlist>
-          <segtitle>Category</segtitle>
-
-          <segtitle>File filter</segtitle>
-
-          <segtitle>Packing</segtitle>
-
-          <segtitle>Settings dialog support</segtitle>
-
-          <segtitle>Dependency</segtitle>
-
-          <seglistitem>
-            <seg>Unpacker</seg>
-
-	    <seg><filename class="extension">*.doc</filename>, <filename
-            class="extension">*.docx</filename>, <filename
-            class="extension">*.docm</filename>, <filename
-            class="extension">*.dot</filename>, <filename
-            class="extension">*.dotx</filename>, <filename
-            class="extension">*.dotm</filename></seg>
-
-            <seg>No</seg>
-
-            <seg>Yes</seg>
-
-            <seg><trademark class="registered">Microsoft</trademark>
-            <application>Word</application></seg>
-          </seglistitem>
-        </segmentedlist></para>
-    </section>
-
     <section id="Plugins_powerpnt">
       <title><filename>CompareMSPowerPointFiles.sct<indexterm>
           <primary>CompareMSPowerPointFiles.sct plugin file</primary>
@@ -511,51 +471,42 @@
         </segmentedlist></para>
     </section>
 
-    <section id="EditorAddin">
-      <title><filename>editor addin.sct<indexterm>
-          <primary>editor addin.sct plugin file</primary>
+    <section id="Plugins_msword">
+      <title><filename>CompareMSWordFiles.sct<indexterm>
+          <primary>CompareMSWordFiles.sct plugin file</primary>
         </indexterm></filename></title>
 
-      <para>Adds five functions to the <menuchoice>
-          <guimenu>Plugins</guimenu>
-
-          <guisubmenu>Scripts</guisubmenu>
-        </menuchoice> menu:</para>
-
-      <itemizedlist>
-        <listitem>
-          <simpara><guimenuitem>MakeUpper</guimenuitem> convert the selection to
-          UPPER CASE.</simpara>
-        </listitem>
-
-        <listitem>
-          <simpara><guimenuitem>MakeLower</guimenuitem> convert the selection to
-          lower case.</simpara>
-        </listitem>
-
-        <listitem>
-          <simpara><guimenuitem>SortAscending</guimenuitem> sort the selection 
-          in ascending order.</simpara>
-        </listitem>
-
-        <listitem>
-          <simpara><guimenuitem>SortDescending</guimenuitem> sort the selection 
-          in descending order.</simpara>
-        </listitem>
-
-        <listitem>
-          <simpara><guimenuitem>ExecFilterCommand</guimenuitem> replace the selection 
-          with the output of the specified filter command.</simpara>
-        </listitem>
-      </itemizedlist>
+      <para>Displays the text content of a <trademark
+      class="registered">Microsoft</trademark> <application>Word</application>
+      file, stripping away all formatting and embedded objects.</para>
 
       <para><segmentedlist>
           <segtitle>Category</segtitle>
+
+          <segtitle>File filter</segtitle>
+
+          <segtitle>Packing</segtitle>
+
           <segtitle>Settings dialog support</segtitle>
 
+          <segtitle>Dependency</segtitle>
+
           <seglistitem>
-            <seg>Editor complement</seg>
+            <seg>Unpacker</seg>
+
+	    <seg><filename class="extension">*.doc</filename>, <filename
+            class="extension">*.docx</filename>, <filename
+            class="extension">*.docm</filename>, <filename
+            class="extension">*.dot</filename>, <filename
+            class="extension">*.dotx</filename>, <filename
+            class="extension">*.dotm</filename></seg>
+
             <seg>No</seg>
+
+            <seg>Yes</seg>
+
+            <seg><trademark class="registered">Microsoft</trademark>
+            <application>Word</application></seg>
           </seglistitem>
         </segmentedlist></para>
     </section>
@@ -755,6 +706,55 @@
             <seg>No</seg>
 
             <seg><xref linkend="MSVBVM60" /></seg>
+          </seglistitem>
+        </segmentedlist></para>
+    </section>
+
+    <section id="EditorAddin">
+      <title><filename>editor addin.sct<indexterm>
+          <primary>editor addin.sct plugin file</primary>
+        </indexterm></filename></title>
+
+      <para>Adds five functions to the <menuchoice>
+          <guimenu>Plugins</guimenu>
+
+          <guisubmenu>Scripts</guisubmenu>
+        </menuchoice> menu:</para>
+
+      <itemizedlist>
+        <listitem>
+          <simpara><guimenuitem>MakeUpper</guimenuitem> convert the selection to
+          UPPER CASE.</simpara>
+        </listitem>
+
+        <listitem>
+          <simpara><guimenuitem>MakeLower</guimenuitem> convert the selection to
+          lower case.</simpara>
+        </listitem>
+
+        <listitem>
+          <simpara><guimenuitem>SortAscending</guimenuitem> sort the selection 
+          in ascending order.</simpara>
+        </listitem>
+
+        <listitem>
+          <simpara><guimenuitem>SortDescending</guimenuitem> sort the selection 
+          in descending order.</simpara>
+        </listitem>
+
+        <listitem>
+          <simpara><guimenuitem>ExecFilterCommand</guimenuitem> replace the selection 
+          with the output of the specified filter command.</simpara>
+        </listitem>
+      </itemizedlist>
+
+      <para><segmentedlist>
+          <segtitle>Category</segtitle>
+          <segtitle>Settings dialog support</segtitle>
+
+          <seglistitem>
+            <seg>Editor complement</seg>
+            <seg>No</seg>
           </seglistitem>
         </segmentedlist></para>
     </section>

--- a/Docs/Manual/EN/Shortcut_keys.xml
+++ b/Docs/Manual/EN/Shortcut_keys.xml
@@ -150,6 +150,12 @@
         </row>
 
         <row>
+          <entry><keycap>Ctrl</keycap>+<keycap>F5</keycap></entry>
+
+          <entry>Reload</entry>
+        </row>
+
+        <row>
           <entry><keycap>F6</keycap></entry>
 
           <entry>Change to next pane (active file)</entry>
@@ -295,6 +301,27 @@
             </keycombo></entry>
 
           <entry>Add synchronization point</entry>
+        </row>
+
+        <row>
+          <entry><keycombo>
+              <keycap>Ctrl</keycap>
+
+              <keycap>U</keycap>
+            </keycombo></entry>
+
+          <entry>Convert selected text to lower case</entry>
+        </row>
+
+        <row>
+          <entry><keycombo>
+              <keycap>Ctrl</keycap>
+              <keycap>Shift</keycap>
+
+              <keycap>U</keycap>
+            </keycombo></entry>
+
+          <entry>Convert selected text to upper case</entry>
         </row>
 
         <row>


### PR DESCRIPTION
- Spelling corrected
- "Getting and installing WinMerge" completed
- "Click Next in the Welcome screen." deleted
- "Create a Quick Launch shortcut" deleted
- Order of plugins adopted
- Shortcuts added

- I found the sentence "At any time, you can click **Defaults** to reload the installed color scheme." in "Options and configuration" -> "Colors page", "Syntax Colors page" and "Folder Compare Colors page".
But in the 3 sections of the options dialog there is no **Defaults** button.
Is there a reason for this?
