### PR TITLE
Refactor: unify open parameters and move recurse to OpenFolderParams

### DIFF
--- a/Src/DirView.cpp
+++ b/Src/DirView.cpp
@@ -1489,10 +1489,13 @@ void CDirView::OpenParentDirectory(CDirDoc *pDocOpen)
 		pDoc->m_pTempPathContext = pDoc->m_pTempPathContext->DeleteHead();
 		[[fallthrough]];
 	case AllowUpwardDirectory::ParentIsRegularPath: 
-		fileopenflags_t dwFlags[3];
-		for (int nIndex = 0; nIndex < pathsParent.GetSize(); ++nIndex)
-			dwFlags[nIndex] = FFILEOPEN_NOMRU | (pDoc->GetReadOnly(nIndex) ? FFILEOPEN_READONLY : 0);
-		GetMainFrame()->DoFileOrFolderOpen(&pathsParent, dwFlags, nullptr, _T(""), GetDiffContext().m_bRecursive, (GetAsyncKeyState(VK_CONTROL) & 0x8000) ? nullptr : pDocOpen);
+		{
+			fileopenflags_t dwFlags[3];
+			for (int nIndex = 0; nIndex < pathsParent.GetSize(); ++nIndex)
+				dwFlags[nIndex] = FFILEOPEN_NOMRU | (pDoc->GetReadOnly(nIndex) ? FFILEOPEN_READONLY : 0);
+			CMainFrame::OpenFolderParams openFolderParams(GetDiffContext().m_bRecursive);
+			GetMainFrame()->DoFileOrFolderOpen(&pathsParent, dwFlags, nullptr, _T(""), (GetAsyncKeyState(VK_CONTROL) & 0x8000) ? nullptr : pDocOpen, nullptr, nullptr, 0, &openFolderParams);
+		}
 		[[fallthrough]];
 	case AllowUpwardDirectory::No:
 		break;
@@ -1585,13 +1588,15 @@ void CDirView::Open(CDirDoc *pDoc, const PathContext& paths, fileopenflags_t dwF
 	{
 		// Open subfolders
 		// Don't add folders to MRU
-		GetMainFrame()->DoFileOrFolderOpen(&paths, dwFlags, nullptr, _T(""), GetDiffContext().m_bRecursive,
-			((GetAsyncKeyState(VK_CONTROL) & 0x8000) || GetDiffContext().m_bRecursive) ? nullptr : pDoc);
+		CMainFrame::OpenFolderParams openFolderParams(GetDiffContext().m_bRecursive);
+		GetMainFrame()->DoFileOrFolderOpen(&paths, dwFlags, nullptr, _T(""),
+			((GetAsyncKeyState(VK_CONTROL) & 0x8000) || GetDiffContext().m_bRecursive) ? nullptr : pDoc, nullptr, nullptr, 0, &openFolderParams);
 	}
 	else if (HasZipSupport() && std::count_if(paths.begin(), paths.end(), ArchiveGuessFormat) == paths.GetSize())
 	{
 		// Open archives, not adding paths to MRU
-		GetMainFrame()->DoFileOrFolderOpen(&paths, dwFlags, nullptr, _T(""), GetDiffContext().m_bRecursive, nullptr, infoUnpacker, nullptr);
+		CMainFrame::OpenFolderParams openFolderParams(GetDiffContext().m_bRecursive);
+		GetMainFrame()->DoFileOrFolderOpen(&paths, dwFlags, nullptr, _T(""), nullptr, infoUnpacker, nullptr, 0, &openFolderParams);
 	}
 	else
 	{
@@ -1859,8 +1864,9 @@ void CDirView::OpenSelectionAs(int sel1, int sel2, int sel3, UINT id)
 	{
 		PackingInfo infoUnpackerAlt(
 				CMainFrame::GetPluginPipelineByMenuId(id, FileTransform::UnpackerEventNames, ID_UNPACKERS_FIRST));
+		CMainFrame::OpenFolderParams openFolderParams(ctxt.m_bRecursive);
 		GetMainFrame()->DoFileOrFolderOpen(&paths, dwFlags, strDesc, _T(""),
-			ctxt.m_bRecursive, nullptr, &infoUnpackerAlt, infoPrediffer, 0);
+			nullptr, &infoUnpackerAlt, infoPrediffer, 0, &openFolderParams);
 	}
 	else
 	{

--- a/Src/HexMergeDoc.cpp
+++ b/Src/HexMergeDoc.cpp
@@ -915,7 +915,7 @@ void CHexMergeDoc::OnFileRecompareAs(UINT nID)
 
 	CloseNow();
 	GetMainFrame()->DoFileOrFolderOpen(&paths, dwFlags, strDesc, _T(""),
-		GetOptionsMgr()->GetBool(OPT_CMP_INCLUDE_SUBDIRS), nullptr, &infoUnpacker, nullptr, nID);
+		nullptr, &infoUnpacker, nullptr, nID);
 }
 
 void CHexMergeDoc::OnOpenWithUnpacker()
