### PR TITLE
Fix PHP syntax highlighting.

### DIFF
--- a/Externals/crystaledit/editlib/parsers/html.cpp
+++ b/Externals/crystaledit/editlib/parsers/html.cpp
@@ -33,7 +33,10 @@ unsigned
 CrystalLineParser::ParseLineHtmlEx (unsigned dwCookie, const TCHAR *pszChars, int nLength, TEXTBLOCK * pBuf, int &nActualItems, int nEmbeddedLanguage)
 {
   if (nLength == 0)
-    return dwCookie & (COOKIE_EXT_COMMENT|COOKIE_EXT_USER1|COOKIE_ELEMENT|COOKIE_BLOCK_SCRIPT|COOKIE_BLOCK_STYLE|COOKIE_EXT_DEFINITION|COOKIE_EXT_VALUE);
+    {
+      unsigned dwCookieStrChar = ((nEmbeddedLanguage == SRC_PHP) && (dwCookie & COOKIE_EXT_USER1)) ? (dwCookie & (COOKIE_STRING | COOKIE_CHAR)) : 0;
+      return dwCookie & (COOKIE_EXT_COMMENT|COOKIE_EXT_USER1|COOKIE_ELEMENT|COOKIE_BLOCK_SCRIPT|COOKIE_BLOCK_STYLE|COOKIE_EXT_DEFINITION|COOKIE_EXT_VALUE|dwCookieStrChar);
+    }
 
   bool bRedefineBlock = true;
   if (!(dwCookie & COOKIE_ELEMENT))
@@ -349,7 +352,8 @@ next:
         }
     }
 
-  dwCookie &= (COOKIE_EXT_COMMENT | COOKIE_STRING | COOKIE_ELEMENT | COOKIE_EXT_USER1 | COOKIE_BLOCK_SCRIPT | COOKIE_BLOCK_STYLE | COOKIE_EXT_DEFINITION | COOKIE_EXT_VALUE);
+  unsigned dwCookieChar = ((nEmbeddedLanguage == SRC_PHP) && (dwCookie & COOKIE_EXT_USER1)) ? (dwCookie & COOKIE_CHAR) : 0;
+  dwCookie &= (COOKIE_EXT_COMMENT | COOKIE_STRING | COOKIE_ELEMENT | COOKIE_EXT_USER1 | COOKIE_BLOCK_SCRIPT | COOKIE_BLOCK_STYLE | COOKIE_EXT_DEFINITION | COOKIE_EXT_VALUE | dwCookieChar);
   return dwCookie;
 }
 

--- a/Externals/crystaledit/editlib/parsers/php.cpp
+++ b/Externals/crystaledit/editlib/parsers/php.cpp
@@ -254,7 +254,7 @@ unsigned
 CrystalLineParser::ParseLinePhpLanguage (unsigned dwCookie, const TCHAR *pszChars, int nLength, TEXTBLOCK * pBuf, int &nActualItems)
 {
   if (nLength == 0)
-    return dwCookie & (COOKIE_EXT_COMMENT);
+    return dwCookie & (COOKIE_EXT_COMMENT | COOKIE_STRING | COOKIE_CHAR);
 
   const TCHAR *pszCommentBegin = nullptr;
   const TCHAR *pszCommentEnd = nullptr;
@@ -514,6 +514,6 @@ out:
         }
     }
 
-  dwCookie &= (COOKIE_EXT_COMMENT | COOKIE_STRING);
+  dwCookie &= (COOKIE_EXT_COMMENT | COOKIE_STRING | COOKIE_CHAR);
   return dwCookie;
 }


### PR DESCRIPTION
Fix the following PHP syntax highlighting issues:
- The second and subsequent lines of the string enclosed in single quotes are not displayed in the string color.
- The lines after the blank line of the string enclosed in double quotes are not displayed in the string color.

Current version:
![current](https://user-images.githubusercontent.com/56220423/117453895-6f206200-af80-11eb-8696-626d0403b521.png)

Fixed version:
![fixed](https://user-images.githubusercontent.com/56220423/117453957-88291300-af80-11eb-931e-be3c68d8dfed.png)