### PR TITLE
Enable Rounded Corners for WinMerge Menu on Windows 11

### DIFF
--- a/Src/Common/BCMenu.cpp
+++ b/Src/Common/BCMenu.cpp
@@ -51,11 +51,7 @@ int BCMenu::m_checkBgWidth = 0;
 int BCMenu::m_gutterWidth = 0;
 int BCMenu::m_arrowWidth = 0;
 HTHEME BCMenu::m_hTheme = nullptr;
-#ifdef _WIN64
-bool BCMenu::m_bEnableOwnerDraw = false;
-#else
 bool BCMenu::m_bEnableOwnerDraw = true;
-#endif
 
 static class GdiplusToken
 {

--- a/Src/Common/BCMenu.cpp
+++ b/Src/Common/BCMenu.cpp
@@ -51,6 +51,11 @@ int BCMenu::m_checkBgWidth = 0;
 int BCMenu::m_gutterWidth = 0;
 int BCMenu::m_arrowWidth = 0;
 HTHEME BCMenu::m_hTheme = nullptr;
+#ifdef _WIN64
+bool BCMenu::m_bEnableOwnerDraw = false;
+#else
+bool BCMenu::m_bEnableOwnerDraw = true;
+#endif
 
 static class GdiplusToken
 {
@@ -767,13 +772,13 @@ bool BCMenu::AppendODMenu(const wchar_t *lpstrText,UINT nFlags,UINT_PTR nID,
 	// Add the MF_OWNERDRAW flag if not specified:
 	if(nID == 0){
 		if((nFlags&MF_BYPOSITION)!=0)
-			nFlags=MF_SEPARATOR|MF_OWNERDRAW|MF_BYPOSITION;
+			nFlags=MF_SEPARATOR|MakeOwnerDrawFlag()|MF_BYPOSITION;
 		else 
-			nFlags=MF_SEPARATOR|MF_OWNERDRAW;
+			nFlags=MF_SEPARATOR|MakeOwnerDrawFlag();
 	}
 	else 
 	if((nFlags & MF_OWNERDRAW)==0)
-		nFlags |= MF_OWNERDRAW;
+		nFlags |= MakeOwnerDrawFlag();
 	
 	if((nFlags & MF_POPUP)!=0){
 		m_AllSubMenus.Add((HMENU)nID);
@@ -791,7 +796,7 @@ bool BCMenu::AppendODMenu(const wchar_t *lpstrText,UINT nFlags,UINT_PTR nID,
 
 	mdata->nFlags = nFlags;
 	mdata->nID = nID;
-	bool returnflag=!!CMenu::AppendMenu(nFlags, nID, (LPCTSTR)mdata);
+	bool returnflag=!!CMenu::AppendMenu(nFlags, nID, MakeItemData(mdata));
 	if(m_loadmenu)RemoveTopLevelOwnerDraw();
 	return returnflag;
 }
@@ -809,10 +814,10 @@ bool BCMenu::InsertODMenu(UINT nPosition,wchar_t *lpstrText,UINT nFlags,UINT_PTR
 	}
 	
 	if(nID==0)
-		nFlags=MF_SEPARATOR|MF_OWNERDRAW|MF_BYPOSITION;
+		nFlags=MF_SEPARATOR|MakeOwnerDrawFlag()|MF_BYPOSITION;
 	else 
 	if((nFlags & MF_OWNERDRAW)==0)
-		nFlags |= MF_OWNERDRAW;
+		nFlags |= MakeOwnerDrawFlag();
 
 	int menustart=0;
 
@@ -838,12 +843,12 @@ bool BCMenu::InsertODMenu(UINT nPosition,wchar_t *lpstrText,UINT nFlags,UINT_PTR
 	else mdata->global_offset = GlobalImageListOffset(static_cast<int>(nID));
 	mdata->nFlags = nFlags;
 	mdata->nID = nID;
-	bool returnflag=!!CMenu::InsertMenu(nPosition,nFlags,nID,(LPCTSTR)mdata);
+	bool returnflag=!!CMenu::InsertMenu(nPosition,nFlags,nID,MakeItemData(mdata));
 	if(m_loadmenu)RemoveTopLevelOwnerDraw();
 	return returnflag;
 }
 
-bool BCMenu::ModifyODMenu(wchar_t *lpstrText,UINT_PTR nID,int nIconNormal)
+bool BCMenu::ModifyODMenu(const wchar_t *lpstrText,UINT_PTR nID,int nIconNormal)
 {
 	UINT nLoc;
 	BCMenuData *mdata;
@@ -868,7 +873,7 @@ bool BCMenu::ModifyODMenu(wchar_t *lpstrText,UINT_PTR nID,int nIconNormal)
 		}
 		else mdata->global_offset = GlobalImageListOffset(static_cast<int>(nID));
 		mdata->nFlags &= ~(MF_BYPOSITION);
-		mdata->nFlags |= MF_OWNERDRAW;
+		mdata->nFlags |= MakeOwnerDrawFlag();
 		mdata->nID = nID;
 		bcsubs.Add(psubmenu);
 		bclocs.Add(nLoc);
@@ -877,7 +882,7 @@ bool BCMenu::ModifyODMenu(wchar_t *lpstrText,UINT_PTR nID,int nIconNormal)
 		else 
 			psubmenu=nullptr;
 	}while(psubmenu != nullptr);
-	return !!CMenu::ModifyMenu(static_cast<UINT>(nID),mdata->nFlags, static_cast<UINT>(nID),(LPCTSTR)mdata);
+	return !!CMenu::ModifyMenu(static_cast<UINT>(nID),mdata->nFlags, static_cast<UINT>(nID),MakeItemData(mdata));
 }
 
 BCMenuData *BCMenu::NewODMenu(UINT pos,UINT nFlags,UINT_PTR nID,CString string)
@@ -892,17 +897,14 @@ BCMenuData *BCMenu::NewODMenu(UINT pos,UINT nFlags,UINT_PTR nID,CString string)
 //	if((nFlags & MF_POPUP)!=0)m_AllSubMenus.Add((HMENU)nID);
 		
 	if ((nFlags&MF_OWNERDRAW)!=0){
-		ASSERT((nFlags&MF_STRING) == 0);
-		ModifyMenu(pos,nFlags,nID,(LPCTSTR)mdata);
+		ModifyMenu(pos,nFlags,nID,MakeItemData(mdata));
 	}
-	else 
-	if ((nFlags&MF_STRING)!=0){
-		ASSERT((nFlags&MF_OWNERDRAW) == 0);
-		ModifyMenu(pos,nFlags,nID,mdata->GetString());
+	else
+	if ((nFlags&MF_SEPARATOR)!=0){
+		ModifyMenu(pos,nFlags,nID);
 	}
 	else{
-		ASSERT((nFlags&MF_SEPARATOR) != 0);
-		ModifyMenu(pos,nFlags,nID);
+		ModifyMenu(pos,nFlags,nID,mdata->GetString());
 	}
 	
 	return mdata;
@@ -1309,6 +1311,37 @@ void BCMenu::DeleteMenuList(void)
 	}
 }
 
+void BCMenu::SetMenuItemBitmap(intptr_t xoffset, int pos, unsigned state)
+{
+	const int cxSMIcon = GetSystemMetrics(SM_CXSMICON);
+	const int cySMIcon = GetSystemMetrics(SM_CYSMICON);
+
+	LoadImages();
+
+	BYTE* pBits;
+	BITMAPINFO bmi{ sizeof(BITMAPINFOHEADER), cxSMIcon, -cySMIcon, 1, 32, BI_RGB };
+	CBitmap *pBitmap = new CBitmap();
+	HBITMAP hBitmap = CreateDIBSection(nullptr, &bmi, DIB_RGB_COLORS, (void**)&pBits, nullptr, 0);
+	pBitmap->Attach(hBitmap);
+	CDC dcMem;
+	dcMem.CreateCompatibleDC(nullptr);
+	CBitmap* pOldBitmap = dcMem.SelectObject(pBitmap);
+	CImage bitmapstandard;
+	GetBitmapFromImageList(nullptr, (int)xoffset, bitmapstandard);
+	if ((state & ODS_GRAYED) != 0)
+		GetDisabledBitmap(bitmapstandard);
+	m_gdiplusToken.InitGdiplus();
+	Gdiplus::Bitmap bm(bitmapstandard.GetWidth(), bitmapstandard.GetHeight(),
+		bitmapstandard.GetPitch(), PixelFormat32bppARGB, (BYTE*)bitmapstandard.GetBits());
+	Gdiplus::Graphics dcDst(dcMem.m_hDC);
+	dcDst.SetInterpolationMode(Gdiplus::InterpolationModeHighQualityBicubic);
+	Gdiplus::Rect rcDst(0, 0, cxSMIcon, cySMIcon);
+	dcDst.DrawImage(&bm, rcDst, 0, 0, m_iconX, m_iconY, Gdiplus::UnitPixel);
+	dcMem.SelectObject(pOldBitmap);
+	SetMenuItemBitmaps(static_cast<UINT>(pos), MF_BYPOSITION, pBitmap, nullptr);
+	m_AllImagesID[xoffset].pBitmap.reset(pBitmap);
+}
+
 void BCMenu::SynchronizeMenu(void)
 {
 	CTypedPtrArray<CPtrArray, BCMenuData*> temp;
@@ -1324,7 +1357,7 @@ void BCMenu::SynchronizeMenu(void)
 			mdata=FindMenuList(submenu);
 			GetMenuString(j,string,MF_BYPOSITION);
 			if(mdata == nullptr)mdata=NewODMenu(j,
-				(state&0xFF)|MF_BYPOSITION|MF_POPUP|MF_OWNERDRAW,submenu,string);
+				(state&0xFF)|MF_BYPOSITION|MF_POPUP|MakeOwnerDrawFlag(),submenu,string);
 			else if(string.GetLength()>0)
 				mdata->SetWideString(string);  //SK: modified for dynamic allocation
 		}
