### PR TITLE
Add the feature to display tooltips on the MDI tab.

### DIFF
--- a/Src/Common/MDITabBar.h
+++ b/Src/Common/MDITabBar.h
@@ -24,9 +24,11 @@ private:
 	bool  m_bAutoMaxWidth;
 	int   m_nDraggingTabItemIndex;
 	CFont m_font;
+	CToolTipCtrl m_tooltips;		/**< Tooltip for the tab */
+	int   m_nTooltipTabItemIndex;	/**< Index of the tab displaying tooltip */
 
 public:
-	CMDITabBar() : m_bInSelchange(false), m_pMainFrame(nullptr), m_bMouseTracking(false), m_bCloseButtonDown(false), m_bAutoMaxWidth(true), m_nDraggingTabItemIndex(-1) {}
+	CMDITabBar() : m_bInSelchange(false), m_pMainFrame(nullptr), m_bMouseTracking(false), m_bCloseButtonDown(false), m_bAutoMaxWidth(true), m_nDraggingTabItemIndex(-1), m_nTooltipTabItemIndex(-1){}
 	virtual ~CMDITabBar() {}
 	BOOL Create(CMDIFrameWnd* pParentWnd);
 	void UpdateTabs();
@@ -56,6 +58,8 @@ public:
 	{ ASSERT(::IsWindow(m_hWnd)); return (BOOL)::SendMessage(m_hWnd, TCM_GETITEMRECT, (WPARAM)nItem, (LPARAM)lpRect); }
 
 protected:
+	virtual BOOL PreTranslateMessage(MSG* pMsg);
+
 	//{{AFX_MSG(CMDITabBar)
 	afx_msg void OnPaint();
 	afx_msg BOOL OnEraseBkgnd(CDC *pDC);
@@ -74,4 +78,6 @@ private:
 	CRect GetCloseButtonRect(int nItem) const;
 	int GetItemIndexFromPoint(CPoint pt) const;
 	void SwapTabs(int nIndexA, int nIndexB);
+	int GetMaxTitleLength() const;
+	void UpdateToolTips(int index);
 };


### PR DESCRIPTION
Show tooltips when the title is too long to display the entire title.
![tooltips](https://user-images.githubusercontent.com/56220423/140026845-2a0afda0-c1fd-43ce-8242-66190011a46c.png)
