### PR TITLE
Add tree-sitter based syntax highlighting support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -31,3 +31,6 @@
 [submodule "Externals/darkmodelib"]
 	path = Externals/darkmodelib
 	url = https://github.com/winmerge/darkmodelib.git
+[submodule "Externals/tree-sitter"]
+	path = Externals/tree-sitter
+	url = https://github.com/tree-sitter/tree-sitter.git

--- a/Externals/crystaledit/editlib/TreeSitterParser.cpp
+++ b/Externals/crystaledit/editlib/TreeSitterParser.cpp
@@ -1,0 +1,1034 @@
+////////////////////////////////////////////////////////////////////////////
+//  File:       TreeSitterParser.cpp
+//  Version:    1.0.1
+//  Created:    2026-03-26
+//
+//  Tree-sitter based syntax highlighting bridge for CrystalEdit.
+//
+//  SPDX-License-Identifier: GPL-2.0-or-later
+////////////////////////////////////////////////////////////////////////////
+
+#include "StdAfx.h"
+#include "TreeSitterParser.h"
+#include "ccrystaltextview.h"
+#include "ccrystaltextbuffer.h"
+
+#include <tree_sitter/api.h>
+
+#include <fstream>
+#include <sstream>
+#include <cassert>
+
+#ifdef _DEBUG
+#define new DEBUG_NEW
+#endif
+
+// ============================================================================
+// CTreeSitterColorMap
+// ============================================================================
+
+CTreeSitterColorMap::CTreeSitterColorMap()
+{
+    // Map standard tree-sitter highlight capture names to WinMerge COLORINDEX.
+    //
+    // Tree-sitter highlight queries use capture names like @keyword, @string,
+    // @comment, etc. These names come from nvim-treesitter conventions.
+    // We collapse them into WinMerge's available color categories.
+
+    // Keywords: control flow, storage, operators as keywords
+    m_map["keyword"]                = COLORINDEX_KEYWORD;
+    m_map["keyword.function"]       = COLORINDEX_KEYWORD;
+    m_map["keyword.operator"]       = COLORINDEX_KEYWORD;
+    m_map["keyword.import"]         = COLORINDEX_KEYWORD;
+    m_map["keyword.type"]           = COLORINDEX_KEYWORD;
+    m_map["keyword.modifier"]       = COLORINDEX_KEYWORD;
+    m_map["keyword.repeat"]         = COLORINDEX_KEYWORD;
+    m_map["keyword.return"]         = COLORINDEX_KEYWORD;
+    m_map["keyword.conditional"]    = COLORINDEX_KEYWORD;
+    m_map["keyword.exception"]      = COLORINDEX_KEYWORD;
+    m_map["keyword.directive"]      = COLORINDEX_PREPROCESSOR;
+    m_map["keyword.coroutine"]      = COLORINDEX_KEYWORD;
+    m_map["include"]                = COLORINDEX_KEYWORD;
+    m_map["repeat"]                 = COLORINDEX_KEYWORD;
+    m_map["conditional"]            = COLORINDEX_KEYWORD;
+    m_map["exception"]              = COLORINDEX_KEYWORD;
+
+    // Functions
+    m_map["function"]               = COLORINDEX_FUNCNAME;
+    m_map["function.call"]          = COLORINDEX_FUNCNAME;
+    m_map["function.builtin"]       = COLORINDEX_FUNCNAME;
+    m_map["function.macro"]         = COLORINDEX_FUNCNAME;
+    m_map["method"]                 = COLORINDEX_FUNCNAME;
+    m_map["method.call"]            = COLORINDEX_FUNCNAME;
+    m_map["constructor"]            = COLORINDEX_FUNCNAME;
+
+    // Comments
+    m_map["comment"]                = COLORINDEX_COMMENT;
+    m_map["comment.documentation"]  = COLORINDEX_COMMENT;
+
+    // Strings
+    m_map["string"]                 = COLORINDEX_STRING;
+    m_map["string.documentation"]   = COLORINDEX_STRING;
+    m_map["string.regex"]           = COLORINDEX_STRING;
+    m_map["string.escape"]          = COLORINDEX_STRING;
+    m_map["string.special"]         = COLORINDEX_STRING;
+    m_map["character"]              = COLORINDEX_STRING;
+    m_map["character.special"]      = COLORINDEX_STRING;
+
+    // Numbers
+    m_map["number"]                 = COLORINDEX_NUMBER;
+    m_map["number.float"]           = COLORINDEX_NUMBER;
+    m_map["float"]                  = COLORINDEX_NUMBER;
+    m_map["boolean"]                = COLORINDEX_NUMBER;
+
+    // Operators and punctuation
+    m_map["operator"]               = COLORINDEX_OPERATOR;
+    m_map["punctuation"]            = COLORINDEX_OPERATOR;
+    m_map["punctuation.bracket"]    = COLORINDEX_OPERATOR;
+    m_map["punctuation.delimiter"]  = COLORINDEX_OPERATOR;
+    m_map["punctuation.special"]    = COLORINDEX_OPERATOR;
+
+    // Preprocessor / attributes
+    m_map["preproc"]                = COLORINDEX_PREPROCESSOR;
+    m_map["define"]                 = COLORINDEX_PREPROCESSOR;
+    m_map["attribute"]              = COLORINDEX_PREPROCESSOR;
+    m_map["attribute.builtin"]      = COLORINDEX_PREPROCESSOR;
+
+    // Types -> USER1 (types are important in F# for merge understanding)
+    m_map["type"]                   = COLORINDEX_USER1;
+    m_map["type.builtin"]           = COLORINDEX_USER1;
+    m_map["type.definition"]        = COLORINDEX_USER1;
+    m_map["type.qualifier"]         = COLORINDEX_USER1;
+    m_map["storageclass"]           = COLORINDEX_USER1;
+
+    // Variables / properties / modules -> USER2 or NORMALTEXT
+    m_map["variable"]               = COLORINDEX_NORMALTEXT;
+    m_map["variable.builtin"]       = COLORINDEX_USER2;
+    m_map["variable.parameter"]     = COLORINDEX_NORMALTEXT;
+    m_map["variable.member"]        = COLORINDEX_USER2;
+    m_map["property"]               = COLORINDEX_USER2;
+    m_map["field"]                  = COLORINDEX_USER2;
+    m_map["constant"]               = COLORINDEX_USER2;
+    m_map["constant.builtin"]       = COLORINDEX_USER2;
+    m_map["constant.macro"]         = COLORINDEX_USER2;
+    m_map["module"]                 = COLORINDEX_USER1;
+    m_map["namespace"]              = COLORINDEX_USER1;
+    m_map["label"]                  = COLORINDEX_USER2;
+    m_map["tag"]                    = COLORINDEX_KEYWORD;
+    m_map["tag.attribute"]          = COLORINDEX_USER2;
+    m_map["tag.delimiter"]          = COLORINDEX_OPERATOR;
+}
+
+int CTreeSitterColorMap::MapCapture(const std::string& sCaptureName) const
+{
+    // Try exact match first
+    auto it = m_map.find(sCaptureName);
+    if (it != m_map.end())
+        return it->second;
+
+    // Try prefix match: e.g. "keyword.control.fsharp" -> "keyword"
+    std::string prefix = sCaptureName;
+    while (true)
+    {
+        auto pos = prefix.rfind('.');
+        if (pos == std::string::npos)
+            break;
+        prefix = prefix.substr(0, pos);
+        it = m_map.find(prefix);
+        if (it != m_map.end())
+            return it->second;
+    }
+
+    return COLORINDEX_NORMALTEXT;
+}
+
+
+// ============================================================================
+// CTreeSitterLanguage
+// ============================================================================
+
+CTreeSitterLanguage::CTreeSitterLanguage()
+    : m_hDll(nullptr)
+    , m_pLanguage(nullptr)
+    , m_pQuery(nullptr)
+{
+}
+
+CTreeSitterLanguage::~CTreeSitterLanguage()
+{
+    if (m_pQuery)
+        ts_query_delete(m_pQuery);
+    if (m_hDll)
+        FreeLibrary(m_hDll);
+}
+
+bool CTreeSitterLanguage::Load(const std::wstring& sGrammarDir, const std::wstring& sLanguage)
+{
+    m_sName = sLanguage;
+
+    // Load the grammar DLL
+    // Expected name: tree-sitter-<language>.dll (e.g. tree-sitter-fsharp.dll)
+    std::wstring sDllPath = sGrammarDir + L"\\tree-sitter-" + sLanguage + L".dll";
+    m_hDll = LoadLibraryW(sDllPath.c_str());
+    if (!m_hDll)
+        return false;
+
+    // Get the language function
+    // Expected export: tree_sitter_<language> (e.g. tree_sitter_fsharp)
+    // Note: hyphens in language names are converted to underscores for the
+    // C export name (e.g. "c-sharp" -> "tree_sitter_c_sharp")
+    std::string sFuncName = "tree_sitter_";
+    for (wchar_t ch : sLanguage)
+    {
+        if (ch == L'-')
+            sFuncName += '_';
+        else
+            sFuncName += static_cast<char>(ch);  // ASCII language names only
+    }
+
+    typedef const TSLanguage* (*TSLanguageFunc)();
+    TSLanguageFunc pfnLanguage = reinterpret_cast<TSLanguageFunc>(
+        GetProcAddress(m_hDll, sFuncName.c_str()));
+    if (!pfnLanguage)
+    {
+        FreeLibrary(m_hDll);
+        m_hDll = nullptr;
+        return false;
+    }
+
+    m_pLanguage = pfnLanguage();
+    if (!m_pLanguage)
+    {
+        FreeLibrary(m_hDll);
+        m_hDll = nullptr;
+        return false;
+    }
+
+    // Load highlight query (.scm file)
+    // Expected name: <language>-highlights.scm (e.g. fsharp-highlights.scm)
+    std::wstring sQueryPath = sGrammarDir + L"\\" + sLanguage + L"-highlights.scm";
+    std::ifstream queryFile(sQueryPath, std::ios::binary);
+    if (queryFile.is_open())
+    {
+        std::string querySource((std::istreambuf_iterator<char>(queryFile)),
+                                 std::istreambuf_iterator<char>());
+
+        uint32_t errorOffset = 0;
+        TSQueryError errorType = TSQueryErrorNone;
+        m_pQuery = ts_query_new(
+            m_pLanguage,
+            querySource.c_str(),
+            static_cast<uint32_t>(querySource.size()),
+            &errorOffset,
+            &errorType);
+
+        if (errorType != TSQueryErrorNone)
+        {
+            // Query compilation failed - log but continue without highlighting
+            m_pQuery = nullptr;
+        }
+    }
+
+    return true;
+}
+
+
+// ============================================================================
+// CTreeSitterParser
+// ============================================================================
+
+CTreeSitterParser::CTreeSitterParser()
+    : m_pParser(nullptr)   // Fix #2: lazy-init, don't call ts_parser_new() here
+    , m_pTree(nullptr)
+    , m_pLang(nullptr)
+    , m_bDirty(false)
+    , m_nLineCount(0)
+{
+}
+
+CTreeSitterParser::~CTreeSitterParser()
+{
+    if (m_pTree)
+        ts_tree_delete(m_pTree);
+    if (m_pParser)
+        ts_parser_delete(m_pParser);
+}
+
+/**
+ * @brief Lazily create the TSParser instance on first use.
+ *
+ * This avoids calling ts_parser_new() in the constructor, which would
+ * happen for every CMergeEditView even when tree-sitter isn't needed.
+ */
+void CTreeSitterParser::EnsureParser()
+{
+    if (!m_pParser)
+        m_pParser = ts_parser_new();
+}
+
+void CTreeSitterParser::SetLanguage(const CTreeSitterLanguage* pLang)
+{
+    m_pLang = pLang;
+    if (pLang && pLang->GetLanguage())
+    {
+        EnsureParser();
+        if (m_pParser)
+            ts_parser_set_language(m_pParser, pLang->GetLanguage());
+    }
+    Invalidate();
+}
+
+void CTreeSitterParser::Invalidate()
+{
+    if (m_pTree)
+    {
+        ts_tree_delete(m_pTree);
+        m_pTree = nullptr;
+    }
+    m_lineBlocks.clear();
+    m_lineUtf8.clear();
+    m_documentText.clear();
+    m_nLineCount = 0;
+    m_bDirty = false;
+}
+
+void CTreeSitterParser::ParseDocument(const tchar_t* const* ppszLines,
+                                       const int* pnLineLengths,
+                                       int nLineCount)
+{
+    EnsureParser();
+    if (!m_pParser || !m_pLang || !m_pLang->GetLanguage())
+        return;
+
+    // Build contiguous document text from line pointers.
+    // Tree-sitter requires UTF-8 input, so we convert from tchar_t (wchar_t on Windows).
+    m_documentText.clear();
+    m_lineUtf8.clear();
+    m_nLineCount = nLineCount;
+
+    // Pre-calculate total size estimate
+    size_t totalEstimate = 0;
+    for (int i = 0; i < nLineCount; i++)
+        totalEstimate += static_cast<size_t>(pnLineLengths[i]) * 3 + 1; // worst case UTF-8
+    m_documentText.reserve(totalEstimate);
+    m_lineUtf8.resize(nLineCount);
+
+    for (int i = 0; i < nLineCount; i++)
+    {
+        if (ppszLines[i] && pnLineLengths[i] > 0)
+        {
+#ifdef _UNICODE
+            // Convert UTF-16 to UTF-8
+            int nLen = WideCharToMultiByte(CP_UTF8, 0,
+                ppszLines[i], pnLineLengths[i],
+                nullptr, 0, nullptr, nullptr);
+            if (nLen > 0)
+            {
+                std::string lineUtf8(nLen, '\0');
+                WideCharToMultiByte(CP_UTF8, 0,
+                    ppszLines[i], pnLineLengths[i],
+                    &lineUtf8[0], nLen,
+                    nullptr, nullptr);
+                m_lineUtf8[i] = lineUtf8;
+                m_documentText.append(lineUtf8);
+            }
+#else
+            m_lineUtf8[i].assign(ppszLines[i], pnLineLengths[i]);
+            m_documentText.append(ppszLines[i], pnLineLengths[i]);
+#endif
+        }
+        if (i < nLineCount - 1)
+            m_documentText += '\n';
+    }
+
+    // Parse the document.
+    // Pass the old tree if available -- tree-sitter can reuse unchanged subtrees
+    // for faster re-parsing. (For full incremental support, ts_tree_edit() should
+    // be called on the old tree before re-parsing, but even without edit info
+    // tree-sitter benefits from having the previous tree as a reference.)
+    TSTree* pOldTree = m_pTree;
+    m_pTree = ts_parser_parse_string(
+        m_pParser,
+        pOldTree,
+        m_documentText.c_str(),
+        static_cast<uint32_t>(m_documentText.size()));
+
+    if (pOldTree)
+        ts_tree_delete(pOldTree);
+
+    if (m_pTree)
+    {
+        RunHighlightQuery();
+        BuildLineCache(nLineCount);
+    }
+
+    // Cache is now fresh
+    m_bDirty = false;
+}
+
+void CTreeSitterParser::ParseFromView(CCrystalTextView* pView)
+{
+    if (!pView)
+        return;
+
+    CCrystalTextBuffer* pBuf = pView->LocateTextBuffer();
+    if (!pBuf)
+        return;
+
+    int nLineCount = pBuf->GetLineCount();
+    if (nLineCount <= 0)
+        return;
+
+    // Collect line pointers and lengths
+    std::vector<const tchar_t*> lines(nLineCount);
+    std::vector<int> lengths(nLineCount);
+    for (int i = 0; i < nLineCount; i++)
+    {
+        lines[i] = pBuf->GetLineChars(i);
+        lengths[i] = pBuf->GetLineLength(i);
+    }
+
+    ParseDocument(lines.data(), lengths.data(), nLineCount);
+}
+
+/**
+ * @brief Notify the parser of an edit for incremental reparsing.
+ *
+ * Reads the last UndoRecord from the buffer to get the edit position,
+ * then calls ts_tree_edit() on the existing tree. This allows tree-sitter
+ * to reuse unchanged subtrees during the next reparse, which is
+ * significantly faster for large documents.
+ *
+ * Falls back to a simple MarkDirty() if the tree or undo info is unavailable.
+ */
+void CTreeSitterParser::NotifyEdit(CCrystalTextBuffer* pBuf)
+{
+    m_bDirty = true;
+
+    // If we don't have a tree, there's nothing to edit incrementally
+    if (!m_pTree || !pBuf || !pBuf->CanUndo())
+        return;
+
+    int nUndoPos = pBuf->GetUndoPosition();
+    if (nUndoPos <= 0)
+        return;
+
+    UndoRecord ur = pBuf->GetUndoRecord(nUndoPos - 1);
+    bool bInsert = (ur.m_dwFlags & UNDO_INSERT) != 0;
+
+    // Convert CEPoint (char-based, line/col) to UTF-8 byte offsets.
+    // m_lineUtf8 holds the per-line UTF-8 from the previous parse.
+    // We need:
+    //   start_byte:     absolute byte offset of the edit start in old doc
+    //   old_end_byte:   absolute byte offset of the old content end
+    //   new_end_byte:   absolute byte offset of the new content end
+
+    // Helper: compute absolute byte offset from (line, charPos) using old m_lineUtf8
+    // Each line in m_documentText is followed by '\n' (except the last)
+    auto charPosToByteOffset = [this](int line, int charPos) -> uint32_t
+    {
+        uint32_t byteOffset = 0;
+        int nLines = static_cast<int>(m_lineUtf8.size());
+
+        // Sum up all lines before 'line'
+        for (int i = 0; i < line && i < nLines; i++)
+        {
+            byteOffset += static_cast<uint32_t>(m_lineUtf8[i].size());
+            byteOffset += 1; // for '\n' separator
+        }
+
+        // Add the byte offset within the target line
+        if (line >= 0 && line < nLines && charPos > 0)
+        {
+#ifdef _UNICODE
+            const std::string& utf8Line = m_lineUtf8[line];
+            // Convert charPos (UTF-16 units) to UTF-8 byte count
+            // We need the original line text to do this properly.
+            // Use the stored UTF-8 line and convert back to count bytes.
+            int nUtf16Len = MultiByteToWideChar(CP_UTF8, 0,
+                utf8Line.c_str(), static_cast<int>(utf8Line.size()),
+                nullptr, 0);
+            if (charPos >= nUtf16Len)
+            {
+                byteOffset += static_cast<uint32_t>(utf8Line.size());
+            }
+            else
+            {
+                // Walk the UTF-8 bytes counting UTF-16 chars until we reach charPos
+                int utf16Count = 0;
+                uint32_t byteIdx = 0;
+                const uint8_t* p = reinterpret_cast<const uint8_t*>(utf8Line.c_str());
+                uint32_t lineLen = static_cast<uint32_t>(utf8Line.size());
+                while (byteIdx < lineLen && utf16Count < charPos)
+                {
+                    uint8_t ch = p[byteIdx];
+                    uint32_t seqLen;
+                    if (ch < 0x80)
+                        seqLen = 1;
+                    else if (ch < 0xE0)
+                        seqLen = 2;
+                    else if (ch < 0xF0)
+                        seqLen = 3;
+                    else
+                        seqLen = 4;
+
+                    byteIdx += seqLen;
+                    // A 4-byte UTF-8 sequence produces a surrogate pair (2 UTF-16 units)
+                    utf16Count += (seqLen == 4) ? 2 : 1;
+                }
+                byteOffset += byteIdx;
+            }
+#else
+            byteOffset += static_cast<uint32_t>(charPos);
+#endif
+        }
+        else if (line >= nLines && line > 0)
+        {
+            // Line is beyond our cached data -- use end of document
+            byteOffset = static_cast<uint32_t>(m_documentText.size());
+        }
+
+        return byteOffset;
+    };
+
+    // Helper: compute TSPoint (row, column in bytes) from (line, charPos)
+    auto charPosToTSPoint = [this](int line, int charPos) -> TSPoint
+    {
+        TSPoint pt;
+        pt.row = static_cast<uint32_t>(line);
+        pt.column = 0;
+
+        if (charPos > 0 && line >= 0 && line < static_cast<int>(m_lineUtf8.size()))
+        {
+            const std::string& utf8Line = m_lineUtf8[line];
+#ifdef _UNICODE
+            int nUtf16Len = MultiByteToWideChar(CP_UTF8, 0,
+                utf8Line.c_str(), static_cast<int>(utf8Line.size()),
+                nullptr, 0);
+            if (charPos >= nUtf16Len)
+            {
+                pt.column = static_cast<uint32_t>(utf8Line.size());
+            }
+            else
+            {
+                int utf16Count = 0;
+                uint32_t byteIdx = 0;
+                const uint8_t* p = reinterpret_cast<const uint8_t*>(utf8Line.c_str());
+                uint32_t lineLen = static_cast<uint32_t>(utf8Line.size());
+                while (byteIdx < lineLen && utf16Count < charPos)
+                {
+                    uint8_t ch = p[byteIdx];
+                    uint32_t seqLen;
+                    if (ch < 0x80)
+                        seqLen = 1;
+                    else if (ch < 0xE0)
+                        seqLen = 2;
+                    else if (ch < 0xF0)
+                        seqLen = 3;
+                    else
+                        seqLen = 4;
+                    byteIdx += seqLen;
+                    utf16Count += (seqLen == 4) ? 2 : 1;
+                }
+                pt.column = byteIdx;
+            }
+#else
+            pt.column = static_cast<uint32_t>(charPos);
+#endif
+        }
+        return pt;
+    };
+
+    TSInputEdit edit;
+    memset(&edit, 0, sizeof(edit));
+
+    if (bInsert)
+    {
+        // Insert: old range is empty (start == old_end), new range is the inserted text
+        edit.start_byte = charPosToByteOffset(ur.m_ptStartPos.y, ur.m_ptStartPos.x);
+        edit.old_end_byte = edit.start_byte;
+        edit.start_point = charPosToTSPoint(ur.m_ptStartPos.y, ur.m_ptStartPos.x);
+        edit.old_end_point = edit.start_point;
+
+        // For new_end, we need the end position after insert.
+        // The UndoRecord's m_ptEndPos gives us the end position in the *new* document.
+        // But our m_lineUtf8 is from the *old* document, so we can't use
+        // charPosToByteOffset for the end position directly.
+        // Instead, compute new_end_byte = start_byte + utf8_length_of_inserted_text.
+        const tchar_t* pInsText = ur.GetText();
+        size_t nInsLen = ur.GetTextLength();
+#ifdef _UNICODE
+        int nUtf8Len = WideCharToMultiByte(CP_UTF8, 0,
+            pInsText, static_cast<int>(nInsLen),
+            nullptr, 0, nullptr, nullptr);
+        edit.new_end_byte = edit.start_byte + static_cast<uint32_t>(nUtf8Len);
+#else
+        edit.new_end_byte = edit.start_byte + static_cast<uint32_t>(nInsLen);
+#endif
+        edit.new_end_point.row = static_cast<uint32_t>(ur.m_ptEndPos.y);
+        // For the column, we can compute it from the text: count bytes after last newline
+        uint32_t lastNewlineBytes = 0;
+        bool foundNewline = false;
+#ifdef _UNICODE
+        // Convert the inserted text to UTF-8 to find the last newline position
+        if (nUtf8Len > 0)
+        {
+            std::string insUtf8(nUtf8Len, '\0');
+            WideCharToMultiByte(CP_UTF8, 0, pInsText, static_cast<int>(nInsLen),
+                &insUtf8[0], nUtf8Len, nullptr, nullptr);
+            auto lastNL = insUtf8.rfind('\n');
+            if (lastNL != std::string::npos)
+            {
+                foundNewline = true;
+                lastNewlineBytes = static_cast<uint32_t>(nUtf8Len - lastNL - 1);
+            }
+        }
+#else
+        {
+            const char* pText = pInsText;
+            for (int i = static_cast<int>(nInsLen) - 1; i >= 0; i--)
+            {
+                if (pText[i] == '\n') { foundNewline = true; lastNewlineBytes = nInsLen - i - 1; break; }
+            }
+        }
+#endif
+        if (foundNewline)
+        {
+            edit.new_end_point.column = lastNewlineBytes;
+        }
+        else
+        {
+            // No newline in inserted text: column = start column + inserted byte length
+            edit.new_end_point.column = edit.start_point.column +
+                (edit.new_end_byte - edit.start_byte);
+        }
+    }
+    else
+    {
+        // Delete: old range is the deleted text, new range is empty (start == new_end)
+        edit.start_byte = charPosToByteOffset(ur.m_ptStartPos.y, ur.m_ptStartPos.x);
+        edit.start_point = charPosToTSPoint(ur.m_ptStartPos.y, ur.m_ptStartPos.x);
+
+        // For old_end, we use the old document positions
+        edit.old_end_byte = charPosToByteOffset(ur.m_ptEndPos.y, ur.m_ptEndPos.x);
+        edit.old_end_point = charPosToTSPoint(ur.m_ptEndPos.y, ur.m_ptEndPos.x);
+
+        // After deletion, the cursor is at start
+        edit.new_end_byte = edit.start_byte;
+        edit.new_end_point = edit.start_point;
+    }
+
+    ts_tree_edit(m_pTree, &edit);
+}
+
+/**
+ * @brief Ensure the document is parsed if the cache is dirty.
+ *
+ * Called lazily from ParseLine during the paint cycle. This means
+ * we reparse at most once per paint, not once per keystroke.
+ */
+void CTreeSitterParser::EnsureParsed(CCrystalTextView* pView)
+{
+    if (m_bDirty && m_pLang)
+    {
+        ParseFromView(pView);
+        // ParseFromView sets m_bDirty = false via ParseDocument
+    }
+}
+
+/**
+ * @brief Convert a UTF-8 byte offset within a line to a UTF-16 character position.
+ *
+ * Tree-sitter reports column positions as byte offsets in the UTF-8 text.
+ * WinMerge's TEXTBLOCK.m_nCharPos expects tchar_t (wchar_t) character indices.
+ * For pure ASCII, these are identical. For multi-byte UTF-8 / surrogate pairs,
+ * we need to walk the UTF-8 bytes and count the corresponding UTF-16 code units.
+ *
+ * @param nLine    Zero-based line index.
+ * @param byteCol  Byte offset within the line's UTF-8 representation.
+ * @return Character position (index into the wchar_t line).
+ */
+int CTreeSitterParser::Utf8ByteOffsetToCharPos(int nLine, uint32_t byteCol) const
+{
+    if (nLine < 0 || nLine >= static_cast<int>(m_lineUtf8.size()))
+        return static_cast<int>(byteCol);
+
+    const std::string& utf8Line = m_lineUtf8[nLine];
+    if (utf8Line.empty() || byteCol == 0)
+        return 0;
+
+    // Clamp to line length
+    uint32_t maxByte = static_cast<uint32_t>(utf8Line.size());
+    if (byteCol > maxByte)
+        byteCol = maxByte;
+
+#ifdef _UNICODE
+    // Convert the prefix [0..byteCol) from UTF-8 to UTF-16 and count chars
+    int nChars = MultiByteToWideChar(CP_UTF8, 0,
+        utf8Line.c_str(), static_cast<int>(byteCol),
+        nullptr, 0);
+    return nChars;
+#else
+    return static_cast<int>(byteCol);
+#endif
+}
+
+/**
+ * @brief Run the highlight query against the parsed tree and collect token ranges.
+ *
+ * This produces per-line block arrays by walking all highlight query matches
+ * and mapping tree-sitter byte positions to WinMerge character positions.
+ */
+void CTreeSitterParser::RunHighlightQuery()
+{
+    if (!m_pTree || !m_pLang || !m_pLang->GetHighlightQuery())
+        return;
+
+    const TSQuery* pQuery = m_pLang->GetHighlightQuery();
+    TSNode rootNode = ts_tree_root_node(m_pTree);
+
+    TSQueryCursor* pCursor = ts_query_cursor_new();
+    if (!pCursor)
+        return;
+
+    ts_query_cursor_exec(pCursor, pQuery, rootNode);
+
+    // Temporary structure to collect all highlights
+    struct HighlightEntry
+    {
+        uint32_t startRow;
+        uint32_t startCol;   // UTF-8 byte offset in line
+        uint32_t endRow;
+        uint32_t endCol;     // UTF-8 byte offset in line
+        int colorIndex;
+    };
+    std::vector<HighlightEntry> highlights;
+
+    TSQueryMatch match;
+    while (ts_query_cursor_next_match(pCursor, &match))
+    {
+        for (uint16_t i = 0; i < match.capture_count; i++)
+        {
+            TSQueryCapture capture = match.captures[i];
+            TSNode node = capture.node;
+
+            uint32_t captureNameLen = 0;
+            const char* captureName = ts_query_capture_name_for_id(
+                pQuery, capture.index, &captureNameLen);
+
+            std::string sName(captureName, captureNameLen);
+            int colorIndex = m_colorMap.MapCapture(sName);
+
+            TSPoint startPoint = ts_node_start_point(node);
+            TSPoint endPoint = ts_node_end_point(node);
+
+            HighlightEntry entry;
+            entry.startRow = startPoint.row;
+            entry.startCol = startPoint.column;
+            entry.endRow = endPoint.row;
+            entry.endCol = endPoint.column;
+            entry.colorIndex = colorIndex;
+
+            highlights.push_back(entry);
+        }
+    }
+
+    ts_query_cursor_delete(pCursor);
+
+    // Sort by start position (row, then column)
+    std::sort(highlights.begin(), highlights.end(),
+        [](const HighlightEntry& a, const HighlightEntry& b)
+        {
+            if (a.startRow != b.startRow)
+                return a.startRow < b.startRow;
+            return a.startCol < b.startCol;
+        });
+
+    // Build per-line block arrays
+    m_lineBlocks.clear();
+    m_lineBlocks.resize(m_nLineCount);
+
+    for (const auto& h : highlights)
+    {
+        // Handle tokens that span multiple lines (e.g. multi-line strings/comments)
+        for (uint32_t row = h.startRow; row <= h.endRow && row < static_cast<uint32_t>(m_nLineCount); row++)
+        {
+            uint32_t byteCol = (row == h.startRow) ? h.startCol : 0;
+
+            // Convert UTF-8 byte offset to UTF-16 character position
+            int charPos = Utf8ByteOffsetToCharPos(static_cast<int>(row), byteCol);
+
+            TreeSitterLineBlock block;
+            block.nCharPos = charPos;
+            block.nColorIndex = h.colorIndex;
+            m_lineBlocks[row].push_back(block);
+        }
+    }
+}
+
+void CTreeSitterParser::BuildLineCache(int nLineCount)
+{
+    // Sort each line's blocks by character position and remove duplicates
+    for (int i = 0; i < nLineCount && i < static_cast<int>(m_lineBlocks.size()); i++)
+    {
+        auto& blocks = m_lineBlocks[i];
+        std::sort(blocks.begin(), blocks.end(),
+            [](const TreeSitterLineBlock& a, const TreeSitterLineBlock& b)
+            {
+                return a.nCharPos < b.nCharPos;
+            });
+
+        // Remove consecutive entries at the same position (keep the last one,
+        // which is typically the more specific/inner match)
+        if (blocks.size() > 1)
+        {
+            std::vector<TreeSitterLineBlock> deduped;
+            deduped.reserve(blocks.size());
+            for (size_t j = 0; j < blocks.size(); j++)
+            {
+                if (j + 1 < blocks.size() && blocks[j].nCharPos == blocks[j + 1].nCharPos)
+                    continue;  // skip, keep the later one
+                deduped.push_back(blocks[j]);
+            }
+            blocks = std::move(deduped);
+        }
+    }
+}
+
+void CTreeSitterParser::GetLineBlocks(int nLineIndex,
+                                           CrystalLineParser::TEXTBLOCK* pBuf,
+                                           int& nActualItems,
+                                           int nMaxBlocks) const
+{
+    // Cookie-only mode (pBuf == nullptr): caller just wants the cookie.
+    // Tree-sitter doesn't use cookies, so nothing to do.
+    if (!pBuf)
+        return;
+
+    // Fix #4: bounds check against cached line count
+    if (nLineIndex < 0 || nLineIndex >= static_cast<int>(m_lineBlocks.size()))
+        return;
+
+    const auto& blocks = m_lineBlocks[nLineIndex];
+
+    // The caller (GetTextBlocks) pre-inserts a NORMALTEXT block at position 0
+    // and sets nActualItems = 1 before calling ParseLine. We follow the same
+    // convention as existing parsers: append our blocks starting at the current
+    // nActualItems, but overwrite the caller's default block if we have our own
+    // block at position 0.
+
+    for (const auto& block : blocks)
+    {
+        // If the caller's last block is at the same position, overwrite it
+        // (same logic as DEFINE_BLOCK macro in crystallineparser.h)
+        if (nActualItems > 0 && pBuf[nActualItems - 1].m_nCharPos == block.nCharPos)
+        {
+            pBuf[nActualItems - 1].m_nColorIndex = block.nColorIndex;
+            pBuf[nActualItems - 1].m_nBgColorIndex = COLORINDEX_BKGND;
+            continue;
+        }
+
+        // Skip if same color as previous block (no visible change)
+        if (nActualItems > 0 && pBuf[nActualItems - 1].m_nColorIndex == block.nColorIndex)
+            continue;
+
+        // Bounds check: stop if we'd overflow the buffer
+        if (nMaxBlocks > 0 && nActualItems >= nMaxBlocks)
+            break;
+
+        pBuf[nActualItems].m_nCharPos = block.nCharPos;
+        pBuf[nActualItems].m_nColorIndex = block.nColorIndex;
+        pBuf[nActualItems].m_nBgColorIndex = COLORINDEX_BKGND;
+        nActualItems++;
+    }
+}
+
+
+// ============================================================================
+// TreeSitterRegistry
+// ============================================================================
+
+// Default extension -> language mappings.
+// Users can extend this via configuration.
+static const struct
+{
+    const wchar_t* ext;
+    const wchar_t* language;
+} s_defaultExtMap[] =
+{
+    // F# (primary target)
+    { L"fs",    L"fsharp" },
+    { L"fsx",   L"fsharp" },
+    { L"fsi",   L"fsharp_signature" },
+
+    // Common languages
+    { L"c",     L"c" },
+    { L"h",     L"c" },
+    { L"cpp",   L"cpp" },
+    { L"cxx",   L"cpp" },
+    { L"cc",    L"cpp" },
+    { L"hpp",   L"cpp" },
+    { L"hxx",   L"cpp" },
+    { L"cs",    L"c-sharp" },
+    { L"py",    L"python" },
+    { L"js",    L"javascript" },
+    { L"ts",    L"typescript" },
+    { L"tsx",   L"tsx" },
+    { L"jsx",   L"javascript" },
+    { L"java",  L"java" },
+    { L"go",    L"go" },
+    { L"rs",    L"rust" },
+    { L"rb",    L"ruby" },
+    { L"lua",   L"lua" },
+    { L"sh",    L"bash" },
+    { L"bash",  L"bash" },
+    { L"json",  L"json" },
+    { L"yaml",  L"yaml" },
+    { L"yml",   L"yaml" },
+    { L"xml",   L"xml" },
+    { L"html",  L"html" },
+    { L"htm",   L"html" },
+    { L"css",   L"css" },
+    { L"sql",   L"sql" },
+    { L"ps1",   L"powershell" },
+    { L"psm1",  L"powershell" },
+    { L"php",   L"php" },
+    { L"pl",    L"perl" },
+    { L"swift", L"swift" },
+    { L"kt",    L"kotlin" },
+    { L"scala", L"scala" },
+    { L"hs",    L"haskell" },
+    { L"ml",    L"ocaml" },
+    { L"mli",   L"ocaml" },
+    { L"ex",    L"elixir" },
+    { L"exs",   L"elixir" },
+    { L"zig",   L"zig" },
+    { L"nim",   L"nim" },
+    { L"toml",  L"toml" },
+    { L"md",    L"markdown" },
+};
+
+TreeSitterRegistry& TreeSitterRegistry::Instance()
+{
+    static TreeSitterRegistry instance;
+    return instance;
+}
+
+void TreeSitterRegistry::Initialize(const std::wstring& sGrammarDir)
+{
+    if (m_bInitialized)
+        return;
+
+    // Determine grammar directory
+    if (sGrammarDir.empty())
+    {
+        // Use <exe_dir>/TreeSitterGrammars/
+        wchar_t szExePath[MAX_PATH] = {};
+        GetModuleFileNameW(nullptr, szExePath, MAX_PATH);
+        std::wstring sExeDir(szExePath);
+        auto pos = sExeDir.rfind(L'\\');
+        if (pos != std::wstring::npos)
+            sExeDir = sExeDir.substr(0, pos);
+        m_sGrammarDir = sExeDir + L"\\TreeSitterGrammars";
+    }
+    else
+    {
+        m_sGrammarDir = sGrammarDir;
+    }
+
+    // Register default extension mappings
+    for (const auto& mapping : s_defaultExtMap)
+    {
+        m_extMap[mapping.ext] = mapping.language;
+    }
+
+    // Check if the grammar directory exists
+    DWORD dwAttrib = GetFileAttributesW(m_sGrammarDir.c_str());
+    if (dwAttrib == INVALID_FILE_ATTRIBUTES || !(dwAttrib & FILE_ATTRIBUTE_DIRECTORY))
+    {
+        // Directory doesn't exist - that's OK, just means no tree-sitter support
+        m_bInitialized = true;
+        return;
+    }
+
+    // Fix #3: Only discover available grammar DLLs, don't load them yet.
+    // Grammars are loaded lazily on first request in GetLanguageForExt().
+    WIN32_FIND_DATAW findData;
+    std::wstring searchPattern = m_sGrammarDir + L"\\tree-sitter-*.dll";
+    HANDLE hFind = FindFirstFileW(searchPattern.c_str(), &findData);
+    if (hFind != INVALID_HANDLE_VALUE)
+    {
+        do
+        {
+            // Extract language name from "tree-sitter-<language>.dll"
+            std::wstring sFileName(findData.cFileName);
+            const std::wstring prefix = L"tree-sitter-";
+            const std::wstring suffix = L".dll";
+            if (sFileName.size() > prefix.size() + suffix.size())
+            {
+                std::wstring sLangName = sFileName.substr(
+                    prefix.size(),
+                    sFileName.size() - prefix.size() - suffix.size());
+
+                // Just record that this language is available
+                m_availableLanguages.insert(sLangName);
+            }
+        } while (FindNextFileW(hFind, &findData));
+        FindClose(hFind);
+    }
+
+    m_bInitialized = true;
+}
+
+const CTreeSitterLanguage* TreeSitterRegistry::GetLanguageForExt(const std::wstring& sExt)
+{
+    // Look up extension -> language name
+    auto itExt = m_extMap.find(sExt);
+    if (itExt == m_extMap.end())
+        return nullptr;
+
+    const std::wstring& sLangName = itExt->second;
+
+    // Check if already loaded
+    auto itLang = m_languages.find(sLangName);
+    if (itLang != m_languages.end())
+    {
+        // Already loaded - return if it has a valid highlight query
+        if (!itLang->second->GetHighlightQuery())
+            return nullptr;
+        return itLang->second.get();
+    }
+
+    // Check if this language previously failed to load
+    if (m_failedLanguages.count(sLangName) > 0)
+        return nullptr;
+
+    // Check if a DLL is available for this language
+    if (m_availableLanguages.count(sLangName) == 0)
+        return nullptr;
+
+    // Lazy load: load the grammar DLL now
+    auto pLang = std::make_unique<CTreeSitterLanguage>();
+    if (!pLang->Load(m_sGrammarDir, sLangName))
+    {
+        // Record failure so we don't retry
+        m_failedLanguages.insert(sLangName);
+        return nullptr;
+    }
+
+    // Check if the loaded grammar has a highlight query
+    if (!pLang->GetHighlightQuery())
+    {
+        m_failedLanguages.insert(sLangName);
+        return nullptr;
+    }
+
+    const CTreeSitterLanguage* pResult = pLang.get();
+    m_languages[sLangName] = std::move(pLang);
+    return pResult;
+}
+
+void TreeSitterRegistry::RegisterExtension(const std::wstring& sExt, const std::wstring& sLanguage)
+{
+    m_extMap[sExt] = sLanguage;
+}

