### PR TITLE
Move custom messages in a separate iss file

### DIFF
--- a/Installer/InnoSetup/WinMergeARM64.is6.iss
+++ b/Installer/InnoSetup/WinMergeARM64.is6.iss
@@ -53,6 +53,7 @@
 #define AppVersion GetFileVersion(SourcePath + "\..\..\Build\" + ARCH + "\Release\WinMergeU.exe")
 #define ShellExtensionVersion GetFileVersion(SourcePath + "..\..\Build\ShellExtension\" + ShellExtension64bit)
 #define WinMergeContextMenuVersion GetFileVersion(SourcePath + "..\..\Build\ShellExtension\" + ARCH + "\WinMergeContextMenu.dll")
+#include WinMergeCustomMessages.iss
 
 [Setup]
 AppName=WinMerge
@@ -167,18 +168,6 @@ Name: Swedish; MessagesFile: ..\..\Translations\InnoSetup\Unbundled.is6\Swedish.
 Name: Tamil; MessagesFile: compiler:Default.isl,..\..\Translations\InnoSetup\Tamil.islu; InfoAfterFile: ..\..\Translations\Docs\Readme\ReadMe-Tamil.txt
 Name: Turkish; MessagesFile: compiler:Languages\Turkish.isl,..\..\Translations\InnoSetup\Turkish.islu; InfoAfterFile: ..\..\Translations\Docs\Readme\ReadMe-Turkish.txt
 Name: Ukrainian; MessagesFile: compiler:Languages\Ukrainian.isl,..\..\Translations\InnoSetup\Ukrainian.islu; InfoAfterFile: ..\..\Translations\Docs\Readme\ReadMe-Ukrainian.txt
