### PR TITLE
Fix an issue where filters are not applied correctly when opening a project file containing multiple items with different filters.

### DIFF
--- a/Src/DirDoc.cpp
+++ b/Src/DirDoc.cpp
@@ -253,7 +253,8 @@ void CDirDoc::InitDiffContext(CDiffContext *pCtxt)
 	// Make sure filters are up-to-date
 	auto* pGlobalFileFilter = theApp.GetGlobalFileFilter();
 	pGlobalFileFilter->ReloadUpdatedFilters();
-	pCtxt->m_piFilterGlobal = pGlobalFileFilter;
+	m_fileHelper.CloneFrom(pGlobalFileFilter);
+	pCtxt->m_piFilterGlobal = &m_fileHelper;
 	
 	// All plugin management is done by our plugin manager
 	pCtxt->m_piPluginInfos = GetOptionsMgr()->GetBool(OPT_PLUGINS_ENABLED) ? &m_pluginman : nullptr;

--- a/Src/DirDoc.h
+++ b/Src/DirDoc.h
@@ -145,6 +145,7 @@ private:
 	bool m_bMarkedRescan; /**< If `true` next rescan scans only marked items */
 	bool m_bGeneratingReport;
 	std::unique_ptr<DirCmpReport> m_pReport;
+	FileFilterHelper m_fileHelper; /**< File filter helper */
 };
 
 /**

--- a/Src/FileFilter.cpp
+++ b/Src/FileFilter.cpp
@@ -29,3 +29,36 @@ void FileFilter::EmptyFilterList(vector<FileFilterElementPtr> *filterList)
 {
 	filterList->clear();
 }
+
+/**
+ * @brief Clone file filter from another filter.
+ * This function clones file filter from another filter.
+ * Current contents in the filter are removed and new contents added from the given filter.
+ * @param [in] filter File filter to clone.
+ */
+void FileFilter::CloneFrom(const FileFilter* filter)
+{
+	if (!filter)
+		return;
+
+	default_include = filter->default_include;
+	name = filter->name;
+	description = filter->description;
+	fullpath = filter->fullpath;
+
+	filefilters.clear();
+	size_t count = filter->filefilters.size();
+	for (size_t i = 0; i < count; i++)
+	{
+		FileFilterElementPtr ptr(new FileFilterElement(filter->filefilters[i].get()));
+		filefilters.push_back(ptr);
+	}
+
+	dirfilters.clear();
+	count = filter->dirfilters.size();
+	for (size_t i = 0; i < count; i++)
+	{
+		FileFilterElementPtr ptr(new FileFilterElement(filter->dirfilters[i].get()));
+		dirfilters.push_back(ptr);
+	}
+}

--- a/Src/FileFilter.h
+++ b/Src/FileFilter.h
@@ -27,7 +27,12 @@
 struct FileFilterElement
 {
 	Poco::RegularExpression regexp; /**< Compiled regular expression */
-	FileFilterElement(const std::string &regex, int reOpts) : regexp(regex, reOpts)
+	std::string _regex; /**< Regular expression string to set to Poco::RegularExpression */
+	int _reOpts; /**< Options to set to Poco::RegularExpression */
+	FileFilterElement(const std::string& regex, int reOpts) : regexp(regex, reOpts), _regex(regex), _reOpts(reOpts)
+	{
+	}
+	FileFilterElement(const FileFilterElement* element) : regexp(element->_regex, element->_reOpts), _regex(element->_regex), _reOpts(element->_reOpts)
 	{
 	}
 };
@@ -55,6 +60,7 @@ struct FileFilter
 	~FileFilter();
 	
 	static void EmptyFilterList(std::vector<FileFilterElementPtr> *filterList);
+	void CloneFrom(const FileFilter* filter);
 };
 
 typedef std::shared_ptr<FileFilter> FileFilterPtr;

--- a/Src/FileFilterHelper.cpp
+++ b/Src/FileFilterHelper.cpp
@@ -445,3 +445,46 @@ String FileFilterHelper::GetUserFilterPathWithCreate() const
 	return paths::EnsurePathExist(m_sUserSelFilterPath);
 }
 