@@ -930,7 +930,7 @@ void CHexMergeDoc::OnOpenWithUnpacker()
 		String strDesc[3] = { m_strDesc[0], m_strDesc[1], m_strDesc[2] };
 		CloseNow();
 		GetMainFrame()->DoFileOrFolderOpen(&paths, dwFlags, strDesc, _T(""),
-			GetOptionsMgr()->GetBool(OPT_CMP_INCLUDE_SUBDIRS), nullptr, &infoUnpacker, nullptr,
+		  nullptr, &infoUnpacker, nullptr,
 			GetOptionsMgr()->GetBool(OPT_PLUGINS_OPEN_IN_SAME_FRAME_TYPE) ? ID_MERGE_COMPARE_HEX : -ID_MERGE_COMPARE_HEX);
 	}
 }

--- a/Src/ImgMergeFrm.cpp
+++ b/Src/ImgMergeFrm.cpp
@@ -1036,7 +1036,7 @@ void CImgMergeFrame::OnFileRecompareAs(UINT nID)
 
 	CloseNow();
 	GetMainFrame()->DoFileOrFolderOpen(&paths, dwFlags, strDesc, _T(""),
-		GetOptionsMgr()->GetBool(OPT_CMP_INCLUDE_SUBDIRS), nullptr, &infoUnpacker, nullptr, nID);
+		nullptr, &infoUnpacker, nullptr, nID);
 }
 
 void CImgMergeFrame::OnUpdateFileRecompareAs(CCmdUI* pCmdUI)
@@ -1057,7 +1057,7 @@ void CImgMergeFrame::OnOpenWithUnpacker()
 		String strDesc[3] = { m_strDesc[0], m_strDesc[1], m_strDesc[2] };
 		CloseNow();
 		GetMainFrame()->DoFileOrFolderOpen(&paths, dwFlags, strDesc, _T(""),
-			GetOptionsMgr()->GetBool(OPT_CMP_INCLUDE_SUBDIRS), nullptr, &infoUnpacker, nullptr,
+			nullptr, &infoUnpacker, nullptr,
 			GetOptionsMgr()->GetBool(OPT_PLUGINS_OPEN_IN_SAME_FRAME_TYPE) ? ID_MERGE_COMPARE_IMAGE : -ID_MERGE_COMPARE_IMAGE);
 	}
 }

