### PR TITLE
Compare folders recursively if "Include subfolders" is checked in the…

### DIFF
--- a/Docs/Manual/EN/Command_line.xml
+++ b/Docs/Manual/EN/Command_line.xml
@@ -26,6 +26,8 @@
 
       <arg choice="opt" rep="norepeat"><option>/r</option></arg>
 
+      <arg choice="opt" rep="norepeat"><option>/r-</option></arg>
+
       <arg choice="opt" rep="norepeat"><option>/e</option></arg>
 
       <arg choice="opt" rep="norepeat"><option>/f</option>
@@ -188,6 +190,18 @@
         increase compare time significantly. Without this parameter, WinMerge
         lists only files and subfolders at the top level of the two target
         folders. It does not compare the subfolders.</para>
+      </listitem>
+    </varlistentry>
+
+    <varlistentry>
+      <indexterm>
+        <primary>non-recursive folder compare</primary>
+      </indexterm>
+      <term><option>/r-</option></term>
+      <listitem>
+        <para>Compares all files within the specified folders
+        but excludes the files and subfolders within its subfolders.
+        This allows for a shorter comparison time.</para>
       </listitem>
     </varlistentry>
 

--- a/Docs/Manual/JP/Command_line.xml
+++ b/Docs/Manual/JP/Command_line.xml
@@ -26,6 +26,8 @@
 
       <arg choice="opt" rep="norepeat"><option>/r</option></arg>
 
+      <arg choice="opt" rep="norepeat"><option>/r-</option></arg>
+
       <arg choice="opt" rep="norepeat"><option>/e</option></arg>
 
       <arg choice="opt" rep="norepeat"><option>/f</option>
@@ -187,6 +189,18 @@
         サブフォルダーまで含めるとかなり比較時間が増大してしまうことに注意してください。
         このパラメーターを指定しなかった場合、WinMergeは比較するフォルダー内のファイルとトップレベルのサブフォルダーのみリストします。
         サブフォルダーの中までは比較しません。</para>
+      </listitem>
+    </varlistentry>
+
+    <varlistentry>
+      <indexterm>
+        <primary>非再帰フォルダー比較</primary>
+      </indexterm>
+      <term><option>/r-</option></term>
+      <listitem>
+        <para>指定されたフォルダー内のすべてのファイルを比較しますが、
+        そのサブフォルダー内のファイルとサブフォルダーは除外します。
+        これにより、比較時間を短縮することができます。</para>
       </listitem>
     </varlistentry>
 