+/**
+ * @brief Clone file filter helper from another file filter helper.
+ * This function clones file filter helper from another file filter helper.
+ * Current contents in the file filter helper are removed and new contents added from the given file filter helper.
+ * @param [in] pHelper File filter helper to clone.
+ */
+void FileFilterHelper::CloneFrom(const FileFilterHelper* pHelper)
+{
+	if (!pHelper)
+		return;
+
+	if (pHelper->m_pMaskFilter)
+	{
+		std::unique_ptr<FilterList> filterList(new FilterList());
+		m_pMaskFilter = std::move(filterList);
+		m_pMaskFilter->CloneFrom(pHelper->m_pMaskFilter.get());
+	}
+
+	if (pHelper->m_fileFilterMgr)
+	{
+		std::unique_ptr<FileFilterMgr> fileFilterMgr(new FileFilterMgr());
+		m_fileFilterMgr = std::move(fileFilterMgr);
+		m_fileFilterMgr->CloneFrom(pHelper->m_fileFilterMgr.get());
+	}
+
+	m_currentFilter = nullptr;
+	if (pHelper->m_currentFilter && pHelper->m_fileFilterMgr)
+	{
+		int count = pHelper->m_fileFilterMgr->GetFilterCount();
+		for (int i = 0; i < count; i++)
+			if (pHelper->m_fileFilterMgr->GetFilterByIndex(i) == pHelper->m_currentFilter)
+			{
+				m_currentFilter = m_fileFilterMgr->GetFilterByIndex(i);
+				break;
+			}
+	}
+
+	m_sFileFilterPath = pHelper->m_sFileFilterPath;
+	m_sMask = pHelper->m_sMask;
+	m_bUseMask = pHelper->m_bUseMask;
+	m_sGlobalFilterPath = pHelper->m_sGlobalFilterPath;
+	m_sUserSelFilterPath = pHelper->m_sUserSelFilterPath;
+}

--- a/Src/FileFilterHelper.h
+++ b/Src/FileFilterHelper.h
@@ -131,6 +131,8 @@ public:
 	bool includeFile(const String& szFileName) const override;
 	bool includeDir(const String& szDirName) const override;
 
+	void CloneFrom(const FileFilterHelper* pHelper);
+
 protected:
 	String ParseExtensions(const String &extensions) const;
 

--- a/Src/FileFilterMgr.cpp
+++ b/Src/FileFilterMgr.cpp
@@ -251,6 +251,20 @@ FileFilter * FileFilterMgr::GetFilterByPath(const String& szFilterPath)
 }
 
 /**
+ * @brief Give client back a pointer to the actual filter.
+ *
+ * @param [in] i Index of filter.
+ * @return Pointer to filefilter in given index or `nullptr`.
+ */
+FileFilter * FileFilterMgr::GetFilterByIndex(int i)
+{
+	if (i < 0 || i >= m_filters.size())
+		return nullptr;
+
+	return m_filters[i].get();
+}
+
+/**
  * @brief Test given string against given regexp list.
  *
  * @param [in] filterList List of regexps to test against.
@@ -376,4 +390,26 @@ int FileFilterMgr::ReloadFilterFromDisk(const String& szFullPath)
 	else
 		errorcode = FILTER_NOTFOUND;
 	return errorcode;
+}
+
+/**
+ * @brief Clone file filter manager from another file filter Manager.
+ * This function clones file filter manager from another file filter manager.
+ * Current contents in the file filter manager are removed and new contents added from the given file filter manager.
+ * @param [in] fileFilterManager File filter manager to clone.
+ */
+void FileFilterMgr::CloneFrom(const FileFilterMgr* fileFilterMgr)
+{
+	if (!fileFilterMgr)
+		return;
+
+	m_filters.clear();
+
+	size_t count = fileFilterMgr->m_filters.size();
+	for (size_t i = 0; i < count; i++)
+	{
+		FileFilterPtr ptr(new FileFilter());
+		ptr->CloneFrom(fileFilterMgr->m_filters[i].get());
+		m_filters.push_back(ptr);
+	}
 }

--- a/Src/FileFilterMgr.h
+++ b/Src/FileFilterMgr.h
@@ -56,6 +56,7 @@ public:
 	String GetFilterDesc(int i) const;
 	String GetFilterDesc(const FileFilter *pFilter) const;
 	FileFilter * GetFilterByPath(const String& szFilterName);
