### PR TITLE
Replace "Match similar lines" with "Align similar lines"

### DIFF
--- a/Docs/Manual/English/Compare_files.xml
+++ b/Docs/Manual/English/Compare_files.xml
@@ -289,14 +289,14 @@
               </indexterm></term>
 
             <listitem>
-              <para>WinMerge tries to match similar lines within difference
-              blocks when you enable <option>Match similar lines</option> in the
+              <para>WinMerge tries to align similar lines within difference
+              blocks when you enable <option>Align similar lines</option> in the
               Options dialog Compare page. What does <quote>similar</quote>
               mean? Generally, this feature works best in simple cases, for
               example where lines that have strong similarities. When detected,
               similar lines are adjusted to align in the File pane. The next
               figure shows comparisons of the same two files, before and after
-              enabling the <option>Match similar lines</option> option:</para>
+              enabling the <option>Align similar lines</option> option:</para>
 
               <simplelist columns="2" type="horiz">
                 <member><emphasis role="strong">Disabled</emphasis>:

--- a/Docs/Manual/English/Configuration.xml
+++ b/Docs/Manual/English/Configuration.xml
@@ -678,8 +678,8 @@
     </section>
 
     <section>
-      <title>Match similar lines<indexterm>
-          <primary>similar lines, matching</primary>
+      <title>Align similar lines<indexterm>
+          <primary>similar lines, aligning</primary>
         </indexterm></title>
 
       <itemizedlist>

--- a/Docs/Manual/Japanese/Compare_files.xml
+++ b/Docs/Manual/Japanese/Compare_files.xml
@@ -257,13 +257,13 @@ linkend="CompareFiles_linediff-highlight" /> for details.</para>
               </indexterm></term>
 
             <listitem>
-              <para>WinMerge tries to match similar lines within difference blocks when you
-enable <option>Match similar lines</option> in the Options dialog Compare
+              <para>WinMerge tries to align similar lines within difference blocks when you
+enable <option>Align similar lines</option> in the Options dialog Compare
 page. What does <quote>similar</quote> mean? Generally, this feature works
 best in simple cases, for example where lines that have strong
 similarities. When detected, similar lines are adjusted to align in the File
 pane. The next figure shows comparisons of the same two files, before and
-after enabling the <option>Match similar lines</option> option:</para>
+after enabling the <option>Align similar lines</option> option:</para>
 
               <simplelist columns="2" type="horiz">
                 <member><emphasis role="strong">Disabled</emphasis>: <inlinemediaobject>

--- a/Docs/Manual/Japanese/Configuration.xml
+++ b/Docs/Manual/Japanese/Configuration.xml
@@ -580,7 +580,7 @@ BOMの有無の違いも検出します。</para>
 
     <section>
       <title>類似行をマッチさせる<indexterm>
-          <primary>similar lines, matching</primary>
+          <primary>similar lines, aligning</primary>
         </indexterm></title>
 
       <itemizedlist>

--- a/Src/Merge.rc
+++ b/Src/Merge.rc
@@ -1724,7 +1724,7 @@ BEGIN
     CONTROL         "Ignore c&omment differences",IDC_FILTERCOMMENTS_CHECK,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,7,120,239,10
     CONTROL         "E&nable moved block detection",IDC_MOVED_BLOCKS,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,7,132,269,10
-    CONTROL         "Align &similar lines",IDC_MATCH_SIMILAR_LINES,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,7,144,269,10
+    CONTROL         "Align &similar lines",IDC_ALIGN_SIMILAR_LINES,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,7,144,269,10
     LTEXT           "Diff &algorithm:",IDC_STATIC,7,156,269,10
     COMBOBOX        IDC_DIFF_ALGORITHM,6,168,270,70,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
     CONTROL         "Enable indent &heuristic",IDC_INDENT_HEURISTIC,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,7,186,269,10

