### PR TITLE
Foreground and background title bars are distinguishable

### DIFF
--- a/Src/Common/MDITabBar.cpp
+++ b/Src/Common/MDITabBar.cpp
@@ -9,6 +9,7 @@
 #include "IMDITab.h"
 #include "cecolor.h"
 #include "RoundedRectWithShadow.h"
+#include "MainFrm.h"
 
 #ifdef _DEBUG
 #define new DEBUG_NEW
@@ -96,7 +97,10 @@ static COLORREF getBackColor(bool onTitleBar)
 	const COLORREF clr = GetSysColor(COLOR_3DFACE);
 	if (!onTitleBar)
 		return clr;
-	return RGB(GetRValue(clr), std::clamp(GetGValue(clr) + 8, 0, 255), std::clamp(GetBValue(clr) + 8, 0, 255));
+	const COLORREF bgclr = dynamic_cast<CMainFrame*>(AfxGetMainWnd())->IsActivate() ?
+		RGB(GetRValue(clr), std::clamp(GetGValue(clr) + 8, 0, 255), std::clamp(GetBValue(clr) + 8, 0, 255))
+		: clr;
+	return bgclr;
 }
 
 static inline bool IsHighContrastEnabled()

--- a/Src/MainFrm.cpp
+++ b/Src/MainFrm.cpp
@@ -221,6 +221,7 @@ BEGIN_MESSAGE_MAP(CMainFrame, CMDIFrameWnd)
 	ON_MESSAGE(WM_COPYDATA, OnCopyData)
 	ON_MESSAGE(WM_USER+1, OnUser1)
 	ON_WM_ACTIVATEAPP()
+	ON_WM_ACTIVATE()
 	ON_WM_NCCALCSIZE()
 	ON_WM_SIZE()
 	ON_UPDATE_COMMAND_UI_RANGE(CMenuBar::FIRST_MENUID, CMenuBar::FIRST_MENUID + 10, OnUpdateMenuBarMenuItem)
@@ -366,6 +367,7 @@ CMainFrame::CMainFrame()
 , m_lfDiff(Options::Font::Load(GetOptionsMgr(), OPT_FONT_FILECMP))
 , m_lfDir(Options::Font::Load(GetOptionsMgr(), OPT_FONT_DIRCMP))
 , m_pDirWatcher(new DirWatcher())
+, m_bActivate(false)
 {
 }
 
@@ -3703,4 +3705,20 @@ LRESULT CMainFrame::OnChildFrameActivated(WPARAM wParam, LPARAM lParam)
 	m_arrChild.InsertAt(0, reinterpret_cast<CMDIChildWnd*>(lParam));
 
 	return 1;
+}
+
+
+void CMainFrame::OnActivate(UINT nState, CWnd* pWndOther, BOOL bMinimized)
+{
+	__super::OnActivate(nState, pWndOther, bMinimized);
+
+	const bool bActivate = (nState != WA_INACTIVE);
+	if (bActivate != m_bActivate)
+	{
+		m_bActivate = bActivate;
+
+		CRect titleBarRect;
+		m_wndTabBar.GetClientRect(&titleBarRect);
+		InvalidateRect(&titleBarRect, TRUE);
+	}
 }

--- a/Src/MainFrm.cpp
+++ b/Src/MainFrm.cpp
@@ -221,7 +221,6 @@ BEGIN_MESSAGE_MAP(CMainFrame, CMDIFrameWnd)
 	ON_MESSAGE(WM_COPYDATA, OnCopyData)
 	ON_MESSAGE(WM_USER+1, OnUser1)
 	ON_WM_ACTIVATEAPP()
-	ON_WM_ACTIVATE()
 	ON_WM_NCCALCSIZE()
 	ON_WM_SIZE()
 	ON_UPDATE_COMMAND_UI_RANGE(CMenuBar::FIRST_MENUID, CMenuBar::FIRST_MENUID + 10, OnUpdateMenuBarMenuItem)
@@ -2542,6 +2541,16 @@ void CMainFrame::OnActivateApp(BOOL bActive, DWORD dwThreadID)
 		if (IMergeDoc* pMergeDoc = GetActiveIMergeDoc())
 			PostMessage(WM_USER + 1);
 	}
