### PR TITLE
Fix an issue where the syntax highlighting scheme is not applied to the split second File pane and the Diff pane when changing it.

### DIFF
--- a/Src/MergeEditView.cpp
+++ b/Src/MergeEditView.cpp
@@ -4323,17 +4323,18 @@ void CMergeEditView::OnChangeScheme(UINT nID)
 	CMergeDoc *pDoc = GetDocument();
 	ASSERT(pDoc != nullptr);
 
-	for (int nPane = 0; nPane < pDoc->m_nBuffers; nPane++) 
-	{
-		CMergeEditView *pView = GetGroupView(nPane);
-		ASSERT(pView != nullptr);
-
-		if (pView != nullptr)
+	for (int nGroup = 0; nGroup < pDoc->m_nGroups; nGroup++)
+		for (int nPane = 0; nPane < pDoc->m_nBuffers; nPane++) 
 		{
-			pView->SetTextType(CrystalLineParser::TextType(nID - ID_COLORSCHEME_FIRST));
-			pView->SetDisableBSAtSOL(false);
+			CMergeEditView *pView = pDoc->GetView(nGroup, nPane);
+			ASSERT(pView != nullptr);
+
+			if (pView != nullptr)
+			{
+				pView->SetTextType(CrystalLineParser::TextType(nID - ID_COLORSCHEME_FIRST));
+				pView->SetDisableBSAtSOL(false);
+			}
 		}
-	}
 
 	OnRefresh();
 }


### PR DESCRIPTION
Register the syntax highlighting scheme in the second split File pane and the Diff pane, when it is changed.