--- a/Externals/crystaledit/editlib/TreeSitterParser.cpp
+++ b/Externals/crystaledit/editlib/TreeSitterParser.cpp
@@ -150,16 +150,49 @@ int CTreeSitterColorMap::MapCapture(const std::string& sCaptureName) const
 CTreeSitterLanguage::CTreeSitterLanguage()
     : m_hDll(nullptr)
     , m_pLanguage(nullptr)
-    , m_pQuery(nullptr)
+    , m_pHighlightQuery(nullptr)
+    , m_pLocalsQuery(nullptr)
+    , m_pInjectionQuery(nullptr)
 {
 }
 
 CTreeSitterLanguage::~CTreeSitterLanguage()
 {
-    if (m_pQuery)
-        ts_query_delete(m_pQuery);
+    if (m_pHighlightQuery)
+        ts_query_delete(m_pHighlightQuery);
+    if (m_pLocalsQuery)
+        ts_query_delete(m_pLocalsQuery);
+    if (m_pInjectionQuery)
+        ts_query_delete(m_pInjectionQuery);
     if (m_hDll)
         FreeLibrary(m_hDll);
+}
+
+TSQuery* CTreeSitterLanguage::LoadQuery(const std::wstring& sPath)
+{
+    std::ifstream file(sPath, std::ios::binary);
+    if (!file.is_open())
+        return nullptr;
+
+    std::string source((std::istreambuf_iterator<char>(file)),
+                        std::istreambuf_iterator<char>());
+
+    uint32_t errorOffset = 0;
+    TSQueryError errorType = TSQueryErrorNone;
+    TSQuery* pQuery = ts_query_new(
+        m_pLanguage,
+        source.c_str(),
+        static_cast<uint32_t>(source.size()),
+        &errorOffset,
+        &errorType);
+
+    if (errorType != TSQueryErrorNone)
+    {
+        // Query compilation failed - log but continue without this query
+        return nullptr;
+    }
+
+    return pQuery;
 }
 
 bool CTreeSitterLanguage::Load(const std::wstring& sGrammarDir, const std::wstring& sLanguage)
