### PR TITLE
Fix Various Warnings

### DIFF
--- a/Externals/poco/XML/src/siphash.h
+++ b/Externals/poco/XML/src/siphash.h
@@ -240,25 +240,25 @@ sip24_final(struct siphash *H) {
   switch (left) {
   case 7:
     b |= (uint64_t)H->buf[6] << 48;
-    /* fall through */
+    [[fallthrough]];
   case 6:
     b |= (uint64_t)H->buf[5] << 40;
-    /* fall through */
+    [[fallthrough]];
   case 5:
     b |= (uint64_t)H->buf[4] << 32;
-    /* fall through */
+    [[fallthrough]];
   case 4:
     b |= (uint64_t)H->buf[3] << 24;
-    /* fall through */
+    [[fallthrough]];
   case 3:
     b |= (uint64_t)H->buf[2] << 16;
-    /* fall through */
+    [[fallthrough]];
   case 2:
     b |= (uint64_t)H->buf[1] << 8;
-    /* fall through */
+    [[fallthrough]];
   case 1:
     b |= (uint64_t)H->buf[0] << 0;
-    /* fall through */
+    [[fallthrough]];
   case 0:
     break;
   }

--- a/Externals/poco/XML/src/xmlparse.cpp
+++ b/Externals/poco/XML/src/xmlparse.cpp
@@ -6393,7 +6393,7 @@ static unsigned long FASTCALL
 hash(XML_Parser parser, KEY s) {
   struct siphash state;
   struct sipkey key;
-  (void)sip24_valid;
+  (void)sip24_valid();
   copy_salt_to_sipkey(parser, &key);
   sip24_init(&state, &key);
   sip24_update(&state, s, keylen(s) * sizeof(XML_Char));

--- a/Externals/poco/XML/src/xmlparse.cpp
+++ b/Externals/poco/XML/src/xmlparse.cpp
@@ -1738,7 +1738,7 @@ XML_Parse(XML_Parser parser, const char *s, int len, int isFinal) {
       parser->m_errorCode = XML_ERROR_NO_MEMORY;
       return XML_STATUS_ERROR;
     }
-    /* fall through */
+    [[fallthrough]];
   default:
     parser->m_parsingStatus.parsing = XML_PARSING;
   }
@@ -1781,7 +1781,7 @@ XML_Parse(XML_Parser parser, const char *s, int len, int isFinal) {
       case XML_INITIALIZED:
       case XML_PARSING:
         parser->m_parsingStatus.parsing = XML_FINISHED;
-        /* fall through */
+        [[fallthrough]];
       default:
         return XML_STATUS_OK;
       }
@@ -1824,7 +1824,7 @@ XML_Parse(XML_Parser parser, const char *s, int len, int isFinal) {
           parser->m_parsingStatus.parsing = XML_FINISHED;
           return XML_STATUS_OK;
         }
-      /* fall through */
+      [[fallthrough]];
       default:
         result = XML_STATUS_OK;
       }
@@ -1892,7 +1892,7 @@ XML_ParseBuffer(XML_Parser parser, int len, int isFinal) {
       parser->m_errorCode = XML_ERROR_NO_MEMORY;
       return XML_STATUS_ERROR;
     }
-    /* fall through */
+    [[fallthrough]];
   default:
     parser->m_parsingStatus.parsing = XML_PARSING;
   }
@@ -1922,7 +1922,9 @@ XML_ParseBuffer(XML_Parser parser, int len, int isFinal) {
         parser->m_parsingStatus.parsing = XML_FINISHED;
         return result;
       }
-    default:; /* should not happen */
+      [[fallthrough]];
+    default: /* should not happen */
+        break;
     }
   }
 
