### PR TITLE
Fix the problem that WinMerge crashes when pressing the "OK" button in the "Display Columns" dialog in the debug version.

### DIFF
--- a/Src/DirColsDlg.cpp
+++ b/Src/DirColsDlg.cpp
@@ -250,15 +250,20 @@ void CDirColsDlg::OnOK()
 {
 	SanitizeOrder();
 
+	size_t colssize = m_cols.size();
 	for (int i = 0; i < m_listColumns.GetItemCount(); i++)
 	{
 		bool checked = !!m_listColumns.GetCheck(i);
 		DWORD_PTR data = m_listColumns.GetItemData(i);
-		column & col1 = m_cols[data];
-		if (checked)
-			col1.phy_col = i;
-		else
-			col1.phy_col = -1;
+		assert(data >= 0 && data < colssize);
+		if (data >= 0 && data < colssize)
+		{
+			column& col1 = m_cols[data];
+			if (checked)
+				col1.phy_col = i;
+			else
+				col1.phy_col = -1;
+		}
 	}
 
 	CTrDialog::OnOK();
@@ -299,5 +304,16 @@ void CDirColsDlg::OnLvnItemchangedColdlgList(NMHDR *pNMHDR, LRESULT *pResult)
 		EnableDlgItem(IDC_DOWN,
 			ind != m_listColumns.GetItemCount() - static_cast<int>(m_listColumns.GetSelectedCount()));
 	}
+
+	// Disable the "OK" button when no items are checked.
+	bool bChecked = false;
+	for (int i = 0; i < m_listColumns.GetItemCount(); i++)
+		if (!!m_listColumns.GetCheck(i))
+		{
+			bChecked = true;
+			break;
+		}
+	EnableDlgItem(IDOK, bChecked);
+
 	*pResult = 0;
 }

--- a/Src/DirView.cpp
+++ b/Src/DirView.cpp
@@ -4550,6 +4550,7 @@ void CDirView::OnEditColumns()
 				dlg.AddColumn(m_pColItems->GetColDisplayName(l), m_pColItems->GetColDescription(l), l);
 			}
 		}
+		assert(m_pColItems->GetColCount() == dlg.GetColumns().size());
 
 		// Add default order of columns for resetting to defaults
 		for (l = 0; l < m_pColItems->GetColCount(); ++l)
@@ -4611,14 +4612,12 @@ void CDirView::OnEditColumns()
 
 	if (m_pColItems->GetDispColCount() < 1)
 	{
-		// Ignore them if they didn't leave a column showing
+		// Set them back to default if they didn't leave a column showing
+		// (However, if none of the items are checked, this process will not be executed because the "OK" button in the "Display Columns" dialog cannot be pressed.)
 		m_pColItems->ResetColumnOrdering();
 	}
-	else
-	{
-		ReloadColumns();
-		Redisplay();
-	}
+	ReloadColumns();
+	Redisplay();
 }
 
 DirActions CDirView::MakeDirActions(DirActions::method_type func) const


### PR DESCRIPTION
WinMerge crashes when the following steps are performed in the debug version.

Step 1. Open the "Display Columns" dialog and check only "Filename" and press the "OK" button.
Step 2. Reopen the "Display Columns" dialog and uncheck all and press the "OK" button.
Step 3. Open the "Display Columns" dialog again and press the "OK" button.

The cause is that the settings (OPT_DIRVIEW_COLUMN_ORDERS or OPT_DIRVIEW3_COLUMN_ORDERS) and the columns in the folder compare window are inconsistent after performing Step 2.
Settings: Revert to their default values
Columns in folder compare window: As they were before the Display Columns dialog was opened.

Due to this inconsistency, when the "Display Columns" dialog is opened in Step 3, the columns that are not displayed in the folder compare window but retained as settings are not registered in the "Display Columns" dialog.
This results in an access violation and crashes Winmerge.

This PR disables the "OK" button in the "Display Columns" dialog when no items are checked.
Also adds some error handling and assertions.