### PR TITLE
Fix crash in #3456 caused by file size races in UniMemFile

### DIFF
--- a/Src/Common/UniFile.cpp
+++ b/Src/Common/UniFile.cpp
@@ -270,6 +270,14 @@ bool UniMemFile::DoOpen(const String& filename, AccessMode mode)
 	return true;
 }
 
+bool UniMemFile::DoGetFileStatus()
+{
+	m_lastError.ClearError();
+	m_filesize = m_hMapping->end() - m_hMapping->begin();
+	m_statusFetched = 1;
+	return true;
+}
+
 /**
  * @brief Check for Unicode BOM (byte order mark) at start of file
  *

--- a/Src/Common/UniFile.cpp
+++ b/Src/Common/UniFile.cpp
@@ -273,7 +273,18 @@ bool UniMemFile::DoOpen(const String& filename, AccessMode mode)
 bool UniMemFile::DoGetFileStatus()
 {
 	m_lastError.ClearError();
-	m_filesize = m_hMapping->end() - m_hMapping->begin();
+
+	if (m_hMapping == nullptr)
+	{
+		m_filesize = 0;
+		m_statusFetched = 1;
+		return true;
+	}
+
+	auto begin = m_hMapping->begin();
+	auto end = m_hMapping->end();
+
+	m_filesize = end - begin;
 	m_statusFetched = 1;
 	return true;
 }

--- a/Src/Common/UniFile.h
+++ b/Src/Common/UniFile.h
@@ -202,6 +202,7 @@ public:
 // Implementation methods
 protected:
 	virtual bool DoOpen(const String& filename, AccessMode mode);
+	virtual bool DoGetFileStatus();
 
 // Implementation data
 private:


### PR DESCRIPTION
## Summary

Use the mapped view size instead of querying the current file size from the filesystem in `UniMemFile`.

Previously, `UniMemFile` obtained the file size by calling `GetFileStatus()` after creating the memory mapping. If another process appended data to the file between these operations, `m_filesize` could become larger than the mapped view size.

This could cause `ReadString()` to read beyond the mapped region, resulting in an access violation during automatic reload.

The file size is now derived directly from the mapped view (`end() - begin()`), ensuring that `m_filesize` always matches the mapped region.

Fixes #3456.