### PR TITLE
Fix PHP syntax highlighting.

### DIFF
--- a/Externals/crystaledit/editlib/parsers/html.cpp
+++ b/Externals/crystaledit/editlib/parsers/html.cpp
@@ -150,6 +150,21 @@ out:
               nActualItems += nActualItemsEmbedded;
               if (!pszEnd)
                 dwCookie |= COOKIE_EXT_USER1;
+              else if ((nEmbeddedLanguage == SRC_PHP) && (dwCookie & (COOKIE_EXT_COMMENT | COOKIE_STRING | COOKIE_CHAR)))
+                {
+                  // A closing tag in a comment or string.
+                  if (dwCookie & COOKIE_EXT_COMMENT)
+                    {
+                      DEFINE_BLOCK(I, COLORINDEX_COMMENT);
+                    }
+                  else if (dwCookie & (COOKIE_STRING | COOKIE_CHAR))
+                    {
+                      DEFINE_BLOCK(I, COLORINDEX_STRING);
+                    }
+                  nextI += 2;    // Length of "?>"
+                  dwCookie |= COOKIE_EXT_USER1;
+                  bRedefineBlock = true;
+                }
               else
                 {
                   dwCookie = 0;


### PR DESCRIPTION
Fixed an issue where the text after the closing tag "?>" in a comment or string is not highlighted correctly.

Current version：
![current](https://user-images.githubusercontent.com/56220423/119227571-8e56ec00-bb49-11eb-9ff2-b28dbb0fb839.png)

Fixed version:
![fixed](https://user-images.githubusercontent.com/56220423/119227579-9878ea80-bb49-11eb-8b37-b00759d5620c.png)

