### PR TITLE
Add "Copy All Displayed Columns" to the context menu of the folder compare window.

### DIFF
--- a/Src/DirView.cpp
+++ b/Src/DirView.cpp
@@ -358,6 +358,9 @@ BEGIN_MESSAGE_MAP(CDirView, CListView)
 	ON_UPDATE_COMMAND_UI(ID_DIR_COPY_RIGHT_TO_CLIPBOARD, OnUpdateCtxtDirCopy2<SIDE_RIGHT>)
 	ON_UPDATE_COMMAND_UI(ID_DIR_COPY_BOTH_TO_CLIPBOARD, OnUpdateCtxtDirCopyBoth2)
 	ON_UPDATE_COMMAND_UI(ID_DIR_COPY_ALL_TO_CLIPBOARD, OnUpdateCtxtDirCopyBoth2)
+	// Context menu -> Copy All Displayed Columns
+	ON_COMMAND(ID_DIR_COPY_ALL_DISP_COLUMNS, OnCopyAllDisplayedColumns)
+	ON_UPDATE_COMMAND_UI(ID_DIR_COPY_ALL_DISP_COLUMNS, OnUpdateCopyAllDisplayedColumns)
 	// Status bar
 	ON_UPDATE_COMMAND_UI(ID_STATUS_DIFFNUM, OnUpdateStatusNum)
 	ON_UPDATE_COMMAND_UI(ID_STATUS_RIGHTDIR_RO, OnUpdateStatusRightRO)
@@ -3256,6 +3259,41 @@ void CDirView::OnCopyBothToClipboard()
 	std::list<String> list;
 	CopyBothPathnames(SelBegin(), SelEnd(), std::back_inserter(list), GetDiffContext());
 	PutFilesToClipboard(list, GetMainFrame()->GetSafeHwnd());
