### PR TITLE
Add the feature to compare multiple files in one action in the folder compare window requested in #324.

### DIFF
--- a/Src/DirView.h
+++ b/Src/DirView.h
@@ -135,6 +135,8 @@ private:
 	void DoOpenWith(SIDE_TYPE stype);
 	void DoOpenWithEditor(SIDE_TYPE stype);
 	void DoOpenParentFolder(SIDE_TYPE stype);
+	bool AreItemsComparable(SELECTIONTYPE selectionType, bool openableForDir = true);
+	bool AreItemsComparableIndivisually(UINT nID, bool openableForDir);
 	void DoUpdateOpen(SELECTIONTYPE selectionType, CCmdUI* pCmdUI, bool openableForDir = true);
 	void RemoveDuplicatedActions(FileActionScript & actions);
 	void ConfirmAndPerformActions(FileActionScript & actions);
@@ -415,8 +417,10 @@ protected:
 private:
 	void Open(CDirDoc *pDoc, const PathContext& paths, fileopenflags_t dwFlags[3], FileTextEncoding encoding[3], PackingInfo * infoUnpacker = nullptr);
 	void OpenSelection(CDirDoc *pDoc, SELECTIONTYPE selectionType = SELECTIONTYPE_NORMAL, PackingInfo * infoUnpacker = nullptr, bool openableForDir = true);
+	void OpenSelection(int sel1, int sel2, int sel3, CDirDoc* pDoc, SELECTIONTYPE selectionType = SELECTIONTYPE_NORMAL, PackingInfo* infoUnpacker = nullptr, bool openableForDir = true);
 	void OpenSelection(SELECTIONTYPE selectionType = SELECTIONTYPE_NORMAL, PackingInfo * infoUnpacker = nullptr, bool openableForDir = true);
 	void OpenSelectionAs(UINT id);
+	void OpenSelectionAs(int sel1, int sel2, int sel3, UINT id);
 	bool GetSelectedItems(int * sel1, int * sel2, int * sel3);
 	void OpenParentDirectory(CDirDoc *pDocOpen);
 	template<SIDE_TYPE srctype, SIDE_TYPE dsttype>


### PR DESCRIPTION
Add the feature to compare multiple files in one action in the folder compare window requested in #324.

The following menu items are now available in the menu bar or the context menu when multiple files or folders are selected:
- Menu bar
  - "Merge" > "Compare"
- Context menu
  - "Compare"
  - "Compare in New Window"
  - "Compare As" > "Text"
  - "Compare As" > "Table"
  - "Compare As" > "Binary"
  - "Compare As" > "Image"
  - "Compare As" > "Webpage"

WinMerge already has the feature to compare two or three items where only one file exists each as you know, and this feature takes precedence over the feature added in this PR.
This means that the comparison process added in this PR will only be used in cases where the existing process is not available.

For example:
  - File A: Only exists in the left side.
  - File B: Only exists in the right side.
  - File C: Both Exists in the left and right sides.

  1. Select File A and File B and compare them.
      This will open the following file compare window:
      - File A (Left) vs. File B (Right)

  2. Select File A and File C and compare them.
      This will open the following file compare window:
      - File A (Left) vs. Empty File
      - File C (Left) vs. File C (Right)

  3. Select File A, File B and File C and compare them.
      This will open the following file compare window:
      - File A (Left) vs. Empty File
      - Empty File vs. File B (Right)
      - File C (Left) vs. File C (Right)