### PR TITLE
Fix an issue where a file is deselected when returning to the folder compare window after opening the file compare window by double-clicking the file in the folder compare window.

### DIFF
--- a/Src/DirView.cpp
+++ b/Src/DirView.cpp
@@ -491,7 +491,8 @@ void CDirView::OnLButtonDblClk(UINT nFlags, CPoint point)
 			OpenSelection();
 		}
 	}
-	CListView::OnLButtonDblClk(nFlags, point);
+	if (GetFocus() == this)
+		CListView::OnLButtonDblClk(nFlags, point);
 }
 
 /**


### PR DESCRIPTION
Sometimes a file is deselected when returning to the folder compare window after opening the file compare window by double-clicking the file in the folder compare window.

For example, it occurs by the following procedure.
Step 0. Set as follows.
  - The "Include subfolders" option is on.
  - The display of the message box "The selected files are identical." is enabled.

Step 1. Compare directories with the same three files.
Step 2. Adjust the window size to just fit the three files.
Step 3. Double-click on the third file. This open a file compare window with the message "The selected files are identical."
Step 4. Close the message box and select the folder compare window. At this time, the third file is deselected.
![diff](https://user-images.githubusercontent.com/56220423/124373108-95d1ef00-dcca-11eb-9a38-986b7d0e3b3b.png)

It is a bit inconvenient because we lose track of which file had been checked when checking the differences between the files in the folder one by one, if the file is deselected when we return to the folder compare window. 

Regarding this behavior, I suspect it is not good that CListView::OnLButtonDblClk() is executed while the focus is out of the folder compare window by opening the file compare window.

With this PR, CDirView::OnLButtonDblClk() now executes CListView::OnLButtonDblClk() only when it is in focus.