### PR TITLE
Fix archive vs folder comparison selecting the wrong source

### DIFF
--- a/Src/Merge.cpp
+++ b/Src/Merge.cpp
@@ -76,6 +76,7 @@
 #include "CrystalLineSyntaxParser.h"
 #include "TreeSitterParser.h"
 #include "SyntaxParserRegistry.h"
+#include "7zCommon.h"
 #include <../src/mfc/afximpl.h>
 
 #ifdef _DEBUG
@@ -924,25 +925,24 @@ void CMergeApp::ShowDialog(MergeCmdLineInfo::DialogType type)
 /**
  * @brief Adjust file and folder paths for comparison.
  */
-bool IsArchiveFile(const String&);
-
-static PathContext AdjustFileFolderPaths(const PathContext& Files)
-	PathContext paths = Files;
+static PathContext AdjustFileFolderPaths(const PathContext& paths)
+{
+	PathContext pathsAdjusted = paths;
 	if (paths.GetSize() < 2)
-		return paths;
+		return pathsAdjusted;
 	paths::PATH_EXISTENCE p1 = paths::DoesPathExist(paths[0]);
 	paths::PATH_EXISTENCE p2 = paths::DoesPathExist(paths[1]);
 	if ((p1 == paths::IS_EXISTING_FILE) && (p2 == paths::IS_EXISTING_DIR) && !IsArchiveFile(paths[0]))
 	{
-		paths[1] = paths::ConcatPath(paths[1], paths::FindFileName(paths[0]));
+		pathsAdjusted[1] = paths::ConcatPath(paths[1], paths::FindFileName(paths[0]));
 		if (paths.GetSize() > 2)
 		{
 			paths::PATH_EXISTENCE p3 = paths::DoesPathExist(paths[2]);
 			if (p3 == paths::IS_EXISTING_DIR)
-				paths[2] = paths::ConcatPath(paths[2], paths::FindFileName(paths[0]));
+				pathsAdjusted[2] = paths::ConcatPath(paths[2], paths::FindFileName(paths[0]));
 		}
 	}
-	return paths;
+	return pathsAdjusted;
 }
 
 /** @brief Read command line arguments and open files for comparison.

--- a/Src/Merge.cpp
+++ b/Src/Merge.cpp
@@ -924,8 +924,9 @@ void CMergeApp::ShowDialog(MergeCmdLineInfo::DialogType type)
 /**
  * @brief Adjust file and folder paths for comparison.
  */
+bool IsArchiveFile(const String&);
+
 static PathContext AdjustFileFolderPaths(const PathContext& Files)
-{
 	PathContext paths = Files;
 	if (paths.GetSize() < 2)
 		return paths;

--- a/Src/Merge.cpp
+++ b/Src/Merge.cpp
@@ -1047,8 +1047,14 @@ bool CMergeApp::ParseArgsAndDoOpen(MergeCmdLineInfo& cmdInfo, CMainFrame* pMainF
 		}
 		else if (cmdInfo.m_Files.GetSize() > 1)
 		{
+			PathContext paths = cmdInfo.m_Files;
+			paths::PATH_EXISTENCE p1 = paths::DoesPathExist(paths[0]);
+			paths::PATH_EXISTENCE p2 = paths::DoesPathExist(paths[1]);
+			if ((p1 == paths::IS_EXISTING_FILE) && (p2 == paths::IS_EXISTING_DIR) && !IsArchiveFile(paths[0]))
+				paths[1] = paths::ConcatPath(paths[1], paths::FindFileName(paths[0]));
+
 			fileopenflags_t dwFlags[3] = {cmdInfo.m_dwLeftFlags, cmdInfo.m_dwRightFlags, FFILEOPEN_NONE};
-			bCompared = pMainFrame->DoFileOrFolderOpen(&cmdInfo.m_Files,
+			bCompared = pMainFrame->DoFileOrFolderOpen(&paths,
 				dwFlags, strDesc, cmdInfo.m_sReportFile, nullptr,
 				infoUnpacker.get(), infoPrediffer.get(), nID, pOpenParams.get());
 		}

--- a/Src/Merge.cpp
+++ b/Src/Merge.cpp
@@ -921,6 +921,29 @@ void CMergeApp::ShowDialog(MergeCmdLineInfo::DialogType type)
 	}
 }
 
