### PR TITLE
Change the file naming method of the file compare report to avoid duplication of the file compare report file name linked from the folder compare report.

### DIFF
--- a/Src/DirView.cpp
+++ b/Src/DirView.cpp
@@ -2856,7 +2856,7 @@ struct FileCmpReport: public IFileCmpReport
 			return false;
 		}
 
-		sLinkPath = di.diffFileInfo[0].GetFile();
+		sLinkPath = strutils::format(_T("%d_"), nIndex) + di.diffFileInfo[0].GetFile();
 
 		strutils::replace(sLinkPath, _T("\\"), _T("_"));
 		sLinkPath += _T(".html");


### PR DESCRIPTION
In rare cases, the file names in the file comparison report linked from the folder comparison report may be duplicated.
It is because "\\" in the file path of the comparison item is replaced with "_".

For example, if the folder to be compared contains "AAA\BBB.txt" and "AAA_BBB.txt", the filenames of the two file compare reports are both "AAA_BBB.txt.html".
At this time, the report file of "AAA\BBB.txt" is overwritten by the report of "AAA_BBB.txt" generated later.
As a result, the report "AAA_BBB.txt" is displayed regardless of whether we click "AAA\BBB.txt" or "AAA_BBB.txt" in the folder compare report.

This PR modifies to add the row number of the folder compare report to the head of the file name in the file compare report.
This change makes the file names of the file compare reports unique and avoids duplication.