### PR TITLE
Modify the "Go to" dialog.

### DIFF
--- a/Src/MergeEditView.cpp
+++ b/Src/MergeEditView.cpp
@@ -3029,6 +3029,7 @@ void CMergeEditView::OnWMGoto()
 	dlg.m_strParam = strutils::to_str(nRealLine + 1);
 	dlg.m_nFile = (pDoc->m_nBuffers < 3) ? (m_nThisPane == 1 ? 2 : 0) : m_nThisPane;
 	dlg.m_nGotoWhat = 0;
+	dlg.m_nFiles = pDoc->m_nBuffers;
 
 	if (dlg.DoModal() == IDOK)
 	{

--- a/Src/WMGotoDlg.cpp
+++ b/Src/WMGotoDlg.cpp
@@ -35,6 +35,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(WMGotoDlg)
 	protected:
+	virtual BOOL OnInitDialog() override;
 	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
@@ -62,6 +63,21 @@ WMGotoDlg::Impl::Impl(WMGotoDlg *p, CWnd* pParent /*= nullptr*/)
 {
 }
 
+/**
+ * @brief Initialize the dialog.
+ * @return Always TRUE.
+ */
+BOOL WMGotoDlg::Impl::OnInitDialog()
+{
+	LangTranslateDialog(m_hWnd);
+	CDialog::OnInitDialog();
+
+	if (m_p->m_nFiles < 3)
+		EnableDlgItem(IDC_WMGOTO_FILEMIDDLE, false);
+
+	return TRUE;
+}
+
 void WMGotoDlg::Impl::DoDataExchange(CDataExchange* pDX)
 {
 	CTrDialog::DoDataExchange(pDX);
@@ -85,7 +101,7 @@ END_MESSAGE_MAP()
 
 
 WMGotoDlg::WMGotoDlg()
-	: m_pimpl(new WMGotoDlg::Impl(this)), m_nFile(-1), m_nGotoWhat(-1) {}
+	: m_pimpl(new WMGotoDlg::Impl(this)), m_nFile(-1), m_nGotoWhat(-1), m_nFiles(-1) {}
 WMGotoDlg::~WMGotoDlg() = default;
 int WMGotoDlg::DoModal() { return static_cast<int>(m_pimpl->DoModal()); }
 

--- a/Src/WMGotoDlg.h
+++ b/Src/WMGotoDlg.h
@@ -21,6 +21,7 @@ public:
 	String m_strParam;   /**< Line/difference number. */
 	int m_nFile;         /**< Target file number. */
 	int m_nGotoWhat;     /**< Goto line or difference? */
+	int m_nFiles;        /**< Number of files being compared. */
 private:
 	WMGotoDlg(const WMGotoDlg &) = delete;
 	WMGotoDlg & operator=(const WMGotoDlg &) = delete;


### PR DESCRIPTION
Disable the "Middle" radio button when doing 2-way file comparisons.