### PR TITLE
Fix an issue where filenames containing "&" are not displayed properly in the MDI tab bar and its tooltips.

### DIFF
--- a/Src/Common/MDITabBar.cpp
+++ b/Src/Common/MDITabBar.cpp
@@ -56,7 +56,7 @@ BOOL CMDITabBar::Create(CMDIFrameWnd* pMainFrame)
 	m_font.CreateFontIndirect(&ncm.lfMenuFont);
 	SetFont(&m_font);
 
-	m_tooltips.Create(m_pMainFrame);
+	m_tooltips.Create(m_pMainFrame, TTS_NOPREFIX);
 	m_tooltips.AddTool(this, _T(""));
 
 	return TRUE;
@@ -304,6 +304,9 @@ void CMDITabBar::UpdateTabs()
 
 		if (strTitle.GetLength() > nMaxTitleLength)
 			strTitle = strTitle.Left(nMaxTitleLength - 3) + _T("...");
+
+		// Escape the '&' to prevent it from being removed and underlining the next character in the string.
+		strTitle.Replace(_T("&"), _T("&&"));
 
 		if (item == -1)
 		{


### PR DESCRIPTION
Filenames containing "&" are not displayed properly in the MDI tab bar and its tooltips.
For example, comparing "AAA&BBB.txt" and "CCC&DDD.txt" is as follows.
![tab](https://user-images.githubusercontent.com/56220423/186053836-c6b0ea6f-10a2-47a1-812a-22d1aae8066a.png)
![tooltips](https://user-images.githubusercontent.com/56220423/186053865-8fa47e1f-a1f7-4981-99e0-0a6de2e0a5c4.png)

This PR fixes this issue by doing the following:
- Add processing to escape "&" in the MDI tab bar.
- Add TTS_NOPREFIX to the tooltip style.