### PR TITLE
Potential fix for code scanning alert no. 1682: Empty branch of conditional

### DIFF
--- a/Src/FilterConditionDlg.cpp
+++ b/Src/FilterConditionDlg.cpp
@@ -179,6 +179,7 @@ BOOL CFilterConditionDlg::OnInitDialog()
 	}
 	else if (m_sField == _T("DateStr"))
 	{
+		// No initialization required for "DateStr" field
 	}
 	else if (m_sField == _T("Content"))
 	{


### PR DESCRIPTION
Potential fix for [https://github.com/WinMerge/winmerge/security/code-scanning/1682](https://github.com/WinMerge/winmerge/security/code-scanning/1682)

To fix the problem, we should add a comment inside the empty block at line 181-182 to indicate that no initialization is required for the "DateStr" field. This will make it clear to future maintainers that the empty block is intentional, and not an oversight. The comment should briefly explain why the block is empty, for example: `// No initialization required for "DateStr" field`. Only lines 181-182 need to be changed; no imports or additional code are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
