### PR TITLE
Fix an issue where the message displayed when two files are identical in a 3-way folder comparison is not translated.

### DIFF
--- a/Src/DirViewColItems.cpp
+++ b/Src/DirViewColItems.cpp
@@ -418,9 +418,9 @@ static String ColStatusGet(const CDiffContext *pCtxt, const void *p, int)
 		{
 			switch (di.diffcode.diffcode & DIFFCODE::COMPAREFLAGS3WAY)
 			{
-			case DIFFCODE::DIFF1STONLY: s += _("(Middle and right are identical)"); break;
-			case DIFFCODE::DIFF2NDONLY: s += _("(Left and right are identical)"); break;
-			case DIFFCODE::DIFF3RDONLY: s += _("(Left and middle are identical)"); break;
+			case DIFFCODE::DIFF1STONLY: s += _(" (Middle and right are identical)"); break;
+			case DIFFCODE::DIFF2NDONLY: s += _(" (Left and right are identical)"); break;
+			case DIFFCODE::DIFF3RDONLY: s += _(" (Left and middle are identical)"); break;
 			}
 		}
 	}


### PR DESCRIPTION
Fix an issue where the following message displayed when two files are identical in a 3-way folder comparison is not translated.
- (Middle and right are identical)
- (Left and right are identical)
- (Left and middle are identical)

The strings defined in Merge.rc have leading spaces, but the strings in DirViewColItems.cpp have no leading spaces and are not translated.
This PR fixes this issue by adding a leading space to the string in DirViewColItems.cpp.
