### PR TITLE
Potential fix for code scanning alert no. 151: Unused static function

### DIFF
--- a/Src/HexMergeView.cpp
+++ b/Src/HexMergeView.cpp
@@ -41,11 +41,7 @@ static HRESULT NTAPI SE(BOOL f)
 	return hr;
 }
 
-static UINT64 NTAPI GetLastWriteTime(HANDLE h)
-{
-	UINT64 ft;
-	return ::GetFileTime(h, 0, 0, reinterpret_cast<FILETIME *>(&ft)) ? ft : 0;
-}
+
 
 static void NTAPI SetLastWriteTime(HANDLE h, UINT64 ft)
 {


### PR DESCRIPTION
Potential fix for [https://github.com/WinMerge/winmerge/security/code-scanning/151](https://github.com/WinMerge/winmerge/security/code-scanning/151)

To fix the problem, the unused static function `GetLastWriteTime` should be removed from the file `Src/HexMergeView.cpp`. This involves deleting its definition (lines 44–48) entirely. No other changes are required, as there are no references to this function elsewhere in the provided code. The removal will not affect existing functionality, as the function is not used.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
