### PR TITLE
Title bar background color and text color follow windows settings when not customized

### DIFF
--- a/Src/Common/MDITabBar.cpp
+++ b/Src/Common/MDITabBar.cpp
@@ -96,6 +96,8 @@ COLORREF CMyTabCtrl::GetBackColor() const
 	const COLORREF clr = GetSysColor(COLOR_3DFACE);
 	if (!m_bOnTitleBar)
 		return clr;
+	if (m_bCustomSystemColor)
+		return  m_bActive ? GetSysColor(COLOR_ACTIVECAPTION) : GetSysColor(COLOR_INACTIVECAPTION);
 	const COLORREF bgclr = m_bActive ?
 		RGB(GetRValue(clr), std::clamp(GetGValue(clr) + 8, 0, 255), std::clamp(GetBValue(clr) + 8, 0, 255))
 		: clr;
@@ -123,7 +125,10 @@ void CMyTabCtrl::OnPaint()
 	const int nCount = GetItemCount();
 	if (nCount == 0)
 	{
-		dc.SetTextColor(getTextColor());
+		auto winTitleColor = COLOR_WINDOWTEXT;
+		if (m_bOnTitleBar && m_bCustomSystemColor)
+			winTitleColor = m_bActive ? COLOR_CAPTIONTEXT : COLOR_INACTIVECAPTIONTEXT;
+		dc.SetTextColor(GetSysColor(winTitleColor));
 		TCHAR szBuf[256];
 		AfxGetMainWnd()->GetWindowText(szBuf, sizeof(szBuf) / sizeof(szBuf[0]));
 		dc.DrawText(szBuf, -1, &rcClient, DT_LEFT | DT_VCENTER | DT_SINGLELINE);
@@ -387,7 +392,10 @@ void CMyTabCtrl::DrawItem(LPDRAWITEMSTRUCT lpDrawItemStruct)
 	}
 	else
 	{
-		SetTextColor(lpDraw->hDC, GetSysColor(COLOR_BTNTEXT));
+		auto txtclr = COLOR_BTNTEXT;
+		if (m_bOnTitleBar && m_bCustomSystemColor)
+				txtclr = m_bActive ? COLOR_CAPTIONTEXT : COLOR_INACTIVECAPTIONTEXT;
+		SetTextColor(lpDraw->hDC, GetSysColor(txtclr));
 	}
 	CSize iconsize(determineIconSize(), determineIconSize());
 	rc.left += sw + pd + iconsize.cx;

--- a/Src/Common/MDITabBar.cpp
+++ b/Src/Common/MDITabBar.cpp
@@ -96,7 +96,7 @@ COLORREF CMyTabCtrl::GetBackColor() const
 	const COLORREF clr = GetSysColor(COLOR_3DFACE);
 	if (!m_bOnTitleBar)
 		return clr;
-	if (m_bCustomSystemColor)
+	if (!m_bCustomSystemColor)
 		return  m_bActive ? GetSysColor(COLOR_ACTIVECAPTION) : GetSysColor(COLOR_INACTIVECAPTION);
 	const COLORREF bgclr = m_bActive ?
 		RGB(GetRValue(clr), std::clamp(GetGValue(clr) + 8, 0, 255), std::clamp(GetBValue(clr) + 8, 0, 255))