--- a/Src/MainFrm.cpp
+++ b/Src/MainFrm.cpp
@@ -1165,7 +1165,7 @@ void CMainFrame::OnOptions()
 
 static bool AddToRecentDocs(const PathContext& paths,
 	const unsigned flags[], const String desc[],
-	bool recurse, const String& filter,
+	std::optional<bool> recurse, const String& filter,
 	const PackingInfo *infoUnpacker, const PrediffingInfo *infoPrediffer,
 	UINT nID, const CMainFrame::OpenFileParams *pOpenParams)
 {
@@ -1193,8 +1193,8 @@ static bool AddToRecentDocs(const PathContext& paths,
 		if (nIndex < paths.GetSize() - 1)
 			title += _T(" - ");
 	}
-	if (recurse)
-		params += _T("/r ");
+	if (recurse.has_value())
+		params += *recurse ? _T("/r ") : _T("/r- ");
 	if (!filter.empty())
 		params += _T("/f \"") + filter + _T("\" ");
 	switch (nID)
@@ -1274,7 +1274,7 @@ static bool AddToRecentDocs(const PathContext& paths,
  */
 bool CMainFrame::DoFileOrFolderOpen(const PathContext * pFiles /*= nullptr*/,
 	const fileopenflags_t dwFlags[] /*= nullptr*/, const String strDesc[] /*= nullptr*/, const String& sReportFile /*= T("")*/,
-	bool bRecurse /*= false*/, CDirDoc* pDirDoc/*= nullptr*/,
+	std::optional<bool> bRecurse /*= false*/, CDirDoc* pDirDoc/*= nullptr*/,
 	const PackingInfo *infoUnpacker /*= nullptr*/, const PrediffingInfo *infoPrediffer /*= nullptr*/,
 	UINT nID /*= 0*/, const OpenFileParams *pOpenParams /*= nullptr*/)
 {
@@ -1297,6 +1297,8 @@ bool CMainFrame::DoFileOrFolderOpen(const PathContext * pFiles /*= nullptr*/,
 		bRO[2] = (dwFlags[2] & FFILEOPEN_READONLY) != 0;
 	};
 
+	bool bRecurse2 = bRecurse.has_value() ? *bRecurse : GetOptionsMgr()->GetBool(OPT_CMP_INCLUDE_SUBDIRS);
+
 	// pop up dialog unless arguments exist (and are compatible)
 	paths::PATH_EXISTENCE pathsType = paths::GetPairComparability(tFiles, IsArchiveFile);
 	bool allowFolderCompare = (static_cast<int>(nID) <= 0);
@@ -1313,7 +1315,7 @@ bool CMainFrame::DoFileOrFolderOpen(const PathContext * pFiles /*= nullptr*/,
 			pOpenDoc->m_dwFlags[2] = dwFlags[2];
 		}
 		pOpenDoc->m_files = tFiles;
-		pOpenDoc->m_bRecurse = bRecurse;
+		pOpenDoc->m_bRecurse = bRecurse2;
 		if (infoUnpacker)
 			pOpenDoc->m_strUnpackerPipeline = infoUnpacker->GetPluginPipeline();
 		CFrameWnd *pFrame = theApp.m_pOpenTemplate->CreateNewFrame(pOpenDoc, nullptr);
@@ -1389,7 +1391,7 @@ bool CMainFrame::DoFileOrFolderOpen(const PathContext * pFiles /*= nullptr*/,
 		{
 			// Anything that can go wrong inside InitCompare() will yield an
 			// exception. There is no point in checking return value.
-			pDirDoc->InitCompare(tFiles, bRecurse, pTempPathContext);
+			pDirDoc->InitCompare(tFiles, bRecurse2, pTempPathContext);
 
 			const auto* pOpenFolderParams = dynamic_cast<const OpenFolderParams*>(pOpenParams);
 			if (pOpenFolderParams)

--- a/Src/MainFrm.h
+++ b/Src/MainFrm.h
@@ -146,7 +146,7 @@ public:
 
 	bool DoFileOrFolderOpen(const PathContext *pFiles = nullptr,
 		const fileopenflags_t dwFlags[] = nullptr, const String strDesc[] = nullptr,
-		const String& sReportFile = _T(""), bool bRecurse = false, CDirDoc *pDirDoc = nullptr,
+		const String& sReportFile = _T(""), std::optional<bool> bRecurse = false, CDirDoc *pDirDoc = nullptr,
 		const PackingInfo * infoUnpacker = nullptr, const PrediffingInfo * infoPrediffer = nullptr,
 		UINT nID = 0, const OpenFileParams *pOpenParams = nullptr);
 	bool DoFileOpen(UINT nID, const PathContext* pFiles,

--- a/Src/MergeCmdLineInfo.cpp
+++ b/Src/MergeCmdLineInfo.cpp
@@ -121,7 +121,6 @@ MergeCmdLineInfo::MergeCmdLineInfo(const tchar_t* q)
 	, m_bShowCompareAsMenu(false)
 	, m_bEscShutdown(false)
 	, m_bExitIfNoDiff(Disabled)
-	, m_bRecurse(false)
 	, m_bNonInteractive(false)
 	, m_nSingleInstance()
 	, m_bShowUsage(false)
@@ -303,7 +302,18 @@ void MergeCmdLineInfo::ParseWinMergeCmdLine(const tchar_t *q)
 		else if (param == _T("r"))
 		{
 			// -r to compare recursively
-			m_bRecurse = true;
+			if (*q == ':')
+			{
+				q = EatParam(q + 1, param);
+				m_bRecurse = (tc::ttoi(param.c_str()) != 0);
+			}
+			else
+				m_bRecurse = true;
+		}
+		else if (param == _T("r-"))
+		{
+			// -r to compare non-recursively
+			m_bRecurse = false;
 		}
 		else if (param == _T("s-"))
 		{

--- a/Src/MergeCmdLineInfo.h
+++ b/Src/MergeCmdLineInfo.h
@@ -89,7 +89,7 @@ public:
 	bool m_bShowCompareAsMenu; /**< Show Compare As menu. */
 	bool m_bEscShutdown; /**< Pressing ESC will close the application */
 	ExitNoDiff m_bExitIfNoDiff; /**< Exit if files are identical. */
-	bool m_bRecurse; /**< Include sub folder in directories compare. */
+	std::optional<bool> m_bRecurse; /**< Include sub folder in directories compare. */
 	std::optional<CompareMethodType> m_nCompMethod; /**< Compare method */
 	bool m_bNonInteractive; /**< Suppress user's notifications. */
 	std::optional<int> m_nSingleInstance; /**< Allow only one instance of WinMerge executable. */


### PR DESCRIPTION
… Options dialog even if the /r command line option is not specified.

Also, add the command line option /r- for non-recursive folder comparison.