@@ -204,30 +237,20 @@ bool CTreeSitterLanguage::Load(const std::wstring& sGrammarDir, const std::wstri
         return false;
     }
 
-    // Load highlight query (.scm file)
+    // Load highlight query (.scm file) - required
     // Expected name: <language>-highlights.scm (e.g. fsharp-highlights.scm)
-    std::wstring sQueryPath = sGrammarDir + L"\\" + sLanguage + L"-highlights.scm";
-    std::ifstream queryFile(sQueryPath, std::ios::binary);
-    if (queryFile.is_open())
-    {
-        std::string querySource((std::istreambuf_iterator<char>(queryFile)),
-                                 std::istreambuf_iterator<char>());
+    std::wstring sHighlightPath = sGrammarDir + L"\\" + sLanguage + L"-highlights.scm";
+    m_pHighlightQuery = LoadQuery(sHighlightPath);
 
-        uint32_t errorOffset = 0;
-        TSQueryError errorType = TSQueryErrorNone;
-        m_pQuery = ts_query_new(
-            m_pLanguage,
-            querySource.c_str(),
-            static_cast<uint32_t>(querySource.size()),
-            &errorOffset,
-            &errorType);
+    // Load locals query (.scm file) - optional
+    // Expected name: <language>-locals.scm (e.g. fsharp-locals.scm)
+    std::wstring sLocalsPath = sGrammarDir + L"\\" + sLanguage + L"-locals.scm";
+    m_pLocalsQuery = LoadQuery(sLocalsPath);
 
-        if (errorType != TSQueryErrorNone)
-        {
-            // Query compilation failed - log but continue without highlighting
-            m_pQuery = nullptr;
-        }
-    }
+    // Load injection query (.scm file) - optional
+    // Expected name: <language>-injections.scm (e.g. html-injections.scm)
+    std::wstring sInjectionPath = sGrammarDir + L"\\" + sLanguage + L"-injections.scm";
+    m_pInjectionQuery = LoadQuery(sInjectionPath);
 
     return true;
 }
@@ -288,6 +311,8 @@ void CTreeSitterParser::Invalidate()
     m_lineBlocks.clear();
     m_lineUtf8.clear();
     m_documentText.clear();
+    m_localScopes.clear();
+    m_localRefHighlights.clear();
     m_nLineCount = 0;
     m_bDirty = false;
 }
@@ -358,7 +383,12 @@ void CTreeSitterParser::ParseDocument(const tchar_t* const* ppszLines,
 
     if (m_pTree)
     {
+        // 1. Run locals query first to build scope/def/ref information
+        RunLocalsQuery();
+        // 2. Run highlight query (uses locals info for scope-aware coloring)
         RunHighlightQuery();
+        // 3. Run injection query to handle embedded languages
+        RunInjectionQuery();
         BuildLineCache(nLineCount);
     }
 
@@ -674,10 +704,207 @@ int CTreeSitterParser::Utf8ByteOffsetToCharPos(int nLine, uint32_t byteCol) cons
 }
 
 /**
+ * @brief Extract a #set! predicate property value from a query pattern.
+ *
+ * Tree-sitter predicates like (#set! injection.language "javascript") are
+ * encoded as sequences of TSQueryPredicateStep:
+ *   [String "set!", String "injection.language", String "javascript", Done]
+ *
+ * @param pQuery       The query containing the pattern.
+ * @param patternIndex The pattern index.
+ * @param key          The property key to look for (e.g. "injection.language").
+ * @return The property value, or empty string if not found.
+ */
+std::string CTreeSitterParser::GetSetProperty(const TSQuery* pQuery,
+                                               uint32_t patternIndex,
+                                               const std::string& key)
+{
+    uint32_t stepCount = 0;
+    const TSQueryPredicateStep* steps =
+        ts_query_predicates_for_pattern(pQuery, patternIndex, &stepCount);
+    if (!steps || stepCount == 0)
+        return std::string();
+
+    // Walk through predicate steps looking for: "set!" <key> <value>
+    for (uint32_t i = 0; i + 2 < stepCount; i++)
+    {
+        // Look for a string step containing "set!"
+        if (steps[i].type != TSQueryPredicateStepTypeString)
+            continue;
+
+        uint32_t nameLen = 0;
+        const char* name = ts_query_string_value_for_id(pQuery, steps[i].value_id, &nameLen);
+        if (!name || std::string(name, nameLen) != "set!")
+            continue;
+
+        // Next step should be the property key (string)
+        if (i + 1 >= stepCount || steps[i + 1].type != TSQueryPredicateStepTypeString)
+            continue;
+
+        uint32_t keyLen = 0;
+        const char* keyStr = ts_query_string_value_for_id(pQuery, steps[i + 1].value_id, &keyLen);
+        if (!keyStr || std::string(keyStr, keyLen) != key)
+        {
+            // Skip to the Done sentinel for this predicate
+            while (i < stepCount && steps[i].type != TSQueryPredicateStepTypeDone)
+                i++;
+            continue;
+        }
+
+        // Next step should be the property value (string)
+        if (i + 2 >= stepCount || steps[i + 2].type != TSQueryPredicateStepTypeString)
+            continue;
+
+        uint32_t valLen = 0;
+        const char* valStr = ts_query_string_value_for_id(pQuery, steps[i + 2].value_id, &valLen);
+        if (valStr)
+            return std::string(valStr, valLen);
+    }
+
+    return std::string();
+}
+
+/**
+ * @brief Run the locals query to build scope/definition/reference information.
+ *
+ * Processes locals.scm captures:
+ *   @local.scope      - Defines a scope boundary
+ *   @local.definition  - Defines a local variable/symbol
+ *   @local.reference   - References a local variable/symbol
+ *
+ * The results are stored in m_localScopes and m_localRefHighlights,
+ * which are used by RunHighlightQuery to provide scope-aware coloring.
+ */
+void CTreeSitterParser::RunLocalsQuery()
+{
+    m_localScopes.clear();
+    m_localRefHighlights.clear();
+
+    if (!m_pTree || !m_pLang || !m_pLang->GetLocalsQuery())
+        return;
+
+    const TSQuery* pQuery = m_pLang->GetLocalsQuery();
+    TSNode rootNode = ts_tree_root_node(m_pTree);
+
+    TSQueryCursor* pCursor = ts_query_cursor_new();
+    if (!pCursor)
+        return;
+
+    ts_query_cursor_exec(pCursor, pQuery, rootNode);
+
+    // Temporary storage for references (resolved after all defs are collected)
+    std::vector<PendingRef> references;
+
+    TSQueryMatch match;
+    while (ts_query_cursor_next_match(pCursor, &match))
+    {
+        for (uint16_t i = 0; i < match.capture_count; i++)
+        {
+            TSQueryCapture capture = match.captures[i];
+            TSNode node = capture.node;
+
+            uint32_t nameLen = 0;
+            const char* captureName = ts_query_capture_name_for_id(
+                pQuery, capture.index, &nameLen);
+            std::string sCapture(captureName, nameLen);
+
+            uint32_t nodeStart = ts_node_start_byte(node);
+            uint32_t nodeEnd = ts_node_end_byte(node);
+
+            if (sCapture == "local.scope")
+            {
+                // Check for #set! local.scope-inherits predicate
+                bool inherits = true;
+                std::string inheritVal = GetSetProperty(pQuery, match.pattern_index, "local.scope-inherits");
+                if (inheritVal == "false")
+                    inherits = false;
+
+                LocalScope scope;
+                scope.startByte = nodeStart;
+                scope.endByte = nodeEnd;
+                scope.inherits = inherits;
+                m_localScopes.push_back(scope);
+            }
+            else if (sCapture == "local.definition")
+            {
+                // Extract the text of the definition node as the symbol name
+                if (nodeStart < m_documentText.size() && nodeEnd <= m_documentText.size())
+                {
+                    std::string defName = m_documentText.substr(nodeStart, nodeEnd - nodeStart);
+
+                    // Find the innermost enclosing scope and add this definition
+                    LocalScope* pBestScope = nullptr;
+                    for (auto& scope : m_localScopes)
+                    {
+                        if (nodeStart >= scope.startByte && nodeEnd <= scope.endByte)
+                        {
+                            if (!pBestScope ||
+                                (scope.endByte - scope.startByte) < (pBestScope->endByte - pBestScope->startByte))
+                            {
+                                pBestScope = &scope;
+                            }
+                        }
+                    }
+                    if (pBestScope)
+                    {
+                        LocalDef def;
+                        def.name = defName;
+                        def.startByte = nodeStart;
+                        def.endByte = nodeEnd;
+                        def.highlight = -1;  // Will be resolved during RunHighlightQuery
+                        pBestScope->defs.push_back(def);
+                    }
+                }
+            }
+            else if (sCapture == "local.reference")
+            {
+                if (nodeStart < m_documentText.size() && nodeEnd <= m_documentText.size())
+                {
+                    PendingRef ref;
+                    ref.name = m_documentText.substr(nodeStart, nodeEnd - nodeStart);
+                    ref.startByte = nodeStart;
+                    ref.endByte = nodeEnd;
+                    ref.scopeStartByte = nodeStart;
+                    references.push_back(ref);
+                }
+            }
+        }
+    }
+
+    ts_query_cursor_delete(pCursor);
+
+    // Sort scopes by start byte, then by size (smallest/innermost first for lookup)
+    std::sort(m_localScopes.begin(), m_localScopes.end(),
+        [](const LocalScope& a, const LocalScope& b)
+        {
+            if (a.startByte != b.startByte)
+                return a.startByte < b.startByte;
+            return (a.endByte - a.startByte) < (b.endByte - b.startByte);
+        });
+
+    // Store references for later resolution in RunHighlightQuery.
+    // We can't resolve them yet because definition highlights haven't been
+    // determined. Instead, store them and resolve after RunHighlightQuery
+    // has assigned highlights to definitions.
+    //
+    // Actually, we'll store the reference info and do a two-pass approach:
+    // RunHighlightQuery will first assign highlights to definition nodes,
+    // then we resolve references.
+    //
+    // For now, store references as pending. The key is (startByte << 32 | endByte).
+    // We'll store reference name -> node range for later lookup.
+    m_pendingRefs = std::move(references);
+}
+
+/**
  * @brief Run the highlight query against the parsed tree and collect token ranges.
  *
  * This produces per-line block arrays by walking all highlight query matches
  * and mapping tree-sitter byte positions to WinMerge character positions.
+ *
+ * If locals information is available, definition nodes get their highlights
+ * recorded, and references are resolved to use the same highlight as their
+ * matching definition.
  */
 void CTreeSitterParser::RunHighlightQuery()
 {
@@ -700,9 +927,16 @@ void CTreeSitterParser::RunHighlightQuery()
         uint32_t startCol;   // UTF-8 byte offset in line
         uint32_t endRow;
         uint32_t endCol;     // UTF-8 byte offset in line
+        uint32_t startByte;
+        uint32_t endByte;
         int colorIndex;
     };
     std::vector<HighlightEntry> highlights;
+
+    // Map from (startByte, endByte) to colorIndex for definition resolution.
+    // Key: (startByte << 32 | endByte). This assumes files < 4GB and that
+    // nodes with identical byte ranges should share the same highlight.
+    std::unordered_map<uint64_t, int> nodeHighlightMap;
 
     TSQueryMatch match;
     while (ts_query_cursor_next_match(pCursor, &match))
@@ -719,6 +953,8 @@ void CTreeSitterParser::RunHighlightQuery()
             std::string sName(captureName, captureNameLen);
             int colorIndex = m_colorMap.MapCapture(sName);
 
+            uint32_t nodeStartByte = ts_node_start_byte(node);
+            uint32_t nodeEndByte = ts_node_end_byte(node);
             TSPoint startPoint = ts_node_start_point(node);
             TSPoint endPoint = ts_node_end_point(node);
 
@@ -727,13 +963,100 @@ void CTreeSitterParser::RunHighlightQuery()
             entry.startCol = startPoint.column;
             entry.endRow = endPoint.row;
             entry.endCol = endPoint.column;
+            entry.startByte = nodeStartByte;
+            entry.endByte = nodeEndByte;
             entry.colorIndex = colorIndex;
 
             highlights.push_back(entry);
+
+            // Record this node's highlight for locals resolution
+            uint64_t nodeKey = (static_cast<uint64_t>(nodeStartByte) << 32) |
+                               static_cast<uint64_t>(nodeEndByte);
+            nodeHighlightMap[nodeKey] = colorIndex;
         }
     }
 
     ts_query_cursor_delete(pCursor);
+
+    // --- Locals resolution ---
+    // Now that we know the highlight for each node, assign highlights to
+    // definitions and resolve references.
+    if (!m_localScopes.empty())
+    {
+        // Pass 1: Assign highlights to definitions based on their node's highlight
+        for (auto& scope : m_localScopes)
+        {
+            for (auto& def : scope.defs)
+            {
+                uint64_t defKey = (static_cast<uint64_t>(def.startByte) << 32) |
+                                  static_cast<uint64_t>(def.endByte);
+                auto it = nodeHighlightMap.find(defKey);
+                if (it != nodeHighlightMap.end())
+                    def.highlight = it->second;
+            }
+        }
+
+        // Pass 2: Resolve references — find matching definition in enclosing scopes
+        for (const auto& ref : m_pendingRefs)
+        {
+            int resolvedHighlight = -1;
+
+            // Search scopes from innermost to outermost
+            // Find all scopes that contain this reference
+            std::vector<const LocalScope*> enclosingScopes;
+            for (const auto& scope : m_localScopes)
+            {
+                if (ref.startByte >= scope.startByte && ref.endByte <= scope.endByte)
+                    enclosingScopes.push_back(&scope);
+            }
+
+            // Sort by size (smallest = innermost first)
+            std::sort(enclosingScopes.begin(), enclosingScopes.end(),
+                [](const LocalScope* a, const LocalScope* b)
+                {
+                    return (a->endByte - a->startByte) < (b->endByte - b->startByte);
+                });
+
+            // Search for a matching definition
+            for (const auto* pScope : enclosingScopes)
+            {
+                for (const auto& def : pScope->defs)
+                {
+                    // Match by name and ensure the definition appears before the reference
+                    if (def.name == ref.name && def.startByte <= ref.startByte && def.highlight >= 0)
+                    {
+                        resolvedHighlight = def.highlight;
+                        break;
+                    }
+                }
+                if (resolvedHighlight >= 0)
+                    break;
+                // If this scope doesn't inherit, stop searching
+                if (!pScope->inherits)
+                    break;
+            }
+
+            if (resolvedHighlight >= 0)
+            {
+                uint64_t refKey = (static_cast<uint64_t>(ref.startByte) << 32) |
+                                  static_cast<uint64_t>(ref.endByte);
+                m_localRefHighlights[refKey] = resolvedHighlight;
+            }
+        }
+
+        // Pass 3: Apply resolved reference highlights to the highlight entries
+        for (auto& h : highlights)
+        {
+            uint64_t key = (static_cast<uint64_t>(h.startByte) << 32) |
+                           static_cast<uint64_t>(h.endByte);
+            auto it = m_localRefHighlights.find(key);
+            if (it != m_localRefHighlights.end())
+                h.colorIndex = it->second;
+        }
+    }
+
+    // Clear pending refs (no longer needed)
+    m_pendingRefs.clear();
 
     // Sort by start position (row, then column)
     std::sort(highlights.begin(), highlights.end(),
@@ -763,6 +1086,216 @@ void CTreeSitterParser::RunHighlightQuery()
             block.nColorIndex = h.colorIndex;
             m_lineBlocks[row].push_back(block);
         }
