### PR TITLE
Potential fix for code scanning alert no. 1116: Local variable address stored in non-local memory

### DIFF
--- a/Src/DirCmpReport.cpp
+++ b/Src/DirCmpReport.cpp
@@ -227,10 +227,10 @@ bool DirCmpReport::GenerateReport(String &errStr)
 				errStr = _("Folder does not exist.");
 				return false;
 			}
-			CFile file(m_sReportFile.c_str(),
+			m_pFile = new CFile(m_sReportFile.c_str(),
 				CFile::modeWrite|CFile::modeCreate|CFile::shareDenyWrite);
-			m_pFile = &file;
 			GenerateReport(m_nReportType);
+			delete m_pFile;
 			m_pFile = nullptr;
 		}
 		bRet = true;


### PR DESCRIPTION
Potential fix for [https://github.com/WinMerge/winmerge/security/code-scanning/1116](https://github.com/WinMerge/winmerge/security/code-scanning/1116)

To fix this problem, we need to ensure that the pointer stored in `m_pFile` remains valid for as long as it is needed. The best way to do this is to allocate the `CFile` object on the heap using `new`, and assign its address to `m_pFile`. After the report is generated, we should delete the heap-allocated object and set `m_pFile` to `nullptr` to avoid a dangling pointer. This change should be made in the function where `file` is currently a local variable (lines 230–235). No changes are needed elsewhere unless there is code that assumes `file` is a stack variable, but based on the provided snippet, this is not the case.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
