### PR TITLE
Ignore special items when finding matching item on Open Dialog Find Item

### DIFF
--- a/Src/DirView.cpp
+++ b/Src/DirView.cpp
@@ -3607,7 +3607,7 @@ void CDirView::OnODFindItem(NMHDR* pNMHDR, LRESULT* pResult)
 		for (size_t i = pFindItem->iStart; i < m_listViewItems.size(); ++i)
 		{
 			DIFFITEM *di = GetItemKey(static_cast<int>(i));
-			if (di)
+			if (di && !IsDiffItemSpecial(di))
 			{
 				String filename = strutils::makelower(di->diffFileInfo[0].filename);
 


### PR DESCRIPTION
Fix issue #354: Crash when typing a character before folder compare has finished
Special item (e.g. parent directory) does not have a filename in some versions of windows