### PR TITLE
Update English.pot for correct translation in others languages

### DIFF
--- a/Translations/WinMerge/English.pot
+++ b/Translations/WinMerge/English.pot
@@ -469,7 +469,7 @@ msgstr ""
 msgid "Tree &Mode"
 msgstr ""
 
-msgid "E&xpand Subfolders"
+msgid "E&xpand All Subfolders"
 msgstr ""
 
 msgid "&All Subfolders"
@@ -1515,7 +1515,7 @@ msgstr ""
 msgid "Align &similar lines"
 msgstr ""
 
-msgid "Diff &algorithm:"
+msgid "Diff &algorithm (Experimental):"
 msgstr ""
 
 msgid "Enable indent &heuristic"


### PR DESCRIPTION
Hi
These two small modifications make it possible to correctly translate WinMerge into another language because otherwise these two occurrences desperately remain in the original language on the interface despite the contry.po file corresponding to its user language.
 
I also think that the expression "E&xpand All Subfolders" like "&Collapse All Subfolders" are not explicit in the winmerge.exe binary and that it would have been more judicious to name these variables "E&xpend TreeView" and &Collapse TreeView ".

I also noted that the line "Diff &Algorithme (Experimental)" changed to "Diff &Algorithme" on version 2.16.32 and that as a result the translations of the text are no longer effective on this occurrence. We should ask the developers if it is a desire to remove the notion (Experimental) or if it is a simple typing error in english.pot

I am aware that what I express lacks clarity and technical rigor but I am neither a developer nor a computer scientist but just a humble translator.

Sincerely