### PR TITLE
Fix renaming process in folder compare window.

### DIFF
--- a/Src/DirActions.h
+++ b/Src/DirActions.h
@@ -559,7 +559,15 @@ bool DoItemRename(InputIterator& it, const CDiffContext& ctxt, const String& szN
 	for (int index = 0; index < nDirs; index++)
 	{
 		di.diffFileInfo[index].filename = szNewItemName;
-		if (bRename[index] || paths::DoesPathExist(GetItemFileName(ctxt, di, index)))
+		bool bSetSideFlag = bRename[index];
+		if (!bSetSideFlag)
+		{
+			paths::PATH_EXISTENCE pathExist = paths::DoesPathExist(GetItemFileName(ctxt, di, index));
+			bool bIsDirectory = di.diffcode.isDirectory();
+			if (((pathExist == paths::IS_EXISTING_DIR) && bIsDirectory) || ((pathExist == paths::IS_EXISTING_FILE) && !bIsDirectory))
+				bSetSideFlag = true;
+		}
+		if (bSetSideFlag)
 			di.diffcode.setSideFlag(index);
 	}
 	return true;


### PR DESCRIPTION
The comparison result is not displayed correctly when renaming a file (directory) that exists on only one side to a name where the directory (file) with the same name exists.

Example 1. Rename file AAA to BBB when file AAA (left only) and directory BBB (right only) exist.
![e1](https://user-images.githubusercontent.com/56220423/158066127-f26d82d7-698e-4b54-ae37-d92a36c92adf.png)

Example 2. Rename directory BBB to AAA when file AAA (left only) and directory BBB (right only) exist.
![e2](https://user-images.githubusercontent.com/56220423/158066143-9bf3cf74-4919-490b-89df-2252c1945f26.png)

This PR fixes this issue by changing to judge that a directory or file exists only if the type (directory or file) of renamed item matches the original diffItem type in the diffItem update process.