### PR TITLE
Drop unused `*POFiles.bat` files

### DIFF
--- a/Translations/WinMerge/InsertLineNumberInPOFiles.bat
+++ b/Translations/WinMerge/InsertLineNumberInPOFiles.bat
@@ -1,4 +1,0 @@
-del "%~dp0English.pot"
-cscript "%~dp0CreateMasterpotFile.vbs" /InsertLineNumbers:True
-cscript "%~dp0UpdatePoFilesFromPotFile.vbs"
-pause

--- a/Translations/WinMerge/RenewPOFiles.bat
+++ b/Translations/WinMerge/RenewPOFiles.bat
@@ -1,4 +1,0 @@
-del "%~dp0English.pot"
-cscript "%~dp0CreateMasterpotFile.vbs"
-cscript "%~dp0UpdatePoFilesFromPotFile.vbs"
-pause


### PR DESCRIPTION
The `InsertLineNumberInPOFiles.bat` and `RenewPOFiles.bat` files call non exsiting scripts, so I think they are unused we can remove them. 😉