### PR TITLE
Add /g command line option for single-instance groups

### DIFF
--- a/Docs/Manual/English/Command_line.xml
+++ b/Docs/Manual/English/Command_line.xml
@@ -324,6 +324,21 @@
 
     <varlistentry>
       <indexterm>
+        <primary>WinMerge window</primary>
+        <secondary>instance groups</secondary>
+      </indexterm>
+
+      <term><option>/g</option>
+      <replaceable>groupname</replaceable></term>
+      <listitem>
+        <para>Specifies a group name for the WinMerge instance. When used with
+        the <option>/s</option> option, instances with the same group name share
+        the same window, allowing you to organize multiple single-instance groups.</para>
+      </listitem>
+    </varlistentry>
+
+    <varlistentry>
+      <indexterm>
         <primary>MRU list</primary>
       </indexterm>
 

--- a/Docs/Manual/English/Command_line.xml
+++ b/Docs/Manual/English/Command_line.xml
@@ -49,6 +49,9 @@
 
       <arg><option>/s-</option></arg>
 
+      <arg choice="opt" rep="norepeat"><option>/g</option>
+      <replaceable>group-name</replaceable></arg>
+
       <arg choice="opt" rep="norepeat"><option>/ul</option></arg>
 
       <arg choice="opt" rep="norepeat"><option>/um</option></arg>
@@ -329,7 +332,7 @@
       </indexterm>
 
       <term><option>/g</option>
-      <replaceable>groupname</replaceable></term>
+      <replaceable>group-name</replaceable></term>
       <listitem>
         <para>Specifies a group name for the WinMerge instance. When used with
         the <option>/s</option> option, instances with the same group name share

--- a/Docs/Manual/French/Command_line.xml
+++ b/Docs/Manual/French/Command_line.xml
@@ -24,14 +24,16 @@ rep="norepeat"><option>/?</option></arg></cmdsynopsis></para>
 rep="norepeat"><option>/r</option></arg> <arg choice="opt"
 rep="norepeat"><option>/r-</option></arg> <arg choice="opt"
 rep="norepeat"><option>/e</option></arg> <arg choice="opt"
-rep="norepeat"><option>/f</option> <replaceable>filtre</replaceable></arg>
+rep="norepeat"><option>/f</option> <replaceable>filter</replaceable></arg>
 <arg choice="opt" rep="norepeat"><option>/m</option>
-<replaceable>méthode-comparaison</replaceable></arg> <arg choice="opt"
+<replaceable>compare-method</replaceable></arg> <arg choice="opt"
 rep="norepeat"><option>/t</option>
-<replaceable>type-fenêtre</replaceable></arg> <arg><option>/x</option></arg>
+<replaceable>window-type</replaceable></arg> <arg><option>/x</option></arg>
 <arg><option>/xq</option></arg> <arg><option>/s</option></arg>
 <arg><option>/sw</option></arg> <arg><option>/s-</option></arg> <arg
-choice="opt" rep="norepeat"><option>/ul</option></arg> <arg choice="opt"
+choice="opt" rep="norepeat"><option>/g</option>
+<replaceable>group-name</replaceable></arg> <arg choice="opt"
+rep="norepeat"><option>/ul</option></arg> <arg choice="opt"
 rep="norepeat"><option>/um</option></arg> <arg choice="opt"
 rep="norepeat"><option>/ur</option></arg> <arg choice="opt"
 rep="norepeat"><option>/u</option></arg> <arg choice="opt"
@@ -46,17 +48,16 @@ rep="norepeat"><option>/clipboard-compare</option></arg>
 choice="opt" rep="norepeat"><option>/fm</option></arg> <arg choice="opt"
 rep="norepeat"><option>/fr</option></arg> <arg choice="opt"
 rep="norepeat"><option>/l</option>
-<replaceable>numéroligne</replaceable></arg> <arg choice="opt"
-rep="norepeat"><option>/c</option>
-<replaceable>poscaractère</replaceable></arg> <arg choice="opt"
-rep="norepeat"><option>/table-delimiter</option>
-<replaceable>délimiteur</replaceable></arg> <arg choice="opt"
+<replaceable>linenumber</replaceable></arg> <arg choice="opt"
+rep="norepeat"><option>/c</option> <replaceable>charpos</replaceable></arg>
+<arg choice="opt" rep="norepeat"><option>/table-delimiter</option>
+<replaceable>delimiter</replaceable></arg> <arg choice="opt"
 rep="norepeat"><option>/dl</option>
-<replaceable>desc_gauche</replaceable></arg> <arg choice="opt"
+<replaceable>leftdesc</replaceable></arg> <arg choice="opt"
 rep="norepeat"><option>/dm</option>
-<replaceable>desc_milieu</replaceable></arg> <arg choice="opt"
+<replaceable>middledesc</replaceable></arg> <arg choice="opt"
 rep="norepeat"><option>/dr</option>
-<replaceable>desc_droite</replaceable></arg> <arg choice="opt"
+<replaceable>rightdesc</replaceable></arg> <arg choice="opt"
 rep="norepeat"><option>/al</option></arg> <arg choice="opt"
 rep="norepeat"><option>/am</option></arg> <arg choice="opt"
 rep="norepeat"><option>/ar</option></arg> <arg choice="opt"
@@ -70,25 +71,24 @@ rep="norepeat"><option>/ignoreeol</option></arg> <arg choice="opt"
 rep="norepeat"><option>/ignorecodepage</option></arg> <arg choice="opt"
 rep="norepeat"><option>/ignorecomments</option></arg> <arg choice="opt"
 rep="norepeat"><option>/unpacker</option>
-<replaceable>nom-décompresseur</replaceable></arg> <arg choice="opt"
+<replaceable>unpacker-name</replaceable></arg> <arg choice="opt"
 rep="norepeat"><option>/prediffer</option>
-<replaceable>nom-prediffer</replaceable></arg> <arg choice="opt"
+<replaceable>prediffer-name</replaceable></arg> <arg choice="opt"
 rep="norepeat"><option>/cp</option>
-<replaceable>page-de-code</replaceable></arg> <arg choice="opt"
+<replaceable>codepage</replaceable></arg> <arg choice="opt"
 rep="norepeat"><option>/fileext</option>
-<replaceable>extension-fichier</replaceable></arg> <arg choice="opt"
+<replaceable>file-extension</replaceable></arg> <arg choice="opt"
 rep="norepeat"><option>/cfg</option>
-<replaceable>nom=valeur</replaceable></arg> <arg choice="opt"
+<replaceable>name=value</replaceable></arg> <arg choice="opt"
 rep="norepeat"><option>/inifile</option>
-<replaceable>fichier_ini</replaceable></arg> <arg choice="plain"
-rep="norepeat"><replaceable>chemin_gauche</replaceable></arg> <arg
-cchoice="opt" rep="norepeat"><replaceable>chemin_milieu</replaceable></arg>
-<arg choice="plain"
-rep="norepeat"><replaceable>chemin_droite</replaceable></arg> <arg
-choice="opt" rep="norepeat"><option>/o</option>
-<replaceable>chemin_sortie</replaceable></arg> <arg choice="opt"
+<replaceable>inifile</replaceable></arg> <arg choice="plain"
+rep="norepeat"><replaceable>leftpath</replaceable></arg> <arg cchoice="opt"
+rep="norepeat"><replaceable>middlepath</replaceable></arg> <arg
+choice="plain" rep="norepeat"><replaceable>rightpath</replaceable></arg>
+<arg choice="opt" rep="norepeat"><option>/o</option>
+<replaceable>outputpath</replaceable></arg> <arg choice="opt"
 rep="norepeat"><option>/or</option>
-<replaceable>chemin_rapport</replaceable></arg></cmdsynopsis></para>
+<replaceable>reportpath</replaceable></arg></cmdsynopsis></para>
 
   <cmdsynopsis sepchar=" ">
 <command>WinMergeU</command> <arg choice="plain"
@@ -250,6 +250,20 @@ existante ou dans une nouvelle fenêtre.</para>
       <listitem>
         <para>Garantit qu'une autre instance est toujours exécutée, en ignorant la valeur
 de l'option « N'autoriser qu'une seule instance à s'exécuter ».</para>
+      </listitem>
+    </varlistentry>
+
+    <varlistentry>
+      <indexterm>
+        <primary>Fenêtre WinMerge</primary>
+        <secondary>instance groups</secondary>
+      </indexterm>
+
+      <term><option>/g</option> <replaceable>group-name</replaceable></term>
+      <listitem>
+        <para>Specifies a group name for the WinMerge instance. When used with the
+<option>/s</option> option, instances with the same group name share the
+same window, allowing you to organize multiple single-instance groups.</para>
       </listitem>
     </varlistentry>
 

--- a/Docs/Manual/Hebrew/Command_line.xml
+++ b/Docs/Manual/Hebrew/Command_line.xml
@@ -30,7 +30,9 @@ rep="norepeat"><option>/t</option>
 <replaceable>window-type</replaceable></arg> <arg><option>/x</option></arg>
 <arg><option>/xq</option></arg> <arg><option>/s</option></arg>
 <arg><option>/sw</option></arg> <arg><option>/s-</option></arg> <arg
-choice="opt" rep="norepeat"><option>/ul</option></arg> <arg choice="opt"
+choice="opt" rep="norepeat"><option>/g</option>
+<replaceable>group-name</replaceable></arg> <arg choice="opt"
+rep="norepeat"><option>/ul</option></arg> <arg choice="opt"
 rep="norepeat"><option>/um</option></arg> <arg choice="opt"
 rep="norepeat"><option>/ur</option></arg> <arg choice="opt"
 rep="norepeat"><option>/u</option></arg> <arg choice="opt"
@@ -234,6 +236,20 @@ keywords <userinput>Full</userinput>, <userinput>Quick</userinput>,
       <listitem>
         <para>ודא שמופע אחר תמיד מבוצע, תוך התעלמות מהערך של האפשרות "אפשר להפעיל רק מופע
 אחד".</para>
+      </listitem>
+    </varlistentry>
+
+    <varlistentry>
+      <indexterm>
+        <primary>חלון WinMerge</primary>
+        <secondary>instance groups</secondary>
+      </indexterm>
+
+      <term><option>/g</option> <replaceable>group-name</replaceable></term>
+      <listitem>
+        <para>Specifies a group name for the WinMerge instance. When used with the
+<option>/s</option> option, instances with the same group name share the
+same window, allowing you to organize multiple single-instance groups.</para>
       </listitem>
     </varlistentry>
 

--- a/Docs/Manual/Italian/Command_line.xml
+++ b/Docs/Manual/Italian/Command_line.xml
@@ -24,14 +24,16 @@ rep="norepeat"><option>/?</option></arg></cmdsynopsis></para>
 rep="norepeat"><option>/r</option></arg> <arg choice="opt"
 rep="norepeat"><option>/r-</option></arg> <arg choice="opt"
 rep="norepeat"><option>/e</option></arg> <arg choice="opt"
-rep="norepeat"><option>/f</option> <replaceable>filtro</replaceable></arg>
-<arg choice="opt" rep="norepeat"><option>/m</option> <replaceable>metodo di
-confronto</replaceable></arg> <arg choice="opt"
-rep="norepeat"><option>/t</option><replaceable>tipo
-finestra</replaceable></arg> <arg><option>/x</option></arg>
+rep="norepeat"><option>/f</option> <replaceable>filter</replaceable></arg>
+<arg choice="opt" rep="norepeat"><option>/m</option>
+<replaceable>compare-method</replaceable></arg> <arg choice="opt"
+rep="norepeat"><option>/t</option>
+<replaceable>window-type</replaceable></arg> <arg><option>/x</option></arg>
 <arg><option>/xq</option></arg> <arg><option>/s</option></arg>
 <arg><option>/sw</option></arg> <arg><option>/s-</option></arg> <arg
-choice="opt" rep="norepeat"><option>/ul</option></arg> <arg choice="opt"
+choice="opt" rep="norepeat"><option>/g</option>
+<replaceable>group-name</replaceable></arg> <arg choice="opt"
+rep="norepeat"><option>/ul</option></arg> <arg choice="opt"
 rep="norepeat"><option>/um</option></arg> <arg choice="opt"
 rep="norepeat"><option>/ur</option></arg> <arg choice="opt"
 rep="norepeat"><option>/u</option></arg> <arg choice="opt"
@@ -45,18 +47,19 @@ rep="norepeat"><option>/clipboard-compare</option></arg>
 <arg choice="opt" rep="norepeat"><option>/fl</option></arg> <arg
 choice="opt" rep="norepeat"><option>/fm</option></arg> <arg choice="opt"
 rep="norepeat"><option>/fr</option></arg> <arg choice="opt"
-rep="norepeat"><option>/l</option><replaceable>numero di
-linea</replaceable></arg> <arg choice="opt"
+rep="norepeat"><option>/l</option>
+<replaceable>linenumber</replaceable></arg> <arg choice="opt"
 rep="norepeat"><option>/c</option> <replaceable>charpos</replaceable></arg>
 <arg choice="opt" rep="norepeat"><option>/table-delimiter</option>
-<replaceable>delimitatore</replaceable></arg> <arg choice="opt"
+<replaceable>delimiter</replaceable></arg> <arg choice="opt"
 rep="norepeat"><option>/dl</option>
 <replaceable>leftdesc</replaceable></arg> <arg choice="opt"
 rep="norepeat"><option>/dm</option>
 <replaceable>middledesc</replaceable></arg> <arg choice="opt"
-rep="norepeat"><option>/dr</option><replaceable>rightdesc</replaceable></arg>
-<arg choice="opt" rep="norepeat"><option>/al</option></arg> <arg
-choice="opt" rep="norepeat"><option>/am</option></arg> <arg choice="opt"
+rep="norepeat"><option>/dr</option>
+<replaceable>rightdesc</replaceable></arg> <arg choice="opt"
+rep="norepeat"><option>/al</option></arg> <arg choice="opt"
+rep="norepeat"><option>/am</option></arg> <arg choice="opt"
 rep="norepeat"><option>/ar</option></arg> <arg choice="opt"
 rep="norepeat"><option>/noninteractive</option></arg> <arg choice="opt"
 rep="norepeat"><option>/noprefs</option></arg> <arg choice="opt"
@@ -67,23 +70,24 @@ rep="norepeat"><option>/ignorecase</option></arg> <arg choice="opt"
 rep="norepeat"><option>/ignoreeol</option></arg> <arg choice="opt"
 rep="norepeat"><option>/ignorecodepage</option></arg> <arg choice="opt"
 rep="norepeat"><option>/ignorecomments</option></arg> <arg choice="opt"
-rep="norepeat"><option>/unpacker</option><replaceable>nome-unpacker</replaceable></arg>
-<arg choice="opt" rep="norepeat"><option>/prediffer</option>
-<replaceable>nome-prediffer</replaceable></arg> <arg choice="opt"
+rep="norepeat"><option>/unpacker</option>
+<replaceable>unpacker-name</replaceable></arg> <arg choice="opt"
+rep="norepeat"><option>/prediffer</option>
+<replaceable>prediffer-name</replaceable></arg> <arg choice="opt"
 rep="norepeat"><option>/cp</option>
 <replaceable>codepage</replaceable></arg> <arg choice="opt"
-rep="norepeat"><option>/fileext</option> <replaceable>estensione
-file</replaceable></arg> <arg choice="opt"
+rep="norepeat"><option>/fileext</option>
+<replaceable>file-extension</replaceable></arg> <arg choice="opt"
 rep="norepeat"><option>/cfg</option>
-<replaceable>nome=valore</replaceable></arg> <arg choice="opt"
-rep="norepeat"><option>/inifile</option><replaceable>fileini</replaceable></arg>
-<arg choice="plain" rep="norepeat"><replaceable>leftpath</replaceable></arg>
-<arg cchoice="opt"
+<replaceable>name=value</replaceable></arg> <arg choice="opt"
+rep="norepeat"><option>/inifile</option>
+<replaceable>inifile</replaceable></arg> <arg choice="plain"
+rep="norepeat"><replaceable>leftpath</replaceable></arg> <arg cchoice="opt"
 rep="norepeat"><replaceable>middlepath</replaceable></arg> <arg
 choice="plain" rep="norepeat"><replaceable>rightpath</replaceable></arg>
 <arg choice="opt" rep="norepeat"><option>/o</option>
 <replaceable>outputpath</replaceable></arg> <arg choice="opt"
-rep="norepeat"><option>/o</option>
+rep="norepeat"><option>/or</option>
 <replaceable>reportpath</replaceable></arg></cmdsynopsis></para>
 
   <cmdsynopsis sepchar=" ">
@@ -245,6 +249,20 @@ che l'istanza che visualizza la finestra termini.</para>
       <listitem>
         <para>Assicurati che venga sempre eseguita un'altra istanza, ignorando il valore
 dell'opzione "Consenti l'esecuzione di una sola istanza".</para>
+      </listitem>
+    </varlistentry>
+
+    <varlistentry>
+      <indexterm>
+        <primary>Finestra WinMerge</primary>
+        <secondary>instance groups</secondary>
+      </indexterm>
+
+      <term><option>/g</option> <replaceable>group-name</replaceable></term>
+      <listitem>
+        <para>Specifies a group name for the WinMerge instance. When used with the
+<option>/s</option> option, instances with the same group name share the
+same window, allowing you to organize multiple single-instance groups.</para>
       </listitem>
     </varlistentry>
 

--- a/Docs/Manual/Japanese/Command_line.xml
+++ b/Docs/Manual/Japanese/Command_line.xml
@@ -28,7 +28,9 @@ rep="norepeat"><option>/t</option>
 <replaceable>window-type</replaceable></arg> <arg><option>/x</option></arg>
 <arg><option>/xq</option></arg> <arg><option>/s</option></arg>
 <arg><option>/sw</option></arg> <arg><option>/s-</option></arg> <arg
-choice="opt" rep="norepeat"><option>/ul</option></arg> <arg choice="opt"
+choice="opt" rep="norepeat"><option>/g</option>
+<replaceable>group-name</replaceable></arg> <arg choice="opt"
+rep="norepeat"><option>/ul</option></arg> <arg choice="opt"
 rep="norepeat"><option>/um</option></arg> <arg choice="opt"
 rep="norepeat"><option>/ur</option></arg> <arg choice="opt"
 rep="norepeat"><option>/u</option></arg> <arg choice="opt"
@@ -217,6 +219,19 @@ Devel</userinput>のようなファイルフィルターの名前です。スペ
       <term><option>/s-</option></term>
       <listitem>
         <para>"複数のインスタンスを起動しない"の設定値を無視して、常に別のインスタンスが起動されるようにします。</para>
+      </listitem>
+    </varlistentry>
+
+    <varlistentry>
+      <indexterm>
+        <primary>WinMergeウィンドウ</primary>
+        <secondary>インスタンスグループ</secondary>
+      </indexterm>
+
+      <term><option>/g</option> <replaceable>group-name</replaceable></term>
+      <listitem>
+        <para>WinMerge インスタンスのグループ名を指定します。<option>/s</option>
+オプションと組み合わせて使用すると、同じグループ名を指定したインスタンスは同じウィンドウを共有します。これにより、複数のシングルインスタンスグループを使用できます。</para>
       </listitem>
     </varlistentry>
 

--- a/Docs/Manual/Spanish/Command_line.xml
+++ b/Docs/Manual/Spanish/Command_line.xml
@@ -24,14 +24,16 @@ rep="norepeat"><option>/?</option></arg></cmdsynopsis></para>
 rep="norepeat"><option>/r</option></arg> <arg choice="opt"
 rep="norepeat"><option>/r-</option></arg> <arg choice="opt"
 rep="norepeat"><option>/e</option></arg> <arg choice="opt"
-rep="norepeat"><option>/f</option> <replaceable>filtro</replaceable></arg>
+rep="norepeat"><option>/f</option> <replaceable>filter</replaceable></arg>
 <arg choice="opt" rep="norepeat"><option>/m</option>
-<replaceable>método-comparación</replaceable></arg> <arg choice="opt"
+<replaceable>compare-method</replaceable></arg> <arg choice="opt"
 rep="norepeat"><option>/t</option>
-<replaceable>tipo-ventana</replaceable></arg> <arg><option>/x</option></arg>
+<replaceable>window-type</replaceable></arg> <arg><option>/x</option></arg>
 <arg><option>/xq</option></arg> <arg><option>/s</option></arg>
 <arg><option>/sw</option></arg> <arg><option>/s-</option></arg> <arg
-choice="opt" rep="norepeat"><option>/ul</option></arg> <arg choice="opt"
+choice="opt" rep="norepeat"><option>/g</option>
+<replaceable>group-name</replaceable></arg> <arg choice="opt"
+rep="norepeat"><option>/ul</option></arg> <arg choice="opt"
 rep="norepeat"><option>/um</option></arg> <arg choice="opt"
 rep="norepeat"><option>/ur</option></arg> <arg choice="opt"
 rep="norepeat"><option>/u</option></arg> <arg choice="opt"
@@ -46,17 +48,16 @@ rep="norepeat"><option>/clipboard-compare</option></arg>
 choice="opt" rep="norepeat"><option>/fm</option></arg> <arg choice="opt"
 rep="norepeat"><option>/fr</option></arg> <arg choice="opt"
 rep="norepeat"><option>/l</option>
-<replaceable>númerolínea</replaceable></arg> <arg choice="opt"
-rep="norepeat"><option>/c</option>
-<replaceable>poscarácter</replaceable></arg> <arg choice="opt"
-rep="norepeat"><option>/table-delimiter</option>
-<replaceable>delimitador</replaceable></arg> <arg choice="opt"
+<replaceable>linenumber</replaceable></arg> <arg choice="opt"
+rep="norepeat"><option>/c</option> <replaceable>charpos</replaceable></arg>
+<arg choice="opt" rep="norepeat"><option>/table-delimiter</option>
+<replaceable>delimiter</replaceable></arg> <arg choice="opt"
 rep="norepeat"><option>/dl</option>
-<replaceable>descizquierda</replaceable></arg> <arg choice="opt"
+<replaceable>leftdesc</replaceable></arg> <arg choice="opt"
 rep="norepeat"><option>/dm</option>
-<replaceable>desccentral</replaceable></arg> <arg choice="opt"
+<replaceable>middledesc</replaceable></arg> <arg choice="opt"
 rep="norepeat"><option>/dr</option>
-<replaceable>descderecha</replaceable></arg> <arg choice="opt"
+<replaceable>rightdesc</replaceable></arg> <arg choice="opt"
 rep="norepeat"><option>/al</option></arg> <arg choice="opt"
 rep="norepeat"><option>/am</option></arg> <arg choice="opt"
 rep="norepeat"><option>/ar</option></arg> <arg choice="opt"
@@ -70,25 +71,24 @@ rep="norepeat"><option>/ignoreeol</option></arg> <arg choice="opt"
 rep="norepeat"><option>/ignorecodepage</option></arg> <arg choice="opt"
 rep="norepeat"><option>/ignorecomments</option></arg> <arg choice="opt"
 rep="norepeat"><option>/unpacker</option>
-<replaceable>nombdesemp</replaceable></arg> <arg choice="opt"
+<replaceable>unpacker-name</replaceable></arg> <arg choice="opt"
 rep="norepeat"><option>/prediffer</option>
-<replaceable>nombpredif</replaceable></arg> <arg choice="opt"
+<replaceable>prediffer-name</replaceable></arg> <arg choice="opt"
 rep="norepeat"><option>/cp</option>
-<replaceable>codifpágina</replaceable></arg> <arg choice="opt"
+<replaceable>codepage</replaceable></arg> <arg choice="opt"
 rep="norepeat"><option>/fileext</option>
-<replaceable>extensión-arch</replaceable></arg> <arg choice="opt"
+<replaceable>file-extension</replaceable></arg> <arg choice="opt"
 rep="norepeat"><option>/cfg</option>
-<replaceable>nombre=valor</replaceable></arg> <arg choice="opt"
+<replaceable>name=value</replaceable></arg> <arg choice="opt"
 rep="norepeat"><option>/inifile</option>
-<replaceable>fichero_ini</replaceable></arg> <arg choice="plain"
-rep="norepeat"><replaceable>ruta_izquierda</replaceable></arg> <arg
-cchoice="opt" rep="norepeat"><replaceable>ruta_central</replaceable></arg>
-<arg choice="plain"
-rep="norepeat"><replaceable>ruta_derecha</replaceable></arg> <arg
-choice="opt" rep="norepeat"><option>/o</option>
-<replaceable>ruta_salida</replaceable></arg> <arg choice="opt"
+<replaceable>inifile</replaceable></arg> <arg choice="plain"
+rep="norepeat"><replaceable>leftpath</replaceable></arg> <arg cchoice="opt"
+rep="norepeat"><replaceable>middlepath</replaceable></arg> <arg
+choice="plain" rep="norepeat"><replaceable>rightpath</replaceable></arg>
+<arg choice="opt" rep="norepeat"><option>/o</option>
+<replaceable>outputpath</replaceable></arg> <arg choice="opt"
 rep="norepeat"><option>/or</option>
-<replaceable>ruta_informe</replaceable></arg></cmdsynopsis></para>
+<replaceable>reportpath</replaceable></arg></cmdsynopsis></para>
 
   <cmdsynopsis sepchar=" ">
 <command>WinMergeU</command> <arg choice="plain"
@@ -252,6 +252,20 @@ en la ventana.</para>
       <listitem>
         <para>Asegúrese de que siempre se ejecute otra instancia, ignorando el valor de la
 opción "Permitir que se ejecute solo una instancia".</para>
+      </listitem>
+    </varlistentry>
+
+    <varlistentry>
+      <indexterm>
+        <primary>Ventana WinMerge</primary>
+        <secondary>instance groups</secondary>
+      </indexterm>
+
+      <term><option>/g</option> <replaceable>group-name</replaceable></term>
+      <listitem>
+        <para>Specifies a group name for the WinMerge instance. When used with the
+<option>/s</option> option, instances with the same group name share the
+same window, allowing you to organize multiple single-instance groups.</para>
       </listitem>
     </varlistentry>
 

--- a/Src/MainFrm.cpp
+++ b/Src/MainFrm.cpp
@@ -414,8 +414,6 @@ CMainFrame::~CMainFrame()
 	strdiff::Close();
 }
 
-const tchar_t CMainFrame::szClassName[] = _T("WinMergeWindowClassW");
-
 /**
  * @brief Change MainFrame window class name
  *        see http://support.microsoft.com/kb/403825/ja
@@ -425,6 +423,8 @@ BOOL CMainFrame::PreCreateWindow(CREATESTRUCT& cs)
 	WNDCLASS wndcls;
 	BOOL bRes = __super::PreCreateWindow(cs);
 	HINSTANCE hInst = AfxGetInstanceHandle();
+	const tchar_t* szClassName = theApp.GetWindowClassName();
+
 	// see if the class already exists
 	if (!::GetClassInfo(hInst, szClassName, &wndcls))
 	{

--- a/Src/MainFrm.h
+++ b/Src/MainFrm.h
@@ -149,7 +149,6 @@ public:
 // Attributes
 public:	
 	bool m_bShowErrors; /**< Show folder compare error items? */
-	static const tchar_t szClassName[];
 
 // Operations
 public:

--- a/Src/Merge.cpp
+++ b/Src/Merge.cpp
@@ -155,24 +155,23 @@ static COptionsMgr *CreateOptionManager(const MergeCmdLineInfo& cmdInfo)
 	return new CRegOptionsMgr(_T("Thingamahoochie\\WinMerge\\"));
 }
 
-static HANDLE CreateMutexHandle()
+HANDLE CMergeApp::CreateMutexHandle() const
 {
 	// Create exclusion mutex name
 	tchar_t szDesktopName[MAX_PATH] = _T("Win9xDesktop");
 	DWORD dwLengthNeeded;
 	GetUserObjectInformation(GetThreadDesktop(GetCurrentThreadId()), UOI_NAME,
 		szDesktopName, sizeof(szDesktopName), &dwLengthNeeded);
-	tchar_t szMutexName[MAX_PATH + 40];
 	// Combine window class name and desktop name to form a unique mutex name.
 	// As the window class name is decorated to distinguish between ANSI and
 	// UNICODE build, so will be the mutex name.
-	wsprintf(szMutexName, _T("%s-%s"), CMainFrame::szClassName, szDesktopName);
-	return CreateMutex(nullptr, FALSE, szMutexName);
+	String sMutexName = strutils::format(_T("%s-%s"), GetWindowClassName(), szDesktopName);
+	return CreateMutex(nullptr, FALSE, sMutexName.c_str());
 }
 
 static HWND ActivatePreviousInstanceAndSendCommandline(tchar_t* cmdLine)
 {
-	HWND hWnd = FindWindow(CMainFrame::szClassName, nullptr);
+	HWND hWnd = FindWindow(theApp.GetWindowClassName(), nullptr);
 	if (hWnd == nullptr)
 		return nullptr;
 	if (IsIconic(hWnd))
@@ -203,6 +202,24 @@ static int ConvertLastCompareResultToExitCode(int nLastCompareResult)
 	else if (nLastCompareResult > 0)
 		return 1;
 	return 2;
+}
+
+const tchar_t* CMergeApp::GetWindowClassName() const
+{
+	if (!m_sWindowClassName.empty())
+		return m_sWindowClassName.c_str();
+	static const tchar_t szClassName[] = _T("WinMergeWindowClassW");
+	if (!m_sGroupName.empty())
+	{
+		// Create class name with group: "WinMergeWindowClassW-groupname"
+		m_sWindowClassName = String(szClassName) + _T("-") + m_sGroupName;
+	}
+	else
+	{
+		// Use default class name
+		m_sWindowClassName = szClassName;
+	}
+	return m_sWindowClassName.c_str();
 }
 
 std::vector<JumpList::Item> CMergeApp::CreateUserTasks(MergeCmdLineInfo::usertasksflags_t flags)
@@ -321,6 +338,10 @@ BOOL CMergeApp::InitInstance()
 		for (auto& msg : cmdInfo.m_sErrorMessages)
 			OutputConsole(msg);
 	}
+
+	// Store group name for later use by CMainFrame
+	if (!cmdInfo.m_sGroupName.empty())
+		SetGroupName(cmdInfo.m_sGroupName);
 
 	// Initialize temp folder
 	SetupTempPath();

--- a/Src/Merge.h
+++ b/Src/Merge.h
@@ -92,6 +92,10 @@ public:
 	static std::vector<JumpList::Item> CreateUserTasks(MergeCmdLineInfo::usertasksflags_t flags);
 	bool GetMergingMode() const;
 	void SetMergingMode(bool bMergingMode);
+	void SetGroupName(const String& groupName) { m_sGroupName = groupName; }
+	const String& GetGroupName() const { return m_sGroupName; }
+	HANDLE CreateMutexHandle() const;
+	const tchar_t* GetWindowClassName() const;
 	static void SetupTempPath();
 	static void InitSyntaxParserFactories();
 	bool IsReallyIdle() const;
@@ -184,6 +188,8 @@ private:
 	LONG m_nActiveOperations; /**< Active operations count. */
 	bool m_bMergingMode; /**< Merging or Edit mode */
 	bool m_bEnableExitCode;
+	String m_sGroupName; /**< Group name for instance grouping */
+	mutable String m_sWindowClassName; /**< Window class name for instance grouping */
 	ATL::CImage m_imageForInitializingGdiplus;
 	std::list<std::function<void()>> m_idleFuncs;
 	std::list<CWinThread*> m_threads;

--- a/Src/MergeCmdLineInfo.cpp
+++ b/Src/MergeCmdLineInfo.cpp
@@ -365,9 +365,18 @@ void MergeCmdLineInfo::ParseWinMergeCmdLine(const tchar_t *q)
 				q = EatParam(q + 1, param);
 				m_nSingleInstance = tc::ttoi(param.c_str());
 			}
-				
 			else
 				m_nSingleInstance = 1;
