### PR TITLE
Update crystallineparser.cpp - AutoIt (*.au3) support as a "Basic"

### DIFF
--- a/Externals/crystaledit/editlib/parsers/crystallineparser.cpp
+++ b/Externals/crystaledit/editlib/parsers/crystallineparser.cpp
@@ -12,7 +12,7 @@ TextDefinition m_SourceDefs[38] =
 {
 	SRC_PLAIN, _T ("Plain"), _T ("txt,doc,diz"), &ParseLinePlain, SRCOPT_AUTOINDENT, /*4,*/ _T (""), _T (""), _T (""), (DWORD)-1,
 	SRC_ASP, _T ("ASP"), _T ("asp,ascx"), &ParseLineAsp, SRCOPT_AUTOINDENT|SRCOPT_BRACEANSI, /*2,*/ _T (""), _T (""), _T ("'"), (DWORD)-1,
-	SRC_BASIC, _T ("Basic"), _T ("bas,vb,vbs,frm,dsm,cls,ctl,pag,dsr"), &ParseLineBasic, SRCOPT_AUTOINDENT, /*4,*/ _T (""), _T (""), _T ("\'"), (DWORD)-1,
+	SRC_BASIC, _T ("Basic"), _T ("bas,vb,vbs,frm,dsm,cls,ctl,pag,dsr,au3"), &ParseLineBasic, SRCOPT_AUTOINDENT, /*4,*/ _T (""), _T (""), _T ("\'"), (DWORD)-1,
 	SRC_BATCH, _T ("Batch"), _T ("bat,btm,cmd"), &ParseLineBatch, SRCOPT_INSERTTABS|SRCOPT_AUTOINDENT, /*4,*/ _T (""), _T (""), _T ("rem "), (DWORD)-1,
 	SRC_C, _T ("C"), _T ("c,cc,cpp,cxx,h,hpp,hxx,hm,inl,rh,tlh,tli,xs"), &ParseLineC, SRCOPT_AUTOINDENT|SRCOPT_BRACEANSI, /*2,*/ _T ("/*"), _T ("*/"), _T ("//"), (DWORD)-1,
 	SRC_CSHARP, _T ("C#"), _T ("cs"), &ParseLineCSharp, SRCOPT_AUTOINDENT|SRCOPT_BRACEANSI, /*2,*/ _T ("/*"), _T ("*/"), _T ("//"), (DWORD)-1,


### PR DESCRIPTION
solution to:
https://github.com/WinMerge/winmerge/issues/446
as discussed here:
https://github.com/WinMerge/winmerge/discussions/542