@@ -1332,21 +1365,24 @@ void BCMenu::SynchronizeMenu(void)
 		if((state&MF_SEPARATOR)!=0){
 			mdata=FindMenuList(0);
 			if(mdata == nullptr)mdata=NewODMenu(j,
-				state|MF_BYPOSITION|MF_SEPARATOR|MF_OWNERDRAW,0,_T(""));//SK: modified for Unicode correctness
-			else ModifyMenu(j,mdata->nFlags,nID,(LPCTSTR)mdata);
+				state|MF_BYPOSITION|MF_SEPARATOR|MakeOwnerDrawFlag(),0,_T(""));//SK: modified for Unicode correctness
+			else ModifyMenu(j,mdata->nFlags,nID,MakeItemData(mdata));
 		}
 		else{
 			nID=GetMenuItemID(j);
 			mdata=FindMenuList(nID);
 			GetMenuString(j,string,MF_BYPOSITION);
-			if(mdata == nullptr)mdata=NewODMenu(j,state|MF_BYPOSITION|MF_OWNERDRAW,
-				nID,string);
+			if(mdata == nullptr)
+				mdata=NewODMenu(j,state|MF_BYPOSITION|MakeOwnerDrawFlag(),nID,string);
 			else{
-				mdata->nFlags=state|MF_BYPOSITION|MF_OWNERDRAW;
+				mdata->nFlags=state|MF_BYPOSITION|MakeOwnerDrawFlag();
 				if(string.GetLength()>0)
 					mdata->SetWideString(string);//SK: modified for dynamic allocation
 				
-				ModifyMenu(j,mdata->nFlags,nID,(LPCTSTR)mdata);
+				ModifyMenu(j,mdata->nFlags,nID,MakeItemData(mdata));
+
+				if(!m_bEnableOwnerDraw && mdata->global_offset >= 0)
+					SetMenuItemBitmap(mdata->global_offset,j,state);
 			}
 		}
 		if(mdata != nullptr)temp.Add(mdata);

