### PR TITLE
Fix "Left to Right" and "Right to Left" copying in 2-way folder comparison.

### DIFF
--- a/Src/DirActions.h
+++ b/Src/DirActions.h
@@ -168,6 +168,7 @@ void SetDiffCompare(DIFFITEM& di, unsigned diffcode);
 void CopyDiffSideAndProperties(DIFFITEM& di, int src, int dst);
 void UnsetDiffSide(DIFFITEM& di, int index);
 void UpdateStatusFromDisk(CDiffContext& ctxt, DIFFITEM& di, int index);
+int UpdateCompareFlagsAfterSync(DIFFITEM& di, bool bRecursive);
 void UpdatePaths(int nDirs, DIFFITEM& di);
 void SetDiffCounts(DIFFITEM& di, unsigned diffs, unsigned ignored);
 void SetItemViewFlag(DIFFITEM& di, unsigned flag, unsigned mask);


### PR DESCRIPTION
In the current version, when doing a "Left to Right" or "Right to Left" copy in 2-way folder comparison, the DIFFCODE::SAME flag is set for the copied item and all its descendants.
For this reason, if we perform a "Left to Right" copy for a directory that contains items that exist only on the right side, the comparison results are displayed as identical even though there is actually a difference in the directory after copying.

![LeftToRight](https://user-images.githubusercontent.com/56220423/191896979-f685dc33-5ccb-418a-adb8-b9f7012798a3.png)

This PR fixes the above issue.