### PR TITLE
Fix build in VS2022 17.13.0

### DIFF
--- a/Src/MouseHook.cpp
+++ b/Src/MouseHook.cpp
@@ -1,6 +1,5 @@
 #include <StdAfx.h>
 #include "MouseHook.h"
-#include <chrono>
 
 #ifndef WM_MOUSEHWHEEL
 #  define WM_MOUSEHWHEEL 0x20e

--- a/Src/MouseHook.h
+++ b/Src/MouseHook.h
@@ -1,3 +1,5 @@
+#include <chrono>
+
 class CMouseHook
 {
 public:


### PR DESCRIPTION
VS2022 17.13.0 could not find std::chrono::system_clock