### PR TITLE
Update documentation for "Include unique subfolders contents" setting

### DIFF
--- a/Docs/Manual/English/Configuration.xml
+++ b/Docs/Manual/English/Configuration.xml
@@ -981,17 +981,17 @@
       <itemizedlist>
         <listitem>
           <para>
-            <option>Enabled</option>:
-            Makes the color of the different lines ignored by line filters and substitution
-            filters the same as the color of the identical lines.
+            <option>Disabled</option> (default):
+            Difference lines ignored by line filters and substitution filters are
+            displayed in the color of Ignored Difference.
           </para>
         </listitem>
 
         <listitem>
           <para>
-            <option>Disabled</option> (default):
-            Difference lines ignored by line filters and substitution filters are
-            displayed in the color of Ignored Difference.
+            <option>Enabled</option>:
+            Makes the color of the different lines ignored by line filters and substitution
+            filters the same as the color of the identical lines.
           </para>
         </listitem>
       </itemizedlist>
@@ -1333,13 +1333,13 @@
       <itemizedlist>
         <listitem>
           <para>
-            <option>Disabled</option>: WinMerge ignore unique subfolders when comparing folders.
+            <option>Enabled</option> (default): WinMerge also shows the content from unique subfolders.
           </para>
         </listitem>
 
         <listitem>
           <para>
-            <option>Enabled</option> (default): WinMerge also shows the content from unique subfolders.
+            <option>Disabled</option>: WinMerge ignore unique subfolders when comparing folders.
           </para>
         </listitem>
       </itemizedlist>

--- a/Docs/Manual/English/Configuration.xml
+++ b/Docs/Manual/English/Configuration.xml
@@ -1257,13 +1257,13 @@
       <itemizedlist>
         <listitem>
           <para>
-            <option>Disabled</option> (default): WinMerge ignore unique subfolders when comparing folders.
+            <option>Disabled</option>: WinMerge ignore unique subfolders when comparing folders.
           </para>
         </listitem>
 
         <listitem>
           <para>
-            <option>Enabled</option>: WinMerge also shows the content from unique subfolders.
+            <option>Enabled</option> (default): WinMerge also shows the content from unique subfolders.
           </para>
         </listitem>
       </itemizedlist>

--- a/Docs/Manual/English/Configuration.xml
+++ b/Docs/Manual/English/Configuration.xml
@@ -1247,30 +1247,6 @@
 
     <section>
       <title>
-        Include unique subfolders contents<indexterm>
-          <primary>include unique subfolders</primary>
-
-          <secondary>detecting and ignoring differences</secondary>
-        </indexterm>
-      </title>
-
-      <itemizedlist>
-        <listitem>
-          <para>
-            <option>Disabled</option>: WinMerge ignore unique subfolders when comparing folders.
-          </para>
-        </listitem>
-
-        <listitem>
-          <para>
-            <option>Enabled</option> (default): WinMerge also shows the content from unique subfolders.
-          </para>
-        </listitem>
-      </itemizedlist>
-    </section>
-
-    <section>
-      <title>
         Include subfolders<indexterm>
           <primary>include subfolders</primary>
 
@@ -1343,6 +1319,30 @@
           </listitem>
         </varlistentry>
       </variablelist>
+    </section>
+
+    <section>
+      <title>
+        Include unique subfolders contents<indexterm>
+          <primary>include unique subfolders</primary>
+
+          <secondary>detecting and ignoring differences</secondary>
+        </indexterm>
+      </title>
+
+      <itemizedlist>
+        <listitem>
+          <para>
+            <option>Disabled</option>: WinMerge ignore unique subfolders when comparing folders.
+          </para>
+        </listitem>
+
+        <listitem>
+          <para>
+            <option>Enabled</option> (default): WinMerge also shows the content from unique subfolders.
+          </para>
+        </listitem>
+      </itemizedlist>
     </section>
 
     <section>

--- a/Docs/Manual/Japanese/Configuration.xml
+++ b/Docs/Manual/Japanese/Configuration.xml
@@ -980,12 +980,12 @@ Difference.</para>
       <itemizedlist>
         <listitem>
           <para>
-<option>無効</option>(デフォルト): WinMerge は、比較時片方しか存在しないサブフォルダーを無視します。</para>
+<option>無効</option>: WinMerge は、比較時片方しか存在しないサブフォルダーを無視します。</para>
         </listitem>
 
         <listitem>
           <para>