+    }
+}
+
+/**
+ * @brief Run the injection query to find embedded language regions.
+ *
+ * Processes injections.scm captures:
+ *   @injection.content   - The node whose content should be parsed as another language
+ *   @injection.language  - The node whose text specifies the language name
+ *   (#set! injection.language "xxx") - Hard-coded language name
+ *
+ * For each injection region, this spawns a sub-parser with the appropriate
+ * language grammar, runs highlights on the injected content, and merges
+ * the results into the main highlight blocks.
+ */
+void CTreeSitterParser::RunInjectionQuery()
+{
+    if (!m_pTree || !m_pLang || !m_pLang->GetInjectionQuery())
+        return;
+
+    const TSQuery* pQuery = m_pLang->GetInjectionQuery();
+    TSNode rootNode = ts_tree_root_node(m_pTree);
+
+    TSQueryCursor* pCursor = ts_query_cursor_new();
+    if (!pCursor)
+        return;
+
+    ts_query_cursor_exec(pCursor, pQuery, rootNode);
+
+    // Collect injection regions
+    struct InjectionRegion
+    {
+        std::string language;       // Target language name
+        uint32_t    contentStart;   // Byte offset in document
+        uint32_t    contentEnd;
+        TSPoint     startPoint;
+        TSPoint     endPoint;
+    };
+    std::vector<InjectionRegion> injections;
+
+    TSQueryMatch match;
+    while (ts_query_cursor_next_match(pCursor, &match))
+    {
+        std::string language;
+        TSNode contentNode = {};
+        bool hasContent = false;
+
+        // Check for #set! injection.language predicate first
+        language = GetSetProperty(pQuery, match.pattern_index, "injection.language");
+
+        // Also check for #set! injection.self
+        if (language.empty())
+        {
+            std::string selfVal = GetSetProperty(pQuery, match.pattern_index, "injection.self");
+            if (!selfVal.empty())
+            {
+                // Use the current language
+                const std::wstring& wname = m_pLang->GetName();
+                for (wchar_t ch : wname)
+                    language += static_cast<char>(ch);  // ASCII only
+            }
+        }
+
+        for (uint16_t i = 0; i < match.capture_count; i++)
+        {
+            TSQueryCapture capture = match.captures[i];
+
+            uint32_t nameLen = 0;
+            const char* captureName = ts_query_capture_name_for_id(
+                pQuery, capture.index, &nameLen);
+            std::string sCapture(captureName, nameLen);
+
+            if (sCapture == "injection.content")
+            {
+                contentNode = capture.node;
+                hasContent = true;
+            }
+            else if (sCapture == "injection.language" && language.empty())
+            {
+                // The captured node's text is the language name
+                uint32_t start = ts_node_start_byte(capture.node);
+                uint32_t end = ts_node_end_byte(capture.node);
+                if (start < m_documentText.size() && end <= m_documentText.size())
+                    language = m_documentText.substr(start, end - start);
+            }
+        }
+
+        if (hasContent && !language.empty())
+        {
+            InjectionRegion region;
+            region.language = language;
+            region.contentStart = ts_node_start_byte(contentNode);
+            region.contentEnd = ts_node_end_byte(contentNode);
+            region.startPoint = ts_node_start_point(contentNode);
+            region.endPoint = ts_node_end_point(contentNode);
+            injections.push_back(region);
+        }
+    }
+
+    ts_query_cursor_delete(pCursor);
+
+    if (injections.empty())
+        return;
+
+    // Process each injection: look up the language, parse the content, run highlights
+    TreeSitterRegistry& registry = TreeSitterRegistry::Instance();
+
+    for (const auto& inj : injections)
+    {
+        // Convert language name to wstring for registry lookup
+        std::wstring wLangName;
+        for (char ch : inj.language)
+            wLangName += static_cast<wchar_t>(ch);
+
+        // Try to find the language — look it up by name directly in the registry's
+        // available languages (we need a way to get language by name, not just by ext).
+        // For now, try common mappings. The language name from injections.scm
+        // is typically the tree-sitter language name (e.g. "javascript", "css").
+        // We can look it up as an extension since many languages use their name
+        // as the extension.
+        const CTreeSitterLanguage* pInjLang = registry.GetLanguageForName(wLangName);
+        if (!pInjLang || !pInjLang->GetHighlightQuery())
+            continue;
+
+        // Extract the injection content
+        if (inj.contentStart >= m_documentText.size() || inj.contentEnd > m_documentText.size())
+            continue;
+
+        std::string injContent = m_documentText.substr(inj.contentStart, inj.contentEnd - inj.contentStart);
+        if (injContent.empty())
+            continue;
+
+        // Create a temporary parser for the injected content
+        TSParser* pInjParser = ts_parser_new();
+        if (!pInjParser)
+            continue;
+
+        ts_parser_set_language(pInjParser, pInjLang->GetLanguage());
+
+        TSTree* pInjTree = ts_parser_parse_string(
+            pInjParser, nullptr,
+            injContent.c_str(),
+            static_cast<uint32_t>(injContent.size()));
+
+        if (pInjTree)
+        {
+            // Run highlight query on the injected tree
+            const TSQuery* pInjQuery = pInjLang->GetHighlightQuery();
+            TSNode injRoot = ts_tree_root_node(pInjTree);
+            TSQueryCursor* pInjCursor = ts_query_cursor_new();
+
+            if (pInjCursor)
+            {
+                ts_query_cursor_exec(pInjCursor, pInjQuery, injRoot);
+
+                TSQueryMatch injMatch;
+                while (ts_query_cursor_next_match(pInjCursor, &injMatch))
+                {
+                    for (uint16_t ci = 0; ci < injMatch.capture_count; ci++)
+                    {
+                        TSQueryCapture cap = injMatch.captures[ci];
+                        TSNode capNode = cap.node;
+
+                        uint32_t capNameLen = 0;
+                        const char* capName = ts_query_capture_name_for_id(
+                            pInjQuery, cap.index, &capNameLen);
+                        std::string sCapName(capName, capNameLen);
+                        int colorIndex = m_colorMap.MapCapture(sCapName);
+
+                        // Map the injected node's position back to the parent document.
+                        // The injection content starts at inj.startPoint in the parent doc.
+                        TSPoint capStart = ts_node_start_point(capNode);
+                        TSPoint capEnd = ts_node_end_point(capNode);
+
+                        // Translate rows/columns to parent document coordinates.
+                        // Since the injection content is a contiguous substring of
+                        // m_documentText, continuation line columns in the sub-parse
+                        // are already correct relative to the parent document lines.
+                        // NOTE: This does NOT handle injection.combined (multiple
+                        // disjoint ranges concatenated into one parse), but we don't
+                        // support that feature currently.
+                        uint32_t parentStartRow = inj.startPoint.row + capStart.row;
+                        uint32_t parentEndRow = inj.startPoint.row + capEnd.row;
+                        uint32_t parentStartCol = (capStart.row == 0)
+                            ? inj.startPoint.column + capStart.column
+                            : capStart.column;
+
+                        // Add to parent's line blocks
+                        for (uint32_t row = parentStartRow;
+                             row <= parentEndRow && row < static_cast<uint32_t>(m_nLineCount);
+                             row++)
+                        {
+                            uint32_t byteCol = (row == parentStartRow) ? parentStartCol : 0;
+                            int charPos = Utf8ByteOffsetToCharPos(static_cast<int>(row), byteCol);
+
+                            TreeSitterLineBlock block;
+                            block.nCharPos = charPos;
+                            block.nColorIndex = colorIndex;
+                            m_lineBlocks[row].push_back(block);
+                        }
+                    }
+                }
+
+                ts_query_cursor_delete(pInjCursor);
+            }
+
+            ts_tree_delete(pInjTree);
+        }
+
+        ts_parser_delete(pInjParser);
     }
 }
 
@@ -1017,6 +1550,44 @@ const CTreeSitterLanguage* TreeSitterRegistry::GetLanguageForExt(const std::wstr
     }
 
     // Check if the loaded grammar has a highlight query
