### PR TITLE
Fix an issue where WinMerge sometimes crashes when executing "Refresh Selected" in the folder compare window.

### DIFF
--- a/Src/DiffThread.cpp
+++ b/Src/DiffThread.cpp
@@ -73,7 +73,7 @@ bool CDiffThread::ShouldAbort() const
  */
 unsigned CDiffThread::CompareDirectories()
 {
-	assert(m_pDiffParm->nThreadState != THREAD_COMPARING);
+	assert(m_pDiffParm->nThreadState != THREAD_COMPARING && m_pDiffParm->nCollectThreadState != THREAD_COMPARING);
 
 	m_pDiffParm->context = m_pDiffContext;
 	m_pDiffParm->m_pAbortgate = m_pAbortgate.get();
@@ -81,6 +81,7 @@ unsigned CDiffThread::CompareDirectories()
 	m_bPaused = false;
 
 	m_pDiffParm->nThreadState = THREAD_COMPARING;
+	m_pDiffParm->nCollectThreadState = THREAD_COMPARING;
 
 	delete m_pDiffParm->pSemaphore;
 	m_pDiffParm->pSemaphore = new Semaphore(0, LONG_MAX);
@@ -115,6 +116,7 @@ static void DiffThreadCollect(void *pParam)
 	myStruct->pSemaphore->set();
 
 	// Send message to UI to update
+	myStruct->nCollectThreadState = CDiffThread::THREAD_COMPLETED;
 	int event = CDiffThread::EVENT_COLLECT_COMPLETED;
 	myStruct->m_listeners.notify(myStruct, event);
 };

--- a/Src/DiffThread.h
+++ b/Src/DiffThread.h
@@ -30,16 +30,20 @@ struct DiffFuncStruct
 	CDiffContext * context; /**< Compare context. */
 	Poco::BasicEvent<int> m_listeners; /**< Event listeners */
 	int nThreadState; /**< Thread state. */
+	int nCollectThreadState; /**< Collect thread state. */
 	DiffThreadAbortable * m_pAbortgate; /**< Interface for aborting compare. */
 	Poco::Semaphore *pSemaphore; /**< Semaphore for synchronizing threads. */
 	std::function<void (DiffFuncStruct*)> m_fncCollect;
 	std::function<void (DiffFuncStruct*)> m_fncCompare;
+	bool bMarkedRescan;	/**< Is the rescan due to "Refresh Selected"? */
 
 	DiffFuncStruct()
 		: context(nullptr)
 		, nThreadState(0/*CDiffThread::THREAD_NOTSTARTED*/)
+		, nCollectThreadState(0/*CDiffThread::THREAD_NOTSTARTED*/)
 		, m_pAbortgate(nullptr)
 		, pSemaphore(nullptr)
+		, bMarkedRescan(false)
 		{}
 };
 
@@ -83,9 +87,12 @@ public:
 	}
 	void SetCollectFunction(std::function<void(DiffFuncStruct*)> func) { m_pDiffParm->m_fncCollect = func; }
 	void SetCompareFunction(std::function<void(DiffFuncStruct*)> func) { m_pDiffParm->m_fncCompare = func; }
+	void SetMarkedRescan(bool bMarkedRescan);
+	bool IsMarkedRescan() const;
 
 // runtime interface for main thread, called on main thread
 	unsigned GetThreadState() const;
+	unsigned GetCollectThreadState() const;
 	void Abort() { m_bAborting = true; }
 	bool IsAborting() const { return m_bAborting; }
 	void Pause() { m_bPaused = true; }
@@ -119,4 +126,29 @@ inline void CDiffThread::SetContext(CDiffContext * pCtx)
 inline unsigned CDiffThread::GetThreadState() const
 {
 	return m_pDiffParm->nThreadState;
+}
+
+/**
+ * @brief Returns collect thread's current state
+ */
+inline unsigned CDiffThread::GetCollectThreadState() const
+{
+	return m_pDiffParm->nCollectThreadState;
+}
+
+/**
+ * @brief Sets whether the rescan is due to "Refresh Selected"
+ * @param [in] bMarkedRescan Is the rescan due to "Refresh Selected"?
+ */
+inline void CDiffThread::SetMarkedRescan(bool bMarkedRescan)
+{
+	m_pDiffParm->bMarkedRescan = bMarkedRescan;
+}
+
+/**
+ * @brief Returns whether the rescan is due to "Refresh Selected"
+ */
+inline bool CDiffThread::IsMarkedRescan() const
+{
+	return m_pDiffParm->bMarkedRescan;
 }

--- a/Src/DirDoc.cpp
+++ b/Src/DirDoc.cpp
@@ -352,15 +352,18 @@ void CDirDoc::Rescan()
 			SetGeneratingReport(false);
 			SetReport(nullptr);
 		});
