### PR TITLE
Multi line comment fix part 2

### DIFF
--- a/Externals/crystaledit/editlib/parsers/fsharp.cpp
+++ b/Externals/crystaledit/editlib/parsers/fsharp.cpp
@@ -324,8 +324,9 @@ CrystalLineParser::ParseLineFSharp (unsigned dwCookie, const tchar_t *pszChars, 
         if ((pszTextEnd < pszChars + I) && (I > 1 && pszChars[I] == '"' && pszChars[nPrevI] == '"' && pszChars[nPrevII] == '"'))
         {
             DEFINE_BLOCK(nPrevII, COLORINDEX_STRING);
+            DEFINE_BLOCK(I, COLORINDEX_STRING);
             dwCookie |= COOKIE_RAWSTRING;
-            break;
+            continue;
         }
 
         //  Preprocessor directive #....


### PR DESCRIPTION
Part 2 of https://github.com/WinMerge/winmerge/pull/2303 : 

Fixed first line of multi-line comment """ where the issue was that an empty string "" mixed to the """

After this PR:
![image](https://github.com/WinMerge/winmerge/assets/229355/5bdb7eb9-61a5-41b9-968d-01f9c3d51b7a)
