### PR TITLE
Add Ctrl+PageUp/Ctrl+PageDown as alternative hotkeys to Ctrl+Tab/Ctrl+Shift+Tab

### DIFF
--- a/Src/HexMergeView.cpp
+++ b/Src/HexMergeView.cpp
@@ -544,6 +544,11 @@ BOOL CHexMergeView::PreTranslateMessage(MSG* pMsg)
 			return false;
 		}
 	}
+
+	if (GetAsyncKeyState(VK_CONTROL) < 0 && (pMsg->wParam == VK_PRIOR || pMsg->wParam == VK_NEXT))
+	{
+		return false;
+	}
 	return m_pif->translate_accelerator(pMsg);
 }
 

--- a/Src/MainFrm.cpp
+++ b/Src/MainFrm.cpp
@@ -2224,6 +2224,13 @@ BOOL CMainFrame::PreTranslateMessage(MSG* pMsg)
 		return TRUE;
 	}
 
+	// Ctrl+PageUp/PageDown as alternatives to Ctrl+Tab/Ctrl+Shift+Tab
+	if (WM_KEYDOWN == pMsg->message && (VK_PRIOR == pMsg->wParam || VK_NEXT == pMsg->wParam) && GetAsyncKeyState(VK_CONTROL) < 0 && m_wndManager.GetChildCount() > 1)
+	{
+		m_wndManager.ShowDialog(this);
+		return TRUE;
+	}
+
 	return __super::PreTranslateMessage(pMsg);
 }
 

--- a/Src/WindowsManagerDialog.cpp
+++ b/Src/WindowsManagerDialog.cpp
@@ -71,6 +71,12 @@ BOOL CWindowsManagerDialog::PreTranslateMessage(MSG* pMsg)
 		PostMessage(WMU_SELECTNEXT, (GetAsyncKeyState(VK_SHIFT) < 0) ? 1 : 0, 0);
 	}
 
+	if (WM_KEYDOWN == pMsg->message && (VK_PRIOR == pMsg->wParam || VK_NEXT == pMsg->wParam))
+	{
+		PostMessage(WMU_SELECTNEXT, (VK_PRIOR == pMsg->wParam) ? 1 : 0, 0);
+		return TRUE;
+	}
+
 	return CDialog::PreTranslateMessage(pMsg);
 }
 


### PR DESCRIPTION
Hello, I am a student who uses WinMerge and this is one of my first open source contributions that I've done on my own time, apologies if I have done something incorrect. I saw issue #2942 and realize I use the same hotkeys in browsers, which gave me motivation to try and tackle this!

I made my changes in the same place that the ctrl+tab hotkeys are checked in mainfrm.cpp, then I just had to add logic in windowsmanagerdialog.cpp to also handle the new hotkeys. I then had to change the hexmergeview.cpp because the hotkeys were not working in the binary editor after testing.

I built and tested the changes on my Windows 11 computer and the behavior exactly matched ctrl+tab and ctrl+shift+tab usage.

Closes #2942 