### PR TITLE
Use isupper+tolower instead of islower+toupper (diffutils ver2.7)

### DIFF
--- a/Src/diffutils/src/util.c
+++ b/Src/diffutils/src/util.c
@@ -482,10 +482,10 @@ line_cmp (char const *s1, size_t len1, char const *s2, size_t len2)
 
 	  if (ignore_case_flag)
 	    {
-	      if (islower (c1))
-		c1 = (unsigned char)toupper (c1);
-	      if (islower (c2))
-		c2 = (unsigned char)toupper (c2);
+	      if (isupper (c1))
+	        c1 = (unsigned char)tolower (c1);
+	      if (isupper(c2))
+	        c2 = (unsigned char)tolower (c2);
 	    }
 
 	  if (ignore_eol_diff)

--- a/Src/stringdiffs.cpp
+++ b/Src/stringdiffs.cpp
@@ -560,7 +560,7 @@ stringdiffs::Hash(const String & str, int begin, int end, unsigned h) const
 		}
 		else
 		{
-			ch = static_cast<unsigned>(_totupper(ch));
+			ch = static_cast<unsigned>(_totlower(ch));
 			h += HASH(h, ch);
 		}
 	}
@@ -609,7 +609,7 @@ stringdiffs::caseMatch(TCHAR ch1, TCHAR ch2) const
 	if (m_case_sensitive) 
 		return ch1==ch2;
 	else 
-		return _totupper(ch1)==_totupper(ch2);
+		return _totlower(ch1)==_totlower(ch2);
 }
 
 /**
@@ -773,7 +773,7 @@ matchchar(const TCHAR *ch1, const TCHAR *ch2, size_t len, bool casitive)
 		return memcmp(ch1, ch2, len * sizeof(TCHAR)) == 0;
 	for (size_t i = 0; i < len; ++i)
 	{
-		if (_totupper(ch1[i]) != _totupper(ch2[i]))
+		if (_totlower(ch1[i]) != _totlower(ch2[i]))
 			return false;
 	}
 	return true;


### PR DESCRIPTION
diffutils ver2.7
> Mon Sep 12 15:52:22 1994
> Use isupper+tolower instead of islower+toupper, for consistency.