### PR TITLE
Add CFR Java decompiler plugin for .class file comparison

### DIFF
--- a/Docs/Manual/English/Plugins.xml
+++ b/Docs/Manual/English/Plugins.xml
@@ -1477,6 +1477,59 @@
         </segmentedlist></para>
     </section>
 
+    <section id="Plugins_DecompileJVM">
+      <title><filename>DecompileJVM<indexterm>
+          <primary>DecompileJVM plugin file</primary>
+        </indexterm></filename></title>
+
+      <para>Java decompiler with CFR - decompiles .class files to readable Java source code</para>
+
+      <cmdsynopsis sepchar=" ">
+        <command>DecompileJVM</command>
+
+        <arg choice="opt"
+         rep="repeat"><replaceable>arguments</replaceable></arg>
+      </cmdsynopsis>
+
+      <variablelist>
+        <varlistentry>
+          <term><option><replaceable>arguments</replaceable></option></term>
+          <listitem>
+            <para>Command line options passed to the CFR decompiler</para>
+          </listitem>
+        </varlistentry>
+      </variablelist>
+
+      <para><segmentedlist>
+          <segtitle>Category</segtitle>
+
+          <segtitle>File filter</segtitle>
+
+          <segtitle>Plugin arguments</segtitle>
+
+          <segtitle>Packing</segtitle>
+
+          <segtitle>Settings dialog support</segtitle>
+
+          <segtitle>Dependency</segtitle>
+
+          <seglistitem>
+            <seg>Unpacker</seg>
+
+            <seg><filename class="extension">*.class</filename>
+            </seg>
+
+            <seg>Yes</seg>
+
+            <seg>No</seg>
+
+            <seg>No</seg>
+
+            <seg><ulink url="https://www.java.com/ja/download/ie_manual.jsp">Java</ulink>, <ulink url="https://github.com/leibnitz27/cfr">CFR</ulink></seg>
+          </seglistitem>
+        </segmentedlist></para>
+    </section>
+
     <section id="Plugins_DisassembleIL">
       <title><filename>DisassembleIL<indexterm>
           <primary>DisassembleIL plugin file</primary>

--- a/Plugins/Commands/CFR/URL.txt
+++ b/Plugins/Commands/CFR/URL.txt
@@ -1,0 +1,2 @@
+https://github.com/leibnitz27/cfr/releases/download/0.152/cfr-0.152.jar
+https://github.com/leibnitz27/cfr

--- a/Plugins/Commands/CFR/cfr.bat
+++ b/Plugins/Commands/CFR/cfr.bat
@@ -1,0 +1,45 @@
+@echo off
+setlocal EnableDelayedExpansion
+set CFRVer=0.152
+set CFRJar=cfr-%CFRVer%.jar
+set DOWNLOAD_URL=https://github.com/leibnitz27/cfr/releases/download/%CFRVer%/%CFRJar%
+set CFR_PATH=Commands\CFR\%CFRJar%
+set MESSAGE='CFR Java Decompiler is not installed. Do you want to download it from %DOWNLOAD_URL%'
+set TITLE='CFR Java Decompiler Plugin'
+set CFR_SHA256=21d86138f8ce39027f782a2c4a5a7e7d6e8c94e3d5df27a2f3c2a68fcaa27b8a
+
+cd /d "%APPDATA%\WinMerge"
+if not exist %CFR_PATH% (
+  cd /d "%~dp0..\.."
+  if not exist %CFR_PATH% (
+    mkdir "%APPDATA%\WinMerge" 2> NUL
+    cd /d "%APPDATA%\WinMerge"
+    for %%i in (%CFR_PATH%) do mkdir %%~pi 2> NUL
+    powershell "if ((New-Object -com WScript.Shell).Popup(%MESSAGE%,0,%TITLE%,1) -ne 1) { throw }" > NUL
+    if errorlevel 1 (
+      echo "download is canceled" 1>&2
+    ) else (
+      start "Downloading..." /WAIT powershell -command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; Invoke-WebRequest -Uri %DOWNLOAD_URL% -UseBasicParsing -Outfile %CFR_PATH%"
+      if not exist %CFR_PATH% (
+        echo %CFR_PATH%: download failed 1>&2
+      )
+    )
+  )
+)
+set TEMP_FILE=%TEMP%\tempfile_%RANDOM%%~x1
+chcp 1252 >NUL
+(echo "%~1") | findstr /C:"%~1" >NUL
+if errorlevel 1 (
+  if /i "%~1"=="%~s1" (
+    mklink /h "%TEMP_FILE%" "%~1" >NUL 2>NUL
+    if errorlevel 1 (
+      copy "%~1" "%TEMP_FILE%" >NUL
+    )
+    call "%~dp0..\Java\java.bat" -jar "%CD%\%CFR_PATH%" %3 %4 %5 %6 %7 %8 %9 "%TEMP_FILE%" > "%~2"
+    del "%TEMP_FILE%" >NUL
+  ) else (
+    call "%~dp0..\Java\java.bat" -jar "%CD%\%CFR_PATH%" %3 %4 %5 %6 %7 %8 %9 "%~s1" > "%~2"
+  )
+) else (
+  call "%~dp0..\Java\java.bat" -jar "%CD%\%CFR_PATH%" %3 %4 %5 %6 %7 %8 %9 "%~1" > "%~2"
+)

--- a/Plugins/Plugins.xml
+++ b/Plugins/Plugins.xml
@@ -215,6 +215,18 @@
       <command>cmd /c javap ${*} "${SRC_FILE}" > "${DST_FILE}"</command>
     </unpack-file>
   </plugin>
+  <plugin name="DecompileJVM">
+    <event value="FILE_PACK_UNPACK" />
+    <description value="Java decompiler (CFR).&#xD;&#xA;Decompiles .class files to readable Java source code.&#xD;&#xA;Arguments: CFR command line options." />
+    <file-filters value="\.class$" />
+    <is-automatic value="false" />
+    <unpacked-file-extension value=".java" />
+    <extended-properties value="ProcessType=Decompilation;MenuCaption=Decompile Java (CFR)" />
+    <arguments value="" />
+    <unpack-file>
+      <command>"${WINMERGE_HOME}\Commands\CFR\cfr.bat" "${SRC_FILE}" "${DST_FILE}" ${*}</command>
+    </unpack-file>
+  </plugin>
   <plugin name="DisassembleIL">
     <event value="FILE_PACK_UNPACK" />
     <description value="IL disassembler (ildasm).&#xD;&#xA;Arguments: ildasm command line options." />


### PR DESCRIPTION
  Adds a new DecompileJVM unpacker plugin that uses CFR (Class File Reader) to decompile .class files into readable Java
   source code, enabling meaningful line-by-line comparison of compiled Java classes.

  This complements the existing DisassembleJVM plugin (javap bytecode output) by providing human-readable Java source
  output instead of raw bytecode instructions.

  The plugin appears under Plugins > Unpacker > Decompilation > "Decompile Java (CFR)" and outputs .java files for
  comparison. It also works with .class files inside JAR archives.

  Changes:
  - Plugins/Commands/CFR/cfr.bat - Launcher script with auto-download support for CFR 0.152
  - Plugins/Commands/CFR/URL.txt - Source URLs
  - Plugins/Plugins.xml - New DecompileJVM plugin entry
  - Docs/Manual/English/Plugins.xml - Plugin documentation