### PR TITLE
feature/4pane-merge: Usability fixes found in real usage

### DIFF
--- a/Src/Merge.rc
+++ b/Src/Merge.rc
@@ -81,6 +81,8 @@ BEGIN
         MENUITEM "Ne&xt Conflict\tAlt+Shift+Down", ID_NEXTCONFLICT
         MENUITEM "Pre&vious Conflict\tAlt+Shift+Up", ID_PREVCONFLICT
         MENUITEM SEPARATOR
+        MENUITEM "A&uto Merge\tCtrl+Alt+M",     ID_AUTO_MERGE
+        MENUITEM SEPARATOR
         MENUITEM "Choose Left\tCtrl+Shift+1",   ID_MERGE_CHOOSE_LEFT
         MENUITEM "Choose Middle\tCtrl+Shift+2", ID_MERGE_CHOOSE_MIDDLE
         MENUITEM "Choose Right\tCtrl+Shift+3",  ID_MERGE_CHOOSE_RIGHT
@@ -108,6 +110,9 @@ IDR_POPUP_MERGEVIEW MENU
 BEGIN
     POPUP "_POPUP_"
     BEGIN
+        MENUITEM "Choose %1 for This Difference", ID_MERGE_CHOOSE_THIS
+        MENUITEM "Choose %1 for Selected Differences", ID_MERGE_COPY_LINES_TO_RESULT
+        MENUITEM SEPARATOR
         MENUITEM "Copy to Middle",              ID_COPY_TO_MIDDLE_L
         MENUITEM "C&opy to Right\tAlt+Right",   ID_COPY_TO_RIGHT_L
         MENUITEM "Copy from Middle",            ID_COPY_FROM_MIDDLE_L
@@ -5407,6 +5412,8 @@ BEGIN
     ID_MERGE_RESULT_SAVE    "Save merge result\nSave Merge Result"
     ID_MERGE_RESULT_SAVEAS  "Save merge result to selected path\nSave Merge Result As"
     ID_MERGE_START_SESSION  "Open the Merge Result pane to merge the compared files; differences start unresolved\nStart Merge Session"
+    ID_MERGE_CHOOSE_THIS    "Put this pane's lines for the difference at the cursor into the Merge Result pane; choosing it again removes them\nChoose for This Difference"
+    ID_MERGE_COPY_LINES_TO_RESULT "Put this pane's lines into the Merge Result pane for every difference the selection covers\nChoose for Selected Differences"
     ID_VIEW_MERGE_RESULT_BAR "Show or hide the merge result pane (3-way compare)\nMerge Result Pane"
     ID_FIRSTFILE            "\nFirst File"
     ID_NEXTFILE             "\nNext File (Ctrl+F8)"

--- a/Src/MergeDoc.cpp
+++ b/Src/MergeDoc.cpp
@@ -1994,18 +1994,32 @@ bool CMergeDoc::PromptAndSaveIfNeeded(bool bAllowCancel)
 	bool bModified[3] = { false, false, false };
 	String paths[3] = { };
 
-	// Merge result pane: ask about unsaved result changes first
-	if (IsMergeResultModified())
+	// Merge result pane: deal with the merge before the source files
+	if (IsMergeResultPaneActive())
 	{
-		int nAnswer = ShowMessageBox(
-			_("The merge result has unsaved changes.\n\nSave the merge result?"),
-			bAllowCancel ? (MB_YESNOCANCEL | MB_ICONWARNING) : (MB_YESNO | MB_ICONWARNING));
-		if (nAnswer == IDCANCEL)
-			return false;
-		if (nAnswer == IDYES && !SaveMergeResult(false))
+		const int nUnresolved = GetResultUnresolvedCount();
+		if (nUnresolved > 0 && bAllowCancel)
 		{
-			if (bAllowCancel)
+			// The merge is unfinished, so there is nothing worth saving:
+			// ask whether to abandon it rather than whether to save
+			const String msg = strutils::format_string1(
+				_("The merge is not finished: %1 difference(s) have not been resolved.\n\nAbandon the merge and close without saving the result?"),
+				strutils::format(_T("%d"), nUnresolved));
+			if (ShowMessageBox(msg, MB_YESNO | MB_ICONWARNING) != IDYES)
 				return false;
+		}
+		else if (IsMergeResultModified())
+		{
+			int nAnswer = ShowMessageBox(
+				_("The merge result has not been saved.\n\nSave the merge result?"),
+				bAllowCancel ? (MB_YESNOCANCEL | MB_ICONWARNING) : (MB_YESNO | MB_ICONWARNING));
+			if (nAnswer == IDCANCEL)
+				return false;
+			if (nAnswer == IDYES && !SaveMergeResult(false))
+			{
+				if (bAllowCancel)
+					return false;
+			}
 		}
 	}
 