-
-
-[Messages]
-English.FinishedLabel=Setup has finished installing WinMerge on your computer.
-English.SetupAppTitle=Setup - WinMerge {#AppVersion}
-English.WizardInfoBefore=License Agreement
-English.InfoBeforeLabel=GNU General Public License
-
-Italian.FinishedLabel=L'installazione di WinMerge è stata completata.
-Italian.SetupAppTitle=Installazione di WinMerge {#AppVersion}
-Italian.WizardInfoBefore=Accordo di licenza
-Italian.InfoBeforeLabel=Licenza GNU (General Public License)
 
 
 [Types]

--- a/Installer/InnoSetup/WinMergeCustomMessages.iss
+++ b/Installer/InnoSetup/WinMergeCustomMessages.iss
@@ -1,0 +1,10 @@
+[Messages]
+English.FinishedLabel=Setup has finished installing WinMerge on your computer.
+English.SetupAppTitle=Setup - WinMerge {#AppVersion}
+English.WizardInfoBefore=License Agreement
+English.InfoBeforeLabel=GNU General Public License
+
+Italian.FinishedLabel=L'installazione di WinMerge è stata completata.
+Italian.SetupAppTitle=Installazione di WinMerge {#AppVersion}
+Italian.WizardInfoBefore=Accordo di licenza
+Italian.InfoBeforeLabel=Licenza GNU (General Public License)

--- a/Installer/InnoSetup/WinMergeX64.is6.iss
+++ b/Installer/InnoSetup/WinMergeX64.is6.iss
@@ -53,6 +53,7 @@
 #define AppVersion GetFileVersion(SourcePath + "\..\..\Build\" + ARCH + "\Release\WinMergeU.exe")
 #define ShellExtensionVersion GetFileVersion(SourcePath + "..\..\Build\ShellExtension\" + ShellExtension64bit)
 #define WinMergeContextMenuVersion GetFileVersion(SourcePath + "..\..\Build\ShellExtension\" + ARCH + "\WinMergeContextMenu.dll")
+#include WinMergeCustomMessages.iss
 
 [Setup]
 AppName=WinMerge
@@ -167,16 +168,6 @@ Name: Tamil; MessagesFile: compiler:Default.isl,..\..\Translations\InnoSetup\Tam
 Name: Turkish; MessagesFile: compiler:Languages\Turkish.isl,..\..\Translations\InnoSetup\Turkish.islu; InfoAfterFile: ..\..\Translations\Docs\Readme\ReadMe-Turkish.txt
 Name: Ukrainian; MessagesFile: compiler:Languages\Ukrainian.isl,..\..\Translations\InnoSetup\Ukrainian.islu; InfoAfterFile: ..\..\Translations\Docs\Readme\ReadMe-Ukrainian.txt
 
-
-[Messages]
-English.FinishedLabel=Setup has finished installing WinMerge on your computer.
-English.SetupAppTitle=Setup - WinMerge {#AppVersion}
-English.WizardInfoBefore=License Agreement
-English.InfoBeforeLabel=GNU General Public License
-Italian.FinishedLabel=L'installazione di WinMerge è stata completata.
-Italian.SetupAppTitle=Installazione di WinMerge {#AppVersion}
-Italian.WizardInfoBefore=Accordo di licenza
-Italian.InfoBeforeLabel=Licenza GNU (General Public License)
 
 [Types]
 Name: typical; Description: {cm:TypicalInstallation}

--- a/Installer/InnoSetup/WinMergeX64.iss
+++ b/Installer/InnoSetup/WinMergeX64.iss
@@ -53,6 +53,7 @@
 #define AppVersion GetFileVersion(SourcePath + "\..\..\Build\" + ARCH + "\Release\WinMergeU.exe")
 #define ShellExtensionVersion GetFileVersion(SourcePath + "..\..\Build\ShellExtension\" + ShellExtension64bit)
 #define WinMergeContextMenuVersion GetFileVersion(SourcePath + "..\..\Build\ShellExtension\" + ARCH + "\WinMergeContextMenu.dll")
+#include WinMergeCustomMessages.iss
 
 [Setup]
 AppName=WinMerge
@@ -163,18 +164,6 @@ Name: Swedish; MessagesFile: ..\..\Translations\InnoSetup\Unbundled.is5\Swedish.
 Name: Tamil; MessagesFile: compiler:Default.isl,..\..\Translations\InnoSetup\Tamil.islu; InfoAfterFile: ..\..\Translations\Docs\Readme\ReadMe-Tamil.txt
 Name: Turkish; MessagesFile: compiler:Languages\Turkish.isl,..\..\Translations\InnoSetup\Turkish.islu; InfoAfterFile: ..\..\Translations\Docs\Readme\ReadMe-Turkish.txt
 Name: Ukrainian; MessagesFile: compiler:Languages\Ukrainian.isl,..\..\Translations\InnoSetup\Ukrainian.islu; InfoAfterFile: ..\..\Translations\Docs\Readme\ReadMe-Ukrainian.txt
-
-
-[Messages]
-English.FinishedLabel=Setup has finished installing WinMerge on your computer.
-English.SetupAppTitle=Setup - WinMerge {#AppVersion}
-English.WizardInfoBefore=License Agreement
-English.InfoBeforeLabel=GNU General Public License
-
-Italian.FinishedLabel=L'installazione di WinMerge è stata completata.
-Italian.SetupAppTitle=Installazione di WinMerge {#AppVersion}
-Italian.WizardInfoBefore=Accordo di licenza
-Italian.InfoBeforeLabel=Licenza GNU (General Public License)
 
 
 [Types]

--- a/Installer/InnoSetup/WinMergeX64NonAdmin.iss
+++ b/Installer/InnoSetup/WinMergeX64NonAdmin.iss
@@ -53,6 +53,7 @@
 #define AppVersion GetFileVersion(SourcePath + "\..\..\Build\" + ARCH + "\Release\WinMergeU.exe")
 #define ShellExtensionVersion GetFileVersion(SourcePath + "..\..\Build\ShellExtension\" + ShellExtension64bit)
 #define WinMergeContextMenuVersion GetFileVersion(SourcePath + "..\..\Build\ShellExtension\" + ARCH + "\WinMergeContextMenu.dll")
+#include WinMergeCustomMessages.iss
 
 [Setup]
 AppName=WinMerge
@@ -162,18 +163,6 @@ Name: Swedish; MessagesFile: ..\..\Translations\InnoSetup\Unbundled.is5\Swedish.
 Name: Tamil; MessagesFile: compiler:Default.isl,..\..\Translations\InnoSetup\Tamil.islu; InfoAfterFile: ..\..\Translations\Docs\Readme\ReadMe-Tamil.txt
 Name: Turkish; MessagesFile: compiler:Languages\Turkish.isl,..\..\Translations\InnoSetup\Turkish.islu; InfoAfterFile: ..\..\Translations\Docs\Readme\ReadMe-Turkish.txt
 Name: Ukrainian; MessagesFile: compiler:Languages\Ukrainian.isl,..\..\Translations\InnoSetup\Ukrainian.islu; InfoAfterFile: ..\..\Translations\Docs\Readme\ReadMe-Ukrainian.txt
-
-
-[Messages]
-English.FinishedLabel=Setup has finished installing WinMerge on your computer.
-English.SetupAppTitle=Setup - WinMerge {#AppVersion}
-English.WizardInfoBefore=License Agreement
-English.InfoBeforeLabel=GNU General Public License
-
-Italian.FinishedLabel=L'installazione di WinMerge è stata completata.
-Italian.SetupAppTitle=Installazione di WinMerge {#AppVersion}
-Italian.WizardInfoBefore=Accordo di licenza
-Italian.InfoBeforeLabel=Licenza GNU (General Public License)
 
 
 [Types]

--- a/Installer/InnoSetup/WinMergeX86.iss
+++ b/Installer/InnoSetup/WinMergeX86.iss
@@ -53,6 +53,7 @@
 #define AppVersion GetFileVersion(SourcePath + "\..\..\Build\" + ARCH + "\Release\WinMergeU.exe")
 #define ShellExtensionVersion GetFileVersion(SourcePath + "..\..\Build\ShellExtension\" + ShellExtension64bit)
 #define WinMergeContextMenuVersion GetFileVersion(SourcePath + "..\..\Build\ShellExtension\x64\WinMergeContextMenu.dll")
+#include WinMergeCustomMessages.iss
 
 [Setup]
 AppName=WinMerge
@@ -161,18 +162,6 @@ Name: Swedish; MessagesFile: ..\..\Translations\InnoSetup\Unbundled.is5\Swedish.
 Name: Tamil; MessagesFile: compiler:Default.isl,..\..\Translations\InnoSetup\Tamil.islu; InfoAfterFile: ..\..\Translations\Docs\Readme\ReadMe-Tamil.txt
 Name: Turkish; MessagesFile: compiler:Languages\Turkish.isl,..\..\Translations\InnoSetup\Turkish.islu; InfoAfterFile: ..\..\Translations\Docs\Readme\ReadMe-Turkish.txt
 Name: Ukrainian; MessagesFile: compiler:Languages\Ukrainian.isl,..\..\Translations\InnoSetup\Ukrainian.islu; InfoAfterFile: ..\..\Translations\Docs\Readme\ReadMe-Ukrainian.txt
-
-
-[Messages]
-English.FinishedLabel=Setup has finished installing WinMerge on your computer.
-English.SetupAppTitle=Setup - WinMerge {#AppVersion}
-English.WizardInfoBefore=License Agreement
-English.InfoBeforeLabel=GNU General Public License
-
-Italian.FinishedLabel=L'installazione di WinMerge è stata completata.
-Italian.SetupAppTitle=Installazione di WinMerge {#AppVersion}
-Italian.WizardInfoBefore=Accordo di licenza
-Italian.InfoBeforeLabel=Licenza GNU (General Public License)
 
 
 [Types]


### PR DESCRIPTION
@sdottaka 

I moved Inno Setup custom messuges (now english/italian - equal for all .iss installer files) in a separate file

**WinMergeCustomMessages.iss**

The it'eseasier for anyone add new language strings without touch main installer script.

And the changes are required in only one file.
befroe these changes you have to apply the custom emssage strings for each .iss installer script.