--- a/Src/MainFrm.cpp
+++ b/Src/MainFrm.cpp
@@ -801,7 +801,7 @@ bool CMainFrame::ShowAutoMergeDoc(UINT nID, IDirDoc * pDirDoc,
 	int nFiles, const FileLocation ifileloc[],
 	const fileopenflags_t dwFlags[], const String strDesc[], const String& sReportFile /*= _T("")*/,
 	const PackingInfo* infoUnpacker /*= nullptr*/, const PrediffingInfo* infoPrediffer /*= nullptr*/,
-	const OpenFileParams* pOpenParams /*= nullptr*/)
+	const OpenParams* pOpenParams /*= nullptr*/)
 {
 	if (sReportFile.empty() && CompareFilesIfFilesAreLarge(pDirDoc, nFiles, ifileloc))
 		return false;
@@ -869,7 +869,7 @@ bool CMainFrame::ShowMergeDoc(UINT nID, IDirDoc* pDirDoc,
 	int nFiles, const FileLocation ifileloc[],
 	const fileopenflags_t dwFlags[], const String strDesc[], const String& sReportFile /*= _T("")*/,
 	const PackingInfo* infoUnpacker /*= nullptr*/, const PrediffingInfo* infoPrediffer /*= nullptr*/,
-	const OpenFileParams* pOpenParams /*= nullptr*/)
+	const OpenParams* pOpenParams /*= nullptr*/)
 {
 	switch (nID)
 	{
@@ -1256,7 +1256,7 @@ void CMainFrame::OnOptions()
 static void AppendComparisonCommandLineParams(
 	String& params,
 	UINT nID,
-	const CMainFrame::OpenFileParams* pOpenParams,
+	const CMainFrame::OpenParams* pOpenParams,
 	const PackingInfo* infoUnpacker,
 	const PrediffingInfo* infoPrediffer)
 {
@@ -1326,7 +1326,7 @@ static bool AddToRecentDocs(const PathContext& paths,
 	const unsigned flags[], const String desc[],
 	std::optional<bool> recurse, const String& filter,
 	const PackingInfo *infoUnpacker, const PrediffingInfo *infoPrediffer,
-	UINT nID, const CMainFrame::OpenFileParams *pOpenParams,
+	UINT nID, const CMainFrame::OpenParams *pOpenParams,
 	bool isSelfCompare = false)
 {
 	ASSERT(paths.GetSize() <= 3);
@@ -1419,17 +1419,17 @@ static bool AddToRecentDocs(const PathContext& paths,
  * @param [in] pszRight Right-side path.
  * @param [in] dwLeftFlags Left-side flags.
  * @param [in] dwRightFlags Right-side flags.
- * @param [in] bRecurse Do we run recursive (folder) compare?
  * @param [in] pDirDoc Dir compare document to use.
  * @param [in] infoUnpacker Unpacker plugin name.
  * @param [in] infoPrediffer Prediffer plugin name.
+ * @param [in] pOpenParams File/folder open parameters (bRecurse is in OpenFolderParams).
  * @return `true` if opening files and compare succeeded, `false` otherwise.
  */
 bool CMainFrame::DoFileOrFolderOpen(const PathContext * pFiles /*= nullptr*/,
 	const fileopenflags_t dwFlags[] /*= nullptr*/, const String strDesc[] /*= nullptr*/, const String& sReportFile /*= T("")*/,
-	std::optional<bool> bRecurse /*= false*/, IDirDoc* pDirDoc/*= nullptr*/,
+	IDirDoc* pDirDoc/*= nullptr*/,
 	const PackingInfo *infoUnpacker /*= nullptr*/, const PrediffingInfo *infoPrediffer /*= nullptr*/,
-	UINT nID /*= 0*/, const OpenFileParams *pOpenParams /*= nullptr*/)
+	UINT nID /*= 0*/, const OpenParams *pOpenParams /*= nullptr*/)
 {
 	if (pDirDoc != nullptr && !pDirDoc->CloseMergeDocs())
 		return false;
@@ -1449,6 +1449,12 @@ bool CMainFrame::DoFileOrFolderOpen(const PathContext * pFiles /*= nullptr*/,
 		bRO[1] = (dwFlags[1] & FFILEOPEN_READONLY) != 0;
 		bRO[2] = (dwFlags[2] & FFILEOPEN_READONLY) != 0;
 	};
+
+	// Get bRecurse from OpenFolderParams if available, otherwise use default
+	std::optional<bool> bRecurse;
+	const auto* pOpenFolderParams = dynamic_cast<const OpenFolderParams*>(pOpenParams);
+	if (pOpenFolderParams && pOpenFolderParams->m_bRecurse.has_value())
+		bRecurse = pOpenFolderParams->m_bRecurse;
 
 	bool bRecurse2 = bRecurse.has_value() ? *bRecurse : GetOptionsMgr()->GetBool(OPT_CMP_INCLUDE_SUBDIRS);
 
@@ -1545,7 +1551,6 @@ bool CMainFrame::DoFileOrFolderOpen(const PathContext * pFiles /*= nullptr*/,
 			// exception. There is no point in checking return value.
 			pDirDoc->InitCompare(tFiles, bRecurse2, pTempPathContext);
 
-			const auto* pOpenFolderParams = dynamic_cast<const OpenFolderParams*>(pOpenParams);
 			if (pOpenFolderParams)
 				pDirDoc->SetHiddenItems(pOpenFolderParams->m_hiddenItems);
 			pDirDoc->SetReportFile(sReportFile);
@@ -1582,7 +1587,7 @@ bool CMainFrame::DoFileOpen(UINT nID, const PathContext* pFiles,
 	const fileopenflags_t dwFlags[] /*= nullptr*/, const String strDesc[] /*= nullptr*/,
 	const String& sReportFile /*= _T("")*/,
 	const PackingInfo *infoUnpacker /*= nullptr*/, const PrediffingInfo *infoPrediffer /*= nullptr*/,
-	const OpenFileParams *pOpenParams /*= nullptr*/)
+	const OpenParams *pOpenParams /*= nullptr*/)
 {
 	ASSERT(pFiles != nullptr);
 	FileLocation fileloc[3];
@@ -1971,7 +1976,8 @@ void CMainFrame::OnDropFiles(const std::vector<String>& dropped_files)
 		}
 	}
 
-	DoFileOrFolderOpen(&tFiles, dwFlags, nullptr, _T(""), recurse);
+	CMainFrame::OpenFolderParams openFolderParams(recurse);
+	DoFileOrFolderOpen(&tFiles, dwFlags, nullptr, _T(""), nullptr, nullptr, nullptr, 0, &openFolderParams);
 }
 
 void CMainFrame::OnPluginUnpackMode(UINT nID )
@@ -2126,7 +2132,7 @@ void CMainFrame::OnSaveConfigData()
 bool CMainFrame::DoFileNew(UINT nID, int nPanes,
 	const fileopenflags_t dwFlags[], const String strDesc[],
 	const PrediffingInfo *infoPrediffer /*= nullptr*/,
-	const OpenFileParams *pOpenParams)
+	const OpenParams *pOpenParams)
 {
 	// Load emptyfile descriptors and open empty docs
 	// Use default codepage
@@ -3004,7 +3010,7 @@ void CMainFrame::OnFileOpenClipboard()
 
 bool CMainFrame::DoOpenClipboard(UINT nID, int nBuffers /*= 2*/, const fileopenflags_t dwFlags[] /*= nullptr*/,
 	const String strDesc[] /*= nullptr*/, const PackingInfo* infoUnpacker /*= nullptr*/,
-	const PrediffingInfo* infoPrediffer /*= nullptr*/, const OpenFileParams* pOpenParams /*= nullptr*/)
+	const PrediffingInfo* infoPrediffer /*= nullptr*/, const OpenParams* pOpenParams /*= nullptr*/)
 {
 	auto historyItems = ClipboardHistory::GetItems(nBuffers);
 
@@ -3101,7 +3107,7 @@ bool CMainFrame::DoOpenConflict(const String& conflictFile, const String strDesc
 				(strDesc && !strDesc[2].empty()) ? strDesc[2] : _("Mine File") };
 			fileopenflags_t dwFlags[2] = {FFILEOPEN_READONLY | FFILEOPEN_NOMRU, FFILEOPEN_NOMRU | FFILEOPEN_MODIFIED};
 			PathContext tmpPathContext(revFile, workFile);
-			conflictCompared = DoFileOrFolderOpen(&tmpPathContext, dwFlags, strDesc2, L"", false, nullptr, nullptr, nullptr, 0, &openParams);
+			conflictCompared = DoFileOrFolderOpen(&tmpPathContext, dwFlags, strDesc2, L"", nullptr, nullptr, nullptr, 0, &openParams);
 		}
 		else
 		{
@@ -3111,7 +3117,7 @@ bool CMainFrame::DoOpenConflict(const String& conflictFile, const String strDesc
 				(strDesc && !strDesc[2].empty()) ? strDesc[2] : _("Mine File") };
 			PathContext tmpPathContext(baseFile, revFile, workFile);
 			fileopenflags_t dwFlags[3] = {FFILEOPEN_READONLY | FFILEOPEN_NOMRU, FFILEOPEN_READONLY | FFILEOPEN_NOMRU, FFILEOPEN_NOMRU | FFILEOPEN_MODIFIED};
-			conflictCompared = DoFileOrFolderOpen(&tmpPathContext, dwFlags, strDesc3, L"", false, nullptr, nullptr, nullptr, 0, &openParams);
+			conflictCompared = DoFileOrFolderOpen(&tmpPathContext, dwFlags, strDesc3, L"", nullptr, nullptr, nullptr, 0, &openParams);
 		}
 	}
 	else
@@ -3123,7 +3129,7 @@ bool CMainFrame::DoOpenConflict(const String& conflictFile, const String strDesc
 
 bool CMainFrame::DoSelfCompare(UINT nID, const String& file, const String strDesc[] /*= nullptr*/,
 	const PackingInfo *infoUnpacker /*= nullptr*/, const PrediffingInfo *infoPrediffer /*= nullptr*/,
-	const OpenFileParams *pOpenParams /*= nullptr*/)
+	const OpenParams *pOpenParams /*= nullptr*/)
 {
 	String ext = paths::FindExtension(file);
 	auto wTemp = std::make_shared<TempFile>(TempFile());

--- a/Src/MainFrm.cpp
+++ b/Src/MainFrm.cpp
@@ -1453,7 +1453,7 @@ bool CMainFrame::DoFileOrFolderOpen(const PathContext * pFiles /*= nullptr*/,
 	// Get bRecurse from OpenFolderParams if available, otherwise use default
 	std::optional<bool> bRecurse;
 	const auto* pOpenFolderParams = dynamic_cast<const OpenFolderParams*>(pOpenParams);
-	if (pOpenFolderParams && pOpenFolderParams->m_bRecurse.has_value())
+	if (pOpenFolderParams)
 		bRecurse = pOpenFolderParams->m_bRecurse;
 
 	bool bRecurse2 = bRecurse.has_value() ? *bRecurse : GetOptionsMgr()->GetBool(OPT_CMP_INCLUDE_SUBDIRS);

--- a/Src/MainFrm.h
+++ b/Src/MainFrm.h
@@ -89,7 +89,7 @@ public:
 		virtual ~OpenParams() {}
 	};
 
-	struct OpenFolderParams : public OpenParams
+	struct OpenFolderParams : virtual public OpenParams
 	{
 		OpenFolderParams() = default;
 		explicit OpenFolderParams(bool bRecurse) : m_bRecurse(bRecurse) {}
@@ -100,7 +100,7 @@ public:
 		std::vector<String> m_hiddenItems;
 	};
 
-	struct OpenTextFileParams : public OpenParams
+	struct OpenTextFileParams : virtual public OpenParams
 	{
 		virtual ~OpenTextFileParams() {}
 		int m_line = -1;
@@ -117,14 +117,14 @@ public:
 		std::optional<bool> m_tableAllowNewlinesInQuotes;
 	};
 
-	struct OpenBinaryFileParams : public OpenParams
+	struct OpenBinaryFileParams : virtual public OpenParams
 	{
 		virtual ~OpenBinaryFileParams() {}
 		int m_address = -1;
 		String m_strSaveAsPath; /**< "3rd path" where output saved if given */
 	};
 
-	struct OpenImageFileParams : public OpenParams
+	struct OpenImageFileParams : virtual public OpenParams
 	{
 		virtual ~OpenImageFileParams() {}
 		int m_x = -1;
@@ -132,13 +132,14 @@ public:
 		String m_strSaveAsPath; /**< "3rd path" where output saved if given */
 	};
 
-	struct OpenWebPageParams : public OpenParams
+	struct OpenWebPageParams : virtual public OpenParams
 	{
 		virtual ~OpenWebPageParams() {}
 	};
 
 	struct OpenAutoParams : public OpenTableFileParams, public OpenBinaryFileParams, public OpenImageFileParams, public OpenWebPageParams, public OpenFolderParams
 	{
+		OpenAutoParams() = default;
 		virtual ~OpenAutoParams() {}
 	};
 

--- a/Src/MainFrm.h
+++ b/Src/MainFrm.h
@@ -46,6 +46,7 @@ class CImgMergeFrame;
 class CWebPageDiffFrame;
 class DirWatcher;
 class COutputDoc;
+class CTempPathContext;
 
 typedef std::shared_ptr<TempFile> TempFilePtr;
 
@@ -83,12 +84,23 @@ public:
 		FRAME_OTHER, /**< No frame? */
 	};
 
-	struct OpenFileParams
+	struct OpenParams
 	{
-		virtual ~OpenFileParams() {}
+		virtual ~OpenParams() {}
 	};
 
-	struct OpenTextFileParams : public OpenFileParams
+	struct OpenFolderParams : public OpenParams
+	{
+		OpenFolderParams() = default;
+		explicit OpenFolderParams(bool bRecurse) : m_bRecurse(bRecurse) {}
+		OpenFolderParams(bool bRecurse, const std::vector<String>& hiddenItems) 
+			: m_bRecurse(bRecurse), m_hiddenItems(hiddenItems) {}
+		virtual ~OpenFolderParams() {}
+		std::vector<String> m_hiddenItems;
+		std::optional<bool> m_bRecurse;
+	};
+
+	struct OpenTextFileParams : public OpenParams
 	{
 		virtual ~OpenTextFileParams() {}
 		int m_line = -1;
@@ -105,14 +117,14 @@ public:
 		std::optional<bool> m_tableAllowNewlinesInQuotes;
 	};
 
-	struct OpenBinaryFileParams : public OpenFileParams
+	struct OpenBinaryFileParams : public OpenParams
 	{
 		virtual ~OpenBinaryFileParams() {}
 		int m_address = -1;
 		String m_strSaveAsPath; /**< "3rd path" where output saved if given */
 	};
 
-	struct OpenImageFileParams : public OpenFileParams
+	struct OpenImageFileParams : public OpenParams
 	{
 		virtual ~OpenImageFileParams() {}
 		int m_x = -1;
@@ -120,20 +132,14 @@ public:
 		String m_strSaveAsPath; /**< "3rd path" where output saved if given */
 	};
 
-	struct OpenWebPageParams : public OpenFileParams
+	struct OpenWebPageParams : public OpenParams
 	{
 		virtual ~OpenWebPageParams() {}
 	};
 
-	struct OpenAutoFileParams : public OpenTableFileParams, public OpenBinaryFileParams, public OpenImageFileParams
+	struct OpenAutoParams : public OpenTableFileParams, public OpenBinaryFileParams, public OpenImageFileParams, public OpenWebPageParams, public OpenFolderParams
 	{
-		virtual ~OpenAutoFileParams() {}
-	};
-
-	struct OpenFolderParams : public OpenFileParams
-	{
-		virtual ~OpenFolderParams() {}
-		std::vector<String> m_hiddenItems;
+		virtual ~OpenAutoParams() {}
 	};
 
 	CMainFrame();
@@ -156,33 +162,33 @@ public:
 
 	bool DoFileOrFolderOpen(const PathContext *pFiles = nullptr,
 		const fileopenflags_t dwFlags[] = nullptr, const String strDesc[] = nullptr,
-		const String& sReportFile = _T(""), std::optional<bool> bRecurse = false, IDirDoc *pDirDoc = nullptr,
+		const String& sReportFile = _T(""), IDirDoc *pDirDoc = nullptr,
 		const PackingInfo * infoUnpacker = nullptr, const PrediffingInfo * infoPrediffer = nullptr,
-		UINT nID = 0, const OpenFileParams *pOpenParams = nullptr);
+		UINT nID = 0, const OpenParams *pOpenParams = nullptr);
 	bool DoFileOpen(UINT nID, const PathContext* pFiles,
 		const fileopenflags_t dwFlags[] = nullptr, const String strDesc[] = nullptr,
 		const String& sReportFile = _T(""),
 		const PackingInfo* infoUnpacker = nullptr, const PrediffingInfo * infoPrediffer = nullptr,
-		const OpenFileParams *pOpenParams = nullptr);
+		const OpenParams *pOpenParams = nullptr);
 	bool DoFileNew(UINT nID, int nPanes,
 		const fileopenflags_t dwFlags[] = nullptr, const String strDesc[] = nullptr,
 		const PrediffingInfo * infoPrediffer = nullptr,
-		const OpenFileParams *pOpenParams = nullptr);
+		const OpenParams *pOpenParams = nullptr);
 	bool DoOpenConflict(const String& conflictFile, const String strDesc[] = nullptr, bool checked = false);
 	bool DoOpenClipboard(UINT nID = 0, int nBuffers = 2, const fileopenflags_t dwFlags[] = nullptr, const String strDesc[] = nullptr,
 		const PackingInfo* infoUnpacker = nullptr, const PrediffingInfo * infoPrediffer = nullptr,
-		const OpenFileParams* pOpenParams = nullptr);
+		const OpenParams* pOpenParams = nullptr);
 	bool DoSelfCompare(UINT nID, const String& file, const String strDesc[] = nullptr,
 		const PackingInfo* infoUnpacker = nullptr, const PrediffingInfo * infoPrediffer = nullptr,
-		const OpenFileParams* pOpenParams = nullptr);
+		const OpenParams* pOpenParams = nullptr);
 	bool ShowAutoMergeDoc(UINT nID, IDirDoc * pDirDoc, int nFiles, const FileLocation fileloc[],
 		const fileopenflags_t dwFlags[], const String strDesc[], const String& sReportFile = _T(""),
 		const PackingInfo * infoUnpacker = nullptr, const PrediffingInfo * infoPrediffer = nullptr,
-		const OpenFileParams *pOpenParams = nullptr);
+		const OpenParams *pOpenParams = nullptr);
 	bool ShowMergeDoc(UINT nID, IDirDoc * pDirDoc, int nFiles, const FileLocation fileloc[],
 		const fileopenflags_t dwFlags[], const String strDesc[], const String& sReportFile = _T(""),
 		const PackingInfo * infoUnpacker = nullptr, const PrediffingInfo * infoPrediffer = nullptr,
-		const OpenFileParams *pOpenParams = nullptr);
+		const OpenParams *pOpenParams = nullptr);
 	bool ShowTextOrTableMergeDoc(std::optional<bool> table, IDirDoc * pDirDoc, int nFiles, const FileLocation fileloc[],
 		const fileopenflags_t dwFlags[], const String strDesc[], const String& sReportFile = _T(""),
 		const PackingInfo * infoUnpacker = nullptr, const PrediffingInfo * infoPrediffer = nullptr,

--- a/Src/MainFrm.h
+++ b/Src/MainFrm.h
@@ -94,7 +94,7 @@ public:
 		OpenFolderParams() = default;
 		explicit OpenFolderParams(bool bRecurse) : m_bRecurse(bRecurse) {}
 		OpenFolderParams(bool bRecurse, const std::vector<String>& hiddenItems) 
-			: m_bRecurse(bRecurse), m_hiddenItems(hiddenItems) {}
+			: m_hiddenItems(hiddenItems), m_bRecurse(bRecurse) {}
 		virtual ~OpenFolderParams() {}
 		std::vector<String> m_hiddenItems;
 		std::optional<bool> m_bRecurse;

--- a/Src/MainFrm.h
+++ b/Src/MainFrm.h
@@ -94,10 +94,10 @@ public:
 		OpenFolderParams() = default;
 		explicit OpenFolderParams(bool bRecurse) : m_bRecurse(bRecurse) {}
 		OpenFolderParams(bool bRecurse, const std::vector<String>& hiddenItems) 
-			: m_hiddenItems(hiddenItems), m_bRecurse(bRecurse) {}
+			: m_bRecurse(bRecurse), m_hiddenItems(hiddenItems) {}
 		virtual ~OpenFolderParams() {}
-		std::vector<String> m_hiddenItems;
 		std::optional<bool> m_bRecurse;
+		std::vector<String> m_hiddenItems;
 	};
 
 	struct OpenTextFileParams : public OpenParams

