### PR TITLE
FolderCompare: Improve performance when tree mode is disabled

### DIFF
--- a/Src/DirView.cpp
+++ b/Src/DirView.cpp
@@ -4423,19 +4423,19 @@ void CDirView::ReflectGetdispinfo(NMLVDISPINFO *pParam)
 	if (pParam->item.mask & LVIF_IMAGE)
 	{
 		pParam->item.iImage = GetColImage(di);
-	}
-	if (pParam->item.mask & LVIF_INDENT)
-	{
-		pParam->item.iIndent = m_listViewItems[nIdx].iIndent;
-	}
-	if ((pParam->item.mask & LVIF_STATE) || (pParam->item.mask & LVIF_IMAGE) /* for WinXP*/)
-	{
 		if ((pParam->item.mask & LVIF_STATE) == 0)
 		{
 			// for WinXP
 			pParam->item.mask |= LVIF_STATE;
 			pParam->item.state = m_pList->GetItemState(nIdx, static_cast<UINT>(~LVIS_STATEIMAGEMASK));
 		}
+	}
+	if (pParam->item.mask & LVIF_INDENT)
+	{
+		pParam->item.iIndent = m_listViewItems[nIdx].iIndent;
+	}
+	if (pParam->item.mask & LVIF_STATE)
+	{
 		pParam->item.stateMask |= LVIS_STATEIMAGEMASK;
 		if (di.HasChildren())
 			pParam->item.state |= INDEXTOSTATEIMAGEMASK((di.customFlags & ViewCustomFlags::EXPANDED) ? 2 : 1);

--- a/Src/DirView.cpp
+++ b/Src/DirView.cpp
@@ -4423,15 +4423,19 @@ void CDirView::ReflectGetdispinfo(NMLVDISPINFO *pParam)
 	if (pParam->item.mask & LVIF_IMAGE)
 	{
 		pParam->item.iImage = GetColImage(di);
-		pParam->item.mask |= LVIF_STATE; // for WinXP
 	}
 	if (pParam->item.mask & LVIF_INDENT)
 	{
 		pParam->item.iIndent = m_listViewItems[nIdx].iIndent;
 	}
-	if (pParam->item.mask & LVIF_STATE)
+	if ((pParam->item.mask & LVIF_STATE) || (pParam->item.mask & LVIF_IMAGE) /* for WinXP*/)
 	{
-		pParam->item.state &= ~LVIS_STATEIMAGEMASK;
+		if ((pParam->item.mask & LVIF_STATE) == 0)
+		{
+			// for WinXP
+			pParam->item.mask |= LVIF_STATE;
+			pParam->item.state = m_pList->GetItemState(nIdx, static_cast<UINT>(~LVIS_STATEIMAGEMASK));
+		}
 		pParam->item.stateMask |= LVIS_STATEIMAGEMASK;
 		if (di.HasChildren())
 			pParam->item.state |= INDEXTOSTATEIMAGEMASK((di.customFlags & ViewCustomFlags::EXPANDED) ? 2 : 1);

--- a/Src/DirView.cpp
+++ b/Src/DirView.cpp
@@ -1696,7 +1696,8 @@ void CDirView::OnUpdateCtxtDirCopyBoth2(CCmdUI* pCmdUI)
  */
 DIFFITEM *CDirView::GetItemKey(int idx) const
 {
-	return (DIFFITEM*)m_listViewItems[idx].lParam;
+	ASSERT(idx >= 0 && idx < static_cast<int>(m_listViewItems.size()));
+	return reinterpret_cast<DIFFITEM*>(m_listViewItems[idx].lParam);
 }
 
 // SetItemKey & GetItemKey encapsulate how the display list items

--- a/Src/DirView.cpp
+++ b/Src/DirView.cpp
@@ -4415,14 +4415,6 @@ void CDirView::ReflectGetdispinfo(NMLVDISPINFO *pParam)
 		return;
 	const CDiffContext &ctxt = GetDiffContext();
 	const DIFFITEM &di = ctxt.GetDiffAt(key);
-	if (pParam->item.mask & LVIF_STATE)
-	{
-		pParam->item.stateMask = LVIS_STATEIMAGEMASK;
-		if (di.HasChildren())
-			pParam->item.state = INDEXTOSTATEIMAGEMASK((di.customFlags & ViewCustomFlags::EXPANDED) ? 2 : 1);
-		else
-			pParam->item.state = 0;
-	}
 	if (pParam->item.mask & LVIF_TEXT)
 	{
 		String s = m_pColItems->ColGetTextToDisplay(&ctxt, i, di);
@@ -4431,10 +4423,18 @@ void CDirView::ReflectGetdispinfo(NMLVDISPINFO *pParam)
 	if (pParam->item.mask & LVIF_IMAGE)
 	{
 		pParam->item.iImage = GetColImage(di);
+		pParam->item.mask |= LVIF_STATE; // for WinXP
 	}
 	if (pParam->item.mask & LVIF_INDENT)
 	{
 		pParam->item.iIndent = m_listViewItems[nIdx].iIndent;
+	}
+	if (pParam->item.mask & LVIF_STATE)
+	{
+		pParam->item.state &= ~LVIS_STATEIMAGEMASK;
+		pParam->item.stateMask |= LVIS_STATEIMAGEMASK;
+		if (di.HasChildren())
+			pParam->item.state |= INDEXTOSTATEIMAGEMASK((di.customFlags & ViewCustomFlags::EXPANDED) ? 2 : 1);
 	}
 }
 

--- a/Src/DirView.h
+++ b/Src/DirView.h
@@ -20,6 +20,7 @@
 #include "UnicodeString.h"
 #include "DirItemIterator.h"
 #include "DirActions.h"
+#include "IListCtrlImpl.h"
 
 class FileActionScript;
 
@@ -162,7 +163,7 @@ public:
 private:
 	void InitiateSort();
 	void NameColumn(const DirColInfo *col, int subitem);
-	int AddNewItem(int i, DIFFITEM *diffpos, int iImage, int iIndent);
+	void AddNewItem(int i, DIFFITEM *diffpos, int iImage, int iIndent);
 // End DirViewCols.cpp
 
 private:
@@ -208,6 +209,7 @@ protected:
 	bool m_bUserCancelEdit; /**< `true` if the user cancels rename */
 	String m_lastCopyFolder; /**< Last Copy To -target folder. */
 
+	std::vector<ListViewOwnerDataItem> m_listViewItems;
 	std::optional<int> m_firstDiffItem;
 	std::optional<int> m_lastDiffItem;
 	DIRCOLORSETTINGS m_cachedColors; /**< Cached color settings */
@@ -382,6 +384,7 @@ protected:
 	afx_msg void OnItemChanged(NMHDR* pNMHDR, LRESULT* pResult);
 	afx_msg void OnBeginLabelEdit(NMHDR* pNMHDR, LRESULT* pResult);
 	afx_msg void OnEndLabelEdit(NMHDR* pNMHDR, LRESULT* pResult);
+	afx_msg void OnODFindItem(NMHDR* pNMHDR, LRESULT* pResult);
 	afx_msg void OnCustomDraw(NMHDR* pNMHDR, LRESULT* pResult);
 	afx_msg void OnSearch();
 	afx_msg void OnBeginDrag(NMHDR* pNMHDR, LRESULT* pResult);

--- a/Src/IListCtrlImpl.h
+++ b/Src/IListCtrlImpl.h
@@ -89,11 +89,11 @@ public:
 
 	int GetNextItem(int sel, bool selected = false, bool reverse = false) const override
 	{
-		//return ListView_GetNextItem(m_hwndListCtrl, sel, (selected ? LVNI_SELECTED : 0) | (reverse ? LVNI_ABOVE : 0));		
 		if (!reverse)
 			return ListView_GetNextItem(m_hwndListCtrl, sel, (selected ? LVNI_SELECTED : 0));		
 		if (!selected)
 			return ListView_GetNextItem(m_hwndListCtrl, sel, LVNI_ABOVE);
+		// It seems that when LVS_OWNERDATA is enabled and LVNI_SELECTED | LVNI_ABOVE is passed to ListView_GetNextItem(), the expected result is not obtained.
 		for (int i = sel - 1; i >= 0; --i)
 		{
 			if (ListView_GetItemState(m_hwndListCtrl, i, LVIS_SELECTED))


### PR DESCRIPTION
This PR uses Virtual ListView(LVS_OWNERDATA) to add a large number of files to the ListView in the folder comparison window without slowing it down too much.

## Before merging PR
![image](https://user-images.githubusercontent.com/98126/144732589-56fea500-b885-4490-a4c5-8ba23cdc5d4c.png)
## After merging PR
![image](https://user-images.githubusercontent.com/98126/144732638-509644b3-bce0-489e-bc42-91a129ad0dfe.png)
