### PR TITLE
[Enhancement] Tab Switching and Tab Bar Scrolling with Mouse Wheel

### DIFF
--- a/Src/Common/MDITabBar.cpp
+++ b/Src/Common/MDITabBar.cpp
@@ -93,6 +93,25 @@ void CMyTabCtrl::SetActive(bool bActive)
 	m_bActive = bActive;
 }
 
+/**
+ * @brief Activate the specific tab by index.
+ * @param nTabIndex [in] Tab index to activate
+ */
+void CMyTabCtrl::ActivateTab(int nTabIndex)
+{
+	if (nTabIndex < 0 || nTabIndex >= GetItemCount())
+		return;
+
+	SetCurSel(nTabIndex);
+
+	// Notify tab selection changed
+	NMHDR nmhdr = {0};
+	nmhdr.hwndFrom = GetSafeHwnd();
+	nmhdr.idFrom = GetDlgCtrlID();
+	nmhdr.code = TCN_SELCHANGE;
+	GetParent()->SendMessage(WM_NOTIFY, nmhdr.idFrom, reinterpret_cast<LPARAM>(&nmhdr));
+}
+
 static inline COLORREF getTextColor()
 {
 	return GetSysColor(COLOR_WINDOWTEXT);
@@ -526,7 +545,7 @@ BOOL CMyTabCtrl::OnMouseWheel(UINT nFlags, short zDelta, CPoint point)
 		if (nSwitchToTabIndex < 0 || nSwitchToTabIndex > nLastTabIndex)
 			return TRUE;
 
-		SetCurSel(nSwitchToTabIndex);
+		ActivateTab(nSwitchToTabIndex);
 	}
 
 	// Otherwise, scroll the tab bar

--- a/Src/Common/MDITabBar.h
+++ b/Src/Common/MDITabBar.h
@@ -47,6 +47,7 @@ public:
 	void SetOnTitleBar(bool onTitleBar) { m_bOnTitleBar = onTitleBar; }
 	bool GetActive() const { return m_bActive; }
 	void SetActive(bool bActive);
+	void ActivateTab(int nTabIndex);
 	COLORREF GetBackColor() const;
 
 // Overrides


### PR DESCRIPTION
## ✨ What's New in This Enhancement
This PR enhances the tab control behavior by enabling intuitive **tab switching** using the mouse wheel with `Ctrl` or `Shift` modifiers, and also supports **tab bar scrolling**.
- Switch tabs with the mouse wheel:
  - `Ctrl + MouseWheel (Up/Down)`: Switches to the previous/next tab **WITH wraparound**
  - `Shift + MouseWheel (Up/Down)`: Switches to the previous/next tab **WITHOUT wraparound**
  - `Ctrl + Shift + MouseWheel (Up/Down)`: Switches to the first/last tab
- Support Tab bar scrolling: When **no modifier key is held** and the tabs exceed the visible area, rotating the mouse wheel scrolls the tab bar.

## ✅ Test Plan
- Manual testing with `Ctrl + MouseWheel`: cycles tabs forward/backward with wraparound.
- Manual testing with `Shift + MouseWheel`: moves forward/backward without wrapping.
- Manual testing with `Ctrl + Shift + MouseWheel`: switches to the first/last tab
- Confirmed tab bar scrolls only when necessary

## 📋 Checklist
 - [x] Code compiles without errors
 - [x] Manual testing completed
 - [x] No regressions in tab scrolling behavior
 - [x] Modifier key handling confirmed across input cases