### PR TITLE
Loop counter should be the same type as the count type.

### DIFF
--- a/ShellExtension/ShellExtension/WinMergeShell.cpp
+++ b/ShellExtension/ShellExtension/WinMergeShell.cpp
@@ -185,7 +185,7 @@ HRESULT CWinMergeShell::Initialize(LPCITEMIDLIST pidlFolder,
 		hr = S_OK;
 
 		// Get all file names.
-		for (WORD x = 0 ; x < uNumFilesDropped; x++)
+		for (UINT x = 0 ; x < uNumFilesDropped; x++)
 		{
 			// Get the number of bytes required by the file's full pathname
 			UINT wPathnameSize = DragQueryFile(hDropInfo, x, NULL, 0);


### PR DESCRIPTION
It is unlikely that somebody selects more than 0xffff files but just in case, don't loop forever.