+    if (!pLang->GetHighlightQuery())
+    {
+        m_failedLanguages.insert(sLangName);
+        return nullptr;
+    }
+
+    const CTreeSitterLanguage* pResult = pLang.get();
+    m_languages[sLangName] = std::move(pLang);
+    return pResult;
+}
+
+const CTreeSitterLanguage* TreeSitterRegistry::GetLanguageForName(const std::wstring& sLangName)
+{
+    // Check if already loaded
+    auto itLang = m_languages.find(sLangName);
+    if (itLang != m_languages.end())
+    {
+        if (!itLang->second->GetHighlightQuery())
+            return nullptr;
+        return itLang->second.get();
+    }
+
+    // Check if this language previously failed to load
+    if (m_failedLanguages.count(sLangName) > 0)
+        return nullptr;
+
+    // Check if a DLL is available for this language
+    if (m_availableLanguages.count(sLangName) == 0)
+        return nullptr;
+
+    // Lazy load: load the grammar DLL now
+    auto pLang = std::make_unique<CTreeSitterLanguage>();
+    if (!pLang->Load(m_sGrammarDir, sLangName))
+    {
+        m_failedLanguages.insert(sLangName);
+        return nullptr;
+    }
+
     if (!pLang->GetHighlightQuery())
     {
         m_failedLanguages.insert(sLangName);

--- a/Externals/crystaledit/editlib/TreeSitterParser.h
+++ b/Externals/crystaledit/editlib/TreeSitterParser.h
@@ -1,0 +1,318 @@
+////////////////////////////////////////////////////////////////////////////
+//  File:       TreeSitterParser.h
+//  Version:    1.0.1
+//  Created:    2026-03-26
+//
+//  Tree-sitter based syntax highlighting bridge for CrystalEdit.
+//
+//  Loads tree-sitter grammar DLLs and highlight query (.scm) files
+//  at runtime. Parses full documents into ASTs and extracts per-line
+//  color blocks mapped to WinMerge's COLORINDEX values.
+//
+//  Grammar DLLs are loaded from a "TreeSitterGrammars" directory
+//  alongside the WinMerge executable. Each DLL exports a function
+//  named tree_sitter_<language>() returning const TSLanguage*.
+//
+//  Highlight queries are loaded from .scm files in the same directory.
+//
+//  SPDX-License-Identifier: GPL-2.0-or-later
+////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "crystalparser.h"
+#include "SyntaxColors.h"
+#include "parsers/crystallineparser.h"
+
+#include <string>
+#include <vector>
+#include <unordered_map>
+#include <unordered_set>
+#include <memory>
+
+// Forward declarations for tree-sitter C API types.
+// The actual tree_sitter/api.h header is included only in the .cpp file.
+typedef struct TSParser TSParser;
+typedef struct TSTree TSTree;
+typedef struct TSQuery TSQuery;
+typedef struct TSLanguage TSLanguage;
+
+class CCrystalTextBuffer;
+
+/**
+ * @brief Manages a tree-sitter grammar loaded from a DLL.
+ *
+ * Each instance holds a loaded grammar DLL, the TSLanguage pointer,
+ * and the compiled highlight query for that language.
+ */
+class CTreeSitterLanguage
+{
+public:
+    CTreeSitterLanguage();
+    ~CTreeSitterLanguage();
+
+    CTreeSitterLanguage(const CTreeSitterLanguage&) = delete;
+    CTreeSitterLanguage& operator=(const CTreeSitterLanguage&) = delete;
+
+    /**
+     * @brief Load a grammar DLL and its highlight query file.
+     * @param sGrammarDir  Directory containing grammar DLLs and .scm files.
+     * @param sLanguage    Language name (e.g. "fsharp", "python", "cpp").
+     * @return true if both the DLL and query loaded successfully.
+     */
+    bool Load(const std::wstring& sGrammarDir, const std::wstring& sLanguage);
+
+    /** @brief Get the loaded TSLanguage pointer (or nullptr). */
+    const TSLanguage* GetLanguage() const { return m_pLanguage; }
+
+    /** @brief Get the compiled highlight TSQuery (or nullptr). */
+    const TSQuery* GetHighlightQuery() const { return m_pQuery; }
+
+    /** @brief Get the language name. */
+    const std::wstring& GetName() const { return m_sName; }
+
+private:
+    HMODULE         m_hDll;
+    const TSLanguage* m_pLanguage;
+    TSQuery*        m_pQuery;
+    std::wstring    m_sName;
+};
+
+
+/**
+ * @brief Maps tree-sitter highlight capture names to COLORINDEX values.
+ *
+ * Standard capture names from nvim-treesitter / tree-sitter highlight queries:
+ *   @keyword, @function, @function.call, @string, @comment, @number,
+ *   @operator, @type, @variable, @property, @constant, @punctuation,
+ *   @constructor, @module, @attribute, @label, @preproc, etc.
+ *
+ * These are collapsed into WinMerge's 9 syntax COLORINDEX values.
+ */
+class CTreeSitterColorMap
+{
+public:
+    CTreeSitterColorMap();
+
+    /**
+     * @brief Map a tree-sitter capture name to a COLORINDEX.
+     * @param sCaptureName  The capture name (e.g. "keyword", "string").
+     * @return The COLORINDEX, or COLORINDEX_NORMALTEXT if unknown.
+     */
+    int MapCapture(const std::string& sCaptureName) const;
+
+private:
+    std::unordered_map<std::string, int> m_map;
+};
+
+
+/**
+ * @brief Per-line cached highlight result.
+ */
+struct TreeSitterLineBlock
+{
+    int nCharPos;
+    int nColorIndex;
+};
+
+
+/**
+ * @brief Tree-sitter based syntax parser for CrystalEdit views.
+ *
+ * This class replaces the line-by-line keyword parsers with full-document
+ * AST-based parsing via tree-sitter. It:
+ *   1. Parses the entire document into a tree-sitter AST.
+ *   2. Runs highlight queries to extract token ranges.
+ *   3. Caches per-line color block arrays.
+ *   4. Serves cached results on per-line ParseLine() calls.
+ *   5. Supports lazy re-parsing: edits mark the cache dirty,
+ *      and the next paint cycle triggers a single reparse.
+ *
+ * Override ParseLine() in the view to call this parser's GetLineBlocks().
+ *
+ * Usage:
+ * @code
+ *   auto pLang = TreeSitterRegistry::GetLanguageForExt(L"fs");
+ *   if (pLang) {
+ *       m_treeSitterParser.SetLanguage(pLang);
+ *       m_treeSitterParser.ParseFromView(pView);
+ *       // In ParseLine override:
+ *       m_treeSitterParser.GetLineBlocks(nLineIndex, pBuf, nActualItems);
+ *   }
+ * @endcode
+ */
+class CTreeSitterParser
+{
+public:
+    CTreeSitterParser();
+    ~CTreeSitterParser();
+
+    CTreeSitterParser(const CTreeSitterParser&) = delete;
+    CTreeSitterParser& operator=(const CTreeSitterParser&) = delete;
+
+    /**
+     * @brief Set the language to use for parsing.
+     * @param pLang  Pointer to a loaded CTreeSitterLanguage.
+     */
+    void SetLanguage(const CTreeSitterLanguage* pLang);
+
+    /**
+     * @brief Parse (or re-parse) the full document.
+     * @param ppszLines  Array of line pointers (from CCrystalTextBuffer).
+     * @param pnLineLengths  Array of line lengths.
+     * @param nLineCount  Number of lines in the document.
+     */
+    void ParseDocument(const tchar_t* const* ppszLines, const int* pnLineLengths, int nLineCount);
+
+    /**
+     * @brief Convenience: parse document from a text buffer view.
+     * @param pView  The text view to read line data from.
+     */
+    void ParseFromView(class CCrystalTextView* pView);
+
+    /**
+     * @brief Mark the parse cache as dirty (e.g. after an edit).
+     *
+     * The next call to EnsureParsed() (from ParseLine/GetLineBlocks)
+     * will trigger a single reparse. This avoids reparsing on every
+     * keystroke and instead defers to the next paint cycle.
+     */
+    void MarkDirty() { m_bDirty = true; }
+
+    /**
+     * @brief Notify the parser of an edit for incremental reparsing.
+     *
+     * Extracts the last edit's position from the buffer's UndoRecord
+     * and calls ts_tree_edit() on the existing tree so tree-sitter
+     * can reuse unchanged subtrees during the next reparse.
+     *
+     * Also marks the cache dirty.
+     *
+     * @param pBuf  The text buffer that was edited.
+     */
+    void NotifyEdit(class CCrystalTextBuffer* pBuf);
+
+    /**
+     * @brief Ensure the document is parsed and cache is up-to-date.
+     * @param pView  The text view to read line data from (if reparse needed).
+     *
+     * Called lazily from ParseLine. Only reparses if marked dirty.
+     */
+    void EnsureParsed(class CCrystalTextView* pView);
+
+    /**
+     * @brief Get the cached color blocks for a specific line.
+     * @param nLineIndex   Zero-based line index.
+     * @param pBuf         Output buffer for TEXTBLOCK entries (may be nullptr for cookie-only).
+     * @param nActualItems In/out: on entry, the number of blocks already in pBuf
+     *                     (caller pre-inserts a default NORMALTEXT block at position 0);
+     *                     on return, the total number of blocks.
+     * @param nMaxBlocks   Maximum number of TEXTBLOCK entries that fit in pBuf.
+     *                     Pass 0 to skip bounds checking (legacy behavior).
+     */
+    void GetLineBlocks(int nLineIndex,
+                       CrystalLineParser::TEXTBLOCK* pBuf,
+                       int& nActualItems,
+                       int nMaxBlocks = 0) const;
+
+    /** @brief Check if a valid tree is available. */
+    bool HasTree() const { return m_pTree != nullptr; }
+
+    /** @brief Check if a language is set. */
+    bool HasLanguage() const { return m_pLang != nullptr; }
+
+    /** @brief Get the number of lines in the cached parse result. */
+    int GetCachedLineCount() const { return m_nLineCount; }
+
+    /** @brief Check if cache needs rebuilding. */
+    bool IsDirty() const { return m_bDirty; }
+
+    /** @brief Invalidate cached results and free tree. */
+    void Invalidate();
+
+private:
+    void EnsureParser();
+    void RunHighlightQuery();
+    void BuildLineCache(int nLineCount);
+    int Utf8ByteOffsetToCharPos(int nLine, uint32_t byteCol) const;
+
+    TSParser*           m_pParser;      // Created lazily on first use
+    TSTree*             m_pTree;
+    const CTreeSitterLanguage* m_pLang;
+    CTreeSitterColorMap m_colorMap;
+    bool                m_bDirty;       // True when cache needs rebuild
+
+    // Cached per-line highlight blocks
+    std::vector<std::vector<TreeSitterLineBlock>> m_lineBlocks;
+
+    // Per-line UTF-8 content (for byte offset -> character position mapping)
+    std::vector<std::string> m_lineUtf8;
+
+    // Full document text (needed for tree-sitter, which requires contiguous input
+    // or a custom read callback)
+    std::string m_documentText;
+    int         m_nLineCount;
+};
+
+
+/**
+ * @brief Global registry for tree-sitter grammars.
+ *
+ * Scans the grammar directory on first use to discover available grammar DLLs,
+ * but loads them lazily on first request. Maps file extensions to languages.
+ */
+class TreeSitterRegistry
+{
+public:
+    /**
+     * @brief Get the singleton instance.
+     */
+    static TreeSitterRegistry& Instance();
+
+    /**
+     * @brief Initialize the registry by scanning the grammar directory.
+     * @param sGrammarDir  Path to directory containing grammar DLLs and .scm files.
+     *                     If empty, uses "<exe_dir>/TreeSitterGrammars/".
+     *
+     * This only discovers available DLL filenames. Grammars are loaded
+     * lazily on first request via GetLanguageForExt().
+     */
+    void Initialize(const std::wstring& sGrammarDir = L"");
+
+    /**
+     * @brief Find a loaded language for a file extension.
+     * @param sExt  File extension without dot (e.g. "fs", "py", "cpp").
+     * @return Pointer to the language, or nullptr if not available.
+     *
+     * Loads the grammar DLL lazily on first request for each language.
+     */
+    const CTreeSitterLanguage* GetLanguageForExt(const std::wstring& sExt);
+
+    /**
+     * @brief Register a file extension mapping to a language name.
+     * @param sExt       Extension (e.g. "fs").
+     * @param sLanguage  Language name (e.g. "fsharp").
+     */
+    void RegisterExtension(const std::wstring& sExt, const std::wstring& sLanguage);
+
+    /** @brief Check if the registry has been initialized. */
+    bool IsInitialized() const { return m_bInitialized; }
+
+private:
+    TreeSitterRegistry() : m_bInitialized(false) {}
+
+    bool m_bInitialized;
+    std::wstring m_sGrammarDir;
+
+    // language name -> loaded grammar (loaded lazily)
+    std::unordered_map<std::wstring, std::unique_ptr<CTreeSitterLanguage>> m_languages;
+
+    // language names that have a DLL available but haven't been loaded yet
+    std::unordered_set<std::wstring> m_availableLanguages;
+
+    // language names that failed to load (don't retry)
+    std::unordered_set<std::wstring> m_failedLanguages;
+
+    // file extension -> language name
+    std::unordered_map<std::wstring, std::wstring> m_extMap;
+};

--- a/Externals/crystaledit/editlib/TreeSitterParser.h
+++ b/Externals/crystaledit/editlib/TreeSitterParser.h
@@ -43,7 +43,7 @@ class CCrystalTextBuffer;
  * @brief Manages a tree-sitter grammar loaded from a DLL.
  *
  * Each instance holds a loaded grammar DLL, the TSLanguage pointer,
- * and the compiled highlight query for that language.
+ * and the compiled highlight, locals, and injection queries for that language.
  */
 class CTreeSitterLanguage
 {
@@ -55,10 +55,13 @@ public:
     CTreeSitterLanguage& operator=(const CTreeSitterLanguage&) = delete;
 
     /**
-     * @brief Load a grammar DLL and its highlight query file.
+     * @brief Load a grammar DLL and its query files.
      * @param sGrammarDir  Directory containing grammar DLLs and .scm files.
      * @param sLanguage    Language name (e.g. "fsharp", "python", "cpp").
-     * @return true if both the DLL and query loaded successfully.
+     * @return true if both the DLL and highlight query loaded successfully.
+     *
+     * Also attempts to load locals.scm and injections.scm if present.
+     * Failure to load locals or injections is not fatal.
      */
     bool Load(const std::wstring& sGrammarDir, const std::wstring& sLanguage);
 
@@ -66,16 +69,27 @@ public:
     const TSLanguage* GetLanguage() const { return m_pLanguage; }
 
     /** @brief Get the compiled highlight TSQuery (or nullptr). */
-    const TSQuery* GetHighlightQuery() const { return m_pQuery; }
+    const TSQuery* GetHighlightQuery() const { return m_pHighlightQuery; }
+
+    /** @brief Get the compiled locals TSQuery (or nullptr). */
+    const TSQuery* GetLocalsQuery() const { return m_pLocalsQuery; }
+
+    /** @brief Get the compiled injection TSQuery (or nullptr). */
+    const TSQuery* GetInjectionQuery() const { return m_pInjectionQuery; }
 
     /** @brief Get the language name. */
     const std::wstring& GetName() const { return m_sName; }
 
 private:
-    HMODULE         m_hDll;
+    /** @brief Helper to load and compile a .scm query file. */
+    TSQuery* LoadQuery(const std::wstring& sPath);
+
+    HMODULE           m_hDll;
     const TSLanguage* m_pLanguage;
-    TSQuery*        m_pQuery;
-    std::wstring    m_sName;
+    TSQuery*          m_pHighlightQuery;
+    TSQuery*          m_pLocalsQuery;
+    TSQuery*          m_pInjectionQuery;
+    std::wstring      m_sName;
 };
 
 
@@ -233,8 +247,21 @@ public:
 private:
     void EnsureParser();
     void RunHighlightQuery();
+    void RunLocalsQuery();
+    void RunInjectionQuery();
     void BuildLineCache(int nLineCount);
     int Utf8ByteOffsetToCharPos(int nLine, uint32_t byteCol) const;
+
+    /**
+     * @brief Extract #set! predicate properties from a query pattern.
+     * @param pQuery       The query containing the pattern.
+     * @param patternIndex The pattern index.
+     * @param key          The property key to look for (e.g. "injection.language").
+     * @return The property value, or empty string if not found.
+     */
+    static std::string GetSetProperty(const TSQuery* pQuery,
+                                       uint32_t patternIndex,
+                                       const std::string& key);
 
     TSParser*           m_pParser;      // Created lazily on first use
     TSTree*             m_pTree;
@@ -252,6 +279,42 @@ private:
     // or a custom read callback)
     std::string m_documentText;
     int         m_nLineCount;
+
+    // --- Locals support ---
+    // Maps (startByte, endByte) of definition nodes to their highlight color.
+    // Built by RunLocalsQuery + RunHighlightQuery cross-referencing.
+    struct LocalDef
+    {
+        std::string name;       // Variable/symbol name
+        uint32_t    startByte;  // Definition node start
+        uint32_t    endByte;    // Definition node end
+        int         highlight;  // COLORINDEX from highlights.scm (-1 = unknown)
+    };
+
+    struct LocalScope
+    {
+        uint32_t startByte;
+        uint32_t endByte;
+        bool     inherits;
+        std::vector<LocalDef> defs;
+    };
+
+    // Scopes from locals.scm, sorted by startByte
+    std::vector<LocalScope> m_localScopes;
+
+    // Map from reference node byte range -> resolved highlight color.
+    // Key: (startByte << 32 | endByte). Assumes files < 4GB.
+    std::unordered_map<uint64_t, int> m_localRefHighlights;
+
+    // Pending references from RunLocalsQuery, resolved during RunHighlightQuery
+    struct PendingRef
+    {
+        std::string name;
+        uint32_t    startByte;
+        uint32_t    endByte;
+        uint32_t    scopeStartByte;
+    };
+    std::vector<PendingRef> m_pendingRefs;
 };
 
 
@@ -287,6 +350,16 @@ public:
      * Loads the grammar DLL lazily on first request for each language.
      */
     const CTreeSitterLanguage* GetLanguageForExt(const std::wstring& sExt);
+
+    /**
+     * @brief Find a loaded language by language name.
+     * @param sLangName  Language name (e.g. "javascript", "css", "python").
+     * @return Pointer to the language, or nullptr if not available.
+     *
+     * Used by injection processing to look up grammars for embedded languages.
+     * Loads the grammar DLL lazily on first request.
+     */
+    const CTreeSitterLanguage* GetLanguageForName(const std::wstring& sLangName);
 
     /**
      * @brief Register a file extension mapping to a language name.

--- a/Externals/crystaledit/editlib/ccrystaltextbuffer.h
+++ b/Externals/crystaledit/editlib/ccrystaltextbuffer.h
@@ -169,7 +169,6 @@ public :
     //  [JRT] Support For Descriptions On Undo/Redo Actions
     virtual void AddUndoRecord (bool bInsert, const CEPoint & ptStartPos, const CEPoint & ptEndPos,
                                 const tchar_t* pszText, size_t cchText, int nActionType = CE_ACTION_UNKNOWN, std::vector<uint32_t> *paSavedRevisionNumbers = nullptr);
-    virtual UndoRecord GetUndoRecord (int nUndoPos) const { return m_aUndoBuf[nUndoPos]; }
 
     virtual std::vector<uint32_t> *CopyRevisionNumbers(int nStartLine, int nEndLine) const;
     virtual void RestoreRevisionNumbers(int nStartLine, std::vector<uint32_t> *psaSavedRevisionNumbers);
@@ -246,6 +245,8 @@ public :
     //  Undo/Redo
     bool CanUndo () const;
     bool CanRedo () const;
+    int GetUndoPosition () const { return m_nUndoPosition; }
+    virtual UndoRecord GetUndoRecord (int nUndoPos) const { return m_aUndoBuf[nUndoPos]; }
     virtual bool Undo (CCrystalTextView * pSource, CEPoint & ptCursorPos);
     virtual bool UndoInsert (CCrystalTextView * pSource, CEPoint & ptCursorPos, const CEPoint apparent_ptStartPos, CEPoint const apparent_ptEndPos, const UndoRecord & ur);
     virtual bool Redo (CCrystalTextView * pSource, CEPoint & ptCursorPos);

--- a/Externals/crystaledit/editlib/ccrystaltextview.h
+++ b/Externals/crystaledit/editlib/ccrystaltextview.h
@@ -695,7 +695,7 @@ private:
 
 public :
     void GoToLine (int nLine, bool bRelative);
-    unsigned ParseLine (unsigned dwCookie, const tchar_t *pszChars, int nLength, CrystalLineParser::TEXTBLOCK * pBuf, int &nActualItems);
+    virtual unsigned ParseLine (unsigned dwCookie, const tchar_t *pszChars, int nLength, CrystalLineParser::TEXTBLOCK * pBuf, int &nActualItems);
 
     // Attributes
 public :

--- a/Externals/crystaledit/editlib/editlib.vcxitems
+++ b/Externals/crystaledit/editlib/editlib.vcxitems
@@ -22,6 +22,7 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)crystaleditviewex.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)crystalparser.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)crystaltextblock.cpp" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)TreeSitterParser.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)dialogs\ceditreplacedlg.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)dialogs\cfindtextdlg.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)dialogs\chcondlg.cpp" />
@@ -72,6 +73,7 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)crystaleditviewex.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)crystalparser.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)crystaltextblock.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)TreeSitterParser.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)darkmodelib.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)dialogs\ceditreplacedlg.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)dialogs\cfindtextdlg.h" />

--- a/Externals/crystaledit/editlib/editlib.vcxitems.filters
+++ b/Externals/crystaledit/editlib/editlib.vcxitems.filters
@@ -100,6 +100,7 @@
       <Filter>Utils</Filter>
     </ClCompile>
     <ClCompile Include="$(MSBuildThisFileDirectory)FindTextHelper.cpp" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)TreeSitterParser.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="$(MSBuildThisFileDirectory)ccrystaleditview.h">
@@ -205,5 +206,6 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)darkmodelib.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="$(MSBuildThisFileDirectory)TreeSitterParser.h" />
   </ItemGroup>
 </Project>

--- a/Externals/versions.txt
+++ b/Externals/versions.txt
@@ -23,3 +23,4 @@ This file lists versions of the external components we are using.
 - md4c: 0.5.2
 - darkmodelib: 0.21.2.0
 - StackWalker: 7af4024 on Aug 4, 2025 (https://github.com/JochenKalmbach/StackWalker)
+- tree-sitter: 0.25.10 (https://github.com/tree-sitter/tree-sitter)

--- a/Src/Merge.vcxproj
+++ b/Src/Merge.vcxproj
@@ -197,6 +197,7 @@
     <Import Project="..\Externals\poco\Foundation\Foundation.vcxitems" Label="Shared" />
     <Import Project="..\Externals\poco\XML\XML.vcxitems" Label="Shared" />
     <Import Project="CrashLogger\CrashLogger.vcxitems" Label="Shared" />
+    <Import Project="..\Externals\tree-sitter\tree-sitter.vcxitems" Label="Shared" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
@@ -1907,6 +1908,23 @@
     <Message Text="Copy visual elements to $(OutDir)" />
     <Copy SourceFiles="@(VisualElementsManifest)" DestinationFolder="$(OutDir)" ContinueOnError="true" />
     <Copy SourceFiles="@(LogoImages)" DestinationFolder="$(OutDir)\LogoImages" ContinueOnError="true" />
+  </Target>
+  <!--
+    Copy tree-sitter grammar DLLs and highlight queries from the Release output
+    to the current build output (Debug, Test, etc.).  Grammars are compiled once
+    via Build\TreeSitterGrammars\build-grammars.ps1 into the Release directory.
+    The copy is skipped silently when the source directory does not exist.
+  -->
+  <Target Name="CopyTreeSitterGrammars" AfterTargets="Build"
+          Condition="'$(Configuration)' != 'Release' AND Exists('$(OutDir)..\Release\TreeSitterGrammars')">
+    <ItemGroup>
+      <TreeSitterDlls Include="$(OutDir)..\Release\TreeSitterGrammars\*.dll" />
+      <TreeSitterQueries Include="$(OutDir)..\Release\TreeSitterGrammars\*.scm" />
+    </ItemGroup>
+    <Message Text="Copying tree-sitter grammars from Release to $(OutDir)TreeSitterGrammars\" Importance="high" />
+    <MakeDir Directories="$(OutDir)TreeSitterGrammars" />
+    <Copy SourceFiles="@(TreeSitterDlls)" DestinationFolder="$(OutDir)TreeSitterGrammars" SkipUnchangedFiles="true" ContinueOnError="true" />
+    <Copy SourceFiles="@(TreeSitterQueries)" DestinationFolder="$(OutDir)TreeSitterGrammars" SkipUnchangedFiles="true" ContinueOnError="true" />
   </Target>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/Src/MergeEditStatus.h
+++ b/Src/MergeEditStatus.h
@@ -14,4 +14,5 @@ class IMergeEditStatus
 public:
 	virtual void SetLineInfo(const tchar_t* szLine, int nChar, int nChars, int nColumn,
 		int nColumns, int nSelectedLines, int nSelectedChars, const tchar_t* szEol, int nCodepage, bool bHasBom) = 0;
+	virtual void SetSyntaxParser(const tchar_t* szParser) = 0;
 };

--- a/Src/MergeEditView.cpp
+++ b/Src/MergeEditView.cpp
@@ -2419,6 +2419,15 @@ void CMergeEditView::OnEditOperation(int nAction, const tchar_t* pszText, size_t
 	// perform original function
 	CCrystalEditViewEx::OnEditOperation(nAction, pszText, cchText);
 
+	// Notify tree-sitter parser of the edit for incremental reparsing.
+	// This calls ts_tree_edit() on the existing tree so tree-sitter can
+	// reuse unchanged subtrees during the next reparse (deferred to paint).
+	// We do NOT reparse here -- doing a full reparse on every keystroke
+	// causes catastrophic memory/CPU usage. Instead, ParseLine() will
+	// call EnsureParsed() lazily when the view is next painted.
+	if (m_treeSitterParser.HasLanguage())
+		m_treeSitterParser.NotifyEdit(m_pTextBuffer);
+
 	// augment with additional operations
 
 	// Change header to inform about changed doc
@@ -4086,6 +4095,9 @@ void CMergeEditView::DocumentsLoaded()
 	bool bInsertTabs = (GetOptionsMgr()->GetInt(OPT_TAB_TYPE) == 0);
 	SetInsertTabs(bInsertTabs);
 
+	// Initialize tree-sitter syntax highlighting (if grammar available)
+	InitializeTreeSitter();
+
 	// Sometimes WinMerge doesn't update scrollbars correctly (they remain
 	// disabled) after docs are open in screen. So lets make sure they are
 	// really updated, even though this is unnecessary in most cases.
@@ -4574,5 +4586,117 @@ void CMergeEditView::OnStatusBarClick(NMHDR* pNMHDR, LRESULT* pResult)
 		break;
 	default:
 		break;
+	}
+}
+
+/**
+ * @brief Override ParseLine to use tree-sitter highlighting when available.
+ *
+ * If a tree-sitter grammar was loaded for the current file type, we serve
+ * cached per-line color blocks from the tree-sitter AST. Otherwise, we fall
+ * back to the default CrystalEdit keyword-based parser.
+ *
+ * If the cache is dirty (edit happened since last parse), we trigger a
+ * lazy reparse here -- at most once per paint cycle.
+ */
+unsigned CMergeEditView::ParseLine(unsigned dwCookie, const tchar_t *pszChars,
+                                    int nLength, CrystalLineParser::TEXTBLOCK *pBuf,
+                                    int &nActualItems)
+{
+	// Guard: tree-sitter requires the view to be fully initialized.
+	// ParseLine can be called during GetParseCookie forward-fill before
+	// the window handle exists (e.g. during AttachToBuffer). In that case,
+	// fall through to the default keyword parser.
+	if (m_treeSitterParser.HasLanguage() && ::IsWindow(m_hWnd))
+	{
+		// Lazy reparse: if cache is dirty, reparse now (once per paint cycle)
+		if (m_treeSitterParser.IsDirty())
+			m_treeSitterParser.EnsureParsed(this);
+
+		if (m_treeSitterParser.HasTree())
+		{
+			// Determine the line index from the cookie.
+			//
+			// The rendering system works as follows:
+			//   - GetParseCookie(-1) returns 0 for line 0
+			//   - GetParseCookie(N) returns the cookie stored from ParseLine(N)
+			//   - GetTextBlocks(N) calls: ParseLine(GetParseCookie(N-1), ...)
+			//   - GetParseCookie() forward-fills by calling ParseLine sequentially
+			//
+			// Our convention: cookie = lineIndex (i.e., cookie for line N-1 = N).
+			// So dwCookie directly gives us the current line index.
+			int nLineIndex = static_cast<int>(dwCookie);
+
+			// Bounds safety: use the parser's cached line count to avoid
+			// accessing stale data. We intentionally avoid calling
+			// LocateTextBuffer() here since ParseLine may be called
+			// before the window handle is fully set up.
+			if (nLineIndex >= 0 && nLineIndex < m_treeSitterParser.GetCachedLineCount())
+			{
+				// Buffer size: GetTextBlocks allocates (nLength+1)*3 TEXTBLOCK entries
+				int nMaxBlocks = (nLength + 1) * 3;
+
+				m_treeSitterParser.GetLineBlocks(nLineIndex, pBuf, nActualItems, nMaxBlocks);
+				return static_cast<unsigned>(nLineIndex + 1);
+			}
+		}
+	}
+
+	// Fallback to the default keyword-based parser
+	return CCrystalTextView::ParseLine(dwCookie, pszChars, nLength, pBuf, nActualItems);
+}
+
+/**
+ * @brief Initialize tree-sitter syntax highlighting for this view.
+ *
+ * Looks up the file extension in the TreeSitterRegistry and, if a grammar
+ * is available, parses the full document to prepare per-line highlighting.
+ * Called from DocumentsLoaded() after the text buffer is fully populated.
+ */
+void CMergeEditView::InitializeTreeSitter()
+{
+	// Make sure the registry is initialized
+	TreeSitterRegistry& registry = TreeSitterRegistry::Instance();
+	if (!registry.IsInitialized())
+		registry.Initialize();
+
+	// Get the file path for this pane to determine the extension
+	CMergeDoc* pDoc = GetDocument();
+	if (!pDoc)
+		return;
+
+	String sFilePath = pDoc->m_filePaths[m_nThisPane];
+	if (sFilePath.empty())
+		return;
+
+	// Extract extension (without dot)
+	String sExt;
+	size_t dotPos = sFilePath.rfind(_T('.'));
+	if (dotPos != String::npos)
+	{
+		sExt = sFilePath.substr(dotPos + 1);
+		// Convert to lowercase for matching
+		for (auto& ch : sExt)
+			ch = static_cast<tchar_t>(towlower(ch));
+	}
+
+	if (sExt.empty())
+		return;
+
+	// Look up the grammar
+	const CTreeSitterLanguage* pLang = registry.GetLanguageForExt(sExt);
+	if (!pLang)
+		return;
+
+	// Set up the parser and parse the document
+	m_treeSitterParser.SetLanguage(pLang);
+	m_treeSitterParser.ParseFromView(this);
+
+	// Update status bar to show tree-sitter is active
+	if (m_piMergeEditStatus)
+	{
+		// Convert the language name from wstring to tchar_t for display
+		const std::wstring& sLangName = pLang->GetName();
+		m_piMergeEditStatus->SetSyntaxParser(sLangName.c_str());
 	}
 }

--- a/Src/MergeEditView.h
+++ b/Src/MergeEditView.h
@@ -30,6 +30,7 @@ constexpr unsigned FLAG_RESCAN_WAITS_FOR_IDLE = 1;
 #include "edtlib.h"
 #include "GhostTextView.h"
 #include "OptionsDiffColors.h"
+#include "TreeSitterParser.h"
 #include <map>
 #include <vector>
 
@@ -58,6 +59,7 @@ protected:
 	CMergeEditView();           // protected constructor used by dynamic creation
 	DECLARE_DYNCREATE(CMergeEditView)
 	CCrystalParser m_xParser; /**< Syntax parser used for syntax highlighting. */
+	CTreeSitterParser m_treeSitterParser; /**< Tree-sitter based syntax parser (optional). */
 
 // Attributes
 public:
@@ -96,6 +98,8 @@ public:
 	bool IsReadOnly(int pane) const;
 	void ShowDiff(bool bScroll, bool bSelectText);
 	virtual void OnEditOperation(int nAction, const tchar_t* pszText, size_t cchText) override;
+	virtual unsigned ParseLine(unsigned dwCookie, const tchar_t *pszChars, int nLength, CrystalLineParser::TEXTBLOCK * pBuf, int &nActualItems) override;
+	void InitializeTreeSitter();
 	bool IsLineInCurrentDiff(int nLine) const;
 	void SelectNone();
 	void SelectDiff(int nDiff, bool bScroll = true, bool bSelectText = true);

--- a/Src/MergeStatusBar.cpp
+++ b/Src/MergeStatusBar.cpp
@@ -287,6 +287,14 @@ void CMergeStatusBar::MergeStatus::Update()
 
 		if (m_nCodepage > 0)
 			strEncoding.Format(_("%s").c_str(), m_sCodepageName.c_str());
+		if (!m_sSyntaxParser.empty())
+		{
+			if (!strEncoding.IsEmpty())
+				strEncoding += _T("  ");
+			strEncoding += _T("[TS:");
+			strEncoding += m_sSyntaxParser.c_str();
+			strEncoding += _T("]");
+		}
 		m_pWndStatusBar->SetPaneText(m_base, strInfo);
 		m_pWndStatusBar->SetPaneText(m_base + 1, strEncoding);
 	}
