### PR TITLE
Update DirCmpReport.cpp

### DIFF
--- a/Src/DirCmpReport.cpp
+++ b/Src/DirCmpReport.cpp
@@ -376,6 +376,9 @@ void DirCmpReport::GenerateHTMLHeader()
 	WriteStringEntityAware(m_sTitle);
 	WriteString(_T("</title>\n"));
 	WriteString(_T("\t<style type=\"text/css\">\n\t<!--\n"));
+	WriteString(_T("\t\tth {\n"));
+	WriteString(_T("\t\t\tposition: sticky; top: 0;\n"));
+	WriteString(_T("\t\t}\n"));
 	WriteString(_T("\t\tbody {\n"));
 	WriteString(_T("\t\t\tfont-family: sans-serif;\n"));
 	WriteString(_T("\t\t\tfont-size: smaller;\n"));


### PR DESCRIPTION
Make the HTML report header sticky so it stays in place when scrolling down.

| Before | After |
| --- | --- |
| ![before](https://github.com/WinMerge/winmerge/assets/5055400/c662200d-1bee-4c1b-91d4-f647bcad5358) [High res before](https://imgur.com/Bv3z0Qv) | ![after](https://github.com/WinMerge/winmerge/assets/5055400/a40834e9-c7d3-4ee8-b83f-021b2af50d3d) [High res after](https://imgur.com/AcCmXBn) |