### PR TITLE
Fix the Select Files or Folders dialog.

### DIFF
--- a/Src/OpenView.cpp
+++ b/Src/OpenView.cpp
@@ -766,6 +766,7 @@ void COpenView::OnLoadProject()
 		m_strUnpackerPipeline = projItem.GetUnpacker();
 
 	UpdateData(FALSE);
+	UpdateButtonStates();
 	LangMessageBox(IDS_PROJFILE_LOAD_SUCCESS, MB_ICONINFORMATION);
 }
 


### PR DESCRIPTION
Fix an issue where the enabled state of "Folder: Filter" and "File: Unpacker Plugin" is not updated when loading a project with the "Load Project..." drop down button.