--- a/Src/Common/BCMenu.cpp
+++ b/Src/Common/BCMenu.cpp
@@ -1313,6 +1313,12 @@ void BCMenu::DeleteMenuList(void)
 
 void BCMenu::SetMenuItemBitmap(intptr_t xoffset, int pos, unsigned state)
 {
+	if (m_AllImagesID[xoffset].state == state && m_AllImagesID[xoffset].pBitmap)
+	{
+		SetMenuItemBitmaps(static_cast<UINT>(pos), MF_BYPOSITION, m_AllImagesID[xoffset].pBitmap.get(), nullptr);
+		return;
+	}
+
 	const int cxSMIcon = GetSystemMetrics(SM_CXSMICON);
 	const int cySMIcon = GetSystemMetrics(SM_CYSMICON);
 
@@ -1340,6 +1346,7 @@ void BCMenu::SetMenuItemBitmap(intptr_t xoffset, int pos, unsigned state)
 	dcMem.SelectObject(pOldBitmap);
 	SetMenuItemBitmaps(static_cast<UINT>(pos), MF_BYPOSITION, pBitmap, nullptr);
 	m_AllImagesID[xoffset].pBitmap.reset(pBitmap);
+	m_AllImagesID[xoffset].state = state;
 }
 
 void BCMenu::SynchronizeMenu(void)
