### PR TITLE
Caret (text cursor) follow windows settings

### DIFF
--- a/Externals/crystaledit/editlib/ccrystaltextview.cpp
+++ b/Externals/crystaledit/editlib/ccrystaltextview.cpp
@@ -2870,7 +2870,11 @@ UpdateCaret ()
           CreateSolidCaret (nCaretWidth, nCaretHeight);
         }
       else
-        CreateSolidCaret (2, nCaretHeight);
+        {
+          DWORD caretWidth = 2;
+          SystemParametersInfo (SPI_GETCARETWIDTH, 0, &caretWidth, 0);
+          CreateSolidCaret (caretWidth, nCaretHeight);
+        }
 
       SetCaretPos (TextToClient (m_ptCursorPos));
       ShowCaret ();


### PR DESCRIPTION
The current text cursor width is hard coded to 2, which is too thin to be noticeable on HiDPI displays. It was changed to the value from Windows Control Panel for text cursor, allowing users to adjust it.