### PR TITLE
Replace line breaks with space in MSExcel formulas

### DIFF
--- a/Plugins/dlls/CompareMSExcelFiles.sct
+++ b/Plugins/dlls/CompareMSExcelFiles.sct
@@ -168,22 +168,26 @@ function writeFormulas(fo, sht) {
   var row, col, formula;
   var rowOffset = sht.UsedRange.Row;
   var colOffset = sht.UsedRange.Column;
+  var keepLineBreaks = regRead(REGKEY_PATH + "CompareFormulasKeepLineBreaks", false);
   try {
     var varCells = sht.UsedRange.Formula;
     if (typeof(varCells) === "string" || typeof(varCells) === "number" || typeof(varCells) === "date") {
-      // Replace line breaks with space
-      var cleanFormula = String(varCells).replace(/[\r\n]+/g, " ");
-      fo.WriteLine(getAddr(1 + rowOffset - 1, 1 + colOffset - 1) + ": " + cleanFormula);
+      var outFormula = String(varCells);
+      if (!keepLineBreaks) {
+        outFormula = outFormula.replace(/[\r\n]+/g, " ");
+      }
+      fo.WriteLine(getAddr(1 + rowOffset - 1, 1 + colOffset - 1) + ": " + outFormula);
     } else {
       try {
         for (var row = 1; row <= varCells.ubound(1); row++) {
           for (var col = 1; col <= varCells.ubound(2); col++) {
             try {
               var formula = varCells.getItem(row, col);
-              if (typeof(formula) === "string" && formula.charAt(0) === "=") { 
-                // Replace line breaks with space
-                var cleanFormula = formula.replace(/[\r\n]+/g, " ");
-                fo.WriteLine(getAddr(row + rowOffset - 1, col + colOffset - 1) + ": " + cleanFormula);
+              if (typeof(formula) === "string" && formula.charAt(0) === "=") {
+                if (!keepLineBreaks) {
+                  formula = formula.replace(/[\r\n]+/g, " ");
+                }
+                fo.WriteLine(getAddr(row + rowOffset - 1, col + colOffset - 1) + ": " + formula);
               }
             } catch (e) {
               fo.WriteLine(getAddr(row + rowOffset - 1, col + colOffset - 1) + ": " + "Error" + e.number);
@@ -730,6 +734,7 @@ function exportSettingsToXMLFile(filepath) {
     "ImageWidth" : 1000,
     "ImageHeight" : 3000,
     "CompareFormulas" : false,
+	"CompareFormulasKeepLineBreaks" : false, 
     "CompareTextsInShapes" : true,
     "CompareHeadersAndFooters" : true,
     "CompareVBAMacros" : true
@@ -856,6 +861,7 @@ function importSettingsFromXMLFile(filepath) {
         txtImageWidth.value = regRead(REGKEY_PATH + "ImageWidth", 1000);
         txtImageHeight.value = regRead(REGKEY_PATH + "ImageHeight", 3000);
         chkCompareFormulas.checked = regRead(REGKEY_PATH + "CompareFormulas", false);
+        chkCompareFormulasBrks.checked = regRead(REGKEY_PATH + "CompareFormulasKeepLineBreaks", false);
         chkCompareTextsInShapes.checked = regRead(REGKEY_PATH + "CompareTextsInShapes", true);
         chkCompareHeadersAndFooters.checked = regRead(REGKEY_PATH + "CompareHeadersAndFooters", true);
         chkCompareVBAMacros.checked = regRead(REGKEY_PATH + "CompareVBAMacros", true);
@@ -890,7 +896,7 @@ function importSettingsFromXMLFile(filepath) {
         if (chkCompareWorksheetsAsHTML.checked)
           chkUnpackToFolder.checked = true;
       }
-
+	  
       function btnOk_onclick() {
         regWrite(REGKEY_PATH + "UnpackToFolder", chkUnpackToFolder.checked, "REG_DWORD");
         regWrite(REGKEY_PATH + "UpdateLinks", chkUpdateLinks.checked ? 3 : 0, "REG_DWORD");
@@ -902,6 +908,7 @@ function importSettingsFromXMLFile(filepath) {
         regWrite(REGKEY_PATH + "ImageWidth", Number(txtImageWidth.value), "REG_DWORD");
         regWrite(REGKEY_PATH + "ImageHeight", Number(txtImageHeight.value), "REG_DWORD");
         regWrite(REGKEY_PATH + "CompareFormulas", chkCompareFormulas.checked, "REG_DWORD");
+        regWrite(REGKEY_PATH + "CompareFormulasKeepLineBreaks", chkCompareFormulasBrks.checked, "REG_DWORD");
         regWrite(REGKEY_PATH + "CompareTextsInShapes", chkCompareTextsInShapes.checked, "REG_DWORD");
         regWrite(REGKEY_PATH + "CompareHeadersAndFooters", chkCompareHeadersAndFooters.checked, "REG_DWORD");
         regWrite(REGKEY_PATH + "CompareVBAMacros", chkCompareVBAMacros.checked, "REG_DWORD");
@@ -996,6 +1003,12 @@ function importSettingsFromXMLFile(filepath) {
         <li>
           <input id="chkCompareFormulas" type="checkbox" />
           <label for="chkCompareFormulas">${Compare formulas}</label>
+          <ul>
+            <li>
+              <input id="chkCompareFormulasBrks" type="checkbox" />
+              <label for="chkCompareFormulasBrks">${Keep line breaks in formulas}</label>
+            </li>
+          </ul>
         </li>
         <li>
           <input id="chkCompareTextsInShapes" type="checkbox" />


### PR DESCRIPTION
This is a suggestion to remove line breaks from formulas when unpacking MSExcel files so the formula is not broken across multiple lines in Winmerge. Line breaks are often added to improve readability in the MSExcel formula bar, but they are not of any interest when looking for differences.