### PR TITLE
Add C# 6.0  reserved words to style list

### DIFF
--- a/Externals/crystaledit/editlib/parsers/csharp.cpp
+++ b/Externals/crystaledit/editlib/parsers/csharp.cpp
@@ -78,6 +78,7 @@ static const TCHAR * s_apszCppKeywordList[] =
     _T ("is"),
     _T ("lock"),
     _T ("long"),
+    _T ("nameof"),
     _T ("namespace"),
     _T ("new"),
     _T ("null"),
@@ -113,6 +114,8 @@ static const TCHAR * s_apszCppKeywordList[] =
     _T ("using"),
     _T ("virtual"),
     _T ("void"),
+    _T ("when"),
+    _T ("while"),
   };
 
 


### PR DESCRIPTION
`when` was include in C# 6.0 for catch and in C# 7.0 for switch/case.
https://docs.microsoft.com/pt-br/dotnet/csharp/language-reference/keywords/when