### PR TITLE
Typo in Italian.po

### DIFF
--- a/Translations/WinMerge/Italian.po
+++ b/Translations/WinMerge/Italian.po
@@ -867,7 +867,7 @@ msgid "&Second left item with first right item"
 msgstr "&Secondo elemento di sinistra con primo elemento di destra"
 
 msgid "Co&mpare As"
-msgstr "Co&fronta come"
+msgstr "Con&fronta come"
 
 #, c-format
 msgid "Left to Middle (%1 of %2)"


### PR DESCRIPTION
Small but annoying typo in the contextual menu for the Italian translation