### PR TITLE
Fix tree-sitter go to definition from context menus

### DIFF
--- a/Externals/crystaledit/editlib/TreeSitterParser.cpp
+++ b/Externals/crystaledit/editlib/TreeSitterParser.cpp
@@ -2079,28 +2079,35 @@ bool CTreeSitterParser::FindDefinition(int nLineIndex, int nCharPos, int& nDefLi
 
     uint32_t tagDefStartByte = 0;
     uint32_t tagDefEndByte = 0;
-    const bool foundTagByName = TryGetTagDefinitionByNameAt(
-        nLineIndex, nCharPos, tagDefStartByte, tagDefEndByte);
+    if (!foundAtPosition)
+    {
+        if (!TryGetTagDefinitionByNameAt(
+                nLineIndex, nCharPos, tagDefStartByte, tagDefEndByte))
+            return false;
 
-    if (!foundAtPosition && !foundTagByName)
-        return false;
-
-    if (foundTagByName)
+        defStartByte = tagDefStartByte;
+        defEndByte = tagDefEndByte;
+    }
+    else
     {
         int posDefLine = 0;
         int posDefChar = 0;
-        const bool positionResolved = foundAtPosition &&
+        const bool positionResolved =
             ByteOffsetToLineChar(defStartByte, posDefLine, posDefChar);
 
-        // If the position-based lookup resolves to the current line, prefer the
-        // tag-definition target when it points somewhere else. This avoids
-        // getting stuck on the clicked type reference after the context-menu
-        // click has moved the caret onto the symbol.
-        if (!positionResolved ||
-            (posDefLine == nLineIndex && tagDefStartByte != defStartByte))
+        // If the position-based lookup resolves back to the clicked symbol,
+        // prefer the tag-definition target when it points somewhere else.
+        // This avoids getting stuck on the clicked type reference after the
+        // context-menu click has moved the caret onto the symbol.
+        if (!positionResolved || (posDefLine == nLineIndex && posDefChar == nCharPos))
         {
-            defStartByte = tagDefStartByte;
-            defEndByte = tagDefEndByte;
+            if (TryGetTagDefinitionByNameAt(
+                    nLineIndex, nCharPos, tagDefStartByte, tagDefEndByte) &&
+                (!positionResolved || tagDefStartByte != defStartByte))
+            {
+                defStartByte = tagDefStartByte;
+                defEndByte = tagDefEndByte;
+            }
         }
     }
 

--- a/Externals/crystaledit/editlib/TreeSitterParser.cpp
+++ b/Externals/crystaledit/editlib/TreeSitterParser.cpp
@@ -2075,9 +2075,34 @@ bool CTreeSitterParser::FindDefinition(int nLineIndex, int nCharPos, int& nDefLi
 
     uint32_t defStartByte = 0;
     uint32_t defEndByte = 0;
-    if (!TryGetDefinitionByteRangeAt(byteOffset, defStartByte, defEndByte) &&
-        !TryGetTagDefinitionByNameAt(nLineIndex, nCharPos, defStartByte, defEndByte))
+    const bool foundAtPosition = TryGetDefinitionByteRangeAt(byteOffset, defStartByte, defEndByte);
+
+    uint32_t tagDefStartByte = 0;
+    uint32_t tagDefEndByte = 0;
+    const bool foundTagByName = TryGetTagDefinitionByNameAt(
+        nLineIndex, nCharPos, tagDefStartByte, tagDefEndByte);
+
+    if (!foundAtPosition && !foundTagByName)
         return false;
+
+    if (foundTagByName)
+    {
+        int posDefLine = 0;
+        int posDefChar = 0;
+        const bool positionResolved = foundAtPosition &&
+            ByteOffsetToLineChar(defStartByte, posDefLine, posDefChar);
+
+        // If the position-based lookup resolves to the current line, prefer the
+        // tag-definition target when it points somewhere else. This avoids
+        // getting stuck on the clicked type reference after the context-menu
+        // click has moved the caret onto the symbol.
+        if (!positionResolved ||
+            (posDefLine == nLineIndex && tagDefStartByte != defStartByte))
+        {
+            defStartByte = tagDefStartByte;
+            defEndByte = tagDefEndByte;
+        }
+    }
 
     return ByteOffsetToLineChar(defStartByte, nDefLine, nDefChar);
 }

--- a/Src/MergeEditView.cpp
+++ b/Src/MergeEditView.cpp
@@ -3003,6 +3003,23 @@ void CMergeEditView::OnContextMenu(CWnd* pWnd, CPoint point)
 		point = rect.TopLeft();
 		point.Offset(5, 5);
 	}
+	else
+	{
+		CPoint clientPoint = point;
+		ScreenToClient(&clientPoint);
+		if (clientPoint.y >= GetTopMarginHeight())
+		{
+			CEPoint textPoint = ClientToText(clientPoint);
+			if (IsValidTextPosY(textPoint))
+			{
+				if (!IsValidTextPosX(textPoint))
+					textPoint.x = GetLineLength(textPoint.y);
+				SetCursorPos(textPoint);
+				SetAnchor(textPoint);
+				SetSelection(textPoint, textPoint);
+			}
+		}
+	}
 
 	pSub->TrackPopupMenu(TPM_LEFTALIGN | TPM_RIGHTBUTTON,
 		point.x, point.y, AfxGetMainWnd());

--- a/Src/MergeEditView.cpp
+++ b/Src/MergeEditView.cpp
@@ -3009,14 +3009,19 @@ void CMergeEditView::OnContextMenu(CWnd* pWnd, CPoint point)
 		ScreenToClient(&clientPoint);
 		if (clientPoint.y >= GetTopMarginHeight())
 		{
-			CEPoint textPoint = ClientToText(clientPoint);
+			CPoint adjustedPoint = clientPoint;
+			AdjustTextPoint(adjustedPoint);
+			CEPoint textPoint = ClientToText(adjustedPoint);
 			if (IsValidTextPosY(textPoint))
 			{
 				if (!IsValidTextPosX(textPoint))
 					textPoint.x = GetLineLength(textPoint.y);
 				SetCursorPos(textPoint);
-				SetAnchor(textPoint);
-				SetSelection(textPoint, textPoint);
+				if (!IsSelection() || !IsInsideSelBlock(textPoint))
+				{
+					SetAnchor(textPoint);
+					SetSelection(textPoint, textPoint);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
- move the caret to the symbol under the mouse before running context-menu navigation commands
- prefer the tagged definition target when a right-clicked type reference resolves to the current line instead of the earlier type definition
- fix right-click go-to-definition for type annotations