### PR TITLE
Update Corsican translation for 2.16.36

### DIFF
--- a/Translations/WinMerge/Corsican.po
+++ b/Translations/WinMerge/Corsican.po
@@ -10,8 +10,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: WinMerge in Corsican\n"
 "Report-Msgid-Bugs-To: https://bugs.winmerge.org/\n"
-"POT-Creation-Date: 2023-09-08 20:55+0000\n"
-"PO-Revision-Date: 2023-09-10 17:36+0200\n"
+"POT-Creation-Date: 2023-11-19 21:53+0000\n"
+"PO-Revision-Date: 2023-11-26 14:57+0100\n"
 "Last-Translator: Patriccollu di Santa Maria è Sichè <https://github.com/Patriccollu/Lingua_Corsa-Infurmatica/#readme>\n"
 "Language-Team: Patriccollu di Santa Maria è Sichè\n"
 "Language: co\n"
@@ -21,7 +21,7 @@ msgstr ""
 "X-Poedit-SourceCharset: UTF-8\n"
 "X-Poedit-Basepath: ../../Src\n"
 "X-Poedit-Language: Corsican\n"
-"X-Generator: Poedit 3.3.2\n"
+"X-Generator: Poedit 3.4.1\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
 #. LANGUAGE, SUBLANGUAGE
@@ -247,22 +247,22 @@ msgid "Fit to Window"
 msgstr "Adattà à a finestra"
 
 msgid "&Event Synchronization"
-msgstr ""
+msgstr "&Sincrunizazione d’evenimentu"
 
 msgid "&Enabled"
-msgstr ""
+msgstr "&Attivatu"
 
 msgid "&Scroll"
-msgstr ""
+msgstr "&Sfilà"
 
 msgid "&Click"
-msgstr ""
+msgstr "&Cliccu"
 
 msgid "&Input"
-msgstr ""
+msgstr "&Entrata"
 
 msgid "&GoBack/Forward"
-msgstr ""
+msgstr "&Rivene o in avanti"
 
 msgid "Clear &Browsing Data"
 msgstr "&Viutà i dati di navigazione"
@@ -3611,7 +3611,7 @@ msgid ""
 "Difference in the Current Line (F4)"
 msgstr ""
 "\n"
-"Sfarenza in a linea attuale (F4)"
+"Sfarenza nant’à a linea attuale (F4)"
 
 msgid ""
 "\n"
@@ -4118,22 +4118,22 @@ msgid "Clipboard Compare"
 msgstr "Paragone di preme’papei"
 
 msgid "&Print..."
-msgstr ""
+msgstr "&Stampà…"
 
 msgid "Pre&v Page"
-msgstr ""
+msgstr "&Pagina precedente"
 
 msgid "&Two Page"
-msgstr ""
+msgstr "&Duie pagine"
 
 msgid "&One Page"
-msgstr ""
+msgstr "&Una pagina"
 
 msgid "Zoom &In"
-msgstr ""
+msgstr "Ingrandamentu più &forte"
 
 msgid "Zoom &Out"
-msgstr ""
+msgstr "Ingrandamentu &menu forte"
 
 msgid "Prettification"
 msgstr "Imbellimentu"


### PR DESCRIPTION
Hello,

This is an update of **Corsican** (co) localization to take these commits into account:

  * https://github.com/WinMerge/winmerge/commit/55ebe92117dd72af2108508550b5c623987bee94 Add "(F4)" to the description of the toolbar icon "Difference in the Current Line"
  * https://github.com/WinMerge/winmerge/commit/a0abf31d882ac5cecaa04a739bc24c52dba409ae Make the Preview bar buttons translatable ("Two Page" and "One Page" are not yet translatable...)
  * https://github.com/WinMerge/winmerge/commit/3255dc305f53d251fba53d8a0fa3007af574158f Webpage Compare: synchronize events (#2111)

Best regards,
Patriccollu.