+}
+
+/**
+ * @brief Copy all displayed columns of selected items to clipboard.
+ */
+void CDirView::OnCopyAllDisplayedColumns()
+{
+	int ncols = m_pColItems->GetDispColCount();
+	String text;
+
+	int row = -1;
+	while (true)
+	{
+		row = m_pList->GetNextItem(row, LVNI_SELECTED);
+		if (row == -1)
+			break;
+		for (int col = 0; col < ncols; col++)
+		{
+			text += m_pList->GetItemText(row, col);
+			if (col < ncols - 1)
+				text += _T("\t");
+		}
+		text += _T("\r\n");
+	}
+
+	PutToClipboard(text, GetMainFrame()->GetSafeHwnd());
+}
+
+/**
+ * @brief Enable/Disable dirview Copy All Displayed Columns context menu item.
+ * @param[in] pCmdUI UI component to update.
+ */
+void CDirView::OnUpdateCopyAllDisplayedColumns(CCmdUI* pCmdUI)
+{
+	pCmdUI->Enable(m_pList->GetSelectedCount() != 0);
 }
 
 /**

--- a/Src/DirView.h
+++ b/Src/DirView.h
@@ -312,6 +312,8 @@ protected:
 	template<SIDE_TYPE side>
 	afx_msg void OnCopyToClipboard();
 	afx_msg void OnCopyBothToClipboard();
+	afx_msg void OnCopyAllDisplayedColumns();
+	afx_msg void OnUpdateCopyAllDisplayedColumns(CCmdUI* pCmdUI);
 	afx_msg void OnItemRename();
 	afx_msg void OnUpdateItemRename(CCmdUI* pCmdUI);
 	afx_msg void OnHideFilenames();

--- a/Src/Merge.rc
+++ b/Src/Merge.rc
@@ -917,6 +917,7 @@ BEGIN
             MENUITEM "Both (%1 of %2)",             ID_DIR_COPY_BOTH_TO_CLIPBOARD
             MENUITEM "All (%1 of %2)",              ID_DIR_COPY_ALL_TO_CLIPBOARD
         END
+        MENUITEM "Copy All Di&splayed Columns"       ID_DIR_COPY_ALL_DISP_COLUMNS
         MENUITEM SEPARATOR
         POPUP "&Zip"
         BEGIN

--- a/Src/resource.h
+++ b/Src/resource.h
@@ -659,11 +659,12 @@
 #define ID_DIR_COPY_RIGHT_TO_CLIPBOARD  17611
 #define ID_DIR_COPY_BOTH_TO_CLIPBOARD   17612
 #define ID_DIR_COPY_ALL_TO_CLIPBOARD    17613
-#define ID_DIR_DEL_LEFT                 17614
-#define ID_DIR_DEL_MIDDLE               17615
-#define ID_DIR_DEL_RIGHT                17616
-#define ID_DIR_DEL_BOTH                 17617
-#define ID_DIR_DEL_ALL                  17618
+#define ID_DIR_COPY_ALL_DISP_COLUMNS    17614
+#define ID_DIR_DEL_LEFT                 17615
+#define ID_DIR_DEL_MIDDLE               17616
+#define ID_DIR_DEL_RIGHT                17617
+#define ID_DIR_DEL_BOTH                 17618
+#define ID_DIR_DEL_ALL                  17619
 #define ID_DIR_OPEN_LEFT                17701
 #define ID_DIR_OPEN_LEFT_WITHEDITOR     17702
 #define ID_DIR_OPEN_LEFT_WITH           17703

--- a/Translations/WinMerge/Arabic.po
+++ b/Translations/WinMerge/Arabic.po
@@ -934,6 +934,9 @@ msgstr "نسخ أ&سماء الملفات"
 msgid "Copy Items To Clip&board"
 msgstr "نسخ ال&عناصر إلى الحافظة"
 
+msgid "Copy All Di&splayed Columns"
+msgstr ""
+
 msgid "&Zip"
 msgstr "Zip"
 

--- a/Translations/WinMerge/Basque.po
+++ b/Translations/WinMerge/Basque.po
@@ -1135,6 +1135,9 @@ msgstr "Kopiatu &Agirizenak"
 msgid "Copy Items To Clip&board"
 msgstr ""
 
+msgid "Copy All Di&splayed Columns"
+msgstr ""
+
 #, c-format
 msgid "&Zip"
 msgstr "&Zipa"

--- a/Translations/WinMerge/Brazilian.po
+++ b/Translations/WinMerge/Brazilian.po
@@ -933,6 +933,9 @@ msgstr "Copiar &os Nomes dos Arquivos"
 msgid "Copy Items To Clip&board"
 msgstr "Copiar Itens Pra Área de Tran&sferência"
 
+msgid "Copy All Di&splayed Columns"
+msgstr ""
+
 msgid "&Zip"
 msgstr "&Zip"
 

--- a/Translations/WinMerge/Bulgarian.po
+++ b/Translations/WinMerge/Bulgarian.po
@@ -930,6 +930,9 @@ msgstr "Копиране на &файловите имена"
 msgid "Copy Items To Clip&board"
 msgstr "&Копиране елементите в системния буфер"
 
+msgid "Copy All Di&splayed Columns"
+msgstr ""
+
 msgid "&Zip"
 msgstr "&Zip"
 

--- a/Translations/WinMerge/Catalan.po
+++ b/Translations/WinMerge/Catalan.po
@@ -1132,6 +1132,9 @@ msgstr "Co&pia els noms de fitxer"
 msgid "Copy Items To Clip&board"
 msgstr "Copia els elements al porta-re&talls"
 
+msgid "Copy All Di&splayed Columns"
+msgstr ""
+
 #, c-format
 msgid "&Zip"
 msgstr "Co&mprimeix"

--- a/Translations/WinMerge/ChineseSimplified.po
+++ b/Translations/WinMerge/ChineseSimplified.po
@@ -934,6 +934,9 @@ msgstr "复制文件名(&F)"
 msgid "Copy Items To Clip&board"
 msgstr "复制项目到剪贴板(&B)"
 
+msgid "Copy All Di&splayed Columns"
+msgstr ""
+
 msgid "&Zip"
 msgstr "Zip (&Z)"
 

--- a/Translations/WinMerge/ChineseTraditional.po
+++ b/Translations/WinMerge/ChineseTraditional.po
@@ -1139,6 +1139,9 @@ msgstr "複製檔名 (&F)"
 msgid "Copy Items To Clip&board"
 msgstr "複製項目到剪貼簿 (&B)"
 
+msgid "Copy All Di&splayed Columns"
+msgstr ""
+
 #, c-format
 msgid "&Zip"
 msgstr "Zip (&Z)"

--- a/Translations/WinMerge/Corsican.po
+++ b/Translations/WinMerge/Corsican.po
@@ -935,6 +935,9 @@ msgstr "Cupià i nomi di &schedariu"
 msgid "Copy Items To Clip&board"
 msgstr "Cupià l’&elementi in u preme’papei"
 
+msgid "Copy All Di&splayed Columns"
+msgstr ""
+
 msgid "&Zip"
 msgstr "Cumpri&me"
 

--- a/Translations/WinMerge/Croatian.po
+++ b/Translations/WinMerge/Croatian.po
@@ -1132,6 +1132,9 @@ msgstr "Kopiraj &nazive datoteka"
 msgid "Copy Items To Clip&board"
 msgstr ""
 
+msgid "Copy All Di&splayed Columns"
+msgstr ""
+
 #, c-format
 msgid "&Zip"
 msgstr "&Zip"

--- a/Translations/WinMerge/Czech.po
+++ b/Translations/WinMerge/Czech.po
@@ -1132,6 +1132,9 @@ msgstr "Kopírovat &název souboru"
 msgid "Copy Items To Clip&board"
 msgstr ""
 
+msgid "Copy All Di&splayed Columns"
+msgstr ""
+
 #, c-format
 msgid "&Zip"
 msgstr "&Archivovat"

--- a/Translations/WinMerge/Danish.po
+++ b/Translations/WinMerge/Danish.po
@@ -1133,6 +1133,9 @@ msgstr "Ko&pier filnavne"
 msgid "Copy Items To Clip&board"
 msgstr ""
 
+msgid "Copy All Di&splayed Columns"
+msgstr ""
+
 #, c-format
 msgid "&Zip"
 msgstr "&Zip"

--- a/Translations/WinMerge/Dutch.po
+++ b/Translations/WinMerge/Dutch.po
@@ -933,6 +933,9 @@ msgstr "Bestandsnamen kopiëren"
 msgid "Copy Items To Clip&board"
 msgstr "Items naar klembord kopiëren"
 
+msgid "Copy All Di&splayed Columns"
+msgstr ""
+
 msgid "&Zip"
 msgstr "Zippen"
 

--- a/Translations/WinMerge/English.pot
+++ b/Translations/WinMerge/English.pot
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: WinMerge\n"
 "Report-Msgid-Bugs-To: https://bugs.winmerge.org/\n"
-"POT-Creation-Date: 2022-10-16 00:15+0000\n"
+"POT-Creation-Date: 2022-12-18 17:41+0000\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: English <winmerge-translate@lists.sourceforge.net>\n"
@@ -925,6 +925,9 @@ msgid "Copy &Filenames"
 msgstr ""
 
 msgid "Copy Items To Clip&board"
+msgstr ""
+
+msgid "Copy All Di&splayed Columns"
 msgstr ""
 
 msgid "&Zip"

--- a/Translations/WinMerge/Finnish.po
+++ b/Translations/WinMerge/Finnish.po
@@ -933,6 +933,9 @@ msgstr "Kopioi tiedostonimet"
 msgid "Copy Items To Clip&board"
 msgstr "Kopioi kohteet leike&pöydälle"
 
+msgid "Copy All Di&splayed Columns"
+msgstr ""
+
 msgid "&Zip"
 msgstr "Pakkaa"
 

--- a/Translations/WinMerge/French.po
+++ b/Translations/WinMerge/French.po
@@ -1139,6 +1139,9 @@ msgstr "Copier les noms de &fichiers"
 msgid "Copy Items To Clip&board"
 msgstr "Copier éléments dans le presse-papier"
 
+msgid "Copy All Di&splayed Columns"
+msgstr ""
+
 #, c-format
 msgid "&Zip"
 msgstr "Co&mpresser"

--- a/Translations/WinMerge/Galician.po
+++ b/Translations/WinMerge/Galician.po
@@ -1136,6 +1136,9 @@ msgstr "Copiar nomes dos &ficheiros"
 msgid "Copy Items To Clip&board"
 msgstr "Copiar elementos ao &portapapeis"
 
+msgid "Copy All Di&splayed Columns"
+msgstr ""
+
 #, c-format
 msgid "&Zip"
 msgstr "&Zip"

--- a/Translations/WinMerge/German.po
+++ b/Translations/WinMerge/German.po
@@ -1135,6 +1135,9 @@ msgstr "&Dateinamen kopieren"
 msgid "Copy Items To Clip&board"
 msgstr "Objekte in die &Zwischenablage kopieren"
 
+msgid "Copy All Di&splayed Columns"
+msgstr ""
+
 #, c-format
 msgid "&Zip"
 msgstr "P&acken"

--- a/Translations/WinMerge/Greek.po
+++ b/Translations/WinMerge/Greek.po
@@ -1131,6 +1131,9 @@ msgstr "Αντιγραφή Ο&νομάτων"
 msgid "Copy Items To Clip&board"
 msgstr ""
 
+msgid "Copy All Di&splayed Columns"
+msgstr ""
+
 #, c-format
 msgid "&Zip"
 msgstr ""

--- a/Translations/WinMerge/Hungarian.po
+++ b/Translations/WinMerge/Hungarian.po
@@ -1134,6 +1134,9 @@ msgstr "&Fájlnevek másolása"
 msgid "Copy Items To Clip&board"
 msgstr "Elemek másolása a vágólapra"
 
+msgid "Copy All Di&splayed Columns"
+msgstr ""
+
 #, c-format
 msgid "&Zip"
 msgstr "&Zip"

--- a/Translations/WinMerge/Italian.po
+++ b/Translations/WinMerge/Italian.po
@@ -931,6 +931,9 @@ msgstr "Copia nomi dei fi&le"
 msgid "Copy Items To Clip&board"
 msgstr "Copia elementi negli A&ppunti"
 
+msgid "Copy All Di&splayed Columns"
+msgstr ""
+
 msgid "&Zip"
 msgstr "Crea &zip"
 

--- a/Translations/WinMerge/Japanese.po
+++ b/Translations/WinMerge/Japanese.po
@@ -932,6 +932,9 @@ msgstr "ファイル名をコピー(&F)"
 msgid "Copy Items To Clip&board"
 msgstr "項目をクリップボードにコピー(&B)"
 
+msgid "Copy All Di&splayed Columns"
+msgstr "すべての表示列をコピー(&S)"
+
 msgid "&Zip"
 msgstr "圧縮(&Z)"
 

--- a/Translations/WinMerge/Korean.po
+++ b/Translations/WinMerge/Korean.po
@@ -1140,6 +1140,9 @@ msgstr "파일 이름들 복사(&F)"
 msgid "Copy Items To Clip&board"
 msgstr "항목을 클립보드로 복사(&B)"
 
+msgid "Copy All Di&splayed Columns"
+msgstr ""
+
 #, c-format
 msgid "&Zip"
 msgstr "Zip 압축(&Z)"

--- a/Translations/WinMerge/Lithuanian.po
+++ b/Translations/WinMerge/Lithuanian.po
@@ -933,6 +933,9 @@ msgstr "Kopijuoti &failų vardus"
 msgid "Copy Items To Clip&board"
 msgstr "Kopijuoti elementus į iš&karpinę"
 
+msgid "Copy All Di&splayed Columns"
+msgstr ""
+
 msgid "&Zip"
 msgstr "&Zip"
 

--- a/Translations/WinMerge/Norwegian.po
+++ b/Translations/WinMerge/Norwegian.po
@@ -932,6 +932,9 @@ msgstr "Kopier &filnavn"
 msgid "Copy Items To Clip&board"
 msgstr ""
 
+msgid "Copy All Di&splayed Columns"
+msgstr ""
+
 msgid "&Zip"
 msgstr "&Zip"
 

--- a/Translations/WinMerge/Persian.po
+++ b/Translations/WinMerge/Persian.po
@@ -1133,6 +1133,9 @@ msgstr "&F رونوشت برداري از نام پرونده ها "
 msgid "Copy Items To Clip&board"
 msgstr ""
 
+msgid "Copy All Di&splayed Columns"
+msgstr ""
+
 #, c-format
 msgid "&Zip"
 msgstr "&Z فشرده سازي "

--- a/Translations/WinMerge/Polish.po
+++ b/Translations/WinMerge/Polish.po
@@ -934,6 +934,9 @@ msgstr "Kopiuj nazwy plików"
 msgid "Copy Items To Clip&board"
 msgstr "Kopiuj elementy do schowka"
 
+msgid "Copy All Di&splayed Columns"
+msgstr ""
+
 msgid "&Zip"
 msgstr "Spakuj"
 

--- a/Translations/WinMerge/Portuguese.po
+++ b/Translations/WinMerge/Portuguese.po
@@ -934,6 +934,9 @@ msgstr "Co&piar nomes de ficheiro"
 msgid "Copy Items To Clip&board"
 msgstr "Copiar itens para a área de transferência"
 
+msgid "Copy All Di&splayed Columns"
+msgstr ""
+
 msgid "&Zip"
 msgstr "&Zip"
 

--- a/Translations/WinMerge/Romanian.po
+++ b/Translations/WinMerge/Romanian.po
@@ -1132,6 +1132,9 @@ msgstr "Copie numele de &fişier"
 msgid "Copy Items To Clip&board"
 msgstr ""
 
+msgid "Copy All Di&splayed Columns"
+msgstr ""
+
 #, c-format
 msgid "&Zip"
 msgstr "Arhivea&ză"

--- a/Translations/WinMerge/Russian.po
+++ b/Translations/WinMerge/Russian.po
@@ -935,6 +935,9 @@ msgstr "Копировать &имена файлов"
 msgid "Copy Items To Clip&board"
 msgstr "Копировать в буфер"
 
+msgid "Copy All Di&splayed Columns"
+msgstr ""
+
 msgid "&Zip"
 msgstr "&Заархивировать"
 

--- a/Translations/WinMerge/Serbian.po
+++ b/Translations/WinMerge/Serbian.po
@@ -1129,6 +1129,9 @@ msgstr "Умножи називе датотека"
 msgid "Copy Items To Clip&board"
 msgstr ""
 
+msgid "Copy All Di&splayed Columns"
+msgstr ""
+
 #, c-format
 msgid "&Zip"
 msgstr "&Зип"

--- a/Translations/WinMerge/Sinhala.po
+++ b/Translations/WinMerge/Sinhala.po
@@ -1132,6 +1132,9 @@ msgstr "ගොනු නම් පිටපත් කිරීම"
 msgid "Copy Items To Clip&board"
 msgstr ""
 
+msgid "Copy All Di&splayed Columns"
+msgstr ""
+
 #, fuzzy, c-format
 msgid "&Zip"
 msgstr "&Zip"

--- a/Translations/WinMerge/Slovak.po
+++ b/Translations/WinMerge/Slovak.po
@@ -933,6 +933,9 @@ msgstr "Kopírovať názvy &súborov"
 msgid "Copy Items To Clip&board"
 msgstr "Kopírovať položky do &schránky"
 
+msgid "Copy All Di&splayed Columns"
+msgstr ""
+
 msgid "&Zip"
 msgstr "&Zbaliť ZIP"
 

--- a/Translations/WinMerge/Slovenian.po
+++ b/Translations/WinMerge/Slovenian.po
@@ -933,6 +933,9 @@ msgstr "Kopiraj &imena datotek"
 msgid "Copy Items To Clip&board"
 msgstr "Kopiraj vnose v o&dložišče"
 
+msgid "Copy All Di&splayed Columns"
+msgstr ""
+
 msgid "&Zip"
 msgstr "&Zip arhiv"
 

--- a/Translations/WinMerge/Spanish.po
+++ b/Translations/WinMerge/Spanish.po
@@ -936,6 +936,9 @@ msgstr "Copiar nombres de &archivos"
 msgid "Copy Items To Clip&board"
 msgstr "Copiar Elementos al Portapapeles"
 
+msgid "Copy All Di&splayed Columns"
+msgstr ""
+
 msgid "&Zip"
 msgstr "&Zip"
 

--- a/Translations/WinMerge/Swedish.po
+++ b/Translations/WinMerge/Swedish.po
@@ -934,6 +934,9 @@ msgstr "Kopiera filnamn"
 msgid "Copy Items To Clip&board"
 msgstr "Kopiera objekt till urklipp"
 
+msgid "Copy All Di&splayed Columns"
+msgstr ""
+
 msgid "&Zip"
 msgstr "Zip"
 

--- a/Translations/WinMerge/Turkish.po
+++ b/Translations/WinMerge/Turkish.po
@@ -933,6 +933,9 @@ msgstr "&Dosya adlarını kopyala"
 msgid "Copy Items To Clip&board"
 msgstr "Ö&geleri panoya kopyala"
 
+msgid "Copy All Di&splayed Columns"
+msgstr ""
+
 msgid "&Zip"
 msgstr "&Sıkıştır"
 

--- a/Translations/WinMerge/Ukrainian.po
+++ b/Translations/WinMerge/Ukrainian.po
@@ -1133,6 +1133,9 @@ msgstr "Скопіювати &імена файлів"
 msgid "Copy Items To Clip&board"
 msgstr ""
 
+msgid "Copy All Di&splayed Columns"
+msgstr ""
+
 #, c-format
 msgid "&Zip"
 msgstr "&Заархівувати"


### PR DESCRIPTION
Copy the string of all displayed columns of selected items to the clipboard.
![contextmenu](https://user-images.githubusercontent.com/56220423/208293200-a8bec790-6f2a-4cd3-83b2-97b176aed203.png)
![paste](https://user-images.githubusercontent.com/56220423/208293213-00f1d56a-dfa2-4258-8166-45b18b167829.png)
