### PR TITLE
typo fixed in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Subfolders include:
 
    You will need to fork the main Winmerge repository and create a branch on that fork
    
-   Your new code needs to follow Eric Allman identation https://en.wikipedia.org/wiki/Indentation_style#Allman_style
+   Your new code needs to follow [Eric Allman indentation](https://en.wikipedia.org/wiki/Indentation_style#Allman_style)
    
    When your code is ready for a review/merge create a pull request explaining the changes that you made
    


### PR DESCRIPTION
There was a typo in "Eric Allman Indentation". I fixed the typo, and hyperlinked the text. Sorry for the low value PR. You can feel free to close this PR without merging. Looking forward to contribute something valuable in near future. Thanks :)