### PR TITLE
Disable rename operations when in read-only mode in the folder compare window.

### DIFF
--- a/Src/DirActions.h
+++ b/Src/DirActions.h
@@ -252,6 +252,20 @@ struct DirActions
 		return false;
 	}
 
+	/**
+	 * @brief Return whether the specified diff item is renamable.
+	 * @param [in] di Diff item to check
+	 * @return true if the specified diff item is renamable.
+	 */
+	bool IsItemRenamable(const DIFFITEM& di) const
+	{
+		int nDirs = m_ctxt.GetCompareDirs();
+		for (int i = 0; i < nDirs; i++)
+			if (di.diffcode.exists(i) && m_RO[i])
+				return false;
+		return true;
+	}
+
 	template <SIDE_TYPE src>
 	bool IsItemMovableToOn(const DIFFITEM& di) const
 	{

--- a/Src/DirView.cpp
+++ b/Src/DirView.cpp
@@ -3266,7 +3266,12 @@ void CDirView::OnItemRename()
 void CDirView::OnUpdateItemRename(CCmdUI* pCmdUI)
 {
 	bool bEnabled = (1 == m_pList->GetSelectedCount());
-	pCmdUI->Enable(bEnabled && SelBegin() != SelEnd());
+	if (bEnabled)
+	{
+		Counts counts = Count(&DirActions::IsItemRenamable);
+		bEnabled = (counts.count > 0 && counts.total == 1);
+	}
+	pCmdUI->Enable(bEnabled);
 }
 
 /**
@@ -3411,7 +3416,8 @@ void CDirView::OnItemChanged(NMHDR* pNMHDR, LRESULT* pResult)
  */
 afx_msg void CDirView::OnBeginLabelEdit(NMHDR* pNMHDR, LRESULT* pResult)
 {
-	*pResult = (SelBegin() == SelEnd());
+	Counts counts = Count(&DirActions::IsItemRenamable);
+	*pResult = !(counts.count > 0 && counts.total == 1);
 
 	// If label edit is allowed.
 	if (*pResult == FALSE)


### PR DESCRIPTION
Disable rename operations when in read-only mode in the folder compare window.