### PR TITLE
Update GitHub Actions CI

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Checkout repository
         id: checkout_repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Initialize CodeQL
         id: init_codeql

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: windows-latest
 
     steps:  
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: Build/WinMergeDownloadDeps
         key: WinMergeDownloadDeps
@@ -27,13 +27,13 @@ jobs:
         .\BuildAll.vs2022.cmd x64 -ci
 
     - name: Upload zip
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: WinMerge-x64.zip
         path: Build/Releases/*.zip
 
     - name: Upload installer
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: WinMerge-x64-Setup-x64.exe
         path: Build/Releases/*.exe


### PR DESCRIPTION
This PR updates outdated actions in the GitHub Actions workflows.

The following updates are performed:
* update [`actions/cache`](https://github.com/actions/cache) to v4
* update [`actions/checkout`](https://github.com/actions/checkout) to v4
* update [`actions/upload-artifact`](https://github.com/actions/upload-artifact) to v4

Still using the outdated actions will generate several warnings in CI runs, for example in https://github.com/WinMerge/winmerge/actions/runs/8879019459:

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/cache@v3, actions/upload-artifact@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

The PR will get rid of those warnings, because the newer versions of those actions use Node.js 20.