### PR TITLE
Speed up diff view rendering for large contiguous hidden sections

### DIFF
--- a/Externals/crystaledit/editlib/ccrystaltextview.cpp
+++ b/Externals/crystaledit/editlib/ccrystaltextview.cpp
@@ -2704,6 +2704,23 @@ OnDraw (CDC * pdc)
   int nCurrentLine = m_nTopLine;
   while (rcLine.top < rcClient.bottom)
     {
+      // Invisible lines have no screen height.
+      // Directly skip to the next visible line instead of iterating perhaps millions of hidden lines
+      if (nCurrentLine < nLineCount && !GetLineVisible (nCurrentLine))
+        {
+          const int nNextSubLine = GetSubLineIndex (nCurrentLine);
+          if (nNextSubLine < GetSubLineCount ())
+            {
+              int nNextLine;
+              int nSubLine;
+              GetLineBySubLine (nNextSubLine, nNextLine, nSubLine);
+              nCurrentLine = nNextLine > nCurrentLine ? nNextLine : nCurrentLine + 1;
+            }
+          else
+            nCurrentLine = nLineCount;
+          continue;
+        }
+
       int nSubLines = 1;
       if( nCurrentLine < nLineCount /*&& GetLineLength( nCurrentLine ) > nMaxLineChars*/ )
         nSubLines = GetSubLines(nCurrentLine);


### PR DESCRIPTION
Diff rendering would process every line regardless of visibility. For some degenerate cases this could be hundreds of thousands or even millions of lines (sparse diffs in large files). Detect hidden lines and skip ahead.

Personally ran into this when trying to diff some ~100MB XML files with only about a dozen differences, scrolling across diff chunk boundaries tooks seconds. There's still some hidden work happening for e.g. syntax highlighting which needs to traverse backwards into hidden regions, but that seems inescapable.