### PR TITLE
Modify the "Options (Compare > Image)" dialog.

### DIFF
--- a/Src/PropCompareImage.cpp
+++ b/Src/PropCompareImage.cpp
@@ -89,6 +89,8 @@ BOOL PropCompareImage::OnInitDialog()
 void PropCompareImage::OnDefaults()
 {
 	m_sFilePatterns = GetOptionsMgr()->GetDefault<String>(OPT_CMP_IMG_FILEPATTERNS);
+	m_bEnableImageCompare = GetOptionsMgr()->GetDefault<bool>(OPT_CMP_ENABLE_IMGCMP_IN_DIRCMP);
+	m_nOcrResultType = GetOptionsMgr()->GetDefault<unsigned>(OPT_CMP_IMG_OCR_RESULT_TYPE);
 	UpdateData(FALSE);
 }
 


### PR DESCRIPTION
The "Defaults" button now resets the following settings to their default values:
- Enable image compare in folder compare
- OCR result
![dialog](https://github.com/user-attachments/assets/ad46b2a9-ee89-4bba-98dc-c41d1c1c8a4b)