@@ -298,6 +306,20 @@ void CMergeStatusBar::MergeStatus::Update()
 void CMergeStatusBar::MergeStatus::UpdateResources()
 {
 	Update();
+}
+
+/**
+ * @brief Set the syntax parser indicator text.
+ * @param szParser  Language name (e.g. "fsharp"), or empty/null to clear.
+ */
+void CMergeStatusBar::MergeStatus::SetSyntaxParser(const tchar_t* szParser)
+{
+	String sParser = szParser ? szParser : _T("");
+	if (m_sSyntaxParser != sParser)
+	{
+		m_sSyntaxParser = sParser;
+		Update();
+	}
 }
 
 /// Visible representation of eol

--- a/Src/MergeStatusBar.h
+++ b/Src/MergeStatusBar.h
@@ -48,6 +48,7 @@ protected:
 		// Implement MergeEditStatus
 		void SetLineInfo(const tchar_t* szLine, int nColumn, int nColumns,
 			int nChar, int nChars, int nSelectedLines, int nSelectedChars, const tchar_t* szEol, int nCodepage, bool bHasBom) override;
+		void SetSyntaxParser(const tchar_t* szParser) override;
 		void UpdateResources();
 	protected:
 		void Update();
@@ -67,6 +68,7 @@ protected:
 		String m_sEol;
 		String m_sEolDisplay;
 		String m_sCodepageName;
+		String m_sSyntaxParser; /**< Tree-sitter language name, empty if not active */
 	};
 	friend class MergeStatus; // MergeStatus accesses status bar
 	MergeStatus m_status[3];

--- a/Tools/TreeSitterGrammars/build-grammars.ps1
+++ b/Tools/TreeSitterGrammars/build-grammars.ps1
@@ -119,6 +119,105 @@ function Get-GrammarSource {
     return $extractDir
 }
 
