### PR TITLE
Fix the Select Files or Folders dialog.

### DIFF
--- a/Src/OpenView.cpp
+++ b/Src/OpenView.cpp
@@ -832,7 +832,7 @@ void COpenView::DropDown(NMHDR* pNMHDR, LRESULT* pResult, UINT nID, UINT nPopupI
 	CMenu* pPopup = menu.GetSubMenu(0);
 	if (pPopup != nullptr)
 	{
-		if (GetDlgItem(IDC_UNPACKER_COMBO)->IsWindowEnabled())
+		if (nID == IDOK && GetDlgItem(IDC_UNPACKER_COMBO)->IsWindowEnabled())
 		{
 			UpdateData(TRUE);
 			String tmpPath[3];


### PR DESCRIPTION
Fix an issue where plugin items are added to the "Save Project ..." drop down button when files (instead of directories) are specified in the "File or Folder" fields.