### PR TITLE
[Bug Fix] Enable/disable 'Switch to ...' options in Compare > Folder page

### DIFF
--- a/Src/PropCompareFolder.cpp
+++ b/Src/PropCompareFolder.cpp
@@ -172,4 +172,6 @@ void PropCompareFolder::UpdateControls()
 	EnableDlgItem(IDC_COMPARE_WALKSUBDIRS, IsDlgButtonChecked(IDC_RECURS_CHECK) == 1);
 	EnableDlgItem(IDC_EXPAND_SUBDIRS, IsDlgButtonChecked(IDC_RECURS_CHECK) == 1);
 	EnableDlgItem(IDC_COMPARE_THREAD_COUNT, pCombo->GetCurSel() <= 1 ? true : false); // true: fullcontent, quickcontent
+	EnableDlgItem(IDC_COMPARE_QUICKC_LIMIT, pCombo->GetCurSel() == 0 ? true : false); // true: fullcontent
+	EnableDlgItem(IDC_COMPARE_BINARYC_LIMIT, pCombo->GetCurSel() <= 1 ? true : false); // true: fullcontent, quickcontent
 }


### PR DESCRIPTION
## 🐞Description
The issue was reported in #2818 

## ✅ Test Plan
Manual testing on Windows 10/11

## 🔗 Related Issue
Merging this PR can close #2818 

## 📋 Checklist
- [x] Code compiles without errors
- [x] Manual testing completed
- [x] No regressions observed