### PR TITLE
Fix an issue where the folder column is not updated for child items after renaming a directory in the folder compare window.

### DIFF
--- a/Src/DirActions.cpp
+++ b/Src/DirActions.cpp
@@ -1100,6 +1100,26 @@ void UpdateStatusFromDisk(CDiffContext& ctxt, DIFFITEM& di, int index)
 	}
 }
 
+/**
+ * @brief Update the paths of the diff items recursively.
+ * @param[in] nDirs Number of directories to compare.
+ * @param[in,out] di@Item to update the path.
+ */
+void UpdatePaths(int nDirs, DIFFITEM& di)
+{
+	assert(nDirs == 2 || nDirs == 3);
+
+	if (di.HasChildren())
+	{
+		for (DIFFITEM* pdic = di.GetFirstChild(); pdic; pdic = pdic->GetFwdSiblingLink())
+		{
+			for (int i = 0; i < nDirs; i++)
+				pdic->diffFileInfo[i].path = paths::ConcatPath(di.diffFileInfo[i].path, di.diffFileInfo[i].filename);
+			UpdatePaths(nDirs, *pdic);
+		}
+	}
+}
+
 void SetDiffCounts(DIFFITEM& di, unsigned diffs, unsigned ignored)
 {
 	di.nidiffs = ignored; // see StoreDiffResult() in DirScan.cpp

--- a/Src/DirActions.h
+++ b/Src/DirActions.h
@@ -168,6 +168,7 @@ void SetDiffCompare(DIFFITEM& di, unsigned diffcode);
 void CopyDiffSideAndProperties(DIFFITEM& di, int src, int dst);
 void UnsetDiffSide(DIFFITEM& di, int index);
 void UpdateStatusFromDisk(CDiffContext& ctxt, DIFFITEM& di, int index);
+void UpdatePaths(int nDirs, DIFFITEM& di);
 void SetDiffCounts(DIFFITEM& di, unsigned diffs, unsigned ignored);
 void SetItemViewFlag(DIFFITEM& di, unsigned flag, unsigned mask);
 void SetItemViewFlag(CDiffContext& ctxt, unsigned flag, unsigned mask);


### PR DESCRIPTION
The folder column is not updated for child items after renaming a directory in the folder compare window.
This PR fixes this issue by updating the path of the child items after renaming the directory.
This PR also fixes an issue where file comparisons of child items after renaming a directory would result in empty files comparison instead of the intended files comparison.