### PR TITLE
Potential fix for code scanning alert no. 150: Unused static function

### DIFF
--- a/Src/HexMergeView.cpp
+++ b/Src/HexMergeView.cpp
@@ -47,10 +47,6 @@ static UINT64 NTAPI GetLastWriteTime(HANDLE h)
 	return ::GetFileTime(h, 0, 0, reinterpret_cast<FILETIME *>(&ft)) ? ft : 0;
 }
 
-static void NTAPI SetLastWriteTime(HANDLE h, UINT64 ft)
-{
-	::SetFileTime(h, 0, 0, reinterpret_cast<FILETIME *>(&ft));
-}
 
 /////////////////////////////////////////////////////////////////////////////
 // CHexMergeView


### PR DESCRIPTION
Potential fix for [https://github.com/WinMerge/winmerge/security/code-scanning/150](https://github.com/WinMerge/winmerge/security/code-scanning/150)

To fix the problem, we should remove the unused static function `SetLastWriteTime` from the file `Src/HexMergeView.cpp`. This involves deleting its definition (lines 50–53) entirely. No other changes are required, as there are no references to this function elsewhere in the provided code. This will not affect existing functionality, as the function is not used.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