+/**
+ * @brief Adjust file and folder paths for comparison.
+ */
+static PathContext AdjustFileFolderPaths(const PathContext& Files)
+{
+	PathContext paths = Files;
+	if (paths.GetSize() < 2)
+		return paths;
+	paths::PATH_EXISTENCE p1 = paths::DoesPathExist(paths[0]);
+	paths::PATH_EXISTENCE p2 = paths::DoesPathExist(paths[1]);
+	if ((p1 == paths::IS_EXISTING_FILE) && (p2 == paths::IS_EXISTING_DIR) && !IsArchiveFile(paths[0]))
+	{
+		paths[1] = paths::ConcatPath(paths[1], paths::FindFileName(paths[0]));
+		if (paths.GetSize() > 2)
+		{
+			paths::PATH_EXISTENCE p3 = paths::DoesPathExist(paths[2]);
+			if (p3 == paths::IS_EXISTING_DIR)
+				paths[2] = paths::ConcatPath(paths[2], paths::FindFileName(paths[0]));
+		}
+	}
+	return paths;
+}
+
 /** @brief Read command line arguments and open files for comparison.
  *
  * The name of the function is a legacy code from the time that this function
@@ -1037,22 +1060,18 @@ bool CMergeApp::ParseArgsAndDoOpen(MergeCmdLineInfo& cmdInfo, CMainFrame* pMainF
 		}
 		if (cmdInfo.m_Files.GetSize() > 2)
 		{
+			PathContext paths = AdjustFileFolderPaths(cmdInfo.m_Files);
 			cmdInfo.m_dwLeftFlags |= FFILEOPEN_CMDLINE;
 			cmdInfo.m_dwMiddleFlags |= FFILEOPEN_CMDLINE;
 			cmdInfo.m_dwRightFlags |= FFILEOPEN_CMDLINE;
 			fileopenflags_t dwFlags[3] = {cmdInfo.m_dwLeftFlags, cmdInfo.m_dwMiddleFlags, cmdInfo.m_dwRightFlags};
-			bCompared = pMainFrame->DoFileOrFolderOpen(&cmdInfo.m_Files,
+			bCompared = pMainFrame->DoFileOrFolderOpen(&paths,
 				dwFlags, strDesc, cmdInfo.m_sReportFile, nullptr,
 				infoUnpacker.get(), infoPrediffer.get(), nID, pOpenParams.get());
 		}
 		else if (cmdInfo.m_Files.GetSize() > 1)
 		{
-			PathContext paths = cmdInfo.m_Files;
-			paths::PATH_EXISTENCE p1 = paths::DoesPathExist(paths[0]);
-			paths::PATH_EXISTENCE p2 = paths::DoesPathExist(paths[1]);
-			if ((p1 == paths::IS_EXISTING_FILE) && (p2 == paths::IS_EXISTING_DIR) && !IsArchiveFile(paths[0]))
-				paths[1] = paths::ConcatPath(paths[1], paths::FindFileName(paths[0]));
-
+			PathContext paths = AdjustFileFolderPaths(cmdInfo.m_Files);
 			fileopenflags_t dwFlags[3] = {cmdInfo.m_dwLeftFlags, cmdInfo.m_dwRightFlags, FFILEOPEN_NONE};
 			bCompared = pMainFrame->DoFileOrFolderOpen(&paths,
 				dwFlags, strDesc, cmdInfo.m_sReportFile, nullptr,

--- a/Src/MergeCmdLineInfo.cpp
+++ b/Src/MergeCmdLineInfo.cpp
@@ -596,17 +596,6 @@ void MergeCmdLineInfo::ParseWinMergeCmdLine(const tchar_t *q)
 			m_sErrorMessages.emplace_back(_T("Unknown option '/") + param + _T("'"));
 		}
 	}
-	// If "compare file dir" make it "compare file dir\file".
-	if (m_Files.GetSize() >= 2)
-	{
-		paths::PATH_EXISTENCE p1 = paths::DoesPathExist(m_Files[0]);
-		paths::PATH_EXISTENCE p2 = paths::DoesPathExist(m_Files[1]);
-
-		if ((p1 == paths::IS_EXISTING_FILE) && (p2 == paths::IS_EXISTING_DIR))
-		{
-			m_Files[1] = paths::ConcatPath(m_Files[1], paths::FindFileName(m_Files[0]));
-		}
-	}
 	if (m_bShowUsage)
 	{
 		m_bNonInteractive = false;


### PR DESCRIPTION
Fixes #3449.

Move the "file + folder" path adjustment from command-line parsing to the comparison stage, and apply it only to regular files.

This preserves the existing behavior for normal file comparisons while allowing archive vs folder comparisons to use the selected sources correctly.