### PR TITLE
Code review fixes for 5 oldest source files

### DIFF
--- a/Src/Common/Shell.cpp
+++ b/Src/Common/Shell.cpp
@@ -46,6 +46,9 @@ void OpenFileOrUrl(const tchar_t * szFile, const tchar_t * szUrl)
 void OpenParentFolder(const tchar_t * szFile)
 {
 	String param = _T("/select,\"") + String(szFile) + _T("\"");
+	// Add extra quotes if filename contains spaces
+	if (param.find(_T(' ')) != String::npos)
+		param = _T("\"") + param + _T("\"");
 	ShellExecute(nullptr, _T("open"), _T("explorer.exe"), param.c_str(), nullptr, SW_SHOWNORMAL);
 }
 

--- a/Src/Common/UnicodeString.cpp
+++ b/Src/Common/UnicodeString.cpp
@@ -53,7 +53,7 @@ String strip_hot_key(const String& str)
 	String str2 = str;
 	auto it = str2.find(_T("(&"));
 	if (it != String::npos)
-		str2.erase(it, it + 2);
+		str2.erase(it, it + 3);
 	strutils::replace(str2, _T("&"), _T(""));
 	return str2;
 }

--- a/Src/Common/VersionInfo.cpp
+++ b/Src/Common/VersionInfo.cpp
@@ -199,10 +199,10 @@ void CVersionInfo::GetVersionInfo()
 	DWORD dwVerInfoSize = ::GetFileVersionInfoSize(szFileName, &dwVerHnd);
 	if (dwVerInfoSize)
 	{
-		m_bVersionFound = true;
 		m_pVffInfo.reset(new BYTE[dwVerInfoSize]);
 		if (::GetFileVersionInfo(szFileName, 0, dwVerInfoSize, m_pVffInfo.get()))
 		{
+			m_bVersionFound = true;
 			GetFixedVersionInfo();
 			if (!m_bVersionOnly)
 				QueryStrings();

--- a/Src/Common/paths.cpp
+++ b/Src/Common/paths.cpp
@@ -400,8 +400,8 @@ PATH_EXISTENCE GetPairComparability(const PathContext & paths, bool (*IsArchiveF
 	PATH_EXISTENCE p2 = DoesPathExist(paths[1], IsArchiveFile);
 	if (p1 != p2)
 	{
-		p1 = DoesPathExist(paths[0]);
-		p2 = DoesPathExist(paths[1]);
+		p1 = DoesPathExist(paths[0], IsArchiveFile);
+		p2 = DoesPathExist(paths[1], IsArchiveFile);
 		if (p1 != p2)
 			return DOES_NOT_EXIST;
 	}
@@ -409,9 +409,9 @@ PATH_EXISTENCE GetPairComparability(const PathContext & paths, bool (*IsArchiveF
 	PATH_EXISTENCE p3 = DoesPathExist(paths[2], IsArchiveFile);
 	if (p2 != p3)
 	{
-		p1 = DoesPathExist(paths[0]);
-		p2 = DoesPathExist(paths[1]);
-		p3 = DoesPathExist(paths[2]);
+		p1 = DoesPathExist(paths[0], IsArchiveFile);
+		p2 = DoesPathExist(paths[1], IsArchiveFile);
+		p3 = DoesPathExist(paths[2], IsArchiveFile);
 		if (p1 != p2 || p2 != p3)
 			return DOES_NOT_EXIST;
 	}


### PR DESCRIPTION
## Summary

This PR contains code review fixes for 5 of the oldest source files in the codebase:

### Files Modified

1. **Src/Common/UnicodeString.cpp** - Fixed `strip_hot_key()` function
   - Bug: The function was erasing only 2 characters ("(&") but should erase 3 characters ("(&X") to fully remove the hotkey marker including the accelerator character
   - Change: `str2.erase(it, it + 2)` → `str2.erase(it, it + 3)`

2. **Src/Common/VersionInfo.cpp** - Fixed `GetVersionInfo()` function
   - Bug: `m_bVersionFound` was set to `true` before calling `GetFileVersionInfo()`, which could leave stale state if the function fails
   - Change: Moved `m_bVersionFound = true` inside the success block after `GetFileVersionInfo()` succeeds

3. **Src/Common/Shell.cpp** - Fixed `OpenParentFolder()` function
   - Bug: Filenames containing spaces were not properly quoted when passed to explorer.exe
   - Change: Added check for spaces and extra quoting when needed

4. **Src/Common/paths.cpp** - Fixed `GetPairComparability()` function
   - Bug: The fallback `DoesPathExist()` calls weren't passing the `IsArchiveFile` callback, causing inconsistent behavior
   - Change: Added `IsArchiveFile` parameter to all fallback `DoesPathExist()` calls

5. **Src/Common/Shell.h** - Reviewed, no issues found (header-only declarations)

### Testing

These changes fix bugs that could cause:
- Incorrect hotkey stripping in menu items
- False positive version info detection
- Explorer failure when opening parent folders of files with spaces in names
- Incorrect path comparison results when archive files are involved

All changes are backward compatible and don't alter the public API.

---
Generated by Claude Code