+
+	const bool bActivate = static_cast<bool>(bActive);
+	if ( bActivate != m_bActivate)
+	{
+		m_bActivate = bActivate;
+
+		CRect titleBarRect;
+		m_wndTabBar.GetClientRect(&titleBarRect);
+		InvalidateRect(&titleBarRect, TRUE);
+	}
 }
 
 void CMainFrame::OnNcCalcSize(BOOL bCalcValidRects, NCCALCSIZE_PARAMS FAR* lpncsp)
@@ -3705,20 +3714,4 @@ LRESULT CMainFrame::OnChildFrameActivated(WPARAM wParam, LPARAM lParam)
 	m_arrChild.InsertAt(0, reinterpret_cast<CMDIChildWnd*>(lParam));
 
 	return 1;
-}
-
-
-void CMainFrame::OnActivate(UINT nState, CWnd* pWndOther, BOOL bMinimized)
-{
-	__super::OnActivate(nState, pWndOther, bMinimized);
-
-	const bool bActivate = (nState != WA_INACTIVE);
-	if (bActivate != m_bActivate)
-	{
-		m_bActivate = bActivate;
-
-		CRect titleBarRect;
-		m_wndTabBar.GetClientRect(&titleBarRect);
-		InvalidateRect(&titleBarRect, TRUE);
-	}
 }

--- a/Src/MainFrm.h
+++ b/Src/MainFrm.h
@@ -228,6 +228,7 @@ public:
 	CMenuBar* GetMenuBar() { return &m_wndMenuBar; }
 	CToolBar* GetToolbar() { return &m_wndToolBar; }
 	static void WaitAndDoMessageLoop(bool& completed, int ms);
+	bool IsActivate() const { return m_bActivate; }
 
 // Overrides
 	virtual void GetMessageString(UINT nID, CString& rMessage) const;
@@ -430,6 +431,7 @@ protected:
 	afx_msg void OnTimer(UINT_PTR nIDEvent);
 	afx_msg void OnDestroy();
 	afx_msg void OnAccelQuit();
+	afx_msg void OnActivate(UINT nState, CWnd* pWndOther, BOOL bMinimized);
 	afx_msg LRESULT OnChildFrameAdded(WPARAM wParam, LPARAM lParam);
 	afx_msg LRESULT OnChildFrameRemoved(WPARAM wParam, LPARAM lParam);
 	afx_msg LRESULT OnChildFrameActivate(WPARAM wParam, LPARAM lParam);
@@ -454,4 +456,5 @@ private:
 	bool CompareFilesIfFilesAreLarge(IDirDoc* pDirDoc, int nFiles, const FileLocation ifileloc[]);
 	std::unique_ptr<WCHAR[]> m_upszLongTextW;
 	std::unique_ptr<CHAR[]> m_upszLongTextA;
+	bool m_bActivate;
 };

--- a/Src/MainFrm.h
+++ b/Src/MainFrm.h
@@ -431,7 +431,6 @@ protected:
 	afx_msg void OnTimer(UINT_PTR nIDEvent);
 	afx_msg void OnDestroy();
 	afx_msg void OnAccelQuit();
-	afx_msg void OnActivate(UINT nState, CWnd* pWndOther, BOOL bMinimized);
 	afx_msg LRESULT OnChildFrameAdded(WPARAM wParam, LPARAM lParam);
 	afx_msg LRESULT OnChildFrameRemoved(WPARAM wParam, LPARAM lParam);
 	afx_msg LRESULT OnChildFrameActivate(WPARAM wParam, LPARAM lParam);


### PR DESCRIPTION
Currently, with multiple WinMerge instances open, it’s difficult to identify the active window. This PR changes the title bar background color when the program loses focus, making it easier to spot the active window among multiple instances.
Before
![屏幕截图 2024-10-27 214315](https://github.com/user-attachments/assets/f216f30b-81d4-4653-b7f8-4e6d39f4b8bd)
After
![f20241027T215958](https://github.com/user-attachments/assets/0354da92-f4bf-448f-88ef-e33bc338fc40)
With colorful picture wallpaper, the distinction between the two backgrounds remains low. However, I believe color adjustments should not be decided by me, so I am only submitting the functional code.