### PR TITLE
Improved F# parsing, support for multi-line comments

### DIFF
--- a/Externals/crystaledit/editlib/parsers/fsharp.cpp
+++ b/Externals/crystaledit/editlib/parsers/fsharp.cpp
@@ -150,6 +150,36 @@ static const tchar_t * s_apszFsKeywordList[] =
     _T ("yield!"),
   };
 
+  static const tchar_t* s_apszUser1KeywordList[] =
+  {
+    _T("Some"),
+    _T("None"),
+    _T("ValueSome"),
+    _T("ValueNone"),
+    _T("__SOURCE_DIRECTORY__"),
+    _T("DateTime"),
+    _T("String"),
+    _T("Decimal"),
+    _T("Char"),
+    _T("Int16"),
+    _T("Int32"),
+    _T("Int64"),
+    _T("IntPtr"),
+    _T("UInt16"),
+    _T("UInt32"),
+    _T("UInt64"),
+    _T("UIntPtr"),
+    _T("Option"),
+    _T("ValueOption"),
+    _T("Async"),
+    _T("Task"),
+    _T("Seq"),
+    _T("Map"),
+    _T("List"),
+    _T("Array"),
+    _T("Unit"),
+    _T("Type"),
+  };
 
 static bool
 IsFsKeyword (const tchar_t *pszChars, int nLength)
@@ -157,8 +187,262 @@ IsFsKeyword (const tchar_t *pszChars, int nLength)
   return ISXKEYWORD (s_apszFsKeywordList, pszChars, nLength);
 }
 
