### PR TITLE
Adjust right-click deselect from down to up to preserve RB + scroll anywhere

### DIFF
--- a/Src/MergeEditView.cpp
+++ b/Src/MergeEditView.cpp
@@ -84,7 +84,7 @@ BEGIN_MESSAGE_MAP(CMergeEditView, CCrystalEditViewEx)
 	ON_WM_TIMER()
 	ON_WM_LBUTTONDBLCLK()
 	ON_WM_LBUTTONUP()
-	ON_WM_RBUTTONDOWN()
+	ON_WM_RBUTTONUP()
 	ON_WM_VSCROLL ()
 	ON_WM_HSCROLL ()
 	ON_WM_SIZE()
@@ -1931,13 +1931,17 @@ void CMergeEditView::OnLButtonUp(UINT nFlags, CPoint point)
 /**
  * @brief Called when mouse right button is pressed.
  *
- * If right button is pressed outside diffs, current diff
+ * If right button is pressed outside diffs, and it is not
+ * right button + wheel scrolling combination, current diff
  * is deselected.
  */
-void CMergeEditView::OnRButtonDown(UINT nFlags, CPoint point)
+void CMergeEditView::OnRButtonUp(UINT nFlags, CPoint point)
 {
-	CCrystalEditViewEx::OnRButtonDown(nFlags, point);
-	DeselectDiffIfCursorNotInCurrentDiff();
+	if (!CMouseHook::IsRightWheelScrolling())
+	{
+		DeselectDiffIfCursorNotInCurrentDiff();
+	}
+	CCrystalEditViewEx::OnRButtonUp(nFlags, point);
 }
 
 void CMergeEditView::OnX2Y(int srcPane, int dstPane, bool selectedLineOnly)

--- a/Src/MergeEditView.h
+++ b/Src/MergeEditView.h
@@ -239,7 +239,7 @@ protected:
 	afx_msg void OnUpdatePrevdiffRO(CCmdUI* pCmdUI);
 	afx_msg void OnLButtonDblClk(UINT nFlags, CPoint point);
 	afx_msg void OnLButtonUp(UINT nFlags, CPoint point);
-	afx_msg void OnRButtonDown(UINT nFlags, CPoint point);
+	afx_msg void OnRButtonUp(UINT nFlags, CPoint point);
 	afx_msg void OnAllLeft();
 	afx_msg void OnUpdateAllLeft(CCmdUI* pCmdUI);
 	afx_msg void OnAllRight();


### PR DESCRIPTION
Right button down + wheel scrolling now works from anywhere in the edit view without needing to move the cursor to the current diff line. The right-click deselect feature for diff lines is still functional, but the deselect action is now triggered on button release instead of button press.