### PR TITLE
Potential fix for code scanning alert no. 1466: Cast between HRESULT and a Boolean type

### DIFF
--- a/Src/AboutDlg.cpp
+++ b/Src/AboutDlg.cpp
@@ -106,7 +106,8 @@ BOOL CAboutDlg::Impl::OnInitDialog()
 {
 	CTrDialog::OnInitDialog();
 
-	if (!m_image.Load(paths::ConcatPath(env::GetProgPath(), _T("Resources\\splash.png")).c_str()))
+	HRESULT hr = m_image.Load(paths::ConcatPath(env::GetProgPath(), _T("Resources\\splash.png")).c_str());
+	if (FAILED(hr))
 	{
 		// FIXME: LoadImageFromResource() seems to fail when running on Wine 5.0.
 	}


### PR DESCRIPTION
Potential fix for [https://github.com/WinMerge/winmerge/security/code-scanning/1466](https://github.com/WinMerge/winmerge/security/code-scanning/1466)

To fix the problem, we should explicitly check the result of `m_image.Load` using the `FAILED` macro, which is the standard way to test for failure when dealing with `HRESULT` values. This means we should assign the result of `Load` to an `HRESULT` variable, and then use `if (FAILED(hr))` to check for failure. This change should be made in `Src/AboutDlg.cpp` at line 109, within the `CAboutDlg::Impl::OnInitDialog()` method. No new imports are needed, as the `FAILED` macro is defined in standard Windows headers.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