+static bool
+IsUserKeyword(const tchar_t* pszChars, int nLength)
+{
+    return ISXKEYWORD(s_apszUser1KeywordList, pszChars, nLength);
+}
+
 unsigned
 CrystalLineParser::ParseLineFSharp (unsigned dwCookie, const tchar_t *pszChars, int nLength, TEXTBLOCK * pBuf, int &nActualItems)
 {
-  return ParseLineCJava (dwCookie, pszChars, nLength, pBuf, nActualItems, IsFsKeyword, nullptr);
+    if (nLength == 0)
+        return dwCookie & COOKIE_EXT_COMMENT;
+
+    bool bFirstChar = (dwCookie & ~COOKIE_EXT_COMMENT) == 0;
+    const tchar_t* pszCommentBegin = nullptr;
+    const tchar_t* pszCommentEnd = nullptr;
+    bool bRedefineBlock = true;
+    bool bDecIndex = false;
+    int nIdentBegin = -1;
+    int nPrevI = -1;
+    int I = 0;
+    for (I = 0;; nPrevI = I, I = static_cast<int>(tc::tcharnext(pszChars + I) - pszChars))
+    {
+        if (I == nPrevI)
+        {
+            // CharNext did not advance, so we're at the end of the string
+            // and we already handled this character, so stop
+            break;
+        }
+
+        if (bRedefineBlock)
+        {
+            int nPos = I;
+            if (bDecIndex)
+                nPos = nPrevI;
+            if (dwCookie & (COOKIE_COMMENT | COOKIE_EXT_COMMENT))
+            {
+                DEFINE_BLOCK(nPos, COLORINDEX_COMMENT);
+            }
+            else if (dwCookie & (COOKIE_CHAR | COOKIE_STRING))
+            {
+                DEFINE_BLOCK(nPos, COLORINDEX_STRING);
+            }
+            else if (dwCookie & COOKIE_PREPROCESSOR)
+            {
+                DEFINE_BLOCK(nPos, COLORINDEX_PREPROCESSOR);
+            }
+            else
+            {
+                if (xisalnum(pszChars[nPos]) || pszChars[nPos] == '.' && nPos > 0 && (!xisalpha(*tc::tcharprev(pszChars, pszChars + nPos)) && !xisalpha(*tc::tcharnext(pszChars + nPos))))
+                {
+                    DEFINE_BLOCK(nPos, COLORINDEX_NORMALTEXT);
+                }
+                else
+                {
+                    DEFINE_BLOCK(nPos, COLORINDEX_OPERATOR);
+                    bRedefineBlock = true;
+                    bDecIndex = true;
+                    goto out;
+                }
+            }
+            bRedefineBlock = false;
+            bDecIndex = false;
+        }
+    out:
+
+        // Can be bigger than length if there is binary data
+        // See bug #1474782 Crash when comparing SQL with with binary data
+        if (I >= nLength || pszChars[I] == 0)
+            break;
+
+        if (dwCookie & COOKIE_COMMENT)
+        {
+            DEFINE_BLOCK(I, COLORINDEX_COMMENT);
+            dwCookie |= COOKIE_COMMENT;
+            break;
+        }
+
+        //  String constant "...."
+        if (dwCookie & COOKIE_STRING)
+        {
+            if (pszChars[I] == '"' && (I == 0 || I == 1 && pszChars[nPrevI] != '\\' || I >= 2 && (pszChars[nPrevI] != '\\' || *tc::tcharprev(pszChars, pszChars + nPrevI) == '\\')))
+            {
+                dwCookie &= ~COOKIE_STRING;
+                bRedefineBlock = true;
+            }
+            continue;
+        }
+
+        //  Char constant '..'
+        if (dwCookie & COOKIE_CHAR)
+        {
+            if (pszChars[I] == '\'' && (I == 0 || I == 1 && pszChars[nPrevI] != '\\' || I >= 2 && (pszChars[nPrevI] != '\\' || *tc::tcharprev(pszChars, pszChars + nPrevI) == '\\')))
+            {
+                dwCookie &= ~COOKIE_CHAR;
+                bRedefineBlock = true;
+            }
+            continue;
+        }
+
+        //  Extended comment /*....*/
+        if (dwCookie & COOKIE_EXT_COMMENT)
+        {
+            if ((pszCommentBegin < pszChars + I) && (I > 0 && pszChars[I] == '(' && pszChars[nPrevI] == '*'))
+            {
+                dwCookie &= ~COOKIE_EXT_COMMENT;
+                bRedefineBlock = true;
+                pszCommentEnd = pszChars + I + 1;
+            }
+            continue;
+        }
+
+        if ((pszCommentEnd < pszChars + I) && (I > 0 && pszChars[I] == '/' && pszChars[nPrevI] == '/'))
+        {
+            DEFINE_BLOCK(nPrevI, COLORINDEX_COMMENT);
+            dwCookie |= COOKIE_COMMENT;
+            break;
+        }
+
+        //  Preprocessor directive #....
+        if (dwCookie & COOKIE_PREPROCESSOR)
+        {
+            if ((pszCommentEnd < pszChars + I) && (I > 0 && pszChars[I] == '*' && pszChars[nPrevI] == ')'))
+            {
+                DEFINE_BLOCK(nPrevI, COLORINDEX_COMMENT);
+                dwCookie |= COOKIE_EXT_COMMENT;
+            }
+            continue;
+        }
+
+        //  Normal text
+        if (pszChars[I] == '"')
+        {
+            DEFINE_BLOCK(I, COLORINDEX_STRING);
+            dwCookie |= COOKIE_STRING;
+            continue;
+        }
+        if (pszChars[I] == '\'')
+        {
+            // if (I + 1 < nLength && pszChars[I + 1] == '\'' || I + 2 < nLength && pszChars[I + 1] != '\\' && pszChars[I + 2] == '\'' || I + 3 < nLength && pszChars[I + 1] == '\\' && pszChars[I + 3] == '\'')
+            if (!I || !xisalnum(pszChars[nPrevI]))
+            {
+                DEFINE_BLOCK(I, COLORINDEX_STRING);
+                dwCookie |= COOKIE_CHAR;
+                continue;
+            }
+        }
+        if ((pszCommentEnd < pszChars + I) && (I > 0 && pszChars[I] == '*' && pszChars[nPrevI] == '/'))
+        {
+            DEFINE_BLOCK(nPrevI, COLORINDEX_COMMENT);
+            dwCookie |= COOKIE_EXT_COMMENT;
+            pszCommentBegin = pszChars + I + 1;
+            continue;
+        }
+
+        if (bFirstChar)
+        {
+            if (pszChars[I] == '#')
+            {
+                DEFINE_BLOCK(I, COLORINDEX_PREPROCESSOR);
+                dwCookie |= COOKIE_PREPROCESSOR;
+                continue;
+            }
+            if (!xisspace(pszChars[I]))
+                bFirstChar = false;
+        }
+
+        if (pBuf == nullptr)
+            continue;               //  We don't need to extract keywords,
+        //  for faster parsing skip the rest of loop
+
+        if (xisalnum(pszChars[I]) || pszChars[I] == '.' && I > 0 && (!xisalpha(pszChars[nPrevI]) && !xisalpha(pszChars[I + 1])))
+        {
+            if (nIdentBegin == -1)
+                nIdentBegin = I;
+        }
+        else
+        {
+            if (nIdentBegin >= 0)
+            {
+                if (IsFsKeyword(pszChars + nIdentBegin, I - nIdentBegin))
+                {
+                    DEFINE_BLOCK(nIdentBegin, COLORINDEX_KEYWORD);
+                }
+                else if (IsUserKeyword && IsUserKeyword(pszChars + nIdentBegin, I - nIdentBegin))
+                {
+                    DEFINE_BLOCK(nIdentBegin, COLORINDEX_USER1);
+                }
+                else if (IsXNumber(pszChars + nIdentBegin, I - nIdentBegin))
+                {
+                    DEFINE_BLOCK(nIdentBegin, COLORINDEX_NUMBER);
+                }
+                else
+                {
+                    // Todo: F# parenthesis are often optional, so functions are not usually this easy to detect!
+                    bool bFunction = false;
+
+                    for (int j = I; j < nLength; j++)
+                    {
+                        if (!xisspace(pszChars[j]))
+                        {
+                            if (pszChars[j] == '(')
+                            {
+                                bFunction = true;
+                            }
+                            break;
+                        }
+                    }
+                    if (bFunction)
+                    {
+                        DEFINE_BLOCK(nIdentBegin, COLORINDEX_FUNCNAME);
+                    }
+                }
+                bRedefineBlock = true;
+                bDecIndex = true;
+                nIdentBegin = -1;
+            }
+        }
+    }
+
+    if (nIdentBegin >= 0)
+    {
+        if (IsFsKeyword(pszChars + nIdentBegin, I - nIdentBegin))
+        {
+            DEFINE_BLOCK(nIdentBegin, COLORINDEX_KEYWORD);
+        }
+        else if (IsUserKeyword && IsUserKeyword(pszChars + nIdentBegin, I - nIdentBegin))
+        {
+            DEFINE_BLOCK(nIdentBegin, COLORINDEX_USER1);
+        }
+        else if (IsXNumber(pszChars + nIdentBegin, I - nIdentBegin))
+        {
+            DEFINE_BLOCK(nIdentBegin, COLORINDEX_NUMBER);
+        }
+        else
+        {
+            bool bFunction = false;
+
+            for (int j = I; j < nLength; j++)
+            {
+                if (!xisspace(pszChars[j]))
+                {
+                    if (pszChars[j] == '(')
+                    {
+                        bFunction = true;
+                    }
+                    break;
+                }
+            }
+            if (bFunction)
+            {
+                DEFINE_BLOCK(nIdentBegin, COLORINDEX_FUNCNAME);
+            }
+        }
+    }
+
+    if (pszChars[nLength - 1] != '\\' || IsMBSTrail(pszChars, nLength - 1))
+        dwCookie &= COOKIE_EXT_COMMENT;
+    return dwCookie;
 }

--- a/Externals/crystaledit/editlib/parsers/fsharp.cpp
+++ b/Externals/crystaledit/editlib/parsers/fsharp.cpp
@@ -333,7 +333,7 @@ CrystalLineParser::ParseLineFSharp (unsigned dwCookie, const tchar_t *pszChars, 
                 continue;
             }
         }
-        if ((pszCommentEnd < pszChars + I) && (I > 0 && pszChars[I] == '*' && pszChars[nPrevI] == '/'))
+        if ((pszCommentEnd < pszChars + I) && (I > 0 && pszChars[I] == '*' && pszChars[nPrevI] == ')'))
         {
             DEFINE_BLOCK(nPrevI, COLORINDEX_COMMENT);
             dwCookie |= COOKIE_EXT_COMMENT;


### PR DESCRIPTION
Effort to improve current initial F# parsing, support for multi-line comments. 
ParseLineCJava was used as base for ParseLineFSharp.
