### PR TITLE
Fix PHP syntax highlighting.

### DIFF
--- a/Externals/crystaledit/editlib/parsers/php.cpp
+++ b/Externals/crystaledit/editlib/parsers/php.cpp
@@ -447,16 +447,10 @@ out:
                     {
                       DEFINE_BLOCK (nIdentBegin, COLORINDEX_FUNCNAME);
                     }
-                  else
-                    {
-                      goto next;
-                    }
                 }
               bRedefineBlock = true;
               bDecIndex = true;
               nIdentBegin = -1;
-next:
-              ;
             }
 
           //  Preprocessor start: $


### PR DESCRIPTION
Fix an issue where the string after the block whose color index is COLORINDEX_NORMALTEXT or COLORINDEX_USER1 is not highlighted correctly.
(The processing of the fixed part is now the same as CrystalLineParser::ParseLineCJava() with this fix.)

Current version：
![current](https://user-images.githubusercontent.com/56220423/115961195-45af1180-a550-11eb-825f-3b2fb3754ab0.png)

Fixed version:
![fixed](https://user-images.githubusercontent.com/56220423/115961203-5495c400-a550-11eb-8411-08900b023721.png)
