### PR TITLE
Fix an issue where a message is not translated.

### DIFF
--- a/Src/ImgMergeFrm.cpp
+++ b/Src/ImgMergeFrm.cpp
@@ -300,7 +300,7 @@ void CImgMergeFrame::DoAutoMerge(int dstPane)
 
 	AfxMessageBox(
 		strutils::format_string2(
-			_T("The number of automatically merged changes: %1\nThe number of unresolved conflicts: %2"), 
+			_("The number of automatically merged changes: %1\nThe number of unresolved conflicts: %2"), 
 			strutils::format(_T("%d"), autoMergedCount),
 			strutils::format(_T("%d"), m_pImgMergeWindow->GetConflictCount())).c_str(),
 		MB_ICONINFORMATION);

--- a/Src/MergeDoc.cpp
+++ b/Src/MergeDoc.cpp
@@ -1126,7 +1126,7 @@ void CMergeDoc::DoAutoMerge(int dstPane)
 
 	ShowMessageBox(
 		strutils::format_string2(
-			_T("The number of automatically merged changes: %1\nThe number of unresolved conflicts: %2"), 
+			_("The number of automatically merged changes: %1\nThe number of unresolved conflicts: %2"), 
 			strutils::format(_T("%d"), autoMergedCount),
 			strutils::format(_T("%d"), unresolvedConflictCount)),
 		MB_ICONINFORMATION);


### PR DESCRIPTION
Fix an issue where the message "The number of automatically merged changes: %1\nThe number of unresolved conflicts: %2" is not translated.