### PR TITLE
Potential fix for code scanning alert no. 697: Missing enum case in switch

### DIFF
--- a/Src/Common/OptionsMgr.cpp
+++ b/Src/Common/OptionsMgr.cpp
@@ -356,6 +356,12 @@ void COption::Reset()
 	case varprop::VT_TIME:
 		m_value.SetTime(m_valueDef.GetTime());
 		break;
+	case varprop::VT_NULL:
+		// Do nothing for VT_NULL
+		break;
+	default:
+		// Do nothing for unknown types
+		break;
 	}
 }
 


### PR DESCRIPTION
Potential fix for [https://github.com/WinMerge/winmerge/security/code-scanning/697](https://github.com/WinMerge/winmerge/security/code-scanning/697)

To fix the problem, we should ensure that the `switch` statement in `COption::Reset()` handles all possible values of the `varprop::VT_TYPE` enum. The best way to do this is to add a `case` for `VT_NULL` and a `default` case to catch any unhandled or future enum values. For consistency with the `SetDefault` method, the `VT_NULL` and `default` cases should do nothing (or possibly log an error, but to avoid changing existing functionality, we will simply leave them empty). The change should be made in the `COption::Reset()` method, starting at line 342 in `Src/Common/OptionsMgr.cpp`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
