### PR TITLE
Potential fix for code scanning alert no. 6: Cast between HRESULT and a Boolean type

### DIFF
--- a/Src/HexMergeDoc.cpp
+++ b/Src/HexMergeDoc.cpp
@@ -41,7 +41,7 @@ static int Try(HRESULT hr, UINT type = MB_OKCANCEL|MB_ICONSTOP);
  */
 static int Try(HRESULT hr, UINT type)
 {
-	return hr ? CInternetException(hr).ReportError(type) : 0;
+	return FAILED(hr) ? CInternetException(hr).ReportError(type) : 0;
 }
 
 /////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Potential fix for [https://github.com/WinMerge/winmerge/security/code-scanning/6](https://github.com/WinMerge/winmerge/security/code-scanning/6)

To fix the problem, replace the direct use of `hr` in the boolean context with the `FAILED(hr)` macro. This makes the code more robust and explicit, as it will correctly handle all possible `HRESULT` values according to Windows API conventions. Specifically, in the function `Try`, change the line:
```cpp
return hr ? CInternetException(hr).ReportError(type) : 0;
```
to:
```cpp
return FAILED(hr) ? CInternetException(hr).ReportError(type) : 0;
```
This change is limited to the function `Try` in `Src/HexMergeDoc.cpp`. No new imports are needed, as `FAILED` is defined in standard Windows headers.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
