### PR TITLE
Rephrase closing window message

### DIFF
--- a/Translations/WinMerge/English.pot
+++ b/Translations/WinMerge/English.pot
@@ -2828,7 +2828,7 @@ msgstr ""
 msgid "You are about to close the window that is comparing folders. Are you sure you want to close the window?"
 msgstr ""
 
-msgid "You are about to close the folder comparison window that took a significant amount of time. Are you sure you want to close the window?"
+msgid "You are about to close the window with folder comparison that took a significant amount of time. Are you sure you want to close the window?"
 msgstr ""
 
 msgid "The file or folder name is invalid."


### PR DESCRIPTION
I think the new version better conveys the fact that the comparison itself took a long time and the window holds its result.