### PR TITLE
Main Menu toggle Show/Hide

### DIFF
--- a/Src/MainFrm.h
+++ b/Src/MainFrm.h
@@ -435,6 +435,8 @@ protected:
 	afx_msg LRESULT OnChildFrameActivate(WPARAM wParam, LPARAM lParam);
 	afx_msg LRESULT OnChildFrameActivated(WPARAM wParam, LPARAM lParam);
 	afx_msg void OnUpdateMenuBarMenuItem(CCmdUI* pCmdUI);
+	afx_msg void OnToggleMainMenu();
+	afx_msg void OnSysCommand(UINT nID, LPARAM lParam);
 	//}}AFX_MSG
 	DECLARE_MESSAGE_MAP()
 
@@ -452,6 +454,7 @@ private:
 	void LoadToolbarImages();
 	HMENU NewMenu( int view, int ID );
 	bool CompareFilesIfFilesAreLarge(IDirDoc* pDirDoc, int nFiles, const FileLocation ifileloc[]);
+	void UpdateSystemMenu();
 	std::unique_ptr<WCHAR[]> m_upszLongTextW;
 	std::unique_ptr<CHAR[]> m_upszLongTextA;
 };

--- a/Src/Merge.rc
+++ b/Src/Merge.rc
@@ -361,6 +361,7 @@ BEGIN
             MENUITEM "&Big",                        ID_TOOLBAR_BIG
             MENUITEM "&Huge",                       ID_TOOLBAR_HUGE
         END
+        MENUITEM "Show/&Hide Main Menu\tShift+F12",ID_TOGGLE_MAIN_MENU
         MENUITEM "&Status Bar",                 ID_VIEW_STATUS_BAR
     END
     POPUP "&Tools"
@@ -507,6 +508,7 @@ BEGIN
             MENUITEM "&Big",                        ID_TOOLBAR_BIG
             MENUITEM "&Huge",                       ID_TOOLBAR_HUGE
         END
+        MENUITEM "Show/&Hide Main Menu\tShift+F12",ID_TOGGLE_MAIN_MENU
         MENUITEM "&Status Bar",                 ID_VIEW_STATUS_BAR
         MENUITEM SEPARATOR
         MENUITEM "Com&pare Statistics...",      ID_VIEW_DIR_STATISTICS
@@ -748,6 +750,7 @@ BEGIN
             MENUITEM "&Big",                        ID_TOOLBAR_BIG
             MENUITEM "&Huge",                       ID_TOOLBAR_HUGE
         END
+        MENUITEM "Show/&Hide Main Menu\tShift+F12",ID_TOGGLE_MAIN_MENU
         MENUITEM "&Status Bar",                 ID_VIEW_STATUS_BAR
         MENUITEM "Diff &Pane",                  ID_VIEW_DETAIL_BAR
         MENUITEM "Lo&cation Pane",              ID_VIEW_LOCATION_BAR
@@ -1408,6 +1411,7 @@ BEGIN
     "1",            ID_SEL_DIFF_COPY_1ST,   VIRTKEY, CONTROL, NOINVERT
     "2",            ID_SEL_DIFF_COPY_2ND,   VIRTKEY, CONTROL, NOINVERT
     "3",            ID_SEL_DIFF_COPY_3RD,   VIRTKEY, CONTROL, NOINVERT
+    VK_F12,         ID_TOGGLE_MAIN_MENU,    VIRTKEY, SHIFT, NOINVERT
 END
 
 
@@ -4570,6 +4574,11 @@ BEGIN
     ID_MICE_R2L             "\nCopy to Left (Alt+Left)\n(Right Button+Wheel Left)\n(Alt+Wheel Left)\n(Alt+Shift+Wheel Up)"
     ID_MICE_L2RNEXT         "\nCopy to Right and Advance (Ctrl+Alt+Right)\n(Ctrl+Alt+Wheel Right)\n(Ctrl+Alt+Shift+Wheel Down)"
     ID_MICE_R2LNEXT         "\nCopy to Left and Advance (Ctrl+Alt+Left)\n(Ctrl+Alt+Wheel Left)\n(Ctrl+Alt+Shift+Wheel Up)"
