### PR TITLE
Tree-sitter: correctness fixes, option gating, and editor UX features

### DIFF
--- a/Externals/crystaledit/editlib/ccrystaltextbuffer.h
+++ b/Externals/crystaledit/editlib/ccrystaltextbuffer.h
@@ -156,7 +156,7 @@ public :
     };
     std::shared_ptr<SharedTableProperties> m_pSharedTableProps;
 
-	void* pParseContext; // context for incremental parsing, owned by the parser
+	void* pParseContext = nullptr; // context for incremental parsing, owned by the parser
 
     //  Helper methods
     void InsertLine (const tchar_t* pszLine, size_t nLength, int nPosition = -1, int nCount = 1);

--- a/Externals/crystaledit/editlib/ccrystaltextmarkers.cpp
+++ b/Externals/crystaledit/editlib/ccrystaltextmarkers.cpp
@@ -74,6 +74,19 @@ void CCrystalTextMarkers::UpdateViews()
 		pView->UpdateView(nullptr, nullptr, 0, -1);
 }
 
+/**
+ * @brief Repaint all attached views without resetting their caches.
+ *
+ * Markers only affect colors, not parse state, line lengths or wrapping,
+ * so a plain repaint is enough to show a marker change. Use this instead
+ * of UpdateViews() for frequent changes (e.g. caret-following markers).
+ */
+void CCrystalTextMarkers::InvalidateViews()
+{
+	for (auto& pView : m_views)
+		pView->Invalidate(false);
+}
+
 CString CCrystalTextMarkers::Serialize() const
 {
 	CString text;

--- a/Externals/crystaledit/editlib/ccrystaltextmarkers.h
+++ b/Externals/crystaledit/editlib/ccrystaltextmarkers.h
@@ -36,6 +36,7 @@ public:
 	void AddView(CCrystalTextView *pView);
 	void DeleteView(CCrystalTextView *pView);
 	void UpdateViews();
+	void InvalidateViews();
 	void SetEnabled(bool enabled) { m_enabled = enabled; };
 	bool GetEnabled() const { return m_enabled; };
 	CString MakeNewId() const;

--- a/Externals/crystaledit/editlib/ccrystaltextview.h
+++ b/Externals/crystaledit/editlib/ccrystaltextview.h
@@ -769,6 +769,7 @@ public :
 
     //  Source type
     CrystalLineParser::TextDefinition *m_CurSourceDef;
+    CrystalLineParser::TextDefinition *GetTextType () const { return m_CurSourceDef; }
     virtual bool DoSetTextType (CrystalLineParser::TextDefinition *def);
     virtual bool SetTextType (const tchar_t* pszExt);
     virtual bool SetTextType (CrystalLineParser::TextType enuType);

--- a/Src/CompareEngines/FullQuickCompare.cpp
+++ b/Src/CompareEngines/FullQuickCompare.cpp
@@ -17,8 +17,6 @@
 #include "codepage_detect.h"
 #include "Logger.h"
 #include "TFile.h"
-#include "coretools.h"
-#include "../TreeSitterWrapper.h"
 
 namespace CompareEngines
 {
@@ -201,30 +199,6 @@ void FullQuickCompare::CompareFiles(DIFFITEM& di) const
 			dw.SetFilterList(m_pCtxt->m_pFilterList);
 			dw.SetSubstitutionList(m_pCtxt->m_pSubstitutionList);
 			dw.SetFilterCommentsSourceDef(Ext);
-
-			std::unique_ptr<void, void(*)(void*)> treeSitterParsers[3] = {
-				{ nullptr, DestroyTreeSitterParseContextForDiff },
-				{ nullptr, DestroyTreeSitterParseContextForDiff },
-				{ nullptr, DestroyTreeSitterParseContextForDiff }
-			};
-			if (dw.GetOptions().m_filterCommentsLines)
-			{
-				DiffFileData* fileDiffs[3] = { &diffdata10, &diffdata12, &diffdata02 };
-				for (int i = 0; i < 3; ++i)
-				{
-					const int targetIndex = (i == 0) ? 1 : (i == 1 ? 0 : 1);
-					std::vector<String> lines;
-					for (int line = 0; line < fileDiffs[i]->m_inf[targetIndex].valid_lines; ++line)
-					{
-						const char* start = fileDiffs[i]->m_inf[targetIndex].linbuf[fileDiffs[i]->m_inf[targetIndex].linbuf_base + line];
-						const char* end = fileDiffs[i]->m_inf[targetIndex].linbuf[fileDiffs[i]->m_inf[targetIndex].linbuf_base + line + 1];
-						const size_t fullLen = static_cast<size_t>(end - start);
-						lines.push_back(ucr::toTString(std::string(start, linelen(start, fullLen))));
-					}
-					treeSitterParsers[i].reset(CreateTreeSitterParseContextForDiff(ucr::toTString(fileDiffs[i]->m_inf[targetIndex].name), lines));
-					dw.SetFilterCommentsParseContext(treeSitterParsers[i].get(), i);
-				}
-			}
 			dw.SetCreateDiffList(&diffList);
 			dw.LoadWinMergeDiffsFromDiffUtilsScript3(
 				script10, script12, script02,

--- a/Src/CompareEngines/Wrap_DiffUtils.cpp
+++ b/Src/CompareEngines/Wrap_DiffUtils.cpp
@@ -22,7 +22,6 @@
 #include "xdiff_gnudiff_compat.h"
 #include "unicoder.h"
 #include "DiffFileData.h"
-#include "../TreeSitterWrapper.h"
 
 namespace CompareEngines
 {
@@ -127,28 +126,6 @@ int DiffUtils::CompareFiles(DiffFileData* diffData)
 			Ext.erase(0, PosOfDot + 1);
 
 		m_pDiffWrapper->SetFilterCommentsSourceDef(Ext);
-
-		std::unique_ptr<void, void(*)(void*)> treeSitterParsers[2] = {
-			{ nullptr, DestroyTreeSitterParseContextForDiff },
-			{ nullptr, DestroyTreeSitterParseContextForDiff }
-		};
-		if (m_pDiffWrapper->GetOptions().m_filterCommentsLines)
-		{
-			for (int i = 0; i < 2; ++i)
-			{
-				std::vector<String> lines;
-				for (int line = 0; line < diffData->m_inf[i].valid_lines; ++line)
-				{
-					const char* start = diffData->m_inf[i].linbuf[diffData->m_inf[i].linbuf_base + line];
-					const char* end = diffData->m_inf[i].linbuf[diffData->m_inf[i].linbuf_base + line + 1];
-					const size_t fullLen = static_cast<size_t>(end - start);
-					String text = ucr::toTString(std::string(start, linelen(start, fullLen)));
-					lines.push_back(std::move(text));
-				}
-				treeSitterParsers[i].reset(CreateTreeSitterParseContextForDiff(ucr::toTString(diffData->m_inf[i].name), lines));
-				m_pDiffWrapper->SetFilterCommentsParseContext(treeSitterParsers[i].get(), i);
-			}
-		}
 
 		struct change *next = script;
 

--- a/Src/CompareOptions.cpp
+++ b/Src/CompareOptions.cpp
@@ -70,6 +70,7 @@ DiffutilsOptions::DiffutilsOptions()
 , m_diffAlgorithm(DIFF_ALGORITHM_DEFAULT)
 , m_contextLines(0)
 , m_filterCommentsLines(false)
+, m_bTreeSitterCommentFilter(true)
 , m_bCompletelyBlankOutIgnoredDiffereneces(false)
 , m_bIndentHeuristic(true)
 {
@@ -85,6 +86,7 @@ DiffutilsOptions::DiffutilsOptions(const CompareOptions& options)
 , m_diffAlgorithm(DIFF_ALGORITHM_DEFAULT)
 , m_contextLines(0)
 , m_filterCommentsLines(false)
+, m_bTreeSitterCommentFilter(true)
 , m_bCompletelyBlankOutIgnoredDiffereneces(false)
 , m_bIndentHeuristic(true)
 {
@@ -99,6 +101,7 @@ void DiffutilsOptions::SetFromDiffOptions(const DIFFOPTIONS & options)
 	CompareOptions::SetFromDiffOptions(options);
 	m_bCompletelyBlankOutIgnoredDiffereneces = options.bCompletelyBlankOutIgnoredChanges;
 	m_filterCommentsLines = options.bFilterCommentsLines;
+	m_bTreeSitterCommentFilter = options.bTreeSitterCommentFilter;
 	m_bIndentHeuristic = options.bIndentHeuristic;
 	switch (options.nDiffAlgorithm)
 	{
@@ -186,6 +189,7 @@ void DiffutilsOptions::GetAsDiffOptions(DIFFOPTIONS &options) const
 {
 	options.bCompletelyBlankOutIgnoredChanges = m_bCompletelyBlankOutIgnoredDiffereneces;
 	options.bFilterCommentsLines = m_filterCommentsLines;
+	options.bTreeSitterCommentFilter = m_bTreeSitterCommentFilter;
 	options.bIgnoreBlankLines = m_bIgnoreBlankLines;
 	options.bIgnoreCase = m_bIgnoreCase;
 	options.bIgnoreEol = m_bIgnoreEOLDifference;

--- a/Src/CompareOptions.h
+++ b/Src/CompareOptions.h
@@ -89,6 +89,7 @@ struct DIFFOPTIONS
 	bool bCompletelyBlankOutIgnoredChanges;
 	bool bIgnoreMissingTrailingEol; /**< Ignore missing trailing EOL -option. */
 	bool bIgnoreLineBreaks; /**< Ignore line breaks (treat as spaces) -option. */
+	bool bTreeSitterCommentFilter = true; /**< Use tree-sitter (when a grammar is available) for the comments filter. */
 };
 
 /**
@@ -130,6 +131,7 @@ public:
 	DiffAlgorithm m_diffAlgorithm; /** Diff algorithm */
 	int m_contextLines; /**< Number of context lines (for patch files) */
 	bool m_filterCommentsLines;/**< Ignore Multiline comments differences.*/
+	bool m_bTreeSitterCommentFilter; /**< Use tree-sitter (when a grammar is available) for the comments filter */
 	bool m_bIndentHeuristic; /**< Indent heuristic */
 	bool m_bCompletelyBlankOutIgnoredDiffereneces; /**< Completely blank out ignored differences */
 };

--- a/Src/DiffWrapper.cpp
+++ b/Src/DiffWrapper.cpp
@@ -231,7 +231,7 @@ static String convertToTString(const char* start, const char* end)
 	}
 }
 
-static unsigned GetLastLineCookie(unsigned dwCookie, int startLine, int endLine, const char **linbuf, CrystalLineParser::TextDefinition* enuType, void* parseContext)
+static unsigned GetLastLineCookie(unsigned dwCookie, int startLine, int endLine, const char **linbuf, CrystalLineParser::TextDefinition* enuType)
 {
 	if (!enuType)
 		return dwCookie;
@@ -240,12 +240,12 @@ static unsigned GetLastLineCookie(unsigned dwCookie, int startLine, int endLine,
 		String text = convertToTString(linbuf[i], linbuf[i + 1]);
 		int nActualItems = 0;
 		std::vector<CrystalLineParser::TEXTBLOCK> blocks(text.length());
-		dwCookie = enuType->ParseLineX(dwCookie, i, text.c_str(), static_cast<int>(text.length()), blocks.data(), nActualItems, parseContext);
+		dwCookie = enuType->ParseLineX(dwCookie, i, text.c_str(), static_cast<int>(text.length()), blocks.data(), nActualItems, nullptr);
 	}
 	return dwCookie;
 }
 
-static std::tuple<std::string, unsigned, std::vector<bool>> GetCommentsFilteredText(unsigned dwCookie, int startLine, int endLine, const char **linbuf, CrystalLineParser::TextDefinition* enuType, void* parseContext)
+static std::tuple<std::string, unsigned, std::vector<bool>> GetCommentsFilteredText(unsigned dwCookie, int startLine, int endLine, const char **linbuf, CrystalLineParser::TextDefinition* enuType)
 {
 	String filteredT;
 	std::vector<bool> allTextIsComment(endLine - startLine + 1);
@@ -261,7 +261,7 @@ static std::tuple<std::string, unsigned, std::vector<bool>> GetCommentsFilteredT
 		{
 			int nActualItems = 0;
 			std::vector<CrystalLineParser::TEXTBLOCK> blocks(textlen);
-			dwCookie = enuType->ParseLineX(dwCookie, i, text.c_str(), textlen, blocks.data(), nActualItems, parseContext);
+			dwCookie = enuType->ParseLineX(dwCookie, i, text.c_str(), textlen, blocks.data(), nActualItems, nullptr);
 
 			if (nActualItems == 0)
 			{
@@ -389,6 +389,15 @@ static std::string GetEOL(const std::string& str)
  * @param [in, out]  thisob	Current change
  * @return Number of trivial diffs inserted
  */
+PostFilterContext::~PostFilterContext()
+{
+	for (void* ctx : pTreeSitterContext)
+	{
+		if (ctx != nullptr)
+			DestroyTreeSitterParseContextForDiff(ctx);
+	}
+}
+
 int CDiffWrapper::PostFilter(PostFilterContext& ctxt, change* thisob, const file_data *file_data_ary) const
 {
 	const int first0 = thisob->line0;
@@ -408,43 +417,81 @@ int CDiffWrapper::PostFilter(PostFilterContext& ctxt, change* thisob, const file
 
 	if (m_options.m_filterCommentsLines)
 	{
-		const bool bUseTreeSitter = m_pParseContext[0] != nullptr && m_pParseContext[1] != nullptr;
+		if (!ctxt.bTreeSitterContextInitialized)
+		{
+			ctxt.bTreeSitterContextInitialized = true;
+			if (m_options.m_bTreeSitterCommentFilter)
+			{
+				// Create tree-sitter parse contexts for both files of this
+				// compared pair from the very text being diffed, so the line
+				// numbers used below always match the parsed text. The
+				// grammar is chosen by file extension: the diffed paths may
+				// be extension-less temp files (editor rescan saves buffers
+				// as "*.tmp"), so prefer the original compare paths when the
+				// caller provided them via SetCompareFiles().
+				for (int side = 0; side < 2; ++side)
+				{
+					const file_data& inf = file_data_ary[side];
+					const int nPane = ctxt.nPaneIndexes[side];
+					String name = (nPane < m_originalFile.GetSize() && !m_originalFile[nPane].empty()) ?
+						m_originalFile[nPane] : ucr::toTString(inf.name);
+					if (!HasTreeSitterLanguageForFile(name))
+						continue;
+					std::vector<String> lines;
+					lines.reserve(inf.valid_lines);
+					for (int line = 0; line < inf.valid_lines; ++line)
+					{
+						const char* start = inf.linbuf[inf.linbuf_base + line];
+						const char* end = inf.linbuf[inf.linbuf_base + line + 1];
+						// Use the same decoding as GetTreeSitterCommentsFilteredText
+						// (convertToTString) so the parser's character positions
+						// line up with the positions queried below.
+						lines.push_back(convertToTString(start, start + linelen(start, end - start)));
+					}
+					ctxt.pTreeSitterContext[side] = CreateTreeSitterParseContextForDiff(name, lines);
+				}
+			}
+		}
+		const bool bUseTreeSitter =
+			ctxt.pTreeSitterContext[0] != nullptr && ctxt.pTreeSitterContext[1] != nullptr;
 
 		if (bUseTreeSitter)
 		{
 			ctxt.nParsedLineEndLeft = lineNumberLeft + qtyLinesLeft - 1;
-			ctxt.nParsedLineEndRight = lineNumberRight + qtyLinesRight - 1;;
+			ctxt.nParsedLineEndRight = lineNumberRight + qtyLinesRight - 1;
 
 			auto resultLeft = GetTreeSitterCommentsFilteredText(
 				lineNumberLeft, ctxt.nParsedLineEndLeft,
-				file_data_ary[0].linbuf + file_data_ary[0].linbuf_base, m_pParseContext[0]);
+				file_data_ary[0].linbuf + file_data_ary[0].linbuf_base, ctxt.pTreeSitterContext[0]);
 			lineDataLeft = std::move(std::get<0>(resultLeft));
 			allTextIsCommentLeft = std::move(std::get<1>(resultLeft));
 
 			auto resultRight = GetTreeSitterCommentsFilteredText(
 				lineNumberRight, ctxt.nParsedLineEndRight,
-				file_data_ary[1].linbuf + file_data_ary[1].linbuf_base, m_pParseContext[1]);
+				file_data_ary[1].linbuf + file_data_ary[1].linbuf_base, ctxt.pTreeSitterContext[1]);
 			lineDataRight = std::move(std::get<0>(resultRight));
 			allTextIsCommentRight = std::move(std::get<1>(resultRight));
 		}
 		else
 		{
+			// Parse the gap since the last processed hunk first so the
+			// multi-line comment state (the cookie) is carried forward.
 			ctxt.dwCookieLeft = GetLastLineCookie(ctxt.dwCookieLeft,
-				ctxt.nParsedLineEndLeft + 1, lineNumberLeft - 1, file_data_ary[0].linbuf + file_data_ary[0].linbuf_base, m_pFilterCommentsDef, m_pParseContext[0]);
+				ctxt.nParsedLineEndLeft + 1, lineNumberLeft - 1, file_data_ary[0].linbuf + file_data_ary[0].linbuf_base, m_pFilterCommentsDef);
 			ctxt.dwCookieRight = GetLastLineCookie(ctxt.dwCookieRight,
-				ctxt.nParsedLineEndRight + 1, lineNumberRight - 1, file_data_ary[1].linbuf + file_data_ary[1].linbuf_base, m_pFilterCommentsDef, m_pParseContext[1]);
+				ctxt.nParsedLineEndRight + 1, lineNumberRight - 1, file_data_ary[1].linbuf + file_data_ary[1].linbuf_base, m_pFilterCommentsDef);
 
 			ctxt.nParsedLineEndLeft = lineNumberLeft + qtyLinesLeft - 1;
-			ctxt.nParsedLineEndRight = lineNumberRight + qtyLinesRight - 1;;
+			ctxt.nParsedLineEndRight = lineNumberRight + qtyLinesRight - 1;
 
 			auto resultLeft = GetCommentsFilteredText(ctxt.dwCookieLeft,
-				lineNumberLeft, ctxt.nParsedLineEndLeft, file_data_ary[0].linbuf + file_data_ary[0].linbuf_base, m_pFilterCommentsDef, m_pParseContext[0]);
+				lineNumberLeft, ctxt.nParsedLineEndLeft, file_data_ary[0].linbuf + file_data_ary[0].linbuf_base, m_pFilterCommentsDef);
 			lineDataLeft = std::move(std::get<0>(resultLeft));
 			ctxt.dwCookieLeft = std::get<1>(resultLeft);
 			allTextIsCommentLeft = std::move(std::get<2>(resultLeft));
 
 			auto resultRight = GetCommentsFilteredText(ctxt.dwCookieRight,
-				lineNumberRight, ctxt.nParsedLineEndRight, file_data_ary[1].linbuf + file_data_ary[1].linbuf_base, m_pFilterCommentsDef, m_pParseContext[1]);
+				lineNumberRight, ctxt.nParsedLineEndRight, file_data_ary[1].linbuf + file_data_ary[1].linbuf_base, m_pFilterCommentsDef);
 			lineDataRight = std::move(std::get<0>(resultRight));
 			ctxt.dwCookieRight = std::get<1>(resultRight);
 			allTextIsCommentRight = std::move(std::get<2>(resultRight));
@@ -1531,9 +1578,12 @@ CDiffWrapper::LoadWinMergeDiffsFromDiffUtilsScript3(
 
 		switch (file)
 		{
-		case 0: next = script10; pdiff = &diff10; pinf = inf10; break;
-		case 1: next = script12; pdiff = &diff12; pinf = inf12; break;
-		case 2: next = script02; pdiff = &diff02; pinf = inf02; break;
+		case 0: next = script10; pdiff = &diff10; pinf = inf10;
+			ctxt.nPaneIndexes[0] = 1; ctxt.nPaneIndexes[1] = 0; break;
+		case 1: next = script12; pdiff = &diff12; pinf = inf12;
+			ctxt.nPaneIndexes[0] = 1; ctxt.nPaneIndexes[1] = 2; break;
+		case 2: next = script02; pdiff = &diff02; pinf = inf02;
+			ctxt.nPaneIndexes[0] = 0; ctxt.nPaneIndexes[1] = 2; break;
 		}
 
 		while (next != nullptr)

--- a/Src/DiffWrapper.h
+++ b/Src/DiffWrapper.h
@@ -149,10 +149,29 @@ struct DIFFSTATUS
 
 struct PostFilterContext
 {
+	PostFilterContext() = default;
+	PostFilterContext(const PostFilterContext&) = delete;
+	PostFilterContext& operator=(const PostFilterContext&) = delete;
+	~PostFilterContext();
+
 	int nParsedLineEndLeft = -1;
 	int nParsedLineEndRight = -1;
 	unsigned dwCookieLeft = 0;
 	unsigned dwCookieRight = 0;
+	/**
+	 * Pane indexes of the left/right file of the compared pair, used to look
+	 * up the original (non-temp) file names for grammar selection. 2-way
+	 * compares use {0, 1}; the 3-way pair scripts use (1,0), (1,2), (0,2).
+	 */
+	int nPaneIndexes[2] = { 0, 1 };
+	/**
+	 * Tree-sitter parse contexts for the left/right file of the compared
+	 * pair. Created lazily by CDiffWrapper::PostFilter from the diffed text
+	 * itself (so line numbers always match, including for each pair of a
+	 * 3-way compare) and freed by the destructor.
+	 */
+	void* pTreeSitterContext[2] = { nullptr, nullptr };
+	bool bTreeSitterContextInitialized = false;
 };
 
 /**
@@ -197,7 +216,6 @@ public:
 	void SetSubstitutionList(std::shared_ptr<SubstitutionList> pSubstitutionFiltersList);
 	void SetFilterCommentsSourceDef(CrystalLineParser::TextDefinition *def) { m_pFilterCommentsDef = def; };
 	void SetFilterCommentsSourceDef(const String& ext);
-	void SetFilterCommentsParseContext(void* parseContext, int index) { m_pParseContext[index] = parseContext; }
 	void SetCodepage(int codepage) { m_codepage = codepage; }
 	void EnablePlugins(bool enable);
 	int PostFilter(PostFilterContext& ctxt, change* thisob, const file_data* file_data_ary) const;
@@ -242,7 +260,6 @@ private:
 	DiffList *m_pDiffList; /**< Pointer to external DiffList */
 	std::unique_ptr<MovedLines> m_pMovedLines[3];
 	CrystalLineParser::TextDefinition *m_pFilterCommentsDef; /**< Text definition for Comments filter  */
-	void* m_pParseContext[3]; /**< Context for incremental parsing, owned by the parser */
 	bool m_bPluginsEnabled; /**< Are plugins enabled? */
 	int m_codepage; /**< Codepage used in line filter */
 };

--- a/Src/MergeAppLib.h
+++ b/Src/MergeAppLib.h
@@ -4,7 +4,7 @@
 
 
  /* File created by MIDL compiler version 8.01.0628 */
-/* at Tue Jan 19 12:14:07 2038
+/* at Tue Jan 19 03:14:07 2038
  */
 /* Compiler settings for MergeAppLib.idl:
     Oicf, W1, Zp8, env=Win64 (32b run), target_arch=AMD64 8.01.0628 

--- a/Src/MergeDoc.cpp
+++ b/Src/MergeDoc.cpp
@@ -72,15 +72,30 @@ bool CMergeDoc::IsTreeSitterEnabled() const
 	return GetOptionsMgr()->GetBool(OPT_TREE_SITTER);
 }
 
+void CMergeDoc::TreeSitterTextDefinitionDeleter::operator()(CrystalLineParser::TextDefinition* p) const
+{
+	FreeTreeSitterTextDefinition(p);
+}
+
 void CMergeDoc::UpdateTreeSitterSupport()
 {
 	m_diffWrapper.SetFilterCommentsSourceDef(GetFileExt(m_ptBuf[0]->m_strTempFileName.c_str(), m_strDesc[0].c_str()));
-	m_diffWrapper.SetFilterCommentsParseContext(nullptr, 0);
-	m_diffWrapper.SetFilterCommentsParseContext(nullptr, 1);
-	m_diffWrapper.SetFilterCommentsParseContext(nullptr, 2);
+	// The comment filter creates its own tree-sitter parse contexts from the
+	// diffed text in CDiffWrapper::PostFilter, gated by
+	// DIFFOPTIONS::bTreeSitterCommentFilter (loaded from OPT_TREE_SITTER).
 
 	for (int nBuffer = 0; nBuffer < m_nBuffers; ++nBuffer)
 	{
+		if (CrystalLineParser::TextDefinition* pOldDef = m_pTreeSitterTextDefs[nBuffer].get())
+		{
+			// Re-point any view still drawing with the definition we are
+			// about to free; the proper type is re-applied afterwards by our
+			// callers (OpenDocs / each view's RefreshOptions).
+			ForEachView(nBuffer, [&](auto& pView) {
+				if (pView->GetTextType() == pOldDef)
+					pView->SetTextType(CrystalLineParser::SRC_PLAIN);
+			});
+		}
 		m_pTreeSitterTextDefs[nBuffer].reset();
 		m_pTreeSitterParsers[nBuffer].reset();
 		m_ptBuf[nBuffer]->SetParseContext(nullptr);
@@ -90,8 +105,7 @@ void CMergeDoc::UpdateTreeSitterSupport()
 		return;
 
 	TreeSitterRegistry& registry = TreeSitterRegistry::Instance();
-	if (!registry.IsInitialized())
-		registry.Initialize();
+	registry.Initialize();
 
 	for (int nBuffer = 0; nBuffer < m_nBuffers; ++nBuffer)
 	{
@@ -112,11 +126,7 @@ void CMergeDoc::UpdateTreeSitterSupport()
 		m_pTreeSitterContexts[nBuffer]->pBuffer = m_ptBuf[nBuffer].get();
 
 		m_ptBuf[nBuffer]->SetParseContext(m_pTreeSitterContexts[nBuffer].get());
-		m_diffWrapper.SetFilterCommentsParseContext(m_pTreeSitterParsers[nBuffer].get(), nBuffer);
 	}
-
-	if (m_pTreeSitterTextDefs[0])
-		m_diffWrapper.SetFilterCommentsSourceDef(m_pTreeSitterTextDefs[0].get());
 }
 
 /////////////////////////////////////////////////////////////////////////////
@@ -2619,13 +2629,16 @@ bool CMergeDoc::OpenDocs(int nFiles, const FileLocation ifileloc[],
 		UpdateTreeSitterSupport();
 
 		// Set TreeSitter TextDefinition as syntax highlighting for each view
-		for (nBuffer = 0; nBuffer < m_nBuffers; nBuffer++)
+		if (GetOptionsMgr()->GetBool(OPT_SYNTAX_HIGHLIGHT))
 		{
-			if (m_pTreeSitterTextDefs[nBuffer])
+			for (nBuffer = 0; nBuffer < m_nBuffers; nBuffer++)
 			{
-				ForEachView(nBuffer, [&](auto& pView) {
-					pView->SetTextType(m_pTreeSitterTextDefs[nBuffer].get());
-				});
+				if (m_pTreeSitterTextDefs[nBuffer])
+				{
+					ForEachView(nBuffer, [&](auto& pView) {
+						pView->SetTextType(m_pTreeSitterTextDefs[nBuffer].get());
+					});
+				}
 			}
 		}
 

--- a/Src/MergeDoc.h
+++ b/Src/MergeDoc.h
@@ -414,7 +414,9 @@ protected:
 	std::unique_ptr<TableProps> m_pTablePropsPrepared;
 	std::unique_ptr<CLineFilterHelperMenu> m_pFilterMenu;
 	std::unique_ptr<CTreeSitterParser> m_pTreeSitterParsers[3]; /**< TreeSitter parsers for each pane */
-	std::unique_ptr<CrystalLineParser::TextDefinition> m_pTreeSitterTextDefs[3]; /**< TreeSitter TextDefinitions for each pane */
+	/** Frees via FreeTreeSitterTextDefinition() (name/exts are allocated separately) */
+	struct TreeSitterTextDefinitionDeleter { void operator()(CrystalLineParser::TextDefinition* p) const; };
+	std::unique_ptr<CrystalLineParser::TextDefinition, TreeSitterTextDefinitionDeleter> m_pTreeSitterTextDefs[3]; /**< TreeSitter TextDefinitions for each pane */
 	std::unique_ptr<TreeSitterParseContext> m_pTreeSitterContexts[3]; /**< TreeSitter parse contexts for each pane */
 	/**
 	 * Are automatic rescans enabled?

--- a/Src/MergeEditStatus.h
+++ b/Src/MergeEditStatus.h
@@ -14,5 +14,5 @@ class IMergeEditStatus
 public:
 	virtual void SetLineInfo(const tchar_t* szLine, int nChar, int nChars, int nColumn,
 		int nColumns, int nSelectedLines, int nSelectedChars, const tchar_t* szEol, int nCodepage, bool bHasBom) = 0;
-	virtual void SetSyntaxParser(const tchar_t* szParser) = 0;
+	virtual void SetSyntaxParser(const tchar_t* szParser, const tchar_t* szSymbol) = 0;
 };

--- a/Src/MergeEditView.cpp
+++ b/Src/MergeEditView.cpp
@@ -29,6 +29,8 @@
 #include "DropHandler.h"
 #include "IDirDoc.h"
 #include "editcmd.h"
+#include "ccrystaltextmarkers.h"
+#include "FindTextHelper.h"
 #include "Shell.h"
 #include "SelectPluginDlg.h"
 #include "Constants.h"
@@ -1299,6 +1301,11 @@ void CMergeEditView::OnEditUndo()
 		{
 			CMergeFrameCommon::LogUndo();
 
+			// Undo bypasses OnEditOperation/NotifyEdit, so the tree-sitter
+			// tree no longer matches the buffer; force a full reparse.
+			if (CTreeSitterParser* pParser = pDoc->GetTreeSitterParser(m_nThisPane))
+				pParser->DiscardTree();
+
 			--pDoc->curUndo;
 			pDoc->UpdateHeaderPath(m_nThisPane);
 			pDoc->FlushAndRescan();
@@ -2451,6 +2458,11 @@ void CMergeEditView::OnEditRedo()
 		{
 			CMergeFrameCommon::LogRedo();
 
+			// Redo bypasses OnEditOperation/NotifyEdit, so the tree-sitter
+			// tree no longer matches the buffer; force a full reparse.
+			if (CTreeSitterParser* pParser = pDoc->GetTreeSitterParser(m_nThisPane))
+				pParser->DiscardTree();
+
 			++pDoc->curUndo;
 			pDoc->UpdateHeaderPath(m_nThisPane);
 			pDoc->FlushAndRescan();
@@ -2757,6 +2769,8 @@ void CMergeEditView::OnUpdateCaret()
 		curChar, chars, selectedLines, selectedChars,
 		sEol, GetDocument()->m_ptBuf[m_nThisPane]->getCodepage(), GetDocument()->m_ptBuf[m_nThisPane]->getHasBom());
 
+	UpdateTreeSitterStatus(cursorPos, (dwLineFlags & LF_GHOST) != 0);
+
 	// Is cursor inside difference?
 	if (dwLineFlags & LF_NONTRIVIAL_DIFF)
 		m_bCurrentLineIsDiff = true;
@@ -2766,6 +2780,59 @@ void CMergeEditView::OnUpdateCaret()
 	CWnd* pWnd = GetFocus();
 	if (!m_bDetailView || (pWnd && pWnd->m_hWnd == this->m_hWnd))
 		UpdateLocationViewPosition(m_nTopSubLine, m_nTopSubLine + GetScreenLines());
+}
+
+/**
+ * @brief Update tree-sitter dependent status for the current caret position.
+ *
+ * Shows the active tree-sitter language and the enclosing symbol breadcrumb
+ * (e.g. "MyClass.MyMethod") in the status bar, and highlights all occurrences
+ * of the identifier under the cursor in all panes via a transient marker.
+ */
+void CMergeEditView::UpdateTreeSitterStatus(const CEPoint& cursorPos, bool bGhostLine)
+{
+	CMergeDoc* pDoc = GetDocument();
+	CTreeSitterParser* pParser = pDoc->IsTreeSitterEnabled() ?
+		pDoc->GetTreeSitterParser(m_nThisPane) : nullptr;
+
+	String sParser, sSymbol, sIdentifier;
+	if (pParser != nullptr && pParser->HasLanguage())
+	{
+		pParser->EnsureParsed(pDoc->m_ptBuf[m_nThisPane].get());
+		sParser = pParser->GetLanguage()->GetName();
+		if (!bGhostLine)
+		{
+			sSymbol = pParser->GetEnclosingSymbols(cursorPos.y, cursorPos.x);
+			sIdentifier = pParser->GetIdentifierAt(cursorPos.y, cursorPos.x);
+		}
+	}
+
+	if (m_piMergeEditStatus != nullptr)
+		m_piMergeEditStatus->SetSyntaxParser(sParser.c_str(), sSymbol.c_str());
+
+	// Highlight all occurrences of the identifier under the cursor using a
+	// transient (non-user-defined, not persisted) marker shared by all panes.
+	// Compare against the live marker table (not a cached copy) so external
+	// marker-table changes cannot leave this logic out of sync.
+	if (CCrystalTextMarkers* pMarkers = theApp.GetMainMarkers())
+	{
+		static const tchar_t MARKER_KEY[] = _T("TREESITTER_SYMBOL");
+		const auto& markers = static_cast<const CCrystalTextMarkers*>(pMarkers)->GetMarkers();
+		const auto it = markers.find(MARKER_KEY);
+		const bool bUnchanged = (it != markers.end()) ?
+			(it->second.sFindWhat == sIdentifier.c_str()) : sIdentifier.empty();
+		if (!bUnchanged)
+		{
+			if (sIdentifier.empty())
+				pMarkers->DeleteMarker(MARKER_KEY);
+			else
+				pMarkers->SetMarker(MARKER_KEY, sIdentifier.c_str(),
+					FIND_MATCH_CASE | FIND_WHOLE_WORD, COLORINDEX_MARKERBKGND0, false);
+			// Markers only change colors; a repaint of the attached views is
+			// enough -- UpdateViews() would reset every view's parse cookies.
+			pMarkers->InvalidateViews();
+		}
+	}
 }
 /**
  * @brief Select linedifference in the current line.

--- a/Src/MergeEditView.h
+++ b/Src/MergeEditView.h
@@ -129,6 +129,7 @@ public:
 		, CEColor & crBkgnd, CEColor & crText, bool & bDrawWhitespace);
 	void WMGoto() { OnWMGoto(); };
 	void GotoTreeSitterDefinition();
+	void UpdateTreeSitterStatus(const CEPoint& cursorPos, bool bGhostLine);
 	void GotoLine(UINT nLine, bool bRealLine, int pane, bool bMoveAnchor = true, int nChar = -1);
 	int GetTopLine() const { return m_nTopLine; }
 	using CCrystalTextView::GetScreenLines;

--- a/Src/MergeStatusBar.cpp
+++ b/Src/MergeStatusBar.cpp
@@ -293,6 +293,11 @@ void CMergeStatusBar::MergeStatus::Update()
 				strEncoding += _T("  ");
 			strEncoding += _T("[TS:");
 			strEncoding += m_sSyntaxParser.c_str();
+			if (!m_sSyntaxSymbol.empty())
+			{
+				strEncoding += _T(" \u25B8 "); // black right-pointing small triangle
+				strEncoding += m_sSyntaxSymbol.c_str();
+			}
 			strEncoding += _T("]");
 		}
 		m_pWndStatusBar->SetPaneText(m_base, strInfo);
@@ -311,13 +316,17 @@ void CMergeStatusBar::MergeStatus::UpdateResources()
 /**
  * @brief Set the syntax parser indicator text.
  * @param szParser  Language name (e.g. "fsharp"), or empty/null to clear.
+ * @param szSymbol  Enclosing symbol breadcrumb at the cursor (e.g.
+ *                  "MyClass.MyMethod"), or empty/null for none.
  */
-void CMergeStatusBar::MergeStatus::SetSyntaxParser(const tchar_t* szParser)
+void CMergeStatusBar::MergeStatus::SetSyntaxParser(const tchar_t* szParser, const tchar_t* szSymbol)
 {
 	String sParser = szParser ? szParser : _T("");
-	if (m_sSyntaxParser != sParser)
+	String sSymbol = szSymbol ? szSymbol : _T("");
+	if (m_sSyntaxParser != sParser || m_sSyntaxSymbol != sSymbol)
 	{
 		m_sSyntaxParser = sParser;
+		m_sSyntaxSymbol = sSymbol;
 		Update();
 	}
 }

--- a/Src/MergeStatusBar.h
+++ b/Src/MergeStatusBar.h
@@ -48,7 +48,7 @@ protected:
 		// Implement MergeEditStatus
 		void SetLineInfo(const tchar_t* szLine, int nColumn, int nColumns,
 			int nChar, int nChars, int nSelectedLines, int nSelectedChars, const tchar_t* szEol, int nCodepage, bool bHasBom) override;
-		void SetSyntaxParser(const tchar_t* szParser) override;
+		void SetSyntaxParser(const tchar_t* szParser, const tchar_t* szSymbol) override;
 		void UpdateResources();
 	protected:
 		void Update();
@@ -69,6 +69,7 @@ protected:
 		String m_sEolDisplay;
 		String m_sCodepageName;
 		String m_sSyntaxParser; /**< Tree-sitter language name, empty if not active */
+		String m_sSyntaxSymbol; /**< Enclosing symbol breadcrumb at the cursor (e.g. "MyClass.MyMethod") */
 	};
 	friend class MergeStatus; // MergeStatus accesses status bar
 	MergeStatus m_status[3];

--- a/Src/OptionsDiffOptions.cpp
+++ b/Src/OptionsDiffOptions.cpp
@@ -42,6 +42,7 @@ void Load(const COptionsMgr *pOptionsMgr, DIFFOPTIONS& options)
 	options.bIgnoreLineBreaks = pOptionsMgr->GetBool(OPT_CMP_IGNORE_LINE_BREAKS);
 	options.bIndentHeuristic = pOptionsMgr->GetBool(OPT_CMP_INDENT_HEURISTIC);
 	options.bCompletelyBlankOutIgnoredChanges = pOptionsMgr->GetBool(OPT_CMP_COMPLETELY_BLANK_OUT_IGNORED_CHANGES);
+	options.bTreeSitterCommentFilter = pOptionsMgr->GetBool(OPT_TREE_SITTER);
 }
 
 void Save(COptionsMgr *pOptionsMgr, const DIFFOPTIONS& options)

--- a/Src/TreeSitterParser.cpp
+++ b/Src/TreeSitterParser.cpp
@@ -22,6 +22,7 @@
 #include <algorithm>
 #include <climits>
 #include <cstring>
+#include <cwctype>
 
 #ifdef _DEBUG
 #define new DEBUG_NEW
@@ -49,6 +50,49 @@ int MakeCapturePriority(const std::string& captureName, uint32_t startByte, uint
     const int specificityScore = CountCaptureSegments(captureName) * 200000;
     const int spanScore = 100000 - static_cast<int>(std::min<uint32_t>(span, 100000));
     return specificityScore + spanScore;
+}
+
+std::wstring ToLowerExtension(const std::wstring& sExt)
+{
+    std::wstring sExtLower(sExt);
+    for (auto& ch : sExtLower)
+        ch = static_cast<wchar_t>(towlower(ch));
+    return sExtLower;
+}
+
+std::wstring Utf8ToWString(const std::string& s)
+{
+    if (s.empty())
+        return std::wstring();
+    int nLen = MultiByteToWideChar(CP_UTF8, 0, s.c_str(), static_cast<int>(s.size()), nullptr, 0);
+    if (nLen <= 0)
+        return std::wstring();
+    std::wstring ws(nLen, L'\0');
+    MultiByteToWideChar(CP_UTF8, 0, s.c_str(), static_cast<int>(s.size()), &ws[0], nLen);
+    return ws;
+}
+
+/**
+ * @brief Heuristic: does this AST node type represent a named definition?
+ *
+ * Matches the node type names used across tree-sitter grammars for
+ * functions, methods, types and modules (e.g. "function_definition",
+ * "method_declaration", "class_specifier", "impl_item", "namespace_definition").
+ */
+bool IsDefinitionLikeNodeType(const char* type)
+{
+    if (!type || strstr(type, "call") != nullptr)
+        return false;
+    static const char* const keywords[] = {
+        "function", "method", "class", "struct", "interface",
+        "namespace", "module", "impl", "trait", "enum", "constructor",
+    };
+    for (const char* kw : keywords)
+    {
+        if (strstr(type, kw) != nullptr)
+            return true;
+    }
+    return false;
 }
 }
 
@@ -303,6 +347,7 @@ CTreeSitterParser::CTreeSitterParser()
     , m_pLang(nullptr)
     , m_bDirty(false)
     , m_nLineCount(0)
+    , m_nextBlockOrder(0)
 {
 }
 
@@ -336,6 +381,16 @@ void CTreeSitterParser::SetLanguage(const CTreeSitterLanguage* pLang)
             ts_parser_set_language(m_pParser, pLang->GetLanguage());
     }
     Invalidate();
+}
+
+void CTreeSitterParser::DiscardTree()
+{
+    if (m_pTree)
+    {
+        ts_tree_delete(m_pTree);
+        m_pTree = nullptr;
+    }
+    m_bDirty = true;
 }
 
 void CTreeSitterParser::Invalidate()
