### PR TITLE
Fixed C#(Java, JavaScript) keyword highlighting.

### DIFF
--- a/Externals/crystaledit/editlib/parsers/cplusplus.cpp
+++ b/Externals/crystaledit/editlib/parsers/cplusplus.cpp
@@ -461,7 +461,7 @@ out:
 
   if (nIdentBegin >= 0)
     {
-      if (IsCppKeyword (pszChars + nIdentBegin, I - nIdentBegin))
+      if (IsKeyword (pszChars + nIdentBegin, I - nIdentBegin))
         {
           DEFINE_BLOCK (nIdentBegin, COLORINDEX_KEYWORD);
         }


### PR DESCRIPTION
Fixed "IsCppKeyword" used in the function "CrystalLineParser :: ParseLineCJava" to "IsKeyword".