### PR TITLE
Fix typo: GPL

### DIFF
--- a/Src/diffutils/src/ifdef.c
+++ b/Src/diffutils/src/ifdef.c
@@ -7,12 +7,12 @@ GNU DIFF is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY.  No author or distributor
 accepts responsibility to anyone for the consequences of using it
 or for whether it serves any particular purpose or works at all,
-unless he says so in writing.  Refer to the GNU DIFF General Public
+unless he says so in writing.  Refer to the GNU General Public
 License for full details.
 
 Everyone is granted permission to copy, modify and redistribute
 GNU DIFF, but only under the conditions described in the
-GNU DIFF General Public License.   A copy of this license is
+GNU General Public License.   A copy of this license is
 supposed to have been given to you along with GNU DIFF so you
 can know your rights and responsibilities.  It should be in a
 file named COPYING.  Among other things, the copyright notice

--- a/Src/diffutils/src/side.c
+++ b/Src/diffutils/src/side.c
@@ -7,12 +7,12 @@ GNU DIFF is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY.  No author or distributor
 accepts responsibility to anyone for the consequences of using it
 or for whether it serves any particular purpose or works at all,
-unless he says so in writing.  Refer to the GNU DIFF General Public
+unless he says so in writing.  Refer to the GNU General Public
 License for full details.
 
 Everyone is granted permission to copy, modify and redistribute
 GNU DIFF, but only under the conditions described in the
-GNU DIFF General Public License.   A copy of this license is
+GNU General Public License.   A copy of this license is
 supposed to have been given to you along with GNU DIFF so you
 can know your rights and responsibilities.  It should be in a
 file named COPYING.  Among other things, the copyright notice


### PR DESCRIPTION
diffutils ver 2.9

> 2007-07-19
> * src/ifdef.c: Fix typo: "GNU DIFF General Public License" should be
> "GNU General Public License".  Reported by Erich Guenther.
> * src/side.c: Likewise.