### PR TITLE
Tree-sitter: fix data race in TreeSitterRegistry (folder-compare workers)

### DIFF
--- a/Src/TreeSitterParser.cpp
+++ b/Src/TreeSitterParser.cpp
@@ -1444,6 +1444,8 @@ TreeSitterRegistry& TreeSitterRegistry::Instance()
 
 void TreeSitterRegistry::Initialize(const std::wstring& sGrammarDir)
 {
+	std::lock_guard<std::mutex> lock(m_mutex);
+
 	if (m_bInitialized)
 		return;
 
@@ -1504,6 +1506,8 @@ void TreeSitterRegistry::Initialize(const std::wstring& sGrammarDir)
 
 const CTreeSitterLanguage* TreeSitterRegistry::GetLanguageForName(const std::wstring& sLangName)
 {
+	std::lock_guard<std::mutex> lock(m_mutex);
+
 	// Check if already loaded
 	auto itLang = m_languages.find(sLangName);
 	if (itLang != m_languages.end())

--- a/Src/TreeSitterParser.h
+++ b/Src/TreeSitterParser.h
@@ -31,6 +31,7 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <memory>
+#include <mutex>
 
 // Forward declarations for tree-sitter C API types.
 // The actual tree_sitter/api.h header is included only in the .cpp file.
@@ -357,6 +358,11 @@ private:
 
 	bool m_bInitialized;
 	std::wstring m_sGrammarDir;
+
+	// Guards lazy initialization and grammar loading: Initialize() and
+	// GetLanguageForName() may be called concurrently from folder-compare
+	// worker threads (via CDiffWrapper::PostFilter) and the UI thread.
+	std::mutex m_mutex;
 
 	// language name -> loaded grammar (loaded lazily)
 	std::unordered_map<std::wstring, std::unique_ptr<CTreeSitterLanguage>> m_languages;


### PR DESCRIPTION
## Problem

`TreeSitterRegistry` (a singleton) loads grammars lazily: `Initialize()` populates `m_availableLanguages`, and `GetLanguageForName()` lazily loads grammar DLLs, mutating `m_languages` / `m_failedLanguages` / `m_bInitialized` on cache misses. None of this is synchronized, yet it is reached concurrently from folder-compare worker threads via `CDiffWrapper::PostFilter` (the ThreadPool runs one `FolderCmp` per worker). The first concurrent use of a not-yet-loaded grammar races on the shared maps/set — a data race that can corrupt the containers or crash during folder compares of source trees.

## Fix

Guard the registry's lazy state with a `std::mutex`:

- add `std::mutex m_mutex` to `TreeSitterRegistry`
- take a `std::lock_guard` at the top of `Initialize()` and `GetLanguageForName()`

No deadlock risk: `CTreeSitterLanguage::Load()` / `GetHighlightQuery()` do not call back into the registry, and no registry method calls another locked registry method, so the non-recursive mutex is safe.

This is the one still-applicable item from an audit of the older `feature/tree-sitter-fixes` work (PR #3413) against the current `feature/tree-sitter` — the registry race was never addressed by the intervening refactors. The other items from that branch are already superseded by the `LangServices`/`ISyntaxParser` architecture and `OPT_TREE_SITTER_MODE` gating.

## Testing

Builds clean: MSBuild `WinMerge.sln -t:Merge -p:Configuration=Release -p:Platform=x64` → 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)