+END
+
+STRINGTABLE
+BEGIN
+    IDS_SHOW_MAIN_MENU      "Show/&Hide Main Menu\tShift+F12"
 END
 
 #endif    // English (United States) resources

--- a/Src/OptionsDef.h
+++ b/Src/OptionsDef.h
@@ -25,6 +25,7 @@ inline const String OPT_SHOW_MISSING_LEFT_ONLY {_T("Settings/ShowMissingLeftOnly
 inline const String OPT_SHOW_MISSING_MIDDLE_ONLY {_T("Settings/ShowMissingMiddleOnly"s)};
 inline const String OPT_SHOW_MISSING_RIGHT_ONLY {_T("Settings/ShowMissingRightOnly"s)};
 inline const String OPT_TREE_MODE {_T("Settings/TreeMode"s)};
+inline const String OPT_HIDE_MAINMENU {_T("Settings/HideMainMenu"s)};
 
 // Show/hide toolbar/statusbar/tabbar
 inline const String OPT_SHOW_TOOLBAR {_T("Settings/ShowToolbar"s)};

--- a/Src/OptionsInit.cpp
+++ b/Src/OptionsInit.cpp
@@ -60,6 +60,7 @@ void Init(COptionsMgr *pOptions)
 	pOptions->InitOption(OPT_SHOW_MISSING_LEFT_ONLY, true);
 	pOptions->InitOption(OPT_SHOW_MISSING_MIDDLE_ONLY, true);
 	pOptions->InitOption(OPT_SHOW_MISSING_RIGHT_ONLY, true);
+	pOptions->InitOption(OPT_HIDE_MAINMENU, false);
 
 	pOptions->InitOption(OPT_SHOW_TOOLBAR, true);
 	pOptions->InitOption(OPT_SHOW_STATUSBAR, true);

--- a/Src/resource.h
+++ b/Src/resource.h
@@ -1038,6 +1038,9 @@
 #define ID_SEL_DIFF_COPY_2ND_3WAY       33274
 #define ID_MICE_L2RNEXT                 33275
 #define ID_MICE_R2LNEXT                 33276
+#define ID_TOGGLE_MAIN_MENU             33277
+#define ID_SHOW_MAIN_MENU               33278
+#define IDS_SHOW_MAIN_MENU              33279
 #define ID_TABBAR_AUTO_MAXWIDTH         33351
 #define ID_IMG_VIEWDIFFERENCES          33353
 #define ID_IMG_ZOOM_25                  33354


### PR DESCRIPTION
Now we can have the simplest user interface, suitable for keyboard-centric power users and small screen users, maximizing the content display area.
The hotkey to show and hide the main menu is Shift+F12. You can also right-click on the title bar or left-click on the system menu icon to select from the system menu. Even with the main menu hidden, the main menu also works normally. For example, pressing Alt+F will bring up the File menu, Alt+E will bring up the Edit menu, and Alt+V will bring up the View menu. So there are other ways to restore the main menu, such as pressing (Alt+Space, H) or (Alt+V, H) or (F10, V, H).

Here is the display effect after hiding the main menu, tab bar, toolbar, diff pane and status bar:
![image](https://github.com/user-attachments/assets/6259b8d2-2b7e-480f-b999-a8dda2bd498f)
![image](https://github.com/user-attachments/assets/0cd90fd7-181c-4f2d-9a5c-dc14e9edc001)
![image](https://github.com/user-attachments/assets/d424897a-c676-448e-b093-a1fd785fe2a4)
![image](https://github.com/user-attachments/assets/8cc36355-f035-490a-9e6f-a65893ceb4af)
