### PR TITLE
Refactor file save logic: extract backup and read-only handling into FileSaveHelper

### DIFF
--- a/Src/FileSaveHelper.cpp
+++ b/Src/FileSaveHelper.cpp
@@ -1,0 +1,297 @@
+/////////////////////////////////////////////////////////////////////////////
+//    WinMerge:  an interactive diff/merge utility
+//    Copyright (C) 1997-2000  Thingamahoochie Software
+//    Author: Dean Grimm
+//    SPDX-License-Identifier: GPL-2.0-or-later
+/////////////////////////////////////////////////////////////////////////////
+/**
+ * @file  FileSaveHelper.cpp
+ *
+ * @brief Implementation of file save helper functions
+ */
+
+#include "stdafx.h"
+#include "FileSaveHelper.h"
+#include "UnicodeString.h"
+#include "paths.h"
+#include "TFile.h"
+#include "Plugins.h"
+#include <ctime>
+
+namespace FileSaveHelper
+{
+
+/** @brief Backup file extension. */
+static const tchar_t BACKUP_FILE_EXT[] = _T("bak");
+
+/**
+ * @brief Creates backup of a file
+ * @param [in] sourcePath Full path to file to backup
+ * @param [in] options Backup options
+ * @return BackupResult with success status and paths
+ */
+BackupResult CreateBackup(const String& sourcePath, const BackupOptions& options)
+{
+	BackupResult result;
+	result.success = true;
+	result.attempted = false;
+	result.sourcePath = sourcePath;
+	result.backupPath.clear();
+	result.errorMessage.clear();
+
+	// If backup is not enabled, return success
+	if (!options.enableBackup)
+		return result;
+
+	// Check if source file exists
+	if (paths::DoesPathExist(sourcePath) != paths::IS_EXISTING_FILE)
+	{
+		// File doesn't exist, nothing to backup
+		return result;
+	}
+
+	result.attempted = true;
+
+	// Split source path
+	String path;
+	String filename;
+	String ext;
+	paths::SplitFilename(paths::GetLongPath(sourcePath), &path, &filename, &ext);
+
+	// Determine backup folder
+	String bakPath;
+	if (options.location == 0) // PropBackups::FOLDER_ORIGINAL
+	{
+		// Put backups to same folder as original file
+		bakPath = path;
+	}
+	else if (options.location == 1) // PropBackups::FOLDER_GLOBAL
+	{
+		// Put backups to global folder
+		bakPath = options.globalFolder;
+		if (bakPath.empty())
+		{
+			bakPath = path;
+		}
+		else
+		{
+			bakPath = paths::GetLongPath(bakPath);
+			if (!paths::CreateIfNeeded(bakPath))
+			{
+				result.success = false;
+				result.errorMessage = _("Unable to create backup folder");
+				return result;
+			}
+		}
+	}
+	else
+	{
+		result.success = false;
+		result.errorMessage = _("Unknown backup location");
+		return result;
+	}
+
+	// Add .bak extension if wanted
+	if (options.addBakExtension)
+	{
+		// Don't add dot if there is no existing extension
+		if (ext.size() > 0)
+			ext += _T(".");
+		ext += BACKUP_FILE_EXT;
+	}
+
+	// Append time to filename if wanted
+	if (options.addTimestamp)
+	{
+		struct tm tm;
+		time_t curtime = 0;
+		time(&curtime);
+		::localtime_s(&tm, &curtime);
+		tchar_t timestr[32];
+		_sntprintf_s(timestr, _countof(timestr), _TRUNCATE,
+			_T("%04d%02d%02d%02d%02d%02d"),
+			tm.tm_year + 1900, tm.tm_mon + 1, tm.tm_mday,
+			tm.tm_hour, tm.tm_min, tm.tm_sec);
+		filename += _T("-");
+		filename += timestr;
+	}
+
+	// Build final backup path
+	bool pathOk = false;
+	if ((bakPath.length() + filename.length() + ext.length()) < MAX_PATH_FULL)
+	{
+		pathOk = true;
+		bakPath = paths::ConcatPath(bakPath, filename + _T(".") + ext);
+		result.backupPath = bakPath;
+	}
+
+	if (!pathOk)
+	{
+		result.success = false;
+		result.errorMessage = _("Backup path too long");
+		return result;
+	}
+
+	// Perform the actual file copy
+	if (!CopyFileW(TFile(sourcePath).wpath().c_str(),
+		TFile(bakPath).wpath().c_str(), FALSE))
+	{
+		result.success = false;
+		result.errorMessage = _("Unable to backup original file");
+		return result;
+	}
+
+	result.success = true;
+	return result;
+}
+
+/**
+ * @brief Checks if file is read-only
+ * @param [in] path Full path to file
+ * @return ReadOnlyCheckResult with readonly status
+ */
+ReadOnlyCheckResult CheckReadOnly(const String& path)
+{
+	ReadOnlyCheckResult result;
+	result.exists = false;
+	result.isReadOnly = false;
+	result.errorMessage.clear();
+
+	if (path.empty())
+		return result;
+
+	try
+	{
+		TFile file(path);
+		result.exists = file.exists();
+		if (result.exists)
+			result.isReadOnly = !file.canWrite();
+	}
+	catch (...)
+	{
+		result.errorMessage = _("Unable to check file status");
+	}
+
+	return result;
+}
+
+/**
+ * @brief Removes read-only attribute from file
+ * @param [in] path Full path to file
+ * @return true if attribute was removed successfully
+ */
+bool RemoveReadOnlyAttribute(const String& path)
+{
+	try
+	{
+		CFileStatus status;
+		if (!CFile::GetStatus(path.c_str(), status))
+			return false;
+
+		status.m_mtime = 0; // Avoid unwanted changes
+		status.m_attribute &= ~CFile::readOnly;
+
+		return !!CFile::SetStatus(path.c_str(), status);
+	}
+	catch (...)
+	{
+		return false;
+	}
+}
+
+/**
+ * @brief Formats packing error message
+ * @param [in] pane Pane index (0=left, 1=middle, 2=right)
+ * @param [in] paneCount Total number of panes
+ * @param [in] path File path
+ * @param [in] plugin Plugin information
+ * @return Formatted error message
+ */
+String GetPackingErrorMessage(int pane, int paneCount, const String& path, const PackingInfo& plugin)
+{
+	String pluginName = plugin.GetPluginPipeline();
+	return strutils::format_string2(
+		pane == 0 ?
+			_("Plugin '%2' cannot pack changes to left file into '%1'.\n\nOriginal unchanged. Save unpacked version?")
+			: (pane == paneCount - 1) ?
+				_("Plugin '%2' cannot pack changes to right file into '%1'.\n\nOriginal unchanged. Save unpacked version?")
+				: _("Plugin '%2' cannot pack changes to middle file into '%1'.\n\nOriginal unchanged. Save unpacked version?"),
+		path, pluginName);
+}
+
+/**
+ * @brief Generates message for readonly override prompt
+ * @param [in] path Full path to readonly file
+ * @param [in] isMultiFile true if handling multiple files/folders
+ * @return Formatted message string
+ */
+String GetReadOnlyOverrideMessage(const String& path, bool isMultiFile)
+{
+	if (isMultiFile)
+	{
+		// Multiple files or folder
+		return strutils::format_string1(_("%1\nis read-only. Override?"), path);
+	}
+	else
+	{
+		// Single file
+		return strutils::format_string1(_("%1 is read-only. Override? Or 'No' to save as new filename?"), path);
+	}
+}
+
+/**
+ * @brief Gets MessageBox flags for readonly prompt
+ * @param [in] isMultiFile true if handling multiple files/folders
+ * @return MessageBox flags (MB_YESNOCANCEL, etc.)
+ */
+UINT GetReadOnlyMessageBoxFlags(bool isMultiFile)
+{
+	if (isMultiFile)
+	{
+		// Multiple files: Yes to All option available, default button is Cancel (3)
+		return MB_YESNOCANCEL | MB_ICONWARNING | MB_DEFBUTTON3 | MB_DONT_ASK_AGAIN | MB_YES_TO_ALL;
+	}
+	else
+	{
+		// Single file: No Yes to All, default button is No (2)
+		return MB_YESNOCANCEL | MB_ICONWARNING | MB_DEFBUTTON2 | MB_DONT_ASK_AGAIN;
+	}
+}
+
+/**
+ * @brief Interprets user's MessageBox choice into action
+ * @param [in] mbResult Result from AfxMessageBox (IDYES, IDNO, etc.)
+ * @param [in] isMultiFile true if handling multiple files/folders
+ * @return UserChoiceResult with action and applyToAll flag
+ */
+UserChoiceResult InterpretUserChoice(UINT mbResult, bool isMultiFile)
+{
+	UserChoiceResult result;
+	result.applyToAll = false;
+
+	switch (mbResult)
+	{
+	case IDYESTOALL:
+		result.applyToAll = true;
+		[[fallthrough]];
+	case IDYES:
+		result.action = ReadOnlyAction::RemoveReadOnly;
+		break;
+
+	case IDNO:
+		if (isMultiFile)
+			result.action = ReadOnlyAction::Skip;
+		else
+			result.action = ReadOnlyAction::SelectNew;
+		break;
+
+	case IDCANCEL:
+	default:
+		result.action = ReadOnlyAction::Cancel;
+		break;
+	}
+
+	return result;
+}
+
+} // namespace FileSaveHelper

