### PR TITLE
Update English.pot

### DIFF
--- a/Translations/WinMerge/English.pot
+++ b/Translations/WinMerge/English.pot
@@ -4088,3 +4088,20 @@ msgstr ""
 msgid "Do not specify the '-p0' command line option for the patch file which includes absolute paths"
 msgstr ""
 
+msgid "&Print"
+msgstr ""
+
+msgid "&Next Page"
+msgstr ""
+
+msgid "Pre&v Page"
+msgstr ""
+
+msgid "Zoom &in"
+msgstr ""
+
+msgid "Zoom &out"
+msgstr ""
+
+msgid "&Close"
+msgstr ""


### PR DESCRIPTION
Hi
to make possible the translation into French (or another language) of the "print preview" window, I tried without success to add the few lines of the missing words in my french.po file but this had no effect. This did not surprise me too much since these words are absent from the English base english.pot but it may not be enough to declare this translation if the binary is not up to date for this. It is possible that my proposal is wrong and in this case I apologize but it would be nice to be able to translate the print preview page into all languages. Kind regards, Denis

PS I haven't found anywhere a possible configuration for my WinMerge to detect updates and I am therefore obliged to visit GitHub from time to time to check for new features.