### PR TITLE
Fix PHP syntax highlighting.

### DIFF
--- a/Externals/crystaledit/editlib/parsers/html.cpp
+++ b/Externals/crystaledit/editlib/parsers/html.cpp
@@ -151,7 +151,10 @@ out:
                   AdjustCharPosInTextBlocks(pBuf, nActualItems, nActualItems + nActualItemsEmbedded - 1, I);
                   nActualItems += nActualItemsEmbedded;
                   if (!pszEnd)
-                    dwCookie |= COOKIE_EXT_USER1;
+                    {
+                      dwCookie |= COOKIE_EXT_USER1;
+                      nextI += 1;
+                    }
                   else if ((nEmbeddedLanguage == SRC_PHP) && (dwCookie & (COOKIE_EXT_COMMENT | COOKIE_STRING | COOKIE_CHAR)))
                     {
                       // A closing tag in a comment or string.
@@ -169,6 +172,8 @@ out:
                     }
                   else
                     {
+                      if (I > 0)
+                        nextI += 1;
                       dwCookie = 0;
                       bRedefineBlock = true;
                     }

--- a/Externals/crystaledit/editlib/parsers/php.cpp
+++ b/Externals/crystaledit/editlib/parsers/php.cpp
@@ -476,6 +476,10 @@ out:
 
   if (nIdentBegin >= 0)
     {
+      if (dwCookie & COOKIE_USER2)
+        {
+          DEFINE_BLOCK(nIdentBegin, COLORINDEX_USER1);
+        }
       if (IsPhpKeyword (pszChars + nIdentBegin, I - nIdentBegin))
         {
           DEFINE_BLOCK (nIdentBegin, COLORINDEX_KEYWORD);


### PR DESCRIPTION
Fix an issue where text is not highlighted correctly if there is no space or symbol between a single line comment or variable and the end tag "?>".

Current version:
![curent](https://user-images.githubusercontent.com/56220423/143051286-eb1b0ab0-8028-4d81-9917-11dd5e6a6ca9.png)

Fixed version:
![fixed](https://user-images.githubusercontent.com/56220423/143051313-1066646a-2b03-420c-8028-53731b6bc258.png)
