### PR TITLE
Potential fix for code scanning alert no. 1056: Multiplication result converted to larger type

### DIFF
--- a/Src/MergeDoc.h
+++ b/Src/MergeDoc.h
@@ -229,7 +229,7 @@ public:
 		}
 		else
 		{
-			list.reserve(m_nGroups * m_nBuffers);
+			list.reserve(static_cast<std::vector<CMergeEditView *>::size_type>(m_nGroups) * m_nBuffers);
 			for (int nGroup3 = 0; nGroup3 < m_nGroups; nGroup3++)
 				for (int nBuffer3 = 0; nBuffer3 < m_nBuffers; ++nBuffer3)
 					list.push_back(m_pView[nGroup3][nBuffer3]);


### PR DESCRIPTION
Potential fix for [https://github.com/WinMerge/winmerge/security/code-scanning/1056](https://github.com/WinMerge/winmerge/security/code-scanning/1056)

To fix the problem, ensure that the multiplication is performed using a type at least as large as `size_t` before the multiplication occurs. This can be done by casting one or both operands to `size_t` (or `std::vector<CMergeEditView *>::size_type`) before multiplying. This ensures that the multiplication is performed in the larger type, preventing overflow. The change should be made only at the line where `list.reserve(m_nGroups * m_nBuffers);` is called (line 232). No additional imports or method definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