+		m_diffThread.SetMarkedRescan(false);
 	}
 	else if (m_bMarkedRescan)
 	{
-		m_diffThread.SetCollectFunction(nullptr);
-		m_diffThread.SetCompareFunction([](DiffFuncStruct* myStruct) {
+		m_diffThread.SetCollectFunction([](DiffFuncStruct* myStruct) {
 			int nItems = DirScan_UpdateMarkedItems(myStruct, nullptr);
 			myStruct->context->m_pCompareStats->IncreaseTotalItems(nItems);
+			});
+		m_diffThread.SetCompareFunction([](DiffFuncStruct* myStruct) {
 			DirScan_CompareRequestedItems(myStruct, nullptr);
-		});
+			});
+		m_diffThread.SetMarkedRescan(true);
 	}
 	else
 	{
@@ -376,6 +379,7 @@ void CDirDoc::Rescan()
 		m_diffThread.SetCompareFunction([](DiffFuncStruct* myStruct) {
 			DirScan_CompareItems(myStruct, nullptr);
 		});
+		m_diffThread.SetMarkedRescan(false);
 	}
 	m_diffThread.CompareDirectories();
 	m_bMarkedRescan = false;

--- a/Src/DirScan.cpp
+++ b/Src/DirScan.cpp
@@ -609,6 +609,12 @@ static int CompareRequestedItems(DiffFuncStruct *myStruct, DIFFITEM *parentdiffp
 	bool bCompareFailure = false;
 	if (parentdiffpos == nullptr)
 		myStruct->pSemaphore->wait();
+
+	// Since the collect thread deletes the DiffItems in the rescan by "Refresh selected",
+	// the compare thread process should not be executed until the collect thread process is completed 
+	// to avoid accessing  the deleted DiffItems.
+	assert(myStruct->nCollectThreadState == CDiffThread::THREAD_COMPLETED);
+
 	DIFFITEM *pos = pCtxt->GetFirstChildDiffPosition(parentdiffpos);
 	while (pos != nullptr)
 	{
@@ -929,7 +935,7 @@ static DIFFITEM *AddToList(const String& sDir1, const String& sDir2, const Strin
 	else
 		di->diffcode.diffcode = code | DIFFCODE::THREEWAY;
 
-	if (myStruct->m_fncCollect)
+	if (!myStruct->bMarkedRescan && myStruct->m_fncCollect)
 	{
 		myStruct->context->m_pCompareStats->IncreaseTotalItems();
 		myStruct->pSemaphore->set();

--- a/Src/DirView.cpp
+++ b/Src/DirView.cpp
@@ -2499,6 +2499,15 @@ LRESULT CDirView::OnUpdateUIMessage(WPARAM wParam, LPARAM lParam)
 	CDirDoc * pDoc = GetDocument();
 	ASSERT(pDoc != nullptr);
 
+	// Since the Collect thread deletes the DiffItems in the rescan by "Update selection",
+	// the UI update process should not be executed until the Collect thread process is completed 
+	// to avoid accessing the deleted DiffItem.
+	if (pDoc->m_diffThread.IsMarkedRescan() && pDoc->m_diffThread.GetCollectThreadState() != CDiffThread::THREAD_COMPLETED)
+	{
+		ASSERT(0);
+		return 0;	// return value unused
+	}
+
 	if (wParam == CDiffThread::EVENT_COMPARE_COMPLETED)
 	{
 		if (pDoc->GetDiffContext().m_pPropertySystem && pDoc->GetDiffContext().m_pPropertySystem->HasHashProperties())


### PR DESCRIPTION
In the current version, WinMerge sometimes crashes when executing "Refresh Selected" in the folder compare window.
In my environment, there is a high probability of a crash, especially if the "Include Subfolders" option is on and many items are selected.
For example, the situation is as shown in the image below. The set of directories compared at this time is attached.
[RefreshSelected.zip](https://github.com/WinMerge/winmerge/files/7834709/RefreshSelected.zip)
![RefreshSelected](https://user-images.githubusercontent.com/56220423/148675534-db094959-2989-4eed-a130-e8f63ecbed90.png)

As a result of monitoring this phenomenon, the situation when "Refresh Selected" is executed is as follows.


- The collection thread DiffThreadCollect() sends the UI update event CDiffThread::EVENT_COLLECT_COMPLETED as soon as it starts because there is nothing to do.
- In the compare thread, DIFFITEM::RemoveChildren() called from DirScan_UpdateMarkedItems() removes DiffItems.
- In response to the UI update event CDiffThread::EVENT_COLLECT_COMPLETED, the UI update process such as CDirView::OnUpdateUIMessage () and CDirView::ReflectGetdispinfo() runs on the main thread.
  At this time this process may refer to the deleted DiffItem in the compare thread running in parallel.

This PR fixes this issue by performing the UI update process after the process that may delete DiffItems is completed.