--- a/Src/MergeDoc.h
+++ b/Src/MergeDoc.h
@@ -344,6 +344,7 @@ public:
 	void UpdateMergeResultAfterRescan();
 	bool IsMergeResultModified() const;
 	int GetResultUnresolvedCount() const;
+	static String GetResultPlaceholderText(ResultSegmentState state);
 	const MergeResultSegment* GetResultSegmentByLine(int nLine) const;
 	const MergeResultSegment* GetResultSegmentByDiff(int nDiff) const;
 	void ResultChooseSource(int nDiff, int srcPane, bool bGroupWithPrevious = false);

--- a/Src/MergeDocResultPane.cpp
+++ b/Src/MergeDocResultPane.cpp
@@ -334,13 +334,16 @@ void CMergeDoc::BuildMergeResult()
 		seg.diffIdx = nDiff;
 		seg.nStartLine = nCurLine;
 		// Without auto-merge every significant difference starts
-		// unresolved; with it only true 3-way conflicts do
+		// unresolved; with it only true 3-way conflicts do. A difference
+		// where the sides agree (or only one side changed) is not a
+		// conflict even while it is still unresolved.
 		if (pdi->op == OP_DIFF ||
 			(!m_bResultAutoMerge && pdi->op != OP_TRIVIAL))
 		{
-			seg.state = ResultSegmentState::Conflict;
+			seg.state = (pdi->op == OP_DIFF) ?
+				ResultSegmentState::Conflict : ResultSegmentState::Unresolved;
 			seg.nLines = 1;
-			text += _("<Merge Conflict>");
+			text += GetResultPlaceholderText(seg.state);
 			text += m_ptResultBuf->GetDefaultEol();
 		}
 		else
