### PR TITLE
Fix an issue where paths with different case are not displayed correctly in the folder column of the folder compare window when comparing three directories.

### DIFF
--- a/Src/DiffItem.cpp
+++ b/Src/DiffItem.cpp
@@ -52,6 +52,24 @@ bool DIFFITEM::IsAncestor(const DIFFITEM *pdi) const
 	return false;
 }
 
+/**
+ * @brief Return all ancestors of the current item.
+ */
+std::vector<const DIFFITEM*> DIFFITEM::GetAncestors() const
+{
+	int depth = GetDepth();
+	std::vector<const DIFFITEM*> ancestors(depth);
+
+	const DIFFITEM* cur;
+	int i;
+	for (i = 0, cur = parent; cur->parent != nullptr; i++, cur = cur->parent)
+	{
+		assert(depth - i - 1 >= 0 && depth - i - 1 < depth);
+		ancestors[depth - i - 1] = cur;
+	}
+	return ancestors;
+}
+
 /** @brief Remove and delete all children DIFFITEM entries */
 void DIFFITEM::RemoveChildren()
 {

--- a/Src/DiffItem.h
+++ b/Src/DiffItem.h
@@ -266,6 +266,7 @@ public:
 	void RemoveChildren();
 	int GetDepth() const;
 	bool IsAncestor(const DIFFITEM *pdi) const;
+	std::vector<const DIFFITEM*> GetAncestors() const;
 	inline DIFFITEM *GetFwdSiblingLink() const { return Flink; }
 	inline DIFFITEM *GetFirstChild() const { return children; }
 	inline DIFFITEM *GetParentLink() const { return parent; }


### PR DESCRIPTION
Both paths are displayed for items that have different case paths in the folder column of the folder compare window when comparing two directories.
In the current version, paths are not displayed correctly when comparing three directories.
This PR fixes the above issue.