+	FileFilter * GetFilterByIndex(int i);
 	String GetFullpath(FileFilter * pfilter) const;
 
 	// methods to actually use filter
@@ -63,6 +64,7 @@ public:
 	bool TestDirNameAgainstFilter(const FileFilter * pFilter, const String& szDirName) const;
 
 	void DeleteAllFilters();
+	void CloneFrom(const FileFilterMgr* fileFilterMgr);
 
 // Implementation methods
 protected:

--- a/Src/FilterList.cpp
+++ b/Src/FilterList.cpp
@@ -97,3 +97,26 @@ bool FilterList::Match(const std::string& string, int codepage/*=CP_UTF8*/)
 	return retval;
 }
 
+/**
+ * @brief Clone filter list from another list.
+ * This function clones filter list from another list. Current items in the
+ * list are removed and new items added from the given list.
+ * @param [in] filterList File list to clone.
+ */
+void FilterList::CloneFrom(const FilterList* filterList)
+{
+	if (!filterList)
+		return;
+
+	m_list.clear();
+
+	size_t count = filterList->m_list.size();
+	for (size_t i = 0; i < count; i++)
+	{
+		filter_item_ptr ptr(new filter_item(filterList->m_list[i].get()));
+		m_list.push_back(ptr);
+
+		if (&filterList->m_list[i]->filterAsString == filterList->m_lastMatchExpression)
+			m_lastMatchExpression = &m_list[i]->filterAsString;
+	}
+}

--- a/Src/FilterList.h
+++ b/Src/FilterList.h
@@ -20,7 +20,9 @@ struct filter_item
 {
 	std::string filterAsString; /** Original regular expression string */
 	Poco::RegularExpression regexp; /**< Compiled regular expression */
-	filter_item(const std::string &filter, int reOpts) : filterAsString(filter), regexp(filter, reOpts) {}
+	int _reOpts; /**< Options to set to Poco::RegularExpression */
+	filter_item(const std::string &filter, int reOpts) : filterAsString(filter), regexp(filter, reOpts), _reOpts(reOpts) {}
+	filter_item(const filter_item* item) : filterAsString(item->filterAsString), regexp(item->filterAsString, item->_reOpts), _reOpts(item->_reOpts) {}
 };
 
 typedef std::shared_ptr<filter_item> filter_item_ptr;
@@ -42,6 +44,7 @@ public:
 	bool HasRegExps() const;
 	bool Match(const std::string& string, int codepage = ucr::CP_UTF_8);
 	const char * GetLastMatchExpression() const;
+	void CloneFrom(const FilterList* filterList);
 
 private:
 	std::vector <filter_item_ptr> m_list;


### PR DESCRIPTION
In the current version, filters are not applied correctly when opening a project file that contains multiple items with different filters, such as the attachment below.
[filter.zip](https://github.com/WinMerge/winmerge/files/7272813/filter.zip)

Specifically, as shown in the image below, for the first project item, the filter is displayed in the status bar correctly, but the files displayed are ones filtered by the filter of the second project item.
![filter](https://user-images.githubusercontent.com/56220423/135742657-6b2cdfdd-6ab6-47f8-823a-3b2e69c2dd92.png)

The processing related to the filter when opening the project is as follows.
Step 1. Set the filter described in the project file to the global file filter. (CMergeApp::LoadAndOpenProjectFile(), in the main thread)
Step 2. Stores a pointer to a global file filter in the diff context of the CDirDoc class. (CDirDoc::InitDiffContext(), in the main thread)
Step 3. Generate an item collection thread (DiffThreadCollect()) and a folder compare thread (DiffThreadCompare()), pass the diff Context and start them. (CDirDoc::Rescan(), in the main thread)
Step 4. List directories and files using the passed diff context. (in the item collection thread and the folder compare thread)

In the process of opening the attached project file, before the item collection thread and the folder compare thread use the file filter in the diff context in Step 4 for the first project item, the main thread has already completed Step 1 for the second project file. As a result, the file filter in the diff context has been changed to the filter of the second project item.

For this reason, I modified the process to duplicate the global file filter and set it in the file filter of the diff context of the CDirDoc class, instead of using the pointer to the global file filter as is.
(I just wanted to duplicate the global file filter, but the fix was a bit big.)