--- a/Src/Merge.cpp
+++ b/Src/Merge.cpp
@@ -973,20 +973,13 @@ bool CMergeApp::ParseArgsAndDoOpen(MergeCmdLineInfo& cmdInfo, CMainFrame* pMainF
 			strDesc[2] = cmdInfo.m_sRightDesc;
 		}
 
-		std::unique_ptr<CMainFrame::OpenParams> pOpenParams;
-		if (cmdInfo.m_nWindowType == MergeCmdLineInfo::TEXT)
-			pOpenParams.reset(new CMainFrame::OpenTextFileParams());
-		else if (cmdInfo.m_nWindowType == MergeCmdLineInfo::TABLE)
-			pOpenParams.reset(new CMainFrame::OpenTableFileParams());
-		else
-			pOpenParams.reset(static_cast<CMainFrame::OpenTableFileParams *>(new CMainFrame::OpenAutoParams()));
+		std::unique_ptr<CMainFrame::OpenParams> pOpenParams(new CMainFrame::OpenAutoParams());
 		if (auto* pOpenTextFileParams = dynamic_cast<CMainFrame::OpenTextFileParams*>(pOpenParams.get()))
 		{
 			pOpenTextFileParams->m_line = cmdInfo.m_nLineIndex;
 			pOpenTextFileParams->m_char = cmdInfo.m_nCharIndex;
 			pOpenTextFileParams->m_fileExt = cmdInfo.m_sFileExt;
 			pOpenTextFileParams->m_strSaveAsPath = cmdInfo.m_sOutputpath;
-
 		}
 		if (auto* pOpenTableFileParams = dynamic_cast<CMainFrame::OpenTableFileParams*>(pOpenParams.get()))
 		{

--- a/Src/Merge.cpp
+++ b/Src/Merge.cpp
@@ -973,13 +973,13 @@ bool CMergeApp::ParseArgsAndDoOpen(MergeCmdLineInfo& cmdInfo, CMainFrame* pMainF
 			strDesc[2] = cmdInfo.m_sRightDesc;
 		}
 
-		std::unique_ptr<CMainFrame::OpenFileParams> pOpenParams;
+		std::unique_ptr<CMainFrame::OpenParams> pOpenParams;
 		if (cmdInfo.m_nWindowType == MergeCmdLineInfo::TEXT)
 			pOpenParams.reset(new CMainFrame::OpenTextFileParams());
 		else if (cmdInfo.m_nWindowType == MergeCmdLineInfo::TABLE)
 			pOpenParams.reset(new CMainFrame::OpenTableFileParams());
 		else
-			pOpenParams.reset(static_cast<CMainFrame::OpenTableFileParams *>(new CMainFrame::OpenAutoFileParams()));
+			pOpenParams.reset(static_cast<CMainFrame::OpenTableFileParams *>(new CMainFrame::OpenAutoParams()));
 		if (auto* pOpenTextFileParams = dynamic_cast<CMainFrame::OpenTextFileParams*>(pOpenParams.get()))
 		{
 			pOpenTextFileParams->m_line = cmdInfo.m_nLineIndex;
@@ -1002,6 +1002,10 @@ bool CMergeApp::ParseArgsAndDoOpen(MergeCmdLineInfo& cmdInfo, CMainFrame* pMainF
 		{
 			pOpenImageFileParams->m_strSaveAsPath = cmdInfo.m_sOutputpath;
 		}
+		if (auto* pOpenFolderFileParams = dynamic_cast<CMainFrame::OpenFolderParams*>(pOpenParams.get()))
+		{
+			pOpenFolderFileParams->m_bRecurse = cmdInfo.m_bRecurse;
+		}
 		if (cmdInfo.m_Files.GetSize() > 2)
 		{
 			cmdInfo.m_dwLeftFlags |= FFILEOPEN_CMDLINE;
@@ -1009,14 +1013,14 @@ bool CMergeApp::ParseArgsAndDoOpen(MergeCmdLineInfo& cmdInfo, CMainFrame* pMainF
 			cmdInfo.m_dwRightFlags |= FFILEOPEN_CMDLINE;
 			fileopenflags_t dwFlags[3] = {cmdInfo.m_dwLeftFlags, cmdInfo.m_dwMiddleFlags, cmdInfo.m_dwRightFlags};
 			bCompared = pMainFrame->DoFileOrFolderOpen(&cmdInfo.m_Files,
-				dwFlags, strDesc, cmdInfo.m_sReportFile, cmdInfo.m_bRecurse, nullptr,
+				dwFlags, strDesc, cmdInfo.m_sReportFile, nullptr,
 				infoUnpacker.get(), infoPrediffer.get(), nID, pOpenParams.get());
 		}
 		else if (cmdInfo.m_Files.GetSize() > 1)
 		{
 			fileopenflags_t dwFlags[3] = {cmdInfo.m_dwLeftFlags, cmdInfo.m_dwRightFlags, FFILEOPEN_NONE};
 			bCompared = pMainFrame->DoFileOrFolderOpen(&cmdInfo.m_Files,
-				dwFlags, strDesc, cmdInfo.m_sReportFile, cmdInfo.m_bRecurse, nullptr,
+				dwFlags, strDesc, cmdInfo.m_sReportFile, nullptr,
 				infoUnpacker.get(), infoPrediffer.get(), nID, pOpenParams.get());
 		}
 		else if (cmdInfo.m_Files.GetSize() == 1)
@@ -1045,7 +1049,7 @@ bool CMergeApp::ParseArgsAndDoOpen(MergeCmdLineInfo& cmdInfo, CMainFrame* pMainF
 			{
 				fileopenflags_t dwFlags[3] = {cmdInfo.m_dwLeftFlags, cmdInfo.m_dwRightFlags, FFILEOPEN_NONE};
 				bCompared = pMainFrame->DoFileOrFolderOpen(&cmdInfo.m_Files,
-					dwFlags, strDesc, cmdInfo.m_sReportFile, cmdInfo.m_bRecurse, nullptr,
+					dwFlags, strDesc, cmdInfo.m_sReportFile, nullptr,
 					infoUnpacker.get(), infoPrediffer.get(), nID, pOpenParams.get());
 			}
 		}
@@ -1519,16 +1523,15 @@ bool CMergeApp::LoadAndOpenProjectFile(const String& sProject, const String& sRe
 
 		std::unique_ptr<CMainFrame::OpenFolderParams> pOpenFolderParams;
 		if ((Options::Project::Get(GetOptionsMgr(), Options::Project::Operation::Open, Options::Project::Item::HiddenItems)) && projItem.HasHiddenItems())
-		{
-			pOpenFolderParams = std::make_unique<CMainFrame::OpenFolderParams>();
-			pOpenFolderParams->m_hiddenItems = projItem.GetHiddenItems();
-		}
+			pOpenFolderParams = std::make_unique<CMainFrame::OpenFolderParams>(bRecursive, projItem.GetHiddenItems());
+		else
+			pOpenFolderParams = std::make_unique<CMainFrame::OpenFolderParams>(bRecursive);
 
-		rtn &= GetMainFrame()->DoFileOrFolderOpen(&tFiles, dwFlags, strDesc, sReportFile, bRecursive,
+		rtn &= GetMainFrame()->DoFileOrFolderOpen(&tFiles, dwFlags, strDesc, sReportFile,
 			nullptr, pInfoUnpacker.get(), pInfoPrediffer.get(), nID,
 			nID == ID_MERGE_COMPARE_TABLE ?
-				static_cast<CMainFrame::OpenFileParams*>(pOpenTableFileParams.get()) :
-				static_cast<CMainFrame::OpenFileParams*>(pOpenFolderParams.get()));
+				static_cast<CMainFrame::OpenParams*>(pOpenTableFileParams.get()) :
+				static_cast<CMainFrame::OpenParams*>(pOpenFolderParams.get()));
 	}
 
 	AddToRecentProjectsMRU(sProject.c_str());

--- a/Src/MergeDoc.cpp
+++ b/Src/MergeDoc.cpp
@@ -2822,7 +2822,7 @@ void CMergeDoc::OnOpenWithUnpacker()
 	nID = GetOptionsMgr()->GetBool(OPT_PLUGINS_OPEN_IN_SAME_FRAME_TYPE) ? nID : -nID;
 
 	if (GetMainFrame()->DoFileOrFolderOpen(&paths, dwFlags, strDesc, _T(""),
-		GetOptionsMgr()->GetBool(OPT_CMP_INCLUDE_SUBDIRS), nullptr, &infoUnpacker, nullptr, nID))
+		nullptr, &infoUnpacker, nullptr, nID))
 		GetParentFrame()->DestroyWindow();
 }
 
@@ -3079,7 +3079,7 @@ void CMergeDoc::OnFileRecompareAs(UINT nID)
 	}
 
 	if (GetMainFrame()->DoFileOrFolderOpen(&m_filePaths, dwFlags, strDesc, _T(""),
-	    GetOptionsMgr()->GetBool(OPT_CMP_INCLUDE_SUBDIRS), nullptr, &infoUnpacker, nullptr, nID))
+		nullptr, &infoUnpacker, nullptr, nID))
 		GetParentFrame()->DestroyWindow();
 }
 