--- a/Src/MergeDoc.cpp
+++ b/Src/MergeDoc.cpp
@@ -527,8 +527,8 @@ int CMergeDoc::Rescan(bool &bBinary, IDENTLEVEL &identical,
 		for (nBuffer = 0; nBuffer < m_nBuffers; nBuffer++)
 			m_ptBuf[nBuffer]->prepareForRescan();
 
-		// Divide diff blocks to match lines.
-		if (GetOptionsMgr()->GetBool(OPT_CMP_MATCH_SIMILAR_LINES))
+		// Divide diff blocks to align similar lines.
+		if (GetOptionsMgr()->GetBool(OPT_CMP_ALIGN_SIMILAR_LINES))
 		{
 			if (m_nBuffers < 3)
 				AdjustDiffBlocks();

--- a/Src/MergeDocDiffSync.cpp
+++ b/Src/MergeDocDiffSync.cpp
@@ -326,7 +326,7 @@ OP_TYPE CMergeDoc::ComputeOpType3way(
 }
 
 /**
- * @brief Divide diff blocks to match lines in diff blocks.
+ * @brief Divide diff blocks to align similar lines in diff blocks.
  */
 void CMergeDoc::AdjustDiffBlocks()
 {
@@ -439,7 +439,7 @@ void CMergeDoc::AdjustDiffBlocks()
 }
 
 /**
- * @brief Divide diff blocks to match lines in diff blocks. (3-way)
+ * @brief Divide diff blocks to align similar lines in diff blocks. (3-way)
  */
 void CMergeDoc::AdjustDiffBlocks3way()
 {

--- a/Src/OptionsDef.h
+++ b/Src/OptionsDef.h
@@ -209,7 +209,7 @@ inline const String OPT_CMP_IGNORE_EOL {_T("Settings/IgnoreEol"s)};
 inline const String OPT_CMP_IGNORE_CODEPAGE {_T("Settings/IgnoreCodepage"s)};
 inline const String OPT_CMP_METHOD {_T("Settings/CompMethod2"s)};
 inline const String OPT_CMP_MOVED_BLOCKS {_T("Settings/MovedBlocks"s)};
-inline const String OPT_CMP_MATCH_SIMILAR_LINES {_T("Settings/MatchSimilarLines"s)};
+inline const String OPT_CMP_ALIGN_SIMILAR_LINES {_T("Settings/AlignSimilarLines"s)};
 inline const String OPT_CMP_STOP_AFTER_FIRST {_T("Settings/StopAfterFirst"s)};
 inline const String OPT_CMP_QUICK_LIMIT {_T("Settings/QuickMethodLimit"s)};
 inline const String OPT_CMP_BINARY_LIMIT {_T("Settings/BinaryMethodLimit"s)};

--- a/Src/OptionsInit.cpp
+++ b/Src/OptionsInit.cpp
@@ -138,7 +138,7 @@ void Init(COptionsMgr *pOptions)
 
 	pOptions->InitOption(OPT_CMP_METHOD, (int)CMP_CONTENT, 0, CMP_SIZE);
 	pOptions->InitOption(OPT_CMP_MOVED_BLOCKS, false);
-	pOptions->InitOption(OPT_CMP_MATCH_SIMILAR_LINES, false);
+	pOptions->InitOption(OPT_CMP_ALIGN_SIMILAR_LINES, false);
 	pOptions->InitOption(OPT_CMP_STOP_AFTER_FIRST, false);
 	pOptions->InitOption(OPT_CMP_QUICK_LIMIT, 4 * 1024 * 1024); // 4 Megs
 	pOptions->InitOption(OPT_CMP_BINARY_LIMIT, 64 * 1024 * 1024); // 64 Megs

--- a/Src/PropCompare.cpp
+++ b/Src/PropCompare.cpp
@@ -27,7 +27,7 @@ PropCompare::PropCompare(COptionsMgr *optionsMgr)
  , m_bIgnoreCodepage(true)
  , m_nIgnoreWhite(-1)
  , m_bMovedBlocks(false)
- , m_bMatchSimilarLines(false)
+ , m_bAlignSimilarLines(false)
  , m_bFilterCommentsLines(false)
  , m_nDiffAlgorithm(0)
  , m_bIndentHeuristic(true)
@@ -49,7 +49,7 @@ void PropCompare::DoDataExchange(CDataExchange* pDX)
 	DDX_Check(pDX, IDC_IGNORE_NUMBERS, m_bIgnoreNumbers);
 	DDX_Radio(pDX, IDC_WHITESPACE, m_nIgnoreWhite);
 	DDX_Check(pDX, IDC_MOVED_BLOCKS, m_bMovedBlocks);
-	DDX_Check(pDX, IDC_MATCH_SIMILAR_LINES, m_bMatchSimilarLines);
+	DDX_Check(pDX, IDC_ALIGN_SIMILAR_LINES, m_bAlignSimilarLines);
 	DDX_Check(pDX, IDC_COMPLETELY_BLANK_OUT_IGNORED_DIFFERENCES, m_bCompleteBlankOutIgnoredChanges);
 	//}}AFX_DATA_MAP
 	UpdateControls();
@@ -78,7 +78,7 @@ void PropCompare::ReadOptions()
 	m_bIgnoreEol = GetOptionsMgr()->GetBool(OPT_CMP_IGNORE_EOL);
 	m_bIgnoreCodepage = GetOptionsMgr()->GetBool(OPT_CMP_IGNORE_CODEPAGE);
 	m_bMovedBlocks = GetOptionsMgr()->GetBool(OPT_CMP_MOVED_BLOCKS);
-	m_bMatchSimilarLines = GetOptionsMgr()->GetBool(OPT_CMP_MATCH_SIMILAR_LINES);
+	m_bAlignSimilarLines = GetOptionsMgr()->GetBool(OPT_CMP_ALIGN_SIMILAR_LINES);
 	m_nDiffAlgorithm = GetOptionsMgr()->GetInt(OPT_CMP_DIFF_ALGORITHM);
 	m_bIndentHeuristic = GetOptionsMgr()->GetBool(OPT_CMP_INDENT_HEURISTIC);
 	m_bCompleteBlankOutIgnoredChanges = GetOptionsMgr()->GetBool(OPT_CMP_COMPLETELY_BLANK_OUT_IGNORED_CHANGES);
@@ -99,7 +99,7 @@ void PropCompare::WriteOptions()
 	GetOptionsMgr()->SaveOption(OPT_CMP_IGNORE_CASE, m_bIgnoreCase);
 	GetOptionsMgr()->SaveOption(OPT_CMP_IGNORE_NUMBERS, m_bIgnoreNumbers);
 	GetOptionsMgr()->SaveOption(OPT_CMP_MOVED_BLOCKS, m_bMovedBlocks);
-	GetOptionsMgr()->SaveOption(OPT_CMP_MATCH_SIMILAR_LINES, m_bMatchSimilarLines);
+	GetOptionsMgr()->SaveOption(OPT_CMP_ALIGN_SIMILAR_LINES, m_bAlignSimilarLines);
 	GetOptionsMgr()->SaveOption(OPT_CMP_DIFF_ALGORITHM, m_nDiffAlgorithm);
 	GetOptionsMgr()->SaveOption(OPT_CMP_INDENT_HEURISTIC, m_bIndentHeuristic);
 	GetOptionsMgr()->SaveOption(OPT_CMP_COMPLETELY_BLANK_OUT_IGNORED_CHANGES, m_bCompleteBlankOutIgnoredChanges);
@@ -130,7 +130,7 @@ void PropCompare::OnDefaults()
 	m_bIgnoreCase = GetOptionsMgr()->GetDefault<bool>(OPT_CMP_IGNORE_CASE);
 	m_bIgnoreNumbers = GetOptionsMgr()->GetDefault<bool>(OPT_CMP_IGNORE_NUMBERS);
 	m_bMovedBlocks = GetOptionsMgr()->GetDefault<bool>(OPT_CMP_MOVED_BLOCKS);
-	m_bMatchSimilarLines = GetOptionsMgr()->GetDefault<bool>(OPT_CMP_MATCH_SIMILAR_LINES);
+	m_bAlignSimilarLines = GetOptionsMgr()->GetDefault<bool>(OPT_CMP_ALIGN_SIMILAR_LINES);
 	m_nDiffAlgorithm = GetOptionsMgr()->GetDefault<unsigned>(OPT_CMP_DIFF_ALGORITHM);
 	m_bIndentHeuristic = GetOptionsMgr()->GetDefault<bool>(OPT_CMP_INDENT_HEURISTIC);
 	m_bCompleteBlankOutIgnoredChanges = GetOptionsMgr()->GetDefault<bool>(OPT_CMP_COMPLETELY_BLANK_OUT_IGNORED_CHANGES);

--- a/Src/PropCompare.h
+++ b/Src/PropCompare.h
@@ -37,7 +37,7 @@ public:
 	bool    m_bIgnoreBlankLines;
 	int     m_nIgnoreWhite;
 	bool    m_bMovedBlocks;
-	bool    m_bMatchSimilarLines;
+	bool    m_bAlignSimilarLines;
 	bool    m_bFilterCommentsLines;
 	int     m_nDiffAlgorithm;
 	bool    m_bIndentHeuristic;

--- a/Src/resource.h
+++ b/Src/resource.h
@@ -477,7 +477,7 @@
 #define IDC_FINDDLG_DONTWRAP            1302
 #define IDC_REPORT_COPYCLIPBOARD        1303
 #define IDC_FILTERFILE_INSTALL          1304
-#define IDC_MATCH_SIMILAR_LINES         1305
+#define IDC_ALIGN_SIMILAR_LINES         1305
 #define IDC_BACKUP_FILECMP              1306
 #define IDC_BACKUP_FOLDERCMP            1307
 #define IDC_BACKUP_ORIGFOLD             1308

--- a/Testing/GoogleTest/GUITests/ConfigTest.cpp
+++ b/Testing/GoogleTest/GUITests/ConfigTest.cpp
@@ -213,7 +213,7 @@ namespace
 		{ OPT_CMP_IGNORE_CODEPAGE, varprop::VT_BOOL, {}, {}},
 		{ OPT_CMP_METHOD, varprop::VT_INT, {0, 1, 2, 3, 4, 5}, {}},
 		{ OPT_CMP_MOVED_BLOCKS, varprop::VT_BOOL, {}, {}},
-		{ OPT_CMP_MATCH_SIMILAR_LINES, varprop::VT_BOOL, {}, {}},
+		{ OPT_CMP_ALIGN_SIMILAR_LINES, varprop::VT_BOOL, {}, {}},
 		{ OPT_CMP_STOP_AFTER_FIRST, varprop::VT_BOOL, {}, {}},
 		{ OPT_CMP_QUICK_LIMIT, varprop::VT_INT, {0, 1, 4, 1024}, {}},
 		{ OPT_CMP_BINARY_LIMIT, varprop::VT_INT, {0, 1, 4, 1024}, {}},

--- a/Translations/Docs/Manual/English.pot
+++ b/Translations/Docs/Manual/English.pot
@@ -2843,7 +2843,7 @@ msgstr ""
 
 #. type: Content of: <article><section><section><section><variablelist><varlistentry><listitem><para>
 #: ./English/Compare_files.xml:292
-msgid "WinMerge tries to match similar lines within difference blocks when you enable <option>Match similar lines</option> in the Options dialog Compare page. What does <quote>similar</quote> mean? Generally, this feature works best in simple cases, for example where lines that have strong similarities. When detected, similar lines are adjusted to align in the File pane. The next figure shows comparisons of the same two files, before and after enabling the <option>Match similar lines</option> option:"
+msgid "WinMerge tries to align similar lines within difference blocks when you enable <option>Align similar lines</option> in the Options dialog Compare page. What does <quote>similar</quote> mean? Generally, this feature works best in simple cases, for example where lines that have strong similarities. When detected, similar lines are adjusted to align in the File pane. The next figure shows comparisons of the same two files, before and after enabling the <option>Align similar lines</option> option:"
 msgstr ""
 
 #. type: Content of: <article><section><section><section><variablelist><varlistentry><listitem><simplelist><member><inlinemediaobject>
@@ -5628,12 +5628,12 @@ msgstr ""
 
 #. type: Content of: <article><section><section><title><indexterm><primary>
 #: ./English/Configuration.xml:682
-msgid "similar lines, matching"
+msgid "similar lines, aligning"
 msgstr ""
 
 #. type: Content of: <article><section><section><title>
 #: ./English/Configuration.xml:681
-msgid "Match similar lines<placeholder type=\"indexterm\" id=\"0\"/>"
+msgid "Align similar lines<placeholder type=\"indexterm\" id=\"0\"/>"
 msgstr ""
 
 #. type: Content of: <article><section><section><itemizedlist><listitem><para>

--- a/Translations/Docs/Manual/Japanese.po
+++ b/Translations/Docs/Manual/Japanese.po
@@ -4376,13 +4376,13 @@ msgstr ""
 #. type: Content of: <article><section><section><section><variablelist><varlistentry><listitem><para>
 #: English/Compare_files.xml:292
 msgid ""
-"WinMerge tries to match similar lines within difference blocks when you "
-"enable <option>Match similar lines</option> in the Options dialog Compare "
+"WinMerge tries to align similar lines within difference blocks when you "
+"enable <option>Align similar lines</option> in the Options dialog Compare "
 "page. What does <quote>similar</quote> mean? Generally, this feature works "
 "best in simple cases, for example where lines that have strong similarities. "
 "When detected, similar lines are adjusted to align in the File pane. The "
 "next figure shows comparisons of the same two files, before and after "
-"enabling the <option>Match similar lines</option> option:"
+"enabling the <option>Align similar lines</option> option:"
 msgstr ""
 
 #. type: Content of: <article><section><section><section><variablelist><varlistentry><listitem><simplelist><member><inlinemediaobject>
@@ -8226,12 +8226,12 @@ msgstr ""
 
 #. type: Content of: <article><section><section><title><indexterm><primary>
 #: English/Configuration.xml:682
-msgid "similar lines, matching"
+msgid "similar lines, aligning"
 msgstr ""
 
 #. type: Content of: <article><section><section><title>
 #: English/Configuration.xml:681
-msgid "Match similar lines<placeholder type=\"indexterm\" id=\"0\"/>"
+msgid "Align similar lines<placeholder type=\"indexterm\" id=\"0\"/>"
 msgstr "類似行をマッチさせる<placeholder type=\"indexterm\" id=\"0\"/>"
 
 #. type: Content of: <article><section><section><itemizedlist><listitem><para>


### PR DESCRIPTION
This PR is a follow-up to #1200.

* One commit is for the documentation, so that it matches the setting name that is displayed in the program.
* The other commit is for the program source, better make things consistent.