--- a/Src/FileSaveHelper.cpp
+++ b/Src/FileSaveHelper.cpp
@@ -13,6 +13,7 @@
 #include "stdafx.h"
 #include "FileSaveHelper.h"
 #include "UnicodeString.h"
+#include "FileTransform.h"
 #include "paths.h"
 #include "TFile.h"
 #include "Plugins.h"
@@ -191,7 +192,8 @@ bool RemoveReadOnlyAttribute(const String& path)
 		status.m_mtime = 0; // Avoid unwanted changes
 		status.m_attribute &= ~CFile::readOnly;
 
-		return !!CFile::SetStatus(path.c_str(), status);
+		CFile::SetStatus(path.c_str(), status);
+		return true;
 	}
 	catch (...)
 	{

--- a/Src/FileSaveHelper.cpp
+++ b/Src/FileSaveHelper.cpp
@@ -122,7 +122,10 @@ BackupResult CreateBackup(const String& sourcePath, const BackupOptions& options
 	if ((bakPath.length() + filename.length() + ext.length()) < MAX_PATH_FULL)
 	{
 		pathOk = true;
-		bakPath = paths::ConcatPath(bakPath, filename + _T(".") + ext);
+		String backupFilename = filename;
+		if (!ext.empty())
+			backupFilename += _T(".") + ext;
+		bakPath = paths::ConcatPath(bakPath, backupFilename);
 		result.backupPath = bakPath;
 	}
 

--- a/Src/FileSaveHelper.h
+++ b/Src/FileSaveHelper.h
@@ -1,0 +1,132 @@
+/////////////////////////////////////////////////////////////////////////////
+//    WinMerge:  an interactive diff/merge utility
+//    Copyright (C) 1997-2000  Thingamahoochie Software
+//    Author: Dean Grimm
+//    SPDX-License-Identifier: GPL-2.0-or-later
+/////////////////////////////////////////////////////////////////////////////
+/**
+ * @file  FileSaveHelper.h
+ *
+ * @brief Declaration of file save helper functions
+ * 
+ * This module provides helper functions for safe file saving operations,
+ * including backup creation, read-only file handling, and error messaging.
+ */
+#pragma once
+
+#include "UnicodeString.h"
+
+class PackingInfo;
+
+namespace FileSaveHelper
+{
+	/**
+	 * @brief Result of backup operation
+	 */
+	struct BackupResult
+	{
+		bool success;           ///< true if backup succeeded or wasn't needed
+		bool attempted;         ///< true if backup was actually attempted
+		String sourcePath;      ///< Original file path
+		String backupPath;      ///< Backup file path (empty if not attempted)
+		String errorMessage;    ///< Error message if failed
+	};
+
+	/**
+	 * @brief Options for backup creation
+	 */
+	struct BackupOptions
+	{
+		bool enableBackup;      ///< Whether backup is enabled
+		int location;           ///< Backup location (0=original folder, 1=global folder)
+		String globalFolder;    ///< Global backup folder path
+		bool addBakExtension;   ///< Add .bak extension
+		bool addTimestamp;      ///< Add timestamp to filename
+	};
+
+	/**
+	 * @brief Result of readonly check operation
+	 */
+	struct ReadOnlyCheckResult
+	{
+		bool exists;            ///< true if file exists
+		bool isReadOnly;        ///< true if file is read-only
+		String errorMessage;    ///< Error message if check failed
+	};
+
+	/**
+	 * @brief Creates backup of a file
+	 * @param [in] sourcePath Full path to file to backup
+	 * @param [in] options Backup options
+	 * @return BackupResult with success status and paths
+	 */
+	BackupResult CreateBackup(const String& sourcePath, const BackupOptions& options);
+
+	/**
+	 * @brief Checks if file is read-only
+	 * @param [in] path Full path to file
+	 * @return ReadOnlyCheckResult with readonly status
+	 */
+	ReadOnlyCheckResult CheckReadOnly(const String& path);
+
+	/**
+	 * @brief Removes read-only attribute from file
+	 * @param [in] path Full path to file
+	 * @return true if attribute was removed successfully
+	 */
+	bool RemoveReadOnlyAttribute(const String& path);
+
+	/**
+	 * @brief Formats packing error message
+	 * @param [in] pane Pane index (0=left, 1=middle, 2=right)
+	 * @param [in] paneCount Total number of panes
+	 * @param [in] path File path
+	 * @param [in] plugin Plugin information
+	 * @return Formatted error message
+	 */
+	String GetPackingErrorMessage(int pane, int paneCount, const String& path, const PackingInfo& plugin);
+
+	/**
+	 * @brief User action for readonly file handling
+	 */
+	enum class ReadOnlyAction
+	{
+		RemoveReadOnly,  ///< Remove readonly attribute and continue
+		SelectNew,       ///< Select new filename (single file only)
+		Skip,            ///< Skip this file (continue without saving)
+		Cancel           ///< Cancel entire operation
+	};
+
+	/**
+	 * @brief Result of user choice interpretation for readonly handling
+	 */
+	struct UserChoiceResult
+	{
+		ReadOnlyAction action;  ///< Action to take
+		bool applyToAll;        ///< Apply this choice to all remaining files
+	};
+
+	/**
+	 * @brief Generates message for readonly override prompt
+	 * @param [in] path Full path to readonly file
+	 * @param [in] isMultiFile true if handling multiple files/folders
+	 * @return Formatted message string
+	 */
+	String GetReadOnlyOverrideMessage(const String& path, bool isMultiFile);
+
+	/**
+	 * @brief Gets MessageBox flags for readonly prompt
+	 * @param [in] isMultiFile true if handling multiple files/folders
+	 * @return MessageBox flags (MB_YESNOCANCEL, etc.)
+	 */
+	UINT GetReadOnlyMessageBoxFlags(bool isMultiFile);
+
+	/**
+	 * @brief Interprets user's MessageBox choice into action
+	 * @param [in] mbResult Result from AfxMessageBox (IDYES, IDNO, etc.)
+	 * @param [in] isMultiFile true if handling multiple files/folders
+	 * @return UserChoiceResult with action and applyToAll flag
+	 */
+	UserChoiceResult InterpretUserChoice(UINT mbResult, bool isMultiFile);
+
+} // namespace FileSaveHelper

--- a/Src/Merge.cpp
+++ b/Src/Merge.cpp
@@ -72,14 +72,12 @@
 #include "Logger.h"
 #include "ColorSchemes.h"
 #include "CrashLogger.h"
+#include "FileSaveHelper.h"
 #include <../src/mfc/afximpl.h>
 
 #ifdef _DEBUG
 #define new DEBUG_NEW
 #endif
-
-/** @brief Backup file extension. */
-static const tchar_t BACKUP_FILE_EXT[] = _T("bak");
 
 /////////////////////////////////////////////////////////////////////////////
 // CMergeApp
@@ -1228,97 +1226,29 @@ void CMergeApp::ShowHelp(const tchar_t* helpLocation /*= nullptr*/)
  */
 bool CMergeApp::CreateBackup(bool bFolder, const String& pszPath)
 {
-	// If user doesn't want to backups in folder compare, return
-	// success so operations don't abort.
-	if (bFolder && !(GetOptionsMgr()->GetBool(OPT_BACKUP_FOLDERCMP)))
-		return true;
-	// Likewise if user doesn't want backups in file compare
-	else if (!bFolder && !(GetOptionsMgr()->GetBool(OPT_BACKUP_FILECMP)))
-		return true;
+	// Prepare backup options from registry settings
+	FileSaveHelper::BackupOptions options;
+	options.enableBackup = bFolder ?
+		GetOptionsMgr()->GetBool(OPT_BACKUP_FOLDERCMP) :
+		GetOptionsMgr()->GetBool(OPT_BACKUP_FILECMP);
+	options.location = GetOptionsMgr()->GetInt(OPT_BACKUP_LOCATION);
+	options.globalFolder = GetOptionsMgr()->GetString(OPT_BACKUP_GLOBALFOLDER);
+	options.addBakExtension = GetOptionsMgr()->GetBool(OPT_BACKUP_ADD_BAK);
+	options.addTimestamp = GetOptionsMgr()->GetBool(OPT_BACKUP_ADD_TIME);
 
-	// create backup copy of file if destination file exists
-	if (paths::DoesPathExist(pszPath) == paths::IS_EXISTING_FILE)
+	// Perform the backup
+	FileSaveHelper::BackupResult result = FileSaveHelper::CreateBackup(pszPath, options);
+
+	// If backup failed, prompt user
+	if (!result.success && result.attempted)
 	{
-		String bakPath;
-		String path;
-		String filename;
-		String ext;
-
-		paths::SplitFilename(paths::GetLongPath(pszPath), &path, &filename, &ext);
-
-		// Determine backup folder
-		if (GetOptionsMgr()->GetInt(OPT_BACKUP_LOCATION) ==
-			PropBackups::FOLDER_ORIGINAL)
-		{
-			// Put backups to same folder than original file
-			bakPath = std::move(path);
-		}
-		else if (GetOptionsMgr()->GetInt(OPT_BACKUP_LOCATION) ==
-			PropBackups::FOLDER_GLOBAL)
-		{
-			// Put backups to global folder defined in options
-			bakPath = GetOptionsMgr()->GetString(OPT_BACKUP_GLOBALFOLDER);
-			if (bakPath.empty())
-				bakPath = std::move(path);
-			else
-				bakPath = paths::GetLongPath(bakPath);
-
-			paths::CreateIfNeeded(bakPath);
-		}
-		else
-		{
-			_RPTF0(_CRT_ERROR, "Unknown backup location!");
-		}
-
-		bool success = false;
-		if (GetOptionsMgr()->GetBool(OPT_BACKUP_ADD_BAK))
-		{
-			// Don't add dot if there is no existing extension
-			if (ext.size() > 0)
-				ext += _T(".");
-			ext += BACKUP_FILE_EXT;
-		}
-
-		// Append time to filename if wanted so
-		// NOTE just adds timestamp at the moment as I couldn't figure out
-		// nice way to add a real time (invalid chars etc).
-		if (GetOptionsMgr()->GetBool(OPT_BACKUP_ADD_TIME))
-		{
-			struct tm tm;
-			time_t curtime = 0;
-			time(&curtime);
-			::localtime_s(&tm, &curtime);
-			CString timestr;
-			timestr.Format(_T("%04d%02d%02d%02d%02d%02d"), tm.tm_year+1900, tm.tm_mon+1, tm.tm_mday, tm.tm_hour, tm.tm_min, tm.tm_sec);
-			filename += _T("-");
-			filename += timestr;
-		}
-
-		// Append filename and extension (+ optional .bak) to path
-		if ((bakPath.length() + filename.length() + ext.length())
-			< MAX_PATH_FULL)
-		{
-			success = true;
-			bakPath = paths::ConcatPath(bakPath, filename + _T(".") + ext);
-		}
-
-		if (success)
-		{
-			success = !!CopyFileW(TFile(pszPath).wpath().c_str(), TFile(bakPath).wpath().c_str(), FALSE);
-		}
-
-		if (!success)
-		{
-			String msg = strutils::format_string1(
-				_("Unable to backup original file:\n%1\n\nContinue anyway?"),
-				pszPath + _T("\n(\u2192 ") + bakPath + _T(")"));
-			if (AfxMessageBox(msg.c_str(), MB_YESNO | MB_ICONWARNING | MB_DONT_ASK_AGAIN, IDS_BACKUP_FAILED_PROMPT) != IDYES)
-				return false;
-		}
-		return true;
+		String msg = strutils::format_string1(
+			_("Unable to backup original file:\n%1\n\nContinue anyway?"),
+			result.sourcePath + (result.backupPath.empty() ? _T("") : (_T("\n(\u2192 ") + result.backupPath + _T(")"))));
+		if (AfxMessageBox(msg.c_str(), MB_YESNO | MB_ICONWARNING | MB_DONT_ASK_AGAIN, IDS_BACKUP_FAILED_PROMPT) != IDYES)
+			return false;
 	}
 
-	// we got here because we're either not backing up of there was nothing to backup
 	return true;
 }
 
@@ -1341,84 +1271,70 @@ int CMergeApp::HandleReadonlySave(String& strSavePath, bool bMultiFile,
 {
 	CFileStatus status;
 	int nRetVal = IDOK;
-	bool bFileRO = false;
-	bool bFileExists = false;
 	String s;
-	String str;
 
-	if (!strSavePath.empty())
-	{
-		try
-		{
-			TFile file(strSavePath);
-			bFileExists = file.exists();
-			if (bFileExists)
-				bFileRO = !file.canWrite();
-		}
-		catch (...)
-		{
-		}
-	}
+	if (strSavePath.empty())
+		return nRetVal;
 
-	if (bFileExists && bFileRO)
+	// Check if file is readonly using FileSaveHelper
+	FileSaveHelper::ReadOnlyCheckResult roCheck = FileSaveHelper::CheckReadOnly(strSavePath);
+
+	if (roCheck.exists && roCheck.isReadOnly)
 	{
 		UINT userChoice = 0;
 
 		// Don't ask again if its already asked
 		if (bApplyToAll)
+		{
 			userChoice = IDYES;
+		}
 		else
 		{
+			// Get message and flags from FileSaveHelper
+			String message = FileSaveHelper::GetReadOnlyOverrideMessage(strSavePath, bMultiFile);
+			UINT flags = FileSaveHelper::GetReadOnlyMessageBoxFlags(bMultiFile);
+
 			// Prompt for user choice
-			if (bMultiFile)
-			{
-				// Multiple files or folder
-				str = strutils::format_string1(_("%1\nis read-only. Override?"), strSavePath);
-				userChoice = AfxMessageBox(str.c_str(), MB_YESNOCANCEL |
-						MB_ICONWARNING | MB_DEFBUTTON3 | MB_DONT_ASK_AGAIN |
-						MB_YES_TO_ALL, IDS_SAVEREADONLY_MULTI);
-			}
-			else
-			{
-				// Single file
-				str = strutils::format_string1(_("%1 is read-only. Override? Or 'No' to save as new filename?"), strSavePath);
-				userChoice = AfxMessageBox(str.c_str(), MB_YESNOCANCEL |
-						MB_ICONWARNING | MB_DEFBUTTON2 | MB_DONT_ASK_AGAIN,
-						IDS_SAVEREADONLY_FMT);
-			}
+			UINT msgboxId = bMultiFile ? IDS_SAVEREADONLY_MULTI : IDS_SAVEREADONLY_FMT;
+			userChoice = AfxMessageBox(message.c_str(), flags, msgboxId);
 		}
-		switch (userChoice)
+
+		// Interpret user choice using FileSaveHelper
+		FileSaveHelper::UserChoiceResult choice = FileSaveHelper::InterpretUserChoice(userChoice, bMultiFile);
+
+		if (choice.applyToAll)
+			bApplyToAll = true;
+
+		switch (choice.action)
 		{
-		// Overwrite read-only file
-		case IDYESTOALL:
-			bApplyToAll = true;  // Don't ask again (no break here)
-			[[fallthrough]];
-		case IDYES:
-			CFile::GetStatus(strSavePath.c_str(), status);
-			status.m_mtime = 0;		// Avoid unwanted changes
-			status.m_attribute &= ~CFile::readOnly;
-			CFile::SetStatus(strSavePath.c_str(), status);
-			nRetVal = IDYES;
+		case FileSaveHelper::ReadOnlyAction::RemoveReadOnly:
+			// Remove readonly attribute and continue
+			if (FileSaveHelper::RemoveReadOnlyAttribute(strSavePath))
+				nRetVal = IDYES;
+			else
+				nRetVal = IDCANCEL;
 			break;
 
-		// Save to new filename (single) /skip this item (multiple)
-		case IDNO:
-			if (!bMultiFile)
+		case FileSaveHelper::ReadOnlyAction::SelectNew:
+			// Single file: Select new filename
+			if (SelectFile(AfxGetMainWnd()->GetSafeHwnd(), s, false, strSavePath.c_str()))
 			{
-				if (SelectFile(AfxGetMainWnd()->GetSafeHwnd(), s, false, strSavePath.c_str()))
-				{
-					strSavePath = s;
-					nRetVal = IDNO;
-				}
-				else
-					nRetVal = IDCANCEL;
+				strSavePath = s;
+				nRetVal = IDNO;
 			}
 			else
-				nRetVal = IDNO;
+			{
+				nRetVal = IDCANCEL;
+			}
 			break;
 
-		// Cancel saving
-		case IDCANCEL:
+		case FileSaveHelper::ReadOnlyAction::Skip:
+			// Multiple files: Skip this item
+			nRetVal = IDNO;
+			break;
+
+		case FileSaveHelper::ReadOnlyAction::Cancel:
+			// Cancel operation
 			nRetVal = IDCANCEL;
 			break;
 		}
@@ -1428,14 +1344,7 @@ int CMergeApp::HandleReadonlySave(String& strSavePath, bool bMultiFile,
 
 String CMergeApp::GetPackingErrorMessage(int pane, int paneCount, const String& path, const PackingInfo& plugin)
 {
-	String pluginName = plugin.GetPluginPipeline();
-	return strutils::format_string2(
-		pane == 0 ? 
-			_("Plugin '%2' cannot pack changes to left file into '%1'.\n\nOriginal unchanged. Save unpacked version?")
-			: (pane == paneCount - 1) ? 
-				_("Plugin '%2' cannot pack changes to right file into '%1'.\n\nOriginal unchanged. Save unpacked version?")
-				: _("Plugin '%2' cannot pack changes to middle file into '%1'.\n\nOriginal unchanged. Save unpacked version?"),
-		path, pluginName);
+	return FileSaveHelper::GetPackingErrorMessage(pane, paneCount, path, plugin);
 }
 
 /**

--- a/Src/Merge.vcxproj
+++ b/Src/Merge.vcxproj
@@ -919,10 +919,9 @@
     </Manifest>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClCompile Include="7zCommon.cpp">
-    </ClCompile>
-    <ClCompile Include="AboutDlg.cpp">
-    </ClCompile>
+    <ClCompile Include="7zCommon.cpp" />
+    <ClCompile Include="AboutDlg.cpp" />
+    <ClCompile Include="FileSaveHelper.cpp" />
     <ClCompile Include="BasicFlatStatusBar.cpp" />
     <ClCompile Include="ClipboardHistory.cpp" />
     <ClCompile Include="ColorSchemes.cpp">
@@ -1505,6 +1504,7 @@
     <ClInclude Include="..\Version.h" />
     <ClInclude Include="7zCommon.h" />
     <ClInclude Include="AboutDlg.h" />
+    <ClInclude Include="FileSaveHelper.h" />
     <ClInclude Include="BasicFlatStatusBar.h" />
     <ClInclude Include="ClipboardHistory.h" />
     <ClInclude Include="ColorSchemes.h" />

--- a/Src/Merge.vcxproj.filters
+++ b/Src/Merge.vcxproj.filters
@@ -375,6 +375,9 @@
     <ClCompile Include="Common\SuperComboBox.cpp">
       <Filter>MFCGui\Common\Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="FileSaveHelper.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="AboutDlg.cpp">
       <Filter>MFCGui\Dialogs\Source Files</Filter>
     </ClCompile>
@@ -1087,6 +1090,9 @@
     </ClInclude>
     <ClInclude Include="Common\SuperComboBox.h">
       <Filter>MFCGui\Common\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="FileSaveHelper.h">
+      <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="AboutDlg.h">
       <Filter>MFCGui\Dialogs\Header Files</Filter>


### PR DESCRIPTION
## Summary

Extract file save logic (backup and read-only handling) into a new `FileSaveHelper` module.

## Changes

- Move backup creation and read-only handling out of `CMergeApp`
- Simplify `Merge.cpp` by delegating to FileSaveHelper

## Notes

No functional changes intended.