### PR TITLE
Fix an issue where WinMerge crashes depending on the filename when generating a file compare report.

### DIFF
--- a/Src/markdown.cpp
+++ b/Src/markdown.cpp
@@ -208,7 +208,7 @@ std::string CMarkdown::Entities(const std::string& v)
 			{
 				ptrdiff_t i = p - &ret[0];
 				ptrdiff_t j = q - &ret[0];
-				size_t b = v.length();
+				size_t b = ret.length();
 				ret.resize(b + cchValue - 1);
 				p = &ret[0] + i;
 				q = &ret[0] + j;


### PR DESCRIPTION
WinMerge crashes depending on the filename when generating a file compare report.
(For example,"&&")
This is because the buffer of the replaced string is not properly resized in the process of replacing the special characters contained in the file name with the HTML entities.
This PR fixes the above issue.