+function Resolve-NodeModulesPath {
+    param([string]$Candidate)
+
+    $normalized = $Candidate -replace '/','\'
+    if (-not $normalized.StartsWith("node_modules\")) {
+        return $null
+    }
+
+    $parts = $normalized -split '\\'
+    if ($parts.Count -lt 3) {
+        return $null
+    }
+
+    $packageName = $parts[1]
+    $restIndex = 2
+    if ($packageName.StartsWith('@')) {
+        if ($parts.Count -lt 4) {
+            return $null
+        }
+        $packageName = $parts[2]
+        $restIndex = 3
+    }
+
+    $cachedSourceDir = Join-Path $TempBase $packageName
+    if (-not (Test-Path $cachedSourceDir)) {
+        return $null
+    }
+
+    $relativePath = $parts[$restIndex..($parts.Count - 1)] -join '\'
+    $resolvedPath = Join-Path $cachedSourceDir $relativePath
+    if (Test-Path $resolvedPath) {
+        return $resolvedPath
+    }
+
+    return $null
+}
+
+function Resolve-QueryFiles {
+    param(
+        [object]$QuerySpec,
+        [string]$SourceDir,
+        [string]$RepoDir,
+        [string]$FallbackRelativePath
+    )
+
+    $resolved = New-Object System.Collections.Generic.List[string]
+
+    if ($QuerySpec) {
+        $queryPaths = if ($QuerySpec -is [array]) { $QuerySpec } else { @($QuerySpec) }
+        foreach ($candidate in $queryPaths) {
+            $tryPaths = @(
+                (Join-Path $RepoDir $candidate),
+                (Join-Path $SourceDir $candidate),
+                (Resolve-NodeModulesPath -Candidate $candidate)
+            ) | Where-Object { $_ }
+
+            foreach ($tryPath in $tryPaths) {
+                if ((Test-Path $tryPath) -and (-not $resolved.Contains($tryPath))) {
+                    $resolved.Add($tryPath)
+                    break
+                }
+            }
+        }
+    }
+
+    if ($resolved.Count -eq 0 -and $FallbackRelativePath) {
+        $fallbacks = @(
+            (Join-Path $SourceDir $FallbackRelativePath),
+            (Join-Path $RepoDir $FallbackRelativePath)
+        )
+        foreach ($fallback in $fallbacks) {
+            if ((Test-Path $fallback) -and (-not $resolved.Contains($fallback))) {
+                $resolved.Add($fallback)
+                break
+            }
+        }
+    }
+
+    return $resolved.ToArray()
+}
+
+function Write-QueryBundle {
+    param(
+        [string]$DestinationPath,
+        [string[]]$SourcePaths
+    )
+
+    if (-not $SourcePaths -or $SourcePaths.Count -eq 0) {
+        return $false
+    }
+
+    $contents = foreach ($sourcePath in $SourcePaths) {
+        [System.IO.File]::ReadAllText($sourcePath)
+    }
+    $bundle = ($contents -join "`r`n`r`n").TrimEnd()
+    [System.IO.File]::WriteAllText($DestinationPath, $bundle + "`r`n", [System.Text.UTF8Encoding]::new($false))
+    return $true
+}
+
 # ---- Compile a grammar to DLL ----
 
 function Build-GrammarDll {
@@ -126,9 +225,9 @@ function Build-GrammarDll {
         [string]$GrammarName,
         [string]$SourceDir,
         [string]$RepoDir,
-        [string]$HighlightsScm,
-        [string]$LocalsScm,
-        [string]$InjectionsScm,
+        [string[]]$HighlightsScm,
+        [string[]]$LocalsScm,
+        [string[]]$InjectionsScm,
         [string]$DllName
     )
     $srcDir   = Join-Path $SourceDir "src"
@@ -182,21 +281,18 @@ function Build-GrammarDll {
         return $false
     }
 
-    if ($HighlightsScm -and (Test-Path $HighlightsScm)) {
+    if (Write-QueryBundle -DestinationPath (Join-Path $OutDir "$GrammarName-highlights.scm") -SourcePaths $HighlightsScm) {
         $dest = Join-Path $OutDir "$GrammarName-highlights.scm"
-        Copy-Item $HighlightsScm $dest -Force
         Write-Host "  Copied highlights -> $GrammarName-highlights.scm"
     } else {
         Write-Warning "  No highlights.scm for $GrammarName"
     }
-    if ($LocalsScm -and (Test-Path $LocalsScm)) {
+    if (Write-QueryBundle -DestinationPath (Join-Path $OutDir "$GrammarName-locals.scm") -SourcePaths $LocalsScm) {
         $dest = Join-Path $OutDir "$GrammarName-locals.scm"
-        Copy-Item $LocalsScm $dest -Force
         Write-Host "  Copied locals -> $GrammarName-locals.scm"
     }
-    if ($InjectionsScm -and (Test-Path $InjectionsScm)) {
+    if (Write-QueryBundle -DestinationPath (Join-Path $OutDir "$GrammarName-injections.scm") -SourcePaths $InjectionsScm) {
         $dest = Join-Path $OutDir "$GrammarName-injections.scm"
-        Copy-Item $InjectionsScm $dest -Force
         Write-Host "  Copied injections -> $GrammarName-injections.scm"
     }
     Write-Host "  OK: $dllPath"
@@ -256,101 +352,11 @@ foreach ($entry in $config.grammars) {
         $sourceDir = if ($gPath -eq ".") { $repoDir } else { Join-Path $repoDir $gPath }
         $dllName   = "tree-sitter-$gName"
 
-        # Resolve highlights.scm — handles three cases:
-        #   1. String: "queries/highlights.scm"
-        #   2. Array: ["node_modules/.../highlights.scm", "queries/highlights.scm"]
-        #   3. Missing: no highlights field at all
-        $hlScm = $null
-        $hlRel = $g.highlights
-        if ($hlRel) {
-            # Normalize to array
-            $hlPaths = if ($hlRel -is [array]) { $hlRel } else { @($hlRel) }
-            # Try each path, use the first that exists on disk
-            foreach ($candidate in $hlPaths) {
-                $tryPath = Join-Path $repoDir $candidate
-                if (Test-Path $tryPath) {
-                    $hlScm = $tryPath
-                    break
-                }
-                $tryPath = Join-Path $sourceDir $candidate
-                if (Test-Path $tryPath) {
-                    $hlScm = $tryPath
-                    break
-                }
-            }
-        }
-        # Fallback: check standard location queries/highlights.scm
-        if (-not $hlScm) {
-            $fallback = Join-Path $sourceDir "queries\highlights.scm"
-            if (Test-Path $fallback) {
-                $hlScm = $fallback
-            } else {
-                $fallback = Join-Path $repoDir "queries\highlights.scm"
-                if (Test-Path $fallback) {
-                    $hlScm = $fallback
-                }
-            }
-        }
-
-        # Resolve locals.scm (same pattern as highlights)
-        $lcScm = $null
-        $lcRel = $g.locals
-        if ($lcRel) {
-            $lcPaths = if ($lcRel -is [array]) { $lcRel } else { @($lcRel) }
-            foreach ($candidate in $lcPaths) {
-                $tryPath = Join-Path $repoDir $candidate
-                if (Test-Path $tryPath) {
-                    $lcScm = $tryPath
-                    break
-                }
-                $tryPath = Join-Path $sourceDir $candidate
-                if (Test-Path $tryPath) {
-                    $lcScm = $tryPath
-                    break
-                }
-            }
-        }
-        if (-not $lcScm) {
-            $fallback = Join-Path $sourceDir "queries\locals.scm"
-            if (Test-Path $fallback) {
-                $lcScm = $fallback
-            } else {
-                $fallback = Join-Path $repoDir "queries\locals.scm"
-                if (Test-Path $fallback) {
-                    $lcScm = $fallback
-                }
-            }
-        }
-
-        # Resolve injections.scm (same pattern as highlights)
-        $ijScm = $null
-        $ijRel = $g.injections
-        if ($ijRel) {
-            $ijPaths = if ($ijRel -is [array]) { $ijRel } else { @($ijRel) }
-            foreach ($candidate in $ijPaths) {
-                $tryPath = Join-Path $repoDir $candidate
-                if (Test-Path $tryPath) {
-                    $ijScm = $tryPath
-                    break
-                }
-                $tryPath = Join-Path $sourceDir $candidate
-                if (Test-Path $tryPath) {
-                    $ijScm = $tryPath
-                    break
-                }
-            }
-        }
-        if (-not $ijScm) {
-            $fallback = Join-Path $sourceDir "queries\injections.scm"
-            if (Test-Path $fallback) {
-                $ijScm = $fallback
-            } else {
-                $fallback = Join-Path $repoDir "queries\injections.scm"
-                if (Test-Path $fallback) {
-                    $ijScm = $fallback
-                }
-            }
-        }
+        # Resolve .scm query files. When tree-sitter.json uses an array, all
+        # matching files are bundled in order so inherited queries are kept.
+        $hlScm = Resolve-QueryFiles -QuerySpec $g.highlights -SourceDir $sourceDir -RepoDir $repoDir -FallbackRelativePath "queries\highlights.scm"
+        $lcScm = Resolve-QueryFiles -QuerySpec $g.locals -SourceDir $sourceDir -RepoDir $repoDir -FallbackRelativePath "queries\locals.scm"
+        $ijScm = Resolve-QueryFiles -QuerySpec $g.injections -SourceDir $sourceDir -RepoDir $repoDir -FallbackRelativePath "queries\injections.scm"
 
         Write-Host "  Grammar: $gName (path: $gPath)"
         $ok = Build-GrammarDll -GrammarName $gName -SourceDir $sourceDir -RepoDir $repoDir -HighlightsScm $hlScm -LocalsScm $lcScm -InjectionsScm $ijScm -DllName $dllName

--- a/Tools/TreeSitterGrammars/build-grammars.ps1
+++ b/Tools/TreeSitterGrammars/build-grammars.ps1
@@ -120,33 +120,42 @@ function Get-GrammarSource {
 }
 
 function Resolve-NodeModulesPath {
-    param([string]$Candidate)
+    param(
+        [string]$Candidate,
+        [string]$CacheBaseDir
+    )
 
-    $normalized = $Candidate -replace '/','\'
-    if (-not $normalized.StartsWith("node_modules\")) {
+    $separator = [string][IO.Path]::DirectorySeparatorChar
+    $escapedSeparator = [regex]::Escape($separator)
+    $normalized = $Candidate -replace '/', $separator
+    if (-not $normalized.StartsWith("node_modules$separator")) {
         return $null
     }
 
-    $parts = $normalized -split '\\'
-    if ($parts.Count -lt 3) {
+    $parts = $normalized -split $escapedSeparator
+    $isScopedPackage = ($parts.Count -ge 2 -and $parts[1].StartsWith('@'))
+    $minPartCount = if ($isScopedPackage) { 4 } else { 3 }
+    if ($parts.Count -lt $minPartCount) {
         return $null
     }
 
     $packageName = $parts[1]
     $restIndex = 2
     $cacheDirs = New-Object System.Collections.Generic.List[string]
-    if ($packageName.StartsWith('@')) {
-        if ($parts.Count -lt 4) {
-            return $null
-        }
-        $packageName = "$packageName\$($parts[2])"
+    if ($isScopedPackage) {
+        $scopedPackageName = $packageName + $separator + $parts[2]
         $restIndex = 3
-        $cacheDirs.Add((Join-Path $TempBase $packageName))
-        $packageName = $parts[2]
+        $cacheDirs.Add((Join-Path $CacheBaseDir $scopedPackageName))
+        $packageNameWithinScope = $parts[2]
+    } else {
+        $packageNameWithinScope = $packageName
     }
-    $cacheDirs.Add((Join-Path $TempBase $packageName))
+    $cacheDirs.Add((Join-Path $CacheBaseDir $packageNameWithinScope))
 
-    $relativePath = $parts[$restIndex..($parts.Count - 1)] -join '\'
+    if ($restIndex -ge $parts.Count) {
+        return $null
+    }
+    $relativePath = $parts[$restIndex..($parts.Count - 1)] -join $separator
     foreach ($cachedSourceDir in $cacheDirs) {
         if (-not (Test-Path $cachedSourceDir)) {
             continue
@@ -165,6 +174,7 @@ function Resolve-QueryFiles {
         [object]$QuerySpec,
         [string]$SourceDir,
         [string]$RepoDir,
+        [string]$CacheBaseDir,
         [string]$FallbackRelativePath
     )
 
@@ -176,7 +186,7 @@ function Resolve-QueryFiles {
             $tryPaths = @(
                 (Join-Path $RepoDir $candidate),
                 (Join-Path $SourceDir $candidate),
-                (Resolve-NodeModulesPath -Candidate $candidate)
+                (Resolve-NodeModulesPath -Candidate $candidate -CacheBaseDir $CacheBaseDir)
             ) | Where-Object { $_ }
 
             foreach ($tryPath in $tryPaths) {
@@ -215,10 +225,20 @@ function Write-QueryBundle {
     }
 
     $contents = foreach ($sourcePath in $SourcePaths) {
-        [System.IO.File]::ReadAllText($sourcePath)
+        try {
+            [System.IO.File]::ReadAllText($sourcePath)
+        } catch {
+            Write-Warning "  Failed to read query source '$sourcePath': $_"
+            return $false
+        }
     }
-    $bundle = ($contents -join "`r`n`r`n").TrimEnd()
-    [System.IO.File]::WriteAllText($DestinationPath, $bundle + "`r`n", [System.Text.UTF8Encoding]::new($false))
+    if ($contents -contains $false) {
+        return $false
+    }
+    $newline = [System.Environment]::NewLine
+    $doubleNewline = $newline + $newline
+    $bundle = ($contents -join $doubleNewline).TrimEnd()
+    [System.IO.File]::WriteAllText($DestinationPath, $bundle + $newline, [System.Text.UTF8Encoding]::new($false))
     return $true
 }
 
@@ -286,15 +306,15 @@ function Build-GrammarDll {
     }
 
     if (Write-QueryBundle -DestinationPath (Join-Path $OutDir "$GrammarName-highlights.scm") -SourcePaths $HighlightsScm) {
-        Write-Host "  Copied highlights -> $GrammarName-highlights.scm"
+        Write-Host "  Bundled highlights -> $GrammarName-highlights.scm"
     } else {
         Write-Warning "  No highlights.scm for $GrammarName"
     }
     if (Write-QueryBundle -DestinationPath (Join-Path $OutDir "$GrammarName-locals.scm") -SourcePaths $LocalsScm) {
-        Write-Host "  Copied locals -> $GrammarName-locals.scm"
+        Write-Host "  Bundled locals -> $GrammarName-locals.scm"
     }
     if (Write-QueryBundle -DestinationPath (Join-Path $OutDir "$GrammarName-injections.scm") -SourcePaths $InjectionsScm) {
-        Write-Host "  Copied injections -> $GrammarName-injections.scm"
+        Write-Host "  Bundled injections -> $GrammarName-injections.scm"
     }
     Write-Host "  OK: $dllPath"
     return $true
@@ -355,9 +375,9 @@ foreach ($entry in $config.grammars) {
 
         # Resolve .scm query files. When tree-sitter.json uses an array, all
         # matching files are bundled in order so inherited queries are kept.
-        $hlScm = Resolve-QueryFiles -QuerySpec $g.highlights -SourceDir $sourceDir -RepoDir $repoDir -FallbackRelativePath "queries\highlights.scm"
-        $lcScm = Resolve-QueryFiles -QuerySpec $g.locals -SourceDir $sourceDir -RepoDir $repoDir -FallbackRelativePath "queries\locals.scm"
-        $ijScm = Resolve-QueryFiles -QuerySpec $g.injections -SourceDir $sourceDir -RepoDir $repoDir -FallbackRelativePath "queries\injections.scm"
+        $hlScm = Resolve-QueryFiles -QuerySpec $g.highlights -SourceDir $sourceDir -RepoDir $repoDir -CacheBaseDir $TempBase -FallbackRelativePath "queries\highlights.scm"
+        $lcScm = Resolve-QueryFiles -QuerySpec $g.locals -SourceDir $sourceDir -RepoDir $repoDir -CacheBaseDir $TempBase -FallbackRelativePath "queries\locals.scm"
+        $ijScm = Resolve-QueryFiles -QuerySpec $g.injections -SourceDir $sourceDir -RepoDir $repoDir -CacheBaseDir $TempBase -FallbackRelativePath "queries\injections.scm"
 
         Write-Host "  Grammar: $gName (path: $gPath)"
         $ok = Build-GrammarDll -GrammarName $gName -SourceDir $sourceDir -RepoDir $repoDir -HighlightsScm $hlScm -LocalsScm $lcScm -InjectionsScm $ijScm -DllName $dllName

--- a/Tools/TreeSitterGrammars/build-grammars.ps1
+++ b/Tools/TreeSitterGrammars/build-grammars.ps1
@@ -1,0 +1,291 @@
+<#
+.SYNOPSIS
+    Downloads and compiles tree-sitter grammar DLLs for WinMerge.
+.DESCRIPTION
+    Reads grammars.json, downloads release tarballs from GitHub, reads each
+    repo's tree-sitter.json for source layout, compiles to DLL via MSVC cl.exe.
+.PARAMETER OutDir
+    Output directory for DLLs and .scm files.
+.PARAMETER Platform
+    Target platform: x64, x86, or ARM64. Default: x64.
+.PARAMETER Configuration
+    Build configuration: Release or Debug. Default: Release.
+.PARAMETER GrammarFilter
+    Optional regex to build only matching grammar names.
+.EXAMPLE
+    .\build-grammars.ps1
+    .\build-grammars.ps1 -GrammarFilter "fsharp"
+#>
+param(
+    [string]$OutDir,
+    [ValidateSet("x64","x86","ARM64")]
+    [string]$Platform = "x64",
+    [ValidateSet("Release","Debug")]
+    [string]$Configuration = "Release",
+    [string]$GrammarFilter
+)
+
+$ErrorActionPreference = "Continue"
+
+$ScriptDir  = Split-Path -Parent $MyInvocation.MyCommand.Path
+$RepoRoot   = (Resolve-Path (Join-Path $ScriptDir "..\..")).Path
+if (-not $OutDir) {
+    $OutDir = Join-Path $RepoRoot "Build\$Platform\$Configuration\TreeSitterGrammars"
+}
+$TempBase   = Join-Path $RepoRoot "BuildTmp\grammar-sources"
+$ConfigFile = Join-Path $ScriptDir "grammars.json"
+
+# ---- Locate and import MSVC environment ----
+
+function Find-VcVarsAll {
+    $vswhere = Join-Path ${env:ProgramFiles(x86)} "Microsoft Visual Studio\Installer\vswhere.exe"
+    if (-not (Test-Path $vswhere)) {
+        $vswhere = Join-Path $env:ProgramFiles "Microsoft Visual Studio\Installer\vswhere.exe"
+    }
+    if (-not (Test-Path $vswhere)) { throw "vswhere.exe not found" }
+    $ip = & $vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath 2>$null
+    if (-not $ip) { throw "No VS with C++ tools found" }
+    $vcvars = Join-Path $ip "VC\Auxiliary\Build\vcvarsall.bat"
+    if (-not (Test-Path $vcvars)) { throw "vcvarsall.bat not found at $vcvars" }
+    return $vcvars
+}
+
+function Import-VcEnvironment {
+    param([string]$Arch)
+    $vcvars = Find-VcVarsAll
+    Write-Host "Importing MSVC environment ($Arch) ..."
+    $batContent = "@call `"$vcvars`" $Arch >nul 2>&1`r`n@set > `"$env:TEMP\vcvars_env.txt`"`r`n"
+    [System.IO.File]::WriteAllText("$env:TEMP\vcvars_capture.bat", $batContent)
+    cmd.exe /c "$env:TEMP\vcvars_capture.bat"
+    if (Test-Path "$env:TEMP\vcvars_env.txt") {
+        foreach ($line in (Get-Content "$env:TEMP\vcvars_env.txt")) {
+            if ($line -match '^([^=]+)=(.*)$') {
+                [Environment]::SetEnvironmentVariable($matches[1], $matches[2], "Process")
+            }
+        }
+        Remove-Item "$env:TEMP\vcvars_capture.bat","$env:TEMP\vcvars_env.txt" -Force -EA SilentlyContinue
+    }
+    $cl = Get-Command cl.exe -EA SilentlyContinue
+    if (-not $cl) { throw "cl.exe not found after importing vcvars" }
+    Write-Host "  cl.exe: $($cl.Source)"
+}
+
+function Get-VcArch {
+    switch ($Platform) {
+        "x64"   { return "amd64" }
+        "x86"   { return "x86" }
+        "ARM64" { return "amd64_arm64" }
+        default { return "amd64" }
+    }
+}
+
+# ---- Download grammar source ----
+
+function Get-GrammarSource {
+    param([string]$Repo, [string]$Tag)
+    $name = ($Repo -split '/')[-1]
+    $extractDir = Join-Path $TempBase $name
+    if (Test-Path (Join-Path $extractDir "tree-sitter.json")) {
+        Write-Host "  Cached: $extractDir"
+        return $extractDir
+    }
+    New-Item -ItemType Directory -Path $TempBase -Force | Out-Null
+    New-Item -ItemType Directory -Path $extractDir -Force | Out-Null
+
+    # Try .tar.gz first, then .tar.xz (older releases use xz)
+    $downloaded = $false
+    foreach ($ext in @("tar.gz", "tar.xz")) {
+        $tarUrl  = "https://github.com/$Repo/releases/download/$Tag/$name.$ext"
+        $tarFile = Join-Path $TempBase "$name.$ext"
+        try {
+            Write-Host "  Downloading $name.$ext ..."
+            Invoke-WebRequest -Uri $tarUrl -OutFile $tarFile -UseBasicParsing -ErrorAction Stop
+            $downloaded = $true
+            break
+        } catch {
+            # Try next format
+        }
+    }
+    if (-not $downloaded) {
+        throw "No release tarball found for $Repo $Tag"
+    }
+
+    Write-Host "  Extracting ..."
+    # Use git-bash tar with Unix-style paths (Windows tar.exe fails on ./prefixed entries)
+    $unixTarFile = $tarFile -replace '\\','/' -replace '^([A-Za-z]):','/$1'
+    $unixExtractDir = $extractDir -replace '\\','/' -replace '^([A-Za-z]):','/$1'
+    bash -c "tar -xf '$unixTarFile' -C '$unixExtractDir'"
+    Remove-Item $tarFile -Force
+    return $extractDir
+}
+
+# ---- Compile a grammar to DLL ----
+
+function Build-GrammarDll {
+    param(
+        [string]$GrammarName,
+        [string]$SourceDir,
+        [string]$RepoDir,
+        [string]$HighlightsScm,
+        [string]$DllName
+    )
+    $srcDir   = Join-Path $SourceDir "src"
+    $parserC  = Join-Path $srcDir "parser.c"
+    $scannerC = Join-Path $srcDir "scanner.c"
+    if (-not (Test-Path $parserC)) {
+        Write-Warning "  parser.c not found at $parserC - skipping $GrammarName"
+        return $false
+    }
+    $sources = @($parserC)
+    if (Test-Path $scannerC) { $sources += $scannerC }
+
+    $buildDir = Join-Path $RepoRoot "BuildTmp\grammar-build\$DllName\$Platform\$Configuration"
+    New-Item -ItemType Directory -Path $buildDir -Force | Out-Null
+    New-Item -ItemType Directory -Path $OutDir   -Force | Out-Null
+    $dllPath = Join-Path $OutDir "$DllName.dll"
+
+    $cflags = @("/nologo","/c","/TC","/W3","/D_USRDLL","/D_WINDOWS","/wd4996","/wd4267","/wd4244","/wd4101")
+    if ($Configuration -eq "Release") {
+        $cflags += @("/O2","/MD","/DNDEBUG","/GL")
+    } else {
+        $cflags += @("/Od","/MDd","/D_DEBUG","/Zi")
+    }
+
+    $objFiles = @()
+    foreach ($src in $sources) {
+        $objName = [IO.Path]::GetFileNameWithoutExtension($src) + ".obj"
+        $objPath = Join-Path $buildDir $objName
+        $objFiles += $objPath
+        $fileName = [IO.Path]::GetFileName($src)
+        Write-Host "  Compiling $fileName ..."
+        $allArgs = $cflags + @("/I`"$srcDir`"", "/Fo`"$objPath`"", "`"$src`"")
+        $p = Start-Process cl.exe -ArgumentList $allArgs -NoNewWindow -Wait -PassThru
+        if ($p.ExitCode -ne 0) {
+            Write-Error "  cl.exe failed for $fileName (exit $($p.ExitCode))"
+            return $false
+        }
+    }
+
+    Write-Host "  Linking $DllName.dll ..."
+    $linkArgs = @("/nologo","/DLL","/OUT:`"$dllPath`"")
+    if ($Configuration -eq "Release") {
+        $linkArgs += @("/LTCG","/OPT:REF","/OPT:ICF")
+    } else {
+        $linkArgs += @("/DEBUG")
+    }
+    $linkArgs += $objFiles
+    $p = Start-Process link.exe -ArgumentList $linkArgs -NoNewWindow -Wait -PassThru
+    if ($p.ExitCode -ne 0) {
+        Write-Error "  link.exe failed for $DllName (exit $($p.ExitCode))"
+        return $false
+    }
+
+    if ($HighlightsScm -and (Test-Path $HighlightsScm)) {
+        $dest = Join-Path $OutDir "$GrammarName-highlights.scm"
+        Copy-Item $HighlightsScm $dest -Force
+        Write-Host "  Copied highlights -> $GrammarName-highlights.scm"
+    } else {
+        Write-Warning "  No highlights.scm for $GrammarName"
+    }
+    Write-Host "  OK: $dllPath"
+    return $true
+}
+
+# ---- Main ----
+
+$succeeded = [int]0
+$failed    = [int]0
+$skipped   = [int]0
+
+Write-Host "=== WinMerge Tree-Sitter Grammar Builder ==="
+Write-Host "Platform:      $Platform"
+Write-Host "Configuration: $Configuration"
+Write-Host "Output:        $OutDir"
+Write-Host ""
+
+Import-VcEnvironment -Arch (Get-VcArch)
+Write-Host ""
+
+$config = Get-Content $ConfigFile -Raw | ConvertFrom-Json
+
+foreach ($entry in $config.grammars) {
+    $repo     = $entry.repo
+    $tag      = $entry.tag
+    $repoName = ($repo -split '/')[-1]
+    Write-Host "--- $repoName ($tag) ---"
+
+    try {
+        $repoDir = Get-GrammarSource -Repo $repo -Tag $tag
+    } catch {
+        Write-Warning "  Download failed: $_"
+        $failed++
+        continue
+    }
+
+    $tsJsonPath = Join-Path $repoDir "tree-sitter.json"
+    if (-not (Test-Path $tsJsonPath)) {
+        Write-Warning "  No tree-sitter.json - skipping"
+        $skipped++
+        continue
+    }
+    $tsJson = Get-Content $tsJsonPath -Raw | ConvertFrom-Json
+
+    foreach ($g in $tsJson.grammars) {
+        $gName = $g.name
+        $gPath = $g.path
+        if (-not $gPath) { $gPath = "." }
+
+        if ($GrammarFilter -and ($gName -notmatch $GrammarFilter)) {
+            Write-Host "  Skipping $gName (filtered)"
+            $skipped++
+            continue
+        }
+
+        $sourceDir = if ($gPath -eq ".") { $repoDir } else { Join-Path $repoDir $gPath }
+        $dllName   = "tree-sitter-$gName"
+
+        # Resolve highlights.scm — handles three cases:
+        #   1. String: "queries/highlights.scm"
+        #   2. Array: ["node_modules/.../highlights.scm", "queries/highlights.scm"]
+        #   3. Missing: no highlights field at all
+        $hlScm = $null
+        $hlRel = $g.highlights
+        if ($hlRel) {
+            # Normalize to array
+            $hlPaths = if ($hlRel -is [array]) { $hlRel } else { @($hlRel) }
+            # Try each path, use the first that exists on disk
+            foreach ($candidate in $hlPaths) {
+                $tryPath = Join-Path $repoDir $candidate
+                if (Test-Path $tryPath) {
+                    $hlScm = $tryPath
+                    break
+                }
+                $tryPath = Join-Path $sourceDir $candidate
+                if (Test-Path $tryPath) {
+                    $hlScm = $tryPath
+                    break
+                }
+            }
+        }
+        # Fallback: check standard location queries/highlights.scm
+        if (-not $hlScm) {
+            $fallback = Join-Path $sourceDir "queries\highlights.scm"
+            if (Test-Path $fallback) {
+                $hlScm = $fallback
+            } else {
+                $fallback = Join-Path $repoDir "queries\highlights.scm"
+                if (Test-Path $fallback) {
+                    $hlScm = $fallback
+                }
+            }
+        }
+
+        Write-Host "  Grammar: $gName (path: $gPath)"
+        $ok = Build-GrammarDll -GrammarName $gName -SourceDir $sourceDir -RepoDir $repoDir -HighlightsScm $hlScm -DllName $dllName
+        if ($ok) { $succeeded++ } else { $failed++ }
+    }
+    Write-Host ""
+}
+
+Write-Host "=== Done: $succeeded succeeded, $failed failed, $skipped skipped ==="
+if ($failed -gt 0) { exit 1 }

--- a/Tools/TreeSitterGrammars/build-grammars.ps1
+++ b/Tools/TreeSitterGrammars/build-grammars.ps1
@@ -127,6 +127,8 @@ function Build-GrammarDll {
         [string]$SourceDir,
         [string]$RepoDir,
         [string]$HighlightsScm,
+        [string]$LocalsScm,
+        [string]$InjectionsScm,
         [string]$DllName
     )
     $srcDir   = Join-Path $SourceDir "src"
@@ -186,6 +188,16 @@ function Build-GrammarDll {
         Write-Host "  Copied highlights -> $GrammarName-highlights.scm"
     } else {
         Write-Warning "  No highlights.scm for $GrammarName"
+    }
+    if ($LocalsScm -and (Test-Path $LocalsScm)) {
+        $dest = Join-Path $OutDir "$GrammarName-locals.scm"
+        Copy-Item $LocalsScm $dest -Force
+        Write-Host "  Copied locals -> $GrammarName-locals.scm"
+    }
+    if ($InjectionsScm -and (Test-Path $InjectionsScm)) {
+        $dest = Join-Path $OutDir "$GrammarName-injections.scm"
+        Copy-Item $InjectionsScm $dest -Force
+        Write-Host "  Copied injections -> $GrammarName-injections.scm"
     }
     Write-Host "  OK: $dllPath"
     return $true
@@ -280,8 +292,68 @@ foreach ($entry in $config.grammars) {
             }
         }
 
+        # Resolve locals.scm (same pattern as highlights)
+        $lcScm = $null
+        $lcRel = $g.locals
+        if ($lcRel) {
+            $lcPaths = if ($lcRel -is [array]) { $lcRel } else { @($lcRel) }
+            foreach ($candidate in $lcPaths) {
+                $tryPath = Join-Path $repoDir $candidate
+                if (Test-Path $tryPath) {
+                    $lcScm = $tryPath
+                    break
+                }
+                $tryPath = Join-Path $sourceDir $candidate
+                if (Test-Path $tryPath) {
+                    $lcScm = $tryPath
+                    break
+                }
+            }
+        }
+        if (-not $lcScm) {
+            $fallback = Join-Path $sourceDir "queries\locals.scm"
+            if (Test-Path $fallback) {
+                $lcScm = $fallback
+            } else {
+                $fallback = Join-Path $repoDir "queries\locals.scm"
+                if (Test-Path $fallback) {
+                    $lcScm = $fallback
+                }
+            }
+        }
+
+        # Resolve injections.scm (same pattern as highlights)
+        $ijScm = $null
+        $ijRel = $g.injections
+        if ($ijRel) {
+            $ijPaths = if ($ijRel -is [array]) { $ijRel } else { @($ijRel) }
+            foreach ($candidate in $ijPaths) {
+                $tryPath = Join-Path $repoDir $candidate
+                if (Test-Path $tryPath) {
+                    $ijScm = $tryPath
+                    break
+                }
+                $tryPath = Join-Path $sourceDir $candidate
+                if (Test-Path $tryPath) {
+                    $ijScm = $tryPath
+                    break
+                }
+            }
+        }
+        if (-not $ijScm) {
+            $fallback = Join-Path $sourceDir "queries\injections.scm"
+            if (Test-Path $fallback) {
+                $ijScm = $fallback
+            } else {
+                $fallback = Join-Path $repoDir "queries\injections.scm"
+                if (Test-Path $fallback) {
+                    $ijScm = $fallback
+                }
+            }
+        }
+
         Write-Host "  Grammar: $gName (path: $gPath)"
-        $ok = Build-GrammarDll -GrammarName $gName -SourceDir $sourceDir -RepoDir $repoDir -HighlightsScm $hlScm -DllName $dllName
+        $ok = Build-GrammarDll -GrammarName $gName -SourceDir $sourceDir -RepoDir $repoDir -HighlightsScm $hlScm -LocalsScm $lcScm -InjectionsScm $ijScm -DllName $dllName
         if ($ok) { $succeeded++ } else { $failed++ }
     }
     Write-Host ""

--- a/Tools/TreeSitterGrammars/build-grammars.ps1
+++ b/Tools/TreeSitterGrammars/build-grammars.ps1
@@ -134,23 +134,27 @@ function Resolve-NodeModulesPath {
 
     $packageName = $parts[1]
     $restIndex = 2
+    $cacheDirs = New-Object System.Collections.Generic.List[string]
     if ($packageName.StartsWith('@')) {
         if ($parts.Count -lt 4) {
             return $null
         }
-        $packageName = $parts[2]
+        $packageName = "$packageName\$($parts[2])"
         $restIndex = 3
+        $cacheDirs.Add((Join-Path $TempBase $packageName))
+        $packageName = $parts[2]
     }
-
-    $cachedSourceDir = Join-Path $TempBase $packageName
-    if (-not (Test-Path $cachedSourceDir)) {
-        return $null
-    }
+    $cacheDirs.Add((Join-Path $TempBase $packageName))
 
     $relativePath = $parts[$restIndex..($parts.Count - 1)] -join '\'
-    $resolvedPath = Join-Path $cachedSourceDir $relativePath
-    if (Test-Path $resolvedPath) {
-        return $resolvedPath
+    foreach ($cachedSourceDir in $cacheDirs) {
+        if (-not (Test-Path $cachedSourceDir)) {
+            continue
+        }
+        $resolvedPath = Join-Path $cachedSourceDir $relativePath
+        if (Test-Path $resolvedPath) {
+            return $resolvedPath
+        }
     }
 
     return $null
@@ -282,17 +286,14 @@ function Build-GrammarDll {
     }
 
     if (Write-QueryBundle -DestinationPath (Join-Path $OutDir "$GrammarName-highlights.scm") -SourcePaths $HighlightsScm) {
-        $dest = Join-Path $OutDir "$GrammarName-highlights.scm"
         Write-Host "  Copied highlights -> $GrammarName-highlights.scm"
     } else {
         Write-Warning "  No highlights.scm for $GrammarName"
     }
     if (Write-QueryBundle -DestinationPath (Join-Path $OutDir "$GrammarName-locals.scm") -SourcePaths $LocalsScm) {
-        $dest = Join-Path $OutDir "$GrammarName-locals.scm"
         Write-Host "  Copied locals -> $GrammarName-locals.scm"
     }
     if (Write-QueryBundle -DestinationPath (Join-Path $OutDir "$GrammarName-injections.scm") -SourcePaths $InjectionsScm) {
-        $dest = Join-Path $OutDir "$GrammarName-injections.scm"
         Write-Host "  Copied injections -> $GrammarName-injections.scm"
     }
     Write-Host "  OK: $dllPath"

--- a/Tools/TreeSitterGrammars/fsharp-highlights.scm
+++ b/Tools/TreeSitterGrammars/fsharp-highlights.scm
@@ -1,0 +1,386 @@
+;; ----------------------------------------------------------------------------
+;; Literals and comments
+
+[
+  (line_comment)
+  (block_comment)
+] @comment @spell
+
+((line_comment) @comment.documentation @spell
+ (#not-match? @comment.documentation "^///"))
+
+(const
+  [
+   (_) @constant
+   (unit) @constant.builtin
+  ])
+
+(primary_constr_args (_) @variable.parameter)
+
+(class_as_reference
+  (_) @variable.parameter.builtin)
+
+
+((argument_patterns (long_identifier (identifier) @character.special))
+ (#match? @character.special "^\_.*"))
+
+;; ----------------------------------------------------------------------------
+;; Punctuation
+
+(type_name type_name: (_) @type.definition)
+(exception_definition exception_name: (_) @type.definition)
+
+[
+ (_type)
+ (atomic_type)
+] @type
+
+(member_signature
+  .
+  (identifier) @function.member
+  (curried_spec
+    (arguments_spec
+      "*"* @operator
+      (argument_spec
+        (argument_name_spec
+          "?"? @character.special
+          name: (_) @variable.parameter)))))
+
+(union_type_case (identifier) @constant)
+
+(rules
+  (rule
+    pattern: (_) @constant
+    block: (_)))
+
+(wildcard_pattern) @character.special
+
+(identifier_pattern
+  .
+  (_) @constant
+  .
+  (_) @variable)
+
+(optional_pattern
+  "?" @character.special)
+
+(fsi_directive_decl . (string) @module)
+
+(import_decl . (_) @module)
+(named_module
+  name: (_) @module)
+(namespace
+  name: (_) @module)
+(module_defn
+  .
+  (_) @module)
+
+(ce_expression
+  .
+  (_) @constant.macro)
+
+(field_initializer
+  field: (_) @property)
+
+(record_fields
+  (record_field
+    .
+    (identifier) @property))
+
+(value_declaration_left . (_) @variable)
+
+(function_declaration_left
+  . (_) @function)
+
+(argument_patterns) @variable.parameter
+(typed_pattern
+  (_pattern) @variable.parameter
+  (_type) @type)
+
+(member_defn
+  (method_or_prop_defn
+    [
+      (property_or_ident) @function
+      (property_or_ident
+        instance: (identifier) @variable.parameter.builtin
+        method: (identifier) @function.method)
+    ]
+    args: (_)* @variable.parameter))
+
+
+(dot_expression
+  .
+  (_) @variable.member
+  .
+  (_))
+
+(application_expression
+  .
+  (_) @function.call
+  .
+  (_) @variable)
+
+((infix_expression
+  .
+  (_)
+  .
+  (infix_op) @operator
+  .
+  (_) @function.call
+  )
+ (#eq? @operator "|>")
+ )
+
+((infix_expression
+  .
+  (_) @function.call
+  .
+  (infix_op) @operator
+  .
+  (_)
+  )
+ (#eq? @operator "<|")
+ )
+
+[
+  (xint)
+  (int)
+  (int16)
+  (uint16)
+  (int32)
+  (uint32)
+  (int64)
+  (uint64)
+  (nativeint)
+  (unativeint)
+] @number
+
+[
+  (ieee32)
+  (ieee64)
+  (float)
+  (decimal)
+] @number.float
+
+(bool) @boolean
+
+([
+  (string)
+  (triple_quoted_string)
+  (verbatim_string)
+  (char)
+] @spell @string)
+
+(compiler_directive_decl) @keyword.directive
+
+(preproc_line
+  "#line" @keyword.directive)
+
+(attribute
+  target: (identifier)? @keyword
+  (_type) @attribute)
+
+[
+  "("
+  ")"
+  "{"
+  "}"
+  "["
+  "]"
+  "[|"
+  "|]"
+  "{|"
+  "|}"
+] @punctuation.bracket
+
+[
+  "[<"
+  ">]"
+] @punctuation.special
+
+(format_string_eval
+  [
+    "{"
+    "}"
+  ] @punctuation.special)
+
+[
+  ","
+  ";"
+  ":"
+  "."
+] @punctuation.delimiter
+
+[
+  "|"
+  "="
+  ">"
+  "<"
+  "-"
+  "~"
+  "->"
+  "<-"
+  "&"
+  "&&"
+  "|"
+  "||"
+  ":>"
+  ":?>"
+  ".."
+  (infix_op)
+  (prefix_op)
+  (op_identifier)
+] @operator
+
+(generic_type
+  [
+   "<"
+   ">"
+  ] @punctuation.bracket)
+
+[
+  "if"
+  "then"
+  "else"
+  "elif"
+  "when"
+  "match"
+  "match!"
+] @keyword.conditional
+
+[
+  "and"
+  "or"
+  "not"
+  "upcast"
+  "downcast"
+] @keyword.operator
+
+[
+  "return"
+  "return!"
+  "yield"
+  "yield!"
+] @keyword.return
+
+[
+  "for"
+  "while"
+  "downto"
+  "to"
+] @keyword.repeat
+
+
+[
+  "open"
+  "#r"
+  "#load"
+] @keyword.import
+
+[
+  "abstract"
+  "delegate"
+  "static"
+  "inline"
+  "mutable"
+  "override"
+  "rec"
+  "global"
+  (access_modifier)
+] @keyword.modifier
+
+[
+  "let"
+  "let!"
+  "use"
+  "use!"
+  "member"
+] @keyword.function
+
+[
+  "enum"
+  "type"
+  "exception"
+  "inherit"
+  "interface"
+  "and"
+  "class"
+  "struct"
+] @keyword.type
+
+((identifier) @keyword.exception
+ (#any-of? @keyword.exception "failwith" "failwithf" "raise" "reraise"))
+
+[
+  "as"
+  "assert"
+  "begin"
+  "end"
+  "done"
+  "default"
+  "in"
+  "do"
+  "do!"
+  "fun"
+  "function"
+  "get"
+  "set"
+  "lazy"
+  "new"
+  "of"
+  "struct"
+  "val"
+  "module"
+  "namespace"
+  "with"
+] @keyword
+
+[
+  "null"
+] @constant.builtin
+
+(match_expression "with" @keyword.conditional)
+
+(try_expression
+  [
+    "try"
+    "with"
+    "finally"
+  ] @keyword.exception)
+
+((_type
+ (simple_type
+    (long_identifier
+      (identifier) @type.builtin)))
+ (#any-of? @type.builtin "bool" "byte" "sbyte" "int16" "uint16" "int" "uint" "int64" "uint64" "nativeint" "unativeint" "decimal" "float" "double" "float32" "single" "char" "string" "unit"))
+
+(preproc_if
+  [
+    "#if" @keyword.directive
+    "#endif" @keyword.directive
+  ]
+  condition: (_)? @keyword.directive)
+
+(preproc_else
+  "#else" @keyword.directive)
+
+((long_identifier
+  (identifier)+ @variable.member
+  .
+  (identifier)))
+
+((identifier) @module.builtin
+ (#any-of? @module.builtin "Array" "Async" "Directory" "File" "List" "Option" "Path" "Map" "Set" "Lazy" "Seq" "Task" "String" "Result" ))
+
+((value_declaration
+   (attributes
+     (attribute
+       (_type
+         (simple_type
+          (long_identifier
+            (identifier) @attribute)))))
+   (function_or_value_defn
+     (value_declaration_left
+       .
+       (_) @constant)))
+ (#eq? @attribute "Literal"))

--- a/Tools/TreeSitterGrammars/fsharp-highlights.scm
+++ b/Tools/TreeSitterGrammars/fsharp-highlights.scm
@@ -3,11 +3,11 @@
 
 [
   (line_comment)
+  (xml_doc)
   (block_comment)
 ] @comment @spell
 
-((line_comment) @comment.documentation @spell
- (#not-match? @comment.documentation "^///"))
+(xml_doc) @comment.documentation @spell
 
 (const
   [
@@ -116,7 +116,20 @@
 
 (application_expression
   .
-  (_) @function.call
+  [
+    (long_identifier_or_op)
+    (dot_expression)
+  ] @function.call
+  .
+  (_) @variable)
+
+(application_expression
+  .
+  (typed_expression
+    (long_identifier_or_op) @function.call
+    "<" @operator
+    (_)
+    ">" @operator)
   .
   (_) @variable)
 
@@ -169,6 +182,8 @@
   (triple_quoted_string)
   (verbatim_string)
   (char)
+  (format_string)
+  (format_triple_quoted_string)
 ] @spell @string)
 
 (compiler_directive_decl) @keyword.directive
@@ -280,6 +295,7 @@
 [
   "abstract"
   "delegate"
+  "extern"
   "static"
   "inline"
   "mutable"
@@ -294,6 +310,7 @@
   "let!"
   "use"
   "use!"
+  "and!"
   "member"
 ] @keyword.function
 

--- a/Tools/TreeSitterGrammars/fsharp-injections.scm
+++ b/Tools/TreeSitterGrammars/fsharp-injections.scm
@@ -1,0 +1,10 @@
+([
+ (line_comment)
+ (block_comment_content)
+] @injection.content
+ (#set! injection.language "comment"))
+
+((xml_doc) @injection.content
+ (#offset! @injection.content 0 3 0 0)
+ (#set! injection.language "xml")
+ (#set! injection.combined))

--- a/Tools/TreeSitterGrammars/fsharp-locals.scm
+++ b/Tools/TreeSitterGrammars/fsharp-locals.scm
@@ -1,0 +1,33 @@
+(identifier) @local.reference
+
+[
+  (namespace)
+  (named_module)
+  (function_or_value_defn)
+] @local.scope
+
+(value_declaration_left
+  .
+  [
+   (_ (identifier) @local.definition)
+   (_ (_ (identifier) @local.definition))
+   (_ (_ (_ (identifier) @local.definition)))
+   (_ (_ (_ (_ (identifier) @local.definition))))
+   (_ (_ (_ (_ (_ (identifier) @local.definition)))))
+   (_ (_ (_ (_ (_ (_ (identifier) @local.definition))))))
+  ])
+
+(function_declaration_left
+  .
+  ((_) @local.definition
+   (#set! "definition.function.scope" "parent"))
+  ((argument_patterns
+     [
+      (_ (identifier) @local.definition)
+      (_ (_ (identifier) @local.definition))
+      (_ (_ (_ (identifier) @local.definition)))
+      (_ (_ (_ (_ (identifier) @local.definition))))
+      (_ (_ (_ (_ (_ (identifier) @local.definition)))))
+      (_ (_ (_ (_ (_ (_ (identifier) @local.definition))))))
+     ])
+  ))

--- a/Tools/TreeSitterGrammars/grammars.json
+++ b/Tools/TreeSitterGrammars/grammars.json
@@ -1,0 +1,21 @@
+{
+  "grammars": [
+    { "repo": "ionide/tree-sitter-fsharp",           "tag": "0.2.2"   },
+    { "repo": "tree-sitter/tree-sitter-c",            "tag": "v0.24.1" },
+    { "repo": "tree-sitter/tree-sitter-cpp",           "tag": "v0.23.4" },
+    { "repo": "tree-sitter/tree-sitter-c-sharp",       "tag": "v0.23.1" },
+    { "repo": "tree-sitter/tree-sitter-python",        "tag": "v0.25.0" },
+    { "repo": "tree-sitter/tree-sitter-javascript",    "tag": "v0.25.0" },
+    { "repo": "tree-sitter/tree-sitter-typescript",    "tag": "v0.23.2" },
+    { "repo": "tree-sitter/tree-sitter-java",          "tag": "v0.23.5" },
+    { "repo": "tree-sitter/tree-sitter-go",            "tag": "v0.25.0" },
+    { "repo": "tree-sitter/tree-sitter-rust",          "tag": "v0.24.1" },
+    { "repo": "tree-sitter/tree-sitter-json",          "tag": "v0.24.8" },
+    { "repo": "tree-sitter/tree-sitter-html",          "tag": "v0.23.2" },
+    { "repo": "tree-sitter/tree-sitter-css",           "tag": "v0.25.0" },
+    { "repo": "tree-sitter/tree-sitter-bash",          "tag": "v0.25.1" },
+    { "repo": "tree-sitter/tree-sitter-ruby",          "tag": "v0.23.1" },
+    { "repo": "tree-sitter/tree-sitter-php",           "tag": "v0.24.2" },
+    { "repo": "tree-sitter-grammars/tree-sitter-xml",  "tag": "v0.7.0"  }
+  ]
+}

--- a/WinMerge.sln
+++ b/WinMerge.sln
@@ -198,6 +198,7 @@ Global
 		Externals\crystaledit\editlib\editlibparsers.vcxitems*{9fda4af0-ccfd-4812-bdb9-53efedb32bde}*SharedItemsImports = 4
 		Externals\poco\Foundation\Foundation.vcxitems*{9fda4af0-ccfd-4812-bdb9-53efedb32bde}*SharedItemsImports = 4
 		Externals\poco\XML\XML.vcxitems*{9fda4af0-ccfd-4812-bdb9-53efedb32bde}*SharedItemsImports = 4
+		Externals\tree-sitter\tree-sitter.vcxitems*{9fda4af0-ccfd-4812-bdb9-53efedb32bde}*SharedItemsImports = 4
 		Externals\xdiff\xdiff.vcxitems*{9fda4af0-ccfd-4812-bdb9-53efedb32bde}*SharedItemsImports = 4
 		Src\CompareEngines\CompareEngines.vcxitems*{9fda4af0-ccfd-4812-bdb9-53efedb32bde}*SharedItemsImports = 4
 		Src\CrashLogger\CrashLogger.vcxitems*{9fda4af0-ccfd-4812-bdb9-53efedb32bde}*SharedItemsImports = 4


### PR DESCRIPTION
Current "highlight a keyword" is not enough for modern programming languages.
This PR integrates a tree-sitter as an optional syntax highlighting engine that supplements the existing keyword-based CrystalEdit parsers. When a grammar DLL and highlight query (.scm) are present in the TreeSitterGrammars directory, tree-sitter provides full AST-based highlighting; otherwise the existing parser runs unchanged.

Core components:
- TreeSitterParser.h/.cpp: CTreeSitterParser, CTreeSitterColorMap, CTreeSitterLanguage, and TreeSitterRegistry classes
- ParseLine virtual override in CMergeEditView for tree-sitter results
- Incremental parsing via ts_tree_edit() on each edit operation
- Lazy reparse with dirty flag (fires once per paint cycle)
- Status bar indicator showing [TS:language] in encoding pane
- Post-build step to copy grammar DLLs from Release to Debug/Test

Supported languages: bash, c, c-sharp, cpp, css, dtd, flow, fsharp, fsharp_signature, go, html, java, javascript, json, php, php_only, python, ruby, rust, tsx, typescript, xml. Many more can be easily added: https://tree-sitter.github.io/tree-sitter/

Grammar DLLs are built separately via build-grammars.ps1.

### Summary
1. When a file is opened, InitializeTreeSitter checks the file extension against TreeSitterRegistry's extension-to-language map
2. If a matching grammar DLL + highlight query exists in TreeSitterGrammars\, tree-sitter takes over syntax highlighting for that file
3. If no grammar is available, the existing CrystalEdit keyword-based parser (CCrystalTextView::ParseLine) runs exactly as before — zero change in behavior
So the 22 languages with grammar DLLs get tree-sitter highlighting, and all other languages (COBOL, Fortran, Pascal, etc.) keep using the existing keyword parsers. It's fully backward-compatible.
