### PR TITLE
Fix an issue where custom colors are not saved.

### DIFF
--- a/Src/OptionsCustomColors.cpp
+++ b/Src/OptionsCustomColors.cpp
@@ -31,10 +31,7 @@ void Save(COptionsMgr *pOptionsMgr, const COLORREF * colors)
 	for (int i = 0; i < 16; i++)
 	{
 		String valuename = strutils::format(_T("%s/%d"), Section, i);
-		if (colors[i] == RGB(255, 255, 255))
-			pOptionsMgr->RemoveOption(valuename);
-		else 
-			pOptionsMgr->SaveOption(valuename, static_cast<int>(colors[i]));
+		pOptionsMgr->SaveOption(valuename, static_cast<int>(colors[i]));
 	}
 }
 


### PR DESCRIPTION
In the current version of WinMerge, custom color settings are not saved when the following steps are performed.

Step 1. 
Open the color dialog by pressing the color button on a sheet such as the "Color" > "Syntax" sheet in the options dialog.
Set white (=RGB(255,255,255)) to one of the custom colors and click the "OK" button.
At this time, the custom color setting that is set to white is deleted by the process of Options::CustomColors::Save().

Step 2.
Open the color dialog again.
Here, the custom color settings are loaded in Options::CustomColors::Load(),
but the custom color setting that was set to white in Step 1 has been deleted and is not loaded because it does not exist.
(In Debug build, an assert error occurs here.)

Step 3.
Assign any color to the custom color setting that was set to white in Step 1 and press the "OK" button.
Here, the custom color settings are saved in Options::CustomColors::Save(),
but the custom color setting that was set to white in Step 1 has been deleted and is not saved because it does not exist.

This PR fixes the above issue by saving the custom color without deleting it even if the color is white.