### PR TITLE
Potential fix for code scanning alert no. 70: Inconsistent definition of copy constructor and assignment ('Rule of Two')

### DIFF
--- a/Src/PathContext.h
+++ b/Src/PathContext.h
@@ -114,6 +114,12 @@ public:
 	{
 	}
 
+	// Copy constructor to match copy assignment operator
+	PathContextIterator(const PathContextIterator& it)
+		: m_pPathContext(it.m_pPathContext), m_sel(it.m_sel)
+	{
+	}
+
 	~PathContextIterator() = default;
 
 	PathContextIterator& operator=(const PathContextIterator& it)


### PR DESCRIPTION
Potential fix for [https://github.com/WinMerge/winmerge/security/code-scanning/70](https://github.com/WinMerge/winmerge/security/code-scanning/70)

To fix the problem, we should define a copy constructor for `PathContextIterator` that matches the copy assignment operator. Since the assignment operator simply copies the `m_sel` and `m_pPathContext` members, the copy constructor should do the same. If the default compiler-generated copy constructor is sufficient, we can explicitly default it using `PathContextIterator(const PathContextIterator&) = default;`. Alternatively, we can define it explicitly to mirror the assignment operator. The best fix is to add an explicit copy constructor, either defaulted or with the same logic as the assignment operator, in the public section of the class definition in `Src/PathContext.h`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
