### PR TITLE
Various fixes to testing

### DIFF
--- a/Src/Test.cpp
+++ b/Src/Test.cpp
@@ -470,10 +470,10 @@ TEST(ImageCompareTest, Open)
 TEST(FileMenu, New)
 {
 	CFrameWnd *pFrame;
-	GetMainFrame()->FileNew(2);
+	GetMainFrame()->FileNew(2, CMainFrame::FRAMETYPE::FRAME_FILE, false);
 	pFrame = GetMainFrame()->GetActiveFrame();
 	pFrame->PostMessage(WM_CLOSE);
-	GetMainFrame()->FileNew(3);
+	GetMainFrame()->FileNew(3, CMainFrame::FRAMETYPE::FRAME_FILE, false);
 	pFrame = GetMainFrame()->GetActiveFrame();
 	pFrame->PostMessage(WM_CLOSE);
 }

--- a/Testing/GoogleTest/GUITests/GUITestUtils.cpp
+++ b/Testing/GoogleTest/GUITests/GUITestUtils.cpp
@@ -172,7 +172,7 @@ std::filesystem::path getInstallerPath()
 		if (pos != std::wstring::npos)
 			return argstr.substr(pos + std::size("--installerpath=") - 1);
 	}
-	return "../../../Build/WinMerge-2.16.7.0-x64-PerUser-Setup.exe";
+	return "../../../Build/WinMerge-2.16.8-x64-PerUser-Setup.exe";
 }
 
 HWND execWinMerge(const std::string& args)
@@ -196,7 +196,13 @@ HWND execWinMerge(const std::string& args)
 HWND execInstaller(const std::string& args)
 {
 	HWND hwndInstaller = nullptr;
-	auto command = "start \"\" \"" + getInstallerPath().string() + "\" " + args;
+	std::filesystem::path sInstallerPath = getInstallerPath();
+
+	if (!exists(sInstallerPath)) {
+		printf("The file \"%s\" does not exist on this system.\n", sInstallerPath.string().c_str());
+		return hwndInstaller;
+	} 
+	auto command = "start \"\" \"" + sInstallerPath.string() + "\" " + args;
 	system(command.c_str());
 	Sleep(3000);
 	for (int i = 0; i < 50 && !hwndInstaller; ++i)

--- a/Testing/GoogleTest/GUITests/InstallerTest.cpp
+++ b/Testing/GoogleTest/GUITests/InstallerTest.cpp
@@ -56,6 +56,10 @@ public:
 
 TEST_P(InstallerTest, Pages)
 {
+	if (m_hwndWinMerge == nullptr) {
+		GTEST_FAIL();
+	}
+
 	saveImage("LicenseAgreement");
 	typeKey(VK_RETURN); Sleep(200);
 	saveImage("SelectComponents");


### PR DESCRIPTION
## ?? Bring FreeImage submodule into sync ??
* I have no idea why **Git** thinks this is necessary.  I'll have no complaint if this commit is rejected.

## Fix syntax errors with **`Test`** solution configuration
* Recent additions have been made to the parameters for the `GetMainFrame()->FileNew()` procedure, but not incorporated into the code for the **`Test`** configuration.

## Fix Failures with **GuiTests** `InstallerTest` module
* If the `...-x64-PerUser-Setup.exe` file is missing from the `Build/` folder tree, then **GuiTests** fails with
  a)  A message box (from deep within the `system()` function) suggesting a file name misspelling, plus
  b)  Seven `ASSERT` failures that have to be individually, manually Ignored.

* This patch allows **GuiTests** to detect the missing file itself and cause a proper **`GTEST_FAIL()`**
action.

* The filename for the required `...Setup.exe` file is upgraded from version `2.16.7.0` to `2.16.8` (the latest
publicly available setup file that I could find).