+		}
+		else if (param == _T("g"))
+		{
+			// -g "groupname" - group name for instance grouping
+			String sGroupName;
+			q = EatParam(q, sGroupName);
+			if (sGroupName.size() == 0 || sGroupName.size() > 128 || sGroupName.find_first_of(_T("\\")) != String::npos)
+				m_sErrorMessages.emplace_back(_T("Invalid group name specified"));
+			else
+				m_sGroupName = sGroupName;
 		}
 		else if (param == _T("noninteractive"))
 		{

--- a/Src/MergeCmdLineInfo.h
+++ b/Src/MergeCmdLineInfo.h
@@ -125,6 +125,8 @@ public:
 	String m_sOutputpath;
 	String m_sReportFile;
 
+	String m_sGroupName; /**< Group name for instance grouping */
+
 	String m_sIniFilepath;
 
 	std::optional<usertasksflags_t> m_dwUserTasksFlags;

--- a/Translations/Docs/Manual/English.pot
+++ b/Translations/Docs/Manual/English.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: WinMerge 2.16\n"
 "Report-Msgid-Bugs-To: https://github.com/WinMerge/winmerge/issues\n"
-"POT-Creation-Date: 2026-06-25 07:56+0900\n"
+"POT-Creation-Date: 2026-07-20 16:31+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -471,85 +471,85 @@ msgstr ""
 
 #. type: Content of: <article><para><cmdsynopsis>
 #: ./English/Command_line.xml:25
-msgid "<command>WinMergeU</command> <arg choice=\"opt\" rep=\"norepeat\"><option>/r</option></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/r-</option></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/e</option></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/f</option> <replaceable>filter</replaceable></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/m</option> <replaceable>compare-method</replaceable></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/t</option> <replaceable>window-type</replaceable></arg> <arg><option>/x</option></arg> <arg><option>/xq</option></arg> <arg><option>/s</option></arg> <arg><option>/sw</option></arg> <arg><option>/s-</option></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/ul</option></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/um</option></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/ur</option></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/u</option></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/wl</option></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/wm</option></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/wr</option></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/new</option></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/self-compare</option></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/clipboard-compare</option></arg> <arg><option>/minimize</option></arg> <arg><option>/maximize</option></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/fl</option></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/fm</option></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/fr</option></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/l</option> <replaceable>linenumber</replaceable></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/c</option> <replaceable>charpos</replaceable></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/table-delimiter</option> <replaceable>delimiter</replaceable></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/dl</option> <replaceable>leftdesc</replaceable></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/dm</option> <replaceable>middledesc</replaceable></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/dr</option> <replaceable>rightdesc</replaceable></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/al</option></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/am</option></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/ar</option></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/noninteractive</option></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/noprefs</option></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/enableexitcode</option></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/ignorews</option></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/ignoreblanklines</option></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/ignorecase</option></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/ignoreeol</option></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/ignorecodepage</option></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/ignorecomments</option></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/unpacker</option> <replaceable>unpacker-name</replaceable></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/prediffer</option> <replaceable>prediffer-name</replaceable></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/cp</option> <replaceable>codepage</replaceable></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/fileext</option> <replaceable>file-extension</replaceable></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/cfg</option> <replaceable>name=value</replaceable></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/inifile</option> <replaceable>inifile</replaceable></arg> <arg choice=\"plain\" rep=\"norepeat\"><replaceable>leftpath</replaceable></arg> <arg cchoice=\"opt\" rep=\"norepeat\"><replaceable>middlepath</replaceable></arg> <arg choice=\"plain\" rep=\"norepeat\"><replaceable>rightpath</replaceable></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/o</option> <replaceable>outputpath</replaceable></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/or</option> <replaceable>reportpath</replaceable></arg>"
+msgid "<command>WinMergeU</command> <arg choice=\"opt\" rep=\"norepeat\"><option>/r</option></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/r-</option></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/e</option></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/f</option> <replaceable>filter</replaceable></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/m</option> <replaceable>compare-method</replaceable></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/t</option> <replaceable>window-type</replaceable></arg> <arg><option>/x</option></arg> <arg><option>/xq</option></arg> <arg><option>/s</option></arg> <arg><option>/sw</option></arg> <arg><option>/s-</option></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/g</option> <replaceable>group-name</replaceable></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/ul</option></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/um</option></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/ur</option></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/u</option></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/wl</option></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/wm</option></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/wr</option></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/new</option></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/self-compare</option></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/clipboard-compare</option></arg> <arg><option>/minimize</option></arg> <arg><option>/maximize</option></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/fl</option></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/fm</option></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/fr</option></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/l</option> <replaceable>linenumber</replaceable></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/c</option> <replaceable>charpos</replaceable></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/table-delimiter</option> <replaceable>delimiter</replaceable></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/dl</option> <replaceable>leftdesc</replaceable></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/dm</option> <replaceable>middledesc</replaceable></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/dr</option> <replaceable>rightdesc</replaceable></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/al</option></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/am</option></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/ar</option></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/noninteractive</option></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/noprefs</option></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/enableexitcode</option></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/ignorews</option></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/ignoreblanklines</option></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/ignorecase</option></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/ignoreeol</option></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/ignorecodepage</option></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/ignorecomments</option></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/unpacker</option> <replaceable>unpacker-name</replaceable></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/prediffer</option> <replaceable>prediffer-name</replaceable></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/cp</option> <replaceable>codepage</replaceable></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/fileext</option> <replaceable>file-extension</replaceable></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/cfg</option> <replaceable>name=value</replaceable></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/inifile</option> <replaceable>inifile</replaceable></arg> <arg choice=\"plain\" rep=\"norepeat\"><replaceable>leftpath</replaceable></arg> <arg cchoice=\"opt\" rep=\"norepeat\"><replaceable>middlepath</replaceable></arg> <arg choice=\"plain\" rep=\"norepeat\"><replaceable>rightpath</replaceable></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/o</option> <replaceable>outputpath</replaceable></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/or</option> <replaceable>reportpath</replaceable></arg>"
 msgstr ""
 
 #. type: Content of: <article><cmdsynopsis>
-#: ./English/Command_line.xml:162
+#: ./English/Command_line.xml:165
 msgid "<command>WinMergeU</command> <arg choice=\"plain\" rep=\"norepeat\"><replaceable>conflictfile</replaceable></arg>"
 msgstr ""
 
 #. type: Content of: <article><para>
-#: ./English/Command_line.xml:168
+#: ./English/Command_line.xml:171
 msgid "Entering the command with no parameters or pathnames simply opens the WinMerge window. Parameters are prefixed with either a forward slash ( <literal>/</literal> ) or dash ( <literal>-</literal> ) character. Pathnames have no prefix character."
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: ./English/Command_line.xml:175
+#: ./English/Command_line.xml:178
 msgid "<option>/?</option>"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: ./English/Command_line.xml:177
+#: ./English/Command_line.xml:180
 msgid "Opens WinMerge Help at this topic."
 msgstr ""
 
 #. type: Content of: <article><section><section><title><indexterm><seealso>
-#: ./English/Command_line.xml:183 ./English/Compare_dirs.xml:54
+#: ./English/Command_line.xml:186 ./English/Compare_dirs.xml:54
 #: ./English/Compare_dirs.xml:254 ./English/Open_paths.xml:288
 #: ./English/Open_paths.xml:294
 msgid "recursive folder compare"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: ./English/Command_line.xml:185
+#: ./English/Command_line.xml:188
 msgid "<option>/r</option>"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: ./English/Command_line.xml:187
+#: ./English/Command_line.xml:190
 msgid "Compares all files in all subfolders (recursive compare). Unique folders (occurring only on one side) are listed in the compare result as separate items. Note that including subfolders can increase compare time significantly. Without this parameter, WinMerge lists only files and subfolders at the top level of the two target folders. It does not compare the subfolders."
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><indexterm><primary>
-#: ./English/Command_line.xml:198
+#: ./English/Command_line.xml:201
 msgid "non-recursive folder compare"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: ./English/Command_line.xml:200
+#: ./English/Command_line.xml:203
 msgid "<option>/r-</option>"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: ./English/Command_line.xml:202
+#: ./English/Command_line.xml:205
 msgid "Compares all files within the specified folders but excludes the files and subfolders within its subfolders.  This allows for a shorter comparison time."
 msgstr ""
 
 #. type: Content of: <article><section><section><title><indexterm><primary>
-#: ./English/Command_line.xml:210 ./English/Command_line.xml:294
-#: ./English/Command_line.xml:417 ./English/Configuration.xml:277
-#: ./English/Quick_start.xml:22
+#: ./English/Command_line.xml:213 ./English/Command_line.xml:297
+#: ./English/Command_line.xml:330 ./English/Command_line.xml:435
+#: ./English/Configuration.xml:277 ./English/Quick_start.xml:22
 msgid "WinMerge window"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><indexterm><secondary>
-#: ./English/Command_line.xml:211
+#: ./English/Command_line.xml:214
 msgid "closing"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: ./English/Command_line.xml:214
+#: ./English/Command_line.xml:217
 msgid "<option>/e</option>"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: ./English/Command_line.xml:216
+#: ./English/Command_line.xml:219
 msgid "Enables you to close WinMerge with a single <keycap>Esc</keycap> key press. This is useful when you use WinMerge as an external compare application: you can close WinMerge quickly, like a dialog. Without this parameter, you might have to press <keycap>Esc</keycap> multiple times to close all its windows."
 msgstr ""
 
 #. type: Content of: <article><section><section><title><indexterm><primary>
-#: ./English/Command_line.xml:226 ./English/Configuration.xml:820
+#: ./English/Command_line.xml:229 ./English/Configuration.xml:820
 #: ./English/Configuration.xml:848 ./English/Configuration.xml:871
 #: ./English/Filters.xml:4 ./English/Filters.xml:96 ./English/Filters.xml:100
 #: ./English/Filters.xml:142 ./English/Filters.xml:1609
@@ -561,776 +561,791 @@ msgid "filters"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><indexterm><secondary>
-#: ./English/Command_line.xml:227 ./English/Command_line.xml:243
-#: ./English/Command_line.xml:259
+#: ./English/Command_line.xml:230 ./English/Command_line.xml:246
+#: ./English/Command_line.xml:262
 msgid "applying in command line"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: ./English/Command_line.xml:230
+#: ./English/Command_line.xml:233
 msgid "<option>/f</option>"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: ./English/Command_line.xml:232
+#: ./English/Command_line.xml:235
 msgid "Applies a specified filter to restrict the comparison. The filter can be a filemask like <filename><userinput>*.h *.cpp</userinput></filename>, or the name of a file filter like <userinput>XML/HTML Devel</userinput>. Add quotation marks around a filter mask or name that contains spaces."
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><indexterm><primary>
-#: ./English/Command_line.xml:242
+#: ./English/Command_line.xml:245
 msgid "compare method"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: ./English/Command_line.xml:246
+#: ./English/Command_line.xml:249
 msgid "<option>/m <replaceable>compare-method</replaceable></option>"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: ./English/Command_line.xml:248
+#: ./English/Command_line.xml:251
 msgid "Sets the compare method to use for the comparison.  This can be one of the keywords <userinput>Full</userinput>, <userinput>Quick</userinput>, <userinput>Binary</userinput>, <userinput>Date</userinput>, <userinput>SizeDate</userinput>, <userinput>Size</userinput> or <userinput>Existence</userinput>."
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><indexterm><primary>
-#: ./English/Command_line.xml:258
+#: ./English/Command_line.xml:261
 msgid "window type"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: ./English/Command_line.xml:262
+#: ./English/Command_line.xml:265
 msgid "<option>/t <replaceable>window-type</replaceable></option>"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: ./English/Command_line.xml:264
+#: ./English/Command_line.xml:267
 msgid "Specifies the type of window in which to display files.  This can be one of the keywords <userinput>Text</userinput>, <userinput>Table</userinput>, <userinput>Binary</userinput>, <userinput>Image</userinput>, <userinput>Webpage</userinput> or <userinput>Folder</userinput>."
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: ./English/Command_line.xml:272
+#: ./English/Command_line.xml:275
 msgid "<option>/x</option>"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: ./English/Command_line.xml:274
+#: ./English/Command_line.xml:277
 msgid "Closes WinMerge (after displaying an information dialog) when you start a comparison of identical files. The parameter has no effect after the comparison, for example if the files become identical as a result of merging or editing. This parameter is useful when you use WinMerge as an external compare application, or when you want to eliminate unnecessary steps by ignoring files that don't have any differences."
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: ./English/Command_line.xml:285
+#: ./English/Command_line.xml:288
 msgid "<option>/xq</option>"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: ./English/Command_line.xml:287
+#: ./English/Command_line.xml:290
 msgid "Is similar to <option>/x</option> but does not show the message about identical files."
 msgstr ""
 
 #. type: Content of: <article><section><section><title><indexterm><secondary>
-#: ./English/Command_line.xml:295 ./English/Configuration.xml:279
+#: ./English/Command_line.xml:298 ./English/Configuration.xml:279
 msgid "limiting instances"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: ./English/Command_line.xml:298
+#: ./English/Command_line.xml:301
 msgid "<option>/s</option>"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: ./English/Command_line.xml:300
+#: ./English/Command_line.xml:303
 msgid "Limits WinMerge windows to a single instance.  For example, if WinMerge is already running, a new compare opens in the same instance. Without this parameter, multiple windows are allowed: depending on other settings, a new compare might open in the existing window or in a new window."
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: ./English/Command_line.xml:309
+#: ./English/Command_line.xml:312
 msgid "<option>/sw</option>"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: ./English/Command_line.xml:311
+#: ./English/Command_line.xml:314
 msgid "Limit the WinMerge window to one instance as well as the option /s.  However, it waits for the instance displaying the window to terminate."
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: ./English/Command_line.xml:318
+#: ./English/Command_line.xml:321
 msgid "<option>/s-</option>"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: ./English/Command_line.xml:320
+#: ./English/Command_line.xml:323
 msgid "Ensure that another instance is always executed, ignoring the value of the \"Allow only one instance to run\" option."
 msgstr ""
 
+#. type: Content of: <article><variablelist><varlistentry><indexterm><secondary>
+#: ./English/Command_line.xml:331
+msgid "instance groups"
+msgstr ""
+
+#. type: Content of: <article><variablelist><varlistentry><term>
+#: ./English/Command_line.xml:334
+msgid "<option>/g</option> <replaceable>group-name</replaceable>"
+msgstr ""
+
+#. type: Content of: <article><variablelist><varlistentry><listitem><para>
+#: ./English/Command_line.xml:337
+msgid "Specifies a group name for the WinMerge instance. When used with the <option>/s</option> option, instances with the same group name share the same window, allowing you to organize multiple single-instance groups."
+msgstr ""
+
 #. type: Content of: <article><section><qandaset><qandaentry><question><para><indexterm><primary>
-#: ./English/Command_line.xml:327 ./English/Configuration.xml:430
+#: ./English/Command_line.xml:345 ./English/Configuration.xml:430
 #: ./English/Faq.xml:114
 msgid "MRU list"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: ./English/Command_line.xml:330
+#: ./English/Command_line.xml:348
 msgid "<option>/ul</option>"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: ./English/Command_line.xml:332
+#: ./English/Command_line.xml:350
 msgid "Prevents WinMerge from adding the left path to the Most Recently Used (MRU) list. External applications should not add paths to the MRU list in the Select Files or Folders dialog."
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: ./English/Command_line.xml:339
+#: ./English/Command_line.xml:357
 msgid "<option>/um</option>"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: ./English/Command_line.xml:341
+#: ./English/Command_line.xml:359
 msgid "Prevents WinMerge from adding the middle path to the Most Recently Used (MRU) list. External applications should not add paths to the MRU list in the Select Files or Folders dialog."
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: ./English/Command_line.xml:348
+#: ./English/Command_line.xml:366
 msgid "<option>/ur</option>"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: ./English/Command_line.xml:350
+#: ./English/Command_line.xml:368
 msgid "Prevents WinMerge from adding the right path to the Most Recently Used (MRU) list. External applications should not add paths to the MRU list in the Select Files or Folders dialog."
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: ./English/Command_line.xml:357
+#: ./English/Command_line.xml:375
 msgid "<option>/u</option>"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: ./English/Command_line.xml:359
+#: ./English/Command_line.xml:377
 msgid "Prevents WinMerge from adding either path (left or right) to the Most Recently Used (MRU) list. External applications should not add paths to the MRU list in the Select Files or Folders dialog."
 msgstr ""
 
 #. type: Content of: <article><section><section><title><indexterm><see>
-#: ./English/Command_line.xml:368 ./English/Compare_dirs.xml:741
+#: ./English/Command_line.xml:386 ./English/Compare_dirs.xml:741
 #: ./English/Compare_dirs.xml:745
 msgid "protecting files"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: ./English/Command_line.xml:371
+#: ./English/Command_line.xml:389
 msgid "<option>/wl</option>"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: ./English/Command_line.xml:373
+#: ./English/Command_line.xml:391
 msgid "Opens the left side as read-only. Use this when you don't want to change left side items in the compare."
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: ./English/Command_line.xml:379
+#: ./English/Command_line.xml:397
 msgid "<option>/wm</option>"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: ./English/Command_line.xml:381
+#: ./English/Command_line.xml:399
 msgid "Opens the middle side as read-only. Use this when you don't want to change right side items in the compare."
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: ./English/Command_line.xml:387
+#: ./English/Command_line.xml:405
 msgid "<option>/wr</option>"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: ./English/Command_line.xml:389
+#: ./English/Command_line.xml:407
 msgid "Opens the right side as read-only. Use this when you don't want to change right side items in the compare."
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: ./English/Command_line.xml:395
+#: ./English/Command_line.xml:413
 msgid "<option>/new</option>"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: ./English/Command_line.xml:397
+#: ./English/Command_line.xml:415
 msgid "Opens a new blank window."
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: ./English/Command_line.xml:402
+#: ./English/Command_line.xml:420
 msgid "<option>/self-compare</option>"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: ./English/Command_line.xml:404
+#: ./English/Command_line.xml:422
 msgid "Compares the specified file with a copy of the file."
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: ./English/Command_line.xml:409
+#: ./English/Command_line.xml:427
 msgid "<option>/clipboard-compare</option>"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: ./English/Command_line.xml:411
+#: ./English/Command_line.xml:429
 msgid "Compares the two most recent contents of the clipboard history."
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><indexterm><secondary>
-#: ./English/Command_line.xml:418
+#: ./English/Command_line.xml:436
 msgid "opening minimized or maximized"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: ./English/Command_line.xml:421
+#: ./English/Command_line.xml:439
 msgid "<option>/minimize</option>"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: ./English/Command_line.xml:423
+#: ./English/Command_line.xml:441
 msgid "Starts WinMerge as a minimized window.  This option can be useful during lengthy compares."
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: ./English/Command_line.xml:429
+#: ./English/Command_line.xml:447
 msgid "<option>/maximize</option>"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: ./English/Command_line.xml:431
+#: ./English/Command_line.xml:449
 msgid "Starts WinMerge as a maximized window."
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: ./English/Command_line.xml:437
+#: ./English/Command_line.xml:455
 msgid "<option>/fl</option>"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: ./English/Command_line.xml:439
+#: ./English/Command_line.xml:457
 msgid "Sets focus to the left side at startup."
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: ./English/Command_line.xml:444
+#: ./English/Command_line.xml:462
 msgid "<option>/fm</option>"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: ./English/Command_line.xml:446
+#: ./English/Command_line.xml:464
 msgid "Sets focus to the middle side at startup."
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: ./English/Command_line.xml:451
+#: ./English/Command_line.xml:469
 msgid "<option>/fr</option>"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: ./English/Command_line.xml:453
+#: ./English/Command_line.xml:471
 msgid "Sets focus to the right side at startup."
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: ./English/Command_line.xml:458
+#: ./English/Command_line.xml:476
 msgid "<option>/l <replaceable>linenumber</replaceable></option>"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: ./English/Command_line.xml:460
+#: ./English/Command_line.xml:478
 msgid "Specifies a line number to jump to after loading the files."
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: ./English/Command_line.xml:465
+#: ./English/Command_line.xml:483
 msgid "<option>/c <replaceable>charpos</replaceable></option>"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: ./English/Command_line.xml:467
+#: ./English/Command_line.xml:485
 msgid "Specifies a character position to jump to after loading the files."
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: ./English/Command_line.xml:472
+#: ./English/Command_line.xml:490
 msgid "<option>/table-delimiter <replaceable>delimiter</replaceable></option>"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: ./English/Command_line.xml:474
+#: ./English/Command_line.xml:492
 msgid "Specifies a delimiter character for table editing. To specify a tab character, specify \"tab\", \"\\t\", or \"\\x09\"."
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: ./English/Command_line.xml:479
+#: ./English/Command_line.xml:497
 msgid "<option>/dl</option>"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: ./English/Command_line.xml:481
+#: ./English/Command_line.xml:499
 msgid "Specifies a description in the left side title bar, overriding the default folder or filename text. For example: <userinput>/dl \"Version 1.0</userinput>\" or <userinput>/dl WorkingCopy</userinput>. Use quotation marks around descriptions that contain spaces."
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: ./English/Command_line.xml:490
+#: ./English/Command_line.xml:508
 msgid "<option>/dm</option>"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: ./English/Command_line.xml:492
+#: ./English/Command_line.xml:510
 msgid "Specifies a description in the middle side title bar, just like <option>/dl</option>."
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: ./English/Command_line.xml:498
+#: ./English/Command_line.xml:516
 msgid "<option>/dr</option>"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: ./English/Command_line.xml:500
+#: ./English/Command_line.xml:518
 msgid "Specifies a description in the right side title bar, just like <option>/dl</option>."
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: ./English/Command_line.xml:506
+#: ./English/Command_line.xml:524
 msgid "<option>/al</option>"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: ./English/Command_line.xml:508
+#: ./English/Command_line.xml:526
 msgid "Auto-merges at the left side at startup."
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: ./English/Command_line.xml:513
+#: ./English/Command_line.xml:531
 msgid "<option>/am</option>"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: ./English/Command_line.xml:515
+#: ./English/Command_line.xml:533
 msgid "Auto-merges at the middle side at startup."
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: ./English/Command_line.xml:520
+#: ./English/Command_line.xml:538
 msgid "<option>/ar</option>"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: ./English/Command_line.xml:522
+#: ./English/Command_line.xml:540
 msgid "Auto-merges at the right side at startup."
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: ./English/Command_line.xml:527
+#: ./English/Command_line.xml:545
 msgid "<option>/noninteractive</option>"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: ./English/Command_line.xml:530
+#: ./English/Command_line.xml:548
 msgid "Runs WinMerge without displaying message boxes during comparison or report generation.  The process terminates automatically when the operation is complete, making it suitable for batch or scripted execution."
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: ./English/Command_line.xml:538
+#: ./English/Command_line.xml:556
 msgid "<option>/noprefs</option>"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: ./English/Command_line.xml:541
+#: ./English/Command_line.xml:559
 msgid "Runs WinMerge without loading or saving settings from the registry.  All comparisons use default preferences only."
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: ./English/Command_line.xml:548
+#: ./English/Command_line.xml:566
 msgid "<option>/enableexitcode</option>"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: ./English/Command_line.xml:550
+#: ./English/Command_line.xml:568
 msgid "Sets the comparison result to the process exit code. 0: identical, 1: different, 2: error"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: ./English/Command_line.xml:555
+#: ./English/Command_line.xml:573
 msgid "<option>/ignorews</option>"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: ./English/Command_line.xml:557
+#: ./English/Command_line.xml:575
 msgid "Controls the \"Whitespaces\" option (whitespace comparison settings) persistently:"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: ./English/Command_line.xml:559
+#: ./English/Command_line.xml:577
 msgid "<option>/ignorews:0</option> - do not ignore whitespace differences."
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: ./English/Command_line.xml:560
+#: ./English/Command_line.xml:578
 msgid "<option>/ignorews</option> or <option>/ignorews:1</option> - ignore differences in the amount of whitespace."
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: ./English/Command_line.xml:561
+#: ./English/Command_line.xml:579
 msgid "<option>/ignorews:2</option> - ignore all whitespace characters."
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: ./English/Command_line.xml:567
+#: ./English/Command_line.xml:585
 msgid "<option>/ignoreblanklines</option>"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: ./English/Command_line.xml:569
+#: ./English/Command_line.xml:587
 msgid "Controls the \"Ignore blank lines\" option persistently:"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: ./English/Command_line.xml:571
+#: ./English/Command_line.xml:589
 msgid "<option>/ignoreblanklines:0</option> - disables ignoring blank lines."
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: ./English/Command_line.xml:572
+#: ./English/Command_line.xml:590
 msgid "<option>/ignoreblanklines</option> or <option>/ignoreblanklines:1</option> - enables ignoring blank lines."
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: ./English/Command_line.xml:578
+#: ./English/Command_line.xml:596
 msgid "<option>/ignorecase</option>"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: ./English/Command_line.xml:580
+#: ./English/Command_line.xml:598
 msgid "Controls the \"Ignore case\" option persistently:"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: ./English/Command_line.xml:582
+#: ./English/Command_line.xml:600
 msgid "<option>/ignorecase:0</option> - disables ignoring case differences."
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: ./English/Command_line.xml:583
+#: ./English/Command_line.xml:601
 msgid "<option>/ignorecase</option> or <option>/ignorecase:1</option> - enables ignoring case differences."
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: ./English/Command_line.xml:589
+#: ./English/Command_line.xml:607
 msgid "<option>/ignoreeol</option>"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: ./English/Command_line.xml:591
+#: ./English/Command_line.xml:609
 msgid "Controls the \"Ignore EOL differences\" option persistently:"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: ./English/Command_line.xml:593
+#: ./English/Command_line.xml:611
 msgid "<option>/ignoreeol:0</option> - disables ignoring EOL differences."
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: ./English/Command_line.xml:594
+#: ./English/Command_line.xml:612
 msgid "<option>/ignoreeol</option> or <option>/ignoreeol:1</option> - enables ignoring EOL differences."
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: ./English/Command_line.xml:600
+#: ./English/Command_line.xml:618
 msgid "<option>/ignorecodepage</option>"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: ./English/Command_line.xml:602
+#: ./English/Command_line.xml:620
 msgid "Controls the \"Ignore codepage differences\" option persistently:"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: ./English/Command_line.xml:604
+#: ./English/Command_line.xml:622
 msgid "<option>/ignorecodepage:0</option> - disables ignoring codepage differences."
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: ./English/Command_line.xml:605
+#: ./English/Command_line.xml:623
 msgid "<option>/ignorecodepage</option> or <option>/ignorecodepage:1</option> - enables ignoring codepage differences."
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: ./English/Command_line.xml:611
+#: ./English/Command_line.xml:629
 msgid "<option>/ignorecomments</option>"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: ./English/Command_line.xml:613
+#: ./English/Command_line.xml:631
 msgid "Controls the \"Ignore comment differences\" option persistently:"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: ./English/Command_line.xml:615
+#: ./English/Command_line.xml:633
 msgid "<option>/ignorecomments:0</option> - disables ignoring comments."
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: ./English/Command_line.xml:616
+#: ./English/Command_line.xml:634
 msgid "<option>/ignorecomments</option> or <option>/ignorecomments:1</option> - enables ignoring comments."
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: ./English/Command_line.xml:622
+#: ./English/Command_line.xml:640
 msgid "<option>/unpacker <replaceable>plugin pipeline</replaceable></option>"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: ./English/Command_line.xml:625
+#: ./English/Command_line.xml:643
 msgid "Specifies the plugin pipeline for the Unpacker plugin.  Example: <option>/unpacker \"SortAscending|SelectLines 1-10\"</option>"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: ./English/Command_line.xml:632
+#: ./English/Command_line.xml:650
 msgid "<option>/prediffer <replaceable>plugin pipeline</replaceable></option>"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: ./English/Command_line.xml:635
+#: ./English/Command_line.xml:653
 msgid "Specifies the plugin pipeline for the Prediffer plugin.  Example: <option>/prediffer \"IgnoreColumns 1-10\"</option>"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: ./English/Command_line.xml:642
+#: ./English/Command_line.xml:660
 msgid "<option>/cp <replaceable>codepage</replaceable></option>"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: ./English/Command_line.xml:645
+#: ./English/Command_line.xml:663
 msgid "Specifies the codepage to use for file comparison.  Example: <option>/cp 65001</option>"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: ./English/Command_line.xml:652
+#: ./English/Command_line.xml:670
 msgid "<option>/fileext <replaceable>file-extension</replaceable></option>"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: ./English/Command_line.xml:654
+#: ./English/Command_line.xml:672
 msgid "Specifies a file extension for determining syntax hightliting."
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: ./English/Command_line.xml:659
+#: ./English/Command_line.xml:677
 msgid "<option>/cfg <replaceable>name=value</replaceable></option>"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: ./English/Command_line.xml:662
+#: ./English/Command_line.xml:680
 msgid "Sets a configuration value in the WinMerge registry or INI file."
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: ./English/Command_line.xml:665
+#: ./English/Command_line.xml:683
 msgid "Example: <option>/cfg Settings/DiffAlgorithm=3</option>"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: ./English/Command_line.xml:668
+#: ./English/Command_line.xml:686
 msgid "If the section name is unambiguous and does not conflict with other setting names, it can be omitted:"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: ./English/Command_line.xml:671
+#: ./English/Command_line.xml:689
 msgid "<option>/cfg DiffAlgo=3</option>"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: ./English/Command_line.xml:674
+#: ./English/Command_line.xml:692
 msgid "Note: This entry does not explain which configuration names are available.  For a list of settings, refer to <filename>HKEY_CURRENT_USER\\Software\\Thingamahoochie\\WinMerge</filename> in regedit."
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: ./English/Command_line.xml:681
+#: ./English/Command_line.xml:699
 msgid "<option><replaceable>leftpath</replaceable></option>"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: ./English/Command_line.xml:683
+#: ./English/Command_line.xml:701
 msgid "Specifies the folder, file or project file to open on the left side."
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: ./English/Command_line.xml:688
+#: ./English/Command_line.xml:706
 msgid "<option><replaceable>middlepath</replaceable></option>"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: ./English/Command_line.xml:690
+#: ./English/Command_line.xml:708
 msgid "Specifies the folder, file or project file to open on the middle side."
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: ./English/Command_line.xml:695
+#: ./English/Command_line.xml:713
 msgid "<option><replaceable>rightpath</replaceable></option>"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: ./English/Command_line.xml:697
+#: ./English/Command_line.xml:715
 msgid "Specifies the folder, file or project file to open on the right side."
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: ./English/Command_line.xml:699
+#: ./English/Command_line.xml:717
 msgid "WinMerge cannot compare files to folders, so the path parameters (<option><replaceable>leftpath</replaceable></option>, <option><replaceable>middlepath</replaceable></option> and <option><replaceable>rightpath</replaceable></option>) must point to the same target type (either folders or files). If WinMerge cannot find either of the specified paths, it opens the Select Files or Folders dialog, where you can browse for the correct paths."
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><tip><para>
-#: ./English/Command_line.xml:708
+#: ./English/Command_line.xml:726
 msgid "In file comparisons, you can specify a folder name in one of the path parameters, as long as the folder contains a file with the same name as the one specified in the other, file path."
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><tip><para>
-#: ./English/Command_line.xml:712
+#: ./English/Command_line.xml:730
 msgid "For example, consider this command:"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><tip><para>
-#: ./English/Command_line.xml:714
+#: ./English/Command_line.xml:732
 msgid "<userinput>WinMergeU <filename>C:\\Folder\\File.txt</filename> <filename class=\"directory\">C:\\Folder2</filename> </userinput>"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><tip><para>
-#: ./English/Command_line.xml:717
+#: ./English/Command_line.xml:735
 msgid "If <filename class=\"directory\">C:\\Folder2</filename> contains a file named <filename>File.txt</filename>: WinMerge implicitly resolves the second path as a file specification, and compares the two files. Of course, the command is invalid if <filename class=\"directory\">C:\\Folder2</filename> does <emphasis>not</emphasis> contain a file named <filename>File.txt</filename>."
 msgstr ""
 
 #. type: Content of: <article><section><section><title><indexterm><primary>
-#: ./English/Command_line.xml:730 ./English/Compare_files.xml:1481
+#: ./English/Command_line.xml:748 ./English/Compare_files.xml:1481
 #: ./English/Intro_diffs.xml:253 ./English/Intro_diffs.xml:407
 msgid "merging differences"
 msgstr ""
 
 #. type: Content of: <article><section><section><title><indexterm><secondary>
-#: ./English/Command_line.xml:731 ./English/Intro_diffs.xml:409
+#: ./English/Command_line.xml:749 ./English/Intro_diffs.xml:409
 msgid "result file"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: ./English/Command_line.xml:734
+#: ./English/Command_line.xml:752
 msgid "<option>/o <replaceable>outputpath</replaceable></option>"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: ./English/Command_line.xml:736
+#: ./English/Command_line.xml:754
 msgid "Specifies an optional output file path where you want merged result files to be saved."
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: ./English/Command_line.xml:739
+#: ./English/Command_line.xml:757
 msgid "The output path is rarely needed when you start WinMerge from the command line. It is meant to be used with version control tools, where you might need to specify a output path for the <wordasword>result</wordasword> file. If you specify a output path, WinMerge still shows only two or three files in the File Compare window. However, if you save either of these files, it is written to the output path, leaving the two or three source files intact."
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: ./English/Command_line.xml:747
+#: ./English/Command_line.xml:765
 msgid "Version control systems typically refer to the source and result files using terms like <glossterm>theirs</glossterm>, <glossterm>mine</glossterm>, and either <glossterm>merged</glossterm> or <glossterm>resolved</glossterm>. If you specify a output path on the WinMerge command line, and are working with a version control system, you should list the files in that order."
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: ./English/Command_line.xml:757
+#: ./English/Command_line.xml:775
 msgid "<option>/or <replaceable>outputpath</replaceable></option>"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: ./English/Command_line.xml:760
+#: ./English/Command_line.xml:778
 msgid "Outputs a comparison report for files or folders.  Example: <option>WinMergeU path1 path2 /or c:\\tmp\\report.html</option>"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: ./English/Command_line.xml:763
+#: ./English/Command_line.xml:781
 msgid "It is often useful to combine this option with:"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: ./English/Command_line.xml:765
+#: ./English/Command_line.xml:783
 msgid "<option>/noninteractive</option> - exits WinMerge after producing the report."
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: ./English/Command_line.xml:766
+#: ./English/Command_line.xml:784
 msgid "<option>/minimize</option> - starts WinMerge in minimized state."
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: ./English/Command_line.xml:767
+#: ./English/Command_line.xml:785
 msgid "<option>/noprefs</option> - ignores the current preferences and uses default settings.  Any changes made with <option>/cfg</option> will then be temporary and not saved."
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: ./English/Command_line.xml:771
+#: ./English/Command_line.xml:789
 msgid "The following <option>/cfg</option> settings can also be useful (parameter names may change in the future):"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: ./English/Command_line.xml:773
+#: ./English/Command_line.xml:791
 msgid "For file comparisons:"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: ./English/Command_line.xml:775
+#: ./English/Command_line.xml:793
 msgid "<option>/cfg Settings/DiffContextV2=0</option> - hides matching lines in the report (equivalent to View -> Diff Context -> 0 Lines)."
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: ./English/Command_line.xml:776
+#: ./English/Command_line.xml:794
 msgid "<option>/cfg Settings/ViewLineNumbers=1</option> - outputs line numbers (set to 0 to disable)."
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: ./English/Command_line.xml:778
+#: ./English/Command_line.xml:796
 msgid "For folder comparisons:"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: ./English/Command_line.xml:780
+#: ./English/Command_line.xml:798
 msgid "<option>/cfg Settings/DirViewExpandSubdirs=1</option> - automatically expand all subfolders."
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: ./English/Command_line.xml:781
+#: ./English/Command_line.xml:799
 msgid "<option>/cfg ReportFiles/ReportType=2</option> - report style: Simple HTML."
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: ./English/Command_line.xml:782
+#: ./English/Command_line.xml:800
 msgid "<option>/cfg ReportFiles/IncludeFileCmpReport=1</option> - include file comparison reports."
 msgstr ""
 
 #. type: Content of: <article><section><section><title><indexterm><primary>
-#: ./English/Command_line.xml:789 ./English/Compare_files.xml:1805
+#: ./English/Command_line.xml:807 ./English/Compare_files.xml:1805
 msgid "conflict files"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><indexterm><secondary>
-#: ./English/Command_line.xml:790 ./English/Command_line.xml:806
+#: ./English/Command_line.xml:808 ./English/Command_line.xml:824
 msgid "specifying on command line"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: ./English/Command_line.xml:793
+#: ./English/Command_line.xml:811
 msgid "<option><replaceable>conflictfile</replaceable></option>"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: ./English/Command_line.xml:795
+#: ./English/Command_line.xml:813
 msgid "Specifies a conflict file, typically generated by a Version control system. The conflict file opens in the File Compare window, where you can merge and resolve conflicts, as described in <xref linkend=\"ResolveConflictFiles\" />. Note that no other paths can be used with a conflict file."
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><indexterm><primary>
-#: ./English/Command_line.xml:805
+#: ./English/Command_line.xml:823
 msgid "ini file"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: ./English/Command_line.xml:809
+#: ./English/Command_line.xml:827
 msgid "<option>/inifile <replaceable>inifile</replaceable></option>"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: ./English/Command_line.xml:811
+#: ./English/Command_line.xml:829
 msgid "specifies an INI file used to load and save settings instead of the registry."
 msgstr ""
 

--- a/Translations/Docs/Manual/French.po
+++ b/Translations/Docs/Manual/French.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: WinMerge 2.16\n"
 "Report-Msgid-Bugs-To: https://github.com/WinMerge/winmerge/issues\n"
-"POT-Creation-Date: 2026-06-25 07:56+0900\n"
+"POT-Creation-Date: 2026-07-20 16:31+0900\n"
 "PO-Revision-Date: 2026-06-26 16:33-0400\n"
 "Last-Translator: t3chnob0y <t3chnob0y at outlook.com>\n"
 "Language-Team: French <winmerge-translate@lists.sourceforge.net>\n"
@@ -630,6 +630,72 @@ msgstr ""
 
 #. type: Content of: <article><para><cmdsynopsis>
 #: English/Command_line.xml:25
+#, fuzzy
+#| msgid ""
+#| "<command>WinMergeU</command> <arg choice=\"opt\" "
+#| "rep=\"norepeat\"><option>/r</option></arg> <arg choice=\"opt\" "
+#| "rep=\"norepeat\"><option>/r-</option></arg> <arg choice=\"opt\" "
+#| "rep=\"norepeat\"><option>/e</option></arg> <arg choice=\"opt\" "
+#| "rep=\"norepeat\"><option>/f</option> <replaceable>filter</replaceable></"
+#| "arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/m</option> "
+#| "<replaceable>compare-method</replaceable></arg> <arg choice=\"opt\" "
+#| "rep=\"norepeat\"><option>/t</option> <replaceable>window-type</"
+#| "replaceable></arg> <arg><option>/x</option></arg> <arg><option>/xq</"
+#| "option></arg> <arg><option>/s</option></arg> <arg><option>/sw</option></"
+#| "arg> <arg><option>/s-</option></arg> <arg choice=\"opt\" "
+#| "rep=\"norepeat\"><option>/ul</option></arg> <arg choice=\"opt\" "
+#| "rep=\"norepeat\"><option>/um</option></arg> <arg choice=\"opt\" "
+#| "rep=\"norepeat\"><option>/ur</option></arg> <arg choice=\"opt\" "
+#| "rep=\"norepeat\"><option>/u</option></arg> <arg choice=\"opt\" "
+#| "rep=\"norepeat\"><option>/wl</option></arg> <arg choice=\"opt\" "
+#| "rep=\"norepeat\"><option>/wm</option></arg> <arg choice=\"opt\" "
+#| "rep=\"norepeat\"><option>/wr</option></arg> <arg choice=\"opt\" "
+#| "rep=\"norepeat\"><option>/new</option></arg> <arg choice=\"opt\" "
+#| "rep=\"norepeat\"><option>/self-compare</option></arg> <arg choice=\"opt\" "
+#| "rep=\"norepeat\"><option>/clipboard-compare</option></arg> <arg><option>/"
+#| "minimize</option></arg> <arg><option>/maximize</option></arg> <arg "
+#| "choice=\"opt\" rep=\"norepeat\"><option>/fl</option></arg> <arg "
+#| "choice=\"opt\" rep=\"norepeat\"><option>/fm</option></arg> <arg "
+#| "choice=\"opt\" rep=\"norepeat\"><option>/fr</option></arg> <arg "
+#| "choice=\"opt\" rep=\"norepeat\"><option>/l</option> "
+#| "<replaceable>linenumber</replaceable></arg> <arg choice=\"opt\" "
+#| "rep=\"norepeat\"><option>/c</option> <replaceable>charpos</replaceable></"
+#| "arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/table-delimiter</"
+#| "option> <replaceable>delimiter</replaceable></arg> <arg choice=\"opt\" "
+#| "rep=\"norepeat\"><option>/dl</option> <replaceable>leftdesc</"
+#| "replaceable></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/dm</"
+#| "option> <replaceable>middledesc</replaceable></arg> <arg choice=\"opt\" "
+#| "rep=\"norepeat\"><option>/dr</option> <replaceable>rightdesc</"
+#| "replaceable></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/al</"
+#| "option></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/am</option></"
+#| "arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/ar</option></arg> <arg "
+#| "choice=\"opt\" rep=\"norepeat\"><option>/noninteractive</option></arg> "
+#| "<arg choice=\"opt\" rep=\"norepeat\"><option>/noprefs</option></arg> <arg "
+#| "choice=\"opt\" rep=\"norepeat\"><option>/enableexitcode</option></arg> "
+#| "<arg choice=\"opt\" rep=\"norepeat\"><option>/ignorews</option></arg> "
+#| "<arg choice=\"opt\" rep=\"norepeat\"><option>/ignoreblanklines</option></"
+#| "arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/ignorecase</option></"
+#| "arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/ignoreeol</option></"
+#| "arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/ignorecodepage</"
+#| "option></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/"
+#| "ignorecomments</option></arg> <arg choice=\"opt\" "
+#| "rep=\"norepeat\"><option>/unpacker</option> <replaceable>unpacker-name</"
+#| "replaceable></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/"
+#| "prediffer</option> <replaceable>prediffer-name</replaceable></arg> <arg "
+#| "choice=\"opt\" rep=\"norepeat\"><option>/cp</option> "
+#| "<replaceable>codepage</replaceable></arg> <arg choice=\"opt\" "
+#| "rep=\"norepeat\"><option>/fileext</option> <replaceable>file-extension</"
+#| "replaceable></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/cfg</"
+#| "option> <replaceable>name=value</replaceable></arg> <arg choice=\"opt\" "
+#| "rep=\"norepeat\"><option>/inifile</option> <replaceable>inifile</"
+#| "replaceable></arg> <arg choice=\"plain\" "
+#| "rep=\"norepeat\"><replaceable>leftpath</replaceable></arg> <arg "
+#| "cchoice=\"opt\" rep=\"norepeat\"><replaceable>middlepath</replaceable></"
+#| "arg> <arg choice=\"plain\" rep=\"norepeat\"><replaceable>rightpath</"
+#| "replaceable></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/o</"
+#| "option> <replaceable>outputpath</replaceable></arg> <arg choice=\"opt\" "
+#| "rep=\"norepeat\"><option>/or</option> <replaceable>reportpath</"
+#| "replaceable></arg>"
 msgid ""
 "<command>WinMergeU</command> <arg choice=\"opt\" rep=\"norepeat\"><option>/"
 "r</option></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/r-</option></"
@@ -640,18 +706,20 @@ msgid ""
 "rep=\"norepeat\"><option>/t</option> <replaceable>window-type</replaceable></"
 "arg> <arg><option>/x</option></arg> <arg><option>/xq</option></arg> "
 "<arg><option>/s</option></arg> <arg><option>/sw</option></arg> <arg><option>/"
-"s-</option></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/ul</option></"
-"arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/um</option></arg> <arg "
-"choice=\"opt\" rep=\"norepeat\"><option>/ur</option></arg> <arg "
-"choice=\"opt\" rep=\"norepeat\"><option>/u</option></arg> <arg "
-"choice=\"opt\" rep=\"norepeat\"><option>/wl</option></arg> <arg "
-"choice=\"opt\" rep=\"norepeat\"><option>/wm</option></arg> <arg "
-"choice=\"opt\" rep=\"norepeat\"><option>/wr</option></arg> <arg "
-"choice=\"opt\" rep=\"norepeat\"><option>/new</option></arg> <arg "
-"choice=\"opt\" rep=\"norepeat\"><option>/self-compare</option></arg> <arg "
-"choice=\"opt\" rep=\"norepeat\"><option>/clipboard-compare</option></arg> "
-"<arg><option>/minimize</option></arg> <arg><option>/maximize</option></arg> "
-"<arg choice=\"opt\" rep=\"norepeat\"><option>/fl</option></arg> <arg "
+"s-</option></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/g</option> "
+"<replaceable>group-name</replaceable></arg> <arg choice=\"opt\" "
+"rep=\"norepeat\"><option>/ul</option></arg> <arg choice=\"opt\" "
+"rep=\"norepeat\"><option>/um</option></arg> <arg choice=\"opt\" "
+"rep=\"norepeat\"><option>/ur</option></arg> <arg choice=\"opt\" "
+"rep=\"norepeat\"><option>/u</option></arg> <arg choice=\"opt\" "
+"rep=\"norepeat\"><option>/wl</option></arg> <arg choice=\"opt\" "
+"rep=\"norepeat\"><option>/wm</option></arg> <arg choice=\"opt\" "
+"rep=\"norepeat\"><option>/wr</option></arg> <arg choice=\"opt\" "
+"rep=\"norepeat\"><option>/new</option></arg> <arg choice=\"opt\" "
+"rep=\"norepeat\"><option>/self-compare</option></arg> <arg choice=\"opt\" "
+"rep=\"norepeat\"><option>/clipboard-compare</option></arg> <arg><option>/"
+"minimize</option></arg> <arg><option>/maximize</option></arg> <arg "
+"choice=\"opt\" rep=\"norepeat\"><option>/fl</option></arg> <arg "
 "choice=\"opt\" rep=\"norepeat\"><option>/fm</option></arg> <arg "
 "choice=\"opt\" rep=\"norepeat\"><option>/fr</option></arg> <arg "
 "choice=\"opt\" rep=\"norepeat\"><option>/l</option> <replaceable>linenumber</"
@@ -758,7 +826,7 @@ msgstr ""
 "replaceable></arg>"
 
 #. type: Content of: <article><cmdsynopsis>
-#: English/Command_line.xml:162
+#: English/Command_line.xml:165
 msgid ""
 "<command>WinMergeU</command> <arg choice=\"plain\" "
 "rep=\"norepeat\"><replaceable>conflictfile</replaceable></arg>"
@@ -767,7 +835,7 @@ msgstr ""
 "rep=\"norepeat\"><replaceable>fichier_conflit</replaceable></arg>"
 
 #. type: Content of: <article><para>
-#: English/Command_line.xml:168
+#: English/Command_line.xml:171
 msgid ""
 "Entering the command with no parameters or pathnames simply opens the "
 "WinMerge window. Parameters are prefixed with either a forward slash "
@@ -780,29 +848,29 @@ msgstr ""
 "noms de chemin n'ont pas de caractère de préfixe."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:175
+#: English/Command_line.xml:178
 msgid "<option>/?</option>"
 msgstr "<option>/?</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:177
+#: English/Command_line.xml:180
 msgid "Opens WinMerge Help at this topic."
 msgstr "Ouvre l'aide de WinMerge sur cette rubrique."
 
 #. type: Content of: <article><section><section><title><indexterm><seealso>
-#: English/Command_line.xml:183 English/Compare_dirs.xml:54
+#: English/Command_line.xml:186 English/Compare_dirs.xml:54
 #: English/Compare_dirs.xml:254 English/Open_paths.xml:288
 #: English/Open_paths.xml:294
 msgid "recursive folder compare"
 msgstr "comparaison récursive de dossiers"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:185
+#: English/Command_line.xml:188
 msgid "<option>/r</option>"
 msgstr "<option>/r</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:187
+#: English/Command_line.xml:190
 msgid ""
 "Compares all files in all subfolders (recursive compare). Unique folders "
 "(occurring only on one side) are listed in the compare result as separate "
@@ -820,17 +888,17 @@ msgstr ""
 "compare pas les sous-dossiers."
 
 #. type: Content of: <article><variablelist><varlistentry><indexterm><primary>
-#: English/Command_line.xml:198
+#: English/Command_line.xml:201
 msgid "non-recursive folder compare"
 msgstr "comparaison non récursive de dossiers"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:200
+#: English/Command_line.xml:203
 msgid "<option>/r-</option>"
 msgstr "<option>/r-</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:202
+#: English/Command_line.xml:205
 msgid ""
 "Compares all files within the specified folders but excludes the files and "
 "subfolders within its subfolders.  This allows for a shorter comparison time."
@@ -840,24 +908,24 @@ msgstr ""
 "temps de comparaison plus court."
 
 #. type: Content of: <article><section><section><title><indexterm><primary>
-#: English/Command_line.xml:210 English/Command_line.xml:294
-#: English/Command_line.xml:417 English/Configuration.xml:277
-#: English/Quick_start.xml:22
+#: English/Command_line.xml:213 English/Command_line.xml:297
+#: English/Command_line.xml:330 English/Command_line.xml:435
+#: English/Configuration.xml:277 English/Quick_start.xml:22
 msgid "WinMerge window"
 msgstr "Fenêtre WinMerge"
 
 #. type: Content of: <article><variablelist><varlistentry><indexterm><secondary>
-#: English/Command_line.xml:211
+#: English/Command_line.xml:214
 msgid "closing"
 msgstr "fermeture"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:214
+#: English/Command_line.xml:217
 msgid "<option>/e</option>"
 msgstr "<option>/e</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:216
+#: English/Command_line.xml:219
 msgid ""
 "Enables you to close WinMerge with a single <keycap>Esc</keycap> key press. "
 "This is useful when you use WinMerge as an external compare application: you "
@@ -871,7 +939,7 @@ msgstr ""
 "<keycap>Echap</keycap> plusieurs fois pour fermer toutes ses fenêtres."
 
 #. type: Content of: <article><section><section><title><indexterm><primary>
-#: English/Command_line.xml:226 English/Configuration.xml:820
+#: English/Command_line.xml:229 English/Configuration.xml:820
 #: English/Configuration.xml:848 English/Configuration.xml:871
 #: English/Filters.xml:4 English/Filters.xml:96 English/Filters.xml:100
 #: English/Filters.xml:142 English/Filters.xml:1609 English/Filters.xml:1613
@@ -882,18 +950,18 @@ msgid "filters"
 msgstr "filtres"
 
 #. type: Content of: <article><variablelist><varlistentry><indexterm><secondary>
-#: English/Command_line.xml:227 English/Command_line.xml:243
-#: English/Command_line.xml:259
+#: English/Command_line.xml:230 English/Command_line.xml:246
+#: English/Command_line.xml:262
 msgid "applying in command line"
 msgstr "application en ligne de commande"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:230
+#: English/Command_line.xml:233
 msgid "<option>/f</option>"
 msgstr "<option>/f</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:232
+#: English/Command_line.xml:235
 msgid ""
 "Applies a specified filter to restrict the comparison. The filter can be a "
 "filemask like <filename><userinput>*.h *.cpp</userinput></filename>, or the "
@@ -907,17 +975,17 @@ msgstr ""
 "contenant des espaces."
 
 #. type: Content of: <article><variablelist><varlistentry><indexterm><primary>
-#: English/Command_line.xml:242
+#: English/Command_line.xml:245
 msgid "compare method"
 msgstr "méthode de comparaison"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:246
+#: English/Command_line.xml:249
 msgid "<option>/m <replaceable>compare-method</replaceable></option>"
 msgstr "<option>/m <replaceable>méthode-comparaison</replaceable></option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:248
+#: English/Command_line.xml:251
 msgid ""
 "Sets the compare method to use for the comparison.  This can be one of the "
 "keywords <userinput>Full</userinput>, <userinput>Quick</userinput>, "
@@ -932,17 +1000,17 @@ msgstr ""
 "<userinput>Size</userinput> (Taille) ou <userinput>Existence</userinput>."
 
 #. type: Content of: <article><variablelist><varlistentry><indexterm><primary>
-#: English/Command_line.xml:258
+#: English/Command_line.xml:261
 msgid "window type"
 msgstr "type de fenêtre"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:262
+#: English/Command_line.xml:265
 msgid "<option>/t <replaceable>window-type</replaceable></option>"
 msgstr "<option>/t <replaceable>type-fenêtre</replaceable></option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:264
+#: English/Command_line.xml:267
 msgid ""
 "Specifies the type of window in which to display files.  This can be one of "
 "the keywords <userinput>Text</userinput>, <userinput>Table</userinput>, "
@@ -956,12 +1024,12 @@ msgstr ""
 "(Page Web) ou <userinput>Folder</userinput>."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:272
+#: English/Command_line.xml:275
 msgid "<option>/x</option>"
 msgstr "<option>/x</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:274
+#: English/Command_line.xml:277
 msgid ""
 "Closes WinMerge (after displaying an information dialog) when you start a "
 "comparison of identical files. The parameter has no effect after the "
@@ -979,12 +1047,12 @@ msgstr ""
 "qui n'ont aucune différence."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:285
+#: English/Command_line.xml:288
 msgid "<option>/xq</option>"
 msgstr "<option>/xq</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:287
+#: English/Command_line.xml:290
 msgid ""
 "Is similar to <option>/x</option> but does not show the message about "
 "identical files."
@@ -993,17 +1061,17 @@ msgstr ""
 "les fichiers identiques."
 
 #. type: Content of: <article><section><section><title><indexterm><secondary>
-#: English/Command_line.xml:295 English/Configuration.xml:279
+#: English/Command_line.xml:298 English/Configuration.xml:279
 msgid "limiting instances"
 msgstr "limitation des instances"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:298
+#: English/Command_line.xml:301
 msgid "<option>/s</option>"
 msgstr "<option>/s</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:300
+#: English/Command_line.xml:303
 msgid ""
 "Limits WinMerge windows to a single instance.  For example, if WinMerge is "
 "already running, a new compare opens in the same instance. Without this "
@@ -1017,12 +1085,12 @@ msgstr ""
 "existante ou dans une nouvelle fenêtre."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:309
+#: English/Command_line.xml:312
 msgid "<option>/sw</option>"
 msgstr "<option>/sw</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:311
+#: English/Command_line.xml:314
 msgid ""
 "Limit the WinMerge window to one instance as well as the option /s.  "
 "However, it waits for the instance displaying the window to terminate."
@@ -1031,12 +1099,12 @@ msgstr ""
 "Cependant, elle attend que l'instance affichant la fenêtre se termine."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:318
+#: English/Command_line.xml:321
 msgid "<option>/s-</option>"
 msgstr "<option>/s-</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:320
+#: English/Command_line.xml:323
 msgid ""
 "Ensure that another instance is always executed, ignoring the value of the "
 "\"Allow only one instance to run\" option."
@@ -1044,19 +1112,39 @@ msgstr ""
 "Garantit qu'une autre instance est toujours exécutée, en ignorant la valeur "
 "de l'option « N'autoriser qu'une seule instance à s'exécuter »."
 
+#. type: Content of: <article><variablelist><varlistentry><indexterm><secondary>
+#: English/Command_line.xml:331
+msgid "instance groups"
+msgstr ""
+
+#. type: Content of: <article><variablelist><varlistentry><term>
+#: English/Command_line.xml:334
+#, fuzzy
+#| msgid "<option>/cp <replaceable>codepage</replaceable></option>"
+msgid "<option>/g</option> <replaceable>group-name</replaceable>"
+msgstr "<option>/cp <replaceable>page-de-code</replaceable></option>"
+
+#. type: Content of: <article><variablelist><varlistentry><listitem><para>
+#: English/Command_line.xml:337
+msgid ""
+"Specifies a group name for the WinMerge instance. When used with the "
+"<option>/s</option> option, instances with the same group name share the "
+"same window, allowing you to organize multiple single-instance groups."
+msgstr ""
+
 #. type: Content of: <article><section><qandaset><qandaentry><question><para><indexterm><primary>
-#: English/Command_line.xml:327 English/Configuration.xml:430
+#: English/Command_line.xml:345 English/Configuration.xml:430
 #: English/Faq.xml:114
 msgid "MRU list"
 msgstr "Liste MRU"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:330
+#: English/Command_line.xml:348
 msgid "<option>/ul</option>"
 msgstr "<option>/ul</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:332
+#: English/Command_line.xml:350
 msgid ""
 "Prevents WinMerge from adding the left path to the Most Recently Used (MRU) "
 "list. External applications should not add paths to the MRU list in the "
@@ -1068,12 +1156,12 @@ msgstr ""
 "fichiers ou des dossiers."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:339
+#: English/Command_line.xml:357
 msgid "<option>/um</option>"
 msgstr "<option>/um</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:341
+#: English/Command_line.xml:359
 msgid ""
 "Prevents WinMerge from adding the middle path to the Most Recently Used "
 "(MRU) list. External applications should not add paths to the MRU list in "
@@ -1085,12 +1173,12 @@ msgstr ""
 "fichiers ou des dossiers."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:348
+#: English/Command_line.xml:366
 msgid "<option>/ur</option>"
 msgstr "<option>/ur</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:350
+#: English/Command_line.xml:368
 msgid ""
 "Prevents WinMerge from adding the right path to the Most Recently Used (MRU) "
 "list. External applications should not add paths to the MRU list in the "
@@ -1102,12 +1190,12 @@ msgstr ""
 "fichiers ou des dossiers."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:357
+#: English/Command_line.xml:375
 msgid "<option>/u</option>"
 msgstr "<option>/u</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:359
+#: English/Command_line.xml:377
 msgid ""
 "Prevents WinMerge from adding either path (left or right) to the Most "
 "Recently Used (MRU) list. External applications should not add paths to the "
@@ -1119,18 +1207,18 @@ msgstr ""
 "dialogue Sélectionner des fichiers ou des dossiers."
 
 #. type: Content of: <article><section><section><title><indexterm><see>
-#: English/Command_line.xml:368 English/Compare_dirs.xml:741
+#: English/Command_line.xml:386 English/Compare_dirs.xml:741
 #: English/Compare_dirs.xml:745
 msgid "protecting files"
 msgstr "protection des fichiers"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:371
+#: English/Command_line.xml:389
 msgid "<option>/wl</option>"
 msgstr "<option>/wl</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:373
+#: English/Command_line.xml:391
 msgid ""
 "Opens the left side as read-only. Use this when you don't want to change "
 "left side items in the compare."
@@ -1139,12 +1227,12 @@ msgstr ""
 "souhaitez pas modifier les éléments du côté gauche lors de la comparaison."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:379
+#: English/Command_line.xml:397
 msgid "<option>/wm</option>"
 msgstr "<option>/wm</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:381
+#: English/Command_line.xml:399
 msgid ""
 "Opens the middle side as read-only. Use this when you don't want to change "
 "right side items in the compare."
@@ -1153,12 +1241,12 @@ msgstr ""
 "ne souhaitez pas modifier les éléments du côté droit lors de la comparaison."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:387
+#: English/Command_line.xml:405
 msgid "<option>/wr</option>"
 msgstr "<option>/wr</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:389
+#: English/Command_line.xml:407
 msgid ""
 "Opens the right side as read-only. Use this when you don't want to change "
 "right side items in the compare."
@@ -1167,48 +1255,48 @@ msgstr ""
 "souhaitez pas modifier les éléments du côté droit lors de la comparaison."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:395
+#: English/Command_line.xml:413
 msgid "<option>/new</option>"
 msgstr "<option>/new</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:397
+#: English/Command_line.xml:415
 msgid "Opens a new blank window."
 msgstr "Ouvre une nouvelle fenêtre vide."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:402
+#: English/Command_line.xml:420
 msgid "<option>/self-compare</option>"
 msgstr "<option>/self-compare</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:404
+#: English/Command_line.xml:422
 msgid "Compares the specified file with a copy of the file."
 msgstr "Compare le fichier spécifié avec une copie de lui-même."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:409
+#: English/Command_line.xml:427
 msgid "<option>/clipboard-compare</option>"
 msgstr "<option>/clipboard-compare</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:411
+#: English/Command_line.xml:429
 msgid "Compares the two most recent contents of the clipboard history."
 msgstr ""
 "Compare les deux contenus les plus récents de l'historique du presse-papiers."
 
 #. type: Content of: <article><variablelist><varlistentry><indexterm><secondary>
-#: English/Command_line.xml:418
+#: English/Command_line.xml:436
 msgid "opening minimized or maximized"
 msgstr "ouverture réduite ou agrandie"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:421
+#: English/Command_line.xml:439
 msgid "<option>/minimize</option>"
 msgstr "<option>/minimize</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:423
+#: English/Command_line.xml:441
 msgid ""
 "Starts WinMerge as a minimized window.  This option can be useful during "
 "lengthy compares."
@@ -1217,77 +1305,77 @@ msgstr ""
 "lors de comparaisons de longue durée."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:429
+#: English/Command_line.xml:447
 msgid "<option>/maximize</option>"
 msgstr "<option>/maximize</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:431
+#: English/Command_line.xml:449
 msgid "Starts WinMerge as a maximized window."
 msgstr "Démarre WinMerge en tant que fenêtre agrandie."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:437
+#: English/Command_line.xml:455
 msgid "<option>/fl</option>"
 msgstr "<option>/fl</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:439
+#: English/Command_line.xml:457
 msgid "Sets focus to the left side at startup."
 msgstr "Place le focus sur le côté gauche au démarrage."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:444
+#: English/Command_line.xml:462
 msgid "<option>/fm</option>"
 msgstr "<option>/fm</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:446
+#: English/Command_line.xml:464
 msgid "Sets focus to the middle side at startup."
 msgstr "Place le focus sur le côté du milieu au démarrage."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:451
+#: English/Command_line.xml:469
 msgid "<option>/fr</option>"
 msgstr "<option>/fr</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:453
+#: English/Command_line.xml:471
 msgid "Sets focus to the right side at startup."
 msgstr "Place le focus sur le côté droit au démarrage."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:458
+#: English/Command_line.xml:476
 msgid "<option>/l <replaceable>linenumber</replaceable></option>"
 msgstr "<option>/l <replaceable>numéroligne</replaceable></option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:460
+#: English/Command_line.xml:478
 msgid "Specifies a line number to jump to after loading the files."
 msgstr ""
 "Spécifie un numéro de ligne vers lequel sauter après le chargement des "
 "fichiers."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:465
+#: English/Command_line.xml:483
 msgid "<option>/c <replaceable>charpos</replaceable></option>"
 msgstr "<option>/c <replaceable>poscaractère</replaceable></option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:467
+#: English/Command_line.xml:485
 msgid "Specifies a character position to jump to after loading the files."
 msgstr ""
 "Spécifie une position de caractère vers laquelle sauter après le chargement "
 "des fichiers."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:472
+#: English/Command_line.xml:490
 msgid "<option>/table-delimiter <replaceable>delimiter</replaceable></option>"
 msgstr ""
 "<option>/table-delimiter <replaceable>délimiteur</replaceable></option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:474
+#: English/Command_line.xml:492
 msgid ""
 "Specifies a delimiter character for table editing. To specify a tab "
 "character, specify \"tab\", \"\\t\", or \"\\x09\"."
@@ -1296,12 +1384,12 @@ msgstr ""
 "une tabulation, indiquez « tab », « \\t » ou « \\x09 »."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:479
+#: English/Command_line.xml:497
 msgid "<option>/dl</option>"
 msgstr "<option>/dl</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:481
+#: English/Command_line.xml:499
 msgid ""
 "Specifies a description in the left side title bar, overriding the default "
 "folder or filename text. For example: <userinput>/dl \"Version 1.0</"
@@ -1315,12 +1403,12 @@ msgstr ""
 "espaces."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:490
+#: English/Command_line.xml:508
 msgid "<option>/dm</option>"
 msgstr "<option>/dm</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:492
+#: English/Command_line.xml:510
 msgid ""
 "Specifies a description in the middle side title bar, just like <option>/dl</"
 "option>."
@@ -1329,12 +1417,12 @@ msgstr ""
 "<option>/dl</option>."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:498
+#: English/Command_line.xml:516
 msgid "<option>/dr</option>"
 msgstr "<option>/dr</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:500
+#: English/Command_line.xml:518
 msgid ""
 "Specifies a description in the right side title bar, just like <option>/dl</"
 "option>."
@@ -1343,42 +1431,42 @@ msgstr ""
 "<option>/dl</option>."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:506
+#: English/Command_line.xml:524
 msgid "<option>/al</option>"
 msgstr "<option>/al</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:508
+#: English/Command_line.xml:526
 msgid "Auto-merges at the left side at startup."
 msgstr "Fusionne automatiquement sur le côté gauche au démarrage."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:513
+#: English/Command_line.xml:531
 msgid "<option>/am</option>"
 msgstr "<option>/am</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:515
+#: English/Command_line.xml:533
 msgid "Auto-merges at the middle side at startup."
 msgstr "Fusionne automatiquement sur le côté milieu au démarrage."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:520
+#: English/Command_line.xml:538
 msgid "<option>/ar</option>"
 msgstr "<option>/ar</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:522
+#: English/Command_line.xml:540
 msgid "Auto-merges at the right side at startup."
 msgstr "Fusionne automatiquement sur le côté droit au démarrage."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:527
+#: English/Command_line.xml:545
 msgid "<option>/noninteractive</option>"
 msgstr "<option>/noninteractive</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:530
+#: English/Command_line.xml:548
 msgid ""
 "Runs WinMerge without displaying message boxes during comparison or report "
 "generation.  The process terminates automatically when the operation is "
@@ -1390,12 +1478,12 @@ msgstr ""
 "batch ou par script."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:538
+#: English/Command_line.xml:556
 msgid "<option>/noprefs</option>"
 msgstr "<option>/noprefs</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:541
+#: English/Command_line.xml:559
 msgid ""
 "Runs WinMerge without loading or saving settings from the registry.  All "
 "comparisons use default preferences only."
@@ -1404,12 +1492,12 @@ msgstr ""
 "Toutes les comparaisons utilisent uniquement les préférences par défaut."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:548
+#: English/Command_line.xml:566
 msgid "<option>/enableexitcode</option>"
 msgstr "<option>/enableexitcode</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:550
+#: English/Command_line.xml:568
 msgid ""
 "Sets the comparison result to the process exit code. 0: identical, 1: "
 "different, 2: error"
@@ -1418,12 +1506,12 @@ msgstr ""
 "identique, 1 : différent, 2 : erreur"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:555
+#: English/Command_line.xml:573
 msgid "<option>/ignorews</option>"
 msgstr "<option>/ignorews</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:557
+#: English/Command_line.xml:575
 msgid ""
 "Controls the \"Whitespaces\" option (whitespace comparison settings) "
 "persistently:"
@@ -1432,13 +1520,13 @@ msgstr ""
 "de manière persistante :"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:559
+#: English/Command_line.xml:577
 msgid "<option>/ignorews:0</option> - do not ignore whitespace differences."
 msgstr ""
 "<option>/ignorews:0</option> - n'ignore pas les différences d'espaces blancs."
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:560
+#: English/Command_line.xml:578
 msgid ""
 "<option>/ignorews</option> or <option>/ignorews:1</option> - ignore "
 "differences in the amount of whitespace."
@@ -1447,31 +1535,31 @@ msgstr ""
 "différences de quantité d'espaces blancs."
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:561
+#: English/Command_line.xml:579
 msgid "<option>/ignorews:2</option> - ignore all whitespace characters."
 msgstr ""
 "<option>/ignorews:2</option> - ignore tous les caractères d'espacement."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:567
+#: English/Command_line.xml:585
 msgid "<option>/ignoreblanklines</option>"
 msgstr "<option>/ignoreblanklines</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:569
+#: English/Command_line.xml:587
 msgid "Controls the \"Ignore blank lines\" option persistently:"
 msgstr ""
 "Contrôle l'option « Ignorer les lignes vides » de manière persistante :"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:571
+#: English/Command_line.xml:589
 msgid "<option>/ignoreblanklines:0</option> - disables ignoring blank lines."
 msgstr ""
 "<option>/ignoreblanklines:0</option> - désactive l'ignorance des lignes "
 "vides."
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:572
+#: English/Command_line.xml:590
 msgid ""
 "<option>/ignoreblanklines</option> or <option>/ignoreblanklines:1</option> - "
 "enables ignoring blank lines."
@@ -1480,24 +1568,24 @@ msgstr ""
 "active l'ignorance des lignes vides."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:578
+#: English/Command_line.xml:596
 msgid "<option>/ignorecase</option>"
 msgstr "<option>/ignorecase</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:580
+#: English/Command_line.xml:598
 msgid "Controls the \"Ignore case\" option persistently:"
 msgstr "Contrôle l'option « Ignorer la casse » de manière persistante :"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:582
+#: English/Command_line.xml:600
 msgid "<option>/ignorecase:0</option> - disables ignoring case differences."
 msgstr ""
 "<option>/ignorecase:0</option> - désactive l'ignorance des différences de "
 "casse."
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:583
+#: English/Command_line.xml:601
 msgid ""
 "<option>/ignorecase</option> or <option>/ignorecase:1</option> - enables "
 "ignoring case differences."
@@ -1506,25 +1594,25 @@ msgstr ""
 "l'ignorance des différences de casse."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:589
+#: English/Command_line.xml:607
 msgid "<option>/ignoreeol</option>"
 msgstr "<option>/ignoreeol</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:591
+#: English/Command_line.xml:609
 msgid "Controls the \"Ignore EOL differences\" option persistently:"
 msgstr ""
 "Contrôle l'option « Ignorer les différences EOL » de manière persistante :"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:593
+#: English/Command_line.xml:611
 msgid "<option>/ignoreeol:0</option> - disables ignoring EOL differences."
 msgstr ""
 "<option>/ignoreeol:0</option> - désactive l'ignorance des différences EOL "
 "(fin de ligne)."
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:594
+#: English/Command_line.xml:612
 msgid ""
 "<option>/ignoreeol</option> or <option>/ignoreeol:1</option> - enables "
 "ignoring EOL differences."
@@ -1533,19 +1621,19 @@ msgstr ""
 "l'ignorance des différences EOL (fin de ligne)."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:600
+#: English/Command_line.xml:618
 msgid "<option>/ignorecodepage</option>"
 msgstr "<option>/ignorecodepage</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:602
+#: English/Command_line.xml:620
 msgid "Controls the \"Ignore codepage differences\" option persistently:"
 msgstr ""
 "Contrôle l'option « Ignorer les différences de page de code » de manière "
 "persistante :"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:604
+#: English/Command_line.xml:622
 msgid ""
 "<option>/ignorecodepage:0</option> - disables ignoring codepage differences."
 msgstr ""
@@ -1553,7 +1641,7 @@ msgstr ""
 "de page de code."
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:605
+#: English/Command_line.xml:623
 msgid ""
 "<option>/ignorecodepage</option> or <option>/ignorecodepage:1</option> - "
 "enables ignoring codepage differences."
@@ -1562,25 +1650,25 @@ msgstr ""
 "active l'ignorance des différences de page de code."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:611
+#: English/Command_line.xml:629
 msgid "<option>/ignorecomments</option>"
 msgstr "<option>/ignorecomments</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:613
+#: English/Command_line.xml:631
 msgid "Controls the \"Ignore comment differences\" option persistently:"
 msgstr ""
 "Contrôle l'option « Ignorer les différences de commentaires » de manière "
 "persistante :"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:615
+#: English/Command_line.xml:633
 msgid "<option>/ignorecomments:0</option> - disables ignoring comments."
 msgstr ""
 "<option>/ignorecomments:0</option> - désactive l'ignorance des commentaires."
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:616
+#: English/Command_line.xml:634
 msgid ""
 "<option>/ignorecomments</option> or <option>/ignorecomments:1</option> - "
 "enables ignoring comments."
@@ -1589,13 +1677,13 @@ msgstr ""
 "active l'ignorance des commentaires."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:622
+#: English/Command_line.xml:640
 msgid "<option>/unpacker <replaceable>plugin pipeline</replaceable></option>"
 msgstr ""
 "<option>/unpacker <replaceable>pipeline de plug-ins</replaceable></option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:625
+#: English/Command_line.xml:643
 msgid ""
 "Specifies the plugin pipeline for the Unpacker plugin.  Example: <option>/"
 "unpacker \"SortAscending|SelectLines 1-10\"</option>"
@@ -1604,13 +1692,13 @@ msgstr ""
 "<option>/unpacker \"SortAscending|SelectLines 1-10\"</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:632
+#: English/Command_line.xml:650
 msgid "<option>/prediffer <replaceable>plugin pipeline</replaceable></option>"
 msgstr ""
 "<option>/prediffer <replaceable>pipeline de plug-ins</replaceable></option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:635
+#: English/Command_line.xml:653
 msgid ""
 "Specifies the plugin pipeline for the Prediffer plugin.  Example: <option>/"
 "prediffer \"IgnoreColumns 1-10\"</option>"
@@ -1619,12 +1707,12 @@ msgstr ""
 "<option>/prediffer \"IgnoreColumns 1-10\"</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:642
+#: English/Command_line.xml:660
 msgid "<option>/cp <replaceable>codepage</replaceable></option>"
 msgstr "<option>/cp <replaceable>page-de-code</replaceable></option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:645
+#: English/Command_line.xml:663
 msgid ""
 "Specifies the codepage to use for file comparison.  Example: <option>/cp "
 "65001</option>"
@@ -1633,35 +1721,35 @@ msgstr ""
 "Exemple : <option>/cp 65001</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:652
+#: English/Command_line.xml:670
 msgid "<option>/fileext <replaceable>file-extension</replaceable></option>"
 msgstr "<option>/fileext <replaceable>extension-fichier</replaceable></option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:654
+#: English/Command_line.xml:672
 msgid "Specifies a file extension for determining syntax hightliting."
 msgstr ""
 "Spécifie une extension de fichier pour déterminer la coloration syntaxique."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:659
+#: English/Command_line.xml:677
 msgid "<option>/cfg <replaceable>name=value</replaceable></option>"
 msgstr "<option>/cfg <replaceable>nom=valeur</replaceable></option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:662
+#: English/Command_line.xml:680
 msgid "Sets a configuration value in the WinMerge registry or INI file."
 msgstr ""
 "Définit une valeur de configuration dans le registre WinMerge ou dans le "
 "fichier INI."
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:665
+#: English/Command_line.xml:683
 msgid "Example: <option>/cfg Settings/DiffAlgorithm=3</option>"
 msgstr "Exemple : <option>/cfg Settings/DiffAlgorithm=3</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:668
+#: English/Command_line.xml:686
 msgid ""
 "If the section name is unambiguous and does not conflict with other setting "
 "names, it can be omitted:"
@@ -1670,12 +1758,12 @@ msgstr ""
 "d'autres noms de paramètres, il peut être omis :"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:671
+#: English/Command_line.xml:689
 msgid "<option>/cfg DiffAlgo=3</option>"
 msgstr "<option>/cfg DiffAlgo=3</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:674
+#: English/Command_line.xml:692
 msgid ""
 "Note: This entry does not explain which configuration names are available.  "
 "For a list of settings, refer to "
@@ -1688,43 +1776,43 @@ msgstr ""
 "dans regedit."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:681
+#: English/Command_line.xml:699
 msgid "<option><replaceable>leftpath</replaceable></option>"
 msgstr "<option><replaceable>chemin_gauche</replaceable></option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:683
+#: English/Command_line.xml:701
 msgid "Specifies the folder, file or project file to open on the left side."
 msgstr ""
 "Spécifie le dossier, le fichier ou le fichier de projet à ouvrir sur le côté "
 "gauche."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:688
+#: English/Command_line.xml:706
 msgid "<option><replaceable>middlepath</replaceable></option>"
 msgstr "<option><replaceable>chemin_milieu</replaceable></option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:690
+#: English/Command_line.xml:708
 msgid "Specifies the folder, file or project file to open on the middle side."
 msgstr ""
 "Spécifie le dossier, le fichier ou le fichier de projet à ouvrir sur le côté "
 "milieu."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:695
+#: English/Command_line.xml:713
 msgid "<option><replaceable>rightpath</replaceable></option>"
 msgstr "<option><replaceable>chemin_droite</replaceable></option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:697
+#: English/Command_line.xml:715
 msgid "Specifies the folder, file or project file to open on the right side."
 msgstr ""
 "Spécifie le dossier, le fichier ou le fichier de projet à ouvrir sur le côté "
 "droit."
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:699
+#: English/Command_line.xml:717
 msgid ""
 "WinMerge cannot compare files to folders, so the path parameters "
 "(<option><replaceable>leftpath</replaceable></option>, "
@@ -1744,7 +1832,7 @@ msgstr ""
 "rechercher les chemins corrects."
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><tip><para>
-#: English/Command_line.xml:708
+#: English/Command_line.xml:726
 msgid ""
 "In file comparisons, you can specify a folder name in one of the path "
 "parameters, as long as the folder contains a file with the same name as the "
@@ -1756,12 +1844,12 @@ msgstr ""
 "fichier."
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><tip><para>
-#: English/Command_line.xml:712
+#: English/Command_line.xml:730
 msgid "For example, consider this command:"
 msgstr "Par exemple, considérez cette commande :"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><tip><para>
-#: English/Command_line.xml:714
+#: English/Command_line.xml:732
 msgid ""
 "<userinput>WinMergeU <filename>C:\\Folder\\File.txt</filename> <filename "
 "class=\"directory\">C:\\Folder2</filename> </userinput>"
@@ -1770,7 +1858,7 @@ msgstr ""
 "class=\"directory\">C:\\Dossier2</filename> </userinput>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><tip><para>
-#: English/Command_line.xml:717
+#: English/Command_line.xml:735
 msgid ""
 "If <filename class=\"directory\">C:\\Folder2</filename> contains a file "
 "named <filename>File.txt</filename>: WinMerge implicitly resolves the second "
@@ -1787,23 +1875,23 @@ msgstr ""
 "emphasis> de fichier nommé <filename>Fichier.txt</filename>."
 
 #. type: Content of: <article><section><section><title><indexterm><primary>
-#: English/Command_line.xml:730 English/Compare_files.xml:1481
+#: English/Command_line.xml:748 English/Compare_files.xml:1481
 #: English/Intro_diffs.xml:253 English/Intro_diffs.xml:407
 msgid "merging differences"
 msgstr "fusion des différences"
 
 #. type: Content of: <article><section><section><title><indexterm><secondary>
-#: English/Command_line.xml:731 English/Intro_diffs.xml:409
+#: English/Command_line.xml:749 English/Intro_diffs.xml:409
 msgid "result file"
 msgstr "fichier résultat"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:734
+#: English/Command_line.xml:752
 msgid "<option>/o <replaceable>outputpath</replaceable></option>"
 msgstr "<option>/o <replaceable>chemin_sortie</replaceable></option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:736
+#: English/Command_line.xml:754
 msgid ""
 "Specifies an optional output file path where you want merged result files to "
 "be saved."
@@ -1812,7 +1900,7 @@ msgstr ""
 "fichiers de résultats fusionnés soient enregistrés."
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:739
+#: English/Command_line.xml:757
 msgid ""
 "The output path is rarely needed when you start WinMerge from the command "
 "line. It is meant to be used with version control tools, where you might "
@@ -1831,7 +1919,7 @@ msgstr ""
 "laissant les deux ou trois fichiers sources intacts."
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:747
+#: English/Command_line.xml:765
 msgid ""
 "Version control systems typically refer to the source and result files using "
 "terms like <glossterm>theirs</glossterm>, <glossterm>mine</glossterm>, and "
@@ -1848,12 +1936,12 @@ msgstr ""
 "version, vous devez lister les fichiers dans cet ordre."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:757
+#: English/Command_line.xml:775
 msgid "<option>/or <replaceable>outputpath</replaceable></option>"
 msgstr "<option>/or <replaceable>cheminsortie</replaceable></option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:760
+#: English/Command_line.xml:778
 msgid ""
 "Outputs a comparison report for files or folders.  Example: "
 "<option>WinMergeU path1 path2 /or c:\\tmp\\report.html</option>"
@@ -1863,12 +1951,12 @@ msgstr ""
 "option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:763
+#: English/Command_line.xml:781
 msgid "It is often useful to combine this option with:"
 msgstr "Il est souvent utile de combiner cette option avec :"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:765
+#: English/Command_line.xml:783
 msgid ""
 "<option>/noninteractive</option> - exits WinMerge after producing the report."
 msgstr ""
@@ -1876,12 +1964,12 @@ msgstr ""
 "rapport."
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:766
+#: English/Command_line.xml:784
 msgid "<option>/minimize</option> - starts WinMerge in minimized state."
 msgstr "<option>/minimize</option> - démarre WinMerge à l'état réduit."
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:767
+#: English/Command_line.xml:785
 msgid ""
 "<option>/noprefs</option> - ignores the current preferences and uses default "
 "settings.  Any changes made with <option>/cfg</option> will then be "
@@ -1892,7 +1980,7 @@ msgstr ""
 "cfg</option> seront alors temporaires et ne seront pas enregistrées."
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:771
+#: English/Command_line.xml:789
 msgid ""
 "The following <option>/cfg</option> settings can also be useful (parameter "
 "names may change in the future):"
@@ -1901,12 +1989,12 @@ msgstr ""
 "(les noms des paramètres peuvent changer à l'avenir) :"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:773
+#: English/Command_line.xml:791
 msgid "For file comparisons:"
 msgstr "Pour les comparaisons de fichiers :"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:775
+#: English/Command_line.xml:793
 msgid ""
 "<option>/cfg Settings/DiffContextV2=0</option> - hides matching lines in the "
 "report (equivalent to View -> Diff Context -> 0 Lines)."
@@ -1916,7 +2004,7 @@ msgstr ""
 "lignes)."
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:776
+#: English/Command_line.xml:794
 msgid ""
 "<option>/cfg Settings/ViewLineNumbers=1</option> - outputs line numbers (set "
 "to 0 to disable)."
@@ -1925,12 +2013,12 @@ msgstr ""
 "ligne (définir sur 0 pour désactiver)."
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:778
+#: English/Command_line.xml:796
 msgid "For folder comparisons:"
 msgstr "Pour les comparaisons de dossiers :"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:780
+#: English/Command_line.xml:798
 msgid ""
 "<option>/cfg Settings/DirViewExpandSubdirs=1</option> - automatically expand "
 "all subfolders."
@@ -1939,7 +2027,7 @@ msgstr ""
 "automatiquement tous les sous-dossiers."
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:781
+#: English/Command_line.xml:799
 msgid ""
 "<option>/cfg ReportFiles/ReportType=2</option> - report style: Simple HTML."
 msgstr ""
@@ -1947,7 +2035,7 @@ msgstr ""
 "Simple."
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:782
+#: English/Command_line.xml:800
 msgid ""
 "<option>/cfg ReportFiles/IncludeFileCmpReport=1</option> - include file "
 "comparison reports."
@@ -1956,22 +2044,22 @@ msgstr ""
 "rapports de comparaison de fichiers."
 
 #. type: Content of: <article><section><section><title><indexterm><primary>
-#: English/Command_line.xml:789 English/Compare_files.xml:1805
+#: English/Command_line.xml:807 English/Compare_files.xml:1805
 msgid "conflict files"
 msgstr "fichiers de conflit"
 
 #. type: Content of: <article><variablelist><varlistentry><indexterm><secondary>
-#: English/Command_line.xml:790 English/Command_line.xml:806
+#: English/Command_line.xml:808 English/Command_line.xml:824
 msgid "specifying on command line"
 msgstr "spécification en ligne de commande"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:793
+#: English/Command_line.xml:811
 msgid "<option><replaceable>conflictfile</replaceable></option>"
 msgstr "<option><replaceable>fichier_conflit</replaceable></option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:795
+#: English/Command_line.xml:813
 msgid ""
 "Specifies a conflict file, typically generated by a Version control system. "
 "The conflict file opens in the File Compare window, where you can merge and "
@@ -1985,17 +2073,17 @@ msgstr ""
 "autre chemin ne peut être utilisé avec un fichier de conflit."
 
 #. type: Content of: <article><variablelist><varlistentry><indexterm><primary>
-#: English/Command_line.xml:805
+#: English/Command_line.xml:823
 msgid "ini file"
 msgstr "fichier ini"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:809
+#: English/Command_line.xml:827
 msgid "<option>/inifile <replaceable>inifile</replaceable></option>"
 msgstr "<option>/inifile <replaceable>fichier_ini</replaceable></option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:811
+#: English/Command_line.xml:829
 msgid ""
 "specifies an INI file used to load and save settings instead of the registry."
 msgstr ""

--- a/Translations/Docs/Manual/Hebrew.po
+++ b/Translations/Docs/Manual/Hebrew.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: WinMerge 2.16\n"
 "Report-Msgid-Bugs-To: https://github.com/WinMerge/winmerge/issues\n"
-"POT-Creation-Date: 2026-06-25 07:56+0900\n"
+"POT-Creation-Date: 2026-07-20 16:31+0900\n"
 "PO-Revision-Date: 2025-03-13 09:13+0900\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -591,6 +591,72 @@ msgstr ""
 
 #. type: Content of: <article><para><cmdsynopsis>
 #: English/Command_line.xml:25
+#, fuzzy
+#| msgid ""
+#| "<command>WinMergeU</command> <arg choice=\"opt\" "
+#| "rep=\"norepeat\"><option>/r</option></arg> <arg choice=\"opt\" "
+#| "rep=\"norepeat\"><option>/r-</option></arg> <arg choice=\"opt\" "
+#| "rep=\"norepeat\"><option>/e</option></arg> <arg choice=\"opt\" "
+#| "rep=\"norepeat\"><option>/f</option> <replaceable>filter</replaceable></"
+#| "arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/m</option> "
+#| "<replaceable>compare-method</replaceable></arg> <arg choice=\"opt\" "
+#| "rep=\"norepeat\"><option>/t</option> <replaceable>window-type</"
+#| "replaceable></arg> <arg><option>/x</option></arg> <arg><option>/xq</"
+#| "option></arg> <arg><option>/s</option></arg> <arg><option>/sw</option></"
+#| "arg> <arg><option>/s-</option></arg> <arg choice=\"opt\" "
+#| "rep=\"norepeat\"><option>/ul</option></arg> <arg choice=\"opt\" "
+#| "rep=\"norepeat\"><option>/um</option></arg> <arg choice=\"opt\" "
+#| "rep=\"norepeat\"><option>/ur</option></arg> <arg choice=\"opt\" "
+#| "rep=\"norepeat\"><option>/u</option></arg> <arg choice=\"opt\" "
+#| "rep=\"norepeat\"><option>/wl</option></arg> <arg choice=\"opt\" "
+#| "rep=\"norepeat\"><option>/wm</option></arg> <arg choice=\"opt\" "
+#| "rep=\"norepeat\"><option>/wr</option></arg> <arg choice=\"opt\" "
+#| "rep=\"norepeat\"><option>/new</option></arg> <arg choice=\"opt\" "
+#| "rep=\"norepeat\"><option>/self-compare</option></arg> <arg choice=\"opt\" "
+#| "rep=\"norepeat\"><option>/clipboard-compare</option></arg> <arg><option>/"
+#| "minimize</option></arg> <arg><option>/maximize</option></arg> <arg "
+#| "choice=\"opt\" rep=\"norepeat\"><option>/fl</option></arg> <arg "
+#| "choice=\"opt\" rep=\"norepeat\"><option>/fm</option></arg> <arg "
+#| "choice=\"opt\" rep=\"norepeat\"><option>/fr</option></arg> <arg "
+#| "choice=\"opt\" rep=\"norepeat\"><option>/l</option> "
+#| "<replaceable>linenumber</replaceable></arg> <arg choice=\"opt\" "
+#| "rep=\"norepeat\"><option>/c</option> <replaceable>charpos</replaceable></"
+#| "arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/table-delimiter</"
+#| "option> <replaceable>delimiter</replaceable></arg> <arg choice=\"opt\" "
+#| "rep=\"norepeat\"><option>/dl</option> <replaceable>leftdesc</"
+#| "replaceable></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/dm</"
+#| "option> <replaceable>middledesc</replaceable></arg> <arg choice=\"opt\" "
+#| "rep=\"norepeat\"><option>/dr</option> <replaceable>rightdesc</"
+#| "replaceable></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/al</"
+#| "option></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/am</option></"
+#| "arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/ar</option></arg> <arg "
+#| "choice=\"opt\" rep=\"norepeat\"><option>/noninteractive</option></arg> "
+#| "<arg choice=\"opt\" rep=\"norepeat\"><option>/noprefs</option></arg> <arg "
+#| "choice=\"opt\" rep=\"norepeat\"><option>/enableexitcode</option></arg> "
+#| "<arg choice=\"opt\" rep=\"norepeat\"><option>/ignorews</option></arg> "
+#| "<arg choice=\"opt\" rep=\"norepeat\"><option>/ignoreblanklines</option></"
+#| "arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/ignorecase</option></"
+#| "arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/ignoreeol</option></"
+#| "arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/ignorecodepage</"
+#| "option></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/"
+#| "ignorecomments</option></arg> <arg choice=\"opt\" "
+#| "rep=\"norepeat\"><option>/unpacker</option> <replaceable>unpacker-name</"
+#| "replaceable></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/"
+#| "prediffer</option> <replaceable>prediffer-name</replaceable></arg> <arg "
+#| "choice=\"opt\" rep=\"norepeat\"><option>/cp</option> "
+#| "<replaceable>codepage</replaceable></arg> <arg choice=\"opt\" "
+#| "rep=\"norepeat\"><option>/fileext</option> <replaceable>file-extension</"
+#| "replaceable></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/cfg</"
+#| "option> <replaceable>name=value</replaceable></arg> <arg choice=\"opt\" "
+#| "rep=\"norepeat\"><option>/inifile</option> <replaceable>inifile</"
+#| "replaceable></arg> <arg choice=\"plain\" "
+#| "rep=\"norepeat\"><replaceable>leftpath</replaceable></arg> <arg "
+#| "cchoice=\"opt\" rep=\"norepeat\"><replaceable>middlepath</replaceable></"
+#| "arg> <arg choice=\"plain\" rep=\"norepeat\"><replaceable>rightpath</"
+#| "replaceable></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/o</"
+#| "option> <replaceable>outputpath</replaceable></arg> <arg choice=\"opt\" "
+#| "rep=\"norepeat\"><option>/or</option> <replaceable>reportpath</"
+#| "replaceable></arg>"
 msgid ""
 "<command>WinMergeU</command> <arg choice=\"opt\" rep=\"norepeat\"><option>/"
 "r</option></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/r-</option></"
@@ -601,18 +667,20 @@ msgid ""
 "rep=\"norepeat\"><option>/t</option> <replaceable>window-type</replaceable></"
 "arg> <arg><option>/x</option></arg> <arg><option>/xq</option></arg> "
 "<arg><option>/s</option></arg> <arg><option>/sw</option></arg> <arg><option>/"
-"s-</option></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/ul</option></"
-"arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/um</option></arg> <arg "
-"choice=\"opt\" rep=\"norepeat\"><option>/ur</option></arg> <arg "
-"choice=\"opt\" rep=\"norepeat\"><option>/u</option></arg> <arg "
-"choice=\"opt\" rep=\"norepeat\"><option>/wl</option></arg> <arg "
-"choice=\"opt\" rep=\"norepeat\"><option>/wm</option></arg> <arg "
-"choice=\"opt\" rep=\"norepeat\"><option>/wr</option></arg> <arg "
-"choice=\"opt\" rep=\"norepeat\"><option>/new</option></arg> <arg "
-"choice=\"opt\" rep=\"norepeat\"><option>/self-compare</option></arg> <arg "
-"choice=\"opt\" rep=\"norepeat\"><option>/clipboard-compare</option></arg> "
-"<arg><option>/minimize</option></arg> <arg><option>/maximize</option></arg> "
-"<arg choice=\"opt\" rep=\"norepeat\"><option>/fl</option></arg> <arg "
+"s-</option></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/g</option> "
+"<replaceable>group-name</replaceable></arg> <arg choice=\"opt\" "
+"rep=\"norepeat\"><option>/ul</option></arg> <arg choice=\"opt\" "
+"rep=\"norepeat\"><option>/um</option></arg> <arg choice=\"opt\" "
+"rep=\"norepeat\"><option>/ur</option></arg> <arg choice=\"opt\" "
+"rep=\"norepeat\"><option>/u</option></arg> <arg choice=\"opt\" "
+"rep=\"norepeat\"><option>/wl</option></arg> <arg choice=\"opt\" "
+"rep=\"norepeat\"><option>/wm</option></arg> <arg choice=\"opt\" "
+"rep=\"norepeat\"><option>/wr</option></arg> <arg choice=\"opt\" "
+"rep=\"norepeat\"><option>/new</option></arg> <arg choice=\"opt\" "
+"rep=\"norepeat\"><option>/self-compare</option></arg> <arg choice=\"opt\" "
+"rep=\"norepeat\"><option>/clipboard-compare</option></arg> <arg><option>/"
+"minimize</option></arg> <arg><option>/maximize</option></arg> <arg "
+"choice=\"opt\" rep=\"norepeat\"><option>/fl</option></arg> <arg "
 "choice=\"opt\" rep=\"norepeat\"><option>/fm</option></arg> <arg "
 "choice=\"opt\" rep=\"norepeat\"><option>/fr</option></arg> <arg "
 "choice=\"opt\" rep=\"norepeat\"><option>/l</option> <replaceable>linenumber</"
@@ -717,7 +785,7 @@ msgstr ""
 "arg>"
 
 #. type: Content of: <article><cmdsynopsis>
-#: English/Command_line.xml:162
+#: English/Command_line.xml:165
 msgid ""
 "<command>WinMergeU</command> <arg choice=\"plain\" "
 "rep=\"norepeat\"><replaceable>conflictfile</replaceable></arg>"
@@ -726,7 +794,7 @@ msgstr ""
 "rep=\"norepeat\"><replaceable>conflictfile</replaceable></arg>"
 
 #. type: Content of: <article><para>
-#: English/Command_line.xml:168
+#: English/Command_line.xml:171
 msgid ""
 "Entering the command with no parameters or pathnames simply opens the "
 "WinMerge window. Parameters are prefixed with either a forward slash "
@@ -738,29 +806,29 @@ msgstr ""
 "literal> ). לנתיבים אין תו קידומת."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:175
+#: English/Command_line.xml:178
 msgid "<option>/?</option>"
 msgstr "<option>/?</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:177
+#: English/Command_line.xml:180
 msgid "Opens WinMerge Help at this topic."
 msgstr "פותח את עזרה של WinMerge בנושא זה."
 
 #. type: Content of: <article><section><section><title><indexterm><seealso>
-#: English/Command_line.xml:183 English/Compare_dirs.xml:54
+#: English/Command_line.xml:186 English/Compare_dirs.xml:54
 #: English/Compare_dirs.xml:254 English/Open_paths.xml:288
 #: English/Open_paths.xml:294
 msgid "recursive folder compare"
 msgstr "השוואת תיקיות רקורסיבית"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:185
+#: English/Command_line.xml:188
 msgid "<option>/r</option>"
 msgstr "<option>/r</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:187
+#: English/Command_line.xml:190
 msgid ""
 "Compares all files in all subfolders (recursive compare). Unique folders "
 "(occurring only on one side) are listed in the compare result as separate "
@@ -776,17 +844,17 @@ msgstr ""
 "תיקיות המשנה."
 
 #. type: Content of: <article><variablelist><varlistentry><indexterm><primary>
-#: English/Command_line.xml:198
+#: English/Command_line.xml:201
 msgid "non-recursive folder compare"
 msgstr "השוואת תיקיות לא רקורסיבית"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:200
+#: English/Command_line.xml:203
 msgid "<option>/r-</option>"
 msgstr "<option>/r-</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:202
+#: English/Command_line.xml:205
 msgid ""
 "Compares all files within the specified folders but excludes the files and "
 "subfolders within its subfolders.  This allows for a shorter comparison time."
@@ -795,24 +863,24 @@ msgstr ""
 "בתוך תיקיות המשנה שלו. זה מאפשר זמן השוואה קצר יותר."
 
 #. type: Content of: <article><section><section><title><indexterm><primary>
-#: English/Command_line.xml:210 English/Command_line.xml:294
-#: English/Command_line.xml:417 English/Configuration.xml:277
-#: English/Quick_start.xml:22
+#: English/Command_line.xml:213 English/Command_line.xml:297
+#: English/Command_line.xml:330 English/Command_line.xml:435
+#: English/Configuration.xml:277 English/Quick_start.xml:22
 msgid "WinMerge window"
 msgstr "חלון WinMerge"
 
 #. type: Content of: <article><variablelist><varlistentry><indexterm><secondary>
-#: English/Command_line.xml:211
+#: English/Command_line.xml:214
 msgid "closing"
 msgstr "סגירה"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:214
+#: English/Command_line.xml:217
 msgid "<option>/e</option>"
 msgstr "<option>/e</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:216
+#: English/Command_line.xml:219
 msgid ""
 "Enables you to close WinMerge with a single <keycap>Esc</keycap> key press. "
 "This is useful when you use WinMerge as an external compare application: you "
@@ -825,7 +893,7 @@ msgstr ""
 "keycap> מספר פעמים כדי לסגור את כל החלונות שלו."
 
 #. type: Content of: <article><section><section><title><indexterm><primary>
-#: English/Command_line.xml:226 English/Configuration.xml:820
+#: English/Command_line.xml:229 English/Configuration.xml:820
 #: English/Configuration.xml:848 English/Configuration.xml:871
 #: English/Filters.xml:4 English/Filters.xml:96 English/Filters.xml:100
 #: English/Filters.xml:142 English/Filters.xml:1609 English/Filters.xml:1613
@@ -836,18 +904,18 @@ msgid "filters"
 msgstr "מסננים"
 
 #. type: Content of: <article><variablelist><varlistentry><indexterm><secondary>
-#: English/Command_line.xml:227 English/Command_line.xml:243
-#: English/Command_line.xml:259
+#: English/Command_line.xml:230 English/Command_line.xml:246
+#: English/Command_line.xml:262
 msgid "applying in command line"
 msgstr "החלה בשורת הפקודה"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:230
+#: English/Command_line.xml:233
 msgid "<option>/f</option>"
 msgstr "<option>/f</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:232
+#: English/Command_line.xml:235
 msgid ""
 "Applies a specified filter to restrict the comparison. The filter can be a "
 "filemask like <filename><userinput>*.h *.cpp</userinput></filename>, or the "
@@ -860,17 +928,17 @@ msgstr ""
 "או שם המכילים רווחים."
 
 #. type: Content of: <article><variablelist><varlistentry><indexterm><primary>
-#: English/Command_line.xml:242
+#: English/Command_line.xml:245
 msgid "compare method"
 msgstr "שיטת השוואה"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:246
+#: English/Command_line.xml:249
 msgid "<option>/m <replaceable>compare-method</replaceable></option>"
 msgstr "<option>/m <replaceable>compare-method</replaceable></option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:248
+#: English/Command_line.xml:251
 #, fuzzy
 #| msgid ""
 #| "Sets the compare method to use for the comparison.  This can be one of "
@@ -890,17 +958,17 @@ msgstr ""
 "<userinput>SizeDate</userinput> או <userinput>Size</userinput>."
 
 #. type: Content of: <article><variablelist><varlistentry><indexterm><primary>
-#: English/Command_line.xml:258
+#: English/Command_line.xml:261
 msgid "window type"
 msgstr "סוג חלון"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:262
+#: English/Command_line.xml:265
 msgid "<option>/t <replaceable>window-type</replaceable></option>"
 msgstr "<option>/t <replaceable>window-type</replaceable></option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:264
+#: English/Command_line.xml:267
 msgid ""
 "Specifies the type of window in which to display files.  This can be one of "
 "the keywords <userinput>Text</userinput>, <userinput>Table</userinput>, "
@@ -913,12 +981,12 @@ msgstr ""
 "<userinput>Webpage</userinput> או <userinput>Folder</userinput>."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:272
+#: English/Command_line.xml:275
 msgid "<option>/x</option>"
 msgstr "<option>/x</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:274
+#: English/Command_line.xml:277
 msgid ""
 "Closes WinMerge (after displaying an information dialog) when you start a "
 "comparison of identical files. The parameter has no effect after the "
@@ -934,29 +1002,29 @@ msgstr ""
 "הבדלים."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:285
+#: English/Command_line.xml:288
 msgid "<option>/xq</option>"
 msgstr "<option>/xq</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:287
+#: English/Command_line.xml:290
 msgid ""
 "Is similar to <option>/x</option> but does not show the message about "
 "identical files."
 msgstr "דומה ל-<option>/x</option> אבל לא מציג את ההודעה על קבצים זהים."
 
 #. type: Content of: <article><section><section><title><indexterm><secondary>
-#: English/Command_line.xml:295 English/Configuration.xml:279
+#: English/Command_line.xml:298 English/Configuration.xml:279
 msgid "limiting instances"
 msgstr "הגבלת מופעים"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:298
+#: English/Command_line.xml:301
 msgid "<option>/s</option>"
 msgstr "<option>/s</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:300
+#: English/Command_line.xml:303
 msgid ""
 "Limits WinMerge windows to a single instance.  For example, if WinMerge is "
 "already running, a new compare opens in the same instance. Without this "
@@ -968,12 +1036,12 @@ msgstr ""
 "אחרות, השוואה חדשה עשויה להיפתח בחלון הקיים או בחלון חדש."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:309
+#: English/Command_line.xml:312
 msgid "<option>/sw</option>"
 msgstr "<option>/sw</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:311
+#: English/Command_line.xml:314
 msgid ""
 "Limit the WinMerge window to one instance as well as the option /s.  "
 "However, it waits for the instance displaying the window to terminate."
@@ -982,12 +1050,12 @@ msgstr ""
 "שהמופע המציג את החלון יסתיים."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:318
+#: English/Command_line.xml:321
 msgid "<option>/s-</option>"
 msgstr "<option>/s-</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:320
+#: English/Command_line.xml:323
 msgid ""
 "Ensure that another instance is always executed, ignoring the value of the "
 "\"Allow only one instance to run\" option."
@@ -995,19 +1063,39 @@ msgstr ""
 "ודא שמופע אחר תמיד מבוצע, תוך התעלמות מהערך של האפשרות \"אפשר להפעיל רק מופע "
 "אחד\"."
 
+#. type: Content of: <article><variablelist><varlistentry><indexterm><secondary>
+#: English/Command_line.xml:331
+msgid "instance groups"
+msgstr ""
+
+#. type: Content of: <article><variablelist><varlistentry><term>
+#: English/Command_line.xml:334
+#, fuzzy
+#| msgid "<option>/c <replaceable>charpos</replaceable></option>"
+msgid "<option>/g</option> <replaceable>group-name</replaceable>"
+msgstr "<option>/c <replaceable>charpos</replaceable></option>"
+
+#. type: Content of: <article><variablelist><varlistentry><listitem><para>
+#: English/Command_line.xml:337
+msgid ""
+"Specifies a group name for the WinMerge instance. When used with the "
+"<option>/s</option> option, instances with the same group name share the "
+"same window, allowing you to organize multiple single-instance groups."
+msgstr ""
+
 #. type: Content of: <article><section><qandaset><qandaentry><question><para><indexterm><primary>
-#: English/Command_line.xml:327 English/Configuration.xml:430
+#: English/Command_line.xml:345 English/Configuration.xml:430
 #: English/Faq.xml:114
 msgid "MRU list"
 msgstr "רשימת MRU"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:330
+#: English/Command_line.xml:348
 msgid "<option>/ul</option>"
 msgstr "<option>/ul</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:332
+#: English/Command_line.xml:350
 msgid ""
 "Prevents WinMerge from adding the left path to the Most Recently Used (MRU) "
 "list. External applications should not add paths to the MRU list in the "
@@ -1018,12 +1106,12 @@ msgstr ""
 "או תיקיות."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:339
+#: English/Command_line.xml:357
 msgid "<option>/um</option>"
 msgstr "<option>/um</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:341
+#: English/Command_line.xml:359
 msgid ""
 "Prevents WinMerge from adding the middle path to the Most Recently Used "
 "(MRU) list. External applications should not add paths to the MRU list in "
@@ -1034,12 +1122,12 @@ msgstr ""
 "או תיקיות."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:348
+#: English/Command_line.xml:366
 msgid "<option>/ur</option>"
 msgstr "<option>/ur</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:350
+#: English/Command_line.xml:368
 msgid ""
 "Prevents WinMerge from adding the right path to the Most Recently Used (MRU) "
 "list. External applications should not add paths to the MRU list in the "
@@ -1050,12 +1138,12 @@ msgstr ""
 "או תיקיות."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:357
+#: English/Command_line.xml:375
 msgid "<option>/u</option>"
 msgstr "<option>/u</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:359
+#: English/Command_line.xml:377
 msgid ""
 "Prevents WinMerge from adding either path (left or right) to the Most "
 "Recently Used (MRU) list. External applications should not add paths to the "
@@ -1066,18 +1154,18 @@ msgstr ""
 "קבצים או תיקיות."
 
 #. type: Content of: <article><section><section><title><indexterm><see>
-#: English/Command_line.xml:368 English/Compare_dirs.xml:741
+#: English/Command_line.xml:386 English/Compare_dirs.xml:741
 #: English/Compare_dirs.xml:745
 msgid "protecting files"
 msgstr "הגנה על קבצים"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:371
+#: English/Command_line.xml:389
 msgid "<option>/wl</option>"
 msgstr "<option>/wl</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:373
+#: English/Command_line.xml:391
 msgid ""
 "Opens the left side as read-only. Use this when you don't want to change "
 "left side items in the compare."
@@ -1086,12 +1174,12 @@ msgstr ""
 "שמאל בהשוואה."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:379
+#: English/Command_line.xml:397
 msgid "<option>/wm</option>"
 msgstr "<option>/wm</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:381
+#: English/Command_line.xml:399
 msgid ""
 "Opens the middle side as read-only. Use this when you don't want to change "
 "right side items in the compare."
@@ -1100,12 +1188,12 @@ msgstr ""
 "ימין בהשוואה."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:387
+#: English/Command_line.xml:405
 msgid "<option>/wr</option>"
 msgstr "<option>/wr</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:389
+#: English/Command_line.xml:407
 msgid ""
 "Opens the right side as read-only. Use this when you don't want to change "
 "right side items in the compare."
@@ -1114,47 +1202,47 @@ msgstr ""
 "בהשוואה."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:395
+#: English/Command_line.xml:413
 msgid "<option>/new</option>"
 msgstr "<option>/new</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:397
+#: English/Command_line.xml:415
 msgid "Opens a new blank window."
 msgstr "פותח חלון ריק חדש."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:402
+#: English/Command_line.xml:420
 msgid "<option>/self-compare</option>"
 msgstr "<option>/self-compare</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:404
+#: English/Command_line.xml:422
 msgid "Compares the specified file with a copy of the file."
 msgstr "משווה את הקובץ שצוין עם עותק של הקובץ."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:409
+#: English/Command_line.xml:427
 msgid "<option>/clipboard-compare</option>"
 msgstr "<option>/clipboard-compare</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:411
+#: English/Command_line.xml:429
 msgid "Compares the two most recent contents of the clipboard history."
 msgstr "משווה את שתי התוכן העדכניים ביותר של היסטוריית הלוח."
 
 #. type: Content of: <article><variablelist><varlistentry><indexterm><secondary>
-#: English/Command_line.xml:418
+#: English/Command_line.xml:436
 msgid "opening minimized or maximized"
 msgstr "פתיחה ממוזערת או מוגדלת"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:421
+#: English/Command_line.xml:439
 msgid "<option>/minimize</option>"
 msgstr "<option>/minimize</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:423
+#: English/Command_line.xml:441
 msgid ""
 "Starts WinMerge as a minimized window.  This option can be useful during "
 "lengthy compares."
@@ -1163,72 +1251,72 @@ msgstr ""
 "ממושכות."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:429
+#: English/Command_line.xml:447
 msgid "<option>/maximize</option>"
 msgstr "<option>/maximize</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:431
+#: English/Command_line.xml:449
 msgid "Starts WinMerge as a maximized window."
 msgstr "מפעיל את WinMerge כחלון מוגדל."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:437
+#: English/Command_line.xml:455
 msgid "<option>/fl</option>"
 msgstr "<option>/fl</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:439
+#: English/Command_line.xml:457
 msgid "Sets focus to the left side at startup."
 msgstr "מגדיר מיקוד לצד שמאל בעת ההפעלה."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:444
+#: English/Command_line.xml:462
 msgid "<option>/fm</option>"
 msgstr "<option>/fm</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:446
+#: English/Command_line.xml:464
 msgid "Sets focus to the middle side at startup."
 msgstr "מגדיר מיקוד לצד האמצעי בעת ההפעלה."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:451
+#: English/Command_line.xml:469
 msgid "<option>/fr</option>"
 msgstr "<option>/fr</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:453
+#: English/Command_line.xml:471
 msgid "Sets focus to the right side at startup."
 msgstr "מגדיר מיקוד לצד ימין בעת ההפעלה."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:458
+#: English/Command_line.xml:476
 msgid "<option>/l <replaceable>linenumber</replaceable></option>"
 msgstr "<option>/l <replaceable>linenumber</replaceable></option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:460
+#: English/Command_line.xml:478
 msgid "Specifies a line number to jump to after loading the files."
 msgstr "מציין מספר שורה לקפיצה אליה לאחר טעינת הקבצים."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:465
+#: English/Command_line.xml:483
 msgid "<option>/c <replaceable>charpos</replaceable></option>"
 msgstr "<option>/c <replaceable>charpos</replaceable></option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:467
+#: English/Command_line.xml:485
 msgid "Specifies a character position to jump to after loading the files."
 msgstr "מציין מיקום תו לקפיצה אליו לאחר טעינת הקבצים."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:472
+#: English/Command_line.xml:490
 msgid "<option>/table-delimiter <replaceable>delimiter</replaceable></option>"
 msgstr "<option>/table-delimiter <replaceable>delimiter</replaceable></option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:474
+#: English/Command_line.xml:492
 msgid ""
 "Specifies a delimiter character for table editing. To specify a tab "
 "character, specify \"tab\", \"\\t\", or \"\\x09\"."
@@ -1237,12 +1325,12 @@ msgstr ""
 "\"\\x09\"."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:479
+#: English/Command_line.xml:497
 msgid "<option>/dl</option>"
 msgstr "<option>/dl</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:481
+#: English/Command_line.xml:499
 msgid ""
 "Specifies a description in the left side title bar, overriding the default "
 "folder or filename text. For example: <userinput>/dl \"Version 1.0</"
@@ -1254,66 +1342,66 @@ msgstr ""
 "dl WorkingCopy</userinput>. השתמש בסימני ציטוט סביב תיאורים המכילים רווחים."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:490
+#: English/Command_line.xml:508
 msgid "<option>/dm</option>"
 msgstr "<option>/dm</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:492
+#: English/Command_line.xml:510
 msgid ""
 "Specifies a description in the middle side title bar, just like <option>/dl</"
 "option>."
 msgstr "מציין תיאור בשורת הכותרת בצד האמצעי, בדיוק כמו <option>/dl</option>."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:498
+#: English/Command_line.xml:516
 msgid "<option>/dr</option>"
 msgstr "<option>/dr</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:500
+#: English/Command_line.xml:518
 msgid ""
 "Specifies a description in the right side title bar, just like <option>/dl</"
 "option>."
 msgstr "מציין תיאור בשורת הכותרת בצד ימין, בדיוק כמו <option>/dl</option>."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:506
+#: English/Command_line.xml:524
 msgid "<option>/al</option>"
 msgstr "<option>/al</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:508
+#: English/Command_line.xml:526
 msgid "Auto-merges at the left side at startup."
 msgstr "ממזג אוטומטית בצד שמאל בעת ההפעלה."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:513
+#: English/Command_line.xml:531
 msgid "<option>/am</option>"
 msgstr "<option>/am</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:515
+#: English/Command_line.xml:533
 msgid "Auto-merges at the middle side at startup."
 msgstr "ממזג אוטומטית בצד האמצעי בעת ההפעלה."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:520
+#: English/Command_line.xml:538
 msgid "<option>/ar</option>"
 msgstr "<option>/ar</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:522
+#: English/Command_line.xml:540
 msgid "Auto-merges at the right side at startup."
 msgstr "ממזג אוטומטית בצד ימין בעת ההפעלה."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:527
+#: English/Command_line.xml:545
 msgid "<option>/noninteractive</option>"
 msgstr "<option>/noninteractive</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:530
+#: English/Command_line.xml:548
 msgid ""
 "Runs WinMerge without displaying message boxes during comparison or report "
 "generation.  The process terminates automatically when the operation is "
@@ -1321,24 +1409,24 @@ msgid ""
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:538
+#: English/Command_line.xml:556
 msgid "<option>/noprefs</option>"
 msgstr "<option>/noprefs</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:541
+#: English/Command_line.xml:559
 msgid ""
 "Runs WinMerge without loading or saving settings from the registry.  All "
 "comparisons use default preferences only."
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:548
+#: English/Command_line.xml:566
 msgid "<option>/enableexitcode</option>"
 msgstr "<option>/enableexitcode</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:550
+#: English/Command_line.xml:568
 msgid ""
 "Sets the comparison result to the process exit code. 0: identical, 1: "
 "different, 2: error"
@@ -1346,12 +1434,12 @@ msgstr ""
 "מגדיר את קוד היציאה של התהליך לתוצאת ההשוואה: 0 – זהה, 1 – שונה, 2 – שגיאה."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:555
+#: English/Command_line.xml:573
 msgid "<option>/ignorews</option>"
 msgstr "<option>/ignorews</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:557
+#: English/Command_line.xml:575
 #, fuzzy
 #| msgid "1 = Ignore comment differences"
 msgid ""
@@ -1360,110 +1448,110 @@ msgid ""
 msgstr "1 = התעלם מהבדלי תגובות"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:559
+#: English/Command_line.xml:577
 #, fuzzy
 #| msgid "0 = Do not ignore codepage differences"
 msgid "<option>/ignorews:0</option> - do not ignore whitespace differences."
 msgstr "0 = אל תתעלם מהבדלי קידוד"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:560
+#: English/Command_line.xml:578
 msgid ""
 "<option>/ignorews</option> or <option>/ignorews:1</option> - ignore "
 "differences in the amount of whitespace."
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:561
+#: English/Command_line.xml:579
 msgid "<option>/ignorews:2</option> - ignore all whitespace characters."
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:567
+#: English/Command_line.xml:585
 msgid "<option>/ignoreblanklines</option>"
 msgstr "<option>/ignoreblanklines</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:569
+#: English/Command_line.xml:587
 msgid "Controls the \"Ignore blank lines\" option persistently:"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:571
+#: English/Command_line.xml:589
 #, fuzzy
 #| msgid "<option>/ignoreblanklines</option>"
 msgid "<option>/ignoreblanklines:0</option> - disables ignoring blank lines."
 msgstr "<option>/ignoreblanklines</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:572
+#: English/Command_line.xml:590
 msgid ""
 "<option>/ignoreblanklines</option> or <option>/ignoreblanklines:1</option> - "
 "enables ignoring blank lines."
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:578
+#: English/Command_line.xml:596
 msgid "<option>/ignorecase</option>"
 msgstr "<option>/ignorecase</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:580
+#: English/Command_line.xml:598
 msgid "Controls the \"Ignore case\" option persistently:"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:582
+#: English/Command_line.xml:600
 #, fuzzy
 #| msgid "<option>Enabled</option>: File encoding differences are ignored."
 msgid "<option>/ignorecase:0</option> - disables ignoring case differences."
 msgstr "<option>Enabled</option>: הבדלים בקידוד קבצים מתעלמים מהם."
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:583
+#: English/Command_line.xml:601
 msgid ""
 "<option>/ignorecase</option> or <option>/ignorecase:1</option> - enables "
 "ignoring case differences."
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:589
+#: English/Command_line.xml:607
 msgid "<option>/ignoreeol</option>"
 msgstr "<option>/ignoreeol</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:591
+#: English/Command_line.xml:609
 msgid "Controls the \"Ignore EOL differences\" option persistently:"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:593
+#: English/Command_line.xml:611
 #, fuzzy
 #| msgid "<option>Enabled</option>: File encoding differences are ignored."
 msgid "<option>/ignoreeol:0</option> - disables ignoring EOL differences."
 msgstr "<option>Enabled</option>: הבדלים בקידוד קבצים מתעלמים מהם."
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:594
+#: English/Command_line.xml:612
 msgid ""
 "<option>/ignoreeol</option> or <option>/ignoreeol:1</option> - enables "
 "ignoring EOL differences."
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:600
+#: English/Command_line.xml:618
 msgid "<option>/ignorecodepage</option>"
 msgstr "<option>/ignorecodepage</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:602
+#: English/Command_line.xml:620
 #, fuzzy
 #| msgid "1 = Ignore codepage differences"
 msgid "Controls the \"Ignore codepage differences\" option persistently:"
 msgstr "1 = התעלם מהבדלי קידוד"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:604
+#: English/Command_line.xml:622
 #, fuzzy
 #| msgid "<option>Enabled</option>: File encoding differences are ignored."
 msgid ""
@@ -1471,33 +1559,33 @@ msgid ""
 msgstr "<option>Enabled</option>: הבדלים בקידוד קבצים מתעלמים מהם."
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:605
+#: English/Command_line.xml:623
 msgid ""
 "<option>/ignorecodepage</option> or <option>/ignorecodepage:1</option> - "
 "enables ignoring codepage differences."
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:611
+#: English/Command_line.xml:629
 msgid "<option>/ignorecomments</option>"
 msgstr "<option>/ignorecomments</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:613
+#: English/Command_line.xml:631
 #, fuzzy
 #| msgid "1 = Ignore comment differences"
 msgid "Controls the \"Ignore comment differences\" option persistently:"
 msgstr "1 = התעלם מהבדלי תגובות"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:615
+#: English/Command_line.xml:633
 #, fuzzy
 #| msgid "<option>/ignorecomments</option>"
 msgid "<option>/ignorecomments:0</option> - disables ignoring comments."
 msgstr "<option>/ignorecomments</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:616
+#: English/Command_line.xml:634
 #, fuzzy
 #| msgid "<option>/ignorecomments</option>"
 msgid ""
@@ -1506,90 +1594,90 @@ msgid ""
 msgstr "<option>/ignorecomments</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:622
+#: English/Command_line.xml:640
 #, fuzzy
 #| msgid "<option>/l <replaceable>linenumber</replaceable></option>"
 msgid "<option>/unpacker <replaceable>plugin pipeline</replaceable></option>"
 msgstr "<option>/l <replaceable>linenumber</replaceable></option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:625
+#: English/Command_line.xml:643
 msgid ""
 "Specifies the plugin pipeline for the Unpacker plugin.  Example: <option>/"
 "unpacker \"SortAscending|SelectLines 1-10\"</option>"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:632
+#: English/Command_line.xml:650
 #, fuzzy
 #| msgid "<option>/inifile <replaceable>inifile</replaceable></option>"
 msgid "<option>/prediffer <replaceable>plugin pipeline</replaceable></option>"
 msgstr "<option>/inifile <replaceable>inifile</replaceable></option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:635
+#: English/Command_line.xml:653
 msgid ""
 "Specifies the plugin pipeline for the Prediffer plugin.  Example: <option>/"
 "prediffer \"IgnoreColumns 1-10\"</option>"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:642
+#: English/Command_line.xml:660
 #, fuzzy
 #| msgid "<option>/c <replaceable>charpos</replaceable></option>"
 msgid "<option>/cp <replaceable>codepage</replaceable></option>"
 msgstr "<option>/c <replaceable>charpos</replaceable></option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:645
+#: English/Command_line.xml:663
 msgid ""
 "Specifies the codepage to use for file comparison.  Example: <option>/cp "
 "65001</option>"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:652
+#: English/Command_line.xml:670
 msgid "<option>/fileext <replaceable>file-extension</replaceable></option>"
 msgstr "<option>/fileext <replaceable>file-extension</replaceable></option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:654
+#: English/Command_line.xml:672
 msgid "Specifies a file extension for determining syntax hightliting."
 msgstr "מציין סיומת קובץ לקביעת הדגשת תחביר."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:659
+#: English/Command_line.xml:677
 #, fuzzy
 #| msgid "<option>/l <replaceable>linenumber</replaceable></option>"
 msgid "<option>/cfg <replaceable>name=value</replaceable></option>"
 msgstr "<option>/l <replaceable>linenumber</replaceable></option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:662
+#: English/Command_line.xml:680
 msgid "Sets a configuration value in the WinMerge registry or INI file."
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:665
+#: English/Command_line.xml:683
 msgid "Example: <option>/cfg Settings/DiffAlgorithm=3</option>"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:668
+#: English/Command_line.xml:686
 msgid ""
 "If the section name is unambiguous and does not conflict with other setting "
 "names, it can be omitted:"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:671
+#: English/Command_line.xml:689
 #, fuzzy
 #| msgid "<option>/cfg</option>"
 msgid "<option>/cfg DiffAlgo=3</option>"
 msgstr "<option>/cfg</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:674
+#: English/Command_line.xml:692
 msgid ""
 "Note: This entry does not explain which configuration names are available.  "
 "For a list of settings, refer to "
@@ -1598,37 +1686,37 @@ msgid ""
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:681
+#: English/Command_line.xml:699
 msgid "<option><replaceable>leftpath</replaceable></option>"
 msgstr "<option><replaceable>leftpath</replaceable></option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:683
+#: English/Command_line.xml:701
 msgid "Specifies the folder, file or project file to open on the left side."
 msgstr "מציין את התיקייה, הקובץ או קובץ הפרויקט לפתיחה בצד שמאל."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:688
+#: English/Command_line.xml:706
 msgid "<option><replaceable>middlepath</replaceable></option>"
 msgstr "<option><replaceable>middlepath</replaceable></option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:690
+#: English/Command_line.xml:708
 msgid "Specifies the folder, file or project file to open on the middle side."
 msgstr "מציין את התיקייה, הקובץ או קובץ הפרויקט לפתיחה בצד האמצעי."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:695
+#: English/Command_line.xml:713
 msgid "<option><replaceable>rightpath</replaceable></option>"
 msgstr "<option><replaceable>rightpath</replaceable></option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:697
+#: English/Command_line.xml:715
 msgid "Specifies the folder, file or project file to open on the right side."
 msgstr "מציין את התיקייה, הקובץ או קובץ הפרויקט לפתיחה בצד ימין."
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:699
+#: English/Command_line.xml:717
 msgid ""
 "WinMerge cannot compare files to folders, so the path parameters "
 "(<option><replaceable>leftpath</replaceable></option>, "
@@ -1647,7 +1735,7 @@ msgstr ""
 "הנכונים."
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><tip><para>
-#: English/Command_line.xml:708
+#: English/Command_line.xml:726
 msgid ""
 "In file comparisons, you can specify a folder name in one of the path "
 "parameters, as long as the folder contains a file with the same name as the "
@@ -1657,12 +1745,12 @@ msgstr ""
 "מכילה קובץ עם אותו שם כמו זה שצוין בנתיב הקובץ האחר."
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><tip><para>
-#: English/Command_line.xml:712
+#: English/Command_line.xml:730
 msgid "For example, consider this command:"
 msgstr "לדוגמה, שקול את הפקודה הזו:"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><tip><para>
-#: English/Command_line.xml:714
+#: English/Command_line.xml:732
 msgid ""
 "<userinput>WinMergeU <filename>C:\\Folder\\File.txt</filename> <filename "
 "class=\"directory\">C:\\Folder2</filename> </userinput>"
@@ -1671,7 +1759,7 @@ msgstr ""
 "class=\"directory\">C:\\Folder2</filename> </userinput>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><tip><para>
-#: English/Command_line.xml:717
+#: English/Command_line.xml:735
 msgid ""
 "If <filename class=\"directory\">C:\\Folder2</filename> contains a file "
 "named <filename>File.txt</filename>: WinMerge implicitly resolves the second "
@@ -1687,23 +1775,23 @@ msgstr ""
 "קובץ בשם <filename>File.txt</filename>."
 
 #. type: Content of: <article><section><section><title><indexterm><primary>
-#: English/Command_line.xml:730 English/Compare_files.xml:1481
+#: English/Command_line.xml:748 English/Compare_files.xml:1481
 #: English/Intro_diffs.xml:253 English/Intro_diffs.xml:407
 msgid "merging differences"
 msgstr "מיזוג הבדלים"
 
 #. type: Content of: <article><section><section><title><indexterm><secondary>
-#: English/Command_line.xml:731 English/Intro_diffs.xml:409
+#: English/Command_line.xml:749 English/Intro_diffs.xml:409
 msgid "result file"
 msgstr "קובץ תוצאה"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:734
+#: English/Command_line.xml:752
 msgid "<option>/o <replaceable>outputpath</replaceable></option>"
 msgstr "<option>/o <replaceable>outputpath</replaceable></option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:736
+#: English/Command_line.xml:754
 msgid ""
 "Specifies an optional output file path where you want merged result files to "
 "be saved."
@@ -1711,7 +1799,7 @@ msgstr ""
 "מציין נתיב קובץ פלט אופציונלי שבו ברצונך לשמור את קבצי התוצאה הממוזגים."
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:739
+#: English/Command_line.xml:757
 msgid ""
 "The output path is rarely needed when you start WinMerge from the command "
 "line. It is meant to be used with version control tools, where you might "
@@ -1727,7 +1815,7 @@ msgstr ""
 "האלה, הוא נכתב לנתיב הפלט, ומשאיר את שניים או שלושת קבצי המקור ללא פגע."
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:747
+#: English/Command_line.xml:765
 msgid ""
 "Version control systems typically refer to the source and result files using "
 "terms like <glossterm>theirs</glossterm>, <glossterm>mine</glossterm>, and "
@@ -1742,37 +1830,37 @@ msgstr ""
 "בסדר זה."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:757
+#: English/Command_line.xml:775
 #, fuzzy
 #| msgid "<option>/o <replaceable>outputpath</replaceable></option>"
 msgid "<option>/or <replaceable>outputpath</replaceable></option>"
 msgstr "<option>/o <replaceable>outputpath</replaceable></option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:760
+#: English/Command_line.xml:778
 msgid ""
 "Outputs a comparison report for files or folders.  Example: "
 "<option>WinMergeU path1 path2 /or c:\\tmp\\report.html</option>"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:763
+#: English/Command_line.xml:781
 msgid "It is often useful to combine this option with:"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:765
+#: English/Command_line.xml:783
 msgid ""
 "<option>/noninteractive</option> - exits WinMerge after producing the report."
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:766
+#: English/Command_line.xml:784
 msgid "<option>/minimize</option> - starts WinMerge in minimized state."
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:767
+#: English/Command_line.xml:785
 msgid ""
 "<option>/noprefs</option> - ignores the current preferences and uses default "
 "settings.  Any changes made with <option>/cfg</option> will then be "
@@ -1780,77 +1868,77 @@ msgid ""
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:771
+#: English/Command_line.xml:789
 msgid ""
 "The following <option>/cfg</option> settings can also be useful (parameter "
 "names may change in the future):"
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:773
+#: English/Command_line.xml:791
 #, fuzzy
 #| msgid "in file comparisons"
 msgid "For file comparisons:"
 msgstr "בהשוואות קבצים"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:775
+#: English/Command_line.xml:793
 msgid ""
 "<option>/cfg Settings/DiffContextV2=0</option> - hides matching lines in the "
 "report (equivalent to View -> Diff Context -> 0 Lines)."
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:776
+#: English/Command_line.xml:794
 msgid ""
 "<option>/cfg Settings/ViewLineNumbers=1</option> - outputs line numbers (set "
 "to 0 to disable)."
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:778
+#: English/Command_line.xml:796
 #, fuzzy
 #| msgid "in folder comparisons"
 msgid "For folder comparisons:"
 msgstr "בהשוואות תיקיות"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:780
+#: English/Command_line.xml:798
 msgid ""
 "<option>/cfg Settings/DirViewExpandSubdirs=1</option> - automatically expand "
 "all subfolders."
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:781
+#: English/Command_line.xml:799
 msgid ""
 "<option>/cfg ReportFiles/ReportType=2</option> - report style: Simple HTML."
 msgstr ""
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:782
+#: English/Command_line.xml:800
 msgid ""
 "<option>/cfg ReportFiles/IncludeFileCmpReport=1</option> - include file "
 "comparison reports."
 msgstr ""
 
 #. type: Content of: <article><section><section><title><indexterm><primary>
-#: English/Command_line.xml:789 English/Compare_files.xml:1805
+#: English/Command_line.xml:807 English/Compare_files.xml:1805
 msgid "conflict files"
 msgstr "קבצי קונפליקט"
 
 #. type: Content of: <article><variablelist><varlistentry><indexterm><secondary>
-#: English/Command_line.xml:790 English/Command_line.xml:806
+#: English/Command_line.xml:808 English/Command_line.xml:824
 msgid "specifying on command line"
 msgstr "ציון בשורת הפקודה"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:793
+#: English/Command_line.xml:811
 msgid "<option><replaceable>conflictfile</replaceable></option>"
 msgstr "<option><replaceable>conflictfile</replaceable></option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:795
+#: English/Command_line.xml:813
 msgid ""
 "Specifies a conflict file, typically generated by a Version control system. "
 "The conflict file opens in the File Compare window, where you can merge and "
@@ -1863,17 +1951,17 @@ msgstr ""
 "אחרים עם קובץ קונפליקט."
 
 #. type: Content of: <article><variablelist><varlistentry><indexterm><primary>
-#: English/Command_line.xml:805
+#: English/Command_line.xml:823
 msgid "ini file"
 msgstr "קובץ ini"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:809
+#: English/Command_line.xml:827
 msgid "<option>/inifile <replaceable>inifile</replaceable></option>"
 msgstr "<option>/inifile <replaceable>inifile</replaceable></option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:811
+#: English/Command_line.xml:829
 msgid ""
 "specifies an INI file used to load and save settings instead of the registry."
 msgstr "מציין קובץ INI המשמש לטעינה ושמירת הגדרות במקום הרישום."

--- a/Translations/Docs/Manual/Italian.po
+++ b/Translations/Docs/Manual/Italian.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/WinMerge/winmerge/issues\n"
-"POT-Creation-Date: 2026-06-25 07:56+0900\n"
+"POT-Creation-Date: 2026-07-20 16:31+0900\n"
 "PO-Revision-Date: 2026-07-11 13:59+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -620,6 +620,72 @@ msgstr ""
 
 #. type: Content of: <article><para><cmdsynopsis>
 #: English/Command_line.xml:25
+#, fuzzy
+#| msgid ""
+#| "<command>WinMergeU</command> <arg choice=\"opt\" "
+#| "rep=\"norepeat\"><option>/r</option></arg> <arg choice=\"opt\" "
+#| "rep=\"norepeat\"><option>/r-</option></arg> <arg choice=\"opt\" "
+#| "rep=\"norepeat\"><option>/e</option></arg> <arg choice=\"opt\" "
+#| "rep=\"norepeat\"><option>/f</option> <replaceable>filter</replaceable></"
+#| "arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/m</option> "
+#| "<replaceable>compare-method</replaceable></arg> <arg choice=\"opt\" "
+#| "rep=\"norepeat\"><option>/t</option> <replaceable>window-type</"
+#| "replaceable></arg> <arg><option>/x</option></arg> <arg><option>/xq</"
+#| "option></arg> <arg><option>/s</option></arg> <arg><option>/sw</option></"
+#| "arg> <arg><option>/s-</option></arg> <arg choice=\"opt\" "
+#| "rep=\"norepeat\"><option>/ul</option></arg> <arg choice=\"opt\" "
+#| "rep=\"norepeat\"><option>/um</option></arg> <arg choice=\"opt\" "
+#| "rep=\"norepeat\"><option>/ur</option></arg> <arg choice=\"opt\" "
+#| "rep=\"norepeat\"><option>/u</option></arg> <arg choice=\"opt\" "
+#| "rep=\"norepeat\"><option>/wl</option></arg> <arg choice=\"opt\" "
+#| "rep=\"norepeat\"><option>/wm</option></arg> <arg choice=\"opt\" "
+#| "rep=\"norepeat\"><option>/wr</option></arg> <arg choice=\"opt\" "
+#| "rep=\"norepeat\"><option>/new</option></arg> <arg choice=\"opt\" "
+#| "rep=\"norepeat\"><option>/self-compare</option></arg> <arg choice=\"opt\" "
+#| "rep=\"norepeat\"><option>/clipboard-compare</option></arg> <arg><option>/"
+#| "minimize</option></arg> <arg><option>/maximize</option></arg> <arg "
+#| "choice=\"opt\" rep=\"norepeat\"><option>/fl</option></arg> <arg "
+#| "choice=\"opt\" rep=\"norepeat\"><option>/fm</option></arg> <arg "
+#| "choice=\"opt\" rep=\"norepeat\"><option>/fr</option></arg> <arg "
+#| "choice=\"opt\" rep=\"norepeat\"><option>/l</option> "
+#| "<replaceable>linenumber</replaceable></arg> <arg choice=\"opt\" "
+#| "rep=\"norepeat\"><option>/c</option> <replaceable>charpos</replaceable></"
+#| "arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/table-delimiter</"
+#| "option> <replaceable>delimiter</replaceable></arg> <arg choice=\"opt\" "
+#| "rep=\"norepeat\"><option>/dl</option> <replaceable>leftdesc</"
+#| "replaceable></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/dm</"
+#| "option> <replaceable>middledesc</replaceable></arg> <arg choice=\"opt\" "
+#| "rep=\"norepeat\"><option>/dr</option> <replaceable>rightdesc</"
+#| "replaceable></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/al</"
+#| "option></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/am</option></"
+#| "arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/ar</option></arg> <arg "
+#| "choice=\"opt\" rep=\"norepeat\"><option>/noninteractive</option></arg> "
+#| "<arg choice=\"opt\" rep=\"norepeat\"><option>/noprefs</option></arg> <arg "
+#| "choice=\"opt\" rep=\"norepeat\"><option>/enableexitcode</option></arg> "
+#| "<arg choice=\"opt\" rep=\"norepeat\"><option>/ignorews</option></arg> "
+#| "<arg choice=\"opt\" rep=\"norepeat\"><option>/ignoreblanklines</option></"
+#| "arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/ignorecase</option></"
+#| "arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/ignoreeol</option></"
+#| "arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/ignorecodepage</"
+#| "option></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/"
+#| "ignorecomments</option></arg> <arg choice=\"opt\" "
+#| "rep=\"norepeat\"><option>/unpacker</option> <replaceable>unpacker-name</"
+#| "replaceable></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/"
+#| "prediffer</option> <replaceable>prediffer-name</replaceable></arg> <arg "
+#| "choice=\"opt\" rep=\"norepeat\"><option>/cp</option> "
+#| "<replaceable>codepage</replaceable></arg> <arg choice=\"opt\" "
+#| "rep=\"norepeat\"><option>/fileext</option> <replaceable>file-extension</"
+#| "replaceable></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/cfg</"
+#| "option> <replaceable>name=value</replaceable></arg> <arg choice=\"opt\" "
+#| "rep=\"norepeat\"><option>/inifile</option> <replaceable>inifile</"
+#| "replaceable></arg> <arg choice=\"plain\" "
+#| "rep=\"norepeat\"><replaceable>leftpath</replaceable></arg> <arg "
+#| "cchoice=\"opt\" rep=\"norepeat\"><replaceable>middlepath</replaceable></"
+#| "arg> <arg choice=\"plain\" rep=\"norepeat\"><replaceable>rightpath</"
+#| "replaceable></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/o</"
+#| "option> <replaceable>outputpath</replaceable></arg> <arg choice=\"opt\" "
+#| "rep=\"norepeat\"><option>/or</option> <replaceable>reportpath</"
+#| "replaceable></arg>"
 msgid ""
 "<command>WinMergeU</command> <arg choice=\"opt\" rep=\"norepeat\"><option>/"
 "r</option></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/r-</option></"
@@ -630,18 +696,20 @@ msgid ""
 "rep=\"norepeat\"><option>/t</option> <replaceable>window-type</replaceable></"
 "arg> <arg><option>/x</option></arg> <arg><option>/xq</option></arg> "
 "<arg><option>/s</option></arg> <arg><option>/sw</option></arg> <arg><option>/"
-"s-</option></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/ul</option></"
-"arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/um</option></arg> <arg "
-"choice=\"opt\" rep=\"norepeat\"><option>/ur</option></arg> <arg "
-"choice=\"opt\" rep=\"norepeat\"><option>/u</option></arg> <arg "
-"choice=\"opt\" rep=\"norepeat\"><option>/wl</option></arg> <arg "
-"choice=\"opt\" rep=\"norepeat\"><option>/wm</option></arg> <arg "
-"choice=\"opt\" rep=\"norepeat\"><option>/wr</option></arg> <arg "
-"choice=\"opt\" rep=\"norepeat\"><option>/new</option></arg> <arg "
-"choice=\"opt\" rep=\"norepeat\"><option>/self-compare</option></arg> <arg "
-"choice=\"opt\" rep=\"norepeat\"><option>/clipboard-compare</option></arg> "
-"<arg><option>/minimize</option></arg> <arg><option>/maximize</option></arg> "
-"<arg choice=\"opt\" rep=\"norepeat\"><option>/fl</option></arg> <arg "
+"s-</option></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/g</option> "
+"<replaceable>group-name</replaceable></arg> <arg choice=\"opt\" "
+"rep=\"norepeat\"><option>/ul</option></arg> <arg choice=\"opt\" "
+"rep=\"norepeat\"><option>/um</option></arg> <arg choice=\"opt\" "
+"rep=\"norepeat\"><option>/ur</option></arg> <arg choice=\"opt\" "
+"rep=\"norepeat\"><option>/u</option></arg> <arg choice=\"opt\" "
+"rep=\"norepeat\"><option>/wl</option></arg> <arg choice=\"opt\" "
+"rep=\"norepeat\"><option>/wm</option></arg> <arg choice=\"opt\" "
+"rep=\"norepeat\"><option>/wr</option></arg> <arg choice=\"opt\" "
+"rep=\"norepeat\"><option>/new</option></arg> <arg choice=\"opt\" "
+"rep=\"norepeat\"><option>/self-compare</option></arg> <arg choice=\"opt\" "
+"rep=\"norepeat\"><option>/clipboard-compare</option></arg> <arg><option>/"
+"minimize</option></arg> <arg><option>/maximize</option></arg> <arg "
+"choice=\"opt\" rep=\"norepeat\"><option>/fl</option></arg> <arg "
 "choice=\"opt\" rep=\"norepeat\"><option>/fm</option></arg> <arg "
 "choice=\"opt\" rep=\"norepeat\"><option>/fr</option></arg> <arg "
 "choice=\"opt\" rep=\"norepeat\"><option>/l</option> <replaceable>linenumber</"
@@ -746,7 +814,7 @@ msgstr ""
 "arg>"
 
 #. type: Content of: <article><cmdsynopsis>
-#: English/Command_line.xml:162
+#: English/Command_line.xml:165
 msgid ""
 "<command>WinMergeU</command> <arg choice=\"plain\" "
 "rep=\"norepeat\"><replaceable>conflictfile</replaceable></arg>"
@@ -755,7 +823,7 @@ msgstr ""
 "rep=\"norepeat\"><replaceable>conflittofile</replaceable></arg>"
 
 #. type: Content of: <article><para>
-#: English/Command_line.xml:168
+#: English/Command_line.xml:171
 msgid ""
 "Entering the command with no parameters or pathnames simply opens the "
 "WinMerge window. Parameters are prefixed with either a forward slash "
@@ -768,29 +836,29 @@ msgstr ""
 "dei percorsi non hanno caratteri di prefisso."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:175
+#: English/Command_line.xml:178
 msgid "<option>/?</option>"
 msgstr "<option>/?</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:177
+#: English/Command_line.xml:180
 msgid "Opens WinMerge Help at this topic."
 msgstr "Apre la Guida di WinMerge in questo argomento."
 
 #. type: Content of: <article><section><section><title><indexterm><seealso>
-#: English/Command_line.xml:183 English/Compare_dirs.xml:54
+#: English/Command_line.xml:186 English/Compare_dirs.xml:54
 #: English/Compare_dirs.xml:254 English/Open_paths.xml:288
 #: English/Open_paths.xml:294
 msgid "recursive folder compare"
 msgstr "confronto ricorsivo di cartelle"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:185
+#: English/Command_line.xml:188
 msgid "<option>/r</option>"
 msgstr "<option>/r</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:187
+#: English/Command_line.xml:190
 msgid ""
 "Compares all files in all subfolders (recursive compare). Unique folders "
 "(occurring only on one side) are listed in the compare result as separate "
@@ -807,17 +875,17 @@ msgstr ""
 "superiore delle due cartelle di destinazione. Non confronta le sottocartelle."
 
 #. type: Content of: <article><variablelist><varlistentry><indexterm><primary>
-#: English/Command_line.xml:198
+#: English/Command_line.xml:201
 msgid "non-recursive folder compare"
 msgstr "confronto di cartelle non ricorsivo"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:200
+#: English/Command_line.xml:203
 msgid "<option>/r-</option>"
 msgstr "<option>/r-</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:202
+#: English/Command_line.xml:205
 msgid ""
 "Compares all files within the specified folders but excludes the files and "
 "subfolders within its subfolders.  This allows for a shorter comparison time."
@@ -827,24 +895,24 @@ msgstr ""
 "consente un tempo di confronto più breve."
 
 #. type: Content of: <article><section><section><title><indexterm><primary>
-#: English/Command_line.xml:210 English/Command_line.xml:294
-#: English/Command_line.xml:417 English/Configuration.xml:277
-#: English/Quick_start.xml:22
+#: English/Command_line.xml:213 English/Command_line.xml:297
+#: English/Command_line.xml:330 English/Command_line.xml:435
+#: English/Configuration.xml:277 English/Quick_start.xml:22
 msgid "WinMerge window"
 msgstr "Finestra WinMerge"
 
 #. type: Content of: <article><variablelist><varlistentry><indexterm><secondary>
-#: English/Command_line.xml:211
+#: English/Command_line.xml:214
 msgid "closing"
 msgstr "chiusura"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:214
+#: English/Command_line.xml:217
 msgid "<option>/e</option>"
 msgstr "<option>/e</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:216
+#: English/Command_line.xml:219
 msgid ""
 "Enables you to close WinMerge with a single <keycap>Esc</keycap> key press. "
 "This is useful when you use WinMerge as an external compare application: you "
@@ -858,7 +926,7 @@ msgstr ""
 "più volte per chiudere tutte le finestre."
 
 #. type: Content of: <article><section><section><title><indexterm><primary>
-#: English/Command_line.xml:226 English/Configuration.xml:820
+#: English/Command_line.xml:229 English/Configuration.xml:820
 #: English/Configuration.xml:848 English/Configuration.xml:871
 #: English/Filters.xml:4 English/Filters.xml:96 English/Filters.xml:100
 #: English/Filters.xml:142 English/Filters.xml:1609 English/Filters.xml:1613
@@ -869,18 +937,18 @@ msgid "filters"
 msgstr "filtri"
 
 #. type: Content of: <article><variablelist><varlistentry><indexterm><secondary>
-#: English/Command_line.xml:227 English/Command_line.xml:243
-#: English/Command_line.xml:259
+#: English/Command_line.xml:230 English/Command_line.xml:246
+#: English/Command_line.xml:262
 msgid "applying in command line"
 msgstr "applicandolo nella riga di comando"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:230
+#: English/Command_line.xml:233
 msgid "<option>/f</option>"
 msgstr "<option>/f</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:232
+#: English/Command_line.xml:235
 msgid ""
 "Applies a specified filter to restrict the comparison. The filter can be a "
 "filemask like <filename><userinput>*.h *.cpp</userinput></filename>, or the "
@@ -894,17 +962,17 @@ msgstr ""
 "che contiene spazi."
 
 #. type: Content of: <article><variablelist><varlistentry><indexterm><primary>
-#: English/Command_line.xml:242
+#: English/Command_line.xml:245
 msgid "compare method"
 msgstr "metodo di confronto"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:246
+#: English/Command_line.xml:249
 msgid "<option>/m <replaceable>compare-method</replaceable></option>"
 msgstr "<option>/m <replaceable>metodo di confronto</replaceable></option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:248
+#: English/Command_line.xml:251
 msgid ""
 "Sets the compare method to use for the comparison.  This can be one of the "
 "keywords <userinput>Full</userinput>, <userinput>Quick</userinput>, "
@@ -919,17 +987,17 @@ msgstr ""
 "<userinput>Existence</userinput>."
 
 #. type: Content of: <article><variablelist><varlistentry><indexterm><primary>
-#: English/Command_line.xml:258
+#: English/Command_line.xml:261
 msgid "window type"
 msgstr "tipo di finestra"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:262
+#: English/Command_line.xml:265
 msgid "<option>/t <replaceable>window-type</replaceable></option>"
 msgstr "<option>/t <replaceable>tipo di finestra</replaceable></option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:264
+#: English/Command_line.xml:267
 msgid ""
 "Specifies the type of window in which to display files.  This can be one of "
 "the keywords <userinput>Text</userinput>, <userinput>Table</userinput>, "
@@ -942,12 +1010,12 @@ msgstr ""
 "<userinput>Webpage</userinput> o <userinput>Folder</userinput>."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:272
+#: English/Command_line.xml:275
 msgid "<option>/x</option>"
 msgstr "<option>/x</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:274
+#: English/Command_line.xml:277
 msgid ""
 "Closes WinMerge (after displaying an information dialog) when you start a "
 "comparison of identical files. The parameter has no effect after the "
@@ -965,12 +1033,12 @@ msgstr ""
 "differenze."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:285
+#: English/Command_line.xml:288
 msgid "<option>/xq</option>"
 msgstr "<option>/xq</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:287
+#: English/Command_line.xml:290
 msgid ""
 "Is similar to <option>/x</option> but does not show the message about "
 "identical files."
@@ -979,17 +1047,17 @@ msgstr ""
 "identici."
 
 #. type: Content of: <article><section><section><title><indexterm><secondary>
-#: English/Command_line.xml:295 English/Configuration.xml:279
+#: English/Command_line.xml:298 English/Configuration.xml:279
 msgid "limiting instances"
 msgstr "istanze limitanti"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:298
+#: English/Command_line.xml:301
 msgid "<option>/s</option>"
 msgstr "<option>/s</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:300
+#: English/Command_line.xml:303
 msgid ""
 "Limits WinMerge windows to a single instance.  For example, if WinMerge is "
 "already running, a new compare opens in the same instance. Without this "
@@ -1003,12 +1071,12 @@ msgstr ""
 "in una nuova finestra."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:309
+#: English/Command_line.xml:312
 msgid "<option>/sw</option>"
 msgstr "<option>/sw</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:311
+#: English/Command_line.xml:314
 msgid ""
 "Limit the WinMerge window to one instance as well as the option /s.  "
 "However, it waits for the instance displaying the window to terminate."
@@ -1017,12 +1085,12 @@ msgstr ""
 "che l'istanza che visualizza la finestra termini."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:318
+#: English/Command_line.xml:321
 msgid "<option>/s-</option>"
 msgstr "<option>/s-</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:320
+#: English/Command_line.xml:323
 msgid ""
 "Ensure that another instance is always executed, ignoring the value of the "
 "\"Allow only one instance to run\" option."
@@ -1030,19 +1098,39 @@ msgstr ""
 "Assicurati che venga sempre eseguita un'altra istanza, ignorando il valore "
 "dell'opzione \"Consenti l'esecuzione di una sola istanza\"."
 
+#. type: Content of: <article><variablelist><varlistentry><indexterm><secondary>
+#: English/Command_line.xml:331
+msgid "instance groups"
+msgstr ""
+
+#. type: Content of: <article><variablelist><varlistentry><term>
+#: English/Command_line.xml:334
+#, fuzzy
+#| msgid "<option>/cp <replaceable>codepage</replaceable></option>"
+msgid "<option>/g</option> <replaceable>group-name</replaceable>"
+msgstr "<option>/cp <replaceable>codepage</replaceable></option>"
+
+#. type: Content of: <article><variablelist><varlistentry><listitem><para>
+#: English/Command_line.xml:337
+msgid ""
+"Specifies a group name for the WinMerge instance. When used with the "
+"<option>/s</option> option, instances with the same group name share the "
+"same window, allowing you to organize multiple single-instance groups."
+msgstr ""
+
 #. type: Content of: <article><section><qandaset><qandaentry><question><para><indexterm><primary>
-#: English/Command_line.xml:327 English/Configuration.xml:430
+#: English/Command_line.xml:345 English/Configuration.xml:430
 #: English/Faq.xml:114
 msgid "MRU list"
 msgstr "Elenco MRU"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:330
+#: English/Command_line.xml:348
 msgid "<option>/ul</option>"
 msgstr "<option>/ul</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:332
+#: English/Command_line.xml:350
 msgid ""
 "Prevents WinMerge from adding the left path to the Most Recently Used (MRU) "
 "list. External applications should not add paths to the MRU list in the "
@@ -1054,12 +1142,12 @@ msgstr ""
 "o cartelle."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:339
+#: English/Command_line.xml:357
 msgid "<option>/um</option>"
 msgstr "<option>/um</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:341
+#: English/Command_line.xml:359
 msgid ""
 "Prevents WinMerge from adding the middle path to the Most Recently Used "
 "(MRU) list. External applications should not add paths to the MRU list in "
@@ -1071,12 +1159,12 @@ msgstr ""
 "o cartelle."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:348
+#: English/Command_line.xml:366
 msgid "<option>/ur</option>"
 msgstr "<option>/ur</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:350
+#: English/Command_line.xml:368
 msgid ""
 "Prevents WinMerge from adding the right path to the Most Recently Used (MRU) "
 "list. External applications should not add paths to the MRU list in the "
@@ -1088,12 +1176,12 @@ msgstr ""
 "o cartelle."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:357
+#: English/Command_line.xml:375
 msgid "<option>/u</option>"
 msgstr "<option>/u</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:359
+#: English/Command_line.xml:377
 msgid ""
 "Prevents WinMerge from adding either path (left or right) to the Most "
 "Recently Used (MRU) list. External applications should not add paths to the "
@@ -1105,18 +1193,18 @@ msgstr ""
 "o cartelle."
 
 #. type: Content of: <article><section><section><title><indexterm><see>
-#: English/Command_line.xml:368 English/Compare_dirs.xml:741
+#: English/Command_line.xml:386 English/Compare_dirs.xml:741
 #: English/Compare_dirs.xml:745
 msgid "protecting files"
 msgstr "proteggere i file"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:371
+#: English/Command_line.xml:389
 msgid "<option>/wl</option>"
 msgstr "<option>/wl</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:373
+#: English/Command_line.xml:391
 msgid ""
 "Opens the left side as read-only. Use this when you don't want to change "
 "left side items in the compare."
@@ -1125,12 +1213,12 @@ msgstr ""
 "elementi sul lato sinistro nel confronto."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:379
+#: English/Command_line.xml:397
 msgid "<option>/wm</option>"
 msgstr "<option>/wm</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:381
+#: English/Command_line.xml:399
 msgid ""
 "Opens the middle side as read-only. Use this when you don't want to change "
 "right side items in the compare."
@@ -1139,12 +1227,12 @@ msgstr ""
 "elementi sul lato destro nel confronto."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:387
+#: English/Command_line.xml:405
 msgid "<option>/wr</option>"
 msgstr "<option>/wr</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:389
+#: English/Command_line.xml:407
 msgid ""
 "Opens the right side as read-only. Use this when you don't want to change "
 "right side items in the compare."
@@ -1153,47 +1241,47 @@ msgstr ""
 "elementi sul lato destro nel confronto."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:395
+#: English/Command_line.xml:413
 msgid "<option>/new</option>"
 msgstr "<option>/nuovo</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:397
+#: English/Command_line.xml:415
 msgid "Opens a new blank window."
 msgstr "Apre una nuova finestra vuota."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:402
+#: English/Command_line.xml:420
 msgid "<option>/self-compare</option>"
 msgstr "<option>/auto-confronto</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:404
+#: English/Command_line.xml:422
 msgid "Compares the specified file with a copy of the file."
 msgstr "Confronta il file specificato con una copia del file."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:409
+#: English/Command_line.xml:427
 msgid "<option>/clipboard-compare</option>"
 msgstr "<option>/clipboard-compare</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:411
+#: English/Command_line.xml:429
 msgid "Compares the two most recent contents of the clipboard history."
 msgstr "Confronta i due contenuti più recenti della cronologia degli appunti."
 
 #. type: Content of: <article><variablelist><varlistentry><indexterm><secondary>
-#: English/Command_line.xml:418
+#: English/Command_line.xml:436
 msgid "opening minimized or maximized"
 msgstr "apertura minimizzata o massimizzata"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:421
+#: English/Command_line.xml:439
 msgid "<option>/minimize</option>"
 msgstr "<option>/minimizza</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:423
+#: English/Command_line.xml:441
 msgid ""
 "Starts WinMerge as a minimized window.  This option can be useful during "
 "lengthy compares."
@@ -1202,74 +1290,74 @@ msgstr ""
 "utile durante lunghi confronti."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:429
+#: English/Command_line.xml:447
 msgid "<option>/maximize</option>"
 msgstr "<option>/massimizza</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:431
+#: English/Command_line.xml:449
 msgid "Starts WinMerge as a maximized window."
 msgstr "Avvia WinMerge come finestra ingrandita."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:437
+#: English/Command_line.xml:455
 msgid "<option>/fl</option>"
 msgstr "<option>/fl</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:439
+#: English/Command_line.xml:457
 msgid "Sets focus to the left side at startup."
 msgstr "Imposta lo stato attivo sul lato sinistro all'avvio."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:444
+#: English/Command_line.xml:462
 msgid "<option>/fm</option>"
 msgstr "<option>/fm</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:446
+#: English/Command_line.xml:464
 msgid "Sets focus to the middle side at startup."
 msgstr "Imposta lo stato attivo sul lato centrale all'avvio."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:451
+#: English/Command_line.xml:469
 msgid "<option>/fr</option>"
 msgstr "<option>/fr</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:453
+#: English/Command_line.xml:471
 msgid "Sets focus to the right side at startup."
 msgstr "Imposta lo stato attivo sul lato destro all'avvio."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:458
+#: English/Command_line.xml:476
 msgid "<option>/l <replaceable>linenumber</replaceable></option>"
 msgstr "<option>/l <replaceable>numero di riga</replaceable></option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:460
+#: English/Command_line.xml:478
 msgid "Specifies a line number to jump to after loading the files."
 msgstr "Specifica un numero di riga a cui passare dopo aver caricato i file."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:465
+#: English/Command_line.xml:483
 msgid "<option>/c <replaceable>charpos</replaceable></option>"
 msgstr "<option>/c <replaceable>charpos</replaceable></option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:467
+#: English/Command_line.xml:485
 msgid "Specifies a character position to jump to after loading the files."
 msgstr ""
 "Specifica la posizione del carattere a cui passare dopo aver caricato i file."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:472
+#: English/Command_line.xml:490
 msgid "<option>/table-delimiter <replaceable>delimiter</replaceable></option>"
 msgstr ""
 "<option>/table-delimiter <replaceable>delimitatore</replaceable></option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:474
+#: English/Command_line.xml:492
 msgid ""
 "Specifies a delimiter character for table editing. To specify a tab "
 "character, specify \"tab\", \"\\t\", or \"\\x09\"."
@@ -1279,12 +1367,12 @@ msgstr ""
 "\"\\x09\"."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:479
+#: English/Command_line.xml:497
 msgid "<option>/dl</option>"
 msgstr "<option>/dl</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:481
+#: English/Command_line.xml:499
 msgid ""
 "Specifies a description in the left side title bar, overriding the default "
 "folder or filename text. For example: <userinput>/dl \"Version 1.0</"
@@ -1298,12 +1386,12 @@ msgstr ""
 "contengono spazi."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:490
+#: English/Command_line.xml:508
 msgid "<option>/dm</option>"
 msgstr "<option>/dm</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:492
+#: English/Command_line.xml:510
 msgid ""
 "Specifies a description in the middle side title bar, just like <option>/dl</"
 "option>."
@@ -1312,12 +1400,12 @@ msgstr ""
 "<option>/dl</option>."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:498
+#: English/Command_line.xml:516
 msgid "<option>/dr</option>"
 msgstr "<option>/dr</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:500
+#: English/Command_line.xml:518
 msgid ""
 "Specifies a description in the right side title bar, just like <option>/dl</"
 "option>."
@@ -1326,42 +1414,42 @@ msgstr ""
 "come <option>/dl</option>."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:506
+#: English/Command_line.xml:524
 msgid "<option>/al</option>"
 msgstr "<option>/al</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:508
+#: English/Command_line.xml:526
 msgid "Auto-merges at the left side at startup."
 msgstr "Si unisce automaticamente sul lato sinistro all'avvio."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:513
+#: English/Command_line.xml:531
 msgid "<option>/am</option>"
 msgstr "<option>/am</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:515
+#: English/Command_line.xml:533
 msgid "Auto-merges at the middle side at startup."
 msgstr "Si unisce automaticamente al lato centrale all'avvio."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:520
+#: English/Command_line.xml:538
 msgid "<option>/ar</option>"
 msgstr "<option>/ar</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:522
+#: English/Command_line.xml:540
 msgid "Auto-merges at the right side at startup."
 msgstr "Si unisce automaticamente sul lato destro all'avvio."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:527
+#: English/Command_line.xml:545
 msgid "<option>/noninteractive</option>"
 msgstr "<option>/non interattivo</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:530
+#: English/Command_line.xml:548
 msgid ""
 "Runs WinMerge without displaying message boxes during comparison or report "
 "generation.  The process terminates automatically when the operation is "
@@ -1373,12 +1461,12 @@ msgstr ""
 "script."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:538
+#: English/Command_line.xml:556
 msgid "<option>/noprefs</option>"
 msgstr "<option>/noprefs</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:541
+#: English/Command_line.xml:559
 msgid ""
 "Runs WinMerge without loading or saving settings from the registry.  All "
 "comparisons use default preferences only."
@@ -1387,12 +1475,12 @@ msgstr ""
 "i confronti usano solo le preferenze predefinite."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:548
+#: English/Command_line.xml:566
 msgid "<option>/enableexitcode</option>"
 msgstr "<option>/enableexitcode</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:550
+#: English/Command_line.xml:568
 msgid ""
 "Sets the comparison result to the process exit code. 0: identical, 1: "
 "different, 2: error"
@@ -1401,12 +1489,12 @@ msgstr ""
 "identico, 1: diverso, 2: errore"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:555
+#: English/Command_line.xml:573
 msgid "<option>/ignorews</option>"
 msgstr "<option>/ignora</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:557
+#: English/Command_line.xml:575
 msgid ""
 "Controls the \"Whitespaces\" option (whitespace comparison settings) "
 "persistently:"
@@ -1415,13 +1503,13 @@ msgstr ""
 "bianchi) in modo persistente:"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:559
+#: English/Command_line.xml:577
 msgid "<option>/ignorews:0</option> - do not ignore whitespace differences."
 msgstr ""
 "<option>/ignorews:0</option> - non ignora le differenze di spazi bianchi."
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:560
+#: English/Command_line.xml:578
 msgid ""
 "<option>/ignorews</option> or <option>/ignorews:1</option> - ignore "
 "differences in the amount of whitespace."
@@ -1430,30 +1518,30 @@ msgstr ""
 "differenze nella quantità di spazi bianchi."
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:561
+#: English/Command_line.xml:579
 msgid "<option>/ignorews:2</option> - ignore all whitespace characters."
 msgstr ""
 "<option>/ignorews:2</option> - ignora tutti i caratteri di spazio bianco."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:567
+#: English/Command_line.xml:585
 msgid "<option>/ignoreblanklines</option>"
 msgstr "<option>/ignoreblanklines</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:569
+#: English/Command_line.xml:587
 msgid "Controls the \"Ignore blank lines\" option persistently:"
 msgstr "Controlla in modo persistente l'opzione \"Ignora righe vuote\":"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:571
+#: English/Command_line.xml:589
 msgid "<option>/ignoreblanklines:0</option> - disables ignoring blank lines."
 msgstr ""
 "<option>/ignoreblanklines:0</option> - disabilita l'ignoranza delle righe "
 "vuote."
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:572
+#: English/Command_line.xml:590
 msgid ""
 "<option>/ignoreblanklines</option> or <option>/ignoreblanklines:1</option> - "
 "enables ignoring blank lines."
@@ -1462,25 +1550,25 @@ msgstr ""
 "consente di ignorare le righe vuote."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:578
+#: English/Command_line.xml:596
 msgid "<option>/ignorecase</option>"
 msgstr "<option>/ignorecase</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:580
+#: English/Command_line.xml:598
 msgid "Controls the \"Ignore case\" option persistently:"
 msgstr ""
 "Controlla l'opzione \"Ignora maiuscole e minuscole\" in modo persistente:"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:582
+#: English/Command_line.xml:600
 msgid "<option>/ignorecase:0</option> - disables ignoring case differences."
 msgstr ""
 "<option>/ignorecase:0</option> - disabilita l'ignoranza delle differenze tra "
 "maiuscole e minuscole."
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:583
+#: English/Command_line.xml:601
 msgid ""
 "<option>/ignorecase</option> or <option>/ignorecase:1</option> - enables "
 "ignoring case differences."
@@ -1489,23 +1577,23 @@ msgstr ""
 "ignorare le differenze tra maiuscole e minuscole."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:589
+#: English/Command_line.xml:607
 msgid "<option>/ignoreeol</option>"
 msgstr "<option>/ignoreol</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:591
+#: English/Command_line.xml:609
 msgid "Controls the \"Ignore EOL differences\" option persistently:"
 msgstr "Controlla in modo persistente l'opzione \"Ignora differenze EOL\":"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:593
+#: English/Command_line.xml:611
 msgid "<option>/ignoreeol:0</option> - disables ignoring EOL differences."
 msgstr ""
 "<option>/ignoreeol:0</option> - disabilita l'ignoranza delle differenze EOL."
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:594
+#: English/Command_line.xml:612
 msgid ""
 "<option>/ignoreeol</option> or <option>/ignoreeol:1</option> - enables "
 "ignoring EOL differences."
@@ -1514,18 +1602,18 @@ msgstr ""
 "ignorare le differenze EOL."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:600
+#: English/Command_line.xml:618
 msgid "<option>/ignorecodepage</option>"
 msgstr "<option>/ignorecodepage</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:602
+#: English/Command_line.xml:620
 msgid "Controls the \"Ignore codepage differences\" option persistently:"
 msgstr ""
 "Controlla in modo persistente l'opzione \"Ignora differenze tabella codici\":"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:604
+#: English/Command_line.xml:622
 msgid ""
 "<option>/ignorecodepage:0</option> - disables ignoring codepage differences."
 msgstr ""
@@ -1533,7 +1621,7 @@ msgstr ""
 "nella tabella codici."
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:605
+#: English/Command_line.xml:623
 msgid ""
 "<option>/ignorecodepage</option> or <option>/ignorecodepage:1</option> - "
 "enables ignoring codepage differences."
@@ -1542,24 +1630,24 @@ msgstr ""
 "consente di ignorare le differenze nella tabella codici."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:611
+#: English/Command_line.xml:629
 msgid "<option>/ignorecomments</option>"
 msgstr "<option>/ignorecomments</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:613
+#: English/Command_line.xml:631
 msgid "Controls the \"Ignore comment differences\" option persistently:"
 msgstr ""
 "Controlla in modo persistente l'opzione \"Ignora differenze commenti\":"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:615
+#: English/Command_line.xml:633
 msgid "<option>/ignorecomments:0</option> - disables ignoring comments."
 msgstr ""
 "<option>/ignorecomments:0</option> - disabilita l'ignoranza dei commenti."
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:616
+#: English/Command_line.xml:634
 msgid ""
 "<option>/ignorecomments</option> or <option>/ignorecomments:1</option> - "
 "enables ignoring comments."
@@ -1568,13 +1656,13 @@ msgstr ""
 "consente di ignorare i commenti."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:622
+#: English/Command_line.xml:640
 msgid "<option>/unpacker <replaceable>plugin pipeline</replaceable></option>"
 msgstr ""
 "<option>/unpacker <replaceable>pipeline di plugin</replaceable></option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:625
+#: English/Command_line.xml:643
 msgid ""
 "Specifies the plugin pipeline for the Unpacker plugin.  Example: <option>/"
 "unpacker \"SortAscending|SelectLines 1-10\"</option>"
@@ -1583,13 +1671,13 @@ msgstr ""
 "unpacker \"SortAscending|SelectLines 1-10\"</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:632
+#: English/Command_line.xml:650
 msgid "<option>/prediffer <replaceable>plugin pipeline</replaceable></option>"
 msgstr ""
 "<option>/prediffer <replaceable>pipeline di plug-in</replaceable></option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:635
+#: English/Command_line.xml:653
 msgid ""
 "Specifies the plugin pipeline for the Prediffer plugin.  Example: <option>/"
 "prediffer \"IgnoreColumns 1-10\"</option>"
@@ -1598,12 +1686,12 @@ msgstr ""
 "<option>/prediffer \"IgnoraColonne 1-10\"</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:642
+#: English/Command_line.xml:660
 msgid "<option>/cp <replaceable>codepage</replaceable></option>"
 msgstr "<option>/cp <replaceable>codepage</replaceable></option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:645
+#: English/Command_line.xml:663
 msgid ""
 "Specifies the codepage to use for file comparison.  Example: <option>/cp "
 "65001</option>"
@@ -1612,35 +1700,35 @@ msgstr ""
 "<option>/cp 65001</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:652
+#: English/Command_line.xml:670
 msgid "<option>/fileext <replaceable>file-extension</replaceable></option>"
 msgstr "<option>/fileext <replaceable>estensione file</replaceable></option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:654
+#: English/Command_line.xml:672
 msgid "Specifies a file extension for determining syntax hightliting."
 msgstr ""
 "Specifica un'estensione di file per determinare l'evidenziazione della "
 "sintassi."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:659
+#: English/Command_line.xml:677
 msgid "<option>/cfg <replaceable>name=value</replaceable></option>"
 msgstr "<option>/cfg <replaceable>nome=valore</replaceable></option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:662
+#: English/Command_line.xml:680
 msgid "Sets a configuration value in the WinMerge registry or INI file."
 msgstr ""
 "Imposta un valore di configurazione nel registro WinMerge o nel file INI."
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:665
+#: English/Command_line.xml:683
 msgid "Example: <option>/cfg Settings/DiffAlgorithm=3</option>"
 msgstr "Esempio: <option>/cfg Impostazioni/DiffAlgorithm=3</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:668
+#: English/Command_line.xml:686
 msgid ""
 "If the section name is unambiguous and does not conflict with other setting "
 "names, it can be omitted:"
@@ -1649,12 +1737,12 @@ msgstr ""
 "di impostazioni, può essere omesso:"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:671
+#: English/Command_line.xml:689
 msgid "<option>/cfg DiffAlgo=3</option>"
 msgstr "<option>/cfg DiffAlgo=3</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:674
+#: English/Command_line.xml:692
 msgid ""
 "Note: This entry does not explain which configuration names are available.  "
 "For a list of settings, refer to "
@@ -1667,43 +1755,43 @@ msgstr ""
 "in regedit."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:681
+#: English/Command_line.xml:699
 msgid "<option><replaceable>leftpath</replaceable></option>"
 msgstr "<option><replaceable>percorso a sinistra</replaceable></option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:683
+#: English/Command_line.xml:701
 msgid "Specifies the folder, file or project file to open on the left side."
 msgstr ""
 "Specifica la cartella, il file o il file di progetto da aprire sul lato "
 "sinistro."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:688
+#: English/Command_line.xml:706
 msgid "<option><replaceable>middlepath</replaceable></option>"
 msgstr "<option><replaceable>percorso intermedio</replaceable></option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:690
+#: English/Command_line.xml:708
 msgid "Specifies the folder, file or project file to open on the middle side."
 msgstr ""
 "Specifica la cartella, il file o il file di progetto da aprire sul lato "
 "centrale."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:695
+#: English/Command_line.xml:713
 msgid "<option><replaceable>rightpath</replaceable></option>"
 msgstr "<option><replaceable>rightpath</replaceable></option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:697
+#: English/Command_line.xml:715
 msgid "Specifies the folder, file or project file to open on the right side."
 msgstr ""
 "Specifica la cartella, il file o il file di progetto da aprire sul lato "
 "destro."
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:699
+#: English/Command_line.xml:717
 msgid ""
 "WinMerge cannot compare files to folders, so the path parameters "
 "(<option><replaceable>leftpath</replaceable></option>, "
@@ -1722,7 +1810,7 @@ msgstr ""
 "Seleziona file o cartelle, dove è possibile cercare i percorsi corretti."
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><tip><para>
-#: English/Command_line.xml:708
+#: English/Command_line.xml:726
 msgid ""
 "In file comparisons, you can specify a folder name in one of the path "
 "parameters, as long as the folder contains a file with the same name as the "
@@ -1733,12 +1821,12 @@ msgstr ""
 "stesso nome di quello specificato nell'altro percorso file."
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><tip><para>
-#: English/Command_line.xml:712
+#: English/Command_line.xml:730
 msgid "For example, consider this command:"
 msgstr "Ad esempio, considera questo comando:"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><tip><para>
-#: English/Command_line.xml:714
+#: English/Command_line.xml:732
 msgid ""
 "<userinput>WinMergeU <filename>C:\\Folder\\File.txt</filename> <filename "
 "class=\"directory\">C:\\Folder2</filename> </userinput>"
@@ -1747,7 +1835,7 @@ msgstr ""
 "class=\"directory\">C:\\Cartella2</filename> </userinput>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><tip><para>
-#: English/Command_line.xml:717
+#: English/Command_line.xml:735
 msgid ""
 "If <filename class=\"directory\">C:\\Folder2</filename> contains a file "
 "named <filename>File.txt</filename>: WinMerge implicitly resolves the second "
@@ -1764,23 +1852,23 @@ msgstr ""
 "<filename>File.txt</filename>."
 
 #. type: Content of: <article><section><section><title><indexterm><primary>
-#: English/Command_line.xml:730 English/Compare_files.xml:1481
+#: English/Command_line.xml:748 English/Compare_files.xml:1481
 #: English/Intro_diffs.xml:253 English/Intro_diffs.xml:407
 msgid "merging differences"
 msgstr "fondere le differenze"
 
 #. type: Content of: <article><section><section><title><indexterm><secondary>
-#: English/Command_line.xml:731 English/Intro_diffs.xml:409
+#: English/Command_line.xml:749 English/Intro_diffs.xml:409
 msgid "result file"
 msgstr "file dei risultati"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:734
+#: English/Command_line.xml:752
 msgid "<option>/o <replaceable>outputpath</replaceable></option>"
 msgstr "<option>/o <replaceable>percorso di output</replaceable></option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:736
+#: English/Command_line.xml:754
 msgid ""
 "Specifies an optional output file path where you want merged result files to "
 "be saved."
@@ -1789,7 +1877,7 @@ msgstr ""
 "i file dei risultati uniti."
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:739
+#: English/Command_line.xml:757
 msgid ""
 "The output path is rarely needed when you start WinMerge from the command "
 "line. It is meant to be used with version control tools, where you might "
@@ -1807,7 +1895,7 @@ msgstr ""
 "percorso di output, lasciando intatti i due o tre file di origine."
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:747
+#: English/Command_line.xml:765
 msgid ""
 "Version control systems typically refer to the source and result files using "
 "terms like <glossterm>theirs</glossterm>, <glossterm>mine</glossterm>, and "
@@ -1823,12 +1911,12 @@ msgstr ""
 "della versione, dovresti elencare i file in quest'ordine."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:757
+#: English/Command_line.xml:775
 msgid "<option>/or <replaceable>outputpath</replaceable></option>"
 msgstr "<option>/o <replaceable>percorso di output</replaceable></option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:760
+#: English/Command_line.xml:778
 msgid ""
 "Outputs a comparison report for files or folders.  Example: "
 "<option>WinMergeU path1 path2 /or c:\\tmp\\report.html</option>"
@@ -1837,12 +1925,12 @@ msgstr ""
 "<option>WinMergeU percorso1 percorso2 /o c:\\tmp\\report.html</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:763
+#: English/Command_line.xml:781
 msgid "It is often useful to combine this option with:"
 msgstr "Spesso è utile combinare questa opzione con:"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:765
+#: English/Command_line.xml:783
 msgid ""
 "<option>/noninteractive</option> - exits WinMerge after producing the report."
 msgstr ""
@@ -1850,12 +1938,12 @@ msgstr ""
 "report."
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:766
+#: English/Command_line.xml:784
 msgid "<option>/minimize</option> - starts WinMerge in minimized state."
 msgstr "<option>/minimize</option> - avvia WinMerge in stato ridotto a icona."
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:767
+#: English/Command_line.xml:785
 msgid ""
 "<option>/noprefs</option> - ignores the current preferences and uses default "
 "settings.  Any changes made with <option>/cfg</option> will then be "
@@ -1866,7 +1954,7 @@ msgstr ""
 "option> sarà quindi temporanea e non verrà salvata."
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:771
+#: English/Command_line.xml:789
 msgid ""
 "The following <option>/cfg</option> settings can also be useful (parameter "
 "names may change in the future):"
@@ -1875,12 +1963,12 @@ msgstr ""
 "nomi dei parametri potrebbero cambiare in futuro):"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:773
+#: English/Command_line.xml:791
 msgid "For file comparisons:"
 msgstr "Per i confronti dei file:"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:775
+#: English/Command_line.xml:793
 msgid ""
 "<option>/cfg Settings/DiffContextV2=0</option> - hides matching lines in the "
 "report (equivalent to View -> Diff Context -> 0 Lines)."
@@ -1890,7 +1978,7 @@ msgstr ""
 "righe)."
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:776
+#: English/Command_line.xml:794
 msgid ""
 "<option>/cfg Settings/ViewLineNumbers=1</option> - outputs line numbers (set "
 "to 0 to disable)."
@@ -1899,12 +1987,12 @@ msgstr ""
 "riga (impostato su 0 per disabilitare)."
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:778
+#: English/Command_line.xml:796
 msgid "For folder comparisons:"
 msgstr "Per i confronti delle cartelle:"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:780
+#: English/Command_line.xml:798
 msgid ""
 "<option>/cfg Settings/DirViewExpandSubdirs=1</option> - automatically expand "
 "all subfolders."
@@ -1913,7 +2001,7 @@ msgstr ""
 "automaticamente tutte le sottocartelle."
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:781
+#: English/Command_line.xml:799
 msgid ""
 "<option>/cfg ReportFiles/ReportType=2</option> - report style: Simple HTML."
 msgstr ""
@@ -1921,7 +2009,7 @@ msgstr ""
 "semplice."
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:782
+#: English/Command_line.xml:800
 msgid ""
 "<option>/cfg ReportFiles/IncludeFileCmpReport=1</option> - include file "
 "comparison reports."
@@ -1930,22 +2018,22 @@ msgstr ""
 "confronto file."
 
 #. type: Content of: <article><section><section><title><indexterm><primary>
-#: English/Command_line.xml:789 English/Compare_files.xml:1805
+#: English/Command_line.xml:807 English/Compare_files.xml:1805
 msgid "conflict files"
 msgstr "file in conflitto"
 
 #. type: Content of: <article><variablelist><varlistentry><indexterm><secondary>
-#: English/Command_line.xml:790 English/Command_line.xml:806
+#: English/Command_line.xml:808 English/Command_line.xml:824
 msgid "specifying on command line"
 msgstr "specificando sulla riga di comando"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:793
+#: English/Command_line.xml:811
 msgid "<option><replaceable>conflictfile</replaceable></option>"
 msgstr "<option><replaceable>file di conflitto</replaceable></option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:795
+#: English/Command_line.xml:813
 msgid ""
 "Specifies a conflict file, typically generated by a Version control system. "
 "The conflict file opens in the File Compare window, where you can merge and "
@@ -1959,17 +2047,17 @@ msgstr ""
 "non è possibile usare altri percorsi con un file in conflitto."
 
 #. type: Content of: <article><variablelist><varlistentry><indexterm><primary>
-#: English/Command_line.xml:805
+#: English/Command_line.xml:823
 msgid "ini file"
 msgstr "questo file"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:809
+#: English/Command_line.xml:827
 msgid "<option>/inifile <replaceable>inifile</replaceable></option>"
 msgstr "<option>/file ini <replaceable>file ini</replaceable></option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:811
+#: English/Command_line.xml:829
 msgid ""
 "specifies an INI file used to load and save settings instead of the registry."
 msgstr ""

--- a/Translations/Docs/Manual/Japanese.po
+++ b/Translations/Docs/Manual/Japanese.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: WinMerge\n"
 "Report-Msgid-Bugs-To: https://github.com/WinMerge/winmerge/issues\n"
-"POT-Creation-Date: 2026-06-25 07:56+0900\n"
+"POT-Creation-Date: 2026-07-20 16:31+0900\n"
 "PO-Revision-Date: 2026-06-25 08:05+0900\n"
 "Last-Translator: Takashi Sawanaka <sawanaka@d1.dion.ne.jp>\n"
 "Language-Team: Japanese <winmerge-translate@lists.sourceforge.net>\n"
@@ -623,18 +623,20 @@ msgid ""
 "rep=\"norepeat\"><option>/t</option> <replaceable>window-type</replaceable></"
 "arg> <arg><option>/x</option></arg> <arg><option>/xq</option></arg> "
 "<arg><option>/s</option></arg> <arg><option>/sw</option></arg> <arg><option>/"
-"s-</option></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/ul</option></"
-"arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/um</option></arg> <arg "
-"choice=\"opt\" rep=\"norepeat\"><option>/ur</option></arg> <arg "
-"choice=\"opt\" rep=\"norepeat\"><option>/u</option></arg> <arg "
-"choice=\"opt\" rep=\"norepeat\"><option>/wl</option></arg> <arg "
-"choice=\"opt\" rep=\"norepeat\"><option>/wm</option></arg> <arg "
-"choice=\"opt\" rep=\"norepeat\"><option>/wr</option></arg> <arg "
-"choice=\"opt\" rep=\"norepeat\"><option>/new</option></arg> <arg "
-"choice=\"opt\" rep=\"norepeat\"><option>/self-compare</option></arg> <arg "
-"choice=\"opt\" rep=\"norepeat\"><option>/clipboard-compare</option></arg> "
-"<arg><option>/minimize</option></arg> <arg><option>/maximize</option></arg> "
-"<arg choice=\"opt\" rep=\"norepeat\"><option>/fl</option></arg> <arg "
+"s-</option></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/g</option> "
+"<replaceable>group-name</replaceable></arg> <arg choice=\"opt\" "
+"rep=\"norepeat\"><option>/ul</option></arg> <arg choice=\"opt\" "
+"rep=\"norepeat\"><option>/um</option></arg> <arg choice=\"opt\" "
+"rep=\"norepeat\"><option>/ur</option></arg> <arg choice=\"opt\" "
+"rep=\"norepeat\"><option>/u</option></arg> <arg choice=\"opt\" "
+"rep=\"norepeat\"><option>/wl</option></arg> <arg choice=\"opt\" "
+"rep=\"norepeat\"><option>/wm</option></arg> <arg choice=\"opt\" "
+"rep=\"norepeat\"><option>/wr</option></arg> <arg choice=\"opt\" "
+"rep=\"norepeat\"><option>/new</option></arg> <arg choice=\"opt\" "
+"rep=\"norepeat\"><option>/self-compare</option></arg> <arg choice=\"opt\" "
+"rep=\"norepeat\"><option>/clipboard-compare</option></arg> <arg><option>/"
+"minimize</option></arg> <arg><option>/maximize</option></arg> <arg "
+"choice=\"opt\" rep=\"norepeat\"><option>/fl</option></arg> <arg "
 "choice=\"opt\" rep=\"norepeat\"><option>/fm</option></arg> <arg "
 "choice=\"opt\" rep=\"norepeat\"><option>/fr</option></arg> <arg "
 "choice=\"opt\" rep=\"norepeat\"><option>/l</option> <replaceable>linenumber</"
@@ -685,18 +687,20 @@ msgstr ""
 "rep=\"norepeat\"><option>/t</option> <replaceable>window-type</replaceable></"
 "arg> <arg><option>/x</option></arg> <arg><option>/xq</option></arg> "
 "<arg><option>/s</option></arg> <arg><option>/sw</option></arg> <arg><option>/"
-"s-</option></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/ul</option></"
-"arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/um</option></arg> <arg "
-"choice=\"opt\" rep=\"norepeat\"><option>/ur</option></arg> <arg "
-"choice=\"opt\" rep=\"norepeat\"><option>/u</option></arg> <arg "
-"choice=\"opt\" rep=\"norepeat\"><option>/wl</option></arg> <arg "
-"choice=\"opt\" rep=\"norepeat\"><option>/wm</option></arg> <arg "
-"choice=\"opt\" rep=\"norepeat\"><option>/wr</option></arg> <arg "
-"choice=\"opt\" rep=\"norepeat\"><option>/new</option></arg> <arg "
-"choice=\"opt\" rep=\"norepeat\"><option>/self-compare</option></arg> <arg "
-"choice=\"opt\" rep=\"norepeat\"><option>/clipboard-compare</option></arg> "
-"<arg><option>/minimize</option></arg> <arg><option>/maximize</option></arg> "
-"<arg choice=\"opt\" rep=\"norepeat\"><option>/fl</option></arg> <arg "
+"s-</option></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/g</option> "
+"<replaceable>group-name</replaceable></arg> <arg choice=\"opt\" "
+"rep=\"norepeat\"><option>/ul</option></arg> <arg choice=\"opt\" "
+"rep=\"norepeat\"><option>/um</option></arg> <arg choice=\"opt\" "
+"rep=\"norepeat\"><option>/ur</option></arg> <arg choice=\"opt\" "
+"rep=\"norepeat\"><option>/u</option></arg> <arg choice=\"opt\" "
+"rep=\"norepeat\"><option>/wl</option></arg> <arg choice=\"opt\" "
+"rep=\"norepeat\"><option>/wm</option></arg> <arg choice=\"opt\" "
+"rep=\"norepeat\"><option>/wr</option></arg> <arg choice=\"opt\" "
+"rep=\"norepeat\"><option>/new</option></arg> <arg choice=\"opt\" "
+"rep=\"norepeat\"><option>/self-compare</option></arg> <arg choice=\"opt\" "
+"rep=\"norepeat\"><option>/clipboard-compare</option></arg> <arg><option>/"
+"minimize</option></arg> <arg><option>/maximize</option></arg> <arg "
+"choice=\"opt\" rep=\"norepeat\"><option>/fl</option></arg> <arg "
 "choice=\"opt\" rep=\"norepeat\"><option>/fm</option></arg> <arg "
 "choice=\"opt\" rep=\"norepeat\"><option>/fr</option></arg> <arg "
 "choice=\"opt\" rep=\"norepeat\"><option>/l</option> <replaceable>linenumber</"
@@ -739,7 +743,7 @@ msgstr ""
 "arg>"
 
 #. type: Content of: <article><cmdsynopsis>
-#: English/Command_line.xml:162
+#: English/Command_line.xml:165
 msgid ""
 "<command>WinMergeU</command> <arg choice=\"plain\" "
 "rep=\"norepeat\"><replaceable>conflictfile</replaceable></arg>"
@@ -748,7 +752,7 @@ msgstr ""
 "rep=\"norepeat\"><replaceable>conflictfile</replaceable></arg>"
 
 #. type: Content of: <article><para>
-#: English/Command_line.xml:168
+#: English/Command_line.xml:171
 msgid ""
 "Entering the command with no parameters or pathnames simply opens the "
 "WinMerge window. Parameters are prefixed with either a forward slash "
@@ -761,29 +765,29 @@ msgstr ""
 "ん。"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:175
+#: English/Command_line.xml:178
 msgid "<option>/?</option>"
 msgstr "<option>/?</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:177
+#: English/Command_line.xml:180
 msgid "Opens WinMerge Help at this topic."
 msgstr "このトピックのWinMergeヘルプを開きます。"
 
 #. type: Content of: <article><section><section><title><indexterm><seealso>
-#: English/Command_line.xml:183 English/Compare_dirs.xml:54
+#: English/Command_line.xml:186 English/Compare_dirs.xml:54
 #: English/Compare_dirs.xml:254 English/Open_paths.xml:288
 #: English/Open_paths.xml:294
 msgid "recursive folder compare"
 msgstr "再帰フォルダー比較"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:185
+#: English/Command_line.xml:188
 msgid "<option>/r</option>"
 msgstr "<option>/r</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:187
+#: English/Command_line.xml:190
 msgid ""
 "Compares all files in all subfolders (recursive compare). Unique folders "
 "(occurring only on one side) are listed in the compare result as separate "
@@ -800,17 +804,17 @@ msgstr ""
 "フォルダーの中までは比較しません。"
 
 #. type: Content of: <article><variablelist><varlistentry><indexterm><primary>
-#: English/Command_line.xml:198
+#: English/Command_line.xml:201
 msgid "non-recursive folder compare"
 msgstr "非再帰フォルダー比較"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:200
+#: English/Command_line.xml:203
 msgid "<option>/r-</option>"
 msgstr "<option>/r-</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:202
+#: English/Command_line.xml:205
 msgid ""
 "Compares all files within the specified folders but excludes the files and "
 "subfolders within its subfolders.  This allows for a shorter comparison time."
@@ -820,24 +824,24 @@ msgstr ""
 "できます。"
 
 #. type: Content of: <article><section><section><title><indexterm><primary>
-#: English/Command_line.xml:210 English/Command_line.xml:294
-#: English/Command_line.xml:417 English/Configuration.xml:277
-#: English/Quick_start.xml:22
+#: English/Command_line.xml:213 English/Command_line.xml:297
+#: English/Command_line.xml:330 English/Command_line.xml:435
+#: English/Configuration.xml:277 English/Quick_start.xml:22
 msgid "WinMerge window"
 msgstr "WinMergeウィンドウ"
 
 #. type: Content of: <article><variablelist><varlistentry><indexterm><secondary>
-#: English/Command_line.xml:211
+#: English/Command_line.xml:214
 msgid "closing"
 msgstr "閉じる"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:214
+#: English/Command_line.xml:217
 msgid "<option>/e</option>"
 msgstr "<option>/e</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:216
+#: English/Command_line.xml:219
 msgid ""
 "Enables you to close WinMerge with a single <keycap>Esc</keycap> key press. "
 "This is useful when you use WinMerge as an external compare application: you "
@@ -855,7 +859,7 @@ msgstr ""
 "しました)"
 
 #. type: Content of: <article><section><section><title><indexterm><primary>
-#: English/Command_line.xml:226 English/Configuration.xml:820
+#: English/Command_line.xml:229 English/Configuration.xml:820
 #: English/Configuration.xml:848 English/Configuration.xml:871
 #: English/Filters.xml:4 English/Filters.xml:96 English/Filters.xml:100
 #: English/Filters.xml:142 English/Filters.xml:1609 English/Filters.xml:1613
@@ -866,18 +870,18 @@ msgid "filters"
 msgstr "フィルター"
 
 #. type: Content of: <article><variablelist><varlistentry><indexterm><secondary>
-#: English/Command_line.xml:227 English/Command_line.xml:243
-#: English/Command_line.xml:259
+#: English/Command_line.xml:230 English/Command_line.xml:246
+#: English/Command_line.xml:262
 msgid "applying in command line"
 msgstr "コマンドラインでの適用"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:230
+#: English/Command_line.xml:233
 msgid "<option>/f</option>"
 msgstr "<option>/f</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:232
+#: English/Command_line.xml:235
 msgid ""
 "Applies a specified filter to restrict the comparison. The filter can be a "
 "filemask like <filename><userinput>*.h *.cpp</userinput></filename>, or the "
@@ -891,17 +895,17 @@ msgstr ""
 "クで括ってください。"
 
 #. type: Content of: <article><variablelist><varlistentry><indexterm><primary>
-#: English/Command_line.xml:242
+#: English/Command_line.xml:245
 msgid "compare method"
 msgstr "比較方法"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:246
+#: English/Command_line.xml:249
 msgid "<option>/m <replaceable>compare-method</replaceable></option>"
 msgstr "<option>/m <replaceable>compare-method</replaceable></option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:248
+#: English/Command_line.xml:251
 msgid ""
 "Sets the compare method to use for the comparison.  This can be one of the "
 "keywords <userinput>Full</userinput>, <userinput>Quick</userinput>, "
@@ -916,17 +920,17 @@ msgstr ""
 "<userinput>Existence</userinput>"
 
 #. type: Content of: <article><variablelist><varlistentry><indexterm><primary>
-#: English/Command_line.xml:258
+#: English/Command_line.xml:261
 msgid "window type"
 msgstr "ウィンドウタイプ"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:262
+#: English/Command_line.xml:265
 msgid "<option>/t <replaceable>window-type</replaceable></option>"
 msgstr "<option>/t <replaceable>window-type</replaceable></option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:264
+#: English/Command_line.xml:267
 msgid ""
 "Specifies the type of window in which to display files.  This can be one of "
 "the keywords <userinput>Text</userinput>, <userinput>Table</userinput>, "
@@ -939,12 +943,12 @@ msgstr ""
 "<userinput>Webpage</userinput>, <userinput>Folder</userinput>"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:272
+#: English/Command_line.xml:275
 msgid "<option>/x</option>"
 msgstr "<option>/x</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:274
+#: English/Command_line.xml:277
 msgid ""
 "Closes WinMerge (after displaying an information dialog) when you start a "
 "comparison of identical files. The parameter has no effect after the "
@@ -960,12 +964,12 @@ msgstr ""
 "分なステップを取り除きたい場合に便利です。"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:285
+#: English/Command_line.xml:288
 msgid "<option>/xq</option>"
 msgstr "<option>/xq</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:287
+#: English/Command_line.xml:290
 msgid ""
 "Is similar to <option>/x</option> but does not show the message about "
 "identical files."
@@ -974,17 +978,17 @@ msgstr ""
 "ジボックスを表示しません。"
 
 #. type: Content of: <article><section><section><title><indexterm><secondary>
-#: English/Command_line.xml:295 English/Configuration.xml:279
+#: English/Command_line.xml:298 English/Configuration.xml:279
 msgid "limiting instances"
 msgstr "インスタンス制限"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:298
+#: English/Command_line.xml:301
 msgid "<option>/s</option>"
 msgstr "<option>/s</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:300
+#: English/Command_line.xml:303
 msgid ""
 "Limits WinMerge windows to a single instance.  For example, if WinMerge is "
 "already running, a new compare opens in the same instance. Without this "
@@ -998,12 +1002,12 @@ msgstr ""
 "こともあります。"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:309
+#: English/Command_line.xml:312
 msgid "<option>/sw</option>"
 msgstr "<option>/sw</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:311
+#: English/Command_line.xml:314
 msgid ""
 "Limit the WinMerge window to one instance as well as the option /s.  "
 "However, it waits for the instance displaying the window to terminate."
@@ -1012,12 +1016,12 @@ msgstr ""
 "ドウを表示しているインスタンスが終了するまで待機します。"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:318
+#: English/Command_line.xml:321
 msgid "<option>/s-</option>"
 msgstr "<option>/s-</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:320
+#: English/Command_line.xml:323
 msgid ""
 "Ensure that another instance is always executed, ignoring the value of the "
 "\"Allow only one instance to run\" option."
@@ -1025,19 +1029,43 @@ msgstr ""
 "\"複数のインスタンスを起動しない\"の設定値を無視して、常に別のインスタンスが"
 "起動されるようにします。"
 
+#. type: Content of: <article><variablelist><varlistentry><indexterm><secondary>
+#: English/Command_line.xml:331
+msgid "instance groups"
+msgstr "インスタンスグループ"
+
+#. type: Content of: <article><variablelist><varlistentry><term>
+#: English/Command_line.xml:334
+#, fuzzy
+#| msgid "<option>/g</option> <replaceable>groupname</replaceable>"
+msgid "<option>/g</option> <replaceable>group-name</replaceable>"
+msgstr "<option>/g</option> <replaceable>グループ名</replaceable>"
+
+#. type: Content of: <article><variablelist><varlistentry><listitem><para>
+#: English/Command_line.xml:337
+msgid ""
+"Specifies a group name for the WinMerge instance. When used with the "
+"<option>/s</option> option, instances with the same group name share the "
+"same window, allowing you to organize multiple single-instance groups."
+msgstr ""
+"WinMerge インスタンスのグループ名を指定します。<option>/s</option> オプション"
+"と組み合わせて使用すると、同じグループ名を指定したインスタンスは同じウィンド"
+"ウを共有します。これにより、複数のシングルインスタンスグループを使用できま"
+"す。"
+
 #. type: Content of: <article><section><qandaset><qandaentry><question><para><indexterm><primary>
-#: English/Command_line.xml:327 English/Configuration.xml:430
+#: English/Command_line.xml:345 English/Configuration.xml:430
 #: English/Faq.xml:114
 msgid "MRU list"
 msgstr "MRU リスト"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:330
+#: English/Command_line.xml:348
 msgid "<option>/ul</option>"
 msgstr "<option>/ul</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:332
+#: English/Command_line.xml:350
 msgid ""
 "Prevents WinMerge from adding the left path to the Most Recently Used (MRU) "
 "list. External applications should not add paths to the MRU list in the "
@@ -1048,12 +1076,12 @@ msgstr ""
 "べきではありません。"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:339
+#: English/Command_line.xml:357
 msgid "<option>/um</option>"
 msgstr "<option>/um</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:341
+#: English/Command_line.xml:359
 msgid ""
 "Prevents WinMerge from adding the middle path to the Most Recently Used "
 "(MRU) list. External applications should not add paths to the MRU list in "
@@ -1064,12 +1092,12 @@ msgstr ""
 "するべきではありません。"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:348
+#: English/Command_line.xml:366
 msgid "<option>/ur</option>"
 msgstr "<option>/ur</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:350
+#: English/Command_line.xml:368
 msgid ""
 "Prevents WinMerge from adding the right path to the Most Recently Used (MRU) "
 "list. External applications should not add paths to the MRU list in the "
@@ -1080,12 +1108,12 @@ msgstr ""
 "べきではありません。"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:357
+#: English/Command_line.xml:375
 msgid "<option>/u</option>"
 msgstr "<option>/u</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:359
+#: English/Command_line.xml:377
 msgid ""
 "Prevents WinMerge from adding either path (left or right) to the Most "
 "Recently Used (MRU) list. External applications should not add paths to the "
@@ -1096,18 +1124,18 @@ msgstr ""
 "フォルダーの選択ダイアログのMRUリストにパスを追加するべきではありません。"
 
 #. type: Content of: <article><section><section><title><indexterm><see>
-#: English/Command_line.xml:368 English/Compare_dirs.xml:741
+#: English/Command_line.xml:386 English/Compare_dirs.xml:741
 #: English/Compare_dirs.xml:745
 msgid "protecting files"
 msgstr "ファイルの保護"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:371
+#: English/Command_line.xml:389
 msgid "<option>/wl</option>"
 msgstr "<option>/wl</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:373
+#: English/Command_line.xml:391
 msgid ""
 "Opens the left side as read-only. Use this when you don't want to change "
 "left side items in the compare."
@@ -1116,12 +1144,12 @@ msgstr ""
 "ください。"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:379
+#: English/Command_line.xml:397
 msgid "<option>/wm</option>"
 msgstr "<option>/wm</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:381
+#: English/Command_line.xml:399
 msgid ""
 "Opens the middle side as read-only. Use this when you don't want to change "
 "right side items in the compare."
@@ -1130,12 +1158,12 @@ msgstr ""
 "ください。"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:387
+#: English/Command_line.xml:405
 msgid "<option>/wr</option>"
 msgstr "<option>/wr</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:389
+#: English/Command_line.xml:407
 msgid ""
 "Opens the right side as read-only. Use this when you don't want to change "
 "right side items in the compare."
@@ -1144,47 +1172,47 @@ msgstr ""
 "ください。"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:395
+#: English/Command_line.xml:413
 msgid "<option>/new</option>"
 msgstr "<option>/new</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:397
+#: English/Command_line.xml:415
 msgid "Opens a new blank window."
 msgstr "新規ブランクウィンドウを開きます。"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:402
+#: English/Command_line.xml:420
 msgid "<option>/self-compare</option>"
 msgstr "<option>/self-compare</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:404
+#: English/Command_line.xml:422
 msgid "Compares the specified file with a copy of the file."
 msgstr "指定された１つのファイルとそのファイルのコピーを比較します。"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:409
+#: English/Command_line.xml:427
 msgid "<option>/clipboard-compare</option>"
 msgstr "<option>/clipboard-compare</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:411
+#: English/Command_line.xml:429
 msgid "Compares the two most recent contents of the clipboard history."
 msgstr "クリップボード履歴の直近2つの内容を比較します。"
 
 #. type: Content of: <article><variablelist><varlistentry><indexterm><secondary>
-#: English/Command_line.xml:418
+#: English/Command_line.xml:436
 msgid "opening minimized or maximized"
 msgstr "最小化または最大化で開く"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:421
+#: English/Command_line.xml:439
 msgid "<option>/minimize</option>"
 msgstr "<option>/minimize</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:423
+#: English/Command_line.xml:441
 msgid ""
 "Starts WinMerge as a minimized window.  This option can be useful during "
 "lengthy compares."
@@ -1193,72 +1221,72 @@ msgstr ""
 "に便利です。"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:429
+#: English/Command_line.xml:447
 msgid "<option>/maximize</option>"
 msgstr "<option>/maximize</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:431
+#: English/Command_line.xml:449
 msgid "Starts WinMerge as a maximized window."
 msgstr "最大化状態でWinMergeを開始します。"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:437
+#: English/Command_line.xml:455
 msgid "<option>/fl</option>"
 msgstr "<option>/fl</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:439
+#: English/Command_line.xml:457
 msgid "Sets focus to the left side at startup."
 msgstr "起動時、左側にフォーカスを当てます。"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:444
+#: English/Command_line.xml:462
 msgid "<option>/fm</option>"
 msgstr "<option>/fm</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:446
+#: English/Command_line.xml:464
 msgid "Sets focus to the middle side at startup."
 msgstr "起動時、中央にフォーカスを当てます。"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:451
+#: English/Command_line.xml:469
 msgid "<option>/fr</option>"
 msgstr "<option>/fr</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:453
+#: English/Command_line.xml:471
 msgid "Sets focus to the right side at startup."
 msgstr "起動時、右側にフォーカスを当てます。"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:458
+#: English/Command_line.xml:476
 msgid "<option>/l <replaceable>linenumber</replaceable></option>"
 msgstr "<option>/l <replaceable>linenumber</replaceable></option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:460
+#: English/Command_line.xml:478
 msgid "Specifies a line number to jump to after loading the files."
 msgstr "ファイルを読み込んだ後にジャンプする行番号を指定します。"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:465
+#: English/Command_line.xml:483
 msgid "<option>/c <replaceable>charpos</replaceable></option>"
 msgstr "<option>/c <replaceable>charpos</replaceable></option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:467
+#: English/Command_line.xml:485
 msgid "Specifies a character position to jump to after loading the files."
 msgstr "ファイルを読み込んだ後にジャンプする文字位置を指定します。"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:472
+#: English/Command_line.xml:490
 msgid "<option>/table-delimiter <replaceable>delimiter</replaceable></option>"
 msgstr "<option>/table-delimiter <replaceable>delimiter</replaceable></option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:474
+#: English/Command_line.xml:492
 msgid ""
 "Specifies a delimiter character for table editing. To specify a tab "
 "character, specify \"tab\", \"\\t\", or \"\\x09\"."
@@ -1267,12 +1295,12 @@ msgstr ""
 "「\\t」、「\\x09」を指定してください。"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:479
+#: English/Command_line.xml:497
 msgid "<option>/dl</option>"
 msgstr "<option>/dl</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:481
+#: English/Command_line.xml:499
 msgid ""
 "Specifies a description in the left side title bar, overriding the default "
 "folder or filename text. For example: <userinput>/dl \"Version 1.0</"
@@ -1285,66 +1313,66 @@ msgstr ""
 "ションマークで括ってください。"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:490
+#: English/Command_line.xml:508
 msgid "<option>/dm</option>"
 msgstr "<option>/dm</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:492
+#: English/Command_line.xml:510
 msgid ""
 "Specifies a description in the middle side title bar, just like <option>/dl</"
 "option>."
 msgstr "<option>/dl</option>と同様に中央タイトルバーの説明を指定します。"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:498
+#: English/Command_line.xml:516
 msgid "<option>/dr</option>"
 msgstr "<option>/dr</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:500
+#: English/Command_line.xml:518
 msgid ""
 "Specifies a description in the right side title bar, just like <option>/dl</"
 "option>."
 msgstr "<option>/dl</option>と同様に右側タイトルバーの説明を指定します。"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:506
+#: English/Command_line.xml:524
 msgid "<option>/al</option>"
 msgstr "<option>/al</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:508
+#: English/Command_line.xml:526
 msgid "Auto-merges at the left side at startup."
 msgstr "起動時、左側で自動マージします。"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:513
+#: English/Command_line.xml:531
 msgid "<option>/am</option>"
 msgstr "<option>/am</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:515
+#: English/Command_line.xml:533
 msgid "Auto-merges at the middle side at startup."
 msgstr "起動時、中央で自動マージします。"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:520
+#: English/Command_line.xml:538
 msgid "<option>/ar</option>"
 msgstr "<option>/ar</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:522
+#: English/Command_line.xml:540
 msgid "Auto-merges at the right side at startup."
 msgstr "起動時、右側で自動マージします。"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:527
+#: English/Command_line.xml:545
 msgid "<option>/noninteractive</option>"
 msgstr "<option>/noninteractive</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:530
+#: English/Command_line.xml:548
 msgid ""
 "Runs WinMerge without displaying message boxes during comparison or report "
 "generation.  The process terminates automatically when the operation is "
@@ -1355,12 +1383,12 @@ msgstr ""
 "しています。"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:538
+#: English/Command_line.xml:556
 msgid "<option>/noprefs</option>"
 msgstr "<option>/noprefs</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:541
+#: English/Command_line.xml:559
 msgid ""
 "Runs WinMerge without loading or saving settings from the registry.  All "
 "comparisons use default preferences only."
@@ -1369,12 +1397,12 @@ msgstr ""
 "ての比較はデフォルトの設定のみを使用します。"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:548
+#: English/Command_line.xml:566
 msgid "<option>/enableexitcode</option>"
 msgstr "<option>/enableexitcode</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:550
+#: English/Command_line.xml:568
 msgid ""
 "Sets the comparison result to the process exit code. 0: identical, 1: "
 "different, 2: error"
@@ -1382,24 +1410,24 @@ msgstr ""
 "比較結果をプロセス終了コードに設定します。0: 同一, 1: 差異あり, 2: エラー"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:555
+#: English/Command_line.xml:573
 msgid "<option>/ignorews</option>"
 msgstr "<option>/ignorews</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:557
+#: English/Command_line.xml:575
 msgid ""
 "Controls the \"Whitespaces\" option (whitespace comparison settings) "
 "persistently:"
 msgstr "「空白」オプションを永続的に制御します:"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:559
+#: English/Command_line.xml:577
 msgid "<option>/ignorews:0</option> - do not ignore whitespace differences."
 msgstr "<option>/ignorews:0</option> - 空白の違いを無視しません。"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:560
+#: English/Command_line.xml:578
 msgid ""
 "<option>/ignorews</option> or <option>/ignorews:1</option> - ignore "
 "differences in the amount of whitespace."
@@ -1408,27 +1436,27 @@ msgstr ""
 "いを無視します。"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:561
+#: English/Command_line.xml:579
 msgid "<option>/ignorews:2</option> - ignore all whitespace characters."
 msgstr "<option>/ignorews:2</option> - すべての空白文字を無視します。"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:567
+#: English/Command_line.xml:585
 msgid "<option>/ignoreblanklines</option>"
 msgstr "<option>/ignoreblanklines</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:569
+#: English/Command_line.xml:587
 msgid "Controls the \"Ignore blank lines\" option persistently:"
 msgstr "「空行を無視する」オプションを永続的に制御します:"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:571
+#: English/Command_line.xml:589
 msgid "<option>/ignoreblanklines:0</option> - disables ignoring blank lines."
 msgstr "<option>/ignoreblanklines:0</option> - 空行を無視しないようにします。"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:572
+#: English/Command_line.xml:590
 msgid ""
 "<option>/ignoreblanklines</option> or <option>/ignoreblanklines:1</option> - "
 "enables ignoring blank lines."
@@ -1437,22 +1465,22 @@ msgstr ""
 "option> - 空行を無視するようにします。"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:578
+#: English/Command_line.xml:596
 msgid "<option>/ignorecase</option>"
 msgstr "<option>/ignorecase</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:580
+#: English/Command_line.xml:598
 msgid "Controls the \"Ignore case\" option persistently:"
 msgstr "「大文字小文字を区別しない」オプションを永続的に制御します:"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:582
+#: English/Command_line.xml:600
 msgid "<option>/ignorecase:0</option> - disables ignoring case differences."
 msgstr "<option>/ignorecase:0</option> - 大文字小文字の違いを無視しません。"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:583
+#: English/Command_line.xml:601
 msgid ""
 "<option>/ignorecase</option> or <option>/ignorecase:1</option> - enables "
 "ignoring case differences."
@@ -1461,22 +1489,22 @@ msgstr ""
 "文字の違いを無視します。"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:589
+#: English/Command_line.xml:607
 msgid "<option>/ignoreeol</option>"
 msgstr "<option>/ignoreeol</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:591
+#: English/Command_line.xml:609
 msgid "Controls the \"Ignore EOL differences\" option persistently:"
 msgstr "「改行文字の違いを無視する」オプションを永続的に制御します:"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:593
+#: English/Command_line.xml:611
 msgid "<option>/ignoreeol:0</option> - disables ignoring EOL differences."
 msgstr "<option>/ignoreeol:0</option> - 改行コードの違いを無視しません。"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:594
+#: English/Command_line.xml:612
 msgid ""
 "<option>/ignoreeol</option> or <option>/ignoreeol:1</option> - enables "
 "ignoring EOL differences."
@@ -1485,24 +1513,24 @@ msgstr ""
 "の違いを無視します。"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:600
+#: English/Command_line.xml:618
 msgid "<option>/ignorecodepage</option>"
 msgstr "<option>/ignorecodepage</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:602
+#: English/Command_line.xml:620
 msgid "Controls the \"Ignore codepage differences\" option persistently:"
 msgstr "「コードページの違いを無視する」オプションを永続的に制御します:"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:604
+#: English/Command_line.xml:622
 msgid ""
 "<option>/ignorecodepage:0</option> - disables ignoring codepage differences."
 msgstr ""
 "<option>/ignorecodepage:0</option> - コードページの違いを無視しません。"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:605
+#: English/Command_line.xml:623
 msgid ""
 "<option>/ignorecodepage</option> or <option>/ignorecodepage:1</option> - "
 "enables ignoring codepage differences."
@@ -1511,22 +1539,22 @@ msgstr ""
 "コードページの違いを無視します。"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:611
+#: English/Command_line.xml:629
 msgid "<option>/ignorecomments</option>"
 msgstr "<option>/ignorecomments</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:613
+#: English/Command_line.xml:631
 msgid "Controls the \"Ignore comment differences\" option persistently:"
 msgstr "「コメントの違いを無視する」オプションを永続的に制御します:"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:615
+#: English/Command_line.xml:633
 msgid "<option>/ignorecomments:0</option> - disables ignoring comments."
 msgstr "<option>/ignorecomments:0</option> - コメントの違いを無視しません。"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:616
+#: English/Command_line.xml:634
 msgid ""
 "<option>/ignorecomments</option> or <option>/ignorecomments:1</option> - "
 "enables ignoring comments."
@@ -1535,13 +1563,13 @@ msgstr ""
 "コメントの違いを無視します。"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:622
+#: English/Command_line.xml:640
 msgid "<option>/unpacker <replaceable>plugin pipeline</replaceable></option>"
 msgstr ""
 "<option>/unpacker <replaceable>プラグインパイプライン</replaceable></option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:625
+#: English/Command_line.xml:643
 msgid ""
 "Specifies the plugin pipeline for the Unpacker plugin.  Example: <option>/"
 "unpacker \"SortAscending|SelectLines 1-10\"</option>"
@@ -1550,13 +1578,13 @@ msgstr ""
 "unpacker \"SortAscending|SelectLines 1-10\"</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:632
+#: English/Command_line.xml:650
 msgid "<option>/prediffer <replaceable>plugin pipeline</replaceable></option>"
 msgstr ""
 "<option>/prediffer <replaceable>プラグインパイプライン</replaceable></option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:635
+#: English/Command_line.xml:653
 msgid ""
 "Specifies the plugin pipeline for the Prediffer plugin.  Example: <option>/"
 "prediffer \"IgnoreColumns 1-10\"</option>"
@@ -1565,12 +1593,12 @@ msgstr ""
 "prediffer \"IgnoreColumns 1-10\"</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:642
+#: English/Command_line.xml:660
 msgid "<option>/cp <replaceable>codepage</replaceable></option>"
 msgstr "<option>/cp <replaceable>コードページ</replaceable></option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:645
+#: English/Command_line.xml:663
 msgid ""
 "Specifies the codepage to use for file comparison.  Example: <option>/cp "
 "65001</option>"
@@ -1579,45 +1607,45 @@ msgstr ""
 "option>"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:652
+#: English/Command_line.xml:670
 msgid "<option>/fileext <replaceable>file-extension</replaceable></option>"
 msgstr "<option>/fileext <replaceable>ファイル拡張子</replaceable></option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:654
+#: English/Command_line.xml:672
 msgid "Specifies a file extension for determining syntax hightliting."
 msgstr ""
 "シンタックスハイライトの種類を決定するため、ファイル拡張子を指定します。"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:659
+#: English/Command_line.xml:677
 msgid "<option>/cfg <replaceable>name=value</replaceable></option>"
 msgstr "<option>/cfg <replaceable>名前=値</replaceable></option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:662
+#: English/Command_line.xml:680
 msgid "Sets a configuration value in the WinMerge registry or INI file."
 msgstr "WinMerge のレジストリまたは INI ファイルに設定値を設定します。"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:665
+#: English/Command_line.xml:683
 msgid "Example: <option>/cfg Settings/DiffAlgorithm=3</option>"
 msgstr "例: <option>/cfg Settings/DiffAlgorithm=3</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:668
+#: English/Command_line.xml:686
 msgid ""
 "If the section name is unambiguous and does not conflict with other setting "
 "names, it can be omitted:"
 msgstr "セクション名が曖昧でなく、他の設定名と衝突しない場合、省略できます:"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:671
+#: English/Command_line.xml:689
 msgid "<option>/cfg DiffAlgo=3</option>"
 msgstr "<option>/cfg DiffAlgo=3</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:674
+#: English/Command_line.xml:692
 msgid ""
 "Note: This entry does not explain which configuration names are available.  "
 "For a list of settings, refer to "
@@ -1629,37 +1657,37 @@ msgstr ""
 "filename> を参照してください。"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:681
+#: English/Command_line.xml:699
 msgid "<option><replaceable>leftpath</replaceable></option>"
 msgstr "<option><replaceable>leftpath</replaceable></option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:683
+#: English/Command_line.xml:701
 msgid "Specifies the folder, file or project file to open on the left side."
 msgstr "左側で開くフォルダーやファイルを指定します。"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:688
+#: English/Command_line.xml:706
 msgid "<option><replaceable>middlepath</replaceable></option>"
 msgstr "<option><replaceable>middlepath</replaceable></option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:690
+#: English/Command_line.xml:708
 msgid "Specifies the folder, file or project file to open on the middle side."
 msgstr "中央で開くフォルダーやファイルを指定します。"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:695
+#: English/Command_line.xml:713
 msgid "<option><replaceable>rightpath</replaceable></option>"
 msgstr "<option><replaceable>rightpath</replaceable></option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:697
+#: English/Command_line.xml:715
 msgid "Specifies the folder, file or project file to open on the right side."
 msgstr "右側で開くフォルダーやファイルを指定します。"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:699
+#: English/Command_line.xml:717
 msgid ""
 "WinMerge cannot compare files to folders, so the path parameters "
 "(<option><replaceable>leftpath</replaceable></option>, "
@@ -1679,7 +1707,7 @@ msgstr ""
 "選択できます。"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><tip><para>
-#: English/Command_line.xml:708
+#: English/Command_line.xml:726
 msgid ""
 "In file comparisons, you can specify a folder name in one of the path "
 "parameters, as long as the folder contains a file with the same name as the "
@@ -1689,12 +1717,12 @@ msgstr ""
 "だし、フォルダーは他方のファイル名と同じファイルを含んでいる必要があります。"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><tip><para>
-#: English/Command_line.xml:712
+#: English/Command_line.xml:730
 msgid "For example, consider this command:"
 msgstr "例えば、以下のコマンドを考えます:"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><tip><para>
-#: English/Command_line.xml:714
+#: English/Command_line.xml:732
 msgid ""
 "<userinput>WinMergeU <filename>C:\\Folder\\File.txt</filename> <filename "
 "class=\"directory\">C:\\Folder2</filename> </userinput>"
@@ -1703,7 +1731,7 @@ msgstr ""
 "class=\"directory\">C:\\Folder2</filename> </userinput>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><tip><para>
-#: English/Command_line.xml:717
+#: English/Command_line.xml:735
 msgid ""
 "If <filename class=\"directory\">C:\\Folder2</filename> contains a file "
 "named <filename>File.txt</filename>: WinMerge implicitly resolves the second "
@@ -1719,23 +1747,23 @@ msgstr ""
 "ば、コマンドは不正とみなされます。"
 
 #. type: Content of: <article><section><section><title><indexterm><primary>
-#: English/Command_line.xml:730 English/Compare_files.xml:1481
+#: English/Command_line.xml:748 English/Compare_files.xml:1481
 #: English/Intro_diffs.xml:253 English/Intro_diffs.xml:407
 msgid "merging differences"
 msgstr "差異をマージする"
 
 #. type: Content of: <article><section><section><title><indexterm><secondary>
-#: English/Command_line.xml:731 English/Intro_diffs.xml:409
+#: English/Command_line.xml:749 English/Intro_diffs.xml:409
 msgid "result file"
 msgstr "結果ファイル"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:734
+#: English/Command_line.xml:752
 msgid "<option>/o <replaceable>outputpath</replaceable></option>"
 msgstr "<option>/o <replaceable>outputpath</replaceable></option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:736
+#: English/Command_line.xml:754
 msgid ""
 "Specifies an optional output file path where you want merged result files to "
 "be saved."
@@ -1743,7 +1771,7 @@ msgstr ""
 "マージした結果のファイルを保存するオプションの出力ファイルパスを指定します。"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:739
+#: English/Command_line.xml:757
 msgid ""
 "The output path is rarely needed when you start WinMerge from the command "
 "line. It is meant to be used with version control tools, where you might "
@@ -1759,7 +1787,7 @@ msgstr ""
 "ファイルは前の状態のままになります。"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:747
+#: English/Command_line.xml:765
 msgid ""
 "Version control systems typically refer to the source and result files using "
 "terms like <glossterm>theirs</glossterm>, <glossterm>mine</glossterm>, and "
@@ -1774,12 +1802,12 @@ msgstr ""
 "ステムと連携するならば、この順番でファイルを並べるべきです。"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:757
+#: English/Command_line.xml:775
 msgid "<option>/or <replaceable>outputpath</replaceable></option>"
 msgstr "<option>/or <replaceable>outputpath</replaceable></option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:760
+#: English/Command_line.xml:778
 msgid ""
 "Outputs a comparison report for files or folders.  Example: "
 "<option>WinMergeU path1 path2 /or c:\\tmp\\report.html</option>"
@@ -1788,24 +1816,24 @@ msgstr ""
 "path1 path2 /or c:\\tmp\\report.html</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:763
+#: English/Command_line.xml:781
 msgid "It is often useful to combine this option with:"
 msgstr "このオプションは以下と組み合わせて使用すると便利です:"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:765
+#: English/Command_line.xml:783
 msgid ""
 "<option>/noninteractive</option> - exits WinMerge after producing the report."
 msgstr ""
 "<option>/noninteractive</option> - レポート出力後に WinMerge を終了します。"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:766
+#: English/Command_line.xml:784
 msgid "<option>/minimize</option> - starts WinMerge in minimized state."
 msgstr "<option>/minimize</option> - WinMerge を最小化状態で開始します。"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:767
+#: English/Command_line.xml:785
 msgid ""
 "<option>/noprefs</option> - ignores the current preferences and uses default "
 "settings.  Any changes made with <option>/cfg</option> will then be "
@@ -1815,7 +1843,7 @@ msgstr ""
 "す。<option>/cfg</option> による変更は一時的なものとなり保存されません。"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:771
+#: English/Command_line.xml:789
 msgid ""
 "The following <option>/cfg</option> settings can also be useful (parameter "
 "names may change in the future):"
@@ -1824,12 +1852,12 @@ msgstr ""
 "る可能性があります）:"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:773
+#: English/Command_line.xml:791
 msgid "For file comparisons:"
 msgstr "ファイル比較の場合:"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:775
+#: English/Command_line.xml:793
 msgid ""
 "<option>/cfg Settings/DiffContextV2=0</option> - hides matching lines in the "
 "report (equivalent to View -> Diff Context -> 0 Lines)."
@@ -1838,7 +1866,7 @@ msgstr ""
 "表示にします (「表示 → Diff コンテキスト → 0 行」と同等)。"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:776
+#: English/Command_line.xml:794
 msgid ""
 "<option>/cfg Settings/ViewLineNumbers=1</option> - outputs line numbers (set "
 "to 0 to disable)."
@@ -1847,12 +1875,12 @@ msgstr ""
 "ると非表示）。"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:778
+#: English/Command_line.xml:796
 msgid "For folder comparisons:"
 msgstr "フォルダー比較の場合:"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:780
+#: English/Command_line.xml:798
 msgid ""
 "<option>/cfg Settings/DirViewExpandSubdirs=1</option> - automatically expand "
 "all subfolders."
@@ -1861,14 +1889,14 @@ msgstr ""
 "に展開します。"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:781
+#: English/Command_line.xml:799
 msgid ""
 "<option>/cfg ReportFiles/ReportType=2</option> - report style: Simple HTML."
 msgstr ""
 "<option>/cfg ReportFiles/ReportType=2</option> - レポート形式: Simple HTML。"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:782
+#: English/Command_line.xml:800
 msgid ""
 "<option>/cfg ReportFiles/IncludeFileCmpReport=1</option> - include file "
 "comparison reports."
@@ -1877,22 +1905,22 @@ msgstr ""
 "トを含めます。"
 
 #. type: Content of: <article><section><section><title><indexterm><primary>
-#: English/Command_line.xml:789 English/Compare_files.xml:1805
+#: English/Command_line.xml:807 English/Compare_files.xml:1805
 msgid "conflict files"
 msgstr "コンフリクトファイル"
 
 #. type: Content of: <article><variablelist><varlistentry><indexterm><secondary>
-#: English/Command_line.xml:790 English/Command_line.xml:806
+#: English/Command_line.xml:808 English/Command_line.xml:824
 msgid "specifying on command line"
 msgstr "コマンドラインでの指定"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:793
+#: English/Command_line.xml:811
 msgid "<option><replaceable>conflictfile</replaceable></option>"
 msgstr "<option><replaceable>conflictfile</replaceable></option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:795
+#: English/Command_line.xml:813
 msgid ""
 "Specifies a conflict file, typically generated by a Version control system. "
 "The conflict file opens in the File Compare window, where you can merge and "
@@ -1906,17 +1934,17 @@ msgstr ""
 "は使用できないことに注意してください。"
 
 #. type: Content of: <article><variablelist><varlistentry><indexterm><primary>
-#: English/Command_line.xml:805
+#: English/Command_line.xml:823
 msgid "ini file"
 msgstr "ini ファイル"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:809
+#: English/Command_line.xml:827
 msgid "<option>/inifile <replaceable>inifile</replaceable></option>"
 msgstr "<option>/inifile <replaceable>inifile</replaceable></option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:811
+#: English/Command_line.xml:829
 msgid ""
 "specifies an INI file used to load and save settings instead of the registry."
 msgstr ""

--- a/Translations/Docs/Manual/Spanish.po
+++ b/Translations/Docs/Manual/Spanish.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/WinMerge/winmerge/issues\n"
-"POT-Creation-Date: 2026-06-25 07:56+0900\n"
+"POT-Creation-Date: 2026-07-20 16:31+0900\n"
 "PO-Revision-Date: 2026-06-21 20:42+0200\n"
 "Last-Translator: P0rsche-911\n"
 "Language-Team: \n"
@@ -619,6 +619,72 @@ msgstr ""
 
 #. type: Content of: <article><para><cmdsynopsis>
 #: English/Command_line.xml:25
+#, fuzzy
+#| msgid ""
+#| "<command>WinMergeU</command> <arg choice=\"opt\" "
+#| "rep=\"norepeat\"><option>/r</option></arg> <arg choice=\"opt\" "
+#| "rep=\"norepeat\"><option>/r-</option></arg> <arg choice=\"opt\" "
+#| "rep=\"norepeat\"><option>/e</option></arg> <arg choice=\"opt\" "
+#| "rep=\"norepeat\"><option>/f</option> <replaceable>filter</replaceable></"
+#| "arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/m</option> "
+#| "<replaceable>compare-method</replaceable></arg> <arg choice=\"opt\" "
+#| "rep=\"norepeat\"><option>/t</option> <replaceable>window-type</"
+#| "replaceable></arg> <arg><option>/x</option></arg> <arg><option>/xq</"
+#| "option></arg> <arg><option>/s</option></arg> <arg><option>/sw</option></"
+#| "arg> <arg><option>/s-</option></arg> <arg choice=\"opt\" "
+#| "rep=\"norepeat\"><option>/ul</option></arg> <arg choice=\"opt\" "
+#| "rep=\"norepeat\"><option>/um</option></arg> <arg choice=\"opt\" "
+#| "rep=\"norepeat\"><option>/ur</option></arg> <arg choice=\"opt\" "
+#| "rep=\"norepeat\"><option>/u</option></arg> <arg choice=\"opt\" "
+#| "rep=\"norepeat\"><option>/wl</option></arg> <arg choice=\"opt\" "
+#| "rep=\"norepeat\"><option>/wm</option></arg> <arg choice=\"opt\" "
+#| "rep=\"norepeat\"><option>/wr</option></arg> <arg choice=\"opt\" "
+#| "rep=\"norepeat\"><option>/new</option></arg> <arg choice=\"opt\" "
+#| "rep=\"norepeat\"><option>/self-compare</option></arg> <arg choice=\"opt\" "
+#| "rep=\"norepeat\"><option>/clipboard-compare</option></arg> <arg><option>/"
+#| "minimize</option></arg> <arg><option>/maximize</option></arg> <arg "
+#| "choice=\"opt\" rep=\"norepeat\"><option>/fl</option></arg> <arg "
+#| "choice=\"opt\" rep=\"norepeat\"><option>/fm</option></arg> <arg "
+#| "choice=\"opt\" rep=\"norepeat\"><option>/fr</option></arg> <arg "
+#| "choice=\"opt\" rep=\"norepeat\"><option>/l</option> "
+#| "<replaceable>linenumber</replaceable></arg> <arg choice=\"opt\" "
+#| "rep=\"norepeat\"><option>/c</option> <replaceable>charpos</replaceable></"
+#| "arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/table-delimiter</"
+#| "option> <replaceable>delimiter</replaceable></arg> <arg choice=\"opt\" "
+#| "rep=\"norepeat\"><option>/dl</option> <replaceable>leftdesc</"
+#| "replaceable></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/dm</"
+#| "option> <replaceable>middledesc</replaceable></arg> <arg choice=\"opt\" "
+#| "rep=\"norepeat\"><option>/dr</option> <replaceable>rightdesc</"
+#| "replaceable></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/al</"
+#| "option></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/am</option></"
+#| "arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/ar</option></arg> <arg "
+#| "choice=\"opt\" rep=\"norepeat\"><option>/noninteractive</option></arg> "
+#| "<arg choice=\"opt\" rep=\"norepeat\"><option>/noprefs</option></arg> <arg "
+#| "choice=\"opt\" rep=\"norepeat\"><option>/enableexitcode</option></arg> "
+#| "<arg choice=\"opt\" rep=\"norepeat\"><option>/ignorews</option></arg> "
+#| "<arg choice=\"opt\" rep=\"norepeat\"><option>/ignoreblanklines</option></"
+#| "arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/ignorecase</option></"
+#| "arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/ignoreeol</option></"
+#| "arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/ignorecodepage</"
+#| "option></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/"
+#| "ignorecomments</option></arg> <arg choice=\"opt\" "
+#| "rep=\"norepeat\"><option>/unpacker</option> <replaceable>unpacker-name</"
+#| "replaceable></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/"
+#| "prediffer</option> <replaceable>prediffer-name</replaceable></arg> <arg "
+#| "choice=\"opt\" rep=\"norepeat\"><option>/cp</option> "
+#| "<replaceable>codepage</replaceable></arg> <arg choice=\"opt\" "
+#| "rep=\"norepeat\"><option>/fileext</option> <replaceable>file-extension</"
+#| "replaceable></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/cfg</"
+#| "option> <replaceable>name=value</replaceable></arg> <arg choice=\"opt\" "
+#| "rep=\"norepeat\"><option>/inifile</option> <replaceable>inifile</"
+#| "replaceable></arg> <arg choice=\"plain\" "
+#| "rep=\"norepeat\"><replaceable>leftpath</replaceable></arg> <arg "
+#| "cchoice=\"opt\" rep=\"norepeat\"><replaceable>middlepath</replaceable></"
+#| "arg> <arg choice=\"plain\" rep=\"norepeat\"><replaceable>rightpath</"
+#| "replaceable></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/o</"
+#| "option> <replaceable>outputpath</replaceable></arg> <arg choice=\"opt\" "
+#| "rep=\"norepeat\"><option>/or</option> <replaceable>reportpath</"
+#| "replaceable></arg>"
 msgid ""
 "<command>WinMergeU</command> <arg choice=\"opt\" rep=\"norepeat\"><option>/"
 "r</option></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/r-</option></"
@@ -629,18 +695,20 @@ msgid ""
 "rep=\"norepeat\"><option>/t</option> <replaceable>window-type</replaceable></"
 "arg> <arg><option>/x</option></arg> <arg><option>/xq</option></arg> "
 "<arg><option>/s</option></arg> <arg><option>/sw</option></arg> <arg><option>/"
-"s-</option></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/ul</option></"
-"arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/um</option></arg> <arg "
-"choice=\"opt\" rep=\"norepeat\"><option>/ur</option></arg> <arg "
-"choice=\"opt\" rep=\"norepeat\"><option>/u</option></arg> <arg "
-"choice=\"opt\" rep=\"norepeat\"><option>/wl</option></arg> <arg "
-"choice=\"opt\" rep=\"norepeat\"><option>/wm</option></arg> <arg "
-"choice=\"opt\" rep=\"norepeat\"><option>/wr</option></arg> <arg "
-"choice=\"opt\" rep=\"norepeat\"><option>/new</option></arg> <arg "
-"choice=\"opt\" rep=\"norepeat\"><option>/self-compare</option></arg> <arg "
-"choice=\"opt\" rep=\"norepeat\"><option>/clipboard-compare</option></arg> "
-"<arg><option>/minimize</option></arg> <arg><option>/maximize</option></arg> "
-"<arg choice=\"opt\" rep=\"norepeat\"><option>/fl</option></arg> <arg "
+"s-</option></arg> <arg choice=\"opt\" rep=\"norepeat\"><option>/g</option> "
+"<replaceable>group-name</replaceable></arg> <arg choice=\"opt\" "
+"rep=\"norepeat\"><option>/ul</option></arg> <arg choice=\"opt\" "
+"rep=\"norepeat\"><option>/um</option></arg> <arg choice=\"opt\" "
+"rep=\"norepeat\"><option>/ur</option></arg> <arg choice=\"opt\" "
+"rep=\"norepeat\"><option>/u</option></arg> <arg choice=\"opt\" "
+"rep=\"norepeat\"><option>/wl</option></arg> <arg choice=\"opt\" "
+"rep=\"norepeat\"><option>/wm</option></arg> <arg choice=\"opt\" "
+"rep=\"norepeat\"><option>/wr</option></arg> <arg choice=\"opt\" "
+"rep=\"norepeat\"><option>/new</option></arg> <arg choice=\"opt\" "
+"rep=\"norepeat\"><option>/self-compare</option></arg> <arg choice=\"opt\" "
+"rep=\"norepeat\"><option>/clipboard-compare</option></arg> <arg><option>/"
+"minimize</option></arg> <arg><option>/maximize</option></arg> <arg "
+"choice=\"opt\" rep=\"norepeat\"><option>/fl</option></arg> <arg "
 "choice=\"opt\" rep=\"norepeat\"><option>/fm</option></arg> <arg "
 "choice=\"opt\" rep=\"norepeat\"><option>/fr</option></arg> <arg "
 "choice=\"opt\" rep=\"norepeat\"><option>/l</option> <replaceable>linenumber</"
@@ -746,7 +814,7 @@ msgstr ""
 "replaceable></arg>"
 
 #. type: Content of: <article><cmdsynopsis>
-#: English/Command_line.xml:162
+#: English/Command_line.xml:165
 msgid ""
 "<command>WinMergeU</command> <arg choice=\"plain\" "
 "rep=\"norepeat\"><replaceable>conflictfile</replaceable></arg>"
@@ -755,7 +823,7 @@ msgstr ""
 "rep=\"norepeat\"><replaceable>Fichero_conflicto</replaceable></arg>"
 
 #. type: Content of: <article><para>
-#: English/Command_line.xml:168
+#: English/Command_line.xml:171
 msgid ""
 "Entering the command with no parameters or pathnames simply opens the "
 "WinMerge window. Parameters are prefixed with either a forward slash "
@@ -768,29 +836,29 @@ msgstr ""
 "nombres de ruta no tienen ningún carácter de prefijo."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:175
+#: English/Command_line.xml:178
 msgid "<option>/?</option>"
 msgstr "<option>/?</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:177
+#: English/Command_line.xml:180
 msgid "Opens WinMerge Help at this topic."
 msgstr "Abre la ayuda de WinMerge en este tema."
 
 #. type: Content of: <article><section><section><title><indexterm><seealso>
-#: English/Command_line.xml:183 English/Compare_dirs.xml:54
+#: English/Command_line.xml:186 English/Compare_dirs.xml:54
 #: English/Compare_dirs.xml:254 English/Open_paths.xml:288
 #: English/Open_paths.xml:294
 msgid "recursive folder compare"
 msgstr "comparación recursiva de carpetas"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:185
+#: English/Command_line.xml:188
 msgid "<option>/r</option>"
 msgstr "<option>/r</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:187
+#: English/Command_line.xml:190
 msgid ""
 "Compares all files in all subfolders (recursive compare). Unique folders "
 "(occurring only on one side) are listed in the compare result as separate "
@@ -808,17 +876,17 @@ msgstr ""
 "las subcarpetas."
 
 #. type: Content of: <article><variablelist><varlistentry><indexterm><primary>
-#: English/Command_line.xml:198
+#: English/Command_line.xml:201
 msgid "non-recursive folder compare"
 msgstr "comparación no recursiva de carpetas"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:200
+#: English/Command_line.xml:203
 msgid "<option>/r-</option>"
 msgstr "<option>/r-</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:202
+#: English/Command_line.xml:205
 msgid ""
 "Compares all files within the specified folders but excludes the files and "
 "subfolders within its subfolders.  This allows for a shorter comparison time."
@@ -828,24 +896,24 @@ msgstr ""
 "reducir el tiempo de comparación."
 
 #. type: Content of: <article><section><section><title><indexterm><primary>
-#: English/Command_line.xml:210 English/Command_line.xml:294
-#: English/Command_line.xml:417 English/Configuration.xml:277
-#: English/Quick_start.xml:22
+#: English/Command_line.xml:213 English/Command_line.xml:297
+#: English/Command_line.xml:330 English/Command_line.xml:435
+#: English/Configuration.xml:277 English/Quick_start.xml:22
 msgid "WinMerge window"
 msgstr "Ventana WinMerge"
 
 #. type: Content of: <article><variablelist><varlistentry><indexterm><secondary>
-#: English/Command_line.xml:211
+#: English/Command_line.xml:214
 msgid "closing"
 msgstr "cierre"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:214
+#: English/Command_line.xml:217
 msgid "<option>/e</option>"
 msgstr "<option>/e</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:216
+#: English/Command_line.xml:219
 msgid ""
 "Enables you to close WinMerge with a single <keycap>Esc</keycap> key press. "
 "This is useful when you use WinMerge as an external compare application: you "
@@ -859,7 +927,7 @@ msgstr ""
 "keycap> varias veces para cerrar todas las ventanas."
 
 #. type: Content of: <article><section><section><title><indexterm><primary>
-#: English/Command_line.xml:226 English/Configuration.xml:820
+#: English/Command_line.xml:229 English/Configuration.xml:820
 #: English/Configuration.xml:848 English/Configuration.xml:871
 #: English/Filters.xml:4 English/Filters.xml:96 English/Filters.xml:100
 #: English/Filters.xml:142 English/Filters.xml:1609 English/Filters.xml:1613
@@ -870,18 +938,18 @@ msgid "filters"
 msgstr "filtros"
 
 #. type: Content of: <article><variablelist><varlistentry><indexterm><secondary>
-#: English/Command_line.xml:227 English/Command_line.xml:243
-#: English/Command_line.xml:259
+#: English/Command_line.xml:230 English/Command_line.xml:246
+#: English/Command_line.xml:262
 msgid "applying in command line"
 msgstr "aplicación en la línea de comandos"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:230
+#: English/Command_line.xml:233
 msgid "<option>/f</option>"
 msgstr "<option>/f</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:232
+#: English/Command_line.xml:235
 msgid ""
 "Applies a specified filter to restrict the comparison. The filter can be a "
 "filemask like <filename><userinput>*.h *.cpp</userinput></filename>, or the "
@@ -895,17 +963,17 @@ msgstr ""
 "si contienen espacios."
 
 #. type: Content of: <article><variablelist><varlistentry><indexterm><primary>
-#: English/Command_line.xml:242
+#: English/Command_line.xml:245
 msgid "compare method"
 msgstr "método de comparación"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:246
+#: English/Command_line.xml:249
 msgid "<option>/m <replaceable>compare-method</replaceable></option>"
 msgstr "<option>/m <replaceable>método-comparación</replaceable></option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:248
+#: English/Command_line.xml:251
 msgid ""
 "Sets the compare method to use for the comparison.  This can be one of the "
 "keywords <userinput>Full</userinput>, <userinput>Quick</userinput>, "
@@ -921,17 +989,17 @@ msgstr ""
 "(Tamaño) o <userinput>Existence</userinput> (Existencia)."
 
 #. type: Content of: <article><variablelist><varlistentry><indexterm><primary>
-#: English/Command_line.xml:258
+#: English/Command_line.xml:261
 msgid "window type"
 msgstr "tipo de ventana"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:262
+#: English/Command_line.xml:265
 msgid "<option>/t <replaceable>window-type</replaceable></option>"
 msgstr "<option>/t <replaceable>tipo_ventana</replaceable></option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:264
+#: English/Command_line.xml:267
 msgid ""
 "Specifies the type of window in which to display files.  This can be one of "
 "the keywords <userinput>Text</userinput>, <userinput>Table</userinput>, "
@@ -945,12 +1013,12 @@ msgstr ""
 "userinput> (Página web)."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:272
+#: English/Command_line.xml:275
 msgid "<option>/x</option>"
 msgstr "<option>/x</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:274
+#: English/Command_line.xml:277
 msgid ""
 "Closes WinMerge (after displaying an information dialog) when you start a "
 "comparison of identical files. The parameter has no effect after the "
@@ -968,12 +1036,12 @@ msgstr ""
 "presentan diferencias."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:285
+#: English/Command_line.xml:288
 msgid "<option>/xq</option>"
 msgstr "<option>/xq</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:287
+#: English/Command_line.xml:290
 msgid ""
 "Is similar to <option>/x</option> but does not show the message about "
 "identical files."
@@ -982,17 +1050,17 @@ msgstr ""
 "idénticos."
 
 #. type: Content of: <article><section><section><title><indexterm><secondary>
-#: English/Command_line.xml:295 English/Configuration.xml:279
+#: English/Command_line.xml:298 English/Configuration.xml:279
 msgid "limiting instances"
 msgstr "limitación de instancias"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:298
+#: English/Command_line.xml:301
 msgid "<option>/s</option>"
 msgstr "<option>/s</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:300
+#: English/Command_line.xml:303
 msgid ""
 "Limits WinMerge windows to a single instance.  For example, if WinMerge is "
 "already running, a new compare opens in the same instance. Without this "
@@ -1006,12 +1074,12 @@ msgstr ""
 "en una nueva ventana."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:309
+#: English/Command_line.xml:312
 msgid "<option>/sw</option>"
 msgstr "<option>/sw</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:311
+#: English/Command_line.xml:314
 msgid ""
 "Limit the WinMerge window to one instance as well as the option /s.  "
 "However, it waits for the instance displaying the window to terminate."
@@ -1021,12 +1089,12 @@ msgstr ""
 "la ventana."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:318
+#: English/Command_line.xml:321
 msgid "<option>/s-</option>"
 msgstr "<option>/s-</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:320
+#: English/Command_line.xml:323
 msgid ""
 "Ensure that another instance is always executed, ignoring the value of the "
 "\"Allow only one instance to run\" option."
@@ -1034,19 +1102,39 @@ msgstr ""
 "Asegúrese de que siempre se ejecute otra instancia, ignorando el valor de la "
 "opción \"Permitir que se ejecute solo una instancia\"."
 
+#. type: Content of: <article><variablelist><varlistentry><indexterm><secondary>
+#: English/Command_line.xml:331
+msgid "instance groups"
+msgstr ""
+
+#. type: Content of: <article><variablelist><varlistentry><term>
+#: English/Command_line.xml:334
+#, fuzzy
+#| msgid "<option>/cp <replaceable>codepage</replaceable></option>"
+msgid "<option>/g</option> <replaceable>group-name</replaceable>"
+msgstr "<option>/cp <replaceable>Codificación</replaceable></option>"
+
+#. type: Content of: <article><variablelist><varlistentry><listitem><para>
+#: English/Command_line.xml:337
+msgid ""
+"Specifies a group name for the WinMerge instance. When used with the "
+"<option>/s</option> option, instances with the same group name share the "
+"same window, allowing you to organize multiple single-instance groups."
+msgstr ""
+
 #. type: Content of: <article><section><qandaset><qandaentry><question><para><indexterm><primary>
-#: English/Command_line.xml:327 English/Configuration.xml:430
+#: English/Command_line.xml:345 English/Configuration.xml:430
 #: English/Faq.xml:114
 msgid "MRU list"
 msgstr "Lista MRU"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:330
+#: English/Command_line.xml:348
 msgid "<option>/ul</option>"
 msgstr "<option>/ul</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:332
+#: English/Command_line.xml:350
 msgid ""
 "Prevents WinMerge from adding the left path to the Most Recently Used (MRU) "
 "list. External applications should not add paths to the MRU list in the "
@@ -1058,12 +1146,12 @@ msgstr ""
 "carpetas."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:339
+#: English/Command_line.xml:357
 msgid "<option>/um</option>"
 msgstr "<option>/um</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:341
+#: English/Command_line.xml:359
 msgid ""
 "Prevents WinMerge from adding the middle path to the Most Recently Used "
 "(MRU) list. External applications should not add paths to the MRU list in "
@@ -1074,12 +1162,12 @@ msgstr ""
 "la lista MRU en el cuadro de diálogo Seleccionar archivos o carpetas."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:348
+#: English/Command_line.xml:366
 msgid "<option>/ur</option>"
 msgstr "<option>/ur</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:350
+#: English/Command_line.xml:368
 msgid ""
 "Prevents WinMerge from adding the right path to the Most Recently Used (MRU) "
 "list. External applications should not add paths to the MRU list in the "
@@ -1090,12 +1178,12 @@ msgstr ""
 "la lista MRU en el cuadro de diálogo Seleccionar archivos o carpetas."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:357
+#: English/Command_line.xml:375
 msgid "<option>/u</option>"
 msgstr "<option>/u</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:359
+#: English/Command_line.xml:377
 msgid ""
 "Prevents WinMerge from adding either path (left or right) to the Most "
 "Recently Used (MRU) list. External applications should not add paths to the "
@@ -1107,18 +1195,18 @@ msgstr ""
 "Seleccionar archivos o carpetas."
 
 #. type: Content of: <article><section><section><title><indexterm><see>
-#: English/Command_line.xml:368 English/Compare_dirs.xml:741
+#: English/Command_line.xml:386 English/Compare_dirs.xml:741
 #: English/Compare_dirs.xml:745
 msgid "protecting files"
 msgstr "protección de archivos"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:371
+#: English/Command_line.xml:389
 msgid "<option>/wl</option>"
 msgstr "<option>/wl</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:373
+#: English/Command_line.xml:391
 msgid ""
 "Opens the left side as read-only. Use this when you don't want to change "
 "left side items in the compare."
@@ -1127,12 +1215,12 @@ msgstr ""
 "los elementos del panel izquierdo en la comparación."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:379
+#: English/Command_line.xml:397
 msgid "<option>/wm</option>"
 msgstr "<option>/wm</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:381
+#: English/Command_line.xml:399
 msgid ""
 "Opens the middle side as read-only. Use this when you don't want to change "
 "right side items in the compare."
@@ -1141,12 +1229,12 @@ msgstr ""
 "los elementos del panel central en la comparación."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:387
+#: English/Command_line.xml:405
 msgid "<option>/wr</option>"
 msgstr "<option>/wr</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:389
+#: English/Command_line.xml:407
 msgid ""
 "Opens the right side as read-only. Use this when you don't want to change "
 "right side items in the compare."
@@ -1155,48 +1243,48 @@ msgstr ""
 "los elementos del panel derecho en la comparación."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:395
+#: English/Command_line.xml:413
 msgid "<option>/new</option>"
 msgstr "<option>/new</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:397
+#: English/Command_line.xml:415
 msgid "Opens a new blank window."
 msgstr "Abre una nueva ventana en blanco."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:402
+#: English/Command_line.xml:420
 msgid "<option>/self-compare</option>"
 msgstr "<option>/self-compare</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:404
+#: English/Command_line.xml:422
 msgid "Compares the specified file with a copy of the file."
 msgstr "Compara el archivo especificado con una copia del archivo."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:409
+#: English/Command_line.xml:427
 msgid "<option>/clipboard-compare</option>"
 msgstr "<option>/clipboard-compare</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:411
+#: English/Command_line.xml:429
 msgid "Compares the two most recent contents of the clipboard history."
 msgstr ""
 "Compara los dos contenidos más recientes del historial del portapapeles."
 
 #. type: Content of: <article><variablelist><varlistentry><indexterm><secondary>
-#: English/Command_line.xml:418
+#: English/Command_line.xml:436
 msgid "opening minimized or maximized"
 msgstr "apertura minimizada o maximizada"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:421
+#: English/Command_line.xml:439
 msgid "<option>/minimize</option>"
 msgstr "<option>/minimize</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:423
+#: English/Command_line.xml:441
 msgid ""
 "Starts WinMerge as a minimized window.  This option can be useful during "
 "lengthy compares."
@@ -1205,76 +1293,76 @@ msgstr ""
 "durante comparaciones largas."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:429
+#: English/Command_line.xml:447
 msgid "<option>/maximize</option>"
 msgstr "<option>/maximize</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:431
+#: English/Command_line.xml:449
 msgid "Starts WinMerge as a maximized window."
 msgstr "Inicia WinMerge con la ventana maximizada."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:437
+#: English/Command_line.xml:455
 msgid "<option>/fl</option>"
 msgstr "<option>/fl</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:439
+#: English/Command_line.xml:457
 msgid "Sets focus to the left side at startup."
 msgstr "Establece el foco en el panel izquierdo al iniciar."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:444
+#: English/Command_line.xml:462
 msgid "<option>/fm</option>"
 msgstr "<option>/fm</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:446
+#: English/Command_line.xml:464
 msgid "Sets focus to the middle side at startup."
 msgstr "Establece el foco en el panel central al iniciar."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:451
+#: English/Command_line.xml:469
 msgid "<option>/fr</option>"
 msgstr "<option>/fr</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:453
+#: English/Command_line.xml:471
 msgid "Sets focus to the right side at startup."
 msgstr "Establece el foco en el panel derecho al iniciar."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:458
+#: English/Command_line.xml:476
 msgid "<option>/l <replaceable>linenumber</replaceable></option>"
 msgstr "<option>/l <replaceable>númerolínea</replaceable></option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:460
+#: English/Command_line.xml:478
 msgid "Specifies a line number to jump to after loading the files."
 msgstr ""
 "Especifica un número de línea al que saltar después de cargar los archivos."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:465
+#: English/Command_line.xml:483
 msgid "<option>/c <replaceable>charpos</replaceable></option>"
 msgstr "<option>/c <replaceable>posicarácter</replaceable></option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:467
+#: English/Command_line.xml:485
 msgid "Specifies a character position to jump to after loading the files."
 msgstr ""
 "Especifica una posición de carácter a la que saltar después de cargar los "
 "archivos."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:472
+#: English/Command_line.xml:490
 msgid "<option>/table-delimiter <replaceable>delimiter</replaceable></option>"
 msgstr ""
 "<option>/table-delimiter <replaceable>delimitador</replaceable></option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:474
+#: English/Command_line.xml:492
 msgid ""
 "Specifies a delimiter character for table editing. To specify a tab "
 "character, specify \"tab\", \"\\t\", or \"\\x09\"."
@@ -1284,12 +1372,12 @@ msgstr ""
 "\"\\x09\"."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:479
+#: English/Command_line.xml:497
 msgid "<option>/dl</option>"
 msgstr "<option>/dl</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:481
+#: English/Command_line.xml:499
 msgid ""
 "Specifies a description in the left side title bar, overriding the default "
 "folder or filename text. For example: <userinput>/dl \"Version 1.0</"
@@ -1303,12 +1391,12 @@ msgstr ""
 "contengan espacios."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:490
+#: English/Command_line.xml:508
 msgid "<option>/dm</option>"
 msgstr "<option>/dm</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:492
+#: English/Command_line.xml:510
 msgid ""
 "Specifies a description in the middle side title bar, just like <option>/dl</"
 "option>."
@@ -1317,12 +1405,12 @@ msgstr ""
 "<option>/dl</option>."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:498
+#: English/Command_line.xml:516
 msgid "<option>/dr</option>"
 msgstr "<option>/dr</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:500
+#: English/Command_line.xml:518
 msgid ""
 "Specifies a description in the right side title bar, just like <option>/dl</"
 "option>."
@@ -1331,42 +1419,42 @@ msgstr ""
 "que <option>/dl</option>."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:506
+#: English/Command_line.xml:524
 msgid "<option>/al</option>"
 msgstr "<option>/al</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:508
+#: English/Command_line.xml:526
 msgid "Auto-merges at the left side at startup."
 msgstr "Se fusiona automáticamente en el lado izquierdo al iniciar."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:513
+#: English/Command_line.xml:531
 msgid "<option>/am</option>"
 msgstr "<option>/am</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:515
+#: English/Command_line.xml:533
 msgid "Auto-merges at the middle side at startup."
 msgstr "Se fusiona automáticamente en el central al iniciar."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:520
+#: English/Command_line.xml:538
 msgid "<option>/ar</option>"
 msgstr "<option>/ar</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:522
+#: English/Command_line.xml:540
 msgid "Auto-merges at the right side at startup."
 msgstr "Se fusiona automáticamente en el lado derecho al iniciar."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:527
+#: English/Command_line.xml:545
 msgid "<option>/noninteractive</option>"
 msgstr "<option>/noninteractive</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:530
+#: English/Command_line.xml:548
 msgid ""
 "Runs WinMerge without displaying message boxes during comparison or report "
 "generation.  The process terminates automatically when the operation is "
@@ -1378,12 +1466,12 @@ msgstr ""
 "mediante guiones."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:538
+#: English/Command_line.xml:556
 msgid "<option>/noprefs</option>"
 msgstr "<option>/noprefs</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:541
+#: English/Command_line.xml:559
 msgid ""
 "Runs WinMerge without loading or saving settings from the registry.  All "
 "comparisons use default preferences only."
@@ -1392,12 +1480,12 @@ msgstr ""
 "Todas las comparaciones utilizan únicamente las preferencias predeterminadas."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:548
+#: English/Command_line.xml:566
 msgid "<option>/enableexitcode</option>"
 msgstr "<option>/enableexitcode</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:550
+#: English/Command_line.xml:568
 msgid ""
 "Sets the comparison result to the process exit code. 0: identical, 1: "
 "different, 2: error"
@@ -1406,12 +1494,12 @@ msgstr ""
 "0: idéntico, 1: diferente, 2: error"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:555
+#: English/Command_line.xml:573
 msgid "<option>/ignorews</option>"
 msgstr "<option>/ignorews</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:557
+#: English/Command_line.xml:575
 msgid ""
 "Controls the \"Whitespaces\" option (whitespace comparison settings) "
 "persistently:"
@@ -1420,14 +1508,14 @@ msgstr ""
 "espacios en blanco) de forma persistente:"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:559
+#: English/Command_line.xml:577
 msgid "<option>/ignorews:0</option> - do not ignore whitespace differences."
 msgstr ""
 "<option>/ignorews:0</option> - no ignorar las diferencias en los espacios en "
 "blanco."
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:560
+#: English/Command_line.xml:578
 msgid ""
 "<option>/ignorews</option> or <option>/ignorews:1</option> - ignore "
 "differences in the amount of whitespace."
@@ -1436,31 +1524,31 @@ msgstr ""
 "diferencias en la cantidad de espacios en blanco."
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:561
+#: English/Command_line.xml:579
 msgid "<option>/ignorews:2</option> - ignore all whitespace characters."
 msgstr ""
 "<option>/ignorews:2</option> - ignora todos los caracteres de espacio en "
 "blanco."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:567
+#: English/Command_line.xml:585
 msgid "<option>/ignoreblanklines</option>"
 msgstr "<option>/ignoreblanklines</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:569
+#: English/Command_line.xml:587
 msgid "Controls the \"Ignore blank lines\" option persistently:"
 msgstr "Controla la opción \"Ignorar líneas en blanco\" de forma persistente:"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:571
+#: English/Command_line.xml:589
 msgid "<option>/ignoreblanklines:0</option> - disables ignoring blank lines."
 msgstr ""
 "<option>/ignoreblanklines:0</option> - desactiva la opción de ignorar líneas "
 "en blanco."
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:572
+#: English/Command_line.xml:590
 msgid ""
 "<option>/ignoreblanklines</option> or <option>/ignoreblanklines:1</option> - "
 "enables ignoring blank lines."
@@ -1469,25 +1557,25 @@ msgstr ""
 "permite ignorar las líneas en blanco."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:578
+#: English/Command_line.xml:596
 msgid "<option>/ignorecase</option>"
 msgstr "<option>/ignorecase</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:580
+#: English/Command_line.xml:598
 msgid "Controls the \"Ignore case\" option persistently:"
 msgstr ""
 "Controla la opción \"Ignorar mayúsculas y minúsculas\" de forma persistente:"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:582
+#: English/Command_line.xml:600
 msgid "<option>/ignorecase:0</option> - disables ignoring case differences."
 msgstr ""
 "<option>/ignorecase:0</option> - desactiva la opción de ignorar las "
 "diferencias entre mayúsculas y minúsculas."
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:583
+#: English/Command_line.xml:601
 msgid ""
 "<option>/ignorecase</option> or <option>/ignorecase:1</option> - enables "
 "ignoring case differences."
@@ -1496,26 +1584,26 @@ msgstr ""
 "ignorar las diferencias entre mayúsculas y minúsculas."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:589
+#: English/Command_line.xml:607
 msgid "<option>/ignoreeol</option>"
 msgstr "<option>/ignoreeol</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:591
+#: English/Command_line.xml:609
 msgid "Controls the \"Ignore EOL differences\" option persistently:"
 msgstr ""
 "Controla la opción \"Ignorar diferencias de fin de línea\" de forma "
 "persistente:"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:593
+#: English/Command_line.xml:611
 msgid "<option>/ignoreeol:0</option> - disables ignoring EOL differences."
 msgstr ""
 "<option>/ignoreeol:0</option> - Desactiva la opción de ignorar las "
 "diferencias de fin de línea."
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:594
+#: English/Command_line.xml:612
 msgid ""
 "<option>/ignoreeol</option> or <option>/ignoreeol:1</option> - enables "
 "ignoring EOL differences."
@@ -1524,19 +1612,19 @@ msgstr ""
 "ignorar las diferencias de fin de línea."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:600
+#: English/Command_line.xml:618
 msgid "<option>/ignorecodepage</option>"
 msgstr "<option>/ignorecodepage</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:602
+#: English/Command_line.xml:620
 msgid "Controls the \"Ignore codepage differences\" option persistently:"
 msgstr ""
 "Controla la opción \"Ignorar diferencias de codificación\" de forma "
 "persistente:"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:604
+#: English/Command_line.xml:622
 msgid ""
 "<option>/ignorecodepage:0</option> - disables ignoring codepage differences."
 msgstr ""
@@ -1544,7 +1632,7 @@ msgstr ""
 "diferencias de codificación."
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:605
+#: English/Command_line.xml:623
 msgid ""
 "<option>/ignorecodepage</option> or <option>/ignorecodepage:1</option> - "
 "enables ignoring codepage differences."
@@ -1553,26 +1641,26 @@ msgstr ""
 "permite ignorar las diferencias de codificación."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:611
+#: English/Command_line.xml:629
 msgid "<option>/ignorecomments</option>"
 msgstr "<option>/ignorecomments</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:613
+#: English/Command_line.xml:631
 msgid "Controls the \"Ignore comment differences\" option persistently:"
 msgstr ""
 "Controla la opción \"Ignorar diferencias en los comentarios\" de forma "
 "persistente:"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:615
+#: English/Command_line.xml:633
 msgid "<option>/ignorecomments:0</option> - disables ignoring comments."
 msgstr ""
 "<option>/ignorecomments:0</option> - desactiva la opción de ignorar los "
 "comentarios."
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:616
+#: English/Command_line.xml:634
 msgid ""
 "<option>/ignorecomments</option> or <option>/ignorecomments:1</option> - "
 "enables ignoring comments."
@@ -1581,14 +1669,14 @@ msgstr ""
 "permite ignorar los comentarios."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:622
+#: English/Command_line.xml:640
 msgid "<option>/unpacker <replaceable>plugin pipeline</replaceable></option>"
 msgstr ""
 "<option>/unpacker <replaceable>secuencia de complementos</replaceable></"
 "option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:625
+#: English/Command_line.xml:643
 msgid ""
 "Specifies the plugin pipeline for the Unpacker plugin.  Example: <option>/"
 "unpacker \"SortAscending|SelectLines 1-10\"</option>"
@@ -1597,14 +1685,14 @@ msgstr ""
 "Example: <option>/unpacker \"SortAscending|SelectLines 1-10\"</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:632
+#: English/Command_line.xml:650
 msgid "<option>/prediffer <replaceable>plugin pipeline</replaceable></option>"
 msgstr ""
 "<option>/prediffer <replaceable>secuencia de complementos</replaceable></"
 "option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:635
+#: English/Command_line.xml:653
 msgid ""
 "Specifies the plugin pipeline for the Prediffer plugin.  Example: <option>/"
 "prediffer \"IgnoreColumns 1-10\"</option>"
@@ -1613,12 +1701,12 @@ msgstr ""
 "Example: <option>/prediffer \"IgnoreColumns 1-10\"</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:642
+#: English/Command_line.xml:660
 msgid "<option>/cp <replaceable>codepage</replaceable></option>"
 msgstr "<option>/cp <replaceable>Codificación</replaceable></option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:645
+#: English/Command_line.xml:663
 msgid ""
 "Specifies the codepage to use for file comparison.  Example: <option>/cp "
 "65001</option>"
@@ -1627,35 +1715,35 @@ msgstr ""
 "Ejemplo: <option>/cp 65001</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:652
+#: English/Command_line.xml:670
 msgid "<option>/fileext <replaceable>file-extension</replaceable></option>"
 msgstr "<option>/fileext <replaceable>extensión-fichero</replaceable></option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:654
+#: English/Command_line.xml:672
 msgid "Specifies a file extension for determining syntax hightliting."
 msgstr ""
 "Especifica una extensión de archivo para determinar el resaltado de sintaxis."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:659
+#: English/Command_line.xml:677
 msgid "<option>/cfg <replaceable>name=value</replaceable></option>"
 msgstr "<option>/cfg <replaceable>nombre=valor</replaceable></option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:662
+#: English/Command_line.xml:680
 msgid "Sets a configuration value in the WinMerge registry or INI file."
 msgstr ""
 "Establece un valor de configuración en el registro de WinMerge o en el "
 "archivo .INI."
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:665
+#: English/Command_line.xml:683
 msgid "Example: <option>/cfg Settings/DiffAlgorithm=3</option>"
 msgstr "Ejemplo: <option>/cfg Settings/DiffAlgorithm=3</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:668
+#: English/Command_line.xml:686
 msgid ""
 "If the section name is unambiguous and does not conflict with other setting "
 "names, it can be omitted:"
@@ -1664,12 +1752,12 @@ msgstr ""
 "nombres de configuración, se puede omitir:"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:671
+#: English/Command_line.xml:689
 msgid "<option>/cfg DiffAlgo=3</option>"
 msgstr "<option>/cfg DiffAlgo=3</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:674
+#: English/Command_line.xml:692
 msgid ""
 "Note: This entry does not explain which configuration names are available.  "
 "For a list of settings, refer to "
@@ -1682,43 +1770,43 @@ msgstr ""
 "en el Registro (regedit)."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:681
+#: English/Command_line.xml:699
 msgid "<option><replaceable>leftpath</replaceable></option>"
 msgstr "<option><replaceable>ladoizquierdo</replaceable></option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:683
+#: English/Command_line.xml:701
 msgid "Specifies the folder, file or project file to open on the left side."
 msgstr ""
 "Especifica la carpeta, el archivo o el archivo de proyecto que se abrirá en "
 "el lado izquierdo."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:688
+#: English/Command_line.xml:706
 msgid "<option><replaceable>middlepath</replaceable></option>"
 msgstr "<option><replaceable>central</replaceable></option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:690
+#: English/Command_line.xml:708
 msgid "Specifies the folder, file or project file to open on the middle side."
 msgstr ""
 "Especifica la carpeta, el archivo o el archivo de proyecto que se abrirá en "
 "la parte central."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:695
+#: English/Command_line.xml:713
 msgid "<option><replaceable>rightpath</replaceable></option>"
 msgstr "<option><replaceable>ladoderecho</replaceable></option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:697
+#: English/Command_line.xml:715
 msgid "Specifies the folder, file or project file to open on the right side."
 msgstr ""
 "Especifica la carpeta, el archivo o el archivo de proyecto que se abrirá en "
 "el lado derecho."
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:699
+#: English/Command_line.xml:717
 msgid ""
 "WinMerge cannot compare files to folders, so the path parameters "
 "(<option><replaceable>leftpath</replaceable></option>, "
@@ -1737,7 +1825,7 @@ msgstr ""
 "Seleccionar archivos o carpetas, donde puede buscar las rutas correctas."
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><tip><para>
-#: English/Command_line.xml:708
+#: English/Command_line.xml:726
 msgid ""
 "In file comparisons, you can specify a folder name in one of the path "
 "parameters, as long as the folder contains a file with the same name as the "
@@ -1748,12 +1836,12 @@ msgstr ""
 "archivo con el mismo nombre que el especificado en la otra ruta de archivo."
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><tip><para>
-#: English/Command_line.xml:712
+#: English/Command_line.xml:730
 msgid "For example, consider this command:"
 msgstr "Por ejemplo, consideremos este comando:"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><tip><para>
-#: English/Command_line.xml:714
+#: English/Command_line.xml:732
 msgid ""
 "<userinput>WinMergeU <filename>C:\\Folder\\File.txt</filename> <filename "
 "class=\"directory\">C:\\Folder2</filename> </userinput>"
@@ -1762,7 +1850,7 @@ msgstr ""
 "class=\"directory\">C:\\Carpeta2</filename> </userinput>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><tip><para>
-#: English/Command_line.xml:717
+#: English/Command_line.xml:735
 msgid ""
 "If <filename class=\"directory\">C:\\Folder2</filename> contains a file "
 "named <filename>File.txt</filename>: WinMerge implicitly resolves the second "
@@ -1779,23 +1867,23 @@ msgstr ""
 "un archivo llamado <filename>Fichero.txt</filename>."
 
 #. type: Content of: <article><section><section><title><indexterm><primary>
-#: English/Command_line.xml:730 English/Compare_files.xml:1481
+#: English/Command_line.xml:748 English/Compare_files.xml:1481
 #: English/Intro_diffs.xml:253 English/Intro_diffs.xml:407
 msgid "merging differences"
 msgstr "combinar diferencias"
 
 #. type: Content of: <article><section><section><title><indexterm><secondary>
-#: English/Command_line.xml:731 English/Intro_diffs.xml:409
+#: English/Command_line.xml:749 English/Intro_diffs.xml:409
 msgid "result file"
 msgstr "archivo de resultados"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:734
+#: English/Command_line.xml:752
 msgid "<option>/o <replaceable>outputpath</replaceable></option>"
 msgstr "<option>/o <replaceable>rutasalida</replaceable></option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:736
+#: English/Command_line.xml:754
 msgid ""
 "Specifies an optional output file path where you want merged result files to "
 "be saved."
@@ -1804,7 +1892,7 @@ msgstr ""
 "archivos de resultados combinados."
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:739
+#: English/Command_line.xml:757
 msgid ""
 "The output path is rarely needed when you start WinMerge from the command "
 "line. It is meant to be used with version control tools, where you might "
@@ -1823,7 +1911,7 @@ msgstr ""
 "o tres archivos de origen."
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:747
+#: English/Command_line.xml:765
 msgid ""
 "Version control systems typically refer to the source and result files using "
 "terms like <glossterm>theirs</glossterm>, <glossterm>mine</glossterm>, and "
@@ -1839,12 +1927,12 @@ msgstr ""
 "sistema de control de versiones, debe enumerar los archivos en ese orden."
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:757
+#: English/Command_line.xml:775
 msgid "<option>/or <replaceable>outputpath</replaceable></option>"
 msgstr "<option>/or <replaceable>rutasalida</replaceable></option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:760
+#: English/Command_line.xml:778
 msgid ""
 "Outputs a comparison report for files or folders.  Example: "
 "<option>WinMergeU path1 path2 /or c:\\tmp\\report.html</option>"
@@ -1853,24 +1941,24 @@ msgstr ""
 "<option>WinMergeU ruta1 ruta2 /or c:\\tmp\\report.html</option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:763
+#: English/Command_line.xml:781
 msgid "It is often useful to combine this option with:"
 msgstr "A menudo resulta útil combinar esta opción con:"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:765
+#: English/Command_line.xml:783
 msgid ""
 "<option>/noninteractive</option> - exits WinMerge after producing the report."
 msgstr ""
 "<option>/noninteractive</option> - cierra WinMerge tras generar el informe."
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:766
+#: English/Command_line.xml:784
 msgid "<option>/minimize</option> - starts WinMerge in minimized state."
 msgstr "<option>/minimize</option> - abre WinMerge en modo minimizado."
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:767
+#: English/Command_line.xml:785
 msgid ""
 "<option>/noprefs</option> - ignores the current preferences and uses default "
 "settings.  Any changes made with <option>/cfg</option> will then be "
@@ -1881,7 +1969,7 @@ msgstr ""
 "option> será temporal y no se guardará."
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:771
+#: English/Command_line.xml:789
 msgid ""
 "The following <option>/cfg</option> settings can also be useful (parameter "
 "names may change in the future):"
@@ -1890,12 +1978,12 @@ msgstr ""
 "útiles (los nombres de los parámetros pueden cambiar en el futuro):"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:773
+#: English/Command_line.xml:791
 msgid "For file comparisons:"
 msgstr "Para comparar archivos:"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:775
+#: English/Command_line.xml:793
 msgid ""
 "<option>/cfg Settings/DiffContextV2=0</option> - hides matching lines in the "
 "report (equivalent to View -> Diff Context -> 0 Lines)."
@@ -1904,7 +1992,7 @@ msgstr ""
 "coincidentes en el informe (equivalente a Ver -> Contexto Difer -> 0 Líneas)."
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:776
+#: English/Command_line.xml:794
 msgid ""
 "<option>/cfg Settings/ViewLineNumbers=1</option> - outputs line numbers (set "
 "to 0 to disable)."
@@ -1913,12 +2001,12 @@ msgstr ""
 "línea (establecer en 0 para desactivarlo)."
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:778
+#: English/Command_line.xml:796
 msgid "For folder comparisons:"
 msgstr "Para comparar carpetas:"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:780
+#: English/Command_line.xml:798
 msgid ""
 "<option>/cfg Settings/DirViewExpandSubdirs=1</option> - automatically expand "
 "all subfolders."
@@ -1927,7 +2015,7 @@ msgstr ""
 "automáticamente todas las subcarpetas."
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:781
+#: English/Command_line.xml:799
 msgid ""
 "<option>/cfg ReportFiles/ReportType=2</option> - report style: Simple HTML."
 msgstr ""
@@ -1935,7 +2023,7 @@ msgstr ""
 "sencillo."
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><itemizedlist><listitem><para>
-#: English/Command_line.xml:782
+#: English/Command_line.xml:800
 msgid ""
 "<option>/cfg ReportFiles/IncludeFileCmpReport=1</option> - include file "
 "comparison reports."
@@ -1944,22 +2032,22 @@ msgstr ""
 "de comparación de archivos."
 
 #. type: Content of: <article><section><section><title><indexterm><primary>
-#: English/Command_line.xml:789 English/Compare_files.xml:1805
+#: English/Command_line.xml:807 English/Compare_files.xml:1805
 msgid "conflict files"
 msgstr "conflictos entre archivos"
 
 #. type: Content of: <article><variablelist><varlistentry><indexterm><secondary>
-#: English/Command_line.xml:790 English/Command_line.xml:806
+#: English/Command_line.xml:808 English/Command_line.xml:824
 msgid "specifying on command line"
 msgstr "especificación en la línea de comandos"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:793
+#: English/Command_line.xml:811
 msgid "<option><replaceable>conflictfile</replaceable></option>"
 msgstr "<option><replaceable>archivodeconflicto</replaceable></option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:795
+#: English/Command_line.xml:813
 msgid ""
 "Specifies a conflict file, typically generated by a Version control system. "
 "The conflict file opens in the File Compare window, where you can merge and "
@@ -1974,17 +2062,17 @@ msgstr ""
 "utilizar otras rutas con un archivo de conflicto."
 
 #. type: Content of: <article><variablelist><varlistentry><indexterm><primary>
-#: English/Command_line.xml:805
+#: English/Command_line.xml:823
 msgid "ini file"
 msgstr "ini file"
 
 #. type: Content of: <article><variablelist><varlistentry><term>
-#: English/Command_line.xml:809
+#: English/Command_line.xml:827
 msgid "<option>/inifile <replaceable>inifile</replaceable></option>"
 msgstr "<option>/inifile <replaceable>ficheroini</replaceable></option>"
 
 #. type: Content of: <article><variablelist><varlistentry><listitem><para>
-#: English/Command_line.xml:811
+#: English/Command_line.xml:829
 msgid ""
 "specifies an INI file used to load and save settings instead of the registry."
 msgstr ""


### PR DESCRIPTION
## Summary

Add a new `/g` command line option to group single-instance WinMerge windows.

When used together with `/s`, WinMerge instances with the same group name reuse the same window, while different group names create separate single-instance groups.

Examples:

- `WinMergeU /s /g project1 ...`
- `WinMergeU /s /g project2 ...`

This makes it possible to use multiple independent single-instance WinMerge windows.