### PR TITLE
Fix issue #3444: ZIP export includes unchanged files in subfolders

### DIFF
--- a/Src/7zCommon.cpp
+++ b/Src/7zCommon.cpp
@@ -320,178 +320,30 @@ SingleItemEnumerator::SingleItemEnumerator(const tchar_t* path, const tchar_t* F
 {
 }
 
-/**
- * @brief Construct a DirItemEnumerator.
- *
- * Argument *nFlags* controls operation as follows:
- * LVNI_ALL:		Enumerate all items.
- * LVNI_SELECTED:	Enumerate selected items only.
- * Original:		Set folder prefix for first iteration to "original"
- * Altered:			Set folder prefix for second iteration to "altered"
- * BalanceFolders:	Ensure that all nonempty folders on either side have a
- *					corresponding folder on the other side, even if it is
- *					empty (DirScan doesn't recurse into folders which
- *					appear only on one side).
- * DiffsOnly:		Enumerate diffs only.
- */
-DirItemEnumerator::DirItemEnumerator(CDirView *pView, int nFlags)
-: m_pView(pView)
-, m_nFlags(nFlags)
-, m_nIndex(-1)
-, m_index(0)
+CompressibleItemEnumerator::CompressibleItemEnumerator(std::vector<CompressibleItem> items)
+ : m_items(std::move(items))
 {
-	if (m_nFlags & Original)
-	{
-		m_rgFolderPrefix.push_back(_T("original"));
-	}
-	if (m_nFlags & Altered)
-	{
-		m_rgFolderPrefix.push_back(_T("altered"));
-	}
-	if (m_nFlags & BalanceFolders)
-	{
-		const CDiffContext& ctxt = pView->GetDiffContext();
-		// Collect implied folders
-		for (UINT i = Open() ; i-- ; )
-		{
-			const DIFFITEM &di = Next();
-			if ((m_nFlags & DiffsOnly) && !IsItemNavigableDiff(ctxt, di))
-			{
-				continue;
-			}
-			// Enumerating items
-			if (di.diffcode.exists(m_index))
-			{
-				// Item is present on right side, i.e. folder is implied
-				m_rgImpliedFolders[m_index][di.diffFileInfo[m_index].path.get()] = PVOID(1);
-			}
-		}
-	}
 }
 
-/**
- * @brief Initialize enumerator, return number of items to be enumerated.
- */
-UINT DirItemEnumerator::Open()
+UINT CompressibleItemEnumerator::Open()
 {
-	m_nIndex = -1;
-	m_curFolderPrefix = m_rgFolderPrefix.begin();
-	if (m_pView->GetDocument()->m_nDirs < 3)
-		m_index = (m_nFlags & Right) != 0 ? 1 : 0;
-	else
-		m_index = ((m_nFlags & Right) != 0) ? 2 : ((m_nFlags & Middle) != 0 ? 1 : 0);
-	size_t nrgFolderPrefix = m_rgFolderPrefix.size();
-	if (nrgFolderPrefix)
-	{
-		m_strFolderPrefix = *m_curFolderPrefix++;
-	}
-	else
-	{
-		nrgFolderPrefix = 1;
-	}
-	return
-	static_cast<UINT>((
-		(m_nFlags & LVNI_SELECTED)
-	?	pView(m_pView)->GetSelectedCount()
-	:	pView(m_pView)->GetItemCount()
-	) * nrgFolderPrefix);
+	m_itemPos = 0;
+	return static_cast<UINT>(m_items.size());
 }
 
-/**
- * @brief Return next item.
- */
-const DIFFITEM &DirItemEnumerator::Next()
+CompressibleItemEnumerator::Envelope* CompressibleItemEnumerator::Enum(Item & item)
 {
-	enum {nMask = LVNI_FOCUSED|LVNI_SELECTED|LVNI_CUT|LVNI_DROPHILITED};
-	while ((m_nIndex = pView(m_pView)->GetNextItem(m_nIndex, m_nFlags & nMask)) == -1)
-	{
-		m_strFolderPrefix = *m_curFolderPrefix++;
-		m_index++;
-	}
-	const auto& di = m_pView->GetDiffItem(m_nIndex);
-	for (const auto* pfdi : m_selectedFolderDiffItems)
-	{
-		if (di.IsAncestor(pfdi))
-			return *DIFFITEM::GetEmptyItem();
-	}
-	if (di.diffcode.isDirectory())
-		m_selectedFolderDiffItems.push_back(&di);
-	return di;
-}
-
-/**
- * @brief Pass information about an item to Merge7z.
- *
- * Information is passed through struct Merge7z::DirItemEnumerator::Item.
- * The *mask* member denotes which of the other members contain valid data.
- * If *mask* is zero upon return, which will be the case if Enum() decides to
- * leave the struct untouched, Merge7z will ignore the item.
- * If Enum() allocates temporary storage for string members, it must also
- * allocate an Envelope, providing a Free() method to free the temporary
- * storage, along with the Envelope itself. The Envelope pointer is passed to
- * Merge7z as the return value of the function. It is not meant to be a success
- * indicator, so if no temporary storage is required, it is perfectly alright
- * to return `nullptr`.
- */
-Merge7z::Envelope *DirItemEnumerator::Enum(Item &item)
-{
-	const CDiffContext& ctxt = m_pView->GetDiffContext();
-	const DIFFITEM &di = Next();
-
-	if (di.isEmpty() || ((m_nFlags & DiffsOnly) && !IsItemNavigableDiff(ctxt, di)))
-	{
+	if (m_itemPos >= m_items.size())
 		return 0;
-	}
-
-	bool isSideOnly = !di.diffcode.exists(m_index);
-
-	Envelope *envelope = new Envelope;
-
-	const String &sFilename = di.diffFileInfo[m_index].filename;
-	const String &sSubdir = di.diffFileInfo[m_index].path;
-	if (sSubdir.length())
-		envelope->Name = paths::ConcatPath(sSubdir, sFilename);
-	else
-		envelope->Name = sFilename;
-	envelope->FullPath = paths::ConcatPath(
-			di.getFilepath(m_index, ctxt.GetNormalizedPath(m_index)),
-			sFilename);
-
-	UINT32 Recurse = item.Mask.Recurse;
-
-	if (m_nFlags & BalanceFolders)
-	{
-		// Enumerating items on right side
-		if (isSideOnly)
-		{
-			// Item is missing on right side
-			PVOID &implied = m_rgImpliedFolders[m_index][di.diffFileInfo[1-m_index].path.get()];
-			if (implied == nullptr)
-			{
-				// Folder is not implied by some other file, and has
-				// not been enumerated so far, so enumerate it now!
-				envelope->Name = di.diffFileInfo[1-m_index].path;
-				envelope->FullPath = di.getFilepath(1-m_index, ctxt.GetNormalizedPath(1-m_index));
-				implied = PVOID(2); // Don't enumerate same folder twice!
-				isSideOnly = false;
-				Recurse = 0;
-			}
-		}
-	}
-
-	if (isSideOnly)
-	{
-		return envelope;
-	}
-
-	if (m_strFolderPrefix.length())
-	{
-		if (envelope->Name.length())
-			envelope->Name.insert(0, _T("\\"));
-		envelope->Name.insert(0, m_strFolderPrefix);
-	}
-
-	item.Mask.Item = item.Mask.Name|item.Mask.FullPath|item.Mask.CheckIfPresent|Recurse;
+	
+	const CompressibleItem & ci = m_items[m_itemPos++];
+	
+	Envelope* envelope = new Envelope;
+	envelope->Name = ci.name;
+	envelope->FullPath = ci.fullPath;
+	
+	item.Mask.Item = item.Mask.Name | item.Mask.FullPath | item.Mask.CheckIfPresent
+		 | (ci.recurse ? item.Mask.Recurse : 0);
 	item.Name = envelope->Name.c_str();
 	item.FullPath = envelope->FullPath.c_str();
 	return envelope;
@@ -500,7 +352,7 @@ Merge7z::Envelope *DirItemEnumerator::Enum(Item &item)
 /**
  * @brief Apply appropriate handlers from left to right.
  */
-bool DirItemEnumerator::MultiStepCompressArchive(const tchar_t* path)
+bool CompressibleItemEnumerator::MultiStepCompressArchive(const tchar_t* path)
 {
 	DeleteFile(path);
 	Merge7z::Format *piHandler = ArchiveGuessFormat(path);
@@ -531,7 +383,7 @@ bool DirItemEnumerator::MultiStepCompressArchive(const tchar_t* path)
 /**
  * @brief Generate archive from DirView items.
  */
-void DirItemEnumerator::CompressArchive(const tchar_t* path)
+void CompressibleItemEnumerator::CompressArchive(const tchar_t* path)
 {
 	String strPath;
 	if (path == nullptr)

--- a/Src/7zCommon.h
+++ b/Src/7zCommon.h
@@ -48,15 +48,23 @@ public:
 };
 
 /**
+ * @brief One file/folder to be added to the archive, fully resolved
+ *        (archive-relative name + physical source path + recurse flag).
+ *        No knowledge of CDirView/DIFFITEM/CDiffContext required.
+ */
+struct CompressibleItem
+{
+   String name;             // Name (relative path) inside the archive
+   String fullPath;         // Physical source path
+   bool   recurse = false;  // true: let 7-Zip physically recurse this folder
+};
+
+/**
  * @brief Merge7z::DirItemEnumerator to compress items from DirView.
  */
-class DirItemEnumerator : public Merge7z::DirItemEnumerator
+class CompressibleItemEnumerator : public Merge7z::DirItemEnumerator
 {
 private:
-	CDirView *m_pView;
-	int m_nFlags;
-	int m_nIndex;
-	typedef CListCtrl *pView;
 	struct Envelope : public Merge7z::Envelope
 	{
 		String Name;
@@ -66,30 +74,17 @@ private:
 			delete this;
 		}
 	};
-	std::list<String> m_rgFolderPrefix;
-	std::list<String>::iterator m_curFolderPrefix;
-	std::vector<const DIFFITEM*> m_selectedFolderDiffItems;
-	String m_strFolderPrefix;
-	int m_index;
-	std::map<String, void *> m_rgImpliedFolders[3];
-//	helper methods
-	const DIFFITEM &Next();
 	bool MultiStepCompressArchive(const tchar_t*);
+
 public:
-	enum
-	{
-		Left = 0x00,
-		Middle = 0x10,
-		Right = 0x20,
-		Original = 0x40,
-		Altered = 0x80,
-		DiffsOnly = 0x100,
-		BalanceFolders = 0x200
-	};
-	DirItemEnumerator(CDirView *, int);
-	virtual UINT Open();
-	virtual Merge7z::Envelope *Enum(Item &);
+	explicit CompressibleItemEnumerator(std::vector<CompressibleItem> items);
+	
+	UINT Open() override;
+	Envelope* Enum(Item& item) override;
 	void CompressArchive(const tchar_t* = 0);
+private:
+	std::vector<CompressibleItem> m_items;
+	size_t m_itemPos = 0;
 };
 
 int NTAPI HasZipSupport();

--- a/Src/DirActions.cpp
+++ b/Src/DirActions.cpp
@@ -170,7 +170,7 @@ void AddZipItem(const CDiffContext& ctxt, const DIFFITEM& di, int index, bool bD
 			return;
 		}
 
-		if (bDiffsOnly && di.diffcode.existAll())
+		if (bDiffsOnly && !IsItemNavigableDiff(ctxt, di))
 			return;
 
 		if (!di.diffcode.exists(index))

--- a/Src/DirActions.cpp
+++ b/Src/DirActions.cpp
@@ -154,6 +154,115 @@ static void ThrowConfirmationNeededException(const CDiffContext& ctxt, const Str
 }
 
 /**
+ * @brief Add a DIFFITEM to the list of items to be compressed.
+ */
+void AddZipItem(const CDiffContext& ctxt, const DIFFITEM& di, int index, bool bDiffsOnly, std::vector<CompressibleItem>& items)
+{
+	if (di.diffcode.diffcode == 0)
+		 return;
+
+	if (di.diffcode.isDirectory())
+	{
+		if (di.HasChildren())
+		{
+			for (DIFFITEM* pdic = di.GetFirstChild(); pdic; pdic = pdic->GetFwdSiblingLink())
+				AddZipItem(ctxt, *pdic, index, bDiffsOnly, items);
+			return;
+		}
+
+		if (bDiffsOnly && di.diffcode.existAll())
+			return;
+
+		if (!di.diffcode.exists(index))
+			return;
+
+		CompressibleItem ci;
+		const String & sFilename = di.diffFileInfo[index].filename.get();
+		const String & sSubdir = di.diffFileInfo[index].path.get();
+		ci.name = sSubdir.length() ? paths::ConcatPath(sSubdir, sFilename) : sFilename;
+		ci.fullPath = paths::ConcatPath(di.getFilepath(index, ctxt.GetNormalizedPath(index)), sFilename);
+		ci.recurse = true;
+		items.push_back(std::move(ci));
+		return;
+	}
+
+	if (bDiffsOnly && !IsItemNavigableDiff(ctxt, di))
+		return;
+	
+	if (!di.diffcode.exists(index))
+		return;
+	
+	CompressibleItem ci;
+	const String & sFilename = di.diffFileInfo[index].filename.get();
+	const String & sSubdir = di.diffFileInfo[index].path.get();
+	ci.name = sSubdir.length() ? paths::ConcatPath(sSubdir, sFilename) : sFilename;
+	ci.fullPath = paths::ConcatPath(di.getFilepath(index, ctxt.GetNormalizedPath(index)), sFilename);
+	ci.recurse = false;
+	items.push_back(std::move(ci));
+}
+
+std::vector<CompressibleItem> CreateZipItems(
+	const CDiffContext& ctxt,
+	const std::vector<const DIFFITEM*>& diffItems,
+	int index,
+	bool bDiffsOnly)
+{
+	std::vector<CompressibleItem> items;
+
+	for (const DIFFITEM* pdi : diffItems)
+	{
+		if (pdi != nullptr)
+			AddZipItem(ctxt, *pdi, index, bDiffsOnly, items);
+	}
+
+	std::sort(items.begin(), items.end(),
+		[](const CompressibleItem& a, const CompressibleItem& b)
+		{
+			return a.name < b.name;
+		});
+
+	items.erase(
+		std::unique(items.begin(), items.end(),
+			[](const CompressibleItem& a, const CompressibleItem& b)
+			{
+				return a.name == b.name;
+			}),
+		items.end());
+
+	return items;
+}
+
+/**
+ * @brief Add a single item to the list of items to be zipped.
+ */
+void BalanceZipFolders(std::vector<CompressibleItem>& original, std::vector<CompressibleItem>& altered)
+{
+	auto collectDirs = [](const std::vector<CompressibleItem>& items)
+	{
+		std::map<String, String> dirs;
+		for (const auto& ci : items)
+		{
+			String dir = paths::GetPathOnly(ci.name);
+			dirs[dir] = paths::GetPathOnly(ci.fullPath);
+		}
+		return dirs;
+	};
+	auto dirsOriginal = collectDirs(original);
+	auto dirsAltered = collectDirs(altered);
+	
+	for (const auto& [dir, physPath] : dirsAltered)
+	{
+		if (dirsOriginal.find(dir) == dirsOriginal.end())
+			original.push_back({ dir, physPath, false });
+	}
+	for (const auto& [dir, physPath] : dirsOriginal)
+	{
+		if (dirsAltered.find(dir) == dirsAltered.end())
+			altered.push_back({ dir, physPath, false });
+	}
+}
+
+/**
  * @brief Confirm actions with user as appropriate
  * (type, whether single or multiple).
  */

--- a/Src/DirActions.cpp
+++ b/Src/DirActions.cpp
@@ -201,67 +201,6 @@ void AddZipItem(const CDiffContext& ctxt, const DIFFITEM& di, int index, bool bD
 	items.push_back(std::move(ci));
 }
 
-std::vector<CompressibleItem> CreateZipItems(
-	const CDiffContext& ctxt,
-	const std::vector<const DIFFITEM*>& diffItems,
-	int index,
-	bool bDiffsOnly)
-{
-	std::vector<CompressibleItem> items;
-
-	for (const DIFFITEM* pdi : diffItems)
-	{
-		if (pdi != nullptr)
-			AddZipItem(ctxt, *pdi, index, bDiffsOnly, items);
-	}
-
-	std::sort(items.begin(), items.end(),
-		[](const CompressibleItem& a, const CompressibleItem& b)
-		{
-			return a.name < b.name;
-		});
-
-	items.erase(
-		std::unique(items.begin(), items.end(),
-			[](const CompressibleItem& a, const CompressibleItem& b)
-			{
-				return a.name == b.name;
-			}),
-		items.end());
-
-	return items;
-}
-
-/**
- * @brief Add a single item to the list of items to be zipped.
- */
-void BalanceZipFolders(std::vector<CompressibleItem>& original, std::vector<CompressibleItem>& altered)
-{
-	auto collectDirs = [](const std::vector<CompressibleItem>& items)
-	{
-		std::map<String, String> dirs;
-		for (const auto& ci : items)
-		{
-			String dir = paths::GetPathOnly(ci.name);
-			dirs[dir] = paths::GetPathOnly(ci.fullPath);
-		}
-		return dirs;
-	};
-	auto dirsOriginal = collectDirs(original);
-	auto dirsAltered = collectDirs(altered);
-	
-	for (const auto& [dir, physPath] : dirsAltered)
-	{
-		if (dirsOriginal.find(dir) == dirsOriginal.end())
-			original.push_back({ dir, physPath, false });
-	}
-	for (const auto& [dir, physPath] : dirsOriginal)
-	{
-		if (dirsAltered.find(dir) == dirsAltered.end())
-			altered.push_back({ dir, physPath, false });
-	}
-}
-
 /**
  * @brief Confirm actions with user as appropriate
  * (type, whether single or multiple).

--- a/Src/DirActions.h
+++ b/Src/DirActions.h
@@ -8,6 +8,7 @@
 #include <algorithm>
 #include "FileTransform.h"
 #include "FileFilterHelper.h"
+#include "7zCommon.h"
 
 class CDiffContext;
 class PathContext;
@@ -598,6 +599,37 @@ struct DirActions
 	const CDiffContext& m_ctxt;
 	const bool *m_RO;
 };
+
+void AddZipItem(const CDiffContext& ctxt, const DIFFITEM& di, int index, bool bDiffsOnly, std::vector<CompressibleItem>& items);
+void BalanceZipFolders(std::vector<CompressibleItem>& original, std::vector<CompressibleItem>& altered);
+template<typename Iterator>
+std::vector<CompressibleItem> CreateZipItems(const CDiffContext& ctxt, Iterator first, Iterator last, int index, bool bDiffsOnly)
+{
+	std::vector<CompressibleItem> items;
+
+	for (; first != last; ++first)
+	{
+		const DIFFITEM* pdi = (*first).second;
+		if (pdi != nullptr)
+			AddZipItem(ctxt, *pdi, index, bDiffsOnly, items);
+	}
+
+	std::sort(items.begin(), items.end(),
+		[](const CompressibleItem& a, const CompressibleItem& b)
+		{
+			return a.name < b.name;
+		});
+
+	items.erase(
+		std::unique(items.begin(), items.end(),
+			[](const CompressibleItem& a, const CompressibleItem& b)
+			{
+				return a.name == b.name;
+			}),
+		items.end());
+
+	return items;
+}
 
 struct Counts {
 	Counts() : count(0), total(0) {}

--- a/Src/DirActions.h
+++ b/Src/DirActions.h
@@ -601,7 +601,6 @@ struct DirActions
 };
 
 void AddZipItem(const CDiffContext& ctxt, const DIFFITEM& di, int index, bool bDiffsOnly, std::vector<CompressibleItem>& items);
-void BalanceZipFolders(std::vector<CompressibleItem>& original, std::vector<CompressibleItem>& altered);
 template<typename Iterator>
 std::vector<CompressibleItem> CreateZipItems(const CDiffContext& ctxt, Iterator first, Iterator last, int index, bool bDiffsOnly)
 {

--- a/Src/DirView.cpp
+++ b/Src/DirView.cpp
@@ -350,9 +350,9 @@ BEGIN_MESSAGE_MAP(CDirView, CListView)
 	ON_COMMAND(ID_DIR_ZIP_LEFT, OnCtxtDirZip<DirViewZipFlags::Left>)
 	ON_COMMAND(ID_DIR_ZIP_MIDDLE, OnCtxtDirZip<DirViewZipFlags::Middle>)
 	ON_COMMAND(ID_DIR_ZIP_RIGHT, OnCtxtDirZip<DirViewZipFlags::Right>)
-	ON_COMMAND(ID_DIR_ZIP_BOTH, OnCtxtDirZip<DirViewZipFlags::Original | DirViewZipFlags::Altered | DirViewZipFlags::BalanceFolders>)
-	ON_COMMAND(ID_DIR_ZIP_ALL, OnCtxtDirZip<DirViewZipFlags::Original | DirViewZipFlags::Altered | DirViewZipFlags::BalanceFolders>)
-	ON_COMMAND(ID_DIR_ZIP_BOTH_DIFFS_ONLY, OnCtxtDirZip<DirViewZipFlags::Original | DirViewZipFlags::Altered | DirViewZipFlags::BalanceFolders | DirViewZipFlags::DiffsOnly>)
+	ON_COMMAND(ID_DIR_ZIP_BOTH, OnCtxtDirZip<DirViewZipFlags::Original | DirViewZipFlags::Altered>)
+	ON_COMMAND(ID_DIR_ZIP_ALL, OnCtxtDirZip<DirViewZipFlags::Original | DirViewZipFlags::Altered>)
+	ON_COMMAND(ID_DIR_ZIP_BOTH_DIFFS_ONLY, OnCtxtDirZip<DirViewZipFlags::Original | DirViewZipFlags::Altered | DirViewZipFlags::DiffsOnly>)
 	ON_UPDATE_COMMAND_UI(ID_DIR_ZIP_LEFT, OnUpdateCtxtDirCopyTo<SIDE_LEFT>)
 	ON_UPDATE_COMMAND_UI(ID_DIR_ZIP_MIDDLE, OnUpdateCtxtDirCopyTo<SIDE_MIDDLE>)
 	ON_UPDATE_COMMAND_UI(ID_DIR_ZIP_RIGHT, OnUpdateCtxtDirCopyTo<SIDE_RIGHT>)
@@ -3466,19 +3466,26 @@ void CDirView::OnCtxtDirZip(int flag)
 	std::vector<CompressibleItem> items;
 	if (bBoth)
 	{
-		auto original = CreateZipItems(ctxt, begin, end, 0, bDiffsOnly);
-		auto altered = CreateZipItems(ctxt, begin, end, 1, bDiffsOnly);
-		if (flag & DirViewZipFlags::BalanceFolders)
-			BalanceZipFolders(original, altered);
-		for (auto& ci : original)
+		String dirnames[3];
+		if (nDirs < 3)
 		{
-			ci.name.insert(0, _T("original\\"));
-			items.push_back(std::move(ci));
+			dirnames[0] = _T("original\\");
+			dirnames[1] = _T("altered\\");
 		}
-		for (auto& ci : altered)
+		else
 		{
-			ci.name.insert(0, _T("altered\\"));
-			items.push_back(std::move(ci));
+			dirnames[0] = _T("1\\");
+			dirnames[1] = _T("2\\");
+			dirnames[2] = _T("3\\");
+		}
+		for (int i = 0; i < nDirs; ++i)
+		{
+			auto zipItems = CreateZipItems(ctxt, begin, end, i, bDiffsOnly);
+			for (auto& ci : zipItems)
+			{
+				ci.name.insert(0, dirnames[i].c_str());
+				items.push_back(std::move(ci));
+			}
 		}
 	}
 	else

--- a/Src/DirView.cpp
+++ b/Src/DirView.cpp
@@ -347,12 +347,12 @@ BEGIN_MESSAGE_MAP(CDirView, CListView)
 	ON_UPDATE_COMMAND_UI(ID_DIR_COPY_PATHNAMES_BOTH, OnUpdateCtxtDirCopyBoth2)
 	ON_UPDATE_COMMAND_UI(ID_DIR_COPY_PATHNAMES_ALL, OnUpdateCtxtDirCopyBoth2)
 	// Context menu -> Zip
-	ON_COMMAND(ID_DIR_ZIP_LEFT, OnCtxtDirZip<DirItemEnumerator::Left>)
-	ON_COMMAND(ID_DIR_ZIP_MIDDLE, OnCtxtDirZip<DirItemEnumerator::Middle>)
-	ON_COMMAND(ID_DIR_ZIP_RIGHT, OnCtxtDirZip<DirItemEnumerator::Right>)
-	ON_COMMAND(ID_DIR_ZIP_BOTH, OnCtxtDirZip<DirItemEnumerator::Original | DirItemEnumerator::Altered | DirItemEnumerator::BalanceFolders>)
-	ON_COMMAND(ID_DIR_ZIP_ALL, OnCtxtDirZip<DirItemEnumerator::Original | DirItemEnumerator::Altered | DirItemEnumerator::BalanceFolders>)
-	ON_COMMAND(ID_DIR_ZIP_BOTH_DIFFS_ONLY, OnCtxtDirZip<DirItemEnumerator::Original | DirItemEnumerator::Altered | DirItemEnumerator::BalanceFolders | DirItemEnumerator::DiffsOnly>)
+	ON_COMMAND(ID_DIR_ZIP_LEFT, OnCtxtDirZip<DirViewZipFlags::Left>)
+	ON_COMMAND(ID_DIR_ZIP_MIDDLE, OnCtxtDirZip<DirViewZipFlags::Middle>)
+	ON_COMMAND(ID_DIR_ZIP_RIGHT, OnCtxtDirZip<DirViewZipFlags::Right>)
+	ON_COMMAND(ID_DIR_ZIP_BOTH, OnCtxtDirZip<DirViewZipFlags::Original | DirViewZipFlags::Altered | DirViewZipFlags::BalanceFolders>)
+	ON_COMMAND(ID_DIR_ZIP_ALL, OnCtxtDirZip<DirViewZipFlags::Original | DirViewZipFlags::Altered | DirViewZipFlags::BalanceFolders>)
+	ON_COMMAND(ID_DIR_ZIP_BOTH_DIFFS_ONLY, OnCtxtDirZip<DirViewZipFlags::Original | DirViewZipFlags::Altered | DirViewZipFlags::BalanceFolders | DirViewZipFlags::DiffsOnly>)
 	ON_UPDATE_COMMAND_UI(ID_DIR_ZIP_LEFT, OnUpdateCtxtDirCopyTo<SIDE_LEFT>)
 	ON_UPDATE_COMMAND_UI(ID_DIR_ZIP_MIDDLE, OnUpdateCtxtDirCopyTo<SIDE_MIDDLE>)
 	ON_UPDATE_COMMAND_UI(ID_DIR_ZIP_RIGHT, OnUpdateCtxtDirCopyTo<SIDE_RIGHT>)
@@ -3456,10 +3456,42 @@ void CDirView::OnCtxtDirZip(int flag)
 		return;
 	}
 
-	DirItemEnumerator
-	(
-		this, LVNI_SELECTED | flag
-	).CompressArchive();
+	const bool bDiffsOnly = (flag & DirViewZipFlags::DiffsOnly) != 0;
+	const bool bBoth = (flag & DirViewZipFlags::Original) && (flag & DirViewZipFlags::Altered);
+	const int nDirs = GetDocument()->m_nDirs;
+	const CDiffContext & ctxt = GetDiffContext();
+	DirItemWithIndexIterator begin(m_pIList.get(), -1, true);
+	DirItemWithIndexIterator end;
+
+	std::vector<CompressibleItem> items;
+	if (bBoth)
+	{
+		auto original = CreateZipItems(ctxt, begin, end, 0, bDiffsOnly);
+		auto altered = CreateZipItems(ctxt, begin, end, 1, bDiffsOnly);
+		if (flag & DirViewZipFlags::BalanceFolders)
+			BalanceZipFolders(original, altered);
+		for (auto& ci : original)
+		{
+			ci.name.insert(0, _T("original\\"));
+			items.push_back(std::move(ci));
+		}
+		for (auto& ci : altered)
+		{
+			ci.name.insert(0, _T("altered\\"));
+			items.push_back(std::move(ci));
+		}
+	}
+	else
+	{
+		int index;
+		if (nDirs < 3)
+			index = (flag & DirViewZipFlags::Right) ? 1 : 0;
+		else
+			index = (flag & DirViewZipFlags::Right) ? 2 : (flag & DirViewZipFlags::Middle) ? 1 : 0;
+		items = CreateZipItems(ctxt, begin, end, index, bDiffsOnly);
+	}
+
+	CompressibleItemEnumerator(std::move(items)).CompressArchive();
 }
 
 void CDirView::ShowShellContextMenu(UINT id)

--- a/Src/DirView.h
+++ b/Src/DirView.h
@@ -23,6 +23,7 @@
 #include "DirActions.h"
 #include "IListCtrlImpl.h"
 #include "FileOpenFlags.h"
+#include "7zCommon.h"
 
 class FileActionScript;
 
@@ -46,6 +47,25 @@ struct IListCtrl;
 class CFileFilterHelperMenu;
 
 /**
+ * @brief Flags controlling CDirView::OnCtxtDirZip() / CollectZipItems() behavior.
+ *        (Moved out of the Merge7z adapter class, since that class no longer
+ *        knows anything about WinMerge's directory-compare domain.)
+ */
+namespace DirViewZipFlags
+{
+	enum
+	{
+		Left = 0x0000,
+		Right = 0x0001,
+		Middle = 0x0002,
+		Original = 0x0004,
+		Altered = 0x0008,
+		BalanceFolders = 0x0010,
+		DiffsOnly = 0x0020,
+	};
+}
+
+/**
  * @brief Position value for special items (..) in directory compare view.
  */
 const uintptr_t SPECIAL_ITEM_POS = (uintptr_t)(reinterpret_cast<DIFFITEM *>( - 1L));
@@ -67,7 +87,6 @@ constexpr int DefColumnWidth = 111;
 class CDirView : public CListView
 {
 	friend struct FileCmpReport;
-	friend DirItemEnumerator;
 protected:
 	CDirView();           // protected constructor used by dynamic creation
 	DECLARE_DYNCREATE(CDirView)
@@ -135,6 +154,7 @@ private:
 	Counts Count(DirActions::method_type2 func) const;
 	void DoDirAction(DirActions::method_type func, const String& status_message);
 	void DoDirActionTo(SIDE_TYPE stype, DirActions::method_type func, const String& status_message);
+	std::vector<CompressibleItem> CollectZipItems(int index, bool bDiffsOnly);
 	void DoOpen(SIDE_TYPE stype);
 	void DoOpenWith(SIDE_TYPE stype);
 	void DoOpenWithEditor(SIDE_TYPE stype);

--- a/Src/DirView.h
+++ b/Src/DirView.h
@@ -47,7 +47,7 @@ struct IListCtrl;
 class CFileFilterHelperMenu;
 
 /**
- * @brief Flags controlling CDirView::OnCtxtDirZip() / CollectZipItems() behavior.
+ * @brief Flags controlling CDirView::OnCtxtDirZip() / CreateZipItems() behavior.
  *        (Moved out of the Merge7z adapter class, since that class no longer
  *        knows anything about WinMerge's directory-compare domain.)
  */

--- a/Src/DirView.h
+++ b/Src/DirView.h
@@ -60,7 +60,6 @@ namespace DirViewZipFlags
 		Middle = 0x0002,
 		Original = 0x0004,
 		Altered = 0x0008,
-		BalanceFolders = 0x0010,
 		DiffsOnly = 0x0020,
 	};
 }
@@ -154,7 +153,6 @@ private:
 	Counts Count(DirActions::method_type2 func) const;
 	void DoDirAction(DirActions::method_type func, const String& status_message);
 	void DoDirActionTo(SIDE_TYPE stype, DirActions::method_type func, const String& status_message);
-	std::vector<CompressibleItem> CollectZipItems(int index, bool bDiffsOnly);
 	void DoOpen(SIDE_TYPE stype);
 	void DoOpenWith(SIDE_TYPE stype);
 	void DoOpenWithEditor(SIDE_TYPE stype);


### PR DESCRIPTION
## Summary

Fixes #3444.

When creating a ZIP archive with **Differences Only**, unchanged files inside subfolders were incorrectly included because entire directories were recursively added to the archive.

This change collects the actual files and directories to archive before invoking the 7-Zip layer, ensuring that only the intended items are included.

## Changes

- Introduce `CompressibleItem` to represent archive entries.
- Move ZIP item collection logic from the 7-Zip adapter into `CDirView`.
- Replace `DirItemEnumerator` with `CompressibleItemEnumerator`.
- Refactor ZIP export code for clearer separation of responsibilities.