### PR TITLE
Prioritize explicitly selected plugins over archive detection

### DIFF
--- a/Src/7zCommon.cpp
+++ b/Src/7zCommon.cpp
@@ -196,7 +196,8 @@ Merge7z::Format *ArchiveGuessFormat(const String& path)
 		if (pFormat == nullptr && !paths::IsURL(path2))
 		{
 			auto* infoUnpacker = Merge7zFormatMergePluginImpl::GetPackingInfo();
-			if (infoUnpacker != nullptr && (!infoUnpacker->GetPluginPipeline().empty() && infoUnpacker->GetPluginPipeline() != _T("<Automatic>")))
+			const auto& pluginPipeline = infoUnpacker->GetPluginPipeline();
+			if (!pluginPipeline.empty() && pluginPipeline != _T("<Automatic>"))
 				return nullptr;
 			pFormat = m_Merge7z->GuessFormat(path2.c_str());
 		}

--- a/Src/7zCommon.cpp
+++ b/Src/7zCommon.cpp
@@ -190,23 +190,16 @@ Merge7z::Format *ArchiveGuessFormat(const String& path)
 	}*/
 	// Default to Merge7z*.dll
 
-	try
+	Merge7z::Format* pFormat = Merge7zFormatRegister::GuessFormat(path2);
+	if (pFormat == nullptr && !paths::IsURL(path2))
 	{
-		Merge7z::Format* pFormat = Merge7zFormatRegister::GuessFormat(path2);
-		if (pFormat == nullptr && !paths::IsURL(path2))
-		{
-			auto* infoUnpacker = Merge7zFormatMergePluginImpl::GetPackingInfo();
-			const auto& pluginPipeline = infoUnpacker->GetPluginPipeline();
-			if (!pluginPipeline.empty() && pluginPipeline != _T("<Automatic>"))
-				return nullptr;
-			pFormat = m_Merge7z->GuessFormat(path2.c_str());
-		}
-		return pFormat;
+		auto* infoUnpacker = Merge7zFormatMergePluginImpl::GetPackingInfo();
+		const auto& pluginPipeline = infoUnpacker->GetPluginPipeline();
+		if (!pluginPipeline.empty() && pluginPipeline != _T("<Automatic>") && pluginPipeline != _("<Automatic>"))
+			return nullptr;
+		pFormat = m_Merge7z->GuessFormat(path2.c_str());
 	}
-	catch (...)
-	{
-		throw;
-	}
+	return pFormat;
 }
 
 /**

--- a/Src/7zCommon.cpp
+++ b/Src/7zCommon.cpp
@@ -95,6 +95,7 @@ DATE:		BY:					DESCRIPTION:
 #include "paths.h"
 #include "Environment.h"
 #include "Merge7zFormatRegister.h"
+#include "Merge7zFormatMergePluginImpl.h"
 #include "Logger.h"
 
 #ifdef _DEBUG
@@ -191,18 +192,18 @@ Merge7z::Format *ArchiveGuessFormat(const String& path)
 
 	try
 	{
-		Merge7z::Format* pFormat = nullptr;
-		if (!paths::IsURL(path2))
+		Merge7z::Format* pFormat = Merge7zFormatRegister::GuessFormat(path2);
+		if (pFormat == nullptr && !paths::IsURL(path2))
+		{
+			auto* infoUnpacker = Merge7zFormatMergePluginImpl::GetPackingInfo();
+			if (infoUnpacker != nullptr && (!infoUnpacker->GetPluginPipeline().empty() && infoUnpacker->GetPluginPipeline() != _T("<Automatic>")))
+				return nullptr;
 			pFormat = m_Merge7z->GuessFormat(path2.c_str());
-		if (pFormat == nullptr)
-			pFormat = Merge7zFormatRegister::GuessFormat(path2);
+		}
 		return pFormat;
 	}
 	catch (...)
 	{
-		Merge7z::Format *pFormat = Merge7zFormatRegister::GuessFormat(path2);
-		if (pFormat != nullptr)
-			return pFormat;
 		throw;
 	}
 }


### PR DESCRIPTION
When a plugin is explicitly specified (non-Automatic), skip 7-Zip archive detection.

This prevents archive handlers from overriding user-selected plugins,
ensuring that plugins like CompareMSExcelFiles are correctly applied
even if the file can be treated as an archive.

Also refactors archive format detection order to try registered formats first,
then fallback to Merge7z.