@@ -417,14 +420,26 @@ bool CMergeDoc::IsMergeResultModified() const
 }
 
 /**
- * @brief Number of still unresolved conflict segments.
+ * @brief Placeholder line shown for a difference that has no content
+ * chosen for it yet.
+ */
+String CMergeDoc::GetResultPlaceholderText(ResultSegmentState state)
+{
+	return (state == ResultSegmentState::Conflict) ?
+		_("<Merge Conflict>") : _("<Unresolved Difference>");
+}
+
+/**
+ * @brief Number of differences with nothing chosen for them yet
+ * (both real conflicts and non-conflicting differences).
  */
 int CMergeDoc::GetResultUnresolvedCount() const
 {
 	int nCount = 0;
 	for (const auto& seg : m_resultSegments)
 	{
-		if (seg.state == ResultSegmentState::Conflict)
+		if (seg.state == ResultSegmentState::Conflict ||
+			seg.state == ResultSegmentState::Unresolved)
 			++nCount;
 	}
 	return nCount;
@@ -510,10 +525,11 @@ void CMergeDoc::ResultChooseSources(int nDiff, const std::vector<int>& srcPanes,
 		text += GetPaneApparentLinesText(srcPane, pdi->dbegin, pdi->dend, &nPaneLines);
 		nNewLines += nPaneLines;
 	}
-	if (srcPanes.empty() && pdi->op == OP_DIFF)
+	if (srcPanes.empty())
 	{
-		// deselected everything: the conflict is unresolved again
-		text = _("<Merge Conflict>");
+		// deselected everything: the difference is unresolved again
+		text = GetResultPlaceholderText(pdi->op == OP_DIFF ?
+			ResultSegmentState::Conflict : ResultSegmentState::Unresolved);
 		text += m_ptResultBuf->GetDefaultEol();
 		nNewLines = 1;
 		bBackToConflict = true;
@@ -553,7 +569,8 @@ void CMergeDoc::ResultChooseSources(int nDiff, const std::vector<int>& srcPanes,
 	m_ptResultBuf->FlushUndoGroup(pSource);
 
 	const int nDelta = nNewLines - seg.nLines;
-	seg.state = bBackToConflict ? ResultSegmentState::Conflict : ResultSegmentState::Chosen;
+	seg.state = !bBackToConflict ? ResultSegmentState::Chosen :
+		(pdi->op == OP_DIFF ? ResultSegmentState::Conflict : ResultSegmentState::Unresolved);
 	seg.srcPanes = srcPanes;
 	seg.nLines = nNewLines;
 	if (nDelta != 0)
@@ -583,6 +600,7 @@ void CMergeDoc::ResultToggleSource(int nDiff, int srcPane)
 	if (pSegment->state == ResultSegmentState::Auto ||
 		pSegment->state == ResultSegmentState::Chosen)
 		srcPanes = pSegment->srcPanes;
+	// (a hand-edited or unresolved segment starts a fresh selection)
 	// (a hand-edited or unresolved segment starts a fresh selection)
 	const auto it = std::find(srcPanes.begin(), srcPanes.end(), srcPane);
 	if (it != srcPanes.end())
@@ -627,7 +645,7 @@ bool CMergeDoc::SaveMergeResult(bool bSaveAs)
 	if (nUnresolved > 0)
 	{
 		const String msg = strutils::format_string1(
-			_("There are still %1 unresolved conflicts in the merge result.\n\nSave the result anyway?"),
+			_("There are still %1 unresolved difference(s) in the merge result.\n\nSave the result anyway?"),
 			strutils::format(_T("%d"), nUnresolved));
 		if (ShowMessageBox(msg, MB_YESNO | MB_ICONWARNING) != IDYES)
 			return false;

--- a/Src/MergeEditView.cpp
+++ b/Src/MergeEditView.cpp
@@ -182,6 +182,11 @@ BEGIN_MESSAGE_MAP(CMergeEditView, CGhostTextView)
 	ON_UPDATE_COMMAND_UI(ID_ALL_RIGHT, OnUpdateAllRight)
 	ON_COMMAND(ID_AUTO_MERGE, OnAutoMerge)
 	ON_UPDATE_COMMAND_UI(ID_AUTO_MERGE, OnUpdateAutoMerge)
+	ON_COMMAND(ID_MERGE_CHOOSE_THIS, OnMergeChooseThis)
+	ON_UPDATE_COMMAND_UI(ID_MERGE_CHOOSE_THIS, OnUpdateMergeChooseThis)
+	ON_COMMAND(ID_MERGE_COPY_LINES_TO_RESULT, OnMergeCopyLinesToResult)
+	ON_UPDATE_COMMAND_UI(ID_MERGE_COPY_LINES_TO_RESULT, OnUpdateMergeCopyLinesToResult)
+	ON_WM_RBUTTONDOWN()
 	ON_COMMAND(ID_L2R, OnL2r)
 	ON_UPDATE_COMMAND_UI(ID_L2R, OnUpdateL2r)
 	ON_COMMAND(ID_LINES_L2R, OnLinesL2r)
@@ -2355,6 +2360,124 @@ void CMergeEditView::OnUpdateAutoMerge(CCmdUI* pCmdUI)
 }
 
 /**
+ * @brief Make this pane the active one, so that commands shown in its
+ * context menu act on it.
+ *
+ * Without this, right-clicking a pane while another view (for example the
+ * merge result pane) is active would leave that other view active, and
+ * the pane commands in the menu would be disabled.
+ */
+void CMergeEditView::OnRButtonDown(UINT nFlags, CPoint point)
+{
+	if (!m_bDetailView && GetParentFrame() != nullptr &&
+		GetParentFrame()->GetActiveView() != this)
+		SetActivePane();
+	// While merging, put the caret where the user clicked so the menu acts
+	// on that difference. An existing selection is kept: the merge commands
+	// work on the selected lines. Outside merging the caret is left alone,
+	// keeping the behavior of a normal compare unchanged.
+	if (GetDocument()->IsMergeResultPaneActive() && !IsSelection())
+	{
+		const CEPoint pt = ClientToText(point);
+		SetCursorPos(pt);
+		SetAnchor(pt);
+		SetSelection(pt, pt);
+	}
+	__super::OnRButtonDown(nFlags, point);
+}
+
+/**
+ * @brief Difference the merge commands in this pane's context menu act on.
+ *
+ * It is the difference the user pointed at: the first one in the selection,
+ * or else the one under the caret. There is deliberately no fallback to the
+ * document's current difference, which may be somewhere else entirely.
+ */
+int CMergeEditView::GetMergeTargetDiff()
+{
+	int firstDiff, lastDiff;
+	GetSelectedDiffs(firstDiff, lastDiff);
+	if (firstDiff != -1 && lastDiff != -1)
+		return firstDiff;
+	return GetDocument()->m_diffList.LineToDiff(GetCursorPos().y);
+}
+
+/**
+ * @brief Use this pane's content of the difference under the cursor in
+ * the merge result (toggles, like the Choose Left/Middle/Right commands).
+ */
+void CMergeEditView::OnMergeChooseThis()
+{
+	CMergeDoc* pDoc = GetDocument();
+	const int nDiff = GetMergeTargetDiff();
+	if (nDiff >= 0)
+		pDoc->ResultToggleSource(nDiff, m_nThisPane);
+}
+
+/**
+ * @brief Name of this pane as the merge commands refer to it.
+ */
+String CMergeEditView::GetPaneNameForMergeMenu() const
+{
+	if (GetDocument()->m_nBuffers < 3)
+		return (m_nThisPane == 0) ? _("Left") : _("Right");
+	return (m_nThisPane == 0) ? _("Left") :
+		(m_nThisPane == 1) ? _("Middle") : _("Right");
+}
+
+void CMergeEditView::OnUpdateMergeChooseThis(CCmdUI* pCmdUI)
+{
+	CMergeDoc* pDoc = GetDocument();
+	const int nDiff = GetMergeTargetDiff();
+	const MergeResultSegment* pSegment =
+		(pDoc->IsMergeResultPaneActive() && nDiff >= 0) ? pDoc->GetResultSegmentByDiff(nDiff) : nullptr;
+	pCmdUI->Enable(pSegment != nullptr);
+	pCmdUI->SetCheck(pSegment != nullptr &&
+		(pSegment->state == ResultSegmentState::Auto ||
+		 pSegment->state == ResultSegmentState::Chosen) &&
+		std::find(pSegment->srcPanes.begin(), pSegment->srcPanes.end(), m_nThisPane) != pSegment->srcPanes.end());
+	// Name the pane, so it is clear which side is chosen
+	pCmdUI->SetText(strutils::format_string1(
+		_("Choose %1 for This Difference"), GetPaneNameForMergeMenu()).c_str());
+}
+
+/**
+ * @brief Use this pane's content for every difference touched by the
+ * selection in the merge result.
+ */
+void CMergeEditView::OnMergeCopyLinesToResult()
+{
+	CMergeDoc* pDoc = GetDocument();
+	int firstDiff, lastDiff;
+	GetSelectedDiffs(firstDiff, lastDiff);
+	if (firstDiff == -1 || lastDiff == -1)
+		return;
+	bool bGroupWithPrevious = false;
+	for (int nDiff = firstDiff; nDiff <= lastDiff; ++nDiff)
+	{
+		if (pDoc->GetResultSegmentByDiff(nDiff) == nullptr)
+			continue;
+		pDoc->ResultChooseSource(nDiff, m_nThisPane, bGroupWithPrevious);
+		bGroupWithPrevious = true;
+	}
+}
+
+void CMergeEditView::OnUpdateMergeCopyLinesToResult(CCmdUI* pCmdUI)
+{
+	CMergeDoc* pDoc = GetDocument();
+	if (!pDoc->IsMergeResultPaneActive())
+	{
+		pCmdUI->Enable(FALSE);
+		return;
+	}
+	int firstDiff, lastDiff;
+	GetSelectedDiffs(firstDiff, lastDiff);
+	pCmdUI->Enable(firstDiff != -1 && lastDiff != -1);
+	pCmdUI->SetText(strutils::format_string1(
+		_("Choose %1 for Selected Differences"), GetPaneNameForMergeMenu()).c_str());
+}
+
+/**
  * @brief Add synchronization point
  */
 void CMergeEditView::OnAddSyncPoint()
@@ -2936,6 +3059,21 @@ void CMergeEditView::OnContextMenu(CWnd* pWnd, CPoint point)
 		text = text.Left(text.Find(_T("\t")));
 		menu.SetMenuText(id, text, MF_BYCOMMAND);
 	};
+
+	// Merge result commands only make sense while merging
+	// (their text names the pane and is set in the update handlers)
+	if (!GetDocument()->IsMergeResultPaneActive())
+	{
+		// Remove within the popup: removing by position from the menu
+		// itself would take out the whole popup
+		if (BCMenu* pMergeSub = static_cast<BCMenu*>(menu.GetSubMenu(0)))
+		{
+			pMergeSub->RemoveMenu(ID_MERGE_CHOOSE_THIS, MF_BYCOMMAND);
+			pMergeSub->RemoveMenu(ID_MERGE_COPY_LINES_TO_RESULT, MF_BYCOMMAND);
+			if ((pMergeSub->GetMenuState(0, MF_BYPOSITION) & MF_SEPARATOR) != 0)
+				pMergeSub->RemoveMenu(0, MF_BYPOSITION); // separator they left behind
+		}
+	}
 
 	// Remove copying item copying from active side
 	if (m_nThisPane == 0) // left?

--- a/Src/MergeEditView.h
+++ b/Src/MergeEditView.h
@@ -266,6 +266,13 @@ protected:
 	afx_msg void OnUpdateAllRight(CCmdUI* pCmdUI);
 	afx_msg void OnAutoMerge();
 	afx_msg void OnUpdateAutoMerge(CCmdUI* pCmdUI);
+	int GetMergeTargetDiff();
+	String GetPaneNameForMergeMenu() const;
+	afx_msg void OnMergeChooseThis();
+	afx_msg void OnUpdateMergeChooseThis(CCmdUI* pCmdUI);
+	afx_msg void OnMergeCopyLinesToResult();
+	afx_msg void OnUpdateMergeCopyLinesToResult(CCmdUI* pCmdUI);
+	afx_msg void OnRButtonDown(UINT nFlags, CPoint point);
 	afx_msg void OnCopyX2Y(UINT nID);
 	afx_msg void OnCopyLinesX2Y(UINT nID);
 	afx_msg void OnX2Y(int srcPane, int dstPane, bool selectedLineOnly = false);

--- a/Src/MergeResultPane.h
+++ b/Src/MergeResultPane.h
@@ -16,11 +16,12 @@ class CMergeDoc;
  */
 enum class ResultSegmentState
 {
-	Common,   /**< Text outside any difference (taken from middle/base pane) */
-	Auto,     /**< Difference resolved automatically (non-conflicting change) */
-	Chosen,   /**< Difference resolved by an explicit Choose Left/Middle/Right */
-	Conflict, /**< Unresolved 3-way conflict (placeholder line in result) */
-	Edited,   /**< Segment has been edited by hand in the result pane */
+	Common,     /**< Text outside any difference (taken from middle/base pane) */
+	Auto,       /**< Difference resolved automatically (non-conflicting change) */
+	Chosen,     /**< Difference resolved by an explicit Choose Left/Middle/Right */
+	Unresolved, /**< Difference not resolved yet, but the sides do not conflict */
+	Conflict,   /**< Unresolved 3-way conflict: all three sides differ */
+	Edited,     /**< Segment has been edited by hand in the result pane */
 };
 
 /**

--- a/Src/MergeResultView.cpp
+++ b/Src/MergeResultView.cpp
@@ -42,10 +42,12 @@ BEGIN_MESSAGE_MAP(CMergeResultView, CGhostTextView)
 	ON_WM_LBUTTONDOWN()
 	ON_WM_CONTEXTMENU()
 	ON_WM_GETDLGCODE()
-	// Difference/conflict navigation is implemented by the compare views;
-	// forward it so it also works while the result view is active
+	// Difference/conflict navigation and Auto Merge are implemented by the
+	// compare views; forward them so they also work while this view is active
 	ON_COMMAND_RANGE(ID_PREVDIFF, ID_NEXTCONFLICT, OnForwardToMergeView)
 	ON_UPDATE_COMMAND_UI_RANGE(ID_PREVDIFF, ID_NEXTCONFLICT, OnUpdateForwardToMergeView)
+	ON_COMMAND_RANGE(ID_AUTO_MERGE, ID_AUTO_MERGE, OnForwardToMergeView)
+	ON_UPDATE_COMMAND_UI_RANGE(ID_AUTO_MERGE, ID_AUTO_MERGE, OnUpdateForwardToMergeView)
 	//}}AFX_MSG_MAP
 END_MESSAGE_MAP()
 
@@ -146,6 +148,19 @@ void CMergeResultView::GetLineColors(int nLineIndex, CEColor & crBkgnd,
 		{
 			crBkgnd = m_cachedColors.clrWordDiff;
 			crText = m_cachedColors.clrWordDiffText;
+		}
+		break;
+	case ResultSegmentState::Unresolved:
+		// not decided yet, but the sides do not conflict
+		if (bCurrent)
+		{
+			crBkgnd = m_cachedColors.clrSelDiff;
+			crText = m_cachedColors.clrSelDiffText;
+		}
+		else
+		{
+			crBkgnd = m_cachedColors.clrDiff;
+			crText = m_cachedColors.clrDiffText;
 		}
 		break;
 	case ResultSegmentState::Auto:

--- a/Src/resource.h
+++ b/Src/resource.h
@@ -1162,6 +1162,8 @@
 #define ID_MERGE_RESULT_SAVE            33385
 #define ID_MERGE_RESULT_SAVEAS          33386
 #define ID_MERGE_START_SESSION          33387
+#define ID_MERGE_CHOOSE_THIS            33388
+#define ID_MERGE_COPY_LINES_TO_RESULT   33389
 #define ID_TABBAR_AUTO_MAXWIDTH         33451
 #define ID_IMG_VIEWDIFFERENCES          33453
 #define ID_IMG_ZOOM_25                  33454


### PR DESCRIPTION
### Summary

- Labelling: When auto-merge is off, identical changes on both sides now show `<Unresolved Difference>`, not `<Merge Conflict>`.
- Fixed the greyed-out clipboard menu 
- Added source-pane commands "Choose Left/Middle/Right for This Difference" 
- Close prompt now reports unresolved differences and offers to abandon the merge instead of asking to save an unfinished one.
- Auto-Merge option to the result pane when auto-merge is off by default.