### PR TITLE
Fix an issue where comparison results are not displayed correctly when "Refresh Selected" is performed by selecting an item that has a directory and file with the same name.

### DIFF
--- a/Src/DirItem.cpp
+++ b/Src/DirItem.cpp
@@ -98,3 +98,12 @@ void DirItem::ClearPartial()
 	size = DirItem::FILE_SIZE_NONE;
 	flags.reset();
 }
+
+/**
+ * @brief Return whether the item is a directory.
+ * @return true if the item is a directory.
+ */
+bool DirItem::IsDirectory() const
+{
+	return ((flags.attributes & FILE_ATTRIBUTE_DIRECTORY) == FILE_ATTRIBUTE_DIRECTORY);
+}

--- a/Src/DirItem.h
+++ b/Src/DirItem.h
@@ -37,4 +37,5 @@ struct DirItem
 	String GetFile() const;
 	bool Update(const String &sFilePath);
 	void ClearPartial();
+	bool IsDirectory() const;
 };

--- a/Src/DirScan.cpp
+++ b/Src/DirScan.cpp
@@ -783,8 +783,15 @@ static void UpdateDiffItem(DIFFITEM &di, bool & bExists, CDiffContext *pCtxt)
 		di.diffFileInfo[i].ClearPartial();
 		if (pCtxt->UpdateInfoFromDiskHalf(di, i))
 		{
-			di.diffcode.diffcode |= DIFFCODE::FIRST << i;
-			bExists = true;
+			if (di.diffFileInfo[i].IsDirectory() == di.diffcode.isDirectory())
+			{
+				di.diffcode.diffcode |= DIFFCODE::FIRST << i;
+				bExists = true;
+			}
+			else
+			{
+				di.diffFileInfo[i].ClearPartial();
+			}
 		}
 	}
 }


### PR DESCRIPTION
Comparison results are not displayed correctly when "Refresh Selected" is performed by selecting an item that has a directory and file with the same name as shown below.

Before executing "Refresh Selected":
![01_before](https://user-images.githubusercontent.com/56220423/153709544-add7ad2c-9778-4689-a03e-9dac9fa60e23.png)

After executing "Refresh Selected" for the directory:
![02_after_dir](https://user-images.githubusercontent.com/56220423/153709550-c8f8cba3-b4f6-4bcc-b56b-300bc5e9abd5.png)

After executing "Refresh Selected" for the file:
![03_after_file](https://user-images.githubusercontent.com/56220423/153709555-7fcf00a1-f018-47be-ab46-c19089ada94a.png)

This PR fixes this issue by changing to judge that a directory or file exists only if the rescanned item type (directory or file) matches the original diffItem type in the diffItem update process.