### PR TITLE
Multi line comment fix

### DIFF
--- a/Externals/crystaledit/editlib/parsers/fsharp.cpp
+++ b/Externals/crystaledit/editlib/parsers/fsharp.cpp
@@ -158,6 +158,7 @@ static const tchar_t * s_apszFsKeywordList[] =
     _T("Char"),
     _T("DateTime"),
     _T("Decimal"),
+    _T("Guid"),
     _T("Int16"),
     _T("Int32"),
     _T("Int64"),
@@ -210,7 +211,7 @@ CrystalLineParser::ParseLineFSharp (unsigned dwCookie, const tchar_t *pszChars, 
     int nPrevI = -1;
     int nPrevII = -2;
     int I = 0;
-    for (I = 0;; nPrevI = I, I = static_cast<int>(tc::tcharnext(pszChars + I) - pszChars))
+    for (I = 0;; nPrevII=nPrevI, nPrevI = I, I = static_cast<int>(tc::tcharnext(pszChars + I) - pszChars))
     {
         if (I == nPrevI)
         {
@@ -345,7 +346,7 @@ CrystalLineParser::ParseLineFSharp (unsigned dwCookie, const tchar_t *pszChars, 
         }
 
         //  Normal text
-        if (pszChars[I] == '"')
+        if (pszChars[I] == '"' && (I < 2 || pszChars[nPrevI] != '"' || pszChars[nPrevII] != '"'))
         {
             DEFINE_BLOCK(I, COLORINDEX_STRING);
             dwCookie |= COOKIE_STRING;


### PR DESCRIPTION
Work continued from https://github.com/WinMerge/winmerge/pull/2301
It does work already better than what is in master now:

![image](https://github.com/WinMerge/winmerge/assets/229355/fbd8c468-d9c6-4e86-ba5d-37454d5d2cc6)

... but it's not exactly perfect, as you can see the first line of multi-line is gray (here the last quote of the multi-line).