@@ -1947,7 +1949,8 @@ XML_GetBuffer(XML_Parser parser, int len) {
   case XML_FINISHED:
     parser->m_errorCode = XML_ERROR_FINISHED;
     return NULL;
-  default:;
+  default:
+    break;
   }
 
   if (len > EXPAT_SAFE_PTR_DIFF(parser->m_bufferLim, parser->m_bufferEnd)) {
@@ -2110,7 +2113,9 @@ XML_ResumeParser(XML_Parser parser) {
         parser->m_parsingStatus.parsing = XML_FINISHED;
         return result;
       }
-    default:;
+	  [[fallthrough]];
+    default:
+      break;
     }
   }
 
@@ -2706,7 +2711,6 @@ doContent(XML_Parser parser, int startTagLevel, const ENCODING *enc,
       break;
     }
     case XML_TOK_START_TAG_NO_ATTS:
-      /* fall through */
     case XML_TOK_START_TAG_WITH_ATTS: {
       TAG *tag;
       enum XML_Error result;
@@ -2774,7 +2778,6 @@ doContent(XML_Parser parser, int startTagLevel, const ENCODING *enc,
       break;
     }
     case XML_TOK_EMPTY_ELEMENT_NO_ATTS:
-      /* fall through */
     case XML_TOK_EMPTY_ELEMENT_WITH_ATTS: {
       const char *rawName = s + enc->minBytesPerChar;
       enum XML_Error result;
@@ -3010,7 +3013,8 @@ doContent(XML_Parser parser, int startTagLevel, const ENCODING *enc,
       return XML_ERROR_NONE;
     case XML_FINISHED:
       return XML_ERROR_ABORTED;
-    default:;
+    default:
+      break;
     }
   }
   /* not reached */
@@ -3587,7 +3591,7 @@ doCdataSection(XML_Parser parser, const ENCODING *enc, const char **startPtr,
   *startPtr = NULL;
 
   for (;;) {
-    const char *next;
+    const char *next = nullptr;
     int tok = XmlCdataSectionTok(enc, s, end, &next);
     *eventEndPP = next;
     switch (tok) {
@@ -3673,7 +3677,8 @@ doCdataSection(XML_Parser parser, const ENCODING *enc, const char **startPtr,
       return XML_ERROR_NONE;
     case XML_FINISHED:
       return XML_ERROR_ABORTED;
-    default:;
+    default:
+      break;
     }
   }
   /* not reached */
@@ -3705,7 +3710,7 @@ ignoreSectionProcessor(XML_Parser parser, const char *start, const char *end,
 static enum XML_Error
 doIgnoreSection(XML_Parser parser, const ENCODING *enc, const char **startPtr,
                 const char *end, const char **nextPtr, XML_Bool haveMore) {
-  const char *next;
+  const char *next = nullptr;
   int tok;
   const char *s = *startPtr;
   const char **eventPP;
@@ -4266,7 +4271,7 @@ doProlog(XML_Parser parser, const ENCODING *enc, const char *s, const char *end,
         handleDefault = XML_FALSE;
         goto alreadyChecked;
       }
-      /* fall through */
+      [[fallthrough]];
     case XML_ROLE_ENTITY_PUBLIC_ID:
       if (! XmlIsPublicId(enc, s, next, eventPP))
         return XML_ERROR_PUBLICID;
@@ -4569,8 +4574,8 @@ doProlog(XML_Parser parser, const ENCODING *enc, const char *s, const char *end,
           return XML_ERROR_NO_MEMORY;
         parser->m_declEntity->publicId = NULL;
       }
+      [[fallthrough]];
 #endif /* XML_DTD */
-      /* fall through */
     case XML_ROLE_ENTITY_SYSTEM_ID:
       if (dtd->keepProcessing && parser->m_declEntity) {
         parser->m_declEntity->systemId
@@ -5156,7 +5161,8 @@ epilogProcessor(XML_Parser parser, const char *s, const char *end,
       return XML_ERROR_NONE;
     case XML_FINISHED:
       return XML_ERROR_ABORTED;
-    default:;
+    default:
+      break;
     }
   }
 }
@@ -5306,7 +5312,7 @@ appendAttributeValue(XML_Parser parser, const ENCODING *enc, XML_Bool isCdata,
                      const char *ptr, const char *end, STRING_POOL *pool) {
   DTD *const dtd = parser->m_dtd; /* save one level of indirection */
   for (;;) {
-    const char *next;
+    const char *next = nullptr;
     int tok = XmlAttributeValueTok(enc, ptr, end, &next);
     switch (tok) {
     case XML_TOK_NONE:
@@ -5352,7 +5358,7 @@ appendAttributeValue(XML_Parser parser, const ENCODING *enc, XML_Bool isCdata,
       break;
     case XML_TOK_TRAILING_CR:
       next = ptr + enc->minBytesPerChar;
-      /* fall through */
+      [[fallthrough]];
     case XML_TOK_ATTRIBUTE_VALUE_S:
     case XML_TOK_DATA_NEWLINE:
       if (! isCdata && (poolLength(pool) == 0 || poolLastChar(pool) == 0x20))
@@ -5493,7 +5499,7 @@ storeEntityValue(XML_Parser parser, const ENCODING *enc,
   }
 
   for (;;) {
-    const char *next;
+    const char *next = nullptr;
     int tok = XmlEntityValueTok(enc, entityTextPtr, entityTextEnd, &next);
     switch (tok) {
     case XML_TOK_PARAM_ENTITY_REF:
@@ -5571,7 +5577,7 @@ storeEntityValue(XML_Parser parser, const ENCODING *enc,
       break;
     case XML_TOK_TRAILING_CR:
       next = entityTextPtr + enc->minBytesPerChar;
-      /* fall through */
+      [[fallthrough]];
     case XML_TOK_DATA_NEWLINE:
       if (pool->end == pool->ptr && ! poolGrow(pool)) {
         result = XML_ERROR_NO_MEMORY;

--- a/Externals/poco/XML/src/xmlparse.cpp
+++ b/Externals/poco/XML/src/xmlparse.cpp
@@ -632,7 +632,7 @@ XML_ParserCreate(const XML_Char *encodingName) {
 
 XML_Parser XMLCALL
 XML_ParserCreateNS(const XML_Char *encodingName, XML_Char nsSep) {
-  XML_Char tmp[2];
+    XML_Char tmp[2] = {};
   *tmp = nsSep;
   return XML_ParserCreate_MM(encodingName, NULL, tmp);
 }
@@ -1249,7 +1249,7 @@ XML_ExternalEntityParserCreate(XML_Parser oldParser, const XML_Char *context,
      would be otherwise.
   */
   if (parser->m_ns) {
-    XML_Char tmp[2];
+      XML_Char tmp[2] = {};
     *tmp = parser->m_namespaceSeparator;
     parser = parserCreate(encodingName, &parser->m_mem, tmp, newDtd);
   } else {
@@ -2362,7 +2362,7 @@ XML_ExpatVersion(void) {
 
 XML_Expat_Version XMLCALL
 XML_ExpatVersionInfo(void) {
-  XML_Expat_Version version;
+    XML_Expat_Version version = {};
 
   version.major = XML_MAJOR_VERSION;
   version.minor = XML_MINOR_VERSION;
@@ -2783,7 +2783,7 @@ doContent(XML_Parser parser, int startTagLevel, const ENCODING *enc,
       enum XML_Error result;
       BINDING *bindings = NULL;
       XML_Bool noElmHandlers = XML_TRUE;
-      TAG_NAME name;
+      TAG_NAME name = {};
       name.str = poolStoreString(&parser->m_tempPool, enc, rawName,
                                  rawName + XmlNameLength(enc, rawName));
       if (! name.str)
@@ -2886,7 +2886,7 @@ doContent(XML_Parser parser, int startTagLevel, const ENCODING *enc,
       if (n < 0)
         return XML_ERROR_BAD_CHAR_REF;
       if (parser->m_characterDataHandler) {
-        XML_Char buf[XML_ENCODE_MAX];
+          XML_Char buf[XML_ENCODE_MAX] = {};
         parser->m_characterDataHandler(parser->m_handlerArg, buf,
                                        XmlEncode(n, (ICHAR *)buf));
       } else if (parser->m_defaultHandler)
@@ -3898,7 +3898,7 @@ processXmlDecl(XML_Parser parser, int isGeneralTextEntity, const char *s,
 static enum XML_Error
 handleUnknownEncoding(XML_Parser parser, const XML_Char *encodingName) {
   if (parser->m_unknownEncodingHandler) {
-    XML_Encoding info;
+      XML_Encoding info = {};
     int i;
     for (i = 0; i < 256; i++)
       info.map[i] = -1;
@@ -5326,7 +5326,7 @@ appendAttributeValue(XML_Parser parser, const ENCODING *enc, XML_Bool isCdata,
         parser->m_eventPtr = ptr;
       return XML_ERROR_INVALID_TOKEN;
     case XML_TOK_CHAR_REF: {
-      XML_Char buf[XML_ENCODE_MAX];
+        XML_Char buf[XML_ENCODE_MAX] = {};
       int i;
       int n = XmlCharRefNumber(enc, ptr);
       if (n < 0) {
@@ -5586,7 +5586,7 @@ storeEntityValue(XML_Parser parser, const ENCODING *enc,
       *(pool->ptr)++ = 0xA;
       break;
     case XML_TOK_CHAR_REF: {
-      XML_Char buf[XML_ENCODE_MAX];
+        XML_Char buf[XML_ENCODE_MAX] = {};
       int i;
       int n = XmlCharRefNumber(enc, entityTextPtr);
       if (n < 0) {
@@ -5718,7 +5718,7 @@ static void
 reportDefault(XML_Parser parser, const ENCODING *enc, const char *s,
               const char *end) {
   if (MUST_CONVERT(enc, s)) {
-    enum XML_Convert_Result convert_res;
+      enum XML_Convert_Result convert_res = {};
     const char **eventPP;
     const char **eventEndPP;
     if (enc == parser->m_encoding) {

--- a/Src/Common/LanguageSelect.cpp
+++ b/Src/Common/LanguageSelect.cpp
@@ -512,7 +512,7 @@ static void unslash(std::wstring &s)
 {
 	wchar_t *p = &*s.begin();
 	wchar_t *q = p;
-	wchar_t c;
+	wchar_t c = {};
 	do
 	{
 		wchar_t *r = q + 1;

--- a/Src/Common/LanguageSelect.cpp
+++ b/Src/Common/LanguageSelect.cpp
@@ -551,7 +551,7 @@ static void unslash(std::wstring &s)
 			}
 			if (q >= r)
 				break;
-			// fall through
+			[[fallthrough]];
 		default:
 			*p = c;
 			q = r;

--- a/Src/DirView.cpp
+++ b/Src/DirView.cpp
@@ -1246,13 +1246,11 @@ void CDirView::OpenParentDirectory()
 		pDoc->m_pTempPathContext = pDoc->m_pTempPathContext->DeleteHead();
 		[[fallthrough]];
 	case AllowUpwardDirectory::ParentIsRegularPath: 
-	{
 		DWORD dwFlags[3];
 		for (int nIndex = 0; nIndex < pathsParent.GetSize(); ++nIndex)
 			dwFlags[nIndex] = FFILEOPEN_NOMRU | (pDoc->GetReadOnly(nIndex) ? FFILEOPEN_READONLY : 0);
 		GetMainFrame()->DoFileOpen(&pathsParent, dwFlags, nullptr, _T(""), GetDiffContext().m_bRecursive, (GetAsyncKeyState(VK_CONTROL) & 0x8000) ? nullptr : pDoc);
 		[[fallthrough]];
-	}
 	case AllowUpwardDirectory::No:
 		break;
 	default:
@@ -2808,7 +2806,7 @@ int CDirView::AddSpecialItems()
 	default:
 		AddParentFolderItem(bEnable);
 		retVal = 1;
-		// fall through
+		[[fallthrough]];
 	case AllowUpwardDirectory::Never:
 		break;
 	}

--- a/Src/EditorFilepathBar.cpp
+++ b/Src/EditorFilepathBar.cpp
@@ -83,10 +83,10 @@ void CEditorFilePathBar::Resize()
 	if (m_hWnd == nullptr)
 		return;
 
-	WINDOWPLACEMENT infoBar;
+	WINDOWPLACEMENT infoBar = {};
 	GetWindowPlacement(&infoBar);
 
-	int widths[3];
+	int widths[3] = {};
 	for (int pane = 0; pane < m_nPanes; pane++)
 		widths[pane] = (infoBar.rcNormalPosition.right / m_nPanes);
 	Resize(widths);

--- a/Src/MainFrm.cpp
+++ b/Src/MainFrm.cpp
@@ -2434,7 +2434,7 @@ void CMainFrame::OnUpdateCompareMethod(CCmdUI* pCmdUI)
 void CMainFrame::OnMRUs(UINT nID)
 {
 	std::vector<JumpList::Item> mrus = JumpList::GetRecentDocs(GetOptionsMgr()->GetInt(OPT_MRU_MAX));
-	const size_t idx = nID - ID_MRU_FIRST;
+	const size_t idx = static_cast<size_t>(nID) - ID_MRU_FIRST;
 	if (idx < mrus.size())
 	{
 		MergeCmdLineInfo cmdInfo((_T("\"") + mrus[idx].path + _T("\" ") + mrus[idx].params).c_str());

--- a/Src/MainFrm.cpp
+++ b/Src/MainFrm.cpp
@@ -1186,7 +1186,7 @@ void CMainFrame::ActivateFrame(int nCmdShow)
 
 	m_bFirstTime = false;
 
-	WINDOWPLACEMENT wp;
+	WINDOWPLACEMENT wp = {};
 	wp.length = sizeof(WINDOWPLACEMENT);
 	GetWindowPlacement(&wp);
 	wp.rcNormalPosition.left=theApp.GetProfileInt(_T("Settings"), _T("MainLeft"),0);
@@ -1244,7 +1244,7 @@ void CMainFrame::OnClose()
 	GetOptionsMgr()->SaveOption(OPT_FILEFILTER_CURRENT, filter);
 
 	// save main window position
-	WINDOWPLACEMENT wp;
+	WINDOWPLACEMENT wp = {};
 	wp.length = sizeof(WINDOWPLACEMENT);
 	GetWindowPlacement(&wp);
 	theApp.WriteProfileInt(_T("Settings"), _T("MainLeft"),wp.rcNormalPosition.left);

--- a/Src/Merge.cpp
+++ b/Src/Merge.cpp
@@ -457,7 +457,7 @@ int CMergeApp::ExitInstance()
 	ClearTempfolder(temp);
 
 	// Cleanup left over tempfiles from previous instances.
-	// Normally this should not neet to do anything - but if for some reason
+	// Normally this should not need to do anything - but if for some reason
 	// WinMerge did not delete temp files this makes sure they are removed.
 	CleanupWMtemp();
 

--- a/Src/MergeFrameCommon.cpp
+++ b/Src/MergeFrameCommon.cpp
@@ -64,7 +64,7 @@ void CMergeFrameCommon::SaveWindowState()
 	// If we are not, do nothing and let the active frame do the job.
  	if (GetParentFrame()->GetActiveFrame() == this)
 	{
-		WINDOWPLACEMENT wp;
+		WINDOWPLACEMENT wp = {};
 		wp.length = sizeof(WINDOWPLACEMENT);
 		GetWindowPlacement(&wp);
 		GetOptionsMgr()->SaveOption(OPT_ACTIVE_FRAME_MAX, (wp.showCmd == SW_MAXIMIZE));

--- a/Src/OpenFrm.cpp
+++ b/Src/OpenFrm.cpp
@@ -92,7 +92,7 @@ void COpenFrame::ActivateFrame(int nCmdShow)
 	CMergeFrameCommon::ActivateFrame(nCmdShow);
 	if (CView *const pView = GetActiveView())
 	{
-		WINDOWPLACEMENT wp;
+		WINDOWPLACEMENT wp = {};
 		wp.length = sizeof wp;
 		GetWindowPlacement(&wp);
 		CRect rc;

--- a/Src/OpenView.cpp
+++ b/Src/OpenView.cpp
@@ -444,7 +444,7 @@ void COpenView::OnWindowPosChanged(WINDOWPOS* lpwndpos)
 		if (pFrameWnd == GetTopLevelFrame()->GetActiveFrame())
 		{
 			m_constraint.Persist(true, false);
-			WINDOWPLACEMENT wp;
+			WINDOWPLACEMENT wp = {};
 			wp.length = sizeof wp;
 			pFrameWnd->GetWindowPlacement(&wp);
 			CRect rc;

--- a/Src/OpenView.cpp
+++ b/Src/OpenView.cpp
@@ -389,7 +389,7 @@ void COpenView::OnMouseMove(UINT nFlags, CPoint point)
 					SetCursor(m_hIconRotate);
 					break;
 				}
-				// fall through
+				[[fallthrough]];
 			default:
 				SetCursor(m_hCursorNo);
 				break;

--- a/Src/markdown.cpp
+++ b/Src/markdown.cpp
@@ -637,7 +637,7 @@ int CMarkdown::Token::IsSpecial(const char *p, const char *ahead)
 					++p;
 				} while (p < ahead && *p != c);
 			}
-			// fall through
+			[[fallthrough]];
 		case '/':
 		case '=':
 		case '<':
@@ -802,6 +802,7 @@ CMarkdown::FileImage::FileImage(const TCHAR *path, size_t trunc, unsigned flags)
 			pImage = pCopy;
 			if (pImage != nullptr)
 			{
+				[[fallthrough]];
 			case 2 + 0:
 			case 2 + 0 + 8:
 				// little endian
@@ -843,6 +844,7 @@ CMarkdown::FileImage::FileImage(const TCHAR *path, size_t trunc, unsigned flags)
 			pImage = pCopy;
 			if (pImage != nullptr)
 			{
+				[[fallthrough]];
 			case 4 + 0:
 			case 4 + 0 + 8:
 			case 4 + 3:


### PR DESCRIPTION
## C26819 warnings
### Fix various "C26819: Unannotated fallthrough between switch labels" warnings
* Continue the use of the **C++** `[fallthrough]` construct as used in the recent patch ([#93981af](https://github.com/WinMerge/winmerge/commit/93981af8002970f711126020711c57368cddd5d7), 01/01/2021) by <[sdottaka](sdottaka@users.sourceforge.net)>.

## LNT1006 warnings
### Fix various "LNT1006: Local Variable Not Initialized" warnings
### Fix various "LNT1006: Local Variable Not Initialized" warnings (2)

* Used "value list initialization" or "aggregate initialization" `= {}` on the various local variables flagged by the compiler.

## C4551 warning
### Fix "C4551: function call missing argument list" warning
* The parameter definition `()` was entirely missing from this function definition; I'm surprised that **C++**  ever parsed this correctly.


## LNT1000 warning
### Fix "LNT1000: A sub-expression may overflow before being assigned to a wider type" warning
* Expanded the sub-expression to a `size_t` before being used in the calculation.
* Also fix a trivial spelling error in an unrelated comment.
 