### PR TITLE
Fixed processing that uses GetAsyncKeyState().

### DIFF
--- a/Src/ImgMergeFrm.cpp
+++ b/Src/ImgMergeFrm.cpp
@@ -353,10 +353,10 @@ void CImgMergeFrame::OnChildPaneEvent(const IImgMergeWindow::Event& evt)
 		case VK_RIGHT:
 		case VK_UP:
 		case VK_DOWN:
-			if (GetAsyncKeyState(VK_SHIFT))
+			if (::GetAsyncKeyState(VK_SHIFT) & 0x8000)
 			{
 				int nActivePane = pFrame->m_pImgMergeWindow->GetActivePane();
-				int m = GetAsyncKeyState(VK_CONTROL) ? 8 : 1;
+				int m = (::GetAsyncKeyState(VK_CONTROL) & 0x8000) ? 8 : 1;
 				int dx = (-(evt.keycode == VK_LEFT) + (evt.keycode == VK_RIGHT)) * m;
 				int dy = (-(evt.keycode == VK_UP) + (evt.keycode == VK_DOWN)) * m;
 				pFrame->m_pImgMergeWindow->AddImageOffset(nActivePane, dx, dy);

--- a/Src/MainFrm.cpp
+++ b/Src/MainFrm.cpp
@@ -1370,7 +1370,7 @@ void CMainFrame::OnDropFiles(const std::vector<String>& dropped_files)
 
 	bool recurse = GetOptionsMgr()->GetBool(OPT_CMP_INCLUDE_SUBDIRS);
 	// Do a reverse comparison with the current 'Include Subfolders' settings when pressing Control key
-	if (!!::GetAsyncKeyState(VK_CONTROL))
+	if (::GetAsyncKeyState(VK_CONTROL) & 0x8000)
 		recurse = !recurse;
 
 	// If user has <Shift> pressed with one file selected,


### PR DESCRIPTION
In the function CMainFrame::OnDropFiles(), `!!::GetAsyncKeyState(VK_CONTROL)` is true not only when the control key is pressed, but also when the control key is not pressed but has been pressed since the last GetAsyncKeyState () was executed.

So, for example, the "Include subfolders" option is applied with the reverse settings when the following steps are performed, which does not seem to be the expected behavior.
Step 1. Open the directory containing the directory to be compared by WinMerge in Explorer.
Step 2. Press the control key once.
Step 3. Select a range of two directories to enter with the mouse. (The control key is not pressed at this time.)
Step 4. Drag and drop the selected directories to WinMerge. (The control key is not pressed at this time.)

Similarly, in the function CImgMergeFrame::OnChildPaneEvent(), when an arrow key is pressed after pressing the shift key or control key, it behaves as if the arrow key is pressed while pressing the shift key or control key.

This PR fixes these behaviors.