@@ -126,7 +126,7 @@ void CMyTabCtrl::OnPaint()
 	if (nCount == 0)
 	{
 		auto winTitleColor = COLOR_WINDOWTEXT;
-		if (m_bOnTitleBar && m_bCustomSystemColor)
+		if (m_bOnTitleBar && !m_bCustomSystemColor)
 			winTitleColor = m_bActive ? COLOR_CAPTIONTEXT : COLOR_INACTIVECAPTIONTEXT;
 		dc.SetTextColor(GetSysColor(winTitleColor));
 		TCHAR szBuf[256];
@@ -393,7 +393,7 @@ void CMyTabCtrl::DrawItem(LPDRAWITEMSTRUCT lpDrawItemStruct)
 	else
 	{
 		auto txtclr = COLOR_BTNTEXT;
-		if (m_bOnTitleBar && m_bCustomSystemColor)
+		if (m_bOnTitleBar && !m_bCustomSystemColor)
 				txtclr = m_bActive ? COLOR_CAPTIONTEXT : COLOR_INACTIVECAPTIONTEXT;
 		SetTextColor(lpDraw->hDC, GetSysColor(txtclr));
 	}

--- a/Src/Common/MDITabBar.h
+++ b/Src/Common/MDITabBar.h
@@ -33,6 +33,7 @@ protected:
 	bool m_bCloseButtonDown;
 	bool m_bOnTitleBar;
 	bool m_bActive;
+	bool m_bCustomSystemColor;
 	CRect m_rcCurrentCloseButtom;
 	int   m_nDraggingTabItemIndex;
 	int   m_nTooltipTabItemIndex;	/**< Index of the tab displaying tooltip */
@@ -48,6 +49,8 @@ public:
 	bool GetActive() const { return m_bActive; }
 	void SetActive(bool bActive) { m_bActive = bActive; }
 	COLORREF GetBackColor() const;
+	bool GetCustomSystemColor() const { return m_bCustomSystemColor; }
+	void SetCustomSystemColor(bool bCustom) { m_bCustomSystemColor = bCustom; }
 
 // Overrides
 	// ClassWizard generated virtual function overrides
@@ -108,6 +111,7 @@ public:
 	virtual ~CMDITabBar() {}
 	BOOL Update(bool bOnTitleBar, bool bMaxmized);
 	void UpdateActive(bool bActive);
+	void UpdateCustomSystemColor(bool bCustom) { m_tabCtrl.SetCustomSystemColor(bCustom); };
 	BOOL Create(CMDIFrameWnd* pParentWnd);
 	void UpdateTabs() { m_tabCtrl.UpdateTabs(); }
 	bool GetAutoMaxWidth() const { return m_tabCtrl.GetAutoMaxWidth(); }

--- a/Src/Common/MDITabBar.h
+++ b/Src/Common/MDITabBar.h
@@ -48,7 +48,7 @@ public:
 	void SetOnTitleBar(bool onTitleBar) { m_bOnTitleBar = onTitleBar; }
 	bool GetActive() const { return m_bActive; }
 	void SetActive(bool bActive) { m_bActive = bActive; }
-	COLORREF GetBackColor() const;
+	COLORREF GetBackColor();
 	bool GetCustomSystemColor() const { return m_bCustomSystemColor; }
 	void SetCustomSystemColor(bool bCustom) { m_bCustomSystemColor = bCustom; }
 
@@ -84,6 +84,8 @@ protected:
 	void SwapTabs(int nIndexA, int nIndexB);
 	int GetMaxTitleLength() const;
 	void UpdateToolTips(int index);
+	COLORREF GetDwmTitleTextColors();
+	COLORREF GetDwmTitlebarColors();
 };
 
 /**

--- a/Src/Common/MDITabBar.h
+++ b/Src/Common/MDITabBar.h
@@ -24,6 +24,7 @@ public:
 		, m_nTooltipTabItemIndex(-1)
 		, m_bOnTitleBar(false)
 		, m_bActive(false)
+		, m_dwInactiveTitleColor(0)
 	{}
 
 protected:
@@ -39,6 +40,7 @@ protected:
 	int   m_nTooltipTabItemIndex;	/**< Index of the tab displaying tooltip */
 	CMDIFrameWnd *m_pMainFrame;
 	CToolTipCtrl m_tooltips;		/**< Tooltip for the tab */
+	COLORREF m_dwInactiveTitleColor;
 
 public:
 	BOOL Create(CMDIFrameWnd* pMainFrame, CWnd* pParent);

--- a/Src/MainFrm.cpp
+++ b/Src/MainFrm.cpp
@@ -413,6 +413,7 @@ int CMainFrame::OnCreate(LPCREATESTRUCT lpCreateStruct)
 		m_bTabsOnTitleBar = GetOptionsMgr()->GetBool(OPT_TABBAR_ON_TITLEBAR);
 
 	m_wndTabBar.Update(m_bTabsOnTitleBar.value_or(false), false);
+	m_wndTabBar.UpdateCustomSystemColor(GetOptionsMgr()->GetBool(OPT_SYSCOLOR_HOOK_ENABLED));
 
 	if (m_bTabsOnTitleBar.value_or(false) && !m_wndTabBar.Create(this))
 	{
@@ -1229,9 +1230,11 @@ void CMainFrame::OnOptions()
 		for (auto pImgMergeFrame : GetAllImgMergeFrames())
 			pImgMergeFrame->RefreshOptions();
 
-		if (sysColorHookEnabled != GetOptionsMgr()->GetBool(OPT_SYSCOLOR_HOOK_ENABLED) ||
-		    sysColorsSerialized != GetOptionsMgr()->GetString(OPT_SYSCOLOR_HOOK_COLORS))
+		const bool optSysColorHookEnabled = GetOptionsMgr()->GetBool(OPT_SYSCOLOR_HOOK_ENABLED);
+		if (sysColorHookEnabled != optSysColorHookEnabled ||
+			sysColorsSerialized != GetOptionsMgr()->GetString(OPT_SYSCOLOR_HOOK_COLORS))
 		{
+			m_wndTabBar.UpdateCustomSystemColor(optSysColorHookEnabled);
 			theApp.ReloadCustomSysColors();
 			AfxGetMainWnd()->SendMessage(WM_SYSCOLORCHANGE);
 			RedrawWindow(nullptr, nullptr, RDW_INVALIDATE | RDW_UPDATENOW | RDW_ERASE | RDW_ALLCHILDREN);


### PR DESCRIPTION
When not check on this option
![image](https://github.com/user-attachments/assets/55868b3d-daaf-4b49-8e28-9fa652589589)
Run WinMerge without command line params, focus and no focus, enable tabs on title bar, title bar bgcolor will follow windows settings COLOR_ACTIVECAPTION and COLOR_INACTIVECAPTION, title text wll follow windows settings COLOR_CAPTIONTEXT and COLOR_INACTIVECAPTIONTEXT
![f20241028T230641](https://github.com/user-attachments/assets/144f75f6-f185-40d0-aa40-ca98eab9ac15)
WinMerge with tabs focus and no focus
![f20241028T230830](https://github.com/user-attachments/assets/b11db466-8c8f-4518-82ec-a50c45a6e1db)
