### PR TITLE
IME switch not toggle menu when menu hide

### DIFF
--- a/Src/MenuBar.cpp
+++ b/Src/MenuBar.cpp
@@ -382,7 +382,7 @@ BOOL CMenuBar::PreTranslateMessage(MSG* pMsg)
 	if (pMsg->message == WM_SYSKEYDOWN || pMsg->message == WM_SYSKEYUP)
 	{
 		const BOOL bShift = ::GetAsyncKeyState(VK_SHIFT) & 0x8000;
-		if ((!bShift && pMsg->wParam == VK_F10) || pMsg->wParam == VK_MENU)
+		if (!bShift && (pMsg->wParam == VK_F10 || pMsg->wParam == VK_MENU))
 		{
 			if (pMsg->message == WM_SYSKEYDOWN)
 			{


### PR DESCRIPTION
When the menu bar is hidden and the IME is switched using the Alt+Shift system shortcut to type some characters, the menu unexpectedly appears and gains focus. However, activating the IME indicates that the user intends to input text in the editor, not to select something from the menu.