### PR TITLE
Potential fix for code scanning alert no. 67: Inconsistent definition of copy constructor and assignment ('Rule of Two')

### DIFF
--- a/Src/DirItemIterator.h
+++ b/Src/DirItemIterator.h
@@ -49,6 +49,11 @@ public:
 
 	~DirItemWithIndexIterator() = default;
 
+	DirItemWithIndexIterator(const DirItemWithIndexIterator& it)
+		: m_pList(it.m_pList), m_sel(it.m_sel), m_selected(it.m_selected), m_reverse(it.m_reverse)
+	{
+	}
+
 	DirItemWithIndexIterator& operator=(const DirItemWithIndexIterator& it)
 	{
 		m_sel = it.m_sel;


### PR DESCRIPTION
Potential fix for [https://github.com/WinMerge/winmerge/security/code-scanning/67](https://github.com/WinMerge/winmerge/security/code-scanning/67)

To fix the problem, we should add a copy constructor to the `DirItemWithIndexIterator` class to match the existing copy assignment operator. Since the assignment operator simply copies the member variables (including the pointer), the copy constructor can be defaulted if the default behavior is acceptable, or explicitly defined to match the assignment operator's logic. The best fix is to add a public copy constructor, either as `DirItemWithIndexIterator(const DirItemWithIndexIterator&) = default;` or with an explicit implementation that copies the member variables. This change should be made in the class definition in `Src/DirItemIterator.h`, ideally near the other special member functions (constructor, destructor, assignment operator).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
