### PR TITLE
Add the feature to open multiple files in the folder compare window requested in #1423.

### DIFF
--- a/Src/DirActions.cpp
+++ b/Src/DirActions.cpp
@@ -502,6 +502,8 @@ bool AreItemsOpenable(const CDiffContext& ctxt, const DIFFITEM &di1, const DIFFI
 /// is it possible to open item ?
 bool IsItemOpenableOn(const DIFFITEM &di, int index)
 {
+	if (di.diffcode.diffcode == 0) return false;
+
 	// impossible if not existing
 	if (!di.diffcode.exists(index)) return false;
 
@@ -512,8 +514,20 @@ bool IsItemOpenableOn(const DIFFITEM &di, int index)
 /// is it possible to open left ... item ?
 bool IsItemOpenableOnWith(const DIFFITEM &di, int index)
 {
-	return (!di.diffcode.isDirectory() && IsItemOpenableOn(di, index));
+	return (di.diffcode.diffcode != 0 && !di.diffcode.isDirectory() && IsItemOpenableOn(di, index));
 }
+
+/**
+ * @brief Is it possible to open the parent folder?
+ * @param [in] di Diff item to check
+ * @param [in] index Index of the item whose parent folder to be opened.
+ * @return True if it is possible to open the parent folder.
+ */
+bool IsParentFolderOpenable(const DIFFITEM& di, int index)
+{
+	return (di.diffcode.diffcode != 0 && di.diffcode.exists(index));
+}
+
 /// is it possible to copy to... left item?
 bool IsItemCopyableToOn(const DIFFITEM &di, int index)
 {

--- a/Src/DirActions.h
+++ b/Src/DirActions.h
@@ -147,6 +147,7 @@ bool AreItemsOpenable(const CDiffContext& ctxt, SELECTIONTYPE selectionType, con
 bool AreItemsOpenable(const CDiffContext& ctxt, const DIFFITEM &di1, const DIFFITEM &di2, const DIFFITEM &di3, bool openableForDir = true);
 bool IsItemOpenableOn(const DIFFITEM &di, int index);
 bool IsItemOpenableOnWith(const DIFFITEM &di, int index);
+bool IsParentFolderOpenable(const DIFFITEM& di, int index);
 bool IsItemCopyableToOn(const DIFFITEM &di, int index);
 bool IsItemNavigableDiff(const CDiffContext& ctxt, const DIFFITEM &di);
 bool IsItemExistAll(const CDiffContext& ctxt, const DIFFITEM &di);
@@ -323,19 +324,19 @@ struct DirActions
 	template <SIDE_TYPE src>
 	bool IsItemOpenableOn(const DIFFITEM& di) const
 	{
-		return (di.diffcode.diffcode != 0 && ::IsItemOpenableOn(di, SideToIndex(m_ctxt, src)));
+		return ::IsItemOpenableOn(di, SideToIndex(m_ctxt, src));
 	}
 
 	template <SIDE_TYPE src>
 	bool IsItemOpenableOnWith(const DIFFITEM& di) const
 	{
-		return (di.diffcode.diffcode != 0 && ::IsItemOpenableOnWith(di, SideToIndex(m_ctxt, src)));
+		return ::IsItemOpenableOnWith(di, SideToIndex(m_ctxt, src));
 	}
 
 	template <SIDE_TYPE src>
 	bool IsParentFolderOpenable(const DIFFITEM& di) const
 	{
-		return (di.diffcode.diffcode != 0 && di.diffcode.exists(SideToIndex(m_ctxt, src)));
+		return ::IsParentFolderOpenable(di, SideToIndex(m_ctxt, src));
 	}
 
 	bool IsItemFile(const DIFFITEM& di) const

--- a/Src/DirView.cpp
+++ b/Src/DirView.cpp
@@ -1924,12 +1924,14 @@ void CDirView::GetItemFileNames(int sel, PathContext * paths) const
  */
 void CDirView::DoOpen(SIDE_TYPE stype)
 {
-	int sel = GetSingleSelectedItem();
-	if (sel == -1) return;
-	DirItemIterator dirBegin = SelBegin();
-	String file = GetSelectedFileName(dirBegin, stype, GetDiffContext());
-	if (file.empty()) return;
-	shell::Edit(file.c_str());
+	for (DirItemIterator it = SelBegin(); it != SelEnd(); ++it)
+	{
+		if (IsItemOpenableOn(*it, SideToIndex(GetDiffContext(), stype))) {
+			String file = GetSelectedFileName(it, stype, GetDiffContext());
+			if (!file.empty())
+				shell::Edit(file.c_str());
+		}
+	}
 }
 
 /// Open with dialog for file on selected side
@@ -1946,23 +1948,26 @@ void CDirView::DoOpenWith(SIDE_TYPE stype)
 /// Open selected file  on specified side to external editor
 void CDirView::DoOpenWithEditor(SIDE_TYPE stype)
 {
-	int sel = GetSingleSelectedItem();
-	if (sel == -1) return;
-	DirItemIterator dirBegin = SelBegin();
-	String file = GetSelectedFileName(dirBegin, stype, GetDiffContext());
-	if (file.empty()) return;
-
-	CMergeApp::OpenFileToExternalEditor(file);
+	for (DirItemIterator it = SelBegin(); it != SelEnd(); ++it)
+	{
+		if (IsItemOpenableOnWith(*it, SideToIndex(GetDiffContext(), stype))) {
+			String file = GetSelectedFileName(it, stype, GetDiffContext());
+			if (!file.empty())
+				CMergeApp::OpenFileToExternalEditor(file);
+		}
+	}
 }
 
 void CDirView::DoOpenParentFolder(SIDE_TYPE stype)
 {
-	int sel = GetSingleSelectedItem();
-	if (sel == -1) return;
-	DirItemIterator dirBegin = SelBegin();
-	String file = GetSelectedFileName(dirBegin, stype, GetDiffContext());
-	if (file.empty()) return;
-	shell::OpenParentFolder(file.c_str());
+	for (DirItemIterator it = SelBegin(); it != SelEnd(); ++it)
+	{
+		if (IsParentFolderOpenable(*it, SideToIndex(GetDiffContext(), stype))) {
+			String file = GetSelectedFileName(it, stype, GetDiffContext());
+			if (!file.empty())
+				shell::OpenParentFolder(file.c_str());
+		}
+	}
 }
 
 /// Update context menuitem "Open left | with editor"
@@ -1970,7 +1975,8 @@ template<SIDE_TYPE stype>
 void CDirView::OnUpdateCtxtDirOpenWithEditor(CCmdUI* pCmdUI)
 {
 	Counts counts = Count(&DirActions::IsItemOpenableOnWith<stype>);
-	pCmdUI->Enable(counts.count > 0 && counts.total == 1);
+	int selected = GetSelectedCount();
+	pCmdUI->Enable(counts.count > 0 && selected == counts.count);
 }
 
 // return selected item index, or -1 if none or multiple
@@ -1988,7 +1994,8 @@ template<SIDE_TYPE stype>
 void CDirView::OnUpdateCtxtDirOpen(CCmdUI* pCmdUI)
 {
 	Counts counts = Count(&DirActions::IsItemOpenableOn<stype>);
-	pCmdUI->Enable(counts.count > 0 && counts.total == 1);
+	int selected = GetSelectedCount();
+	pCmdUI->Enable(counts.count > 0 && selected == counts.count);
 }
 
 // Enable/disable Open Left With menu choice on context menu
@@ -2004,7 +2011,8 @@ template<SIDE_TYPE stype>
 void CDirView::OnUpdateCtxtDirOpenParentFolder(CCmdUI* pCmdUI)
 {
 	Counts counts = Count(&DirActions::IsParentFolderOpenable<stype>);
-	pCmdUI->Enable(counts.count > 0 && counts.total == 1);
+	int selected = GetSelectedCount();
+	pCmdUI->Enable(counts.count > 0 && selected == counts.count);
 }
 
 // Used for Open


### PR DESCRIPTION
The following menu items are now available in the context menu when multiple files or folders are selected:
- "Open Left/Middle/Right" > "With Registered Application"
- "Open Left/Middle/Right" > "With External Editor"
- "Open Left/Middle/Right" > "Open Parent Folder..."

("Open Left/Center/Right" > "With..." are not included in this feature addition because multiple "Open With" dialogs cannot be opened at the same time at least in Windows 11.)