### PR TITLE
Fixed the problem that the language setting is not applied to the context menu of the MDI tab when the language setting is changed.

### DIFF
--- a/Src/Common/MDITabBar.cpp
+++ b/Src/Common/MDITabBar.cpp
@@ -154,12 +154,17 @@ void CMDITabBar::OnContextMenu(CWnd *pWnd, CPoint point)
 	if (!pPopup->GetMenuItemInfo(ID_CLOSE_OTHER_TABS, &mii, FALSE))
 	{
 		pPopup->AppendMenu(MF_SEPARATOR, 0, _T(""));
-		pPopup->AppendMenu(MF_STRING, ID_TABBAR_AUTO_MAXWIDTH, _("Enable &Auto Max Width").c_str());
+		pPopup->AppendMenu(MF_STRING, ID_TABBAR_AUTO_MAXWIDTH, _T(""));
 		pPopup->AppendMenu(MF_SEPARATOR, 0, _T(""));
-		pPopup->AppendMenu(MF_STRING, ID_CLOSE_OTHER_TABS, _("Close &Other Tabs").c_str());
-		pPopup->AppendMenu(MF_STRING, ID_CLOSE_RIGHT_TABS, _("Close R&ight Tabs").c_str());
-		pPopup->AppendMenu(MF_STRING, ID_CLOSE_LEFT_TABS, _("Close &Left Tabs").c_str());
+		pPopup->AppendMenu(MF_STRING, ID_CLOSE_OTHER_TABS, _T(""));
+		pPopup->AppendMenu(MF_STRING, ID_CLOSE_RIGHT_TABS, _T(""));
+		pPopup->AppendMenu(MF_STRING, ID_CLOSE_LEFT_TABS, _T(""));
 	}
+	pPopup->ModifyMenu(ID_TABBAR_AUTO_MAXWIDTH, MF_BYCOMMAND, ID_TABBAR_AUTO_MAXWIDTH, _("Enable &Auto Max Width").c_str());
+	pPopup->ModifyMenu(ID_CLOSE_OTHER_TABS, MF_BYCOMMAND, ID_CLOSE_OTHER_TABS, _("Close &Other Tabs").c_str());
+	pPopup->ModifyMenu(ID_CLOSE_RIGHT_TABS, MF_BYCOMMAND, ID_CLOSE_RIGHT_TABS, _("Close R&ight Tabs").c_str());
+	pPopup->ModifyMenu(ID_CLOSE_LEFT_TABS, MF_BYCOMMAND, ID_CLOSE_LEFT_TABS, _("Close &Left Tabs").c_str());
+
 	pPopup->CheckMenuItem(ID_TABBAR_AUTO_MAXWIDTH, m_bAutoMaxWidth ? MF_CHECKED : MF_UNCHECKED);
 	// invoke context menu
 	int command = pPopup->TrackPopupMenu(TPM_LEFTALIGN | TPM_RIGHTBUTTON | TPM_RETURNCMD, point.x, point.y,


### PR DESCRIPTION
In the current version of WinMerge, the language setting is not applied to the context menu of the MDI tab when the language setting is changed.
It is because the context menu strings of the MDI tab are set based on the language setting at that time only at the first display for each tab, and the set strings are used from the second time.
This PR Fixes to set the menu strings based on the language setting every time the context menu is displayed.