### PR TITLE
Improve vertical alignment string

### DIFF
--- a/Translations/WinMerge/English.pot
+++ b/Translations/WinMerge/English.pot
@@ -1434,7 +1434,7 @@ msgstr ""
 msgid "E&nable moved block detection"
 msgstr ""
 
-msgid "&Match similar lines"
+msgid "Align &similar lines"
 msgstr ""
 
 msgid "Diff &algorithm (Experimental):"


### PR DESCRIPTION
I experienced the same issue as in: https://github.com/WinMerge/winmerge/issues/1008

Both that user and I were misled by the "Match similar lines" string.  In English, it's confusing within the context of a comparison application because "match" is also a comparison term.

As such, I improved it to be "Align similar items".