### PR TITLE
Fix report generation process about replacement with HTML entity

### DIFF
--- a/Src/DirCmpReport.cpp
+++ b/Src/DirCmpReport.cpp
@@ -547,7 +547,7 @@ void DirCmpReport::GenerateXmlHtmlContent(bool xml)
 				WriteString(_T("/"));
 				WriteString(sLinkPath);
 				WriteString(_T("\">"));
-				WriteString(m_pList->GetItemText(currRow, currCol));
+				WriteStringEntityAware(m_pList->GetItemText(currRow, currCol));
 				WriteString(_T("</a>"));
 			}
 			else


### PR DESCRIPTION
The string with the hyperlink to the file compare report is not replaced with the HTML entity, when generating an HTML-style folder compare report with the "Include File Compare Report" option enabled.
Therefore, for example, if the filename field is "TEST.TXT|test.txt|\<None\>", the "\<None\>" part will not be displayed properly when the report is displayed in the browser.
This PR fixes the above issue.