### PR TITLE
Update PHP syntax highlighting keyword list.

### DIFF
--- a/Externals/crystaledit/editlib/parsers/php.cpp
+++ b/Externals/crystaledit/editlib/parsers/php.cpp
@@ -85,6 +85,7 @@ static const tchar_t * s_apszPhpKeywordList[] =
     _T ("private"),
     _T ("protected"),
     _T ("public"),
+    _T ("readonly"),        // as of PHP 8.1.0
     _T ("require"),
     _T ("require_once"),
     _T ("return"),
@@ -168,6 +169,7 @@ static const tchar_t * s_apszPredefinedConstantList[] =
     _T ("PEAR_INSTALL_DIR"),
     _T ("PHP_BINARY"),
     _T ("PHP_BINDIR"),
+    _T ("PHP_CLI_PROCESS_TITLE"),
     _T ("PHP_CONFIG_FILE_PATH"),
     _T ("PHP_CONFIG_FILE_SCAN_DIR"),
     _T ("PHP_DATADIR"),
@@ -201,7 +203,12 @@ static const tchar_t * s_apszPredefinedConstantList[] =
     _T ("PHP_WINDOWS_EVENT_CTRL_BREAK"),    // as of PHP 7.4.0
     _T ("PHP_WINDOWS_EVENT_CTRL_C"),        // as of PHP 7.4.0
     _T ("PHP_ZTS"),                         // as of PHP 5.2.7
+    _T ("STDERR"),
+    _T ("STDIN"),
+    _T ("STDOUT"),
     _T ("true"),
+    _T ("ZEND_DEBUG_BUILD"),
+    _T ("ZEND_THREAD_SAFE"),
   };
 
 // Reserved words
@@ -209,11 +216,13 @@ static const tchar_t * s_apszPredefinedConstantList[] =
 static const tchar_t * s_apszReservedWordList[] =
   {
     _T ("bool"),        // as of PHP 7
+    _T ("enum"),
 //  _T ("false"),       // as of PHP 7.  This is also defined as a predefined constant, so comment it out.
     _T ("float"),       // as of PHP 7
     _T ("int"),         // as of PHP 7
     _T ("iterable"),    // as of PHP 7.1
     _T ("mixed"),       // as of PHP 7
+    _T ("never"),       // as of PHP 8.1
 //  _T ("null"),        // as of PHP 7.  This is also defined as a predefined constant, so comment it out.
     _T ("numeric"),     // as of PHP 7
     _T ("object"),      // as of PHP 7.2


### PR DESCRIPTION
Add some keywords defined in PHP 8.3.
- Keywords are from https://www.php.net/manual/en/reserved.php