--- a/Src/OpenView.cpp
+++ b/Src/OpenView.cpp
@@ -819,22 +819,21 @@ void COpenView::OnCompare(UINT nID)
 	bool recurse = pDoc->m_bRecurse;
 	std::unique_ptr<CMainFrame::OpenFolderParams> pOpenFolderParams;
 	if (!pDoc->m_hiddenItems.empty())
-	{
-		pOpenFolderParams = std::make_unique<CMainFrame::OpenFolderParams>();
-		pOpenFolderParams->m_hiddenItems = pDoc->m_hiddenItems;
-	}
+		pOpenFolderParams = std::make_unique<CMainFrame::OpenFolderParams>(recurse, pDoc->m_hiddenItems);
+	else
+		pOpenFolderParams = std::make_unique<CMainFrame::OpenFolderParams>(recurse);
 	if (nID == IDOK)
 	{
 		GetMainFrame()->DoFileOrFolderOpen(
 			&tmpPathContext, dwFlags.data(),
-			nullptr, _T(""), recurse, nullptr, &tmpPackingInfo, &tmpPrediffingInfo, 0, pOpenFolderParams.get());
+			nullptr, _T(""), nullptr, &tmpPackingInfo, &tmpPrediffingInfo, 0, pOpenFolderParams.get());
 	}
 	else if (ID_UNPACKERS_FIRST <= nID && nID <= ID_UNPACKERS_LAST)
 	{
 		tmpPackingInfo.SetPluginPipeline(CMainFrame::GetPluginPipelineByMenuId(nID, FileTransform::UnpackerEventNames, ID_UNPACKERS_FIRST));
 		GetMainFrame()->DoFileOrFolderOpen(
 			&tmpPathContext, dwFlags.data(),
-			nullptr, _T(""), recurse, nullptr, &tmpPackingInfo, &tmpPrediffingInfo, 0, pOpenFolderParams.get());
+			nullptr, _T(""), nullptr, &tmpPackingInfo, &tmpPrediffingInfo, 0, pOpenFolderParams.get());
 	}
 	else if (nID == ID_OPEN_WITH_UNPACKER)
 	{
@@ -845,7 +844,7 @@ void COpenView::OnCompare(UINT nID)
 			tmpPackingInfo.SetPluginPipeline(dlg.GetPluginPipeline());
 			GetMainFrame()->DoFileOrFolderOpen(
 				&tmpPathContext, dwFlags.data(),
-				nullptr, _T(""), recurse, nullptr, &tmpPackingInfo, &tmpPrediffingInfo, 0, pOpenFolderParams.get());
+				nullptr, _T(""), nullptr, &tmpPackingInfo, &tmpPrediffingInfo, 0, pOpenFolderParams.get());
 		}
 	}
 	else