@@ -1380,10 +1387,9 @@ void BCMenu::SynchronizeMenu(void)
 					mdata->SetWideString(string);//SK: modified for dynamic allocation
 				
 				ModifyMenu(j,mdata->nFlags,nID,MakeItemData(mdata));
-
-				if(!m_bEnableOwnerDraw && mdata->global_offset >= 0)
-					SetMenuItemBitmap(mdata->global_offset,j,state);
 			}
+			if(!m_bEnableOwnerDraw && mdata->global_offset >= 0)
+				SetMenuItemBitmap(mdata->global_offset,j,state);
 		}
 		if(mdata != nullptr)temp.Add(mdata);
 	}
@@ -1899,6 +1905,8 @@ INT_PTR BCMenu::AddToGlobalImageList(int nIconNormal,int nID)
 	if(existsloc>=0){
 		m_AllImagesID[existsloc].resourceId = (nIconNormal & 0x40000000) ? (nIconNormal & 0xffff) : nIconNormal;
 		m_AllImagesID[existsloc].bitmapIndex = (nIconNormal & 0x40000000) ? ((nIconNormal & 0x3fff0000) >> 16) : -1;
+		m_AllImagesID[existsloc].pBitmap.reset();
+		m_AllImagesID[existsloc].state = 0;
 		loc = existsloc;
 	}
 	else{

--- a/Src/Common/BCMenu.h
+++ b/Src/Common/BCMenu.h
@@ -35,7 +35,7 @@ public:
 	BCMenuData () {pContext=nullptr;
 	nFlags=0;nID=0;syncflag=0;m_szMenuText=nullptr;global_offset=-1;};
 	void SetWideString(const wchar_t *szWideString);
-	const wchar_t *GetWideString(void) {return m_szMenuText;};
+	const wchar_t *GetWideString(void) const {return m_szMenuText;};
 	~BCMenuData ();
 	CString GetString(void);//returns the menu text
 	INT_PTR global_offset;
@@ -84,7 +84,7 @@ public:
 	bool InsertODMenu(UINT nPosition,wchar_t *lpstrText,UINT nFlags = MF_OWNERDRAW,UINT_PTR nID = 0,int nIconNormal = -1);  
 
 	// functions for modifying a menu option, use the ModifyODMenu call (see above define)
-	bool ModifyODMenu(wchar_t *lpstrText,UINT_PTR nID=0,int nIconNormal=-1);
+	bool ModifyODMenu(const wchar_t *lpstrText,UINT_PTR nID=0,int nIconNormal=-1);
 
 	// for deleting and removing menu options
 	bool	RemoveMenu(UINT uiId,UINT nFlags);
@@ -145,6 +145,7 @@ protected:
 	void DrawCheckMark(CDC* pDC,int x,int y,COLORREF color,bool narrowflag=false);
 	void DrawRadioDot(CDC *pDC,int x,int y,COLORREF color);
 	BCMenuData *NewODMenu(UINT pos,UINT nFlags,UINT_PTR nID,CString string);
+	void SetMenuItemBitmap(intptr_t xoffset, int pos, unsigned state);
 	void SynchronizeMenu(void);
 	void InitializeMenuList(int value);
 	void DeleteMenuList(void);
@@ -167,6 +168,8 @@ protected:
 	INT_PTR AddToGlobalImageList(int nIconNormal,int nID);
 	int GlobalImageListOffset(int nID);
 	void LoadImages();
+	inline unsigned MakeOwnerDrawFlag() const { return BCMenu::m_bEnableOwnerDraw ? MF_OWNERDRAW : MF_STRING; }
+	inline const tchar_t *MakeItemData(const BCMenuData* mdata) const { return m_bEnableOwnerDraw ? reinterpret_cast<const tchar_t *>(mdata) : mdata->GetWideString(); }
 	
 // Member Variables
 protected:
@@ -179,7 +182,7 @@ protected:
 	static CTypedPtrArray<CPtrArray, HMENU>  m_AllSubMenus;
 	// Global ImageList
 	static CImageList m_AllImages;
-	struct ImageData { int id; int resourceId; int bitmapIndex; };
+	struct ImageData { int id; int resourceId; int bitmapIndex; std::unique_ptr<CBitmap> pBitmap; };
 	static std::vector<ImageData> m_AllImagesID;
 	static bool m_bHasNotLoadedImages;
 	// icon size
@@ -198,5 +201,6 @@ protected:
 	static int m_gutterWidth;
 	static int m_arrowWidth;
 	static HTHEME m_hTheme;
+	static bool m_bEnableOwnerDraw;
 }; 
 