-<option>有効</option>: WinMerge は、片方しか存在しないサブフォルダー内の内容も表示します。</para>
+<option>有効</option>(デフォルト): WinMerge は、片方しか存在しないサブフォルダー内の内容も表示します。</para>
         </listitem>
       </itemizedlist>
     </section>

--- a/Docs/Manual/Japanese/Configuration.xml
+++ b/Docs/Manual/Japanese/Configuration.xml
@@ -767,16 +767,16 @@ Completely unhighlight the ignored differences<indexterm>
       <itemizedlist>
         <listitem>
           <para>
-<option>Enabled</option>: Makes the color of the different lines ignored by
-line filters and substitution filters the same as the color of the identical
-lines.</para>
+<option>Disabled</option> (default): Difference lines ignored by line
+filters and substitution filters are displayed in the color of Ignored
+Difference.</para>
         </listitem>
 
         <listitem>
           <para>
-<option>Disabled</option> (default): Difference lines ignored by line
-filters and substitution filters are displayed in the color of Ignored
-Difference.</para>
+<option>Enabled</option>: Makes the color of the different lines ignored by
+line filters and substitution filters the same as the color of the identical
+lines.</para>
         </listitem>
       </itemizedlist>
     </section>
@@ -1050,12 +1050,12 @@ folder.</para>
       <itemizedlist>
         <listitem>
           <para>
-<option>無効</option>: WinMerge は、比較時片方しか存在しないサブフォルダーを無視します。</para>
+<option>有効</option>(デフォルト): WinMerge は、片方しか存在しないサブフォルダー内の内容も表示します。</para>
         </listitem>
 
         <listitem>
           <para>
-<option>有効</option>(デフォルト): WinMerge は、片方しか存在しないサブフォルダー内の内容も表示します。</para>
+<option>無効</option>: WinMerge は、比較時片方しか存在しないサブフォルダーを無視します。</para>
         </listitem>
       </itemizedlist>
     </section>

--- a/Docs/Manual/Japanese/Configuration.xml
+++ b/Docs/Manual/Japanese/Configuration.xml
@@ -971,27 +971,6 @@ Difference.</para>
 
     <section>
       <title>
-片方にしか存在しないフォルダー内も含める<indexterm>
-          <primary>include unique subfolders</primary>
-
-          <secondary>detecting and ignoring differences</secondary>
-        </indexterm></title>
-
-      <itemizedlist>
-        <listitem>
-          <para>
-<option>無効</option>: WinMerge は、比較時片方しか存在しないサブフォルダーを無視します。</para>
-        </listitem>
-
-        <listitem>
-          <para>
-<option>有効</option>(デフォルト): WinMerge は、片方しか存在しないサブフォルダー内の内容も表示します。</para>
-        </listitem>
-      </itemizedlist>
-    </section>
-
-    <section>
-      <title>
 Include subfolders<indexterm>
           <primary>include subfolders</primary>
 
@@ -1058,6 +1037,27 @@ folder.</para>
           </listitem>
         </varlistentry>
       </variablelist>
+    </section>
+
+    <section>
+      <title>
+片方にしか存在しないフォルダー内も含める<indexterm>
+          <primary>include unique subfolders</primary>
+
+          <secondary>detecting and ignoring differences</secondary>
+        </indexterm></title>
+
+      <itemizedlist>
+        <listitem>
+          <para>
+<option>無効</option>: WinMerge は、比較時片方しか存在しないサブフォルダーを無視します。</para>
+        </listitem>
+
+        <listitem>
+          <para>
+<option>有効</option>(デフォルト): WinMerge は、片方しか存在しないサブフォルダー内の内容も表示します。</para>
+        </listitem>
+      </itemizedlist>
     </section>
 
     <section>


### PR DESCRIPTION
* Update default value: since WinMerge 2.16.8, this setting is enabled by default, refs https://github.com/WinMerge/winmerge/commit/9735fb828f009cd83bc8e44e9d20d3233a39cacd.
* Match position of this setting in the program:
  1. "Include unique subfolders contents" has been moved below "Include subfolders", refs #1645.
  2. Later, "Automatically expand subfolders after comparison" dropdown has been implemented, immediately below "Include subfolders", refs #1964.