--- a/Src/WebPageDiffFrm.cpp
+++ b/Src/WebPageDiffFrm.cpp
@@ -767,7 +767,7 @@ void CWebPageDiffFrame::OnFileRecompareAs(UINT nID)
 
 	CloseNow();
 	GetMainFrame()->DoFileOrFolderOpen(&paths, dwFlags, strDesc, _T(""),
-		GetOptionsMgr()->GetBool(OPT_CMP_INCLUDE_SUBDIRS), nullptr, &infoUnpacker, nullptr, nID);
+		nullptr, &infoUnpacker, nullptr, nID);
 }
 
 void CWebPageDiffFrame::OnUpdateFileRecompareAs(CCmdUI* pCmdUI)
@@ -1493,7 +1493,8 @@ void CWebPageDiffFrame::OnWebCompareResourceTrees()
 				fileopenflags_t dwFlags[3]{};
 				for (int pane = 0; pane < paths.GetSize(); ++pane)
 					dwFlags[pane] = FFILEOPEN_NOMRU;
-				GetMainFrame()->DoFileOrFolderOpen(&paths, dwFlags, descs.data(), _T(""), true);
+				CMainFrame::OpenFolderParams openFolderParams(true);
+				GetMainFrame()->DoFileOrFolderOpen(&paths, dwFlags, descs.data(), _T(""), nullptr, nullptr, nullptr, 0, &openFolderParams);
 				return S_OK;
 			}));
 }


### PR DESCRIPTION
Refactor open parameter handling by introducing OpenParams as a common base.

- Rename OpenFileParams to OpenParams
- Move recurse option to OpenFolderParams
- Update all call sites to use OpenParams
- Centralize folder-related options (recurse, hidden items)

Behavior remains unchanged (falls back to options when not specified).