@@ -452,11 +507,24 @@ void CTreeSitterParser::ParseDocument(const tchar_t* const* ppszLines,
  */
 void CTreeSitterParser::NotifyEdit(const TextEdit& textEdit)
 {
+    const bool bWasDirty = m_bDirty;
     m_bDirty = true;
 
     // If we don't have a tree, there's nothing to edit incrementally
     if (!m_pTree)
         return;
+
+    // m_lineUtf8/m_documentText describe the text as of the last parse.
+    // If an edit already happened since then, byte offsets computed from
+    // them no longer match the current tree state; applying another
+    // ts_tree_edit() would corrupt the tree and make tree-sitter reuse
+    // wrong subtrees on the next parse. Drop the tree and reparse fully.
+    if (bWasDirty)
+    {
+        DiscardTree();
+        return;
+    }
+
 
     // Convert CEPoint (char-based, line/col) to UTF-8 byte offsets.
     // m_lineUtf8 holds the per-line UTF-8 from the previous parse.
@@ -465,72 +533,11 @@ void CTreeSitterParser::NotifyEdit(const TextEdit& textEdit)
     //   old_end_byte:   absolute byte offset of the old content end
     //   new_end_byte:   absolute byte offset of the new content end
 
-    // Helper: compute absolute byte offset from (line, charPos) using old m_lineUtf8
-    // Each line in m_documentText is followed by '\n' (except the last)
+    // Helper: compute absolute byte offset from (line, charPos) using the
+    // m_lineUtf8 snapshot from the previous parse.
     auto charPosToByteOffset = [this](int line, int charPos) -> uint32_t
     {
-        uint32_t byteOffset = 0;
-        int nLines = static_cast<int>(m_lineUtf8.size());
-
-        // Sum up all lines before 'line'
-        for (int i = 0; i < line && i < nLines; i++)
-        {
-            byteOffset += static_cast<uint32_t>(m_lineUtf8[i].size());
-            byteOffset += 1; // for '\n' separator
-        }
-
-        // Add the byte offset within the target line
-        if (line >= 0 && line < nLines && charPos > 0)
-        {
-#ifdef _UNICODE
-            const std::string& utf8Line = m_lineUtf8[line];
-            // Convert charPos (UTF-16 units) to UTF-8 byte count
-            // We need the original line text to do this properly.
-            // Use the stored UTF-8 line and convert back to count bytes.
-            int nUtf16Len = MultiByteToWideChar(CP_UTF8, 0,
-                utf8Line.c_str(), static_cast<int>(utf8Line.size()),
-                nullptr, 0);
-            if (charPos >= nUtf16Len)
-            {
-                byteOffset += static_cast<uint32_t>(utf8Line.size());
-            }
-            else
-            {
-                // Walk the UTF-8 bytes counting UTF-16 chars until we reach charPos
-                int utf16Count = 0;
-                uint32_t byteIdx = 0;
-                const uint8_t* p = reinterpret_cast<const uint8_t*>(utf8Line.c_str());
-                uint32_t lineLen = static_cast<uint32_t>(utf8Line.size());
-                while (byteIdx < lineLen && utf16Count < charPos)
-                {
-                    uint8_t ch = p[byteIdx];
-                    uint32_t seqLen;
-                    if (ch < 0x80)
-                        seqLen = 1;
-                    else if (ch < 0xE0)
-                        seqLen = 2;
-                    else if (ch < 0xF0)
-                        seqLen = 3;
-                    else
-                        seqLen = 4;
-
-                    byteIdx += seqLen;
-                    // A 4-byte UTF-8 sequence produces a surrogate pair (2 UTF-16 units)
-                    utf16Count += (seqLen == 4) ? 2 : 1;
-                }
-                byteOffset += byteIdx;
-            }
-#else
-            byteOffset += static_cast<uint32_t>(charPos);
-#endif
-        }
-        else if (line >= nLines && line > 0)
-        {
-            // Line is beyond our cached data -- use end of document
-            byteOffset = static_cast<uint32_t>(m_documentText.size());
-        }
-
-        return byteOffset;
+        return LineCharToByteOffset(line, charPos);
     };
 
     // Helper: compute TSPoint (row, column in bytes) from (line, charPos)
@@ -538,46 +545,7 @@ void CTreeSitterParser::NotifyEdit(const TextEdit& textEdit)
     {
         TSPoint pt;
         pt.row = static_cast<uint32_t>(line);
-        pt.column = 0;
-
-        if (charPos > 0 && line >= 0 && line < static_cast<int>(m_lineUtf8.size()))
-        {
-            const std::string& utf8Line = m_lineUtf8[line];
-#ifdef _UNICODE
-            int nUtf16Len = MultiByteToWideChar(CP_UTF8, 0,
-                utf8Line.c_str(), static_cast<int>(utf8Line.size()),
-                nullptr, 0);
-            if (charPos >= nUtf16Len)
-            {
-                pt.column = static_cast<uint32_t>(utf8Line.size());
-            }
-            else
-            {
-                int utf16Count = 0;
-                uint32_t byteIdx = 0;
-                const uint8_t* p = reinterpret_cast<const uint8_t*>(utf8Line.c_str());
-                uint32_t lineLen = static_cast<uint32_t>(utf8Line.size());
-                while (byteIdx < lineLen && utf16Count < charPos)
-                {
-                    uint8_t ch = p[byteIdx];
-                    uint32_t seqLen;
-                    if (ch < 0x80)
-                        seqLen = 1;
-                    else if (ch < 0xE0)
-                        seqLen = 2;
-                    else if (ch < 0xF0)
-                        seqLen = 3;
-                    else
-                        seqLen = 4;
-                    byteIdx += seqLen;
-                    utf16Count += (seqLen == 4) ? 2 : 1;
-                }
-                pt.column = byteIdx;
-            }
-#else
-            pt.column = static_cast<uint32_t>(charPos);
-#endif
-        }
+        pt.column = LineCharToByteOffset(line, charPos) - LineCharToByteOffset(line, 0);
         return pt;
     };
 
@@ -1621,6 +1589,8 @@ TreeSitterRegistry& TreeSitterRegistry::Instance()
 
 void TreeSitterRegistry::Initialize(const std::wstring& sGrammarDir)
 {
+    std::lock_guard<std::mutex> lock(m_mutex);
+
     if (m_bInitialized)
         return;
 
@@ -1685,15 +1655,12 @@ void TreeSitterRegistry::Initialize(const std::wstring& sGrammarDir)
     m_bInitialized = true;
 }
 
-const CTreeSitterLanguage* TreeSitterRegistry::GetLanguageForExt(const std::wstring& sExt)
+/**
+ * @brief Load (or return the already loaded) grammar for a language name.
+ * @note The caller must hold m_mutex.
+ */
+const CTreeSitterLanguage* TreeSitterRegistry::LoadLanguage(const std::wstring& sLangName)
 {
-    // Look up extension -> language name
-    auto itExt = m_extMap.find(sExt);
-    if (itExt == m_extMap.end())
-        return nullptr;
-
-    const std::wstring& sLangName = itExt->second;
-
     // Check if already loaded
     auto itLang = m_languages.find(sLangName);
     if (itLang != m_languages.end())
@@ -1714,66 +1681,44 @@ const CTreeSitterLanguage* TreeSitterRegistry::GetLanguageForExt(const std::wstr
 
     // Lazy load: load the grammar DLL now
     auto pLang = std::make_unique<CTreeSitterLanguage>();
-    if (!pLang->Load(m_sGrammarDir, sLangName))
+    if (!pLang->Load(m_sGrammarDir, sLangName) || !pLang->GetHighlightQuery())
     {
         // Record failure so we don't retry
         m_failedLanguages.insert(sLangName);
         return nullptr;
     }
 
-    // Check if the loaded grammar has a highlight query
-    if (!pLang->GetHighlightQuery())
-    {
-        m_failedLanguages.insert(sLangName);
-        return nullptr;
-    }
-
     const CTreeSitterLanguage* pResult = pLang.get();
     m_languages[sLangName] = std::move(pLang);
     return pResult;
+}
+
+const CTreeSitterLanguage* TreeSitterRegistry::GetLanguageForExt(const std::wstring& sExt)
+{
+    const std::wstring sExtLower = ToLowerExtension(sExt);
+
+    std::lock_guard<std::mutex> lock(m_mutex);
+
+    // Look up extension -> language name
+    auto itExt = m_extMap.find(sExtLower);
+    if (itExt == m_extMap.end())
+        return nullptr;
+
+    return LoadLanguage(itExt->second);
 }
 
 const CTreeSitterLanguage* TreeSitterRegistry::GetLanguageForName(const std::wstring& sLangName)
 {
-    // Check if already loaded
-    auto itLang = m_languages.find(sLangName);
-    if (itLang != m_languages.end())
-    {
-        if (!itLang->second->GetHighlightQuery())
-            return nullptr;
-        return itLang->second.get();
-    }
-
-    // Check if this language previously failed to load
-    if (m_failedLanguages.count(sLangName) > 0)
-        return nullptr;
-
-    // Check if a DLL is available for this language
-    if (m_availableLanguages.count(sLangName) == 0)
-        return nullptr;
-
-    // Lazy load: load the grammar DLL now
-    auto pLang = std::make_unique<CTreeSitterLanguage>();
-    if (!pLang->Load(m_sGrammarDir, sLangName))
-    {
-        m_failedLanguages.insert(sLangName);
-        return nullptr;
-    }
-
-    if (!pLang->GetHighlightQuery())
-    {
-        m_failedLanguages.insert(sLangName);
-        return nullptr;
-    }
-
-    const CTreeSitterLanguage* pResult = pLang.get();
-    m_languages[sLangName] = std::move(pLang);
-    return pResult;
+    std::lock_guard<std::mutex> lock(m_mutex);
+    return LoadLanguage(sLangName);
 }
 
 void TreeSitterRegistry::RegisterExtension(const std::wstring& sExt, const std::wstring& sLanguage)
 {
-    m_extMap[sExt] = sLanguage;
+    const std::wstring sExtLower = ToLowerExtension(sExt);
+
+    std::lock_guard<std::mutex> lock(m_mutex);
+    m_extMap[sExtLower] = sLanguage;
 }
 
 // ============================================================================
@@ -1806,53 +1751,54 @@ void CTreeSitterParser::ParseFromBuffer(ITextBuffer* pBuffer)
 }
 
 /**
- * @brief Get the node type name at a specific position.
- * 
- * This is used for comment filtering and other syntax-aware operations.
+ * @brief Convert (line, UTF-16 character position) to an absolute UTF-8 byte offset.
+ *
+ * Counterpart of Utf8ByteOffsetToCharPos(). A 4-byte UTF-8 sequence counts
+ * as two UTF-16 code units (a surrogate pair). Positions past the end of the
+ * document are clamped to the document size.
  */
-std::wstring CTreeSitterParser::GetNodeTypeAt(int nLineIndex, int nCharPos) const
+uint32_t CTreeSitterParser::LineCharToByteOffset(int nLineIndex, int nCharPos) const
 {
-    if (!m_pTree || nLineIndex < 0 || nLineIndex >= m_nLineCount)
-        return _T("");
-
-    // Convert line + character position to byte offset
-    if (nLineIndex >= static_cast<int>(m_lineUtf8.size()))
-        return _T("");
-
-    // Calculate byte offset
+    const uint32_t nDocSize = static_cast<uint32_t>(m_documentText.size());
     uint32_t byteOffset = 0;
+    const int nLines = static_cast<int>(m_lineUtf8.size());
+    for (int i = 0; i < nLineIndex && i < nLines; ++i)
+        byteOffset += static_cast<uint32_t>(m_lineUtf8[i].size()) + 1; // +1 for '\n'
 
-    // Add bytes from all previous lines
-    for (int i = 0; i < nLineIndex; i++)
-    {
-        if (i >= static_cast<int>(m_lineUtf8.size()))
-            return _T("");
-        byteOffset += static_cast<uint32_t>(m_lineUtf8[i].size());
-        byteOffset++;  // newline character
-    }
+    if (nLineIndex < 0 || nLineIndex >= nLines)
+        return (byteOffset > nDocSize) ? nDocSize : byteOffset;
 
-    // Add bytes from current line up to nCharPos
     const std::string& lineUtf8 = m_lineUtf8[nLineIndex];
-    int charCount = 0;
-    for (size_t i = 0; i < lineUtf8.size() && charCount < nCharPos; )
+    int utf16Count = 0;
+    size_t i = 0;
+    while (i < lineUtf8.size() && utf16Count < nCharPos)
     {
-        unsigned char byte = lineUtf8[i];
-
-        // UTF-8 character length determination
-        int charLen = 1;
-        if ((byte & 0x80) == 0x00)
-            charLen = 1;  // ASCII
-        else if ((byte & 0xE0) == 0xC0)
+        const unsigned char byte = static_cast<unsigned char>(lineUtf8[i]);
+        size_t charLen = 1;
+        if ((byte & 0xE0) == 0xC0)
             charLen = 2;
         else if ((byte & 0xF0) == 0xE0)
             charLen = 3;
         else if ((byte & 0xF8) == 0xF0)
             charLen = 4;
-
         i += charLen;
-        byteOffset += charLen;
-        charCount++;
+        utf16Count += (charLen == 4) ? 2 : 1;
     }
+    return byteOffset + static_cast<uint32_t>((std::min)(i, lineUtf8.size()));
+}
+
+/**
+ * @brief Get the node type name at a specific position.
+ *
+ * This is used for comment filtering and other syntax-aware operations.
+ */
+std::wstring CTreeSitterParser::GetNodeTypeAt(int nLineIndex, int nCharPos) const
+{
+    if (!m_pTree || nLineIndex < 0 || nLineIndex >= m_nLineCount ||
+        nLineIndex >= static_cast<int>(m_lineUtf8.size()))
+        return _T("");
+
+    const uint32_t byteOffset = LineCharToByteOffset(nLineIndex, nCharPos);
 
     // Get the tree-sitter node at this byte position
     TSNode rootNode = ts_tree_root_node(m_pTree);
@@ -1866,24 +1812,100 @@ std::wstring CTreeSitterParser::GetNodeTypeAt(int nLineIndex, int nCharPos) cons
     if (!pszType)
         return _T("");
 
-    // Convert from UTF-8 to wstring/String
-#ifdef UNICODE
-    int nLen = MultiByteToWideChar(CP_UTF8, 0, pszType, -1, nullptr, 0);
-    if (nLen == 0)
-        return _T("");
-
-    std::vector<wchar_t> buffer(nLen);
-    MultiByteToWideChar(CP_UTF8, 0, pszType, -1, buffer.data(), nLen);
-    return std::wstring(buffer.data());
-#else
-    return String(pszType);
-#endif
+    return Utf8ToWString(pszType);
 }
 
 bool CTreeSitterParser::IsCommentPosition(int nLineIndex, int nCharPos) const
 {
     const std::wstring sNodeType = GetNodeTypeAt(nLineIndex, nCharPos);
     return sNodeType.find(L"comment") != std::wstring::npos;
+}
+
+std::wstring CTreeSitterParser::GetEnclosingSymbols(int nLineIndex, int nCharPos) const
+{
+    if (!m_pTree || nLineIndex < 0 || nLineIndex >= m_nLineCount ||
+        nLineIndex >= static_cast<int>(m_lineUtf8.size()))
+        return std::wstring();
+
+    const uint32_t byteOffset = LineCharToByteOffset(nLineIndex, nCharPos);
+    TSNode node = ts_node_descendant_for_byte_range(
+        ts_tree_root_node(m_pTree), byteOffset, byteOffset);
+
+    // Collect the names of enclosing definition-like nodes, innermost first.
+    // Requiring a "body" field filters out references and invocations that
+    // match the type-name heuristic (e.g. "method_invocation", a bodyless
+    // "struct_specifier" in a variable declaration, forward declarations).
+    std::vector<std::string> names;
+    while (!ts_node_is_null(node))
+    {
+        if (IsDefinitionLikeNodeType(ts_node_type(node)) &&
+            !ts_node_is_null(ts_node_child_by_field_name(node, "body", 4)))
+        {
+            // Most grammars expose the symbol as a "name" field; C/C++ use a
+            // (possibly nested) "declarator" field instead.
+            TSNode nameNode = ts_node_child_by_field_name(node, "name", 4);
+            if (ts_node_is_null(nameNode))
+            {
+                TSNode declNode = ts_node_child_by_field_name(node, "declarator", 10);
+                while (!ts_node_is_null(declNode))
+                {
+                    TSNode inner = ts_node_child_by_field_name(declNode, "declarator", 10);
+                    if (ts_node_is_null(inner))
+                        break;
+                    declNode = inner;
+                }
+                nameNode = declNode;
+            }
+            if (!ts_node_is_null(nameNode))
+            {
+                const uint32_t s = ts_node_start_byte(nameNode);
+                const uint32_t e = ts_node_end_byte(nameNode);
+                if (s < e && e <= m_documentText.size() && e - s <= 256)
+                    names.push_back(m_documentText.substr(s, e - s));
+            }
+        }
+        node = ts_node_parent(node);
+    }
+
+    if (names.empty())
+        return std::wstring();
+
+    // Join outermost -> innermost, keeping at most the 3 innermost names.
+    const size_t nCount = names.size() < 3 ? names.size() : 3;
+    std::string joined;
+    for (size_t i = nCount; i-- > 0; )
+    {
+        if (!joined.empty())
+            joined += '.';
+        joined += names[i];
+    }
+    return Utf8ToWString(joined);
+}
+
+std::wstring CTreeSitterParser::GetIdentifierAt(int nLineIndex, int nCharPos) const
+{
+    if (!m_pTree || nLineIndex < 0 || nLineIndex >= m_nLineCount ||
+        nLineIndex >= static_cast<int>(m_lineUtf8.size()))
+        return std::wstring();
+
+    const uint32_t byteOffset = LineCharToByteOffset(nLineIndex, nCharPos);
+    TSNode node = ts_node_descendant_for_byte_range(
+        ts_tree_root_node(m_pTree), byteOffset, byteOffset);
+    if (ts_node_is_null(node) || !ts_node_is_named(node))
+        return std::wstring();
+
+    // Accept identifier-like leaf nodes only ("identifier", "type_identifier",
+    // "field_identifier", "word", ...), not comments/strings/keywords.
+    const char* type = ts_node_type(node);
+    if (!type || (strstr(type, "identifier") == nullptr && strcmp(type, "word") != 0))
+        return std::wstring();
+
+    const uint32_t s = ts_node_start_byte(node);
+    const uint32_t e = ts_node_end_byte(node);
+    if (s >= e || e > m_documentText.size() || e - s > 256)
+        return std::wstring();
+
+    return Utf8ToWString(m_documentText.substr(s, e - s));
 }
 
 bool CTreeSitterParser::TryGetDefinitionByteRangeAt(uint32_t byteOffset, uint32_t& defStartByte, uint32_t& defEndByte) const
@@ -2065,31 +2087,11 @@ bool CTreeSitterParser::TryGetTagDefinitionByNameAt(ITextBuffer* pBuffer, int nL
 
 bool CTreeSitterParser::FindDefinition(ITextBuffer* pBuffer, int nLineIndex, int nCharPos, int& nDefLine, int& nDefChar) const
 {
-    if (!m_pTree || nLineIndex < 0 || nLineIndex >= m_nLineCount)
+    if (!m_pTree || nLineIndex < 0 || nLineIndex >= m_nLineCount ||
+        nLineIndex >= static_cast<int>(m_lineUtf8.size()))
         return false;
 
-    uint32_t byteOffset = 0;
-    for (int i = 0; i < nLineIndex; ++i)
-        byteOffset += static_cast<uint32_t>(m_lineUtf8[i].size()) + 1;
-
-    const std::string& lineUtf8 = m_lineUtf8[nLineIndex];
-    int charCount = 0;
-    for (size_t i = 0; i < lineUtf8.size() && charCount < nCharPos; )
-    {
-        const unsigned char byte = static_cast<unsigned char>(lineUtf8[i]);
-        int charLen = 1;
-        if ((byte & 0x80) == 0x00)
-            charLen = 1;
-        else if ((byte & 0xE0) == 0xC0)
-            charLen = 2;
-        else if ((byte & 0xF0) == 0xE0)
-            charLen = 3;
-        else if ((byte & 0xF8) == 0xF0)
-            charLen = 4;
-        i += charLen;
-        byteOffset += charLen;
-        charCount++;
-    }
+    const uint32_t byteOffset = LineCharToByteOffset(nLineIndex, nCharPos);
 
     uint32_t defStartByte = 0;
     uint32_t defEndByte = 0;

--- a/Src/TreeSitterParser.h
+++ b/Src/TreeSitterParser.h
@@ -28,6 +28,7 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <memory>
+#include <mutex>
 
 // Forward declarations for tree-sitter C API types.
 // The actual tree_sitter/api.h header is included only in the .cpp file.
@@ -244,6 +245,16 @@ public:
     /** @brief Invalidate cached results and free tree. */
     void Invalidate();
 
+    /**
+     * @brief Drop the parse tree and mark dirty, keeping cached blocks.
+     *
+     * Use when the buffer changed in a way that cannot be described by
+     * ts_tree_edit() (e.g. undo/redo or multiple coalesced edits); the
+     * next EnsureParsed() does a full (non-incremental) reparse while the
+     * stale color cache is still served until then.
+     */
+    void DiscardTree();
+
     /** @brief Get the language object (for service layer). */
     const CTreeSitterLanguage* GetLanguage() const { return m_pLang; }
 
@@ -262,6 +273,26 @@ public:
 
     bool FindDefinition(ITextBuffer* pBuffer, int nLineIndex, int nCharPos, int& nDefLine, int& nDefChar) const;
 
+    /**
+     * @brief Get a breadcrumb of the enclosing named definitions at a position.
+     * @param nLineIndex  Zero-based line index.
+     * @param nCharPos    Zero-based character position in line.
+     * @return Outermost-to-innermost names joined with '.', e.g.
+     *         "MyClass.MyMethod", or an empty string if the position is not
+     *         inside any named definition (function, class, namespace, ...).
+     */
+    std::wstring GetEnclosingSymbols(int nLineIndex, int nCharPos) const;
+
+    /**
+     * @brief Get the identifier text at a position.
+     * @param nLineIndex  Zero-based line index.
+     * @param nCharPos    Zero-based character position in line.
+     * @return The identifier under the position, or an empty string if the
+     *         position is not on an identifier node (comments, strings,
+     *         operators, whitespace, ...).
+     */
+    std::wstring GetIdentifierAt(int nLineIndex, int nCharPos) const;
+
 	/**
 	 * @brief Convenience: parse document from a text buffer.
 	 * @param pBuffer  The text buffer to read line data from.
@@ -276,6 +307,7 @@ private:
     void RunInjectionQuery();
     void BuildLineCache(int nLineCount);
     int Utf8ByteOffsetToCharPos(int nLine, uint32_t byteCol) const;
+    uint32_t LineCharToByteOffset(int nLineIndex, int nCharPos) const;
     bool TryGetDefinitionByteRangeAt(uint32_t byteOffset, uint32_t& defStartByte, uint32_t& defEndByte) const;
     bool ByteOffsetToLineChar(uint32_t byteOffset, int& nLineIndex, int& nCharPos) const;
     bool TryGetTagDefinitionByNameAt(ITextBuffer* pBuffer, int nLineIndex, int nCharPos, uint32_t& defStartByte, uint32_t& defEndByte) const;
@@ -415,14 +447,24 @@ public:
      */
     void RegisterExtension(const std::wstring& sExt, const std::wstring& sLanguage);
 
-    /** @brief Check if the registry has been initialized. */
+    /**
+     * @brief Check if the registry has been initialized.
+     * @note Unsynchronized; prefer calling Initialize() unconditionally
+     *       (it is idempotent and re-checks under the registry lock).
+     */
     bool IsInitialized() const { return m_bInitialized; }
 
 private:
     TreeSitterRegistry() : m_bInitialized(false) {}
 
+    const CTreeSitterLanguage* LoadLanguage(const std::wstring& sLangName);
+
     bool m_bInitialized;
     std::wstring m_sGrammarDir;
+
+    // Guards all members: lazy loading may be triggered concurrently from
+    // folder-compare worker threads and the UI thread.
+    std::mutex m_mutex;
 
     // language name -> loaded grammar (loaded lazily)
     std::unordered_map<std::wstring, std::unique_ptr<CTreeSitterLanguage>> m_languages;

--- a/Src/TreeSitterWrapper.cpp
+++ b/Src/TreeSitterWrapper.cpp
@@ -49,7 +49,7 @@ unsigned ParseLineTreeSitter(unsigned dwCookie, int nLineIndex, const tchar_t* p
                 // Buffer size: GetTextBlocks allocates (nLength+1)*3 TEXTBLOCK entries
                 int nMaxBlocks = (nLength + 1) * 3;
 
-                pParser->GetLineBlocks(nLineIndex, pBuf, nActualItems, 0);
+                pParser->GetLineBlocks(nLineIndex, pBuf, nActualItems, nMaxBlocks);
 
                 // Return cookie for next line
                 return 0;
@@ -156,19 +156,35 @@ void FreeTreeSitterTextDefinition(CrystalLineParser::TextDefinition* pDef)
     delete pDef;
 }
 
-void* CreateTreeSitterParseContextForDiff(const std::wstring& filePath, const std::vector<std::wstring>& lines)
+/**
+ * @brief Look up the tree-sitter language for a file by its extension.
+ */
+static const CTreeSitterLanguage* GetTreeSitterLanguageForFile(const std::wstring& filePath)
 {
     std::wstring ext = filePath;
     size_t posOfDot = ext.rfind('.');
-    if (posOfDot != std::wstring::npos)
-        ext.erase(0, posOfDot + 1);
+    if (posOfDot == std::wstring::npos)
+        return nullptr;
+    ext.erase(0, posOfDot + 1);
 
     TreeSitterRegistry& registry = TreeSitterRegistry::Instance();
-    if (!registry.IsInitialized())
-        registry.Initialize();
+    registry.Initialize();
 
     const CTreeSitterLanguage* pLang = registry.GetLanguageForExt(ext.c_str());
     if (pLang == nullptr || pLang->GetLanguage() == nullptr)
+        return nullptr;
+    return pLang;
+}
+
+bool HasTreeSitterLanguageForFile(const std::wstring& filePath)
+{
+    return GetTreeSitterLanguageForFile(filePath) != nullptr;
+}
+
+void* CreateTreeSitterParseContextForDiff(const std::wstring& filePath, const std::vector<std::wstring>& lines)
+{
+    const CTreeSitterLanguage* pLang = GetTreeSitterLanguageForFile(filePath);
+    if (pLang == nullptr)
         return nullptr;
 
     auto* pParser = new CTreeSitterParser();

--- a/Src/TreeSitterWrapper.h
+++ b/Src/TreeSitterWrapper.h
@@ -60,6 +60,15 @@ CrystalLineParser::TextDefinition* CreateTreeSitterTextDefinition(
  */
 void FreeTreeSitterTextDefinition(CrystalLineParser::TextDefinition* pDef);
 
+/**
+ * @brief Check whether a tree-sitter grammar is available for a file.
+ * @param filePath  File path; the grammar is selected by its extension.
+ *
+ * Cheap pre-check for CreateTreeSitterParseContextForDiff() so callers can
+ * skip materializing the file's lines when no grammar exists.
+ */
+bool HasTreeSitterLanguageForFile(const std::wstring& filePath);
+
 void* CreateTreeSitterParseContextForDiff(const std::wstring& filePath, const std::vector<std::wstring>& lines);
 void DestroyTreeSitterParseContextForDiff(void* parseContext);
 bool IsTreeSitterCommentPositionForDiff(void* parseContext, int nLineIndex, int nCharPos);


### PR DESCRIPTION
Bug fixes

- Comment filter ("Ignore comment differences"): parse contexts are now created lazily inside `CDiffWrapper::PostFilter` from the exact text being diffed, fixing three bugs at once: 3-way compares queried the wrong file's parse tree (pair scripts are (1,0)/(1,2)/(0,2), contexts were always [0]/[1]), merge-editor rescans used ghost-line-shifted line numbers, and editor rescans looked up the grammar from the .tmp temp-file name (grammar selection now uses the original compare paths via `SetCompareFiles`). Decodes with `convertToTString` so positions match the queried text.
- Lifetime/memory: dynamic TextDefinitions are freed with the matching deleter (name/exts leaked before) and views are re-pointed before a definition is freed (use-after-free on reload to a grammar-less extension).
- Incremental parsing safety: an edit arriving while the parse cache is already dirty discards the tree and forces a full reparse instead of applying `ts_tree_edit()` against stale byte offsets; undo/redo handlers discard the tree explicitly via `DiscardTree()`.
- Thread safety: grammar registry is mutex-guarded (folder-compare workers load grammars concurrently); extension lookup is case-insensitive.
- Option gating: `OPT_TREE_SITTER` now flows through `DIFFOPTIONS::bTreeSitterCommentFilter`, so disabling tree-sitter consistently affects the editor, folder compare, and patch generation.

New features

- Status bar breadcrumb: shows the active grammar and enclosing symbol at the caret, e.g. `[TS:cpp ▸ MyClass::Foo]` (AST walk; supports name and nested declarator fields, requires a body to exclude forward declarations/invocations).
- Symbol occurrence highlighting: all occurrences of the identifier under the caret are highlighted in every pane via a transient marker (AST-confirmed identifiers only — not comments/strings/keywords; never persisted or shown in the marker dialog). Uses a new lightweight `CCrystalTextMarkers::InvalidateViews()` repaint instead of the cache-resetting `UpdateViews()`.

---

**2026-06-12: rebased onto current `feature/tree-sitter`.** Parts of the original commit that the base branch has since implemented independently were dropped: the UndoRecord decoupling (superseded by `ITextBuffer`/`TextEdit`, commit 68b5e200d), the PostFilter cookie-ordering restore (5096704a6), the `m_pBuffer` initialization (member removed by the stateless refactor, 53b3e0a1e), and the undo-position synchronization (`AddUndoRecord` now notifies the parser of every record, so the dirty-state check above covers multi-edit staleness). The accidental `Externals/jq` pointer bump and `Externals/tree-sitter` gitlink are also removed.