--- a/Src/Common/BCMenu.h
+++ b/Src/Common/BCMenu.h
@@ -182,7 +182,7 @@ protected:
 	static CTypedPtrArray<CPtrArray, HMENU>  m_AllSubMenus;
 	// Global ImageList
 	static CImageList m_AllImages;
-	struct ImageData { int id; int resourceId; int bitmapIndex; std::unique_ptr<CBitmap> pBitmap; };
+	struct ImageData { int id; int resourceId; int bitmapIndex; std::unique_ptr<CBitmap> pBitmap; unsigned state; };
 	static std::vector<ImageData> m_AllImagesID;
 	static bool m_bHasNotLoadedImages;
 	// icon size

--- a/Src/Common/BCMenu.h
+++ b/Src/Common/BCMenu.h
@@ -58,6 +58,8 @@ public:
 	BCMenu(); 
 	virtual ~BCMenu();
 
+	static void DisableOwnerDraw() { m_bEnableOwnerDraw = false; }
+
 	// Functions for loading and applying bitmaps to menus (see example application)
 	virtual BOOL LoadMenu(LPCTSTR lpszResourceName);
 	virtual BOOL LoadMenu(int nResource)

--- a/Src/Common/LanguageSelect.cpp
+++ b/Src/Common/LanguageSelect.cpp
@@ -779,6 +779,7 @@ void CLanguageSelect::SetIndicators(CStatusBar &sb, const UINT *rgid, int n) con
 
 void CLanguageSelect::TranslateMenu(HMENU h) const
 {
+	BCMenu* pBCMenu = dynamic_cast<BCMenu*>(CMenu::FromHandle(h));
 	int i = ::GetMenuItemCount(h);
 	while (i > 0)
 	{
@@ -796,7 +797,8 @@ void CLanguageSelect::TranslateMenu(HMENU h) const
 			TranslateMenu(mii.hSubMenu);
 			mii.wID = static_cast<UINT>(reinterpret_cast<uintptr_t>(mii.hSubMenu));
 		}
-		if (BCMenuData *pItemData = reinterpret_cast<BCMenuData *>(mii.dwItemData))
+		BCMenuData *pItemData = reinterpret_cast<BCMenuData *>(mii.dwItemData);
+		if (pItemData)
 		{
 			if (LPCWSTR text = pItemData->GetWideString())
 			{
@@ -810,7 +812,11 @@ void CLanguageSelect::TranslateMenu(HMENU h) const
 		{
 			std::wstring s;
 			if (TranslateString(text, s))
+			{
+				if (pBCMenu && !pItemData)
+					pBCMenu->SetMenuText(i, s.c_str(), MF_BYPOSITION);
 				::ModifyMenuW(h, i, mii.fState | MF_BYPOSITION, mii.wID, s.c_str());
+			}
 		}
 	}
 }

--- a/Src/Merge.cpp
+++ b/Src/Merge.cpp
@@ -62,6 +62,8 @@
 #include "OptionsProject.h"
 #include "MergeAppCOMClass.h"
 #include "RegKey.h"
+#include "Win_VersionHelper.h"
+#include "BCMenu.h"
 
 #ifdef _DEBUG
 #define new DEBUG_NEW
@@ -401,6 +403,9 @@ BOOL CMergeApp::InitInstance()
 
 	strdiff::Init(); // String diff init
 	strdiff::SetBreakChars(GetOptionsMgr()->GetString(OPT_BREAK_SEPARATORS).c_str());
+
+	if (IsWin11_OrGreater())
+		BCMenu::DisableOwnerDraw();
 
 	m_bMergingMode = GetOptionsMgr()->GetBool(OPT_MERGE_MODE);
 


### PR DESCRIPTION
This PR fixes the issue where WinMerge menus do not have rounded corners on Windows 11 by removing the owner draw.
However, there is still an issue with radio items not being drawn properly, which has not been resolved.

WinMerge version 2.16.40
![image](https://github.com/WinMerge/winmerge/assets/98126/3a5f0fec-ce03-4d02-a9b2-ac93533956a9)

WinMerge version 2.16.42 (this PR)
![image](https://github.com/WinMerge/winmerge/assets/98126/938b604e-d132-4c77-aed7-a0faedc84593)
