### PR TITLE
Translate some plugin error messages

### DIFF
--- a/Src/DiffWrapper.cpp
+++ b/Src/DiffWrapper.cpp
@@ -494,8 +494,8 @@ bool CDiffWrapper::RunFileDiff()
 			if (m_infoPrediffer && !m_infoPrediffer->Prediffing(strFileTemp[file], m_sToFindPrediffer, m_bPathsAreTemp, { strFileTemp[file] }))
 			{
 				// display a message box
-				String sError = strutils::format(
-					_T("An error occurred while prediffing the file '%s' with the plugin '%s'. The prediffing is not applied any more."),
+				String sError = strutils::format_string2(
+					_("An error occurred while prediffing the file '%1' with the plugin '%2'. The prediffing is not applied any more."),
 					strFileTemp[file].c_str(),
 					m_infoPrediffer->GetPluginPipeline().c_str());
 				AppErrorMessageBox(sError);

--- a/Src/FileTransform.cpp
+++ b/Src/FileTransform.cpp
@@ -269,7 +269,7 @@ bool PackingInfo::GetPackUnpackPlugin(const String& filteredFilenames, bool bUrl
 						else
 						{
 							plugin = nullptr;
-							errorMessage = strutils::format(_T("'%s' is not PACK_UNPACK plugin"), pluginName);
+							errorMessage = strutils::format_string1(_("'%1' is not unpacker plugin"), pluginName);
 						}
 						return false;
 					}
@@ -553,7 +553,7 @@ bool PrediffingInfo::GetPrediffPlugin(const String& filteredFilenames, bool bRev
 					}
 					else
 					{
-						errorMessage = strutils::format(_T("'%s' is not PREDIFF plugin"), pluginName);
+						errorMessage = strutils::format_string1(_("'%1' is not prediffer plugin"), pluginName);
 					}
 					return false;
 				}

--- a/Src/Merge.rc
+++ b/Src/Merge.rc
@@ -4141,6 +4141,12 @@ BEGIN
     IDS_PLUGIN_MISSING_QUOTATION_MARK 
                             "Missing quotation mark in plugin pipeline: %1"
     IDS_PLUGIN_TITLE1       "Specify plugin arguments"
+    IDS_PLUGIN_NOTFOUND_INVALID
+                            "Plugin not found or invalid: %1"
+    IDS_PLUGIN_NOT_UNPACK   "'%1' is not unpacker plugin"
+    IDS_PLUGIN_NOT_PREDIFF  "'%1' is not prediffer plugin"
+    IDS_PLUGIN_PREDIFF_ERROR
+                            "An error occurred while prediffing the file '%1' with the plugin '%2'. The prediffing is not applied any more."
 END
 
 STRINGTABLE

--- a/Src/resource.h
+++ b/Src/resource.h
@@ -1606,6 +1606,10 @@
 #define IDS_PLUGIN_MISSING_PLUGIN_NAME  44490
 #define IDS_PLUGIN_MISSING_QUOTATION_MARK 44491
 #define IDS_PLUGIN_TITLE1               44492
+#define IDS_PLUGIN_NOTFOUND_INVALID     44493
+#define IDS_PLUGIN_NOT_UNPACK           44494
+#define IDS_PLUGIN_NOT_PREDIFF          44495
+#define IDS_PLUGIN_PREDIFF_ERROR        44496
 #define IDS_L2M                         44500
 #define IDS_R2M                         44501
 #define IDS_COPY_FROM_MIDDLE_R          44502

--- a/Translations/WinMerge/Arabic.po
+++ b/Translations/WinMerge/Arabic.po
@@ -3933,6 +3933,22 @@ msgstr ""
 msgid "Specify plugin arguments"
 msgstr ""
 
+#, c-format
+msgid "Plugin not found or invalid: %1"
+msgstr ""
+
+#, c-format
+msgid "'%1' is not unpacker plugin"
+msgstr ""
+
+#, c-format
+msgid "'%1' is not prediffer plugin"
+msgstr ""
+
+#, c-format
+msgid "An error occurred while prediffing the file '%1' with the plugin '%2'. The prediffing is not applied any more."
+msgstr ""
+
 msgid "Filter applied"
 msgstr ""
 

--- a/Translations/WinMerge/Basque.po
+++ b/Translations/WinMerge/Basque.po
@@ -4540,6 +4540,22 @@ msgstr ""
 msgid "Specify plugin arguments"
 msgstr ""
 
+#, c-format
+msgid "Plugin not found or invalid: %1"
+msgstr ""
+
+#, c-format
+msgid "'%1' is not unpacker plugin"
+msgstr ""
+
+#, c-format
+msgid "'%1' is not prediffer plugin"
+msgstr ""
+
+#, c-format
+msgid "An error occurred while prediffing the file '%1' with the plugin '%2'. The prediffing is not applied any more."
+msgstr ""
+
 msgid "Filter applied"
 msgstr ""
 

--- a/Translations/WinMerge/Brazilian.po
+++ b/Translations/WinMerge/Brazilian.po
@@ -3615,6 +3615,22 @@ msgstr "Marca das aspas ausentes na tubulação do plugin: %1"
 msgid "Specify plugin arguments"
 msgstr "Especificar os argumentos do plugin"
 
+#, c-format
+msgid "Plugin not found or invalid: %1"
+msgstr ""
+
+#, c-format
+msgid "'%1' is not unpacker plugin"
+msgstr ""
+
+#, c-format
+msgid "'%1' is not prediffer plugin"
+msgstr ""
+
+#, c-format
+msgid "An error occurred while prediffing the file '%1' with the plugin '%2'. The prediffing is not applied any more."
+msgstr ""
+
 msgid "Filter applied"
 msgstr "Filtro aplicado"
 

--- a/Translations/WinMerge/Bulgarian.po
+++ b/Translations/WinMerge/Bulgarian.po
@@ -4017,6 +4017,22 @@ msgstr ""
 msgid "Specify plugin arguments"
 msgstr ""
 
+#, c-format
+msgid "Plugin not found or invalid: %1"
+msgstr ""
+
+#, c-format
+msgid "'%1' is not unpacker plugin"
+msgstr ""
+
+#, c-format
+msgid "'%1' is not prediffer plugin"
+msgstr ""
+
+#, c-format
+msgid "An error occurred while prediffing the file '%1' with the plugin '%2'. The prediffing is not applied any more."
+msgstr ""
+
 msgid "Filter applied"
 msgstr ""
 

--- a/Translations/WinMerge/Catalan.po
+++ b/Translations/WinMerge/Catalan.po
@@ -4695,6 +4695,22 @@ msgstr "Manca les cometes a la seqüència: %1"
 msgid "Specify plugin arguments"
 msgstr "Especifiqueu els paràmetres del connector"
 
+#, c-format
+msgid "Plugin not found or invalid: %1"
+msgstr ""
+
+#, c-format
+msgid "'%1' is not unpacker plugin"
+msgstr ""
+
+#, c-format
+msgid "'%1' is not prediffer plugin"
+msgstr ""
+
+#, c-format
+msgid "An error occurred while prediffing the file '%1' with the plugin '%2'. The prediffing is not applied any more."
+msgstr ""
+
 msgid "Filter applied"
 msgstr "Filtre aplicat"
 

--- a/Translations/WinMerge/ChineseSimplified.po
+++ b/Translations/WinMerge/ChineseSimplified.po
@@ -4037,6 +4037,22 @@ msgstr "插件流程（pipeline）中缺少引号: %1"
 msgid "Specify plugin arguments"
 msgstr "指定插件参数"
 
+#, c-format
+msgid "Plugin not found or invalid: %1"
+msgstr ""
+
+#, c-format
+msgid "'%1' is not unpacker plugin"
+msgstr ""
+
+#, c-format
+msgid "'%1' is not prediffer plugin"
+msgstr ""
+
+#, c-format
+msgid "An error occurred while prediffing the file '%1' with the plugin '%2'. The prediffing is not applied any more."
+msgstr ""
+
 msgid "Filter applied"
 msgstr "过滤器已应用"
 

--- a/Translations/WinMerge/ChineseTraditional.po
+++ b/Translations/WinMerge/ChineseTraditional.po
@@ -4694,6 +4694,22 @@ msgstr "外掛程式管線缺少引號：%1"
 msgid "Specify plugin arguments"
 msgstr "指定外掛程式參數"
 
+#, c-format
+msgid "Plugin not found or invalid: %1"
+msgstr ""
+
+#, c-format
+msgid "'%1' is not unpacker plugin"
+msgstr ""
+
+#, c-format
+msgid "'%1' is not prediffer plugin"
+msgstr ""
+
+#, c-format
+msgid "An error occurred while prediffing the file '%1' with the plugin '%2'. The prediffing is not applied any more."
+msgstr ""
+
 msgid "Filter applied"
 msgstr ""
 

--- a/Translations/WinMerge/Corsican.po
+++ b/Translations/WinMerge/Corsican.po
@@ -4008,6 +4008,22 @@ msgstr "Marca di citazione assente in u cundottu di u modulu d’estensione : %
 msgid "Specify plugin arguments"
 msgstr "Indicate i parametri di u modulu d’estensione"
 
+#, c-format
+msgid "Plugin not found or invalid: %1"
+msgstr ""
+
+#, c-format
+msgid "'%1' is not unpacker plugin"
+msgstr ""
+
+#, c-format
+msgid "'%1' is not prediffer plugin"
+msgstr ""
+
+#, c-format
+msgid "An error occurred while prediffing the file '%1' with the plugin '%2'. The prediffing is not applied any more."
+msgstr ""
+
 msgid "Filter applied"
 msgstr "Filtru appiecatu"
 

--- a/Translations/WinMerge/Croatian.po
+++ b/Translations/WinMerge/Croatian.po
@@ -4539,6 +4539,22 @@ msgstr ""
 msgid "Specify plugin arguments"
 msgstr ""
 
+#, c-format
+msgid "Plugin not found or invalid: %1"
+msgstr ""
+
+#, c-format
+msgid "'%1' is not unpacker plugin"
+msgstr ""
+
+#, c-format
+msgid "'%1' is not prediffer plugin"
+msgstr ""
+
+#, c-format
+msgid "An error occurred while prediffing the file '%1' with the plugin '%2'. The prediffing is not applied any more."
+msgstr ""
+
 msgid "Filter applied"
 msgstr ""
 

--- a/Translations/WinMerge/Czech.po
+++ b/Translations/WinMerge/Czech.po
@@ -4472,6 +4472,22 @@ msgstr ""
 msgid "Specify plugin arguments"
 msgstr ""
 
+#, c-format
+msgid "Plugin not found or invalid: %1"
+msgstr ""
+
+#, c-format
+msgid "'%1' is not unpacker plugin"
+msgstr ""
+
+#, c-format
+msgid "'%1' is not prediffer plugin"
+msgstr ""
+
+#, c-format
+msgid "An error occurred while prediffing the file '%1' with the plugin '%2'. The prediffing is not applied any more."
+msgstr ""
+
 msgid "Filter applied"
 msgstr ""
 

--- a/Translations/WinMerge/Danish.po
+++ b/Translations/WinMerge/Danish.po
@@ -4577,6 +4577,22 @@ msgstr ""
 msgid "Specify plugin arguments"
 msgstr ""
 
+#, c-format
+msgid "Plugin not found or invalid: %1"
+msgstr ""
+
+#, c-format
+msgid "'%1' is not unpacker plugin"
+msgstr ""
+
+#, c-format
+msgid "'%1' is not prediffer plugin"
+msgstr ""
+
+#, c-format
+msgid "An error occurred while prediffing the file '%1' with the plugin '%2'. The prediffing is not applied any more."
+msgstr ""
+
 msgid "Filter applied"
 msgstr ""
 

--- a/Translations/WinMerge/Dutch.po
+++ b/Translations/WinMerge/Dutch.po
@@ -3994,6 +3994,22 @@ msgstr "Ontbrekend aanhalingsteken in plugin-pipeline: %1"
 msgid "Specify plugin arguments"
 msgstr "Plugin-argumenten opgeven"
 
+#, c-format
+msgid "Plugin not found or invalid: %1"
+msgstr ""
+
+#, c-format
+msgid "'%1' is not unpacker plugin"
+msgstr ""
+
+#, c-format
+msgid "'%1' is not prediffer plugin"
+msgstr ""
+
+#, c-format
+msgid "An error occurred while prediffing the file '%1' with the plugin '%2'. The prediffing is not applied any more."
+msgstr ""
+
 msgid "Filter applied"
 msgstr "Filter toegepast"
 

--- a/Translations/WinMerge/English.pot
+++ b/Translations/WinMerge/English.pot
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: WinMerge\n"
 "Report-Msgid-Bugs-To: https://bugs.winmerge.org/\n"
-"POT-Creation-Date: 2023-05-01 23:13+0000\n"
+"POT-Creation-Date: 2023-05-27 17:24+0000\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: English <winmerge-translate@lists.sourceforge.net>\n"
@@ -3607,6 +3607,22 @@ msgid "Missing quotation mark in plugin pipeline: %1"
 msgstr ""
 
 msgid "Specify plugin arguments"
+msgstr ""
+
+#, c-format
+msgid "Plugin not found or invalid: %1"
+msgstr ""
+
+#, c-format
+msgid "'%1' is not unpacker plugin"
+msgstr ""
+
+#, c-format
+msgid "'%1' is not prediffer plugin"
+msgstr ""
+
+#, c-format
+msgid "An error occurred while prediffing the file '%1' with the plugin '%2'. The prediffing is not applied any more."
 msgstr ""
 
 msgid "Filter applied"

--- a/Translations/WinMerge/Finnish.po
+++ b/Translations/WinMerge/Finnish.po
@@ -4029,6 +4029,22 @@ msgstr "Puuttuva lainausmerkki laajennusputkessa: %1"
 msgid "Specify plugin arguments"
 msgstr "Määritä laajennuksen argumentit"
 
+#, c-format
+msgid "Plugin not found or invalid: %1"
+msgstr ""
+
+#, c-format
+msgid "'%1' is not unpacker plugin"
+msgstr ""
+
+#, c-format
+msgid "'%1' is not prediffer plugin"
+msgstr ""
+
+#, c-format
+msgid "An error occurred while prediffing the file '%1' with the plugin '%2'. The prediffing is not applied any more."
+msgstr ""
+
 msgid "Filter applied"
 msgstr "Sovellettu suodatin"
 

--- a/Translations/WinMerge/French.po
+++ b/Translations/WinMerge/French.po
@@ -4722,6 +4722,22 @@ msgstr "Guillemet manquant dans la chaîne de traitement du plug-in : %1"
 msgid "Specify plugin arguments"
 msgstr "Spécifier les arguments du plug-in"
 
+#, c-format
+msgid "Plugin not found or invalid: %1"
+msgstr ""
+
+#, c-format
+msgid "'%1' is not unpacker plugin"
+msgstr ""
+
+#, c-format
+msgid "'%1' is not prediffer plugin"
+msgstr ""
+
+#, c-format
+msgid "An error occurred while prediffing the file '%1' with the plugin '%2'. The prediffing is not applied any more."
+msgstr ""
+
 msgid "Filter applied"
 msgstr "Filtre appliqué"
 

--- a/Translations/WinMerge/Galician.po
+++ b/Translations/WinMerge/Galician.po
@@ -3998,6 +3998,22 @@ msgstr "Faltan comiñas na canalización de complementos %1"
 msgid "Specify plugin arguments"
 msgstr "Especificar os argumentos do complemento"
 
+#, c-format
+msgid "Plugin not found or invalid: %1"
+msgstr ""
+
+#, c-format
+msgid "'%1' is not unpacker plugin"
+msgstr ""
+
+#, c-format
+msgid "'%1' is not prediffer plugin"
+msgstr ""
+
+#, c-format
+msgid "An error occurred while prediffing the file '%1' with the plugin '%2'. The prediffing is not applied any more."
+msgstr ""
+
 msgid "Filter applied"
 msgstr "Filtro aplicado"
 

--- a/Translations/WinMerge/German.po
+++ b/Translations/WinMerge/German.po
@@ -4335,6 +4335,22 @@ msgstr "Fehlendes Anführungszeichen in der Plugin-Pipeline: %1"
 msgid "Specify plugin arguments"
 msgstr "Plugin-Argumente angeben"
 
+#, c-format
+msgid "Plugin not found or invalid: %1"
+msgstr ""
+
+#, c-format
+msgid "'%1' is not unpacker plugin"
+msgstr ""
+
+#, c-format
+msgid "'%1' is not prediffer plugin"
+msgstr ""
+
+#, c-format
+msgid "An error occurred while prediffing the file '%1' with the plugin '%2'. The prediffing is not applied any more."
+msgstr ""
+
 msgid "Filter applied"
 msgstr "Angewandter Filter"
 

--- a/Translations/WinMerge/Greek.po
+++ b/Translations/WinMerge/Greek.po
@@ -4517,6 +4517,22 @@ msgstr ""
 msgid "Specify plugin arguments"
 msgstr ""
 
+#, c-format
+msgid "Plugin not found or invalid: %1"
+msgstr ""
+
+#, c-format
+msgid "'%1' is not unpacker plugin"
+msgstr ""
+
+#, c-format
+msgid "'%1' is not prediffer plugin"
+msgstr ""
+
+#, c-format
+msgid "An error occurred while prediffing the file '%1' with the plugin '%2'. The prediffing is not applied any more."
+msgstr ""
+
 msgid "Filter applied"
 msgstr ""
 

--- a/Translations/WinMerge/Hungarian.po
+++ b/Translations/WinMerge/Hungarian.po
@@ -4678,6 +4678,22 @@ msgstr "Hiányzó idézőjel a bővítmény pipeline-ban: %1"
 msgid "Specify plugin arguments"
 msgstr "Bővítmény argumentumok megadása"
 
+#, c-format
+msgid "Plugin not found or invalid: %1"
+msgstr ""
+
+#, c-format
+msgid "'%1' is not unpacker plugin"
+msgstr ""
+
+#, c-format
+msgid "'%1' is not prediffer plugin"
+msgstr ""
+
+#, c-format
+msgid "An error occurred while prediffing the file '%1' with the plugin '%2'. The prediffing is not applied any more."
+msgstr ""
+
 msgid "Filter applied"
 msgstr "Szűrő alkalmazva"
 

--- a/Translations/WinMerge/Italian.po
+++ b/Translations/WinMerge/Italian.po
@@ -3974,6 +3974,22 @@ msgstr "Virgoletta mancante nella pipeline dei plugin: %1"
 msgid "Specify plugin arguments"
 msgstr ""
 
+#, c-format
+msgid "Plugin not found or invalid: %1"
+msgstr ""
+
+#, c-format
+msgid "'%1' is not unpacker plugin"
+msgstr ""
+
+#, c-format
+msgid "'%1' is not prediffer plugin"
+msgstr ""
+
+#, c-format
+msgid "An error occurred while prediffing the file '%1' with the plugin '%2'. The prediffing is not applied any more."
+msgstr ""
+
 msgid "Filter applied"
 msgstr ""
 

--- a/Translations/WinMerge/Japanese.po
+++ b/Translations/WinMerge/Japanese.po
@@ -3999,6 +3999,22 @@ msgstr "プラグイン パイプラインが引用符で閉じていません: 
 msgid "Specify plugin arguments"
 msgstr "プラグイン引数を指定してください"
 
+#, c-format
+msgid "Plugin not found or invalid: %1"
+msgstr "プラグインが見つからないまたは無効です: %1"
+
+#, c-format
+msgid "'%1' is not unpacker plugin"
+msgstr "'%1'は展開プラグインではありません"
+
+#, c-format
+msgid "'%1' is not prediffer plugin"
+msgstr "'%1'は比較前処理プラグインではありません"
+
+#, c-format
+msgid "An error occurred while prediffing the file '%1' with the plugin '%2'. The prediffing is not applied any more."
+msgstr "プラグイン'%2'でファイル'%1'の比較前処理を実行中にエラーが発生しました。比較前処理は適用されませんでした。"
+
 msgid "Filter applied"
 msgstr "フィルター適用"
 

--- a/Translations/WinMerge/Korean.po
+++ b/Translations/WinMerge/Korean.po
@@ -4720,6 +4720,22 @@ msgstr "플러그인 파이프라인에 따옴표가 없습니다: %1"
 msgid "Specify plugin arguments"
 msgstr "플러그인 인수 지정"
 
+#, c-format
+msgid "Plugin not found or invalid: %1"
+msgstr ""
+
+#, c-format
+msgid "'%1' is not unpacker plugin"
+msgstr ""
+
+#, c-format
+msgid "'%1' is not prediffer plugin"
+msgstr ""
+
+#, c-format
+msgid "An error occurred while prediffing the file '%1' with the plugin '%2'. The prediffing is not applied any more."
+msgstr ""
+
 msgid "Filter applied"
 msgstr "Filter 적용됨"
 

--- a/Translations/WinMerge/Lithuanian.po
+++ b/Translations/WinMerge/Lithuanian.po
@@ -3615,6 +3615,22 @@ msgstr "Trūksta kabučių papildinio komandų grandinėje: %1"
 msgid "Specify plugin arguments"
 msgstr "Nurodykite papildinio argumentus"
 
+#, c-format
+msgid "Plugin not found or invalid: %1"
+msgstr ""
+
+#, c-format
+msgid "'%1' is not unpacker plugin"
+msgstr ""
+
+#, c-format
+msgid "'%1' is not prediffer plugin"
+msgstr ""
+
+#, c-format
+msgid "An error occurred while prediffing the file '%1' with the plugin '%2'. The prediffing is not applied any more."
+msgstr ""
+
 msgid "Filter applied"
 msgstr "Pritaikytas filtras"
 

--- a/Translations/WinMerge/Norwegian.po
+++ b/Translations/WinMerge/Norwegian.po
@@ -4002,6 +4002,22 @@ msgstr ""
 msgid "Specify plugin arguments"
 msgstr ""
 
+#, c-format
+msgid "Plugin not found or invalid: %1"
+msgstr ""
+
+#, c-format
+msgid "'%1' is not unpacker plugin"
+msgstr ""
+
+#, c-format
+msgid "'%1' is not prediffer plugin"
+msgstr ""
+
+#, c-format
+msgid "An error occurred while prediffing the file '%1' with the plugin '%2'. The prediffing is not applied any more."
+msgstr ""
+
 msgid "Filter applied"
 msgstr ""
 

--- a/Translations/WinMerge/Persian.po
+++ b/Translations/WinMerge/Persian.po
@@ -4586,6 +4586,22 @@ msgstr ""
 msgid "Specify plugin arguments"
 msgstr ""
 
+#, c-format
+msgid "Plugin not found or invalid: %1"
+msgstr ""
+
+#, c-format
+msgid "'%1' is not unpacker plugin"
+msgstr ""
+
+#, c-format
+msgid "'%1' is not prediffer plugin"
+msgstr ""
+
+#, c-format
+msgid "An error occurred while prediffing the file '%1' with the plugin '%2'. The prediffing is not applied any more."
+msgstr ""
+
 msgid "Filter applied"
 msgstr ""
 

--- a/Translations/WinMerge/Polish.po
+++ b/Translations/WinMerge/Polish.po
@@ -3616,6 +3616,22 @@ msgstr "Brakujący cudzysłów we wtyczce pipeline: %1"
 msgid "Specify plugin arguments"
 msgstr "Określ argumenty wtyczki"
 
+#, c-format
+msgid "Plugin not found or invalid: %1"
+msgstr ""
+
+#, c-format
+msgid "'%1' is not unpacker plugin"
+msgstr ""
+
+#, c-format
+msgid "'%1' is not prediffer plugin"
+msgstr ""
+
+#, c-format
+msgid "An error occurred while prediffing the file '%1' with the plugin '%2'. The prediffing is not applied any more."
+msgstr ""
+
 msgid "Filter applied"
 msgstr "Zastosowano filtr"
 

--- a/Translations/WinMerge/Portuguese.po
+++ b/Translations/WinMerge/Portuguese.po
@@ -4040,6 +4040,22 @@ msgstr "Marca de cotação em falta no plugin pipeline: %1"
 msgid "Specify plugin arguments"
 msgstr "Especificar argumentos de plugin"
 
+#, c-format
+msgid "Plugin not found or invalid: %1"
+msgstr ""
+
+#, c-format
+msgid "'%1' is not unpacker plugin"
+msgstr ""
+
+#, c-format
+msgid "'%1' is not prediffer plugin"
+msgstr ""
+
+#, c-format
+msgid "An error occurred while prediffing the file '%1' with the plugin '%2'. The prediffing is not applied any more."
+msgstr ""
+
 msgid "Filter applied"
 msgstr "Filtro aplicado"
 

--- a/Translations/WinMerge/Romanian.po
+++ b/Translations/WinMerge/Romanian.po
@@ -4522,6 +4522,22 @@ msgstr ""
 msgid "Specify plugin arguments"
 msgstr ""
 
+#, c-format
+msgid "Plugin not found or invalid: %1"
+msgstr ""
+
+#, c-format
+msgid "'%1' is not unpacker plugin"
+msgstr ""
+
+#, c-format
+msgid "'%1' is not prediffer plugin"
+msgstr ""
+
+#, c-format
+msgid "An error occurred while prediffing the file '%1' with the plugin '%2'. The prediffing is not applied any more."
+msgstr ""
+
 msgid "Filter applied"
 msgstr ""
 

--- a/Translations/WinMerge/Russian.po
+++ b/Translations/WinMerge/Russian.po
@@ -3617,6 +3617,22 @@ msgstr "Отсутствует кавычка в конвейере плагин
 msgid "Specify plugin arguments"
 msgstr "Укажите аргументы плагина"
 
+#, c-format
+msgid "Plugin not found or invalid: %1"
+msgstr ""
+
+#, c-format
+msgid "'%1' is not unpacker plugin"
+msgstr ""
+
+#, c-format
+msgid "'%1' is not prediffer plugin"
+msgstr ""
+
+#, c-format
+msgid "An error occurred while prediffing the file '%1' with the plugin '%2'. The prediffing is not applied any more."
+msgstr ""
+
 msgid "Filter applied"
 msgstr "Фильтр применен"
 

--- a/Translations/WinMerge/Serbian.po
+++ b/Translations/WinMerge/Serbian.po
@@ -4511,6 +4511,22 @@ msgstr ""
 msgid "Specify plugin arguments"
 msgstr ""
 
+#, c-format
+msgid "Plugin not found or invalid: %1"
+msgstr ""
+
+#, c-format
+msgid "'%1' is not unpacker plugin"
+msgstr ""
+
+#, c-format
+msgid "'%1' is not prediffer plugin"
+msgstr ""
+
+#, c-format
+msgid "An error occurred while prediffing the file '%1' with the plugin '%2'. The prediffing is not applied any more."
+msgstr ""
+
 msgid "Filter applied"
 msgstr ""
 

--- a/Translations/WinMerge/Sinhala.po
+++ b/Translations/WinMerge/Sinhala.po
@@ -4540,6 +4540,22 @@ msgstr ""
 msgid "Specify plugin arguments"
 msgstr ""
 
+#, c-format
+msgid "Plugin not found or invalid: %1"
+msgstr ""
+
+#, c-format
+msgid "'%1' is not unpacker plugin"
+msgstr ""
+
+#, c-format
+msgid "'%1' is not prediffer plugin"
+msgstr ""
+
+#, c-format
+msgid "An error occurred while prediffing the file '%1' with the plugin '%2'. The prediffing is not applied any more."
+msgstr ""
+
 msgid "Filter applied"
 msgstr ""
 

--- a/Translations/WinMerge/Slovak.po
+++ b/Translations/WinMerge/Slovak.po
@@ -3973,6 +3973,22 @@ msgstr "Chýbajúca úvodzovka v rozšírení: %1"
 msgid "Specify plugin arguments"
 msgstr "Určenie argumentov rozšírenia"
 
+#, c-format
+msgid "Plugin not found or invalid: %1"
+msgstr ""
+
+#, c-format
+msgid "'%1' is not unpacker plugin"
+msgstr ""
+
+#, c-format
+msgid "'%1' is not prediffer plugin"
+msgstr ""
+
+#, c-format
+msgid "An error occurred while prediffing the file '%1' with the plugin '%2'. The prediffing is not applied any more."
+msgstr ""
+
 msgid "Filter applied"
 msgstr "Použitý filter"
 

--- a/Translations/WinMerge/Slovenian.po
+++ b/Translations/WinMerge/Slovenian.po
@@ -3998,6 +3998,22 @@ msgstr "Manjka narekovaj v cevovodu vtičnika: %1"
 msgid "Specify plugin arguments"
 msgstr "Določi argumente vtičnika"
 
+#, c-format
+msgid "Plugin not found or invalid: %1"
+msgstr ""
+
+#, c-format
+msgid "'%1' is not unpacker plugin"
+msgstr ""
+
+#, c-format
+msgid "'%1' is not prediffer plugin"
+msgstr ""
+
+#, c-format
+msgid "An error occurred while prediffing the file '%1' with the plugin '%2'. The prediffing is not applied any more."
+msgstr ""
+
 msgid "Filter applied"
 msgstr "Filter je uporabljen"
 

--- a/Translations/WinMerge/Spanish.po
+++ b/Translations/WinMerge/Spanish.po
@@ -4000,6 +4000,22 @@ msgstr "Faltan comillas en la canalización de complementos %1"
 msgid "Specify plugin arguments"
 msgstr "Especifique argumentos del complemento"
 
+#, c-format
+msgid "Plugin not found or invalid: %1"
+msgstr ""
+
+#, c-format
+msgid "'%1' is not unpacker plugin"
+msgstr ""
+
+#, c-format
+msgid "'%1' is not prediffer plugin"
+msgstr ""
+
+#, c-format
+msgid "An error occurred while prediffing the file '%1' with the plugin '%2'. The prediffing is not applied any more."
+msgstr ""
+
 msgid "Filter applied"
 msgstr "Filtro aplicado"
 

--- a/Translations/WinMerge/Swedish.po
+++ b/Translations/WinMerge/Swedish.po
@@ -4075,6 +4075,22 @@ msgstr "Saknar citationstecken i programtilläggets kommandoslinga: %1"
 msgid "Specify plugin arguments"
 msgstr "Ange programtilläggets kommandoalternativ"
 
+#, c-format
+msgid "Plugin not found or invalid: %1"
+msgstr ""
+
+#, c-format
+msgid "'%1' is not unpacker plugin"
+msgstr ""
+
+#, c-format
+msgid "'%1' is not prediffer plugin"
+msgstr ""
+
+#, c-format
+msgid "An error occurred while prediffing the file '%1' with the plugin '%2'. The prediffing is not applied any more."
+msgstr ""
+
 msgid "Filter applied"
 msgstr "Filter verkställt"
 

--- a/Translations/WinMerge/Turkish.po
+++ b/Translations/WinMerge/Turkish.po
@@ -4068,6 +4068,22 @@ msgstr "Eklenti bağlantı yolunda tırnak karakteri eksik: %1"
 msgid "Specify plugin arguments"
 msgstr "Eklenti değişkenlerini belirtin"
 
+#, c-format
+msgid "Plugin not found or invalid: %1"
+msgstr ""
+
+#, c-format
+msgid "'%1' is not unpacker plugin"
+msgstr ""
+
+#, c-format
+msgid "'%1' is not prediffer plugin"
+msgstr ""
+
+#, c-format
+msgid "An error occurred while prediffing the file '%1' with the plugin '%2'. The prediffing is not applied any more."
+msgstr ""
+
 msgid "Filter applied"
 msgstr "Süzgeç uygulandı"
 

--- a/Translations/WinMerge/Ukrainian.po
+++ b/Translations/WinMerge/Ukrainian.po
@@ -4543,6 +4543,22 @@ msgstr ""
 msgid "Specify plugin arguments"
 msgstr ""
 
+#, c-format
+msgid "Plugin not found or invalid: %1"
+msgstr ""
+
+#, c-format
+msgid "'%1' is not unpacker plugin"
+msgstr ""
+
+#, c-format
+msgid "'%1' is not prediffer plugin"
+msgstr ""
+
+#, c-format
+msgid "An error occurred while prediffing the file '%1' with the plugin '%2'. The prediffing is not applied any more."
+msgstr ""
+
 msgid "Filter applied"
 msgstr ""
 


### PR DESCRIPTION
Make the following plugin error messages translatable.
- "Plugin not found or invalid: %1"
- "'%s' is not PACK_UNPACK plugin"
- "'%s' is not PREDIFF plugin"
- "An error occurred while prediffing the file '%s' with the plugin '%s'. The prediffing is not applied any more."