### PR TITLE
Syntax/Pascal: Support multiline strings

### DIFF
--- a/Externals/crystaledit/editlib/parsers/pascal.cpp
+++ b/Externals/crystaledit/editlib/parsers/pascal.cpp
@@ -149,7 +149,7 @@ unsigned
 CrystalLineParser::ParseLinePascal (unsigned dwCookie, const tchar_t *pszChars, int nLength, TEXTBLOCK * pBuf, int &nActualItems)
 {
   if (nLength == 0)
-    return dwCookie & (COOKIE_EXT_COMMENT | COOKIE_EXT_COMMENT2);
+    return dwCookie & (COOKIE_EXT_COMMENT | COOKIE_EXT_COMMENT2 | COOKIE_BLOCK_STYLE);
 
   bool bRedefineBlock = true;
   bool bDecIndex = false;
@@ -174,7 +174,7 @@ CrystalLineParser::ParseLinePascal (unsigned dwCookie, const tchar_t *pszChars, 
             {
               DEFINE_BLOCK (nPos, COLORINDEX_COMMENT);
             }
-          else if (dwCookie & (COOKIE_CHAR | COOKIE_STRING))
+          else if (dwCookie & (COOKIE_CHAR | COOKIE_STRING | COOKIE_BLOCK_STYLE))
             {
               DEFINE_BLOCK (nPos, COLORINDEX_STRING);
             }
@@ -221,12 +221,32 @@ out:
         }
 
       //  Char constant '..'
-      if (dwCookie & COOKIE_CHAR)
+      if (dwCookie & COOKIE_CHAR || dwCookie & COOKIE_BLOCK_STYLE)
         {
           if (pszChars[I] == '\'' && (I == 0 || I == 1 && pszChars[nPrevI] != '\\' || I >= 2 && (pszChars[nPrevI] != '\\' || *tc::tcharprev(pszChars, pszChars + nPrevI) == '\\')))
             {
-              dwCookie &= ~COOKIE_CHAR;
-              bRedefineBlock = true;
+              // Multiline string ('''...''')?
+              if (((nLength >= I + 1) && (pszChars[I+1] == '\'')) || (dwCookie & COOKIE_BLOCK_STYLE))
+                {
+                  if (dwCookie & COOKIE_BLOCK_STYLE)
+                  {
+                      // End of multiline string
+                      dwCookie &= ~COOKIE_BLOCK_STYLE;                      
+                  }
+                  else 
+                  {
+                      // Start of multiline string
+                      dwCookie |= COOKIE_BLOCK_STYLE;
+                      // Skip one
+                      I++;
+                  }
+                }
+              else
+              {
+                  dwCookie &= ~COOKIE_CHAR;
+                  
+                  bRedefineBlock = true;
+              }
             }
           continue;
         }
@@ -278,7 +298,7 @@ out:
               continue;
             }
         }
-      if (I > 0 && pszChars[I] == '*' && pszChars[nPrevI] == '(')
+      if (I > 0 && pszChars[I] == '*' && pszChars[nPrevI] == '(') // (*
         {
           DEFINE_BLOCK (nPrevI, COLORINDEX_COMMENT);
           dwCookie |= COOKIE_EXT_COMMENT;
@@ -319,6 +339,6 @@ out:
     }
 
   if (pszChars[nLength - 1] != '\\' || IsMBSTrail(pszChars, nLength - 1))
-    dwCookie &= (COOKIE_EXT_COMMENT | COOKIE_EXT_COMMENT2);
+    dwCookie &= (COOKIE_EXT_COMMENT | COOKIE_EXT_COMMENT2 | COOKIE_BLOCK_STYLE);
   return dwCookie;
 }


### PR DESCRIPTION
Delphi introduced multiline strings in version 12. They start with ``'''`` and end with ``'''```.

Before:
![grafik](https://github.com/user-attachments/assets/bce96779-2e62-4f5c-8e77-6c969a630488)


After:
![grafik](https://github.com/user-attachments/assets/95a5bb1d-1d70-4e2c-804d-51e51ae94c60)
