### PR TITLE
Update Corsican translation for 2.16.33

### DIFF
--- a/Translations/WinMerge/Corsican.po
+++ b/Translations/WinMerge/Corsican.po
@@ -10,8 +10,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: WinMerge in Corsican\n"
 "Report-Msgid-Bugs-To: https://bugs.winmerge.org/\n"
-"POT-Creation-Date: 2023-06-12 00:06+0000\n"
-"PO-Revision-Date: 2023-07-06 17:40+0200\n"
+"POT-Creation-Date: 2023-09-08 20:55+0000\n"
+"PO-Revision-Date: 2023-09-10 17:36+0200\n"
 "Last-Translator: Patriccollu di Santa Maria è Sichè <https://github.com/Patriccollu/Lingua_Corsa-Infurmatica/#readme>\n"
 "Language-Team: Patriccollu di Santa Maria è Sichè\n"
 "Language: co\n"
@@ -478,16 +478,16 @@ msgid "Tree &Mode"
 msgstr "&Modu in arburu"
 
 msgid "E&xpand Subfolders"
-msgstr ""
+msgstr "&Allargà i sottucartulari"
 
 msgid "&All Subfolders"
-msgstr ""
+msgstr "&Tutti i sottucartulari"
 
 msgid "&Different Subfolders"
-msgstr ""
+msgstr "I sottucartulari &sfarenti"
 
 msgid "&Identical Subfolders"
-msgstr ""
+msgstr "I sottucartulari &uguali"
 
 msgid "&Collapse All Subfolders"
 msgstr "&Ripiegà tutti i sottucartulari"
@@ -972,10 +972,10 @@ msgid "Right Shell menu"
 msgstr "Listinu cuntestuale à diritta"
 
 msgid "Both Shell menu"
-msgstr ""
+msgstr "I dui listini cuntestuali"
 
 msgid "All Shell menu"
-msgstr ""
+msgstr "Tutti i listini cuntestuali"
 
 msgid "Copy"
 msgstr "Cupià"
@@ -1526,7 +1526,7 @@ msgid "Align &similar lines"
 msgstr "&Alineà e linee simile"
 
 msgid "Diff &algorithm:"
-msgstr "Cudificazione di sfarenza:"
+msgstr "Cudificazione di sfarenza :"
 
 msgid "Enable indent &heuristic"
 msgstr "Attivà l’indentazione &euristica"
@@ -1994,7 +1994,7 @@ msgid "Ign&ore time differences less than 3 seconds"
 msgstr "Ignurà e sfarenze di tempu di &menu di 3 seconde"
 
 msgid "&Automatically expand subfolders after comparison:"
-msgstr ""
+msgstr "&Allargà autumaticamente i sottucartulari dopu à u paragone :"
 
 msgid "Include &unique subfolders contents"
 msgstr "Include u cuntenutu &unicu di i sottucartulari"
@@ -2297,16 +2297,16 @@ msgid "XML Files (*.xml)|*.xml|All Files (*.*)|*.*||"
 msgstr "Schedarii XML (*.xml)|*.xml|Tutti i schedarii (*.*)|*.*||"
 
 msgid "Do not expand"
-msgstr ""
+msgstr "Ùn allargà micca"
 
 msgid "Expand all subfolders"
-msgstr ""
+msgstr "Allargà tutti i sottucartulari"
 
 msgid "Expand different subfolders"
-msgstr ""
+msgstr "Allargà i sottucartulari sfarenti"
 
 msgid "Expand identical subfolders"
-msgstr ""
+msgstr "Allargà i sottucartulari uguali"
 
 msgid "File Type"
 msgstr "Tipu di schedariu"
@@ -2505,7 +2505,7 @@ msgstr "Paragone di l’elementi…"
 
 #, c-format
 msgid "%.1f[items/sec]"
-msgstr ""
+msgstr "%.1f[elementi/sec]"
 
 msgid "Select two existing folders or files to compare."
 msgstr "Selezziunà dui cartulari o schedarii esistente à paragunà."
@@ -2902,7 +2902,7 @@ msgid "You are about to close the window that is comparing folders. Are you sure
 msgstr "State per chjode a finestra chì paraguneghja i cartulari. Da veru vulete chjode a finestra ?"
 
 msgid "You are about to close the folder comparison window that took a significant amount of time. Are you sure you want to close the window?"
-msgstr ""
+msgstr "State per chjode a finestra di paragone di cartulare chì hà pigliatu un bellu pezzu. Da veru vulete chjode a finestra ?"
 
 msgid "The file or folder name is invalid."
 msgstr "U nome di u schedariu o di u cartulare hè inaccettevule."
@@ -4516,7 +4516,7 @@ msgid "Compare worksheets as image (very slow)"
 msgstr "Paragunà i foglii di calculu tale fiure (pianu pianu)"
 
 msgid " - Image split size: "
-msgstr " - Dimensione di spartera di a fiura :"
+msgstr " - Dimensione di spartera di a fiura : "
 
 msgid "Compare worksheets as HTML"
 msgstr "Paragunà i foglii di calculu tale HTML"
@@ -4598,7 +4598,7 @@ msgid "Find what"
 msgstr "Cosa circà"
 
 msgid "Replace with"
-msgstr "Rimpiazzà cù "
+msgstr "Rimpiazzà cù"
 
 msgid "Settings"
 msgstr "Preferenze"


### PR DESCRIPTION
Hello,

This is an update of **Corsican** (co) localization to take these commits into account:

  * https://github.com/WinMerge/winmerge/commit/3a044647a66565544c171900b20540149b4b11a3 Allow changing the number of CPU cores to use while doing folder comp (#1945)
  * https://github.com/WinMerge/winmerge/commit/5c7e459449f53a021024f78b1b8d772477e93f21 Add Expand Different Subfolders menu item (#1964)
  * https://github.com/WinMerge/winmerge/commit/bc37ff99220d46f1e5a7adaee639d60312313251 Show confirmation message when closing a window that took a long time to compare folders
  * https://github.com/WinMerge/winmerge/commit/71bc85c1a7d37febfeb0742596e8b0809f97eba5 Allow Diff algorithms (patience, histogram) other than default to be (#2015)
  * https://github.com/WinMerge/winmerge/commit/2f3a49e463a5147672447a5b5c5c065f718e97e3 Folder compare: Add Both Shell Menu (refs #1986) (#2021) 

Best regards,
Patriccollu.