### PR TITLE
Expression is always true

### DIFF
--- a/Src/PatchHTML.cpp
+++ b/Src/PatchHTML.cpp
@@ -433,11 +433,8 @@ output_1_escapedhtml(const char *text, const char *limit)
 	{
 	  unsigned spaces = TAB_WIDTH - column % TAB_WIDTH;
 	  column += spaces;
-	  if (spaces > 0)
-	    {
-	      putc (' ', out);
-	      spaces--;
-	    }
+	  putc (' ', out);
+	  spaces--;    
 	  if (spaces == 0)
 	    break;
 	  do


### PR DESCRIPTION
#612 since spaces is unsigned it is never lower than 0, so this check is unnecessary and can be removed