### PR TITLE
Fix issue #1985: Wimerge saves changes to the wrong file

### DIFF
--- a/Src/HexMergeDoc.h
+++ b/Src/HexMergeDoc.h
@@ -87,6 +87,9 @@ public:
 	String GetDescription(int pane) const override { return m_strDesc[pane]; };
 	void SetDescription(int pane, const String& strDesc) {  m_strDesc[pane] = strDesc; };
 	void SaveAs(int nBuffer, bool packing = true) { DoFileSaveAs(nBuffer, packing); }
+	String GetSaveAsPath() const { return m_strSaveAsPath; }
+	void SetSaveAsPath(const String& strSaveAsPath) { m_strSaveAsPath = strSaveAsPath; }
+
 private:
 	bool DoFileSave(int nBuffer);
 	bool DoFileSaveAs(int nBuffer, bool packing = true);
@@ -99,6 +102,7 @@ protected:
 	String m_strDesc[3]; /**< Left/right side description text */
 	BUFFERTYPE m_nBufferType[3];
 	PackingInfo m_infoUnpacker;
+	String m_strSaveAsPath; /**< "3rd path" where output saved if given */
 
 // Generated message map functions
 protected:

--- a/Src/HexMergeView.cpp
+++ b/Src/HexMergeView.cpp
@@ -318,22 +318,6 @@ HRESULT CHexMergeView::LoadFile(const tchar_t* path)
  */
 HRESULT CHexMergeView::SaveFile(const tchar_t* path, bool packing)
 {
-	// Warn user in case file has been changed by someone else
-	if (IsFileChangedOnDisk(path) == IMergeDoc::FileChange::Changed)
-	{
-		String msg = strutils::format_string1(_("Another application has updated file\n%1\nsince WinMerge loaded it.\n\nOverwrite changed file?"), path);
-		if (AfxMessageBox(msg.c_str(), MB_ICONWARNING | MB_YESNO) == IDNO)
-			return E_FAIL;
-	}
-	// Ask user what to do about FILE_ATTRIBUTE_READONLY
-	String strPath = path;
-	bool bApplyToAll = false;
-	if (CMergeApp::HandleReadonlySave(strPath, false, bApplyToAll) == IDCANCEL)
-		return E_FAIL;
-	path = strPath.c_str();
-	// Take a chance to create a backup
-	if (!CMergeApp::CreateBackup(false, path))
-		return E_FAIL;
 	// Write data to an intermediate file
 	String tempPath = env::GetTemporaryPath();
 	String sIntermediateFilename = env::GetTemporaryFileName(tempPath, _T("MRG_"), 0);

--- a/Src/ImgMergeFrm.cpp
+++ b/Src/ImgMergeFrm.cpp
@@ -1215,10 +1215,10 @@ bool CImgMergeFrame::PromptAndSaveIfNeeded(bool bAllowCancel)
 		dlg.m_bDisableCancel = true;
 	if (!m_filePaths.GetLeft().empty())
 	{
-		if (theApp.m_strSaveAsPath.empty())
+		if (m_strSaveAsPath.empty())
 			dlg.m_sLeftFile = m_filePaths.GetLeft();
 		else
-			dlg.m_sLeftFile = theApp.m_strSaveAsPath;
+			dlg.m_sLeftFile = m_strSaveAsPath;
 	}
 	else
 		dlg.m_sLeftFile = m_strDesc[0];
@@ -1226,20 +1226,20 @@ bool CImgMergeFrame::PromptAndSaveIfNeeded(bool bAllowCancel)
 	{
 		if (!m_filePaths.GetMiddle().empty())
 		{
-			if (theApp.m_strSaveAsPath.empty())
+			if (m_strSaveAsPath.empty())
 				dlg.m_sMiddleFile = m_filePaths.GetMiddle();
 			else
-				dlg.m_sMiddleFile = theApp.m_strSaveAsPath;
+				dlg.m_sMiddleFile = m_strSaveAsPath;
 		}
 		else
 			dlg.m_sMiddleFile = m_strDesc[1];
 	}
 	if (!m_filePaths.GetRight().empty())
 	{
-		if (theApp.m_strSaveAsPath.empty())
+		if (m_strSaveAsPath.empty())
 			dlg.m_sRightFile = m_filePaths.GetRight();
 		else
-			dlg.m_sRightFile = theApp.m_strSaveAsPath;
+			dlg.m_sRightFile = m_strSaveAsPath;
 	}
 	else
 		dlg.m_sRightFile = m_strDesc[m_pImgMergeWindow->GetPaneCount() - 1];

--- a/Src/ImgMergeFrm.cpp
+++ b/Src/ImgMergeFrm.cpp
@@ -1217,35 +1217,20 @@ bool CImgMergeFrame::PromptAndSaveIfNeeded(bool bAllowCancel)
 	if (!bAllowCancel)
 		dlg.m_bDisableCancel = true;
 	if (!m_filePaths.GetLeft().empty())
-	{
-		if (m_strSaveAsPath.empty())
-			dlg.m_sLeftFile = m_filePaths.GetLeft();
-		else
-			dlg.m_sLeftFile = m_strSaveAsPath;
-	}
+		dlg.m_sLeftFile = m_strSaveAsPath.empty() ? m_filePaths.GetLeft() : m_strSaveAsPath;
 	else
-		dlg.m_sLeftFile = m_strDesc[0];
+		dlg.m_sLeftFile = m_strSaveAsPath.empty() ?m_strDesc[0] : m_strSaveAsPath;
 	if (m_pImgMergeWindow->GetPaneCount() == 3)
 	{
 		if (!m_filePaths.GetMiddle().empty())
-		{
-			if (m_strSaveAsPath.empty())
-				dlg.m_sMiddleFile = m_filePaths.GetMiddle();
-			else
-				dlg.m_sMiddleFile = m_strSaveAsPath;
-		}
+			dlg.m_sMiddleFile = m_strSaveAsPath.empty() ? m_filePaths.GetMiddle() : m_strSaveAsPath;
 		else
-			dlg.m_sMiddleFile = m_strDesc[1];
+			dlg.m_sMiddleFile = m_strSaveAsPath.empty() ? m_strDesc[1] : m_strSaveAsPath;
 	}
 	if (!m_filePaths.GetRight().empty())
-	{
-		if (m_strSaveAsPath.empty())
-			dlg.m_sRightFile = m_filePaths.GetRight();
-		else
-			dlg.m_sRightFile = m_strSaveAsPath;
-	}
+		dlg.m_sRightFile = m_strSaveAsPath.empty() ? m_filePaths.GetRight() : m_strSaveAsPath;
 	else
-		dlg.m_sRightFile = m_strDesc[m_pImgMergeWindow->GetPaneCount() - 1];
+		dlg.m_sRightFile = m_strSaveAsPath.empty() ? m_strDesc[m_pImgMergeWindow->GetPaneCount() - 1] : m_strSaveAsPath;
 
 	if (dlg.DoModal() == IDOK)
 	{

--- a/Src/ImgMergeFrm.cpp
+++ b/Src/ImgMergeFrm.cpp
@@ -722,7 +722,8 @@ bool CImgMergeFrame::DoFileSave(int pane)
 				return false;
 			CMergeApp::CreateBackup(false, m_filePaths[pane]);
 			int savepoint = m_pImgMergeWindow->GetSavePoint(pane);
-			if (!m_pImgMergeWindow->SaveImage(pane))
+			bool result = m_strSaveAsPath.empty() ? m_pImgMergeWindow->SaveImage(pane) : m_pImgMergeWindow->SaveImageAs(pane, m_strSaveAsPath.c_str());
+			if (!result)
 			{
 				String str = strutils::format_string2(_("Saving file failed.\n%1\n%2\nDo you want to:\n\t- use a different filename (Press OK)\n\t- abort the current operation (Press Cancel)?"), filename, GetSysError());
 				int answer = AfxMessageBox(str.c_str(), MB_OKCANCEL | MB_ICONWARNING);
@@ -730,6 +731,8 @@ bool CImgMergeFrame::DoFileSave(int pane)
 					return DoFileSaveAs(pane);
 				return false;
 			}
+			if (!m_strSaveAsPath.empty())
+				m_filePaths[pane] = m_strSaveAsPath;
 			if (filename != m_filePaths[pane])
 			{
 				if (!m_infoUnpacker.Packing(filename, m_filePaths[pane], m_unpackerSubcodes[pane], { m_filePaths[pane] }))

--- a/Src/ImgMergeFrm.h
+++ b/Src/ImgMergeFrm.h
@@ -73,6 +73,8 @@ public:
 	void CheckFileChanged(void) override;
 	String GetDescription(int pane) const override { return m_strDesc[pane]; }
 	static bool IsLoadable();
+	String GetSaveAsPath() const { return m_strSaveAsPath; }
+	void SetSaveAsPath(const String& strSaveAsPath) { m_strSaveAsPath = strSaveAsPath; }
 
 // Attributes
 protected:
@@ -121,6 +123,7 @@ private:
 	BUFFERTYPE m_nBufferType[3];
 	DiffFileInfo m_fileInfo[3];
 	bool m_bRO[3];
+	String m_strSaveAsPath; /**< "3rd path" where output saved if given */
 	bool m_bAutoMerged;
 	CDirDoc *m_pDirDoc;
 	int m_nActivePane;

--- a/Src/MainFrm.cpp
+++ b/Src/MainFrm.cpp
@@ -976,6 +976,9 @@ bool CMainFrame::ShowTextOrTableMergeDoc(std::optional<bool> table, CDirDoc * pD
 		true,
 		pOpenParams ? pOpenParams->m_char: -1);
 
+	if (pOpenParams && !pOpenParams->m_strSaveAsPath.empty())
+		pMergeDoc->SetSaveAsPath(pOpenParams->m_strSaveAsPath);
+
 	if (!sReportFile.empty())
 		pMergeDoc->GenerateReport(sReportFile);
 
@@ -1015,6 +1018,9 @@ bool CMainFrame::ShowHexMergeDoc(CDirDoc * pDirDoc, int nFiles, const FileLocati
 
 	pHexMergeDoc->MoveOnLoad(GetActivePaneFromFlags(nFiles, dwFlags));
 	
+	if (pOpenParams && !pOpenParams->m_strSaveAsPath.empty())
+		pHexMergeDoc->SetSaveAsPath(pOpenParams->m_strSaveAsPath);
+
 	if (!sReportFile.empty())
 		pHexMergeDoc->GenerateReport(sReportFile);
 
@@ -1043,6 +1049,9 @@ bool CMainFrame::ShowImgMergeDoc(CDirDoc * pDirDoc, int nFiles, const FileLocati
 	}
 
 	pImgMergeFrame->MoveOnLoad(GetActivePaneFromFlags(nFiles, dwFlags));
+
+	if (pOpenParams && !pOpenParams->m_strSaveAsPath.empty())
+		pImgMergeFrame->SetSaveAsPath(pOpenParams->m_strSaveAsPath);
 
 	if (!sReportFile.empty())
 		pImgMergeFrame->GenerateReport(sReportFile);
@@ -2794,7 +2803,8 @@ bool CMainFrame::DoOpenConflict(const String& conflictFile, const String strDesc
 	{
 		// Open two parsed files to WinMerge, telling WinMerge to
 		// save over original file (given as third filename).
-		theApp.m_strSaveAsPath = conflictFile;
+		OpenTextFileParams openParams;
+		openParams.m_strSaveAsPath = conflictFile;
 		if (!threeWay)
 		{
 			String strDesc2[2] = { 
@@ -2802,7 +2812,7 @@ bool CMainFrame::DoOpenConflict(const String& conflictFile, const String strDesc
 				(strDesc && !strDesc[2].empty()) ? strDesc[2] : _("Mine File") };
 			fileopenflags_t dwFlags[2] = {FFILEOPEN_READONLY | FFILEOPEN_NOMRU, FFILEOPEN_NOMRU | FFILEOPEN_MODIFIED};
 			PathContext tmpPathContext(revFile, workFile);
-			conflictCompared = DoFileOrFolderOpen(&tmpPathContext, dwFlags, strDesc2);
+			conflictCompared = DoFileOrFolderOpen(&tmpPathContext, dwFlags, strDesc2, L"", false, nullptr, nullptr, nullptr, 0, &openParams);
 		}
 		else
 		{
@@ -2812,7 +2822,7 @@ bool CMainFrame::DoOpenConflict(const String& conflictFile, const String strDesc
 				(strDesc && !strDesc[2].empty()) ? strDesc[2] : _("Mine File") };
 			PathContext tmpPathContext(baseFile, revFile, workFile);
 			fileopenflags_t dwFlags[3] = {FFILEOPEN_READONLY | FFILEOPEN_NOMRU, FFILEOPEN_READONLY | FFILEOPEN_NOMRU, FFILEOPEN_NOMRU | FFILEOPEN_MODIFIED};
-			conflictCompared = DoFileOrFolderOpen(&tmpPathContext, dwFlags, strDesc3);
+			conflictCompared = DoFileOrFolderOpen(&tmpPathContext, dwFlags, strDesc3, L"", false, nullptr, nullptr, nullptr, 0, &openParams);
 		}
 	}
 	else

--- a/Src/MainFrm.h
+++ b/Src/MainFrm.h
@@ -84,6 +84,7 @@ public:
 		int m_line = -1;
 		int m_char = -1;
 		String m_fileExt;
+		String m_strSaveAsPath; /**< "3rd path" where output saved if given */
 	};
 
 	struct OpenTableFileParams : public OpenTextFileParams
@@ -98,6 +99,7 @@ public:
 	{
 		virtual ~OpenBinaryFileParams() {}
 		int m_address = -1;
+		String m_strSaveAsPath; /**< "3rd path" where output saved if given */
 	};
 
 	struct OpenImageFileParams : public OpenFileParams
@@ -105,6 +107,7 @@ public:
 		virtual ~OpenImageFileParams() {}
 		int m_x = -1;
 		int m_y = -1;
+		String m_strSaveAsPath; /**< "3rd path" where output saved if given */
 	};
 
 	struct OpenWebPageParams : public OpenFileParams

--- a/Src/Merge.cpp
+++ b/Src/Merge.cpp
@@ -852,8 +852,6 @@ bool CMergeApp::ParseArgsAndDoOpen(MergeCmdLineInfo& cmdInfo, CMainFrame* pMainF
 		m_bExitIfNoDiff = cmdInfo.m_bExitIfNoDiff;
 		m_bEscShutdown = cmdInfo.m_bEscShutdown;
 
-		m_strSaveAsPath = cmdInfo.m_sOutputpath;
-
 		strDesc[0] = cmdInfo.m_sLeftDesc;
 		if (cmdInfo.m_Files.GetSize() < 3)
 		{
@@ -877,12 +875,15 @@ bool CMergeApp::ParseArgsAndDoOpen(MergeCmdLineInfo& cmdInfo, CMainFrame* pMainF
 			pOpenTextFileParams->m_line = cmdInfo.m_nLineIndex;
 			pOpenTextFileParams->m_char = cmdInfo.m_nCharIndex;
 			pOpenTextFileParams->m_fileExt = cmdInfo.m_sFileExt;
+			pOpenTextFileParams->m_strSaveAsPath = cmdInfo.m_sOutputpath;
+
 		}
 		if (auto* pOpenTableFileParams = dynamic_cast<CMainFrame::OpenTableFileParams*>(pOpenParams.get()))
 		{
 			pOpenTableFileParams->m_tableDelimiter = cmdInfo.m_cTableDelimiter;
 			pOpenTableFileParams->m_tableQuote = cmdInfo.m_cTableQuote;
 			pOpenTableFileParams->m_tableAllowNewlinesInQuotes = cmdInfo.m_bTableAllowNewlinesInQuotes;
+			pOpenTableFileParams->m_strSaveAsPath = cmdInfo.m_sOutputpath;
 		}
 		if (cmdInfo.m_Files.GetSize() > 2)
 		{

--- a/Src/Merge.cpp
+++ b/Src/Merge.cpp
@@ -883,7 +883,14 @@ bool CMergeApp::ParseArgsAndDoOpen(MergeCmdLineInfo& cmdInfo, CMainFrame* pMainF
 			pOpenTableFileParams->m_tableDelimiter = cmdInfo.m_cTableDelimiter;
 			pOpenTableFileParams->m_tableQuote = cmdInfo.m_cTableQuote;
 			pOpenTableFileParams->m_tableAllowNewlinesInQuotes = cmdInfo.m_bTableAllowNewlinesInQuotes;
-			pOpenTableFileParams->m_strSaveAsPath = cmdInfo.m_sOutputpath;
+		}
+		if (auto* pOpenBinaryFileParams = dynamic_cast<CMainFrame::OpenBinaryFileParams*>(pOpenParams.get()))
+		{
+			pOpenBinaryFileParams->m_strSaveAsPath = cmdInfo.m_sOutputpath;
+		}
+		if (auto* pOpenImageFileParams = dynamic_cast<CMainFrame::OpenImageFileParams*>(pOpenParams.get()))
+		{
+			pOpenImageFileParams->m_strSaveAsPath = cmdInfo.m_sOutputpath;
 		}
 		if (cmdInfo.m_Files.GetSize() > 2)
 		{

--- a/Src/Merge.h
+++ b/Src/Merge.h
@@ -63,7 +63,6 @@ public:
 	std::unique_ptr<CLanguageSelect> m_pLangDlg;
 	std::unique_ptr<SyntaxColors> m_pSyntaxColors; /**< Syntax color container */
 	std::unique_ptr<CCrystalTextMarkers> m_pMarkers; /**< Marker container */
-	String m_strSaveAsPath; /**< "3rd path" where output saved if given */
 	bool m_bEscShutdown; /**< If commandline switch -e given ESC closes appliction */
 	SyntaxColors * GetMainSyntaxColors() { return m_pSyntaxColors.get(); }
 	CCrystalTextMarkers * GetMainMarkers() const { return m_pMarkers.get(); }

--- a/Src/MergeDoc.cpp
+++ b/Src/MergeDoc.cpp
@@ -1681,18 +1681,18 @@ bool CMergeDoc::DoSave(const tchar_t* szPath, bool &bSaveSuccess, int nBuffer)
 	bSaveSuccess = false;
 	
 	// Check third arg possibly given from command-line
-	if (!theApp.m_strSaveAsPath.empty())
+	if (!m_strSaveAsPath.empty())
 	{
-		if (paths::DoesPathExist(theApp.m_strSaveAsPath) == paths::IS_EXISTING_DIR)
+		if (paths::DoesPathExist(m_strSaveAsPath) == paths::IS_EXISTING_DIR)
 		{
 			// third arg was a directory, so get append the filename
 			String sname;
 			paths::SplitFilename(szPath, 0, &sname, 0);
-			strSavePath = theApp.m_strSaveAsPath;
+			strSavePath = m_strSaveAsPath;
 			strSavePath = paths::ConcatPath(strSavePath, sname);
 		}
 		else
-			strSavePath = theApp.m_strSaveAsPath;	
+			strSavePath = m_strSaveAsPath;	
 	}
 
 	nRetVal = CMergeApp::HandleReadonlySave(strSavePath, false, bApplyToAll);
@@ -2645,10 +2645,10 @@ bool CMergeDoc::PromptAndSaveIfNeeded(bool bAllowCancel)
 		dlg.m_bDisableCancel = true;
 	if (!m_filePaths.GetLeft().empty())
 	{
-		if (theApp.m_strSaveAsPath.empty())
+		if (m_strSaveAsPath.empty())
 			dlg.m_sLeftFile = m_filePaths.GetLeft();
 		else
-			dlg.m_sLeftFile = theApp.m_strSaveAsPath;
+			dlg.m_sLeftFile = m_strSaveAsPath;
 	}
 	else
 		dlg.m_sLeftFile = m_strDesc[0];
@@ -2656,20 +2656,20 @@ bool CMergeDoc::PromptAndSaveIfNeeded(bool bAllowCancel)
 	{
 		if (!m_filePaths.GetMiddle().empty())
 		{
-			if (theApp.m_strSaveAsPath.empty())
+			if (m_strSaveAsPath.empty())
 				dlg.m_sMiddleFile = m_filePaths.GetMiddle();
 			else
-				dlg.m_sMiddleFile = theApp.m_strSaveAsPath;
+				dlg.m_sMiddleFile = m_strSaveAsPath;
 		}
 		else
 			dlg.m_sMiddleFile = m_strDesc[1];
 	}
 	if (!m_filePaths.GetRight().empty())
 	{
-		if (theApp.m_strSaveAsPath.empty())
+		if (m_strSaveAsPath.empty())
 			dlg.m_sRightFile = m_filePaths.GetRight();
 		else
-			dlg.m_sRightFile = theApp.m_strSaveAsPath;
+			dlg.m_sRightFile = m_strSaveAsPath;
 	}
 	else
 		dlg.m_sRightFile = m_strDesc[m_nBuffers - 1];

--- a/Src/MergeDoc.cpp
+++ b/Src/MergeDoc.cpp
@@ -1657,7 +1657,7 @@ bool CMergeDoc::TrySaveAs(String &strPath, int &nSaveResult, String & sError,
 bool CMergeDoc::DoSave(const tchar_t* szPath, bool &bSaveSuccess, int nBuffer)
 {
 	DiffFileInfo fileInfo;
-	String strSavePath(szPath);
+	String strSavePath(m_strSaveAsPath.empty() ? szPath : m_strSaveAsPath);
 	FileChange fileChanged;
 	bool bApplyToAll = false;	
 	int nRetVal = -1;
@@ -1680,21 +1680,6 @@ bool CMergeDoc::DoSave(const tchar_t* szPath, bool &bSaveSuccess, int nBuffer)
 
 	bSaveSuccess = false;
 	
-	// Check third arg possibly given from command-line
-	if (!m_strSaveAsPath.empty())
-	{
-		if (paths::DoesPathExist(m_strSaveAsPath) == paths::IS_EXISTING_DIR)
-		{
-			// third arg was a directory, so get append the filename
-			String sname;
-			paths::SplitFilename(szPath, 0, &sname, 0);
-			strSavePath = m_strSaveAsPath;
-			strSavePath = paths::ConcatPath(strSavePath, sname);
-		}
-		else
-			strSavePath = m_strSaveAsPath;	
-	}
-
 	nRetVal = CMergeApp::HandleReadonlySave(strSavePath, false, bApplyToAll);
 	if (nRetVal == IDCANCEL)
 		return false;
@@ -2644,35 +2629,20 @@ bool CMergeDoc::PromptAndSaveIfNeeded(bool bAllowCancel)
 	if (!bAllowCancel)
 		dlg.m_bDisableCancel = true;
 	if (!m_filePaths.GetLeft().empty())
-	{
-		if (m_strSaveAsPath.empty())
-			dlg.m_sLeftFile = m_filePaths.GetLeft();
-		else
-			dlg.m_sLeftFile = m_strSaveAsPath;
-	}
+		dlg.m_sLeftFile = m_strSaveAsPath.empty() ? m_filePaths.GetLeft() : m_strSaveAsPath;
 	else
-		dlg.m_sLeftFile = m_strDesc[0];
+		dlg.m_sLeftFile = m_strSaveAsPath.empty() ? m_strDesc[0] : m_strSaveAsPath;
 	if (m_nBuffers == 3)
 	{
 		if (!m_filePaths.GetMiddle().empty())
-		{
-			if (m_strSaveAsPath.empty())
-				dlg.m_sMiddleFile = m_filePaths.GetMiddle();
-			else
-				dlg.m_sMiddleFile = m_strSaveAsPath;
-		}
+			dlg.m_sMiddleFile = m_strSaveAsPath.empty() ? m_filePaths.GetMiddle() : m_strSaveAsPath;
 		else
-			dlg.m_sMiddleFile = m_strDesc[1];
+			dlg.m_sMiddleFile = m_strSaveAsPath.empty() ? m_strDesc[1] : m_strSaveAsPath;
 	}
 	if (!m_filePaths.GetRight().empty())
-	{
-		if (m_strSaveAsPath.empty())
-			dlg.m_sRightFile = m_filePaths.GetRight();
-		else
-			dlg.m_sRightFile = m_strSaveAsPath;
-	}
+		dlg.m_sRightFile = m_strSaveAsPath.empty() ?m_filePaths.GetRight() : m_strSaveAsPath;
 	else
-		dlg.m_sRightFile = m_strDesc[m_nBuffers - 1];
+		dlg.m_sRightFile = m_strSaveAsPath.empty() ? m_strDesc[m_nBuffers - 1] : m_strSaveAsPath;
 
 	if (dlg.DoModal() == IDOK)
 	{

--- a/Src/MergeDoc.cpp
+++ b/Src/MergeDoc.cpp
@@ -1610,7 +1610,7 @@ bool CMergeDoc::TrySaveAs(String &strPath, int &nSaveResult, String & sError,
 			if (nSaveResult == SAVE_DONE)
 			{
 				// We are saving scratchpad (unnamed file)
-				if (strPath.empty())
+				if (m_nBufferType[nBuffer] == BUFFERTYPE::UNNAMED)
 				{
 					m_nBufferType[nBuffer] = BUFFERTYPE::UNNAMED_SAVED;
 					m_strDesc[nBuffer].erase();

--- a/Src/MergeDoc.h
+++ b/Src/MergeDoc.h
@@ -326,6 +326,8 @@ public:
 	bool GetAutomaticRescan() const { return m_bAutomaticRescan; }
 	// to customize the mergeview menu
 	HMENU createPrediffersSubmenu(HMENU hMenu);
+	String GetSaveAsPath() const { return m_strSaveAsPath; }
+	void SetSaveAsPath(const String& strSaveAsPath) { m_strSaveAsPath = strSaveAsPath; }
 
 // implementation methods
 private:
@@ -353,6 +355,7 @@ protected:
 	BUFFERTYPE m_nBufferType[3];
 	bool m_bEditAfterRescan[3]; /**< Left/middle/right doc edited after rescanning */
 	TempFile m_tempFiles[3]; /**< Temp files for compared files */
+	String m_strSaveAsPath; /**< "3rd path" where output saved if given */
 	int m_nDiffContext;
 	bool m_bInvertDiffContext;
 	bool m_bMixedEol; /**< Does this document have mixed EOL style? */


### PR DESCRIPTION
This PR makes it so that if you specify an alternate destination filename with the command line option `/o filename` , it will not affect the destination of files opened in other tabs.
It also allows the `/o` command line option to work in binary and image comparison windows.