### PR TITLE
Easy move small main window when tab on titlebar

### DIFF
--- a/Src/TitleBarHelper.cpp
+++ b/Src/TitleBarHelper.cpp
@@ -163,7 +163,11 @@ LRESULT CTitleBarHelper::OnNcHitTest(CPoint pt)
 	if (rc.right - borderWidth <= pt.x)
 		return HTRIGHT;
 	if (pt.x < rc.left + leftMargin)
+	{
+		if (pt.x > rc.left + leftMargin * 2 / 3)
+			return HTCAPTION;
 		return HTSYSMENU;
+	}
 	for (int i = 0; i < 3; i++)
 	{
 		static const int htbuttons[]{ HTMINBUTTON, HTMAXBUTTON, HTCLOSE };


### PR DESCRIPTION
When the titlebar is filled with tabs or the main window is too small, there's no space left for dragging and moving the window. This PR allows the rightmost third of the system menu icon area to be used for dragging the window.
![image](https://github.com/user-attachments/assets/37820d2b-0a94-4e9e-81aa-fd828e5cd914)

