### PR TITLE
Make the file name refreshed to detect case changes when running "Refresh Selected".

### DIFF
--- a/Src/DirItem.cpp
+++ b/Src/DirItem.cpp
@@ -11,6 +11,7 @@
 #include "paths.h"
 #include "TFile.h"
 #include "DebugNew.h"
+#include <filesystem>
 
 /**
  * @brief Set filename and path for the item.
@@ -69,6 +70,29 @@ bool DirItem::Update(const String &sFilePath)
 
 			flags.attributes = GetFileAttributes(file.wpath().c_str());
 
+			retVal = true;
+		}
+		catch (...)
+		{
+		}
+	}
+	return retVal;
+}
+
+/**
+ * @brief Update filename from given file.
+ * @param [in] sFilePath Full path to file/directory to update
+ * @return true if information was updated (item was found).
+ */
+bool DirItem::UpdateFileName(const String& sFilePath)
+{
+	bool retVal = false;
+	if (!sFilePath.empty())
+	{
+		try
+		{
+			std::filesystem::path canonicalPath = std::filesystem::canonical(sFilePath);
+			filename = canonicalPath.filename();
 			retVal = true;
 		}
 		catch (...)

--- a/Src/DirItem.h
+++ b/Src/DirItem.h
@@ -36,6 +36,7 @@ struct DirItem
 	void SetFile(const String &fullPath);
 	String GetFile() const;
 	bool Update(const String &sFilePath);
+	bool UpdateFileName(const String& sFilePath);
 	void ClearPartial();
 	bool IsDirectory() const;
 };

--- a/Src/DirScan.cpp
+++ b/Src/DirScan.cpp
@@ -796,15 +796,18 @@ static void UpdateDiffItem(DIFFITEM &di, bool & bExists, CDiffContext *pCtxt)
 		di.diffFileInfo[i].ClearPartial();
 		if (pCtxt->UpdateInfoFromDiskHalf(di, i))
 		{
+			bool bUpdated = false;
 			if (di.diffFileInfo[i].IsDirectory() == di.diffcode.isDirectory())
 			{
-				di.diffcode.diffcode |= DIFFCODE::FIRST << i;
-				bExists = true;
+				String filepath = paths::ConcatPath(pCtxt->GetPath(i), di.diffFileInfo[i].GetFile());
+				if (di.diffFileInfo[i].UpdateFileName(filepath)) {
+					di.diffcode.diffcode |= DIFFCODE::FIRST << i;
+					bExists = true;
+					bUpdated = true;
+				}
 			}
-			else
-			{
+			if (!bUpdated)
 				di.diffFileInfo[i].ClearPartial();
-			}
 		}
 	}
 }


### PR DESCRIPTION
In the current version, the file name display is not updated when we change the case of the file name and then execute "Refresh Selected".
For example, even if we rename "TEST.TXT" to "test.txt" and then perform "Refresh Selected", the item display remains "TEST.TXT".
In this PR, the file name is now updated when we run "Refresh Selected".