### PR TITLE
Support adding plugins to pipelines from menus

### DIFF
--- a/Src/DirView.cpp
+++ b/Src/DirView.cpp
@@ -1882,7 +1882,7 @@ void CDirView::OpenSelectionAs(int sel1, int sel2, int sel3, UINT id)
 	if (ID_UNPACKERS_FIRST <= id && id <= ID_UNPACKERS_LAST)
 	{
 		PackingInfo infoUnpackerAlt(
-				PluginMenu::GetPluginPipelineByMenuId(id, FileTransform::UnpackerEventNames, ID_UNPACKERS_FIRST));
+				PluginMenu::GetPluginPipelineByMenuId(nullptr, id, FileTransform::UnpackerEventNames, ID_UNPACKERS_FIRST));
 		CMainFrame::OpenFolderParams openFolderParams(ctxt.m_bRecursive);
 		GetMainFrame()->DoFileOrFolderOpen(&paths, dwFlags, strDesc, _T(""),
 			nullptr, &infoUnpackerAlt, infoPrediffer, 0, &openFolderParams);
@@ -4669,7 +4669,7 @@ void CDirView::OnUpdateNoUnpacker(CCmdUI *pCmdUI)
 		return;
 
 	String filteredFilenames = GetDiffContext().GetFilteredFilenames(*GetItemKey(sel));
-	PluginMenu::AppendPluginMenus(pCmdUI->m_pMenu, filteredFilenames,
+	PluginMenu::AppendPluginMenus(pCmdUI->m_pMenu, nullptr, filteredFilenames,
 		FileTransform::UnpackerEventNames, PluginMenu::AddAllMenu|PluginMenu::AddSelectMenu, ID_UNPACKERS_FIRST);
 }
 

--- a/Src/HexMergeDoc.cpp
+++ b/Src/HexMergeDoc.cpp
@@ -913,7 +913,7 @@ void CHexMergeDoc::OnFileRecompareAs(UINT nID)
 	}
 	if (ID_UNPACKERS_FIRST <= nID && nID <= ID_UNPACKERS_LAST)
 	{
-		infoUnpacker.SetPluginPipeline(PluginMenu::GetPluginPipelineByMenuId(nID, FileTransform::UnpackerEventNames, ID_UNPACKERS_FIRST));
+		infoUnpacker.SetPluginPipeline(PluginMenu::GetPluginPipelineByMenuId(&infoUnpacker, nID, FileTransform::UnpackerEventNames, ID_UNPACKERS_FIRST));
 		nID = GetOptionsMgr()->GetBool(OPT_PLUGINS_OPEN_IN_SAME_FRAME_TYPE) ? ID_MERGE_COMPARE_HEX : -ID_MERGE_COMPARE_HEX;
 	}
 

--- a/Src/ImgMergeFrm.cpp
+++ b/Src/ImgMergeFrm.cpp
@@ -1054,7 +1054,7 @@ void CImgMergeFrame::OnFileRecompareAs(UINT nID)
 	}
 	if (ID_UNPACKERS_FIRST <= nID && nID <= ID_UNPACKERS_LAST)
 	{
-		infoUnpacker.SetPluginPipeline(PluginMenu::GetPluginPipelineByMenuId(nID, FileTransform::UnpackerEventNames, ID_UNPACKERS_FIRST));
+		infoUnpacker.SetPluginPipeline(PluginMenu::GetPluginPipelineByMenuId(&infoUnpacker, nID, FileTransform::UnpackerEventNames, ID_UNPACKERS_FIRST));
 		nID = GetOptionsMgr()->GetBool(OPT_PLUGINS_OPEN_IN_SAME_FRAME_TYPE) ? ID_MERGE_COMPARE_IMAGE : -ID_MERGE_COMPARE_IMAGE;
 	}
 

--- a/Src/MainFrm.cpp
+++ b/Src/MainFrm.cpp
@@ -744,38 +744,33 @@ void CMainFrame::OnInitMenuPopup(CMenu* pPopupMenu, UINT nIndex, BOOL bSysMenu)
 				paths.SetPath(i, pMergeDoc->GetPath(i));
 			String filteredFilenames = strutils::join(paths.begin(), paths.end(), _T("|"));
 			unsigned topMenuId = pPopupMenu->GetMenuItemID(0);
-			if (topMenuId == ID_NO_PREDIFFER)
-			{
-				UpdatePrediffersMenu(pPopupMenu);
-			}
-			else if (topMenuId == ID_MERGE_COMPARE_TEXT)
+			if (topMenuId == ID_MERGE_COMPARE_TEXT)
 			{
 				CMenu* pMenu = pPopupMenu;
 				// empty the menu
 				for (int i = pMenu->GetMenuItemCount() - 1; i > (ID_MERGE_COMPARE_FOLDER - ID_MERGE_COMPARE_TEXT); --i)
 					pMenu->DeleteMenu(i, MF_BYPOSITION);
 
-				PluginMenu::AppendPluginMenus(pMenu, filteredFilenames, FileTransform::UnpackerEventNames,
+				PluginMenu::AppendPluginMenus(pMenu, pMergeDoc->GetUnpacker(), filteredFilenames, FileTransform::UnpackerEventNames,
 					PluginMenu::AddAllMenu|PluginMenu::AddSelectMenu, ID_UNPACKERS_FIRST);
-			}
-			else if (topMenuId == ID_NO_EDIT_SCRIPTS || topMenuId == ID_NO_EDIT_SCRIPTS_FOR_COPYING)
-			{
-				CMenu* pMenu = pPopupMenu;
-				ASSERT(pMenu != nullptr);
-
-				// empty the menu
-				int i = pMenu->GetMenuItemCount();
-				while (i--)
-					pMenu->DeleteMenu(0, MF_BYPOSITION);
-
-				PluginMenu::AppendPluginMenus(pMenu, filteredFilenames, FileTransform::EditorScriptEventNames, 0, 
-					topMenuId == ID_NO_EDIT_SCRIPTS ? ID_SCRIPT_FIRST : ID_SCRIPT_FOR_COPYING_FIRST);
 			}
 			else if (topMenuId == ID_PLUGINS_LIST)
 			{
-				for (int j = 0; j < 2; j++)
+				for (int j = 0; j < 4; j++)
 				{
-					CMenu* pMenu = pPopupMenu->GetSubMenu((j == 0) ? 8 : (pPopupMenu->GetMenuItemCount() - 5));
+					CMenu* pMenu = nullptr;
+					if (j == 0)
+						pMenu = pPopupMenu->GetSubMenu(8);
+					else if (j == 1)
+						pMenu = pPopupMenu->GetSubMenu(11);
+					else if (j == 2)
+						pMenu = pPopupMenu->GetSubMenu(pPopupMenu->GetMenuItemCount() - 5);
+					else
+					{
+						pMenu = pPopupMenu->GetSubMenu(pPopupMenu->GetMenuItemCount() - 3);
+						if (pMenu)
+							pMenu = pMenu->GetSubMenu(0);
+					}
 					ASSERT(pMenu != nullptr);
 
 					// empty the menu
@@ -784,9 +779,14 @@ void CMainFrame::OnInitMenuPopup(CMenu* pPopupMenu, UINT nIndex, BOOL bSysMenu)
 						pMenu->DeleteMenu(0, MF_BYPOSITION);
 
 					if (j == 0)
-						PluginMenu::AppendPluginMenus(pMenu, filteredFilenames, FileTransform::UnpackerEventNames, 0, ID_UNPACKERS_FIRST);
+						PluginMenu::AppendPluginMenus(pMenu, pMergeDoc->GetUnpacker(), filteredFilenames, FileTransform::UnpackerEventNames, 0, ID_UNPACKERS_FIRST);
+					else if (j == 1)
+						PluginMenu::AppendPluginMenus(pMenu, pMergeDoc->GetPrediffer(), filteredFilenames, FileTransform::PredifferEventNames,
+							PluginMenu::FlattenMenu, ID_PREDIFFERS_FIRST);
+					else if (j == 2)
+						PluginMenu::AppendPluginMenus(pMenu, nullptr, filteredFilenames, FileTransform::EditorScriptEventNames, 0, ID_SCRIPT_FIRST);
 					else
-						PluginMenu::AppendPluginMenus(pMenu, filteredFilenames, FileTransform::EditorScriptEventNames, 0, ID_SCRIPT_FIRST);
+						PluginMenu::AppendPluginMenus(pMenu, pMergeDoc->GetEditorScript(), filteredFilenames, FileTransform::EditorScriptEventNames, 0, ID_SCRIPT_FOR_COPYING_FIRST);
 				}
 			}
 		}
@@ -2386,28 +2386,6 @@ CMergeEditView * CMainFrame::GetActiveMergeEditView()
 	return pFrame->GetMergeDoc()->GetActiveMergeView();
 }
 
-void CMainFrame::UpdatePrediffersMenu(CMenu* pPredifferMenu)
-{
-	if (pPredifferMenu == nullptr)
-		return;
-
-	HMENU prediffersSubmenu = pPredifferMenu->m_hMenu;
-	if (prediffersSubmenu != nullptr)
-	{
-		CMergeEditView * pEditView = GetActiveMergeEditView();
-		if (pEditView != nullptr)
-			pEditView->GetDocument()->createPrediffersSubmenu(prediffersSubmenu);
-		else
-		{
-			// no view or dir view : display an empty submenu
-			int i = GetMenuItemCount(prediffersSubmenu);
-			while (i --)
-				::DeleteMenu(prediffersSubmenu, 0, MF_BYPOSITION);
-			::AppendMenu(prediffersSubmenu, MF_SEPARATOR, 0, nullptr);
-		}
-	}
-}
-
 /**
  * @brief Save WinMerge configuration and info to file
  */
@@ -3846,10 +3824,10 @@ void CMainFrame::OnStatusBarClick(NMHDR* pNMHDR, LRESULT* pResult)
 		CPoint pt = CPoint(rects[subidx].left, rects[subidx].top);
 		m_wndStatusBar.ClientToScreen(&pt);
 		if (subidx == 0)
-			PluginMenu::ShowMenu(filteredFilenames, FileTransform::UnpackerEventNames, 
+			PluginMenu::ShowMenu(pMergeDoc->GetUnpacker(), filteredFilenames, FileTransform::UnpackerEventNames,
 				PluginMenu::AddSelectMenu, ID_UNPACKERS_FIRST, pt.x, pt.y, this);
 		else if (subidx == 1)
-			PluginMenu::ShowMenu(filteredFilenames, FileTransform::PredifferEventNames,
+			PluginMenu::ShowMenu(pMergeDoc->GetPrediffer(), filteredFilenames, FileTransform::PredifferEventNames,
 				PluginMenu::FlattenMenu|PluginMenu::AddSelectMenu, ID_PREDIFFERS_FIRST, pt.x, pt.y, this);
 	}
 }

--- a/Src/MainFrm.cpp
+++ b/Src/MainFrm.cpp
@@ -754,6 +754,18 @@ void CMainFrame::OnInitMenuPopup(CMenu* pPopupMenu, UINT nIndex, BOOL bSysMenu)
 				PluginMenu::AppendPluginMenus(pMenu, pMergeDoc->GetUnpacker(), filteredFilenames, FileTransform::UnpackerEventNames,
 					PluginMenu::AddAllMenu|PluginMenu::AddSelectMenu, ID_UNPACKERS_FIRST);
 			}
+			else if (topMenuId == ID_NO_EDIT_SCRIPTS)
+			{
+				CMenu* pMenu = pPopupMenu;
+				ASSERT(pMenu != nullptr);
+
+				// empty the menu
+				int i = pMenu->GetMenuItemCount();
+				while (i--)
+					pMenu->DeleteMenu(0, MF_BYPOSITION);
+
+				PluginMenu::AppendPluginMenus(pMenu, nullptr, filteredFilenames, FileTransform::EditorScriptEventNames, 0, ID_SCRIPT_FIRST);
+			}
 			else if (topMenuId == ID_PLUGINS_LIST)
 			{
 				for (int j = 0; j < 4; j++)

--- a/Src/Merge.cpp
+++ b/Src/Merge.cpp
@@ -876,7 +876,7 @@ bool CMergeApp::ShowCompareAsMenu(MergeCmdLineInfo& cmdInfo)
 	if (!pPopup)
 		return false;
 	String filteredFilenames = strutils::join(cmdInfo.m_Files.begin(), cmdInfo.m_Files.end(), _T("|"));
-	PluginMenu::AppendPluginMenus(pPopup, filteredFilenames, FileTransform::UnpackerEventNames,
+	PluginMenu::AppendPluginMenus(pPopup, nullptr, filteredFilenames, FileTransform::UnpackerEventNames,
 		PluginMenu::AddAllMenu|PluginMenu::AddSelectMenu, ID_UNPACKERS_FIRST);
 
 	CPoint point;
@@ -915,7 +915,7 @@ bool CMergeApp::ShowCompareAsMenu(MergeCmdLineInfo& cmdInfo)
 		}
 		else if(nID >= ID_UNPACKERS_FIRST && nID <= ID_UNPACKERS_LAST)
 		{
-			cmdInfo.m_sUnpacker = PluginMenu::GetPluginPipelineByMenuId(nID, FileTransform::UnpackerEventNames, ID_UNPACKERS_FIRST);
+			cmdInfo.m_sUnpacker = PluginMenu::GetPluginPipelineByMenuId(nullptr, nID, FileTransform::UnpackerEventNames, ID_UNPACKERS_FIRST);
 		}
 		else
 		{

--- a/Src/Merge.rc
+++ b/Src/Merge.rc
@@ -5632,6 +5632,7 @@ BEGIN
     IDS_PLUGIN_TARGETS_1ST_2ND "1st and 2nd"
     IDS_PLUGIN_TARGETS_1ST_3RD "1st and 3rd"
     IDS_PLUGIN_TARGETS_2ND_3RD "2nd and 3rd"
+    IDS_PLUGIN_CTRL_CLICK   "(Ctrl+Click to add to pipeline)"
 END
 
 STRINGTABLE

--- a/Src/MergeDoc.cpp
+++ b/Src/MergeDoc.cpp
@@ -103,6 +103,7 @@ BEGIN_MESSAGE_MAP(CMergeDoc, CDocument)
 	ON_UPDATE_COMMAND_UI(ID_MERGE_COMPARE_TABLE, OnUpdateFileRecompareAsTable)
 	ON_COMMAND_RANGE(ID_MERGE_COMPARE_HEX, ID_MERGE_COMPARE_FOLDER, OnFileRecompareAs)
 	ON_COMMAND_RANGE(ID_UNPACKERS_FIRST, ID_UNPACKERS_LAST, OnFileRecompareAs)
+	ON_UPDATE_COMMAND_UI_RANGE(ID_UNPACKERS_FIRST, ID_UNPACKERS_LAST, OnUpdateFileRecompareAs)
 	// [View] menu
 	ON_COMMAND_RANGE(ID_VIEW_DIFFCONTEXT_ALL, ID_VIEW_DIFFCONTEXT_INVERT, OnDiffContext)
 	ON_UPDATE_COMMAND_UI_RANGE(ID_VIEW_DIFFCONTEXT_ALL, ID_VIEW_DIFFCONTEXT_INVERT, OnUpdateDiffContext)
@@ -156,8 +157,6 @@ CMergeDoc::CMergeDoc()
 , m_nGroups(0)
 , m_pView{nullptr}
 , m_bAutomaticRescan(false)
-, m_CurrentPredifferID(0)
-, m_CurrentEditorScriptID(ID_SCRIPT_FOR_COPYING_NONE)
 , m_bChangedSchemeManually(false)
 , m_editorScriptInfo(_T(""))
 {
@@ -2950,81 +2949,7 @@ void CMergeDoc::OnApplyPrediffer()
 		return;
 	prediffer.SetPluginPipeline(dlg.GetPluginPipeline());
 	SetPrediffer(&prediffer);
-	m_CurrentPredifferID = -1;
 	FlushAndRescan(true);
-}
-
-/**
- * @brief Create the dynamic submenu for prediffers
- *
- * @note The plugins are grouped in (suggested) and (not suggested)
- *       The IDs follow the order of GetAvailableScripts
- *       For example :
- *				suggested 0         ID_1ST + 0 
- *				suggested 1         ID_1ST + 2 
- *				suggested 2         ID_1ST + 5 
- *				not suggested 0     ID_1ST + 1 
- *				not suggested 1     ID_1ST + 3 
- *				not suggested 2     ID_1ST + 4 
- */
-HMENU CMergeDoc::createPrediffersSubmenu(HMENU hMenu)
-{
-	// empty the menu
-	int j = GetMenuItemCount(hMenu);
-	while (j --)
-		DeleteMenu(hMenu, 0, MF_BYPOSITION);
-
-	// title
-	AppendMenu(hMenu, MF_STRING, ID_NO_PREDIFFER, _("No Prediffer (Normal)").c_str());
-	
-	if (!GetOptionsMgr()->GetBool(OPT_PLUGINS_ENABLED))
-		return hMenu;
-
-	m_CurrentPredifferID = -1;
-
-	// compute the m_CurrentPredifferID (to set the radio button)
-	PrediffingInfo prediffer;
-	GetPrediffer(&prediffer);
-	if (prediffer.GetPluginPipeline().empty())
-		m_CurrentPredifferID = ID_NO_PREDIFFER;
-
-	// get the scriptlet files
-	const auto& [ suggestedPlugins, allPlugins ]= FileTransform::CreatePluginMenuInfos(
-		m_strBothFilenames, FileTransform::PredifferEventNames, ID_PREDIFFERS_FIRST);
-
-	// build the menu : first part, Suggested Plugins
-	// title
-	AppendMenu(hMenu, MF_SEPARATOR, 0, nullptr);
-	AppendMenu(hMenu, MF_STRING, ID_SUGGESTED_PLUGINS, _("Suggested Plugins").c_str());
-
-	for (const auto& [caption, name, id, plugin ] : suggestedPlugins)
-		AppendMenu(hMenu, MF_STRING, id, caption.c_str());
-
-	// build the menu : second part, others plugins
-	// title
-	AppendMenu(hMenu, MF_SEPARATOR, 0, nullptr);
-	AppendMenu(hMenu, MF_STRING, ID_NOT_SUGGESTED_PLUGINS, _("All Plugins").c_str());
-
-	String lastPluginName;
-	String errorMessage;
-	auto result = prediffer.ParsePluginPipeline(errorMessage);
-	if (result.size() > 0)
-		lastPluginName = result.back().name;
-	
-	for (const auto& [processType, pluginAry] : allPlugins)
-	{
-		for (const auto& [caption, name, id, plugin] : pluginAry)
-		{
-			if (!name.empty())
-			{
-				AppendMenu(hMenu, MF_STRING, id, caption.c_str());
-				if (lastPluginName == plugin->m_name)
-					m_CurrentPredifferID = id;
-			}
-		}
-	}
-
-	return hMenu;
 }
 
 /**
@@ -3032,22 +2957,7 @@ HMENU CMergeDoc::createPrediffersSubmenu(HMENU hMenu)
  */
 void CMergeDoc::OnUpdatePrediffer(CCmdUI* pCmdUI)
 {
-	pCmdUI->Enable(true);
-
-	PrediffingInfo prediffer;
-	GetPrediffer(&prediffer);
-
-	if (prediffer.GetPluginPipeline().find(_T("<Automatic>")) != String::npos)
-	{
-		pCmdUI->SetRadio(false);
-		return;
-	}
-
-	// Detect when CDiffWrapper::RunFileDiff has canceled a buggy prediffer
-	if (prediffer.GetPluginPipeline().empty())
-		m_CurrentPredifferID = ID_NO_PREDIFFER;
-
-	pCmdUI->SetRadio(pCmdUI->m_nID == static_cast<UINT>(m_CurrentPredifferID));
+	PluginMenu::UpdateMenu(pCmdUI);
 }
 
 /**
@@ -3055,48 +2965,29 @@ void CMergeDoc::OnUpdatePrediffer(CCmdUI* pCmdUI)
  */
 void CMergeDoc::OnPrediffer(UINT nID )
 {
-	SetPredifferByMenu(nID);
-	FlushAndRescan(true);
-}
-
-/**
- * @brief Handler for all prediffer choices.
- * Prediffer choises include ID_PREDIFF_MANUAL, ID_PREDIFF_AUTO,
- * ID_NO_PREDIFFER, & specific prediffers.
- */
-void CMergeDoc::SetPredifferByMenu(UINT nID)
-{
-	// update data for the radio button
-	m_CurrentPredifferID = nID;
-
-	if (nID == ID_NO_PREDIFFER)
-	{
-		// All flags are set correctly during the construction
-		PrediffingInfo infoPrediffer(false);
-		SetPrediffer(&infoPrediffer);
-		return;
-	}
-
-	String pluginName = PluginMenu::GetPluginPipelineByMenuId(nID, FileTransform::PredifferEventNames, ID_PREDIFFERS_FIRST);
+	PrediffingInfo infoPrediffer;
+	GetPrediffer(&infoPrediffer);
 
 	// build a PrediffingInfo structure fom the ID
-	PrediffingInfo prediffer(pluginName);
+	infoPrediffer.SetPluginPipeline(
+		PluginMenu::GetPluginPipelineByMenuId(&infoPrediffer, nID, FileTransform::PredifferEventNames, ID_PREDIFFERS_FIRST));
 	
 	// update the prediffer and rescan
-	SetPrediffer(&prediffer);
+	SetPrediffer(&infoPrediffer);
+
+	FlushAndRescan(true);
 }
 
 void CMergeDoc::OnScriptsForCopying(UINT nID)
 {
-	m_CurrentEditorScriptID = nID;
 	m_editorScriptInfo.SetPluginPipeline(
-		PluginMenu::GetPluginPipelineByMenuId(nID, FileTransform::EditorScriptEventNames, ID_SCRIPT_FOR_COPYING_FIRST));
+		PluginMenu::GetPluginPipelineByMenuId(&m_editorScriptInfo, nID, FileTransform::EditorScriptEventNames, ID_SCRIPT_FOR_COPYING_FIRST));
 }
 
 void CMergeDoc::OnUpdateScriptsForCopying(CCmdUI* pCmdUI)
 {
 	pCmdUI->Enable(true);
-	pCmdUI->SetRadio(pCmdUI->m_nID == static_cast<UINT>(m_CurrentEditorScriptID));
+	PluginMenu::UpdateMenu(pCmdUI);
 }
 
 void CMergeDoc::OnSelectEditorScriptForCopying() 
@@ -3108,7 +2999,6 @@ void CMergeDoc::OnSelectEditorScriptForCopying()
 	if (dlg.DoModal() != IDOK)
 		return;
 	m_editorScriptInfo.SetPluginPipeline(dlg.GetPluginPipeline());
-	m_CurrentEditorScriptID = 0;
 }
 
 void CMergeDoc::OnBnClickedFileEncoding()
@@ -3185,7 +3075,7 @@ void CMergeDoc::OnFileRecompareAs(UINT nID)
 	}
 	if (ID_UNPACKERS_FIRST <= nID && nID <= ID_UNPACKERS_LAST)
 	{
-		infoUnpacker.SetPluginPipeline(PluginMenu::GetPluginPipelineByMenuId(nID, FileTransform::UnpackerEventNames, ID_UNPACKERS_FIRST));
+		infoUnpacker.SetPluginPipeline(PluginMenu::GetPluginPipelineByMenuId(&infoUnpacker, nID, FileTransform::UnpackerEventNames, ID_UNPACKERS_FIRST));
 		nID = m_ptBuf[0]->GetTableEditing() ? ID_MERGE_COMPARE_TABLE : ID_MERGE_COMPARE_TEXT;
 		nID = GetOptionsMgr()->GetBool(OPT_PLUGINS_OPEN_IN_SAME_FRAME_TYPE) ? nID : -static_cast<int>(nID);
 	}
@@ -3193,6 +3083,11 @@ void CMergeDoc::OnFileRecompareAs(UINT nID)
 	if (GetMainFrame()->DoFileOrFolderOpen(&m_filePaths, dwFlags, strDesc, _T(""),
 		nullptr, &infoUnpacker, nullptr, nID))
 		GetParentFrame()->DestroyWindow();
+}
+
+void CMergeDoc::OnUpdateFileRecompareAs(CCmdUI* pCmdUI)
+{
+	PluginMenu::UpdateMenu(pCmdUI);
 }
 
 // Return file extension either from file name 

--- a/Src/MergeDoc.h
+++ b/Src/MergeDoc.h
@@ -373,8 +373,6 @@ public:
 	bool GetChangedSchemeManually() const { return m_bChangedSchemeManually; }
 
 	bool GetAutomaticRescan() const { return m_bAutomaticRescan; }
-	// to customize the mergeview menu
-	HMENU createPrediffersSubmenu(HMENU hMenu);
 	const String& GetSaveAsPath() const { return m_strSaveAsPath; }
 	void SetSaveAsPath(const String& strSaveAsPath) { m_strSaveAsPath = strSaveAsPath; }
 
@@ -422,8 +420,6 @@ protected:
 	 */
 	bool m_bAutomaticRescan;
 	/// active prediffer ID : helper to check the radio button
-	int m_CurrentPredifferID;
-	int m_CurrentEditorScriptID;
 	bool m_bChangedSchemeManually;	/**< `true` if the syntax highlighting scheme is changed manually */
 	String m_sCurrentHeaderTitle[3];
 	EditorScriptInfo m_editorScriptInfo;
@@ -460,7 +456,6 @@ protected:
 	afx_msg void OnUpdateStatusRO(CCmdUI* pCmdUI);
 	afx_msg void OnDiffContext(UINT nID);
 	afx_msg void OnUpdateDiffContext(CCmdUI* pCmdUI);
-	afx_msg void OnToolsGeneratePatch();
 	afx_msg void OnOpenWithUnpacker();
 	afx_msg void OnApplyPrediffer();
 	afx_msg void OnBnClickedFileEncoding();
@@ -472,6 +467,7 @@ protected:
 	afx_msg void OnUpdateFileRecompareAsText(CCmdUI* pCmdUI);
 	afx_msg void OnUpdateFileRecompareAsTable(CCmdUI* pCmdUI);
 	afx_msg void OnFileRecompareAs(UINT nID);
+	afx_msg void OnUpdateFileRecompareAs(CCmdUI* pCmdUI);
 	template<int srcPane, int dstPane>
 	afx_msg void OnViewSwapPanes();
 	afx_msg void OnUpdateSwapContext(CCmdUI* pCmdUI);
@@ -502,7 +498,6 @@ private:
 	void FlagMovedLines();
 	String GetFileExt(const tchar_t* sFileName, const tchar_t* sDescription) const;
 	void DoFileSave(int pane);
-	void SetPredifferByMenu(UINT nID);
 };
 
 /**

--- a/Src/MergeEditView.cpp
+++ b/Src/MergeEditView.cpp
@@ -3523,7 +3523,7 @@ void CMergeEditView::OnScripts(UINT nID)
 	String text{ ctext, static_cast<unsigned>(ctext.GetLength()) };
 
 	EditorScriptInfo scriptInfo(
-		PluginMenu::GetPluginPipelineByMenuId(nID, FileTransform::EditorScriptEventNames, ID_SCRIPT_FIRST));
+		PluginMenu::GetPluginPipelineByMenuId(nullptr, nID, FileTransform::EditorScriptEventNames, ID_SCRIPT_FIRST));
 	// transform the text with a script/ActiveX function, event=EDITOR_SCRIPT
 	bool bChanged = false;
 	scriptInfo.TransformText(m_nThisPane, text, { GetDocument()->m_filePaths[m_nThisPane] }, bChanged);

--- a/Src/OpenView.cpp
+++ b/Src/OpenView.cpp
@@ -745,7 +745,7 @@ void COpenView::OnCompare(UINT nID)
 			PackingInfo tmpPackingInfo(m_strUnpackerPipeline);
 			if (ID_UNPACKERS_FIRST <= nID && nID <= ID_UNPACKERS_LAST)
 			{
-				tmpPackingInfo.SetPluginPipeline(PluginMenu::GetPluginPipelineByMenuId(nID, FileTransform::UnpackerEventNames, ID_UNPACKERS_FIRST));
+				tmpPackingInfo.SetPluginPipeline(PluginMenu::GetPluginPipelineByMenuId(&tmpPackingInfo, nID, FileTransform::UnpackerEventNames, ID_UNPACKERS_FIRST));
 				nID = 0;
 			}
 			PrediffingInfo tmpPrediffingInfo(m_strPredifferPipeline);
@@ -852,7 +852,7 @@ void COpenView::OnCompare(UINT nID)
 	}
 	else if (ID_UNPACKERS_FIRST <= nID && nID <= ID_UNPACKERS_LAST)
 	{
-		tmpPackingInfo.SetPluginPipeline(PluginMenu::GetPluginPipelineByMenuId(nID, FileTransform::UnpackerEventNames, ID_UNPACKERS_FIRST));
+		tmpPackingInfo.SetPluginPipeline(PluginMenu::GetPluginPipelineByMenuId(&tmpPackingInfo, nID, FileTransform::UnpackerEventNames, ID_UNPACKERS_FIRST));
 		GetMainFrame()->DoFileOrFolderOpen(
 			&tmpPathContext, dwFlags.data(),
 			nullptr, _T(""), nullptr, &tmpPackingInfo, &tmpPrediffingInfo, 0, pOpenFolderParams.get());
@@ -1151,7 +1151,7 @@ void COpenView::DropDown(NMHDR* pNMHDR, LRESULT* pResult, UINT nID, UINT nPopupI
 			for (int i = 0; i < 3; i++)
 				tmpPath[i] = m_strPath[i].empty() ? _T("|.|") : m_strPath[i];
 			String filteredFilenames = strutils::join(std::begin(tmpPath), std::end(tmpPath), _T("|"));
-			PluginMenu::AppendPluginMenus(pPopup, filteredFilenames, FileTransform::UnpackerEventNames, 
+			PluginMenu::AppendPluginMenus(pPopup, nullptr, filteredFilenames, FileTransform::UnpackerEventNames, 
 				PluginMenu::AddAllMenu|PluginMenu::AddSelectMenu, ID_UNPACKERS_FIRST);
 		}
 		pPopup->TrackPopupMenu(TPM_LEFTALIGN | TPM_RIGHTBUTTON,

--- a/Src/PluginMenu.cpp
+++ b/Src/PluginMenu.cpp
@@ -151,7 +151,10 @@ String PluginMenu::GetPluginPipelineByMenuId(const PluginForFile* pluginInfo, un
 	{
 		String pipeline = pluginInfo ? pluginInfo->GetPluginPipeline() : _T("");
 		if (bCtrlKey)
-			pipeline = pipeline.empty() ? pluginName : (pipeline + _T("|") + pluginName);
+		{
+			if (!pluginName.empty())
+				pipeline = pipeline.empty() ? pluginName : (pipeline + _T("|") + pluginName);
+		}
 		else
 			pipeline = pluginName;
 		if (!pluginFound->GetExtendedPropertyValue(_T("ArgumentsRequired")).has_value() &&

--- a/Src/PluginMenu.cpp
+++ b/Src/PluginMenu.cpp
@@ -38,11 +38,12 @@ static int GetMenuItemData(CMenu* pMenu, unsigned id)
 
 static void AddMenuItem(CMenu* pMenu, const std::vector<PluginForFile::PipelineItem>& plugins, const String& name, const String& caption, unsigned id)
 {
-	const int order = GetPluginPipelineOrder(plugins, name);
-	const String caption2 = order >= 0 ? caption + _T(" (") + std::to_wstring(order + 1) + _T(")") : caption;
+	const bool isNone = name.empty();
+	const int order = isNone ? (plugins.empty() ? 0 : -1) : GetPluginPipelineOrder(plugins, name);
+	const String caption2 = (!isNone && order >= 0) ? caption + _T(" (") + std::to_wstring(order + 1) + _T(")") : caption;
 	pMenu->AppendMenu(MF_STRING, id, caption2.c_str());
-	if (order >= 0)
-		SetMenuItemData(pMenu, id, order + 1);
+	if ((isNone && plugins.empty()) || (!isNone && order >= 0))
+		SetMenuItemData(pMenu, id, isNone ? 1 : (order + 1));
 }
 
 void PluginMenu::AppendPluginMenus(CMenu *pMenu, const PluginForFile* pluginInfo, const String& filteredFilenames,

--- a/Src/PluginMenu.cpp
+++ b/Src/PluginMenu.cpp
@@ -10,7 +10,42 @@
 #include "OptionsMgr.h"
 #include "OptionsDef.h"
 
-void PluginMenu::AppendPluginMenus(CMenu *pMenu, const String& filteredFilenames,
+static int GetPluginPipelineOrder(const std::vector<PluginForFile::PipelineItem>& plugins, const String& pluginName)
+{
+	for (size_t i = 0; i < plugins.size(); ++i)
+	{
+		if (plugins[i].name == pluginName)
+			return static_cast<int>(i);
+	}
+	return -1;
+}
+
+static void SetMenuItemData(CMenu* pMenu, unsigned id, int order)
+{
+	MENUITEMINFO mii = { sizeof(MENUITEMINFO) };
+	mii.fMask = MIIM_DATA;
+	mii.dwItemData = order;
+	pMenu->SetMenuItemInfo(id, &mii, FALSE);
+}
+
+static int GetMenuItemData(CMenu* pMenu, unsigned id)
+{
+	MENUITEMINFO mii = { sizeof(MENUITEMINFO) };
+	mii.fMask = MIIM_DATA;
+	pMenu->GetMenuItemInfo(id, &mii, FALSE);
+	return static_cast<int>(mii.dwItemData);
+}
+
+static void AddMenuItem(CMenu* pMenu, const std::vector<PluginForFile::PipelineItem>& plugins, const String& name, const String& caption, unsigned id)
+{
+	const int order = GetPluginPipelineOrder(plugins, name);
+	const String caption2 = order >= 0 ? caption + _T(" (") + std::to_wstring(order + 1) + _T(")") : caption;
+	pMenu->AppendMenu(MF_STRING, id, caption2.c_str());
+	if (order >= 0)
+		SetMenuItemData(pMenu, id, order + 1);
+}
+
+void PluginMenu::AppendPluginMenus(CMenu *pMenu, const PluginForFile* pluginInfo, const String& filteredFilenames,
 	const std::vector<std::wstring>& events, unsigned flags, unsigned baseId)
 {
 	if (!GetOptionsMgr()->GetBool(OPT_PLUGINS_ENABLED))
@@ -18,19 +53,20 @@ void PluginMenu::AppendPluginMenus(CMenu *pMenu, const String& filteredFilenames
 
 	CWaitCursor waitstatus;
 
+	String errorMessage;
+	std::vector<PluginForFile::PipelineItem> plugins;
+	if (pluginInfo)
+		plugins = pluginInfo->ParsePluginPipeline(errorMessage);
+
 	auto [suggestedPlugins, allPlugins] = FileTransform::CreatePluginMenuInfos(filteredFilenames, events, baseId);
 
 	if ((flags & MenuFlags::AddAllMenu) == 0)
-	{
 		pMenu->AppendMenu(MF_STRING, ID_SUGGESTED_PLUGINS, _("Suggested Plugins").c_str());
-	}
 	else
-	{
 		pMenu->AppendMenu(MF_SEPARATOR);
-	}
 
 	for (const auto& [caption, name, id, plugin] : suggestedPlugins)
-		pMenu->AppendMenu(MF_STRING, id, caption.c_str());
+		AddMenuItem(pMenu, plugins, name, caption, id);
 
 	CMenu* pMenu2 = pMenu;
 	CMenu popupAll;
@@ -61,21 +97,21 @@ void PluginMenu::AppendPluginMenus(CMenu *pMenu, const String& filteredFilenames
 		if ((flags & MenuFlags::FlattenMenu) != 0)
 		{
 			for (const auto& [caption, name, id, plugin] : allPlugins[processType])
-				pMenu2->AppendMenu(MF_STRING, id, caption.c_str());
+				AddMenuItem(pMenu2, plugins, name, caption, id);
 		}
 		else
 		{
 			if (processType.empty())
 			{
 				for (const auto& [caption, name, id, plugin] : allPlugins[processType])
-					pMenu2->AppendMenu(MF_STRING, id, caption.c_str());
+					AddMenuItem(pMenu2, plugins, name, caption, id);
 			}
 			else
 			{
 				CMenu popup;
 				popup.CreatePopupMenu();
 				for (const auto& [caption, name, id, plugin] : allPlugins[processType])
-					popup.AppendMenu(MF_STRING, id, caption.c_str());
+					AddMenuItem(&popup, plugins, name, caption, id);
 				pMenu2->AppendMenu(MF_POPUP, reinterpret_cast<UINT_PTR>(popup.Detach()), processType.c_str());
 			}
 		}
@@ -88,11 +124,14 @@ void PluginMenu::AppendPluginMenus(CMenu *pMenu, const String& filteredFilenames
 		else if (baseId == ID_PREDIFFERS_FIRST)
 			pMenu2->AppendMenu(MF_STRING, ID_APPLY_PREDIFFER, _("&Select...").c_str());
 	}
+	if (pluginInfo)
+		pMenu->AppendMenu(MF_STRING | MF_GRAYED, 0, _("(Ctrl+Click to add to pipeline)").c_str());
 	popupAll.Detach();
 }
 
-String PluginMenu::GetPluginPipelineByMenuId(unsigned idSearch, const std::vector<std::wstring>& events, unsigned baseId)
+String PluginMenu::GetPluginPipelineByMenuId(const PluginForFile* pluginInfo, unsigned idSearch, const std::vector<std::wstring>& events, unsigned baseId)
 {
+	bool bCtrlKey = (::GetAsyncKeyState(VK_CONTROL) & 0x8000) != 0;
 	PluginInfo* pluginFound = nullptr;
 	String pluginName;
 	[[maybe_unused]] auto [_, allPlugins] = FileTransform::CreatePluginMenuInfos(_T(""), events, baseId);
@@ -110,10 +149,15 @@ String PluginMenu::GetPluginPipelineByMenuId(unsigned idSearch, const std::vecto
 	}
 	if (pluginFound)
 	{
-		if (!pluginFound->GetExtendedPropertyValue(_T("ArgumentsRequired")).has_value() && 
-		    !pluginFound->GetExtendedPropertyValue(pluginName + _T(".ArgumentsRequired")).has_value())
-			return pluginName;
-		CSelectPluginDlg dlg(pluginName, _T(""), 
+		String pipeline = pluginInfo ? pluginInfo->GetPluginPipeline() : _T("");
+		if (bCtrlKey)
+			pipeline = pipeline.empty() ? pluginName : (pipeline + _T("|") + pluginName);
+		else
+			pipeline = pluginName;
+		if (!pluginFound->GetExtendedPropertyValue(_T("ArgumentsRequired")).has_value() &&
+			!pluginFound->GetExtendedPropertyValue(pluginName + _T(".ArgumentsRequired")).has_value())
+			return pipeline;
+		CSelectPluginDlg dlg(pipeline, _T(""), 
 			(baseId == ID_UNPACKERS_FIRST)  ? CSelectPluginDlg::PluginType::Unpacker    : (
 			(baseId == ID_PREDIFFERS_FIRST) ? CSelectPluginDlg::PluginType::Prediffer   : 
 			                                  CSelectPluginDlg::PluginType::EditorScript), true);
@@ -124,10 +168,17 @@ String PluginMenu::GetPluginPipelineByMenuId(unsigned idSearch, const std::vecto
 	return {};
 }
 
-void PluginMenu::ShowMenu(const String& filteredFilenames, const std::vector<std::wstring>& events, unsigned flags, unsigned baseId, int x, int y, CWnd* pParentWnd)
+void PluginMenu::ShowMenu(const PluginForFile* pluginInfo, const String& filteredFilenames, const std::vector<std::wstring>& events, unsigned flags, unsigned baseId, int x, int y, CWnd* pParentWnd)
 {
 	CMenu menu;
 	menu.CreatePopupMenu();
-	AppendPluginMenus(&menu, filteredFilenames, events, flags, baseId);
+	AppendPluginMenus(&menu, pluginInfo, filteredFilenames, events, flags, baseId);
 	menu.TrackPopupMenu(TPM_LEFTALIGN | TPM_RIGHTBUTTON, x, y, pParentWnd);
+}
+
+void PluginMenu::UpdateMenu(CCmdUI* pCmdUI)
+{
+	if (!pCmdUI || !pCmdUI->m_pMenu)
+		return;
+	pCmdUI->SetCheck(GetMenuItemData(pCmdUI->m_pMenu, pCmdUI->m_nID) > 0);
 }

--- a/Src/PluginMenu.h
+++ b/Src/PluginMenu.h
@@ -4,12 +4,14 @@
  */
 #pragma once
 
-class CMenu;
-class CWnd;
-
 #include "UnicodeString.h"
 #include <vector>
 #include <string>
+
+class CMenu;
+class PluginForFile;
+class CCmdUI;
+
 namespace PluginMenu
 {
 	enum MenuFlags
@@ -19,7 +21,8 @@ namespace PluginMenu
 		AddSelectMenu = 1 << 1, /**< Add "Select..." menu item */
 		FlattenMenu = 1 << 2 /**< Flatten the menu structure */
 	};
-	void AppendPluginMenus(CMenu* pMenu, const String& filteredFilenames, const std::vector<std::wstring>& events, unsigned flags, unsigned baseId);
-	String GetPluginPipelineByMenuId(unsigned idSearch, const std::vector<std::wstring>& events, unsigned baseId);
-	void ShowMenu(const String& filteredFilenames, const std::vector<std::wstring>& events, unsigned flags, unsigned baseId, int x, int y, CWnd* pParentWnd);
+	void AppendPluginMenus(CMenu* pMenu, const PluginForFile* pluginInfo, const String& filteredFilenames, const std::vector<std::wstring>& events, unsigned flags, unsigned baseId);
+	String GetPluginPipelineByMenuId(const PluginForFile* pluginInfo, unsigned idSearch, const std::vector<std::wstring>& events, unsigned baseId);
+	void ShowMenu(const PluginForFile* pluginInfo, const String& filteredFilenames, const std::vector<std::wstring>& events, unsigned flags, unsigned baseId, int x, int y, CWnd* pParentWnd);
+	void UpdateMenu(CCmdUI* pCmdUI);
 }

--- a/Src/PluginMenu.h
+++ b/Src/PluginMenu.h
@@ -11,6 +11,7 @@
 class CMenu;
 class PluginForFile;
 class CCmdUI;
+class CWnd;
 
 namespace PluginMenu
 {

--- a/Src/WebPageDiffFrm.cpp
+++ b/Src/WebPageDiffFrm.cpp
@@ -762,7 +762,7 @@ void CWebPageDiffFrame::OnFileRecompareAs(UINT nID)
 	}
 	if (ID_UNPACKERS_FIRST <= nID && nID <= ID_UNPACKERS_LAST)
 	{
-		infoUnpacker.SetPluginPipeline(PluginMenu::GetPluginPipelineByMenuId(nID, FileTransform::UnpackerEventNames, ID_UNPACKERS_FIRST));
+		infoUnpacker.SetPluginPipeline(PluginMenu::GetPluginPipelineByMenuId(&infoUnpacker, nID, FileTransform::UnpackerEventNames, ID_UNPACKERS_FIRST));
 		nID = GetOptionsMgr()->GetBool(OPT_PLUGINS_OPEN_IN_SAME_FRAME_TYPE) ? ID_MERGE_COMPARE_WEBPAGE : -ID_MERGE_COMPARE_WEBPAGE;
 	}
 

--- a/Src/resource.h
+++ b/Src/resource.h
@@ -2227,6 +2227,7 @@
 #define IDS_PLUGIN_TARGETS_1ST_2ND      44504
 #define IDS_PLUGIN_TARGETS_1ST_3RD      44505
 #define IDS_PLUGIN_TARGETS_2ND_3RD      44506
+#define IDS_PLUGIN_CTRL_CLICK           44507
 #define IDS_L2M                         44600
 #define IDS_R2M                         44601
 #define IDS_COPY_FROM_MIDDLE_R          44602

--- a/Translations/WinMerge/Arabic.po
+++ b/Translations/WinMerge/Arabic.po
@@ -24,7 +24,7 @@ msgstr ""
 "Language: ar_SA\n"
 
 #. LANGUAGE, SUBLANGUAGE
-#: Merge.rc:26 Merge.rc:59 Merge.rc:5817
+#: Merge.rc:26 Merge.rc:59 Merge.rc:5818
 msgid "LANG_ENGLISH, SUBLANG_ENGLISH_US"
 msgstr "LANG_ARABIC, SUBLANG_ARABIC_SAUDI_ARABIA"
 
@@ -231,7 +231,7 @@ msgid "Auto-Fit All Columns"
 msgstr ""
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN
-#: Merge.rc:153 Merge.rc:5645
+#: Merge.rc:153 Merge.rc:5646
 msgid "&Filter by This Column"
 msgstr ""
 
@@ -292,7 +292,7 @@ msgid "&Previous Page"
 msgstr "ال&صفحة السابقة"
 
 #. IDS_PREVIEWBAR_NEXTPAGE
-#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5678
+#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5679
 msgid "&Next Page"
 msgstr "الص&فحة التالية"
 
@@ -665,7 +665,7 @@ msgid "&Huge"
 msgstr "&ضخم"
 
 #. IDS_VIEW_MENU_BAR
-#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5713
+#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5714
 msgid "Men&u Bar"
 msgstr ""
 
@@ -4194,7 +4194,7 @@ msgid "Items compared:"
 msgstr "العناصر التي تمت مقارنتها:"
 
 #. IDS_PREVIEWBAR_CLOSE
-#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5684
+#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5685
 msgid "&Close"
 msgstr "إ&غلاق"
 
@@ -8280,447 +8280,452 @@ msgstr ""
 msgid "2nd and 3rd"
 msgstr ""
 
+#. IDS_PLUGIN_CTRL_CLICK
+#: Merge.rc:5635
+msgid "(Ctrl+Click to add to pipeline)"
+msgstr ""
+
 #. IDS_FILTER_APPLIED
-#: Merge.rc:5639
+#: Merge.rc:5640
 msgid "Filter applied"
 msgstr ""
 
 #. IDS_FILTERMENU_COMPARE
-#: Merge.rc:5644
+#: Merge.rc:5645
 #, c-format
 msgid "Compare %1"
 msgstr ""
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN2
-#: Merge.rc:5646
+#: Merge.rc:5647
 msgid "&Filter by This Column..."
 msgstr ""
 
 #. IDS_CLIPBOARDHISTORY_TIME
-#: Merge.rc:5651
+#: Merge.rc:5652
 #, c-format
 msgid "Clipboard at %s"
 msgstr ""
 
 #. IDS_CLIPBOARDHISTORY_DISABLED
-#: Merge.rc:5652
+#: Merge.rc:5653
 msgid "Clipboard history disabled.\r\nEnable: Windows logo key + V, then Turn on."
 msgstr ""
 
-#: Merge.rc:5654
+#: Merge.rc:5655
 msgid "This system does not support clipboard history."
 msgstr ""
 
-#: Merge.rc:5656
+#: Merge.rc:5657
 msgid "32-bit WinMerge does not support Clipboard Compare"
 msgstr ""
 
 #. IDS_WEBVIEW2_RUNTIME_NOT_INSTALLED
-#: Merge.rc:5661
+#: Merge.rc:5662
 msgid "WebView2 runtime not installed. Download it?"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_TEXT_COMPARE
-#: Merge.rc:5666
+#: Merge.rc:5667
 msgid "New Text Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_TABLE_COMPARE
-#: Merge.rc:5667
+#: Merge.rc:5668
 msgid "New Table Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_BINARY_COMPARE
-#: Merge.rc:5668
+#: Merge.rc:5669
 msgid "New Binary Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_IMAGE_COMPARE
-#: Merge.rc:5669
+#: Merge.rc:5670
 msgid "New Image Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_WEBPAGE_COMPARE
-#: Merge.rc:5670
+#: Merge.rc:5671
 msgid "New Webpage Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_FOLDER_COMPARE
-#: Merge.rc:5671
+#: Merge.rc:5672
 msgid "New Folder Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_CLIPBOARD_COMPARE
-#: Merge.rc:5672
+#: Merge.rc:5673
 msgid "Clipboard Compare"
 msgstr ""
 
 #. IDS_PREVIEWBAR_PRINT
-#: Merge.rc:5677
+#: Merge.rc:5678
 msgid "&Print..."
 msgstr ""
 
 #. IDS_PREVIEWBAR_PREVPAGE
-#: Merge.rc:5679
+#: Merge.rc:5680
 msgid "Pre&v Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_TWOPAGE
-#: Merge.rc:5680
+#: Merge.rc:5681
 msgid "&Two Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_ONEPAGE
-#: Merge.rc:5681
+#: Merge.rc:5682
 msgid "&One Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_ZOOMIN
-#: Merge.rc:5682
+#: Merge.rc:5683
 msgid "Zoom &In"
 msgstr ""
 
 #. IDS_PREVIEWBAR_ZOOMOUT
-#: Merge.rc:5683
+#: Merge.rc:5684
 msgid "Zoom &Out"
 msgstr ""
 
 #. IDS_WEBPAGE_COMPARING
-#: Merge.rc:5689
+#: Merge.rc:5690
 msgid "Comparing..."
 msgstr ""
 
 #. IDS_WEBPAGE_ZOOM
-#: Merge.rc:5690
+#: Merge.rc:5691
 msgid "Zoom:"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_DIFFHUNK
-#: Merge.rc:5695
+#: Merge.rc:5696
 msgid "Diff hunk"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_INLINE
-#: Merge.rc:5696
+#: Merge.rc:5697
 msgid "Inline diff"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_LINE
-#: Merge.rc:5697
+#: Merge.rc:5698
 msgid "Line"
 msgstr ""
 
-#: Merge.rc:5698
+#: Merge.rc:5699
 msgid "Character"
 msgstr ""
 
 #. ID_MICE_PREVDIFF
-#: Merge.rc:5703
+#: Merge.rc:5704
 msgid "\nPrevious Difference (Alt+Up)\n(Right Button+Wheel Up)\n(Alt+Wheel Up)"
 msgstr ""
 
 #. ID_MICE_NEXTDIFF
-#: Merge.rc:5704
+#: Merge.rc:5705
 msgid "\nNext Difference (Alt+Down)\n(Right Button+Wheel Down)\n(Alt+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_L2R
-#: Merge.rc:5705
+#: Merge.rc:5706
 msgid "\nCopy to Right (Alt+Right)\n(Right Button+Wheel Right)\n(Alt+Wheel Right)\n(Alt+Shift+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_R2L
-#: Merge.rc:5706
+#: Merge.rc:5707
 msgid "\nCopy to Left (Alt+Left)\n(Right Button+Wheel Left)\n(Alt+Wheel Left)\n(Alt+Shift+Wheel Up)"
 msgstr ""
 
 #. ID_MICE_L2RNEXT
-#: Merge.rc:5707
+#: Merge.rc:5708
 msgid "\nCopy to Right and Advance (Ctrl+Alt+Right)\n(Ctrl+Alt+Wheel Right)\n(Ctrl+Alt+Shift+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_R2LNEXT
-#: Merge.rc:5708
+#: Merge.rc:5709
 msgid "\nCopy to Left and Advance (Ctrl+Alt+Left)\n(Ctrl+Alt+Wheel Left)\n(Ctrl+Alt+Shift+Wheel Up)"
 msgstr ""
 
 #. IDS_LOG_COMPARING_2
-#: Merge.rc:5718
+#: Merge.rc:5719
 #, c-format
 msgid "Comparing %1 with %2"
 msgstr ""
 
 #. IDS_LOG_COMPARING_3
-#: Merge.rc:5719
+#: Merge.rc:5720
 #, c-format
 msgid "Comparing %1 with %2 and %3"
 msgstr ""
 
 #. IDS_LOG_COMPARE_COMPLETED
-#: Merge.rc:5720
+#: Merge.rc:5721
 msgid "Comparison completed"
 msgstr ""
 
 #. IDS_LOG_COMPARE_ERROR_2
-#: Merge.rc:5721
+#: Merge.rc:5722
 #, c-format
 msgid "Failed to compare %1 with %2: "
 msgstr ""
 
 #. IDS_LOG_COMPARE_ERROR_3
-#: Merge.rc:5722
+#: Merge.rc:5723
 #, c-format
 msgid "Failed to compare %1 with %2 and %3: "
 msgstr ""
 
 #. IDS_LOG_FILE_SAVED
-#: Merge.rc:5723
+#: Merge.rc:5724
 msgid "File saved"
 msgstr ""
 
 #. IDS_LOG_COPYING_FILES
-#: Merge.rc:5724
+#: Merge.rc:5725
 msgid "Copying files..."
 msgstr ""
 
 #. IDS_LOG_MOVING_FILES
-#: Merge.rc:5725
+#: Merge.rc:5726
 msgid "Moving files..."
 msgstr ""
 
 #. IDS_LOG_DELETING_FILES
-#: Merge.rc:5726
+#: Merge.rc:5727
 msgid "Deleting files..."
 msgstr ""
 
 #. IDS_LOG_RECYCLEBIN
-#: Merge.rc:5727
+#: Merge.rc:5728
 msgid "Recycle Bin"
 msgstr ""
 
 #. IDS_LOG_PERMANENTLY_DELETED
-#: Merge.rc:5728
+#: Merge.rc:5729
 msgid "Permanently deleted"
 msgstr ""
 
 #. IDS_LOG_FILEOPERATION_COMPLETED
-#: Merge.rc:5729
+#: Merge.rc:5730
 msgid "File operation completed successfully"
 msgstr ""
 
 #. IDS_LOG_FILEOPERATION_CANCELED
-#: Merge.rc:5730
+#: Merge.rc:5731
 msgid "File operation canceled"
 msgstr ""
 
 #. IDS_FILTER_ERROR_NO_ERROR
-#: Merge.rc:5735
+#: Merge.rc:5736
 msgid "No error"
 msgstr ""
 
 #. IDS_FILTER_ERROR_EMPTY_EXPRESSION
-#: Merge.rc:5736
+#: Merge.rc:5737
 msgid "Filter expression is empty"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNKNOWN_CHAR
-#: Merge.rc:5737
+#: Merge.rc:5738
 msgid "Unknown character in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNTERMINATED_STRING
-#: Merge.rc:5738
+#: Merge.rc:5739
 msgid "Unterminated string literal"
 msgstr ""
 
 #. IDS_FILTER_ERROR_SYNTAX_ERROR
-#: Merge.rc:5739
+#: Merge.rc:5740
 msgid "Syntax error in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_PARSE_FAILURE
-#: Merge.rc:5740
+#: Merge.rc:5741
 msgid "Failed to parse filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_LITERAL
-#: Merge.rc:5741
+#: Merge.rc:5742
 msgid "Invalid literal value"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_REGULAR_EXPRESSION
-#: Merge.rc:5742
+#: Merge.rc:5743
 msgid "Invalid regular expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNDEFINED_IDENTIFIER
-#: Merge.rc:5743
+#: Merge.rc:5744
 msgid "Undefined identifier"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_ARGUMENT_COUNT
-#: Merge.rc:5744
+#: Merge.rc:5745
 msgid "Invalid number of arguments"
 msgstr ""
 
 #. IDS_FILTER_ERROR_FILTER_NAME_NOT_FOUND
-#: Merge.rc:5745
+#: Merge.rc:5746
 msgid "Filter name not found"
 msgstr ""
 
 #. IDS_FILTER_ERROR_DIVIDE_BY_ZERO
-#: Merge.rc:5746
+#: Merge.rc:5747
 msgid "Division by zero in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNKNOWN_ERROR
-#: Merge.rc:5747
+#: Merge.rc:5748
 msgid "Unknown error"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_PROPERTY_NAME
-#: Merge.rc:5748
+#: Merge.rc:5749
 msgid "Invalid property name"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_DIRECTIVE
-#: Merge.rc:5749
+#: Merge.rc:5750
 msgid "Invalid directive"
 msgstr ""
 
 #. IDS_FILTER_OP_EQUALS
-#: Merge.rc:5754
+#: Merge.rc:5755
 msgid "Equals"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_EQUALS
-#: Merge.rc:5755
+#: Merge.rc:5756
 msgid "Does not equal"
 msgstr ""
 
 #. IDS_FILTER_OP_LESS_THAN
-#: Merge.rc:5756
+#: Merge.rc:5757
 msgid "Less than"
 msgstr ""
 
 #. IDS_FILTER_OP_LESS_EQUAL
-#: Merge.rc:5757
+#: Merge.rc:5758
 msgid "Less than or equal to"
 msgstr ""
 
 #. IDS_FILTER_OP_GREATER_EQUAL
-#: Merge.rc:5758
+#: Merge.rc:5759
 msgid "Greater than or equal to"
 msgstr ""
 
 #. IDS_FILTER_OP_GREATER_THAN
-#: Merge.rc:5759
+#: Merge.rc:5760
 msgid "Greater than"
 msgstr ""
 
 #. IDS_FILTER_OP_BETWEEN
-#: Merge.rc:5760
+#: Merge.rc:5761
 msgid "Between"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_BETWEEN
-#: Merge.rc:5761
+#: Merge.rc:5762
 msgid "Not Between"
 msgstr ""
 
 #. IDS_FILTER_OP_CONTAINS
-#: Merge.rc:5762
+#: Merge.rc:5763
 msgid "Contains"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_CONTAINS
-#: Merge.rc:5763
+#: Merge.rc:5764
 msgid "Not Contains"
 msgstr ""
 
 #. IDS_FILTER_OP_RECONTAINS
-#: Merge.rc:5764
+#: Merge.rc:5765
 msgid "Contains (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_RECONTAINS
-#: Merge.rc:5765
+#: Merge.rc:5766
 msgid "Not Contains (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_LIKE
-#: Merge.rc:5766
+#: Merge.rc:5767
 msgid "Match (wildcard)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_LIKE
-#: Merge.rc:5767
+#: Merge.rc:5768
 msgid "Not match (wildcard)"
 msgstr ""
 
 #. IDS_FILTER_OP_MATCHES
-#: Merge.rc:5768
+#: Merge.rc:5769
 msgid "Match (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_MATCHES
-#: Merge.rc:5769
+#: Merge.rc:5770
 msgid "Not match (regex)"
 msgstr ""
 
 #. IDS_COLORMODE_LIGHT
-#: Merge.rc:5774
+#: Merge.rc:5775
 msgid "Light"
 msgstr ""
 
 #. IDS_COLORMODE_DARK
-#: Merge.rc:5775
+#: Merge.rc:5776
 msgid "Dark"
 msgstr ""
 
 #. IDS_COLORMODE_FOLLOWSYSTEM
-#: Merge.rc:5776
+#: Merge.rc:5777
 msgid "Follow system"
 msgstr ""
 
 #. IDS_EXAMPLE
-#: Merge.rc:5781
+#: Merge.rc:5782
 #, c-format
 msgid "e.g. %1"
 msgstr ""
 
 #. IDS_DETECTED_PREVIOUS_CRASH
-#: Merge.rc:5786
+#: Merge.rc:5787
 msgid "WinMerge detected a previous crash. Please report this if possible."
 msgstr ""
 
 #. IDS_REGEX_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5791
+#: Merge.rc:5792
 msgid "# Regex replacement list\r\n# Format: regex<TAB>replacement\r\n# Backreferences like $1, $2 are supported\r\n\r\n(\\d{4})-(\\d{2})-(\\d{2})\t$1_$2_$3\r\n"
 msgstr ""
 
 #. IDS_STRING_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5792
+#: Merge.rc:5793
 msgid "# Replacement list\r\n# Format: search<TAB>replacement\r\n# Lines starting with # are ignored\r\n\r\nfrom1\tto1\r\nfrom2\tto2\r\n"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_ONLY
-#: Merge.rc:5797
+#: Merge.rc:5798
 msgid "Built-in only"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_FIRST
-#: Merge.rc:5798
+#: Merge.rc:5799
 msgid "Built-in first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_FIRST
-#: Merge.rc:5799
+#: Merge.rc:5800
 msgid "Tree-sitter first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_ONLY
-#: Merge.rc:5800
+#: Merge.rc:5801
 msgid "Tree-sitter only"
 msgstr ""
 

--- a/Translations/WinMerge/Basque.po
+++ b/Translations/WinMerge/Basque.po
@@ -24,7 +24,7 @@ msgstr ""
 "X-Generator: Poedit 1.5.3\n"
 
 #. LANGUAGE, SUBLANGUAGE
-#: Merge.rc:26 Merge.rc:59 Merge.rc:5817
+#: Merge.rc:26 Merge.rc:59 Merge.rc:5818
 #, c-format
 msgid "LANG_ENGLISH, SUBLANG_ENGLISH_US"
 msgstr "LANG_BASQUE, SUBLANG_DEFAULT"
@@ -241,7 +241,7 @@ msgid "Auto-Fit All Columns"
 msgstr ""
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN
-#: Merge.rc:153 Merge.rc:5645
+#: Merge.rc:153 Merge.rc:5646
 msgid "&Filter by This Column"
 msgstr ""
 
@@ -307,7 +307,7 @@ msgid "&Previous Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_NEXTPAGE
-#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5678
+#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5679
 #, c-format
 msgid "&Next Page"
 msgstr ""
@@ -713,7 +713,7 @@ msgid "&Huge"
 msgstr ""
 
 #. IDS_VIEW_MENU_BAR
-#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5713
+#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5714
 msgid "Men&u Bar"
 msgstr ""
 
@@ -4568,7 +4568,7 @@ msgid "Items compared:"
 msgstr "Alderatutako gaiak:"
 
 #. IDS_PREVIEWBAR_CLOSE
-#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5684
+#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5685
 #, c-format
 msgid "&Close"
 msgstr "&Itxi"
@@ -8894,447 +8894,452 @@ msgstr ""
 msgid "2nd and 3rd"
 msgstr ""
 
+#. IDS_PLUGIN_CTRL_CLICK
+#: Merge.rc:5635
+msgid "(Ctrl+Click to add to pipeline)"
+msgstr ""
+
 #. IDS_FILTER_APPLIED
-#: Merge.rc:5639
+#: Merge.rc:5640
 msgid "Filter applied"
 msgstr ""
 
 #. IDS_FILTERMENU_COMPARE
-#: Merge.rc:5644
+#: Merge.rc:5645
 #, c-format
 msgid "Compare %1"
 msgstr ""
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN2
-#: Merge.rc:5646
+#: Merge.rc:5647
 msgid "&Filter by This Column..."
 msgstr ""
 
 #. IDS_CLIPBOARDHISTORY_TIME
-#: Merge.rc:5651
+#: Merge.rc:5652
 #, c-format
 msgid "Clipboard at %s"
 msgstr ""
 
 #. IDS_CLIPBOARDHISTORY_DISABLED
-#: Merge.rc:5652
+#: Merge.rc:5653
 msgid "Clipboard history disabled.\r\nEnable: Windows logo key + V, then Turn on."
 msgstr ""
 
-#: Merge.rc:5654
+#: Merge.rc:5655
 msgid "This system does not support clipboard history."
 msgstr ""
 
-#: Merge.rc:5656
+#: Merge.rc:5657
 msgid "32-bit WinMerge does not support Clipboard Compare"
 msgstr ""
 
 #. IDS_WEBVIEW2_RUNTIME_NOT_INSTALLED
-#: Merge.rc:5661
+#: Merge.rc:5662
 msgid "WebView2 runtime not installed. Download it?"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_TEXT_COMPARE
-#: Merge.rc:5666
+#: Merge.rc:5667
 msgid "New Text Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_TABLE_COMPARE
-#: Merge.rc:5667
+#: Merge.rc:5668
 msgid "New Table Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_BINARY_COMPARE
-#: Merge.rc:5668
+#: Merge.rc:5669
 msgid "New Binary Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_IMAGE_COMPARE
-#: Merge.rc:5669
+#: Merge.rc:5670
 msgid "New Image Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_WEBPAGE_COMPARE
-#: Merge.rc:5670
+#: Merge.rc:5671
 msgid "New Webpage Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_FOLDER_COMPARE
-#: Merge.rc:5671
+#: Merge.rc:5672
 msgid "New Folder Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_CLIPBOARD_COMPARE
-#: Merge.rc:5672
+#: Merge.rc:5673
 msgid "Clipboard Compare"
 msgstr ""
 
 #. IDS_PREVIEWBAR_PRINT
-#: Merge.rc:5677
+#: Merge.rc:5678
 msgid "&Print..."
 msgstr ""
 
 #. IDS_PREVIEWBAR_PREVPAGE
-#: Merge.rc:5679
+#: Merge.rc:5680
 msgid "Pre&v Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_TWOPAGE
-#: Merge.rc:5680
+#: Merge.rc:5681
 msgid "&Two Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_ONEPAGE
-#: Merge.rc:5681
+#: Merge.rc:5682
 msgid "&One Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_ZOOMIN
-#: Merge.rc:5682
+#: Merge.rc:5683
 msgid "Zoom &In"
 msgstr ""
 
 #. IDS_PREVIEWBAR_ZOOMOUT
-#: Merge.rc:5683
+#: Merge.rc:5684
 msgid "Zoom &Out"
 msgstr ""
 
 #. IDS_WEBPAGE_COMPARING
-#: Merge.rc:5689
+#: Merge.rc:5690
 msgid "Comparing..."
 msgstr ""
 
 #. IDS_WEBPAGE_ZOOM
-#: Merge.rc:5690
+#: Merge.rc:5691
 msgid "Zoom:"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_DIFFHUNK
-#: Merge.rc:5695
+#: Merge.rc:5696
 msgid "Diff hunk"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_INLINE
-#: Merge.rc:5696
+#: Merge.rc:5697
 msgid "Inline diff"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_LINE
-#: Merge.rc:5697
+#: Merge.rc:5698
 msgid "Line"
 msgstr ""
 
-#: Merge.rc:5698
+#: Merge.rc:5699
 msgid "Character"
 msgstr ""
 
 #. ID_MICE_PREVDIFF
-#: Merge.rc:5703
+#: Merge.rc:5704
 msgid "\nPrevious Difference (Alt+Up)\n(Right Button+Wheel Up)\n(Alt+Wheel Up)"
 msgstr ""
 
 #. ID_MICE_NEXTDIFF
-#: Merge.rc:5704
+#: Merge.rc:5705
 msgid "\nNext Difference (Alt+Down)\n(Right Button+Wheel Down)\n(Alt+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_L2R
-#: Merge.rc:5705
+#: Merge.rc:5706
 msgid "\nCopy to Right (Alt+Right)\n(Right Button+Wheel Right)\n(Alt+Wheel Right)\n(Alt+Shift+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_R2L
-#: Merge.rc:5706
+#: Merge.rc:5707
 msgid "\nCopy to Left (Alt+Left)\n(Right Button+Wheel Left)\n(Alt+Wheel Left)\n(Alt+Shift+Wheel Up)"
 msgstr ""
 
 #. ID_MICE_L2RNEXT
-#: Merge.rc:5707
+#: Merge.rc:5708
 msgid "\nCopy to Right and Advance (Ctrl+Alt+Right)\n(Ctrl+Alt+Wheel Right)\n(Ctrl+Alt+Shift+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_R2LNEXT
-#: Merge.rc:5708
+#: Merge.rc:5709
 msgid "\nCopy to Left and Advance (Ctrl+Alt+Left)\n(Ctrl+Alt+Wheel Left)\n(Ctrl+Alt+Shift+Wheel Up)"
 msgstr ""
 
 #. IDS_LOG_COMPARING_2
-#: Merge.rc:5718
+#: Merge.rc:5719
 #, c-format
 msgid "Comparing %1 with %2"
 msgstr ""
 
 #. IDS_LOG_COMPARING_3
-#: Merge.rc:5719
+#: Merge.rc:5720
 #, c-format
 msgid "Comparing %1 with %2 and %3"
 msgstr ""
 
 #. IDS_LOG_COMPARE_COMPLETED
-#: Merge.rc:5720
+#: Merge.rc:5721
 msgid "Comparison completed"
 msgstr ""
 
 #. IDS_LOG_COMPARE_ERROR_2
-#: Merge.rc:5721
+#: Merge.rc:5722
 #, c-format
 msgid "Failed to compare %1 with %2: "
 msgstr ""
 
 #. IDS_LOG_COMPARE_ERROR_3
-#: Merge.rc:5722
+#: Merge.rc:5723
 #, c-format
 msgid "Failed to compare %1 with %2 and %3: "
 msgstr ""
 
 #. IDS_LOG_FILE_SAVED
-#: Merge.rc:5723
+#: Merge.rc:5724
 msgid "File saved"
 msgstr ""
 
 #. IDS_LOG_COPYING_FILES
-#: Merge.rc:5724
+#: Merge.rc:5725
 msgid "Copying files..."
 msgstr ""
 
 #. IDS_LOG_MOVING_FILES
-#: Merge.rc:5725
+#: Merge.rc:5726
 msgid "Moving files..."
 msgstr ""
 
 #. IDS_LOG_DELETING_FILES
-#: Merge.rc:5726
+#: Merge.rc:5727
 msgid "Deleting files..."
 msgstr ""
 
 #. IDS_LOG_RECYCLEBIN
-#: Merge.rc:5727
+#: Merge.rc:5728
 msgid "Recycle Bin"
 msgstr ""
 
 #. IDS_LOG_PERMANENTLY_DELETED
-#: Merge.rc:5728
+#: Merge.rc:5729
 msgid "Permanently deleted"
 msgstr ""
 
 #. IDS_LOG_FILEOPERATION_COMPLETED
-#: Merge.rc:5729
+#: Merge.rc:5730
 msgid "File operation completed successfully"
 msgstr ""
 
 #. IDS_LOG_FILEOPERATION_CANCELED
-#: Merge.rc:5730
+#: Merge.rc:5731
 msgid "File operation canceled"
 msgstr ""
 
 #. IDS_FILTER_ERROR_NO_ERROR
-#: Merge.rc:5735
+#: Merge.rc:5736
 msgid "No error"
 msgstr ""
 
 #. IDS_FILTER_ERROR_EMPTY_EXPRESSION
-#: Merge.rc:5736
+#: Merge.rc:5737
 msgid "Filter expression is empty"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNKNOWN_CHAR
-#: Merge.rc:5737
+#: Merge.rc:5738
 msgid "Unknown character in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNTERMINATED_STRING
-#: Merge.rc:5738
+#: Merge.rc:5739
 msgid "Unterminated string literal"
 msgstr ""
 
 #. IDS_FILTER_ERROR_SYNTAX_ERROR
-#: Merge.rc:5739
+#: Merge.rc:5740
 msgid "Syntax error in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_PARSE_FAILURE
-#: Merge.rc:5740
+#: Merge.rc:5741
 msgid "Failed to parse filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_LITERAL
-#: Merge.rc:5741
+#: Merge.rc:5742
 msgid "Invalid literal value"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_REGULAR_EXPRESSION
-#: Merge.rc:5742
+#: Merge.rc:5743
 msgid "Invalid regular expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNDEFINED_IDENTIFIER
-#: Merge.rc:5743
+#: Merge.rc:5744
 msgid "Undefined identifier"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_ARGUMENT_COUNT
-#: Merge.rc:5744
+#: Merge.rc:5745
 msgid "Invalid number of arguments"
 msgstr ""
 
 #. IDS_FILTER_ERROR_FILTER_NAME_NOT_FOUND
-#: Merge.rc:5745
+#: Merge.rc:5746
 msgid "Filter name not found"
 msgstr ""
 
 #. IDS_FILTER_ERROR_DIVIDE_BY_ZERO
-#: Merge.rc:5746
+#: Merge.rc:5747
 msgid "Division by zero in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNKNOWN_ERROR
-#: Merge.rc:5747
+#: Merge.rc:5748
 msgid "Unknown error"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_PROPERTY_NAME
-#: Merge.rc:5748
+#: Merge.rc:5749
 msgid "Invalid property name"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_DIRECTIVE
-#: Merge.rc:5749
+#: Merge.rc:5750
 msgid "Invalid directive"
 msgstr ""
 
 #. IDS_FILTER_OP_EQUALS
-#: Merge.rc:5754
+#: Merge.rc:5755
 msgid "Equals"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_EQUALS
-#: Merge.rc:5755
+#: Merge.rc:5756
 msgid "Does not equal"
 msgstr ""
 
 #. IDS_FILTER_OP_LESS_THAN
-#: Merge.rc:5756
+#: Merge.rc:5757
 msgid "Less than"
 msgstr ""
 
 #. IDS_FILTER_OP_LESS_EQUAL
-#: Merge.rc:5757
+#: Merge.rc:5758
 msgid "Less than or equal to"
 msgstr ""
 
 #. IDS_FILTER_OP_GREATER_EQUAL
-#: Merge.rc:5758
+#: Merge.rc:5759
 msgid "Greater than or equal to"
 msgstr ""
 
 #. IDS_FILTER_OP_GREATER_THAN
-#: Merge.rc:5759
+#: Merge.rc:5760
 msgid "Greater than"
 msgstr ""
 
 #. IDS_FILTER_OP_BETWEEN
-#: Merge.rc:5760
+#: Merge.rc:5761
 msgid "Between"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_BETWEEN
-#: Merge.rc:5761
+#: Merge.rc:5762
 msgid "Not Between"
 msgstr ""
 
 #. IDS_FILTER_OP_CONTAINS
-#: Merge.rc:5762
+#: Merge.rc:5763
 msgid "Contains"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_CONTAINS
-#: Merge.rc:5763
+#: Merge.rc:5764
 msgid "Not Contains"
 msgstr ""
 
 #. IDS_FILTER_OP_RECONTAINS
-#: Merge.rc:5764
+#: Merge.rc:5765
 msgid "Contains (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_RECONTAINS
-#: Merge.rc:5765
+#: Merge.rc:5766
 msgid "Not Contains (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_LIKE
-#: Merge.rc:5766
+#: Merge.rc:5767
 msgid "Match (wildcard)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_LIKE
-#: Merge.rc:5767
+#: Merge.rc:5768
 msgid "Not match (wildcard)"
 msgstr ""
 
 #. IDS_FILTER_OP_MATCHES
-#: Merge.rc:5768
+#: Merge.rc:5769
 msgid "Match (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_MATCHES
-#: Merge.rc:5769
+#: Merge.rc:5770
 msgid "Not match (regex)"
 msgstr ""
 
 #. IDS_COLORMODE_LIGHT
-#: Merge.rc:5774
+#: Merge.rc:5775
 msgid "Light"
 msgstr ""
 
 #. IDS_COLORMODE_DARK
-#: Merge.rc:5775
+#: Merge.rc:5776
 msgid "Dark"
 msgstr ""
 
 #. IDS_COLORMODE_FOLLOWSYSTEM
-#: Merge.rc:5776
+#: Merge.rc:5777
 msgid "Follow system"
 msgstr ""
 
 #. IDS_EXAMPLE
-#: Merge.rc:5781
+#: Merge.rc:5782
 #, c-format
 msgid "e.g. %1"
 msgstr ""
 
 #. IDS_DETECTED_PREVIOUS_CRASH
-#: Merge.rc:5786
+#: Merge.rc:5787
 msgid "WinMerge detected a previous crash. Please report this if possible."
 msgstr ""
 
 #. IDS_REGEX_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5791
+#: Merge.rc:5792
 msgid "# Regex replacement list\r\n# Format: regex<TAB>replacement\r\n# Backreferences like $1, $2 are supported\r\n\r\n(\\d{4})-(\\d{2})-(\\d{2})\t$1_$2_$3\r\n"
 msgstr ""
 
 #. IDS_STRING_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5792
+#: Merge.rc:5793
 msgid "# Replacement list\r\n# Format: search<TAB>replacement\r\n# Lines starting with # are ignored\r\n\r\nfrom1\tto1\r\nfrom2\tto2\r\n"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_ONLY
-#: Merge.rc:5797
+#: Merge.rc:5798
 msgid "Built-in only"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_FIRST
-#: Merge.rc:5798
+#: Merge.rc:5799
 msgid "Built-in first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_FIRST
-#: Merge.rc:5799
+#: Merge.rc:5800
 msgid "Tree-sitter first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_ONLY
-#: Merge.rc:5800
+#: Merge.rc:5801
 msgid "Tree-sitter only"
 msgstr ""
 

--- a/Translations/WinMerge/Brazilian.po
+++ b/Translations/WinMerge/Brazilian.po
@@ -25,7 +25,7 @@ msgstr ""
 "X-Generator: Poedit 3.9\n"
 
 #. LANGUAGE, SUBLANGUAGE
-#: Merge.rc:26 Merge.rc:59 Merge.rc:5817
+#: Merge.rc:26 Merge.rc:59 Merge.rc:5818
 msgid "LANG_ENGLISH, SUBLANG_ENGLISH_US"
 msgstr "LANG_PORTUGUESE, SUBLANG_PORTUGUESE_BRAZILIAN"
 
@@ -232,7 +232,7 @@ msgid "Auto-Fit All Columns"
 msgstr "Ajustar Automaticamente Todas as Colunas"
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN
-#: Merge.rc:153 Merge.rc:5645
+#: Merge.rc:153 Merge.rc:5646
 msgid "&Filter by This Column"
 msgstr "&Filtrar por Esta Coluna"
 
@@ -293,7 +293,7 @@ msgid "&Previous Page"
 msgstr "&Página Anterior"
 
 #. IDS_PREVIEWBAR_NEXTPAGE
-#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5678
+#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5679
 msgid "&Next Page"
 msgstr "Pá&gina Seguinte"
 
@@ -666,7 +666,7 @@ msgid "&Huge"
 msgstr "&Enorme"
 
 #. IDS_VIEW_MENU_BAR
-#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5713
+#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5714
 msgid "Men&u Bar"
 msgstr "Barra de Men&us"
 
@@ -4191,7 +4191,7 @@ msgid "Items compared:"
 msgstr "Itens comparados:"
 
 #. IDS_PREVIEWBAR_CLOSE
-#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5684
+#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5685
 msgid "&Close"
 msgstr "&Fechar"
 
@@ -8394,30 +8394,35 @@ msgstr "1º e 3º"
 msgid "2nd and 3rd"
 msgstr "2º e 3º"
 
+#. IDS_PLUGIN_CTRL_CLICK
+#: Merge.rc:5635
+msgid "(Ctrl+Click to add to pipeline)"
+msgstr ""
+
 #. IDS_FILTER_APPLIED
-#: Merge.rc:5639
+#: Merge.rc:5640
 msgid "Filter applied"
 msgstr "Filtro aplicado"
 
 #. IDS_FILTERMENU_COMPARE
-#: Merge.rc:5644
+#: Merge.rc:5645
 #, c-format
 msgid "Compare %1"
 msgstr "Comparar %1"
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN2
-#: Merge.rc:5646
+#: Merge.rc:5647
 msgid "&Filter by This Column..."
 msgstr "&Filtrar por Esta Coluna..."
 
 #. IDS_CLIPBOARDHISTORY_TIME
-#: Merge.rc:5651
+#: Merge.rc:5652
 #, c-format
 msgid "Clipboard at %s"
 msgstr "Área de transferência em %s"
 
 #. IDS_CLIPBOARDHISTORY_DISABLED
-#: Merge.rc:5652
+#: Merge.rc:5653
 msgid ""
 "Clipboard history disabled.\r\n"
 "Enable: Windows logo key + V, then Turn on."
@@ -8425,115 +8430,115 @@ msgstr ""
 "Histórico da área de transferência desabilitado.\r\n"
 "Habilitar: tecla do logotipo do Windows + V e, em seguida, Ativar."
 
-#: Merge.rc:5654
+#: Merge.rc:5655
 msgid "This system does not support clipboard history."
 msgstr "Este sistema não suporta histórico da área de transferência."
 
-#: Merge.rc:5656
+#: Merge.rc:5657
 msgid "32-bit WinMerge does not support Clipboard Compare"
 msgstr "O WinMerge de 32 bits não suporta a Comparação da Área de Transferência"
 
 #. IDS_WEBVIEW2_RUNTIME_NOT_INSTALLED
-#: Merge.rc:5661
+#: Merge.rc:5662
 msgid "WebView2 runtime not installed. Download it?"
 msgstr "O WebView2 runtime não está instalado. Baixá-lo?"
 
 #. IDS_JUMPLIST_NEW_TEXT_COMPARE
-#: Merge.rc:5666
+#: Merge.rc:5667
 msgid "New Text Compare"
 msgstr "Nova Comparação de Textos"
 
 #. IDS_JUMPLIST_NEW_TABLE_COMPARE
-#: Merge.rc:5667
+#: Merge.rc:5668
 msgid "New Table Compare"
 msgstr "Nova Comparação de Tabelas"
 
 #. IDS_JUMPLIST_NEW_BINARY_COMPARE
-#: Merge.rc:5668
+#: Merge.rc:5669
 msgid "New Binary Compare"
 msgstr "Nova Comparação de Binários"
 
 #. IDS_JUMPLIST_NEW_IMAGE_COMPARE
-#: Merge.rc:5669
+#: Merge.rc:5670
 msgid "New Image Compare"
 msgstr "Nova Comparação de Imagens"
 
 #. IDS_JUMPLIST_NEW_WEBPAGE_COMPARE
-#: Merge.rc:5670
+#: Merge.rc:5671
 msgid "New Webpage Compare"
 msgstr "Nova Comparação de Páginas da Web"
 
 #. IDS_JUMPLIST_NEW_FOLDER_COMPARE
-#: Merge.rc:5671
+#: Merge.rc:5672
 msgid "New Folder Compare"
 msgstr "Nova Comparação de Pastas"
 
 #. IDS_JUMPLIST_CLIPBOARD_COMPARE
-#: Merge.rc:5672
+#: Merge.rc:5673
 msgid "Clipboard Compare"
 msgstr "Comparação da Área de Transferência"
 
 #. IDS_PREVIEWBAR_PRINT
-#: Merge.rc:5677
+#: Merge.rc:5678
 msgid "&Print..."
 msgstr "&Imprimir..."
 
 #. IDS_PREVIEWBAR_PREVPAGE
-#: Merge.rc:5679
+#: Merge.rc:5680
 msgid "Pre&v Page"
 msgstr "&Página Anterior"
 
 #. IDS_PREVIEWBAR_TWOPAGE
-#: Merge.rc:5680
+#: Merge.rc:5681
 msgid "&Two Page"
 msgstr "&Duas Páginas"
 
 #. IDS_PREVIEWBAR_ONEPAGE
-#: Merge.rc:5681
+#: Merge.rc:5682
 msgid "&One Page"
 msgstr "&Uma Página"
 
 #. IDS_PREVIEWBAR_ZOOMIN
-#: Merge.rc:5682
+#: Merge.rc:5683
 msgid "Zoom &In"
 msgstr "&Ampliar"
 
 #. IDS_PREVIEWBAR_ZOOMOUT
-#: Merge.rc:5683
+#: Merge.rc:5684
 msgid "Zoom &Out"
 msgstr "&Reduzir"
 
 #. IDS_WEBPAGE_COMPARING
-#: Merge.rc:5689
+#: Merge.rc:5690
 msgid "Comparing..."
 msgstr "Comparando..."
 
 #. IDS_WEBPAGE_ZOOM
-#: Merge.rc:5690
+#: Merge.rc:5691
 msgid "Zoom:"
 msgstr "Zoom:"
 
 #. IDS_COPY_GRANULARITY_DIFFHUNK
-#: Merge.rc:5695
+#: Merge.rc:5696
 msgid "Diff hunk"
 msgstr "Bloco da diferenciação"
 
 #. IDS_COPY_GRANULARITY_INLINE
-#: Merge.rc:5696
+#: Merge.rc:5697
 msgid "Inline diff"
 msgstr "Diferenciação em linha"
 
 #. IDS_COPY_GRANULARITY_LINE
-#: Merge.rc:5697
+#: Merge.rc:5698
 msgid "Line"
 msgstr "Linha"
 
-#: Merge.rc:5698
+#: Merge.rc:5699
 msgid "Character"
 msgstr "Caracter"
 
 #. ID_MICE_PREVDIFF
-#: Merge.rc:5703
+#: Merge.rc:5704
 msgid ""
 "\n"
 "Previous Difference (Alt+Up)\n"
@@ -8546,7 +8551,7 @@ msgstr ""
 "(Alt+Rolagem para Cima)"
 
 #. ID_MICE_NEXTDIFF
-#: Merge.rc:5704
+#: Merge.rc:5705
 msgid ""
 "\n"
 "Next Difference (Alt+Down)\n"
@@ -8559,7 +8564,7 @@ msgstr ""
 "(Alt+Rolagem para Baixo)"
 
 #. ID_MICE_L2R
-#: Merge.rc:5705
+#: Merge.rc:5706
 msgid ""
 "\n"
 "Copy to Right (Alt+Right)\n"
@@ -8574,7 +8579,7 @@ msgstr ""
 "(Alt+Shift+Rolagem para Baixo)"
 
 #. ID_MICE_R2L
-#: Merge.rc:5706
+#: Merge.rc:5707
 msgid ""
 "\n"
 "Copy to Left (Alt+Left)\n"
@@ -8589,7 +8594,7 @@ msgstr ""
 "(Alt+Shift+Rolagem para Cima)"
 
 #. ID_MICE_L2RNEXT
-#: Merge.rc:5707
+#: Merge.rc:5708
 msgid ""
 "\n"
 "Copy to Right and Advance (Ctrl+Alt+Right)\n"
@@ -8602,7 +8607,7 @@ msgstr ""
 "(Ctrl+Alt+Shift+Rolagem para Baixo)"
 
 #. ID_MICE_R2LNEXT
-#: Merge.rc:5708
+#: Merge.rc:5709
 msgid ""
 "\n"
 "Copy to Left and Advance (Ctrl+Alt+Left)\n"
@@ -8615,257 +8620,257 @@ msgstr ""
 "(Ctrl+Alt+Shift+Rolagem para Cima)"
 
 #. IDS_LOG_COMPARING_2
-#: Merge.rc:5718
+#: Merge.rc:5719
 #, c-format
 msgid "Comparing %1 with %2"
 msgstr "Comparando %1 com %2"
 
 #. IDS_LOG_COMPARING_3
-#: Merge.rc:5719
+#: Merge.rc:5720
 #, c-format
 msgid "Comparing %1 with %2 and %3"
 msgstr "Comparando %1 com %2 e %3"
 
 #. IDS_LOG_COMPARE_COMPLETED
-#: Merge.rc:5720
+#: Merge.rc:5721
 msgid "Comparison completed"
 msgstr "Comparação completada"
 
 #. IDS_LOG_COMPARE_ERROR_2
-#: Merge.rc:5721
+#: Merge.rc:5722
 #, c-format
 msgid "Failed to compare %1 with %2: "
 msgstr "Falha ao comparar %1 com %2: "
 
 #. IDS_LOG_COMPARE_ERROR_3
-#: Merge.rc:5722
+#: Merge.rc:5723
 #, c-format
 msgid "Failed to compare %1 with %2 and %3: "
 msgstr "Falha ao comparar %1 com %2 e %3: "
 
 #. IDS_LOG_FILE_SAVED
-#: Merge.rc:5723
+#: Merge.rc:5724
 msgid "File saved"
 msgstr "Arquivo salvo"
 
 #. IDS_LOG_COPYING_FILES
-#: Merge.rc:5724
+#: Merge.rc:5725
 msgid "Copying files..."
 msgstr "Copiando arquivos..."
 
 #. IDS_LOG_MOVING_FILES
-#: Merge.rc:5725
+#: Merge.rc:5726
 msgid "Moving files..."
 msgstr "Movendo arquivos..."
 
 #. IDS_LOG_DELETING_FILES
-#: Merge.rc:5726
+#: Merge.rc:5727
 msgid "Deleting files..."
 msgstr "Excluindo arquivos..."
 
 #. IDS_LOG_RECYCLEBIN
-#: Merge.rc:5727
+#: Merge.rc:5728
 msgid "Recycle Bin"
 msgstr "Lixeira"
 
 #. IDS_LOG_PERMANENTLY_DELETED
-#: Merge.rc:5728
+#: Merge.rc:5729
 msgid "Permanently deleted"
 msgstr "Excluído(s) permanentemente"
 
 #. IDS_LOG_FILEOPERATION_COMPLETED
-#: Merge.rc:5729
+#: Merge.rc:5730
 msgid "File operation completed successfully"
 msgstr "Operação de arquivos completada com sucesso"
 
 #. IDS_LOG_FILEOPERATION_CANCELED
-#: Merge.rc:5730
+#: Merge.rc:5731
 msgid "File operation canceled"
 msgstr "Operação de arquivos cancelada"
 
 #. IDS_FILTER_ERROR_NO_ERROR
-#: Merge.rc:5735
+#: Merge.rc:5736
 msgid "No error"
 msgstr "Sem erro"
 
 #. IDS_FILTER_ERROR_EMPTY_EXPRESSION
-#: Merge.rc:5736
+#: Merge.rc:5737
 msgid "Filter expression is empty"
 msgstr "A expressão de filtro está vazia"
 
 #. IDS_FILTER_ERROR_UNKNOWN_CHAR
-#: Merge.rc:5737
+#: Merge.rc:5738
 msgid "Unknown character in filter expression"
 msgstr "Caracter desconhecido na expressão de filtro"
 
 #. IDS_FILTER_ERROR_UNTERMINATED_STRING
-#: Merge.rc:5738
+#: Merge.rc:5739
 msgid "Unterminated string literal"
 msgstr "Literal de string não terminado"
 
 #. IDS_FILTER_ERROR_SYNTAX_ERROR
-#: Merge.rc:5739
+#: Merge.rc:5740
 msgid "Syntax error in filter expression"
 msgstr "Erro de sintaxe na expressão de filtro"
 
 #. IDS_FILTER_ERROR_PARSE_FAILURE
-#: Merge.rc:5740
+#: Merge.rc:5741
 msgid "Failed to parse filter expression"
 msgstr "Falha ao analisar a expressão de filtro"
 
 #. IDS_FILTER_ERROR_INVALID_LITERAL
-#: Merge.rc:5741
+#: Merge.rc:5742
 msgid "Invalid literal value"
 msgstr "Valor de literal inválido"
 
 #. IDS_FILTER_ERROR_INVALID_REGULAR_EXPRESSION
-#: Merge.rc:5742
+#: Merge.rc:5743
 msgid "Invalid regular expression"
 msgstr "Expressão regular inválida"
 
 #. IDS_FILTER_ERROR_UNDEFINED_IDENTIFIER
-#: Merge.rc:5743
+#: Merge.rc:5744
 msgid "Undefined identifier"
 msgstr "Identificador indefinido"
 
 #. IDS_FILTER_ERROR_INVALID_ARGUMENT_COUNT
-#: Merge.rc:5744
+#: Merge.rc:5745
 msgid "Invalid number of arguments"
 msgstr "Número de argumentos inválido"
 
 #. IDS_FILTER_ERROR_FILTER_NAME_NOT_FOUND
-#: Merge.rc:5745
+#: Merge.rc:5746
 msgid "Filter name not found"
 msgstr "Nome de filtro não encontrado"
 
 #. IDS_FILTER_ERROR_DIVIDE_BY_ZERO
-#: Merge.rc:5746
+#: Merge.rc:5747
 msgid "Division by zero in filter expression"
 msgstr "Divisão por zero na expressão de filtro"
 
 #. IDS_FILTER_ERROR_UNKNOWN_ERROR
-#: Merge.rc:5747
+#: Merge.rc:5748
 msgid "Unknown error"
 msgstr "Erro desconhecido"
 
 #. IDS_FILTER_ERROR_INVALID_PROPERTY_NAME
-#: Merge.rc:5748
+#: Merge.rc:5749
 msgid "Invalid property name"
 msgstr "Nome de propriedade inválido"
 
 #. IDS_FILTER_ERROR_INVALID_DIRECTIVE
-#: Merge.rc:5749
+#: Merge.rc:5750
 msgid "Invalid directive"
 msgstr "Diretiva inválida"
 
 #. IDS_FILTER_OP_EQUALS
-#: Merge.rc:5754
+#: Merge.rc:5755
 msgid "Equals"
 msgstr "Igual a"
 
 #. IDS_FILTER_OP_NOT_EQUALS
-#: Merge.rc:5755
+#: Merge.rc:5756
 msgid "Does not equal"
 msgstr "Não é igual a"
 
 #. IDS_FILTER_OP_LESS_THAN
-#: Merge.rc:5756
+#: Merge.rc:5757
 msgid "Less than"
 msgstr "Menor que"
 
 #. IDS_FILTER_OP_LESS_EQUAL
-#: Merge.rc:5757
+#: Merge.rc:5758
 msgid "Less than or equal to"
 msgstr "Menor que ou igual a"
 
 #. IDS_FILTER_OP_GREATER_EQUAL
-#: Merge.rc:5758
+#: Merge.rc:5759
 msgid "Greater than or equal to"
 msgstr "Maior que ou igual a"
 
 #. IDS_FILTER_OP_GREATER_THAN
-#: Merge.rc:5759
+#: Merge.rc:5760
 msgid "Greater than"
 msgstr "Maior que"
 
 #. IDS_FILTER_OP_BETWEEN
-#: Merge.rc:5760
+#: Merge.rc:5761
 msgid "Between"
 msgstr "Entre"
 
 #. IDS_FILTER_OP_NOT_BETWEEN
-#: Merge.rc:5761
+#: Merge.rc:5762
 msgid "Not Between"
 msgstr "Não Entre"
 
 #. IDS_FILTER_OP_CONTAINS
-#: Merge.rc:5762
+#: Merge.rc:5763
 msgid "Contains"
 msgstr "Contém"
 
 #. IDS_FILTER_OP_NOT_CONTAINS
-#: Merge.rc:5763
+#: Merge.rc:5764
 msgid "Not Contains"
 msgstr "Não Contém"
 
 #. IDS_FILTER_OP_RECONTAINS
-#: Merge.rc:5764
+#: Merge.rc:5765
 msgid "Contains (regex)"
 msgstr "Contém (regex)"
 
 #. IDS_FILTER_OP_NOT_RECONTAINS
-#: Merge.rc:5765
+#: Merge.rc:5766
 msgid "Not Contains (regex)"
 msgstr "Não Contém (regex)"
 
 #. IDS_FILTER_OP_LIKE
-#: Merge.rc:5766
+#: Merge.rc:5767
 msgid "Match (wildcard)"
 msgstr "Correspondência (curinga)"
 
 #. IDS_FILTER_OP_NOT_LIKE
-#: Merge.rc:5767
+#: Merge.rc:5768
 msgid "Not match (wildcard)"
 msgstr "Sem correspondência (curinga)"
 
 #. IDS_FILTER_OP_MATCHES
-#: Merge.rc:5768
+#: Merge.rc:5769
 msgid "Match (regex)"
 msgstr "Correspondência (regex)"
 
 #. IDS_FILTER_OP_NOT_MATCHES
-#: Merge.rc:5769
+#: Merge.rc:5770
 msgid "Not match (regex)"
 msgstr "Sem correspondência (regex)"
 
 #. IDS_COLORMODE_LIGHT
-#: Merge.rc:5774
+#: Merge.rc:5775
 msgid "Light"
 msgstr "Claro"
 
 #. IDS_COLORMODE_DARK
-#: Merge.rc:5775
+#: Merge.rc:5776
 msgid "Dark"
 msgstr "Escuro"
 
 #. IDS_COLORMODE_FOLLOWSYSTEM
-#: Merge.rc:5776
+#: Merge.rc:5777
 msgid "Follow system"
 msgstr "Seguir o sistema"
 
 #. IDS_EXAMPLE
-#: Merge.rc:5781
+#: Merge.rc:5782
 #, c-format
 msgid "e.g. %1"
 msgstr "p.ex. %1"
 
 #. IDS_DETECTED_PREVIOUS_CRASH
-#: Merge.rc:5786
+#: Merge.rc:5787
 msgid "WinMerge detected a previous crash. Please report this if possible."
 msgstr "O WinMerge detectou uma falha anterior. Por favor, relate isso se possível."
 
 #. IDS_REGEX_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5791
+#: Merge.rc:5792
 msgid ""
 "# Regex replacement list\r\n"
 "# Format: regex<TAB>replacement\r\n"
@@ -8880,7 +8885,7 @@ msgstr ""
 "(\\d{4})-(\\d{2})-(\\d{2})\t$1_$2_$3\r\n"
 
 #. IDS_STRING_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5792
+#: Merge.rc:5793
 msgid ""
 "# Replacement list\r\n"
 "# Format: search<TAB>replacement\r\n"
@@ -8897,22 +8902,22 @@ msgstr ""
 "de2\tpara2\r\n"
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_ONLY
-#: Merge.rc:5797
+#: Merge.rc:5798
 msgid "Built-in only"
 msgstr "Integrado apenas"
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_FIRST
-#: Merge.rc:5798
+#: Merge.rc:5799
 msgid "Built-in first"
 msgstr "Integrado primeiro"
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_FIRST
-#: Merge.rc:5799
+#: Merge.rc:5800
 msgid "Tree-sitter first"
 msgstr "Tree-sitter primeiro"
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_ONLY
-#: Merge.rc:5800
+#: Merge.rc:5801
 msgid "Tree-sitter only"
 msgstr "Tree-sitter apenas"
 

--- a/Translations/WinMerge/Bulgarian.po
+++ b/Translations/WinMerge/Bulgarian.po
@@ -20,7 +20,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 #. LANGUAGE, SUBLANGUAGE
-#: Merge.rc:26 Merge.rc:59 Merge.rc:5817
+#: Merge.rc:26 Merge.rc:59 Merge.rc:5818
 msgid "LANG_ENGLISH, SUBLANG_ENGLISH_US"
 msgstr "LANG_BULGARIAN, SUBLANG_DEFAULT"
 
@@ -227,7 +227,7 @@ msgid "Auto-Fit All Columns"
 msgstr "Автоматично побиране на колоните"
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN
-#: Merge.rc:153 Merge.rc:5645
+#: Merge.rc:153 Merge.rc:5646
 msgid "&Filter by This Column"
 msgstr ""
 
@@ -288,7 +288,7 @@ msgid "&Previous Page"
 msgstr "&Предишна страница"
 
 #. IDS_PREVIEWBAR_NEXTPAGE
-#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5678
+#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5679
 msgid "&Next Page"
 msgstr "&Следваща страница"
 
@@ -661,7 +661,7 @@ msgid "&Huge"
 msgstr "&Огромен"
 
 #. IDS_VIEW_MENU_BAR
-#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5713
+#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5714
 msgid "Men&u Bar"
 msgstr "&Лента с менюто"
 
@@ -4186,7 +4186,7 @@ msgid "Items compared:"
 msgstr "Сравнени:"
 
 #. IDS_PREVIEWBAR_CLOSE
-#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5684
+#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5685
 msgid "&Close"
 msgstr "&Затваряне"
 
@@ -8341,144 +8341,149 @@ msgstr ""
 msgid "2nd and 3rd"
 msgstr ""
 
+#. IDS_PLUGIN_CTRL_CLICK
+#: Merge.rc:5635
+msgid "(Ctrl+Click to add to pipeline)"
+msgstr ""
+
 #. IDS_FILTER_APPLIED
-#: Merge.rc:5639
+#: Merge.rc:5640
 msgid "Filter applied"
 msgstr ""
 
 #. IDS_FILTERMENU_COMPARE
-#: Merge.rc:5644
+#: Merge.rc:5645
 #, c-format
 msgid "Compare %1"
 msgstr "Сравняване на %1"
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN2
-#: Merge.rc:5646
+#: Merge.rc:5647
 msgid "&Filter by This Column..."
 msgstr ""
 
 #. IDS_CLIPBOARDHISTORY_TIME
-#: Merge.rc:5651
+#: Merge.rc:5652
 #, c-format
 msgid "Clipboard at %s"
 msgstr ""
 
 #. IDS_CLIPBOARDHISTORY_DISABLED
-#: Merge.rc:5652
+#: Merge.rc:5653
 msgid ""
 "Clipboard history disabled.\r\n"
 "Enable: Windows logo key + V, then Turn on."
 msgstr ""
 
-#: Merge.rc:5654
+#: Merge.rc:5655
 msgid "This system does not support clipboard history."
 msgstr ""
 
-#: Merge.rc:5656
+#: Merge.rc:5657
 msgid "32-bit WinMerge does not support Clipboard Compare"
 msgstr ""
 
 #. IDS_WEBVIEW2_RUNTIME_NOT_INSTALLED
-#: Merge.rc:5661
+#: Merge.rc:5662
 msgid "WebView2 runtime not installed. Download it?"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_TEXT_COMPARE
-#: Merge.rc:5666
+#: Merge.rc:5667
 msgid "New Text Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_TABLE_COMPARE
-#: Merge.rc:5667
+#: Merge.rc:5668
 msgid "New Table Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_BINARY_COMPARE
-#: Merge.rc:5668
+#: Merge.rc:5669
 msgid "New Binary Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_IMAGE_COMPARE
-#: Merge.rc:5669
+#: Merge.rc:5670
 msgid "New Image Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_WEBPAGE_COMPARE
-#: Merge.rc:5670
+#: Merge.rc:5671
 msgid "New Webpage Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_FOLDER_COMPARE
-#: Merge.rc:5671
+#: Merge.rc:5672
 msgid "New Folder Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_CLIPBOARD_COMPARE
-#: Merge.rc:5672
+#: Merge.rc:5673
 msgid "Clipboard Compare"
 msgstr ""
 
 #. IDS_PREVIEWBAR_PRINT
-#: Merge.rc:5677
+#: Merge.rc:5678
 msgid "&Print..."
 msgstr ""
 
 #. IDS_PREVIEWBAR_PREVPAGE
-#: Merge.rc:5679
+#: Merge.rc:5680
 msgid "Pre&v Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_TWOPAGE
-#: Merge.rc:5680
+#: Merge.rc:5681
 msgid "&Two Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_ONEPAGE
-#: Merge.rc:5681
+#: Merge.rc:5682
 msgid "&One Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_ZOOMIN
-#: Merge.rc:5682
+#: Merge.rc:5683
 msgid "Zoom &In"
 msgstr ""
 
 #. IDS_PREVIEWBAR_ZOOMOUT
-#: Merge.rc:5683
+#: Merge.rc:5684
 msgid "Zoom &Out"
 msgstr ""
 
 #. IDS_WEBPAGE_COMPARING
-#: Merge.rc:5689
+#: Merge.rc:5690
 msgid "Comparing..."
 msgstr "Сравняване…"
 
 #. IDS_WEBPAGE_ZOOM
-#: Merge.rc:5690
+#: Merge.rc:5691
 msgid "Zoom:"
 msgstr "Мащаб:"
 
 #. IDS_COPY_GRANULARITY_DIFFHUNK
-#: Merge.rc:5695
+#: Merge.rc:5696
 msgid "Diff hunk"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_INLINE
-#: Merge.rc:5696
+#: Merge.rc:5697
 msgid "Inline diff"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_LINE
-#: Merge.rc:5697
+#: Merge.rc:5698
 msgid "Line"
 msgstr "Ред"
 
-#: Merge.rc:5698
+#: Merge.rc:5699
 msgid "Character"
 msgstr "Знак"
 
 #. ID_MICE_PREVDIFF
-#: Merge.rc:5703
+#: Merge.rc:5704
 msgid ""
 "\n"
 "Previous Difference (Alt+Up)\n"
@@ -8487,7 +8492,7 @@ msgid ""
 msgstr ""
 
 #. ID_MICE_NEXTDIFF
-#: Merge.rc:5704
+#: Merge.rc:5705
 msgid ""
 "\n"
 "Next Difference (Alt+Down)\n"
@@ -8496,7 +8501,7 @@ msgid ""
 msgstr ""
 
 #. ID_MICE_L2R
-#: Merge.rc:5705
+#: Merge.rc:5706
 msgid ""
 "\n"
 "Copy to Right (Alt+Right)\n"
@@ -8506,7 +8511,7 @@ msgid ""
 msgstr ""
 
 #. ID_MICE_R2L
-#: Merge.rc:5706
+#: Merge.rc:5707
 msgid ""
 "\n"
 "Copy to Left (Alt+Left)\n"
@@ -8516,7 +8521,7 @@ msgid ""
 msgstr ""
 
 #. ID_MICE_L2RNEXT
-#: Merge.rc:5707
+#: Merge.rc:5708
 msgid ""
 "\n"
 "Copy to Right and Advance (Ctrl+Alt+Right)\n"
@@ -8525,7 +8530,7 @@ msgid ""
 msgstr ""
 
 #. ID_MICE_R2LNEXT
-#: Merge.rc:5708
+#: Merge.rc:5709
 msgid ""
 "\n"
 "Copy to Left and Advance (Ctrl+Alt+Left)\n"
@@ -8534,282 +8539,282 @@ msgid ""
 msgstr ""
 
 #. IDS_LOG_COMPARING_2
-#: Merge.rc:5718
+#: Merge.rc:5719
 #, c-format
 msgid "Comparing %1 with %2"
 msgstr ""
 
 #. IDS_LOG_COMPARING_3
-#: Merge.rc:5719
+#: Merge.rc:5720
 #, c-format
 msgid "Comparing %1 with %2 and %3"
 msgstr ""
 
 #. IDS_LOG_COMPARE_COMPLETED
-#: Merge.rc:5720
+#: Merge.rc:5721
 msgid "Comparison completed"
 msgstr ""
 
 #. IDS_LOG_COMPARE_ERROR_2
-#: Merge.rc:5721
+#: Merge.rc:5722
 #, c-format
 msgid "Failed to compare %1 with %2: "
 msgstr ""
 
 #. IDS_LOG_COMPARE_ERROR_3
-#: Merge.rc:5722
+#: Merge.rc:5723
 #, c-format
 msgid "Failed to compare %1 with %2 and %3: "
 msgstr ""
 
 #. IDS_LOG_FILE_SAVED
-#: Merge.rc:5723
+#: Merge.rc:5724
 msgid "File saved"
 msgstr ""
 
 #. IDS_LOG_COPYING_FILES
-#: Merge.rc:5724
+#: Merge.rc:5725
 msgid "Copying files..."
 msgstr ""
 
 #. IDS_LOG_MOVING_FILES
-#: Merge.rc:5725
+#: Merge.rc:5726
 msgid "Moving files..."
 msgstr ""
 
 #. IDS_LOG_DELETING_FILES
-#: Merge.rc:5726
+#: Merge.rc:5727
 msgid "Deleting files..."
 msgstr ""
 
 #. IDS_LOG_RECYCLEBIN
-#: Merge.rc:5727
+#: Merge.rc:5728
 msgid "Recycle Bin"
 msgstr ""
 
 #. IDS_LOG_PERMANENTLY_DELETED
-#: Merge.rc:5728
+#: Merge.rc:5729
 msgid "Permanently deleted"
 msgstr ""
 
 #. IDS_LOG_FILEOPERATION_COMPLETED
-#: Merge.rc:5729
+#: Merge.rc:5730
 msgid "File operation completed successfully"
 msgstr ""
 
 #. IDS_LOG_FILEOPERATION_CANCELED
-#: Merge.rc:5730
+#: Merge.rc:5731
 msgid "File operation canceled"
 msgstr ""
 
 #. IDS_FILTER_ERROR_NO_ERROR
-#: Merge.rc:5735
+#: Merge.rc:5736
 msgid "No error"
 msgstr ""
 
 #. IDS_FILTER_ERROR_EMPTY_EXPRESSION
-#: Merge.rc:5736
+#: Merge.rc:5737
 msgid "Filter expression is empty"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNKNOWN_CHAR
-#: Merge.rc:5737
+#: Merge.rc:5738
 msgid "Unknown character in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNTERMINATED_STRING
-#: Merge.rc:5738
+#: Merge.rc:5739
 msgid "Unterminated string literal"
 msgstr ""
 
 #. IDS_FILTER_ERROR_SYNTAX_ERROR
-#: Merge.rc:5739
+#: Merge.rc:5740
 msgid "Syntax error in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_PARSE_FAILURE
-#: Merge.rc:5740
+#: Merge.rc:5741
 msgid "Failed to parse filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_LITERAL
-#: Merge.rc:5741
+#: Merge.rc:5742
 msgid "Invalid literal value"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_REGULAR_EXPRESSION
-#: Merge.rc:5742
+#: Merge.rc:5743
 msgid "Invalid regular expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNDEFINED_IDENTIFIER
-#: Merge.rc:5743
+#: Merge.rc:5744
 msgid "Undefined identifier"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_ARGUMENT_COUNT
-#: Merge.rc:5744
+#: Merge.rc:5745
 msgid "Invalid number of arguments"
 msgstr ""
 
 #. IDS_FILTER_ERROR_FILTER_NAME_NOT_FOUND
-#: Merge.rc:5745
+#: Merge.rc:5746
 msgid "Filter name not found"
 msgstr ""
 
 #. IDS_FILTER_ERROR_DIVIDE_BY_ZERO
-#: Merge.rc:5746
+#: Merge.rc:5747
 msgid "Division by zero in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNKNOWN_ERROR
-#: Merge.rc:5747
+#: Merge.rc:5748
 msgid "Unknown error"
 msgstr "Неочаквана грешка"
 
 #. IDS_FILTER_ERROR_INVALID_PROPERTY_NAME
-#: Merge.rc:5748
+#: Merge.rc:5749
 msgid "Invalid property name"
 msgstr "Неприемливо име на свойство"
 
 #. IDS_FILTER_ERROR_INVALID_DIRECTIVE
-#: Merge.rc:5749
+#: Merge.rc:5750
 msgid "Invalid directive"
 msgstr ""
 
 #. IDS_FILTER_OP_EQUALS
-#: Merge.rc:5754
+#: Merge.rc:5755
 msgid "Equals"
 msgstr "Е равно на"
 
 #. IDS_FILTER_OP_NOT_EQUALS
-#: Merge.rc:5755
+#: Merge.rc:5756
 msgid "Does not equal"
 msgstr "Не е равно на"
 
 #. IDS_FILTER_OP_LESS_THAN
-#: Merge.rc:5756
+#: Merge.rc:5757
 msgid "Less than"
 msgstr "По-малко от"
 
 #. IDS_FILTER_OP_LESS_EQUAL
-#: Merge.rc:5757
+#: Merge.rc:5758
 msgid "Less than or equal to"
 msgstr "По-малко или равно на"
 
 #. IDS_FILTER_OP_GREATER_EQUAL
-#: Merge.rc:5758
+#: Merge.rc:5759
 msgid "Greater than or equal to"
 msgstr "По-голямо или равно на"
 
 #. IDS_FILTER_OP_GREATER_THAN
-#: Merge.rc:5759
+#: Merge.rc:5760
 msgid "Greater than"
 msgstr "По-голямо на"
 
 #. IDS_FILTER_OP_BETWEEN
-#: Merge.rc:5760
+#: Merge.rc:5761
 msgid "Between"
 msgstr "Между"
 
 #. IDS_FILTER_OP_NOT_BETWEEN
-#: Merge.rc:5761
+#: Merge.rc:5762
 msgid "Not Between"
 msgstr "Не меЖду"
 
 #. IDS_FILTER_OP_CONTAINS
-#: Merge.rc:5762
+#: Merge.rc:5763
 msgid "Contains"
 msgstr "Съдържа"
 
 #. IDS_FILTER_OP_NOT_CONTAINS
-#: Merge.rc:5763
+#: Merge.rc:5764
 msgid "Not Contains"
 msgstr "Не съдържа"
 
 #. IDS_FILTER_OP_RECONTAINS
-#: Merge.rc:5764
+#: Merge.rc:5765
 msgid "Contains (regex)"
 msgstr "Съдържа (регулярен израз)"
 
 #. IDS_FILTER_OP_NOT_RECONTAINS
-#: Merge.rc:5765
+#: Merge.rc:5766
 msgid "Not Contains (regex)"
 msgstr "Не съдържа (регулярен израз)"
 
 #. IDS_FILTER_OP_LIKE
-#: Merge.rc:5766
+#: Merge.rc:5767
 msgid "Match (wildcard)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_LIKE
-#: Merge.rc:5767
+#: Merge.rc:5768
 msgid "Not match (wildcard)"
 msgstr ""
 
 #. IDS_FILTER_OP_MATCHES
-#: Merge.rc:5768
+#: Merge.rc:5769
 msgid "Match (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_MATCHES
-#: Merge.rc:5769
+#: Merge.rc:5770
 msgid "Not match (regex)"
 msgstr ""
 
 #. IDS_COLORMODE_LIGHT
-#: Merge.rc:5774
+#: Merge.rc:5775
 msgid "Light"
 msgstr "Светла"
 
 #. IDS_COLORMODE_DARK
-#: Merge.rc:5775
+#: Merge.rc:5776
 msgid "Dark"
 msgstr "Тъмна"
 
 #. IDS_COLORMODE_FOLLOWSYSTEM
-#: Merge.rc:5776
+#: Merge.rc:5777
 msgid "Follow system"
 msgstr "Според системата"
 
 #. IDS_EXAMPLE
-#: Merge.rc:5781
+#: Merge.rc:5782
 #, c-format
 msgid "e.g. %1"
 msgstr ""
 
 #. IDS_DETECTED_PREVIOUS_CRASH
-#: Merge.rc:5786
+#: Merge.rc:5787
 msgid "WinMerge detected a previous crash. Please report this if possible."
 msgstr ""
 
 #. IDS_REGEX_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5791
+#: Merge.rc:5792
 msgid "# Regex replacement list\r\n# Format: regex<TAB>replacement\r\n# Backreferences like $1, $2 are supported\r\n\r\n(\\d{4})-(\\d{2})-(\\d{2})\t$1_$2_$3\r\n"
 msgstr ""
 
 #. IDS_STRING_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5792
+#: Merge.rc:5793
 msgid "# Replacement list\r\n# Format: search<TAB>replacement\r\n# Lines starting with # are ignored\r\n\r\nfrom1\tto1\r\nfrom2\tto2\r\n"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_ONLY
-#: Merge.rc:5797
+#: Merge.rc:5798
 msgid "Built-in only"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_FIRST
-#: Merge.rc:5798
+#: Merge.rc:5799
 msgid "Built-in first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_FIRST
-#: Merge.rc:5799
+#: Merge.rc:5800
 msgid "Tree-sitter first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_ONLY
-#: Merge.rc:5800
+#: Merge.rc:5801
 msgid "Tree-sitter only"
 msgstr ""
 

--- a/Translations/WinMerge/Catalan.po
+++ b/Translations/WinMerge/Catalan.po
@@ -22,7 +22,7 @@ msgstr ""
 "X-Generator: Poedit 3.4.2\n"
 
 #. LANGUAGE, SUBLANGUAGE
-#: Merge.rc:26 Merge.rc:59 Merge.rc:5817
+#: Merge.rc:26 Merge.rc:59 Merge.rc:5818
 #, c-format
 msgid "LANG_ENGLISH, SUBLANG_ENGLISH_US"
 msgstr "LANG_CATALAN, SUBLANG_DEFAULT"
@@ -239,7 +239,7 @@ msgid "Auto-Fit All Columns"
 msgstr "Ajusta automàticament totes les columnes"
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN
-#: Merge.rc:153 Merge.rc:5645
+#: Merge.rc:153 Merge.rc:5646
 msgid "&Filter by This Column"
 msgstr ""
 
@@ -305,7 +305,7 @@ msgid "&Previous Page"
 msgstr "&Pàgina anterior"
 
 #. IDS_PREVIEWBAR_NEXTPAGE
-#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5678
+#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5679
 #, c-format
 msgid "&Next Page"
 msgstr "Pàgina següe&nt"
@@ -711,7 +711,7 @@ msgid "&Huge"
 msgstr "&Immensa"
 
 #. IDS_VIEW_MENU_BAR
-#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5713
+#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5714
 msgid "Men&u Bar"
 msgstr ""
 
@@ -4567,7 +4567,7 @@ msgid "Items compared:"
 msgstr "Elements comparats:"
 
 #. IDS_PREVIEWBAR_CLOSE
-#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5684
+#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5685
 #, c-format
 msgid "&Close"
 msgstr "&Tanca"
@@ -9041,30 +9041,35 @@ msgstr ""
 msgid "2nd and 3rd"
 msgstr ""
 
+#. IDS_PLUGIN_CTRL_CLICK
+#: Merge.rc:5635
+msgid "(Ctrl+Click to add to pipeline)"
+msgstr ""
+
 #. IDS_FILTER_APPLIED
-#: Merge.rc:5639
+#: Merge.rc:5640
 msgid "Filter applied"
 msgstr "Filtre aplicat"
 
 #. IDS_FILTERMENU_COMPARE
-#: Merge.rc:5644
+#: Merge.rc:5645
 #, c-format
 msgid "Compare %1"
 msgstr ""
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN2
-#: Merge.rc:5646
+#: Merge.rc:5647
 msgid "&Filter by This Column..."
 msgstr ""
 
 #. IDS_CLIPBOARDHISTORY_TIME
-#: Merge.rc:5651
+#: Merge.rc:5652
 #, c-format
 msgid "Clipboard at %s"
 msgstr "Porta-retalls a %s"
 
 #. IDS_CLIPBOARDHISTORY_DISABLED
-#: Merge.rc:5652
+#: Merge.rc:5653
 msgid ""
 "Clipboard history disabled.\r\n"
 "Enable: Windows logo key + V, then Turn on."
@@ -9072,420 +9077,420 @@ msgstr ""
 "L'historial del porta-retalls està desactivat.\r\n"
 "Per activar l'historial del porta-retalls, premeu la tecla del logotip de Windows + V i aleshores feu clic al botó Activa."
 
-#: Merge.rc:5654
+#: Merge.rc:5655
 msgid "This system does not support clipboard history."
 msgstr "Aquest sistema no té suport per a l'historial del porta-retalls."
 
-#: Merge.rc:5656
+#: Merge.rc:5657
 msgid "32-bit WinMerge does not support Clipboard Compare"
 msgstr "La versió de 32 bits del WinMerge no suporta comparar via porta-retalls"
 
 #. IDS_WEBVIEW2_RUNTIME_NOT_INSTALLED
-#: Merge.rc:5661
+#: Merge.rc:5662
 msgid "WebView2 runtime not installed. Download it?"
 msgstr "L'entorn d'execució WebView2 no està instal·lat. El voleu descarregar?"
 
 #. IDS_JUMPLIST_NEW_TEXT_COMPARE
-#: Merge.rc:5666
+#: Merge.rc:5667
 msgid "New Text Compare"
 msgstr "Nova comparació de text"
 
 #. IDS_JUMPLIST_NEW_TABLE_COMPARE
-#: Merge.rc:5667
+#: Merge.rc:5668
 msgid "New Table Compare"
 msgstr "Nova comparació de taules"
 
 #. IDS_JUMPLIST_NEW_BINARY_COMPARE
-#: Merge.rc:5668
+#: Merge.rc:5669
 msgid "New Binary Compare"
 msgstr "Nova comparació binària"
 
 #. IDS_JUMPLIST_NEW_IMAGE_COMPARE
-#: Merge.rc:5669
+#: Merge.rc:5670
 msgid "New Image Compare"
 msgstr "Nova comparació d'imatges"
 
 #. IDS_JUMPLIST_NEW_WEBPAGE_COMPARE
-#: Merge.rc:5670
+#: Merge.rc:5671
 msgid "New Webpage Compare"
 msgstr "Nova comparació de pàgines web"
 
 #. IDS_JUMPLIST_NEW_FOLDER_COMPARE
-#: Merge.rc:5671
+#: Merge.rc:5672
 msgid "New Folder Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_CLIPBOARD_COMPARE
-#: Merge.rc:5672
+#: Merge.rc:5673
 msgid "Clipboard Compare"
 msgstr "Comparació del porta-retalls"
 
 #. IDS_PREVIEWBAR_PRINT
-#: Merge.rc:5677
+#: Merge.rc:5678
 msgid "&Print..."
 msgstr "&Imprimeix..."
 
 #. IDS_PREVIEWBAR_PREVPAGE
-#: Merge.rc:5679
+#: Merge.rc:5680
 msgid "Pre&v Page"
 msgstr "Pàgina &anterior"
 
 #. IDS_PREVIEWBAR_TWOPAGE
-#: Merge.rc:5680
+#: Merge.rc:5681
 msgid "&Two Page"
 msgstr "&Dues pàgines"
 
 #. IDS_PREVIEWBAR_ONEPAGE
-#: Merge.rc:5681
+#: Merge.rc:5682
 msgid "&One Page"
 msgstr "&Una pàgina"
 
 #. IDS_PREVIEWBAR_ZOOMIN
-#: Merge.rc:5682
+#: Merge.rc:5683
 msgid "Zoom &In"
 msgstr "A&propa"
 
 #. IDS_PREVIEWBAR_ZOOMOUT
-#: Merge.rc:5683
+#: Merge.rc:5684
 msgid "Zoom &Out"
 msgstr "All&unya"
 
 #. IDS_WEBPAGE_COMPARING
-#: Merge.rc:5689
+#: Merge.rc:5690
 msgid "Comparing..."
 msgstr "Comparant..."
 
 #. IDS_WEBPAGE_ZOOM
-#: Merge.rc:5690
+#: Merge.rc:5691
 msgid "Zoom:"
 msgstr "Zoom:"
 
 #. IDS_COPY_GRANULARITY_DIFFHUNK
-#: Merge.rc:5695
+#: Merge.rc:5696
 msgid "Diff hunk"
 msgstr "Tros de diferència"
 
 #. IDS_COPY_GRANULARITY_INLINE
-#: Merge.rc:5696
+#: Merge.rc:5697
 msgid "Inline diff"
 msgstr "Diferència en línia"
 
 #. IDS_COPY_GRANULARITY_LINE
-#: Merge.rc:5697
+#: Merge.rc:5698
 msgid "Line"
 msgstr "Línia"
 
-#: Merge.rc:5698
+#: Merge.rc:5699
 msgid "Character"
 msgstr "Caràcter"
 
 #. ID_MICE_PREVDIFF
-#: Merge.rc:5703
+#: Merge.rc:5704
 msgid "\nPrevious Difference (Alt+Up)\n(Right Button+Wheel Up)\n(Alt+Wheel Up)"
 msgstr ""
 
 #. ID_MICE_NEXTDIFF
-#: Merge.rc:5704
+#: Merge.rc:5705
 msgid "\nNext Difference (Alt+Down)\n(Right Button+Wheel Down)\n(Alt+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_L2R
-#: Merge.rc:5705
+#: Merge.rc:5706
 msgid "\nCopy to Right (Alt+Right)\n(Right Button+Wheel Right)\n(Alt+Wheel Right)\n(Alt+Shift+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_R2L
-#: Merge.rc:5706
+#: Merge.rc:5707
 msgid "\nCopy to Left (Alt+Left)\n(Right Button+Wheel Left)\n(Alt+Wheel Left)\n(Alt+Shift+Wheel Up)"
 msgstr ""
 
 #. ID_MICE_L2RNEXT
-#: Merge.rc:5707
+#: Merge.rc:5708
 msgid "\nCopy to Right and Advance (Ctrl+Alt+Right)\n(Ctrl+Alt+Wheel Right)\n(Ctrl+Alt+Shift+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_R2LNEXT
-#: Merge.rc:5708
+#: Merge.rc:5709
 msgid "\nCopy to Left and Advance (Ctrl+Alt+Left)\n(Ctrl+Alt+Wheel Left)\n(Ctrl+Alt+Shift+Wheel Up)"
 msgstr ""
 
 #. IDS_LOG_COMPARING_2
-#: Merge.rc:5718
+#: Merge.rc:5719
 #, c-format
 msgid "Comparing %1 with %2"
 msgstr ""
 
 #. IDS_LOG_COMPARING_3
-#: Merge.rc:5719
+#: Merge.rc:5720
 #, c-format
 msgid "Comparing %1 with %2 and %3"
 msgstr ""
 
 #. IDS_LOG_COMPARE_COMPLETED
-#: Merge.rc:5720
+#: Merge.rc:5721
 msgid "Comparison completed"
 msgstr ""
 
 #. IDS_LOG_COMPARE_ERROR_2
-#: Merge.rc:5721
+#: Merge.rc:5722
 #, c-format
 msgid "Failed to compare %1 with %2: "
 msgstr ""
 
 #. IDS_LOG_COMPARE_ERROR_3
-#: Merge.rc:5722
+#: Merge.rc:5723
 #, c-format
 msgid "Failed to compare %1 with %2 and %3: "
 msgstr ""
 
 #. IDS_LOG_FILE_SAVED
-#: Merge.rc:5723
+#: Merge.rc:5724
 msgid "File saved"
 msgstr ""
 
 #. IDS_LOG_COPYING_FILES
-#: Merge.rc:5724
+#: Merge.rc:5725
 msgid "Copying files..."
 msgstr ""
 
 #. IDS_LOG_MOVING_FILES
-#: Merge.rc:5725
+#: Merge.rc:5726
 msgid "Moving files..."
 msgstr ""
 
 #. IDS_LOG_DELETING_FILES
-#: Merge.rc:5726
+#: Merge.rc:5727
 msgid "Deleting files..."
 msgstr ""
 
 #. IDS_LOG_RECYCLEBIN
-#: Merge.rc:5727
+#: Merge.rc:5728
 msgid "Recycle Bin"
 msgstr ""
 
 #. IDS_LOG_PERMANENTLY_DELETED
-#: Merge.rc:5728
+#: Merge.rc:5729
 msgid "Permanently deleted"
 msgstr ""
 
 #. IDS_LOG_FILEOPERATION_COMPLETED
-#: Merge.rc:5729
+#: Merge.rc:5730
 msgid "File operation completed successfully"
 msgstr ""
 
 #. IDS_LOG_FILEOPERATION_CANCELED
-#: Merge.rc:5730
+#: Merge.rc:5731
 msgid "File operation canceled"
 msgstr ""
 
 #. IDS_FILTER_ERROR_NO_ERROR
-#: Merge.rc:5735
+#: Merge.rc:5736
 msgid "No error"
 msgstr ""
 
 #. IDS_FILTER_ERROR_EMPTY_EXPRESSION
-#: Merge.rc:5736
+#: Merge.rc:5737
 msgid "Filter expression is empty"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNKNOWN_CHAR
-#: Merge.rc:5737
+#: Merge.rc:5738
 msgid "Unknown character in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNTERMINATED_STRING
-#: Merge.rc:5738
+#: Merge.rc:5739
 msgid "Unterminated string literal"
 msgstr ""
 
 #. IDS_FILTER_ERROR_SYNTAX_ERROR
-#: Merge.rc:5739
+#: Merge.rc:5740
 msgid "Syntax error in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_PARSE_FAILURE
-#: Merge.rc:5740
+#: Merge.rc:5741
 msgid "Failed to parse filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_LITERAL
-#: Merge.rc:5741
+#: Merge.rc:5742
 msgid "Invalid literal value"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_REGULAR_EXPRESSION
-#: Merge.rc:5742
+#: Merge.rc:5743
 msgid "Invalid regular expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNDEFINED_IDENTIFIER
-#: Merge.rc:5743
+#: Merge.rc:5744
 msgid "Undefined identifier"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_ARGUMENT_COUNT
-#: Merge.rc:5744
+#: Merge.rc:5745
 msgid "Invalid number of arguments"
 msgstr ""
 
 #. IDS_FILTER_ERROR_FILTER_NAME_NOT_FOUND
-#: Merge.rc:5745
+#: Merge.rc:5746
 msgid "Filter name not found"
 msgstr ""
 
 #. IDS_FILTER_ERROR_DIVIDE_BY_ZERO
-#: Merge.rc:5746
+#: Merge.rc:5747
 msgid "Division by zero in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNKNOWN_ERROR
-#: Merge.rc:5747
+#: Merge.rc:5748
 msgid "Unknown error"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_PROPERTY_NAME
-#: Merge.rc:5748
+#: Merge.rc:5749
 msgid "Invalid property name"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_DIRECTIVE
-#: Merge.rc:5749
+#: Merge.rc:5750
 msgid "Invalid directive"
 msgstr ""
 
 #. IDS_FILTER_OP_EQUALS
-#: Merge.rc:5754
+#: Merge.rc:5755
 msgid "Equals"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_EQUALS
-#: Merge.rc:5755
+#: Merge.rc:5756
 msgid "Does not equal"
 msgstr ""
 
 #. IDS_FILTER_OP_LESS_THAN
-#: Merge.rc:5756
+#: Merge.rc:5757
 msgid "Less than"
 msgstr ""
 
 #. IDS_FILTER_OP_LESS_EQUAL
-#: Merge.rc:5757
+#: Merge.rc:5758
 msgid "Less than or equal to"
 msgstr ""
 
 #. IDS_FILTER_OP_GREATER_EQUAL
-#: Merge.rc:5758
+#: Merge.rc:5759
 msgid "Greater than or equal to"
 msgstr ""
 
 #. IDS_FILTER_OP_GREATER_THAN
-#: Merge.rc:5759
+#: Merge.rc:5760
 msgid "Greater than"
 msgstr ""
 
 #. IDS_FILTER_OP_BETWEEN
-#: Merge.rc:5760
+#: Merge.rc:5761
 msgid "Between"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_BETWEEN
-#: Merge.rc:5761
+#: Merge.rc:5762
 msgid "Not Between"
 msgstr ""
 
 #. IDS_FILTER_OP_CONTAINS
-#: Merge.rc:5762
+#: Merge.rc:5763
 msgid "Contains"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_CONTAINS
-#: Merge.rc:5763
+#: Merge.rc:5764
 msgid "Not Contains"
 msgstr ""
 
 #. IDS_FILTER_OP_RECONTAINS
-#: Merge.rc:5764
+#: Merge.rc:5765
 msgid "Contains (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_RECONTAINS
-#: Merge.rc:5765
+#: Merge.rc:5766
 msgid "Not Contains (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_LIKE
-#: Merge.rc:5766
+#: Merge.rc:5767
 msgid "Match (wildcard)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_LIKE
-#: Merge.rc:5767
+#: Merge.rc:5768
 msgid "Not match (wildcard)"
 msgstr ""
 
 #. IDS_FILTER_OP_MATCHES
-#: Merge.rc:5768
+#: Merge.rc:5769
 msgid "Match (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_MATCHES
-#: Merge.rc:5769
+#: Merge.rc:5770
 msgid "Not match (regex)"
 msgstr ""
 
 #. IDS_COLORMODE_LIGHT
-#: Merge.rc:5774
+#: Merge.rc:5775
 msgid "Light"
 msgstr ""
 
 #. IDS_COLORMODE_DARK
-#: Merge.rc:5775
+#: Merge.rc:5776
 msgid "Dark"
 msgstr ""
 
 #. IDS_COLORMODE_FOLLOWSYSTEM
-#: Merge.rc:5776
+#: Merge.rc:5777
 msgid "Follow system"
 msgstr ""
 
 #. IDS_EXAMPLE
-#: Merge.rc:5781
+#: Merge.rc:5782
 #, c-format
 msgid "e.g. %1"
 msgstr ""
 
 #. IDS_DETECTED_PREVIOUS_CRASH
-#: Merge.rc:5786
+#: Merge.rc:5787
 msgid "WinMerge detected a previous crash. Please report this if possible."
 msgstr ""
 
 #. IDS_REGEX_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5791
+#: Merge.rc:5792
 msgid "# Regex replacement list\r\n# Format: regex<TAB>replacement\r\n# Backreferences like $1, $2 are supported\r\n\r\n(\\d{4})-(\\d{2})-(\\d{2})\t$1_$2_$3\r\n"
 msgstr ""
 
 #. IDS_STRING_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5792
+#: Merge.rc:5793
 msgid "# Replacement list\r\n# Format: search<TAB>replacement\r\n# Lines starting with # are ignored\r\n\r\nfrom1\tto1\r\nfrom2\tto2\r\n"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_ONLY
-#: Merge.rc:5797
+#: Merge.rc:5798
 msgid "Built-in only"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_FIRST
-#: Merge.rc:5798
+#: Merge.rc:5799
 msgid "Built-in first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_FIRST
-#: Merge.rc:5799
+#: Merge.rc:5800
 msgid "Tree-sitter first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_ONLY
-#: Merge.rc:5800
+#: Merge.rc:5801
 msgid "Tree-sitter only"
 msgstr ""
 

--- a/Translations/WinMerge/ChineseSimplified.po
+++ b/Translations/WinMerge/ChineseSimplified.po
@@ -27,7 +27,7 @@ msgstr ""
 "X-Poedit-SearchPath-0: .\n"
 
 #. LANGUAGE, SUBLANGUAGE
-#: Merge.rc:26 Merge.rc:59 Merge.rc:5817
+#: Merge.rc:26 Merge.rc:59 Merge.rc:5818
 msgid "LANG_ENGLISH, SUBLANG_ENGLISH_US"
 msgstr "LANG_CHINESE, SUBLANG_CHINESE_SIMPLIFIED"
 
@@ -234,7 +234,7 @@ msgid "Auto-Fit All Columns"
 msgstr "自动适应所有列"
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN
-#: Merge.rc:153 Merge.rc:5645
+#: Merge.rc:153 Merge.rc:5646
 msgid "&Filter by This Column"
 msgstr "按该列过滤(&F)"
 
@@ -295,7 +295,7 @@ msgid "&Previous Page"
 msgstr "上一页(&P)"
 
 #. IDS_PREVIEWBAR_NEXTPAGE
-#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5678
+#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5679
 msgid "&Next Page"
 msgstr "下一页(&N)"
 
@@ -668,7 +668,7 @@ msgid "&Huge"
 msgstr "特大(&H)"
 
 #. IDS_VIEW_MENU_BAR
-#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5713
+#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5714
 msgid "Men&u Bar"
 msgstr "菜单栏(&U)"
 
@@ -4193,7 +4193,7 @@ msgid "Items compared:"
 msgstr "已比较条目："
 
 #. IDS_PREVIEWBAR_CLOSE
-#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5684
+#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5685
 msgid "&Close"
 msgstr "关闭(&C)"
 
@@ -8405,30 +8405,35 @@ msgstr "第一个和第三个"
 msgid "2nd and 3rd"
 msgstr "第二个和第三个"
 
+#. IDS_PLUGIN_CTRL_CLICK
+#: Merge.rc:5635
+msgid "(Ctrl+Click to add to pipeline)"
+msgstr ""
+
 #. IDS_FILTER_APPLIED
-#: Merge.rc:5639
+#: Merge.rc:5640
 msgid "Filter applied"
 msgstr "过滤器已应用"
 
 #. IDS_FILTERMENU_COMPARE
-#: Merge.rc:5644
+#: Merge.rc:5645
 #, c-format
 msgid "Compare %1"
 msgstr "比较 %1"
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN2
-#: Merge.rc:5646
+#: Merge.rc:5647
 msgid "&Filter by This Column..."
 msgstr "按该列过滤(&F)..."
 
 #. IDS_CLIPBOARDHISTORY_TIME
-#: Merge.rc:5651
+#: Merge.rc:5652
 #, c-format
 msgid "Clipboard at %s"
 msgstr "剪贴板位于 %s"
 
 #. IDS_CLIPBOARDHISTORY_DISABLED
-#: Merge.rc:5652
+#: Merge.rc:5653
 msgid ""
 "Clipboard history disabled.\r\n"
 "Enable: Windows logo key + V, then Turn on."
@@ -8436,115 +8441,115 @@ msgstr ""
 "剪贴板历史记录被禁用了。\r\n"
 "要启用剪贴板历史记录， 请按 Windows 徽标键 + V，然后单击“打开”按钮。"
 
-#: Merge.rc:5654
+#: Merge.rc:5655
 msgid "This system does not support clipboard history."
 msgstr "当前系统不支持剪贴板历史记录。"
 
-#: Merge.rc:5656
+#: Merge.rc:5657
 msgid "32-bit WinMerge does not support Clipboard Compare"
 msgstr "32 位的 WinMerge 不支持剪贴板比较"
 
 #. IDS_WEBVIEW2_RUNTIME_NOT_INSTALLED
-#: Merge.rc:5661
+#: Merge.rc:5662
 msgid "WebView2 runtime not installed. Download it?"
 msgstr "未安装 WebView2 运行库。您想下载吗？"
 
 #. IDS_JUMPLIST_NEW_TEXT_COMPARE
-#: Merge.rc:5666
+#: Merge.rc:5667
 msgid "New Text Compare"
 msgstr "新的文本比较"
 
 #. IDS_JUMPLIST_NEW_TABLE_COMPARE
-#: Merge.rc:5667
+#: Merge.rc:5668
 msgid "New Table Compare"
 msgstr "新的表格比较"
 
 #. IDS_JUMPLIST_NEW_BINARY_COMPARE
-#: Merge.rc:5668
+#: Merge.rc:5669
 msgid "New Binary Compare"
 msgstr "新的二进制比较"
 
 #. IDS_JUMPLIST_NEW_IMAGE_COMPARE
-#: Merge.rc:5669
+#: Merge.rc:5670
 msgid "New Image Compare"
 msgstr "新的图像比较"
 
 #. IDS_JUMPLIST_NEW_WEBPAGE_COMPARE
-#: Merge.rc:5670
+#: Merge.rc:5671
 msgid "New Webpage Compare"
 msgstr "新的网页比较"
 
 #. IDS_JUMPLIST_NEW_FOLDER_COMPARE
-#: Merge.rc:5671
+#: Merge.rc:5672
 msgid "New Folder Compare"
 msgstr "新建文件夹比较"
 
 #. IDS_JUMPLIST_CLIPBOARD_COMPARE
-#: Merge.rc:5672
+#: Merge.rc:5673
 msgid "Clipboard Compare"
 msgstr "剪贴板比较"
 
 #. IDS_PREVIEWBAR_PRINT
-#: Merge.rc:5677
+#: Merge.rc:5678
 msgid "&Print..."
 msgstr "打印(&P)..."
 
 #. IDS_PREVIEWBAR_PREVPAGE
-#: Merge.rc:5679
+#: Merge.rc:5680
 msgid "Pre&v Page"
 msgstr "上一页(&V)"
 
 #. IDS_PREVIEWBAR_TWOPAGE
-#: Merge.rc:5680
+#: Merge.rc:5681
 msgid "&Two Page"
 msgstr "双页(&T)"
 
 #. IDS_PREVIEWBAR_ONEPAGE
-#: Merge.rc:5681
+#: Merge.rc:5682
 msgid "&One Page"
 msgstr "单页(&O)"
 
 #. IDS_PREVIEWBAR_ZOOMIN
-#: Merge.rc:5682
+#: Merge.rc:5683
 msgid "Zoom &In"
 msgstr "放大(&I)"
 
 #. IDS_PREVIEWBAR_ZOOMOUT
-#: Merge.rc:5683
+#: Merge.rc:5684
 msgid "Zoom &Out"
 msgstr "缩小(&O)"
 
 #. IDS_WEBPAGE_COMPARING
-#: Merge.rc:5689
+#: Merge.rc:5690
 msgid "Comparing..."
 msgstr "比较中..."
 
 #. IDS_WEBPAGE_ZOOM
-#: Merge.rc:5690
+#: Merge.rc:5691
 msgid "Zoom:"
 msgstr "缩放："
 
 #. IDS_COPY_GRANULARITY_DIFFHUNK
-#: Merge.rc:5695
+#: Merge.rc:5696
 msgid "Diff hunk"
 msgstr "整个差异块"
 
 #. IDS_COPY_GRANULARITY_INLINE
-#: Merge.rc:5696
+#: Merge.rc:5697
 msgid "Inline diff"
 msgstr "行内差异"
 
 #. IDS_COPY_GRANULARITY_LINE
-#: Merge.rc:5697
+#: Merge.rc:5698
 msgid "Line"
 msgstr "整行"
 
-#: Merge.rc:5698
+#: Merge.rc:5699
 msgid "Character"
 msgstr "字符"
 
 #. ID_MICE_PREVDIFF
-#: Merge.rc:5703
+#: Merge.rc:5704
 msgid ""
 "\n"
 "Previous Difference (Alt+Up)\n"
@@ -8557,7 +8562,7 @@ msgstr ""
 "(Alt+滚轮上滚)"
 
 #. ID_MICE_NEXTDIFF
-#: Merge.rc:5704
+#: Merge.rc:5705
 msgid ""
 "\n"
 "Next Difference (Alt+Down)\n"
@@ -8570,7 +8575,7 @@ msgstr ""
 "(Alt+滚轮下滚)"
 
 #. ID_MICE_L2R
-#: Merge.rc:5705
+#: Merge.rc:5706
 msgid ""
 "\n"
 "Copy to Right (Alt+Right)\n"
@@ -8585,7 +8590,7 @@ msgstr ""
 "(Alt+Shift+滚轮下滚)"
 
 #. ID_MICE_R2L
-#: Merge.rc:5706
+#: Merge.rc:5707
 msgid ""
 "\n"
 "Copy to Left (Alt+Left)\n"
@@ -8600,7 +8605,7 @@ msgstr ""
 "(Alt+Shift+滚轮上滚)"
 
 #. ID_MICE_L2RNEXT
-#: Merge.rc:5707
+#: Merge.rc:5708
 msgid ""
 "\n"
 "Copy to Right and Advance (Ctrl+Alt+Right)\n"
@@ -8613,7 +8618,7 @@ msgstr ""
 "(Ctrl+Alt+Shift+滚轮下滚)"
 
 #. ID_MICE_R2LNEXT
-#: Merge.rc:5708
+#: Merge.rc:5709
 msgid ""
 "\n"
 "Copy to Left and Advance (Ctrl+Alt+Left)\n"
@@ -8626,257 +8631,257 @@ msgstr ""
 "(Ctrl+Alt+Shift+滚轮上滚)"
 
 #. IDS_LOG_COMPARING_2
-#: Merge.rc:5718
+#: Merge.rc:5719
 #, c-format
 msgid "Comparing %1 with %2"
 msgstr "比较 %1 和 %2"
 
 #. IDS_LOG_COMPARING_3
-#: Merge.rc:5719
+#: Merge.rc:5720
 #, c-format
 msgid "Comparing %1 with %2 and %3"
 msgstr "比较 %1、%2 和 %3"
 
 #. IDS_LOG_COMPARE_COMPLETED
-#: Merge.rc:5720
+#: Merge.rc:5721
 msgid "Comparison completed"
 msgstr "比较已完成"
 
 #. IDS_LOG_COMPARE_ERROR_2
-#: Merge.rc:5721
+#: Merge.rc:5722
 #, c-format
 msgid "Failed to compare %1 with %2: "
 msgstr "比较 %1 和 %2 失败："
 
 #. IDS_LOG_COMPARE_ERROR_3
-#: Merge.rc:5722
+#: Merge.rc:5723
 #, c-format
 msgid "Failed to compare %1 with %2 and %3: "
 msgstr "比较 %1 %2 和 %3 失败："
 
 #. IDS_LOG_FILE_SAVED
-#: Merge.rc:5723
+#: Merge.rc:5724
 msgid "File saved"
 msgstr "文件已保存"
 
 #. IDS_LOG_COPYING_FILES
-#: Merge.rc:5724
+#: Merge.rc:5725
 msgid "Copying files..."
 msgstr "复制文件..."
 
 #. IDS_LOG_MOVING_FILES
-#: Merge.rc:5725
+#: Merge.rc:5726
 msgid "Moving files..."
 msgstr "移动文件..."
 
 #. IDS_LOG_DELETING_FILES
-#: Merge.rc:5726
+#: Merge.rc:5727
 msgid "Deleting files..."
 msgstr "删除文件..."
 
 #. IDS_LOG_RECYCLEBIN
-#: Merge.rc:5727
+#: Merge.rc:5728
 msgid "Recycle Bin"
 msgstr "回收站"
 
 #. IDS_LOG_PERMANENTLY_DELETED
-#: Merge.rc:5728
+#: Merge.rc:5729
 msgid "Permanently deleted"
 msgstr "已永久删除"
 
 #. IDS_LOG_FILEOPERATION_COMPLETED
-#: Merge.rc:5729
+#: Merge.rc:5730
 msgid "File operation completed successfully"
 msgstr "文件操作已成功完成"
 
 #. IDS_LOG_FILEOPERATION_CANCELED
-#: Merge.rc:5730
+#: Merge.rc:5731
 msgid "File operation canceled"
 msgstr "文件操作已取消"
 
 #. IDS_FILTER_ERROR_NO_ERROR
-#: Merge.rc:5735
+#: Merge.rc:5736
 msgid "No error"
 msgstr "无错误"
 
 #. IDS_FILTER_ERROR_EMPTY_EXPRESSION
-#: Merge.rc:5736
+#: Merge.rc:5737
 msgid "Filter expression is empty"
 msgstr "过滤器表达式为空"
 
 #. IDS_FILTER_ERROR_UNKNOWN_CHAR
-#: Merge.rc:5737
+#: Merge.rc:5738
 msgid "Unknown character in filter expression"
 msgstr "过滤器表达式存在未知字符"
 
 #. IDS_FILTER_ERROR_UNTERMINATED_STRING
-#: Merge.rc:5738
+#: Merge.rc:5739
 msgid "Unterminated string literal"
 msgstr "未终止的字符串字面量"
 
 #. IDS_FILTER_ERROR_SYNTAX_ERROR
-#: Merge.rc:5739
+#: Merge.rc:5740
 msgid "Syntax error in filter expression"
 msgstr "过滤器表达式语法错误"
 
 #. IDS_FILTER_ERROR_PARSE_FAILURE
-#: Merge.rc:5740
+#: Merge.rc:5741
 msgid "Failed to parse filter expression"
 msgstr "无法解析过滤器表达式"
 
 #. IDS_FILTER_ERROR_INVALID_LITERAL
-#: Merge.rc:5741
+#: Merge.rc:5742
 msgid "Invalid literal value"
 msgstr "无效的字面量值"
 
 #. IDS_FILTER_ERROR_INVALID_REGULAR_EXPRESSION
-#: Merge.rc:5742
+#: Merge.rc:5743
 msgid "Invalid regular expression"
 msgstr "无效的正则表达式"
 
 #. IDS_FILTER_ERROR_UNDEFINED_IDENTIFIER
-#: Merge.rc:5743
+#: Merge.rc:5744
 msgid "Undefined identifier"
 msgstr "未定义的标识符"
 
 #. IDS_FILTER_ERROR_INVALID_ARGUMENT_COUNT
-#: Merge.rc:5744
+#: Merge.rc:5745
 msgid "Invalid number of arguments"
 msgstr "无效的参数数量"
 
 #. IDS_FILTER_ERROR_FILTER_NAME_NOT_FOUND
-#: Merge.rc:5745
+#: Merge.rc:5746
 msgid "Filter name not found"
 msgstr "过滤器名称不存在"
 
 #. IDS_FILTER_ERROR_DIVIDE_BY_ZERO
-#: Merge.rc:5746
+#: Merge.rc:5747
 msgid "Division by zero in filter expression"
 msgstr "过滤器表达式存在除零错误"
 
 #. IDS_FILTER_ERROR_UNKNOWN_ERROR
-#: Merge.rc:5747
+#: Merge.rc:5748
 msgid "Unknown error"
 msgstr "未知错误"
 
 #. IDS_FILTER_ERROR_INVALID_PROPERTY_NAME
-#: Merge.rc:5748
+#: Merge.rc:5749
 msgid "Invalid property name"
 msgstr "无效的属性名称"
 
 #. IDS_FILTER_ERROR_INVALID_DIRECTIVE
-#: Merge.rc:5749
+#: Merge.rc:5750
 msgid "Invalid directive"
 msgstr "无效的指示"
 
 #. IDS_FILTER_OP_EQUALS
-#: Merge.rc:5754
+#: Merge.rc:5755
 msgid "Equals"
 msgstr "等于"
 
 #. IDS_FILTER_OP_NOT_EQUALS
-#: Merge.rc:5755
+#: Merge.rc:5756
 msgid "Does not equal"
 msgstr "不等于"
 
 #. IDS_FILTER_OP_LESS_THAN
-#: Merge.rc:5756
+#: Merge.rc:5757
 msgid "Less than"
 msgstr "小于"
 
 #. IDS_FILTER_OP_LESS_EQUAL
-#: Merge.rc:5757
+#: Merge.rc:5758
 msgid "Less than or equal to"
 msgstr "小于等于"
 
 #. IDS_FILTER_OP_GREATER_EQUAL
-#: Merge.rc:5758
+#: Merge.rc:5759
 msgid "Greater than or equal to"
 msgstr "大于等于"
 
 #. IDS_FILTER_OP_GREATER_THAN
-#: Merge.rc:5759
+#: Merge.rc:5760
 msgid "Greater than"
 msgstr "大于"
 
 #. IDS_FILTER_OP_BETWEEN
-#: Merge.rc:5760
+#: Merge.rc:5761
 msgid "Between"
 msgstr "在"
 
 #. IDS_FILTER_OP_NOT_BETWEEN
-#: Merge.rc:5761
+#: Merge.rc:5762
 msgid "Not Between"
 msgstr "不在"
 
 #. IDS_FILTER_OP_CONTAINS
-#: Merge.rc:5762
+#: Merge.rc:5763
 msgid "Contains"
 msgstr "包含"
 
 #. IDS_FILTER_OP_NOT_CONTAINS
-#: Merge.rc:5763
+#: Merge.rc:5764
 msgid "Not Contains"
 msgstr "未包含"
 
 #. IDS_FILTER_OP_RECONTAINS
-#: Merge.rc:5764
+#: Merge.rc:5765
 msgid "Contains (regex)"
 msgstr "包含（正则表达式）"
 
 #. IDS_FILTER_OP_NOT_RECONTAINS
-#: Merge.rc:5765
+#: Merge.rc:5766
 msgid "Not Contains (regex)"
 msgstr "未包含（正则表达式）"
 
 #. IDS_FILTER_OP_LIKE
-#: Merge.rc:5766
+#: Merge.rc:5767
 msgid "Match (wildcard)"
 msgstr "匹配（通配符）"
 
 #. IDS_FILTER_OP_NOT_LIKE
-#: Merge.rc:5767
+#: Merge.rc:5768
 msgid "Not match (wildcard)"
 msgstr "未匹配（通配符）"
 
 #. IDS_FILTER_OP_MATCHES
-#: Merge.rc:5768
+#: Merge.rc:5769
 msgid "Match (regex)"
 msgstr "匹配（正则式）"
 
 #. IDS_FILTER_OP_NOT_MATCHES
-#: Merge.rc:5769
+#: Merge.rc:5770
 msgid "Not match (regex)"
 msgstr "未匹配（正则式）"
 
 #. IDS_COLORMODE_LIGHT
-#: Merge.rc:5774
+#: Merge.rc:5775
 msgid "Light"
 msgstr "浅色"
 
 #. IDS_COLORMODE_DARK
-#: Merge.rc:5775
+#: Merge.rc:5776
 msgid "Dark"
 msgstr "深色"
 
 #. IDS_COLORMODE_FOLLOWSYSTEM
-#: Merge.rc:5776
+#: Merge.rc:5777
 msgid "Follow system"
 msgstr "跟随系统"
 
 #. IDS_EXAMPLE
-#: Merge.rc:5781
+#: Merge.rc:5782
 #, c-format
 msgid "e.g. %1"
 msgstr "例：%1"
 
 #. IDS_DETECTED_PREVIOUS_CRASH
-#: Merge.rc:5786
+#: Merge.rc:5787
 msgid "WinMerge detected a previous crash. Please report this if possible."
 msgstr "WinMerge 检测到之前发生过崩溃。如有可能，请提交此问题报告。"
 
 #. IDS_REGEX_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5791
+#: Merge.rc:5792
 msgid ""
 "# Regex replacement list\r\n"
 "# Format: regex<TAB>replacement\r\n"
@@ -8891,7 +8896,7 @@ msgstr ""
 "(\\d{4})-(\\d{2})-(\\d{2})\t$1_$2_$3\n"
 
 #. IDS_STRING_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5792
+#: Merge.rc:5793
 msgid ""
 "# Replacement list\r\n"
 "# Format: search<TAB>replacement\r\n"
@@ -8908,22 +8913,22 @@ msgstr ""
 "from2\tto2\n"
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_ONLY
-#: Merge.rc:5797
+#: Merge.rc:5798
 msgid "Built-in only"
 msgstr "仅限内置"
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_FIRST
-#: Merge.rc:5798
+#: Merge.rc:5799
 msgid "Built-in first"
 msgstr "内置优先"
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_FIRST
-#: Merge.rc:5799
+#: Merge.rc:5800
 msgid "Tree-sitter first"
 msgstr "Tree-sitter 优先"
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_ONLY
-#: Merge.rc:5800
+#: Merge.rc:5801
 msgid "Tree-sitter only"
 msgstr "仅限 Tree-sitter"
 

--- a/Translations/WinMerge/ChineseTraditional.po
+++ b/Translations/WinMerge/ChineseTraditional.po
@@ -22,7 +22,7 @@ msgstr ""
 "X-Generator: Poedit 3.9\n"
 
 #. LANGUAGE, SUBLANGUAGE
-#: Merge.rc:26 Merge.rc:59 Merge.rc:5817
+#: Merge.rc:26 Merge.rc:59 Merge.rc:5818
 msgid "LANG_ENGLISH, SUBLANG_ENGLISH_US"
 msgstr "LANG_CHINESE, SUBLANG_CHINESE_TRADITIONAL"
 
@@ -229,7 +229,7 @@ msgid "Auto-Fit All Columns"
 msgstr "自動調整所有欄位寬度"
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN
-#: Merge.rc:153 Merge.rc:5645
+#: Merge.rc:153 Merge.rc:5646
 msgid "&Filter by This Column"
 msgstr "依此欄篩選(&F)"
 
@@ -290,7 +290,7 @@ msgid "&Previous Page"
 msgstr "前一頁 (&P)"
 
 #. IDS_PREVIEWBAR_NEXTPAGE
-#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5678
+#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5679
 msgid "&Next Page"
 msgstr "後一頁 (&N)"
 
@@ -663,7 +663,7 @@ msgid "&Huge"
 msgstr "超大圖示 (&H)"
 
 #. IDS_VIEW_MENU_BAR
-#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5713
+#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5714
 msgid "Men&u Bar"
 msgstr "選單列 (&U)"
 
@@ -4199,7 +4199,7 @@ msgid "Items compared:"
 msgstr "比對過的項目："
 
 #. IDS_PREVIEWBAR_CLOSE
-#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5684
+#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5685
 msgid "&Close"
 msgstr "關閉 (&C)"
 
@@ -8430,30 +8430,35 @@ msgstr "第一和第三"
 msgid "2nd and 3rd"
 msgstr "第二和第三"
 
+#. IDS_PLUGIN_CTRL_CLICK
+#: Merge.rc:5635
+msgid "(Ctrl+Click to add to pipeline)"
+msgstr ""
+
 #. IDS_FILTER_APPLIED
-#: Merge.rc:5639
+#: Merge.rc:5640
 msgid "Filter applied"
 msgstr "已應用篩選器"
 
 #. IDS_FILTERMENU_COMPARE
-#: Merge.rc:5644
+#: Merge.rc:5645
 #, c-format
 msgid "Compare %1"
 msgstr "比對 %1"
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN2
-#: Merge.rc:5646
+#: Merge.rc:5647
 msgid "&Filter by This Column..."
 msgstr "依此欄篩選... (&F)"
 
 #. IDS_CLIPBOARDHISTORY_TIME
-#: Merge.rc:5651
+#: Merge.rc:5652
 #, c-format
 msgid "Clipboard at %s"
 msgstr "於 %s 的剪貼簿"
 
 #. IDS_CLIPBOARDHISTORY_DISABLED
-#: Merge.rc:5652
+#: Merge.rc:5653
 msgid ""
 "Clipboard history disabled.\r\n"
 "Enable: Windows logo key + V, then Turn on."
@@ -8461,115 +8466,115 @@ msgstr ""
 "剪貼簿歷史記錄已停用。\r\n"
 "要啟用剪貼簿歷史記錄，請按下 Windows 徽標鍵 + V，然後點選「開啟」按鈕。"
 
-#: Merge.rc:5654
+#: Merge.rc:5655
 msgid "This system does not support clipboard history."
 msgstr "此系統不支援剪貼簿歷史紀錄。"
 
-#: Merge.rc:5656
+#: Merge.rc:5657
 msgid "32-bit WinMerge does not support Clipboard Compare"
 msgstr "32 位元版本的 WinMerge 不支援剪貼簿比對"
 
 #. IDS_WEBVIEW2_RUNTIME_NOT_INSTALLED
-#: Merge.rc:5661
+#: Merge.rc:5662
 msgid "WebView2 runtime not installed. Download it?"
 msgstr "尚未安裝 WebView2 執行階段。是否要下載安裝？"
 
 #. IDS_JUMPLIST_NEW_TEXT_COMPARE
-#: Merge.rc:5666
+#: Merge.rc:5667
 msgid "New Text Compare"
 msgstr "新文字比對"
 
 #. IDS_JUMPLIST_NEW_TABLE_COMPARE
-#: Merge.rc:5667
+#: Merge.rc:5668
 msgid "New Table Compare"
 msgstr "新表格比對"
 
 #. IDS_JUMPLIST_NEW_BINARY_COMPARE
-#: Merge.rc:5668
+#: Merge.rc:5669
 msgid "New Binary Compare"
 msgstr "新二進位比對"
 
 #. IDS_JUMPLIST_NEW_IMAGE_COMPARE
-#: Merge.rc:5669
+#: Merge.rc:5670
 msgid "New Image Compare"
 msgstr "新圖片比對"
 
 #. IDS_JUMPLIST_NEW_WEBPAGE_COMPARE
-#: Merge.rc:5670
+#: Merge.rc:5671
 msgid "New Webpage Compare"
 msgstr "新網頁比對"
 
 #. IDS_JUMPLIST_NEW_FOLDER_COMPARE
-#: Merge.rc:5671
+#: Merge.rc:5672
 msgid "New Folder Compare"
 msgstr "新增資料夾比對"
 
 #. IDS_JUMPLIST_CLIPBOARD_COMPARE
-#: Merge.rc:5672
+#: Merge.rc:5673
 msgid "Clipboard Compare"
 msgstr "剪貼簿比對"
 
 #. IDS_PREVIEWBAR_PRINT
-#: Merge.rc:5677
+#: Merge.rc:5678
 msgid "&Print..."
 msgstr "列印... (&P)"
 
 #. IDS_PREVIEWBAR_PREVPAGE
-#: Merge.rc:5679
+#: Merge.rc:5680
 msgid "Pre&v Page"
 msgstr "上一頁 (&V)"
 
 #. IDS_PREVIEWBAR_TWOPAGE
-#: Merge.rc:5680
+#: Merge.rc:5681
 msgid "&Two Page"
 msgstr "雙頁 (&T)"
 
 #. IDS_PREVIEWBAR_ONEPAGE
-#: Merge.rc:5681
+#: Merge.rc:5682
 msgid "&One Page"
 msgstr "單頁 (&O)"
 
 #. IDS_PREVIEWBAR_ZOOMIN
-#: Merge.rc:5682
+#: Merge.rc:5683
 msgid "Zoom &In"
 msgstr "放大 (&I)"
 
 #. IDS_PREVIEWBAR_ZOOMOUT
-#: Merge.rc:5683
+#: Merge.rc:5684
 msgid "Zoom &Out"
 msgstr "縮小 (&O)"
 
 #. IDS_WEBPAGE_COMPARING
-#: Merge.rc:5689
+#: Merge.rc:5690
 msgid "Comparing..."
 msgstr "正在比對..."
 
 #. IDS_WEBPAGE_ZOOM
-#: Merge.rc:5690
+#: Merge.rc:5691
 msgid "Zoom:"
 msgstr "縮放："
 
 #. IDS_COPY_GRANULARITY_DIFFHUNK
-#: Merge.rc:5695
+#: Merge.rc:5696
 msgid "Diff hunk"
 msgstr "差異區塊"
 
 #. IDS_COPY_GRANULARITY_INLINE
-#: Merge.rc:5696
+#: Merge.rc:5697
 msgid "Inline diff"
 msgstr "行內差異"
 
 #. IDS_COPY_GRANULARITY_LINE
-#: Merge.rc:5697
+#: Merge.rc:5698
 msgid "Line"
 msgstr "行"
 
-#: Merge.rc:5698
+#: Merge.rc:5699
 msgid "Character"
 msgstr "字元"
 
 #. ID_MICE_PREVDIFF
-#: Merge.rc:5703
+#: Merge.rc:5704
 msgid ""
 "\n"
 "Previous Difference (Alt+Up)\n"
@@ -8582,7 +8587,7 @@ msgstr ""
 "(Alt+滾輪上滾)"
 
 #. ID_MICE_NEXTDIFF
-#: Merge.rc:5704
+#: Merge.rc:5705
 msgid ""
 "\n"
 "Next Difference (Alt+Down)\n"
@@ -8595,7 +8600,7 @@ msgstr ""
 "(Alt+滾輪下滾)"
 
 #. ID_MICE_L2R
-#: Merge.rc:5705
+#: Merge.rc:5706
 msgid ""
 "\n"
 "Copy to Right (Alt+Right)\n"
@@ -8610,7 +8615,7 @@ msgstr ""
 "(Alt+Shift+滾輪下滾)"
 
 #. ID_MICE_R2L
-#: Merge.rc:5706
+#: Merge.rc:5707
 msgid ""
 "\n"
 "Copy to Left (Alt+Left)\n"
@@ -8625,7 +8630,7 @@ msgstr ""
 "(Alt+Shift+滾輪上滾)"
 
 #. ID_MICE_L2RNEXT
-#: Merge.rc:5707
+#: Merge.rc:5708
 msgid ""
 "\n"
 "Copy to Right and Advance (Ctrl+Alt+Right)\n"
@@ -8638,7 +8643,7 @@ msgstr ""
 "(Ctrl+Alt+Shift+滾輪下滾)"
 
 #. ID_MICE_R2LNEXT
-#: Merge.rc:5708
+#: Merge.rc:5709
 msgid ""
 "\n"
 "Copy to Left and Advance (Ctrl+Alt+Left)\n"
@@ -8651,257 +8656,257 @@ msgstr ""
 "(Ctrl+Alt+Shift+滾輪上滾)"
 
 #. IDS_LOG_COMPARING_2
-#: Merge.rc:5718
+#: Merge.rc:5719
 #, c-format
 msgid "Comparing %1 with %2"
 msgstr "正在比對 %1 與 %2"
 
 #. IDS_LOG_COMPARING_3
-#: Merge.rc:5719
+#: Merge.rc:5720
 #, c-format
 msgid "Comparing %1 with %2 and %3"
 msgstr "正在比對 %1 與 %2 及 %3"
 
 #. IDS_LOG_COMPARE_COMPLETED
-#: Merge.rc:5720
+#: Merge.rc:5721
 msgid "Comparison completed"
 msgstr "比對完成"
 
 #. IDS_LOG_COMPARE_ERROR_2
-#: Merge.rc:5721
+#: Merge.rc:5722
 #, c-format
 msgid "Failed to compare %1 with %2: "
 msgstr "無法比對 %1 與 %2："
 
 #. IDS_LOG_COMPARE_ERROR_3
-#: Merge.rc:5722
+#: Merge.rc:5723
 #, c-format
 msgid "Failed to compare %1 with %2 and %3: "
 msgstr "無法比對 %1 與 %2 及 %3："
 
 #. IDS_LOG_FILE_SAVED
-#: Merge.rc:5723
+#: Merge.rc:5724
 msgid "File saved"
 msgstr "檔案已儲存"
 
 #. IDS_LOG_COPYING_FILES
-#: Merge.rc:5724
+#: Merge.rc:5725
 msgid "Copying files..."
 msgstr "正在複製檔案..."
 
 #. IDS_LOG_MOVING_FILES
-#: Merge.rc:5725
+#: Merge.rc:5726
 msgid "Moving files..."
 msgstr "正在移動檔案..."
 
 #. IDS_LOG_DELETING_FILES
-#: Merge.rc:5726
+#: Merge.rc:5727
 msgid "Deleting files..."
 msgstr "正在刪除檔案..."
 
 #. IDS_LOG_RECYCLEBIN
-#: Merge.rc:5727
+#: Merge.rc:5728
 msgid "Recycle Bin"
 msgstr "回收站"
 
 #. IDS_LOG_PERMANENTLY_DELETED
-#: Merge.rc:5728
+#: Merge.rc:5729
 msgid "Permanently deleted"
 msgstr "永久刪除"
 
 #. IDS_LOG_FILEOPERATION_COMPLETED
-#: Merge.rc:5729
+#: Merge.rc:5730
 msgid "File operation completed successfully"
 msgstr "檔案操作已成功完成"
 
 #. IDS_LOG_FILEOPERATION_CANCELED
-#: Merge.rc:5730
+#: Merge.rc:5731
 msgid "File operation canceled"
 msgstr "檔案操作已取消"
 
 #. IDS_FILTER_ERROR_NO_ERROR
-#: Merge.rc:5735
+#: Merge.rc:5736
 msgid "No error"
 msgstr "無錯誤"
 
 #. IDS_FILTER_ERROR_EMPTY_EXPRESSION
-#: Merge.rc:5736
+#: Merge.rc:5737
 msgid "Filter expression is empty"
 msgstr "篩選表示式為空"
 
 #. IDS_FILTER_ERROR_UNKNOWN_CHAR
-#: Merge.rc:5737
+#: Merge.rc:5738
 msgid "Unknown character in filter expression"
 msgstr "篩選表示式中存在未知字符"
 
 #. IDS_FILTER_ERROR_UNTERMINATED_STRING
-#: Merge.rc:5738
+#: Merge.rc:5739
 msgid "Unterminated string literal"
 msgstr "未終止的字串文字"
 
 #. IDS_FILTER_ERROR_SYNTAX_ERROR
-#: Merge.rc:5739
+#: Merge.rc:5740
 msgid "Syntax error in filter expression"
 msgstr "篩選表示式中的語法錯誤"
 
 #. IDS_FILTER_ERROR_PARSE_FAILURE
-#: Merge.rc:5740
+#: Merge.rc:5741
 msgid "Failed to parse filter expression"
 msgstr "解析篩選表示式失敗"
 
 #. IDS_FILTER_ERROR_INVALID_LITERAL
-#: Merge.rc:5741
+#: Merge.rc:5742
 msgid "Invalid literal value"
 msgstr "無效的文字值"
 
 #. IDS_FILTER_ERROR_INVALID_REGULAR_EXPRESSION
-#: Merge.rc:5742
+#: Merge.rc:5743
 msgid "Invalid regular expression"
 msgstr "無效的正規表示式"
 
 #. IDS_FILTER_ERROR_UNDEFINED_IDENTIFIER
-#: Merge.rc:5743
+#: Merge.rc:5744
 msgid "Undefined identifier"
 msgstr "未定義標識符"
 
 #. IDS_FILTER_ERROR_INVALID_ARGUMENT_COUNT
-#: Merge.rc:5744
+#: Merge.rc:5745
 msgid "Invalid number of arguments"
 msgstr "引數數量無效"
 
 #. IDS_FILTER_ERROR_FILTER_NAME_NOT_FOUND
-#: Merge.rc:5745
+#: Merge.rc:5746
 msgid "Filter name not found"
 msgstr "未找到篩選器名稱"
 
 #. IDS_FILTER_ERROR_DIVIDE_BY_ZERO
-#: Merge.rc:5746
+#: Merge.rc:5747
 msgid "Division by zero in filter expression"
 msgstr "篩選表示式中除以零"
 
 #. IDS_FILTER_ERROR_UNKNOWN_ERROR
-#: Merge.rc:5747
+#: Merge.rc:5748
 msgid "Unknown error"
 msgstr "未知錯誤"
 
 #. IDS_FILTER_ERROR_INVALID_PROPERTY_NAME
-#: Merge.rc:5748
+#: Merge.rc:5749
 msgid "Invalid property name"
 msgstr "無效的屬性名稱"
 
 #. IDS_FILTER_ERROR_INVALID_DIRECTIVE
-#: Merge.rc:5749
+#: Merge.rc:5750
 msgid "Invalid directive"
 msgstr "無效指令"
 
 #. IDS_FILTER_OP_EQUALS
-#: Merge.rc:5754
+#: Merge.rc:5755
 msgid "Equals"
 msgstr "等於"
 
 #. IDS_FILTER_OP_NOT_EQUALS
-#: Merge.rc:5755
+#: Merge.rc:5756
 msgid "Does not equal"
 msgstr "不等於"
 
 #. IDS_FILTER_OP_LESS_THAN
-#: Merge.rc:5756
+#: Merge.rc:5757
 msgid "Less than"
 msgstr "小於"
 
 #. IDS_FILTER_OP_LESS_EQUAL
-#: Merge.rc:5757
+#: Merge.rc:5758
 msgid "Less than or equal to"
 msgstr "小於或等於"
 
 #. IDS_FILTER_OP_GREATER_EQUAL
-#: Merge.rc:5758
+#: Merge.rc:5759
 msgid "Greater than or equal to"
 msgstr "大於或等於"
 
 #. IDS_FILTER_OP_GREATER_THAN
-#: Merge.rc:5759
+#: Merge.rc:5760
 msgid "Greater than"
 msgstr "大於"
 
 #. IDS_FILTER_OP_BETWEEN
-#: Merge.rc:5760
+#: Merge.rc:5761
 msgid "Between"
 msgstr "介於"
 
 #. IDS_FILTER_OP_NOT_BETWEEN
-#: Merge.rc:5761
+#: Merge.rc:5762
 msgid "Not Between"
 msgstr "不介於"
 
 #. IDS_FILTER_OP_CONTAINS
-#: Merge.rc:5762
+#: Merge.rc:5763
 msgid "Contains"
 msgstr "包括"
 
 #. IDS_FILTER_OP_NOT_CONTAINS
-#: Merge.rc:5763
+#: Merge.rc:5764
 msgid "Not Contains"
 msgstr "不包括"
 
 #. IDS_FILTER_OP_RECONTAINS
-#: Merge.rc:5764
+#: Merge.rc:5765
 msgid "Contains (regex)"
 msgstr "包括（正規表示式）"
 
 #. IDS_FILTER_OP_NOT_RECONTAINS
-#: Merge.rc:5765
+#: Merge.rc:5766
 msgid "Not Contains (regex)"
 msgstr "不包括（正規表示式）"
 
 #. IDS_FILTER_OP_LIKE
-#: Merge.rc:5766
+#: Merge.rc:5767
 msgid "Match (wildcard)"
 msgstr "符合 (萬用字元)"
 
 #. IDS_FILTER_OP_NOT_LIKE
-#: Merge.rc:5767
+#: Merge.rc:5768
 msgid "Not match (wildcard)"
 msgstr "不符合 (萬用字元)"
 
 #. IDS_FILTER_OP_MATCHES
-#: Merge.rc:5768
+#: Merge.rc:5769
 msgid "Match (regex)"
 msgstr "符合 (正規表示式)"
 
 #. IDS_FILTER_OP_NOT_MATCHES
-#: Merge.rc:5769
+#: Merge.rc:5770
 msgid "Not match (regex)"
 msgstr "不符合 (正規表示式)"
 
 #. IDS_COLORMODE_LIGHT
-#: Merge.rc:5774
+#: Merge.rc:5775
 msgid "Light"
 msgstr "亮色"
 
 #. IDS_COLORMODE_DARK
-#: Merge.rc:5775
+#: Merge.rc:5776
 msgid "Dark"
 msgstr "暗色"
 
 #. IDS_COLORMODE_FOLLOWSYSTEM
-#: Merge.rc:5776
+#: Merge.rc:5777
 msgid "Follow system"
 msgstr "遵循系統"
 
 #. IDS_EXAMPLE
-#: Merge.rc:5781
+#: Merge.rc:5782
 #, c-format
 msgid "e.g. %1"
 msgstr "例:%1"
 
 #. IDS_DETECTED_PREVIOUS_CRASH
-#: Merge.rc:5786
+#: Merge.rc:5787
 msgid "WinMerge detected a previous crash. Please report this if possible."
 msgstr "WinMerge 偵測到上一次執行時發生損毀。如果可以的話，請協助回報此問題。"
 
 #. IDS_REGEX_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5791
+#: Merge.rc:5792
 msgid ""
 "# Regex replacement list\r\n"
 "# Format: regex<TAB>replacement\r\n"
@@ -8916,7 +8921,7 @@ msgstr ""
 "(\\d{4})-(\\d{2})-(\\d{2})\t$1_$2_$3\r\n"
 
 #. IDS_STRING_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5792
+#: Merge.rc:5793
 msgid ""
 "# Replacement list\r\n"
 "# Format: search<TAB>replacement\r\n"
@@ -8933,22 +8938,22 @@ msgstr ""
 "from2\tto2\r\n"
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_ONLY
-#: Merge.rc:5797
+#: Merge.rc:5798
 msgid "Built-in only"
 msgstr "僅內建"
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_FIRST
-#: Merge.rc:5798
+#: Merge.rc:5799
 msgid "Built-in first"
 msgstr "內建優先"
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_FIRST
-#: Merge.rc:5799
+#: Merge.rc:5800
 msgid "Tree-sitter first"
 msgstr "Tree-sitter 優先"
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_ONLY
-#: Merge.rc:5800
+#: Merge.rc:5801
 msgid "Tree-sitter only"
 msgstr "僅 Tree-sitter"
 

--- a/Translations/WinMerge/Corsican.po
+++ b/Translations/WinMerge/Corsican.po
@@ -25,7 +25,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
 #. LANGUAGE, SUBLANGUAGE
-#: Merge.rc:26 Merge.rc:59 Merge.rc:5817
+#: Merge.rc:26 Merge.rc:59 Merge.rc:5818
 msgid "LANG_ENGLISH, SUBLANG_ENGLISH_US"
 msgstr "LANG_CORSICAN, SUBLANG_DEFAULT"
 
@@ -232,7 +232,7 @@ msgid "Auto-Fit All Columns"
 msgstr "Adattà autumaticamente tutte e culonne"
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN
-#: Merge.rc:153 Merge.rc:5645
+#: Merge.rc:153 Merge.rc:5646
 msgid "&Filter by This Column"
 msgstr "&Filtru da sta culonna"
 
@@ -293,7 +293,7 @@ msgid "&Previous Page"
 msgstr "Pagina &precedente"
 
 #. IDS_PREVIEWBAR_NEXTPAGE
-#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5678
+#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5679
 msgid "&Next Page"
 msgstr "Pagina &seguente"
 
@@ -666,7 +666,7 @@ msgid "&Huge"
 msgstr "&Tamanta"
 
 #. IDS_VIEW_MENU_BAR
-#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5713
+#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5714
 msgid "Men&u Bar"
 msgstr "Barra di &listinu"
 
@@ -4191,7 +4191,7 @@ msgid "Items compared:"
 msgstr "Elementi paragunati :"
 
 #. IDS_PREVIEWBAR_CLOSE
-#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5684
+#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5685
 msgid "&Close"
 msgstr "&Chjode"
 
@@ -8389,30 +8389,35 @@ msgstr "1ᵘ è 3ᵘ"
 msgid "2nd and 3rd"
 msgstr "2ᵘ è 3ᵘ"
 
+#. IDS_PLUGIN_CTRL_CLICK
+#: Merge.rc:5635
+msgid "(Ctrl+Click to add to pipeline)"
+msgstr ""
+
 #. IDS_FILTER_APPLIED
-#: Merge.rc:5639
+#: Merge.rc:5640
 msgid "Filter applied"
 msgstr "Filtru appiecatu"
 
 #. IDS_FILTERMENU_COMPARE
-#: Merge.rc:5644
+#: Merge.rc:5645
 #, c-format
 msgid "Compare %1"
 msgstr "Paragunà %1"
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN2
-#: Merge.rc:5646
+#: Merge.rc:5647
 msgid "&Filter by This Column..."
 msgstr "&Filtru da sta culonna…"
 
 #. IDS_CLIPBOARDHISTORY_TIME
-#: Merge.rc:5651
+#: Merge.rc:5652
 #, c-format
 msgid "Clipboard at %s"
 msgstr "Preme’papei di u %s"
 
 #. IDS_CLIPBOARDHISTORY_DISABLED
-#: Merge.rc:5652
+#: Merge.rc:5653
 msgid ""
 "Clipboard history disabled.\r\n"
 "Enable: Windows logo key + V, then Turn on."
@@ -8420,115 +8425,115 @@ msgstr ""
 "A cronolugia di u preme’papei hè disattivata.\r\n"
 "Per attivalla, appughjate nant’à i tasti Windows + V è tandu cliccu nant’à « Attivà »."
 
-#: Merge.rc:5654
+#: Merge.rc:5655
 msgid "This system does not support clipboard history."
 msgstr "Stu sistema ùn accetta micca a cronolugia di u preme’papei."
 
-#: Merge.rc:5656
+#: Merge.rc:5657
 msgid "32-bit WinMerge does not support Clipboard Compare"
 msgstr "A versione 32-bit di WinMerge ùn accetta micca u paragone di preme’papei"
 
 #. IDS_WEBVIEW2_RUNTIME_NOT_INSTALLED
-#: Merge.rc:5661
+#: Merge.rc:5662
 msgid "WebView2 runtime not installed. Download it?"
 msgstr "L’ambiente d’esecuzione WebView2 ùn hè micca installatu. Vulete scaricallu ?"
 
 #. IDS_JUMPLIST_NEW_TEXT_COMPARE
-#: Merge.rc:5666
+#: Merge.rc:5667
 msgid "New Text Compare"
 msgstr "Paragone novu di testu"
 
 #. IDS_JUMPLIST_NEW_TABLE_COMPARE
-#: Merge.rc:5667
+#: Merge.rc:5668
 msgid "New Table Compare"
 msgstr "Paragone novu di tavulone"
 
 #. IDS_JUMPLIST_NEW_BINARY_COMPARE
-#: Merge.rc:5668
+#: Merge.rc:5669
 msgid "New Binary Compare"
 msgstr "Paragone binariu novu"
 
 #. IDS_JUMPLIST_NEW_IMAGE_COMPARE
-#: Merge.rc:5669
+#: Merge.rc:5670
 msgid "New Image Compare"
 msgstr "Paragone novu di fiura"
 
 #. IDS_JUMPLIST_NEW_WEBPAGE_COMPARE
-#: Merge.rc:5670
+#: Merge.rc:5671
 msgid "New Webpage Compare"
 msgstr "Paragone novu di pagina web"
 
 #. IDS_JUMPLIST_NEW_FOLDER_COMPARE
-#: Merge.rc:5671
+#: Merge.rc:5672
 msgid "New Folder Compare"
 msgstr "Paragone novu di cartulare"
 
 #. IDS_JUMPLIST_CLIPBOARD_COMPARE
-#: Merge.rc:5672
+#: Merge.rc:5673
 msgid "Clipboard Compare"
 msgstr "Paragone di preme’papei"
 
 #. IDS_PREVIEWBAR_PRINT
-#: Merge.rc:5677
+#: Merge.rc:5678
 msgid "&Print..."
 msgstr "&Stampà…"
 
 #. IDS_PREVIEWBAR_PREVPAGE
-#: Merge.rc:5679
+#: Merge.rc:5680
 msgid "Pre&v Page"
 msgstr "&Pagina precedente"
 
 #. IDS_PREVIEWBAR_TWOPAGE
-#: Merge.rc:5680
+#: Merge.rc:5681
 msgid "&Two Page"
 msgstr "&Duie pagine"
 
 #. IDS_PREVIEWBAR_ONEPAGE
-#: Merge.rc:5681
+#: Merge.rc:5682
 msgid "&One Page"
 msgstr "&Una pagina"
 
 #. IDS_PREVIEWBAR_ZOOMIN
-#: Merge.rc:5682
+#: Merge.rc:5683
 msgid "Zoom &In"
 msgstr "Ingrandamentu più &forte"
 
 #. IDS_PREVIEWBAR_ZOOMOUT
-#: Merge.rc:5683
+#: Merge.rc:5684
 msgid "Zoom &Out"
 msgstr "Ingrandamentu &menu forte"
 
 #. IDS_WEBPAGE_COMPARING
-#: Merge.rc:5689
+#: Merge.rc:5690
 msgid "Comparing..."
 msgstr "Paragone…"
 
 #. IDS_WEBPAGE_ZOOM
-#: Merge.rc:5690
+#: Merge.rc:5691
 msgid "Zoom:"
 msgstr "Ingrandamentu :"
 
 #. IDS_COPY_GRANULARITY_DIFFHUNK
-#: Merge.rc:5695
+#: Merge.rc:5696
 msgid "Diff hunk"
 msgstr "Gruppu di sfarenze"
 
 #. IDS_COPY_GRANULARITY_INLINE
-#: Merge.rc:5696
+#: Merge.rc:5697
 msgid "Inline diff"
 msgstr "Sfarenza framessa"
 
 #. IDS_COPY_GRANULARITY_LINE
-#: Merge.rc:5697
+#: Merge.rc:5698
 msgid "Line"
 msgstr "Linea"
 
-#: Merge.rc:5698
+#: Merge.rc:5699
 msgid "Character"
 msgstr "Caratteru"
 
 #. ID_MICE_PREVDIFF
-#: Merge.rc:5703
+#: Merge.rc:5704
 msgid ""
 "\n"
 "Previous Difference (Alt+Up)\n"
@@ -8541,7 +8546,7 @@ msgstr ""
 "(Alt+Rutulella di u topu insù)"
 
 #. ID_MICE_NEXTDIFF
-#: Merge.rc:5704
+#: Merge.rc:5705
 msgid ""
 "\n"
 "Next Difference (Alt+Down)\n"
@@ -8554,7 +8559,7 @@ msgstr ""
 "(Alt+Rutulella di u topu inghjò)"
 
 #. ID_MICE_L2R
-#: Merge.rc:5705
+#: Merge.rc:5706
 msgid ""
 "\n"
 "Copy to Right (Alt+Right)\n"
@@ -8568,7 +8573,7 @@ msgstr ""
 "(Alt+Maiusc+Rutulella inghjò)"
 
 #. ID_MICE_R2L
-#: Merge.rc:5706
+#: Merge.rc:5707
 msgid ""
 "\n"
 "Copy to Left (Alt+Left)\n"
@@ -8582,7 +8587,7 @@ msgstr ""
 "(Alt+Maiusc+Rutulella insù)"
 
 #. ID_MICE_L2RNEXT
-#: Merge.rc:5707
+#: Merge.rc:5708
 msgid ""
 "\n"
 "Copy to Right and Advance (Ctrl+Alt+Right)\n"
@@ -8595,7 +8600,7 @@ msgstr ""
 "(Ctrl+Alt+Maiusc+Rutulella inghjò)"
 
 #. ID_MICE_R2LNEXT
-#: Merge.rc:5708
+#: Merge.rc:5709
 msgid ""
 "\n"
 "Copy to Left and Advance (Ctrl+Alt+Left)\n"
@@ -8608,257 +8613,257 @@ msgstr ""
 "(Ctrl+Alt+Maiusc+Rutulella insù)"
 
 #. IDS_LOG_COMPARING_2
-#: Merge.rc:5718
+#: Merge.rc:5719
 #, c-format
 msgid "Comparing %1 with %2"
 msgstr "Paragone di %1 cù %2"
 
 #. IDS_LOG_COMPARING_3
-#: Merge.rc:5719
+#: Merge.rc:5720
 #, c-format
 msgid "Comparing %1 with %2 and %3"
 msgstr "Paragone di %1 cù %2 è %3"
 
 #. IDS_LOG_COMPARE_COMPLETED
-#: Merge.rc:5720
+#: Merge.rc:5721
 msgid "Comparison completed"
 msgstr "U paragone hè compiu"
 
 #. IDS_LOG_COMPARE_ERROR_2
-#: Merge.rc:5721
+#: Merge.rc:5722
 #, c-format
 msgid "Failed to compare %1 with %2: "
 msgstr "Fiascu per paragunà %1 cù %2 : "
 
 #. IDS_LOG_COMPARE_ERROR_3
-#: Merge.rc:5722
+#: Merge.rc:5723
 #, c-format
 msgid "Failed to compare %1 with %2 and %3: "
 msgstr "Fiascu per paragunà %1 cù %2 è %3 : "
 
 #. IDS_LOG_FILE_SAVED
-#: Merge.rc:5723
+#: Merge.rc:5724
 msgid "File saved"
 msgstr "U schedariu hè arregistratu"
 
 #. IDS_LOG_COPYING_FILES
-#: Merge.rc:5724
+#: Merge.rc:5725
 msgid "Copying files..."
 msgstr "Copia di i schedarii…"
 
 #. IDS_LOG_MOVING_FILES
-#: Merge.rc:5725
+#: Merge.rc:5726
 msgid "Moving files..."
 msgstr "Dispiazzamentu di i schedarii…"
 
 #. IDS_LOG_DELETING_FILES
-#: Merge.rc:5726
+#: Merge.rc:5727
 msgid "Deleting files..."
 msgstr "Squassatura di schedarii…"
 
 #. IDS_LOG_RECYCLEBIN
-#: Merge.rc:5727
+#: Merge.rc:5728
 msgid "Recycle Bin"
 msgstr "Curbella"
 
 #. IDS_LOG_PERMANENTLY_DELETED
-#: Merge.rc:5728
+#: Merge.rc:5729
 msgid "Permanently deleted"
 msgstr "Squassatu ab’eternu"
 
 #. IDS_LOG_FILEOPERATION_COMPLETED
-#: Merge.rc:5729
+#: Merge.rc:5730
 msgid "File operation completed successfully"
 msgstr "Operazione di schedariu compia currettamente"
 
 #. IDS_LOG_FILEOPERATION_CANCELED
-#: Merge.rc:5730
+#: Merge.rc:5731
 msgid "File operation canceled"
 msgstr "Operazione di schedariu abbandunata"
 
 #. IDS_FILTER_ERROR_NO_ERROR
-#: Merge.rc:5735
+#: Merge.rc:5736
 msgid "No error"
 msgstr "Nisunu sbagliu"
 
 #. IDS_FILTER_ERROR_EMPTY_EXPRESSION
-#: Merge.rc:5736
+#: Merge.rc:5737
 msgid "Filter expression is empty"
 msgstr "L’espressione di filtru hè viota"
 
 #. IDS_FILTER_ERROR_UNKNOWN_CHAR
-#: Merge.rc:5737
+#: Merge.rc:5738
 msgid "Unknown character in filter expression"
 msgstr "Caratteru scunnisciutu in l’espressione di filtru"
 
 #. IDS_FILTER_ERROR_UNTERMINATED_STRING
-#: Merge.rc:5738
+#: Merge.rc:5739
 msgid "Unterminated string literal"
 msgstr "Litterale di catena micca compia"
 
 #. IDS_FILTER_ERROR_SYNTAX_ERROR
-#: Merge.rc:5739
+#: Merge.rc:5740
 msgid "Syntax error in filter expression"
 msgstr "Sbagliu di sintassa in l’espressione di filtru"
 
 #. IDS_FILTER_ERROR_PARSE_FAILURE
-#: Merge.rc:5740
+#: Merge.rc:5741
 msgid "Failed to parse filter expression"
 msgstr "Fiascu per analizà l’espressione di filtru"
 
 #. IDS_FILTER_ERROR_INVALID_LITERAL
-#: Merge.rc:5741
+#: Merge.rc:5742
 msgid "Invalid literal value"
 msgstr "Valore litterale inaccettevule"
 
 #. IDS_FILTER_ERROR_INVALID_REGULAR_EXPRESSION
-#: Merge.rc:5742
+#: Merge.rc:5743
 msgid "Invalid regular expression"
 msgstr "Espressione regulare inaccettevule"
 
 #. IDS_FILTER_ERROR_UNDEFINED_IDENTIFIER
-#: Merge.rc:5743
+#: Merge.rc:5744
 msgid "Undefined identifier"
 msgstr "Identificatore indefinitu"
 
 #. IDS_FILTER_ERROR_INVALID_ARGUMENT_COUNT
-#: Merge.rc:5744
+#: Merge.rc:5745
 msgid "Invalid number of arguments"
 msgstr "Numeru inaccettevule di parametri"
 
 #. IDS_FILTER_ERROR_FILTER_NAME_NOT_FOUND
-#: Merge.rc:5745
+#: Merge.rc:5746
 msgid "Filter name not found"
 msgstr "Nome di filtru intruvevule"
 
 #. IDS_FILTER_ERROR_DIVIDE_BY_ZERO
-#: Merge.rc:5746
+#: Merge.rc:5747
 msgid "Division by zero in filter expression"
 msgstr "Divisione da zeru in l’espressione di filtru"
 
 #. IDS_FILTER_ERROR_UNKNOWN_ERROR
-#: Merge.rc:5747
+#: Merge.rc:5748
 msgid "Unknown error"
 msgstr "Sbagliu scunnisciutu"
 
 #. IDS_FILTER_ERROR_INVALID_PROPERTY_NAME
-#: Merge.rc:5748
+#: Merge.rc:5749
 msgid "Invalid property name"
 msgstr "Nome di pruprietà inaccettevule"
 
 #. IDS_FILTER_ERROR_INVALID_DIRECTIVE
-#: Merge.rc:5749
+#: Merge.rc:5750
 msgid "Invalid directive"
 msgstr "Direttiva inaccettevule"
 
 #. IDS_FILTER_OP_EQUALS
-#: Merge.rc:5754
+#: Merge.rc:5755
 msgid "Equals"
 msgstr "Hè uguale à"
 
 #. IDS_FILTER_OP_NOT_EQUALS
-#: Merge.rc:5755
+#: Merge.rc:5756
 msgid "Does not equal"
 msgstr "Ùn hè micca uguale à"
 
 #. IDS_FILTER_OP_LESS_THAN
-#: Merge.rc:5756
+#: Merge.rc:5757
 msgid "Less than"
 msgstr "Hè inferiore à"
 
 #. IDS_FILTER_OP_LESS_EQUAL
-#: Merge.rc:5757
+#: Merge.rc:5758
 msgid "Less than or equal to"
 msgstr "Hè inferiore o uguale à"
 
 #. IDS_FILTER_OP_GREATER_EQUAL
-#: Merge.rc:5758
+#: Merge.rc:5759
 msgid "Greater than or equal to"
 msgstr "Hè superiore o uguale à"
 
 #. IDS_FILTER_OP_GREATER_THAN
-#: Merge.rc:5759
+#: Merge.rc:5760
 msgid "Greater than"
 msgstr "Hè superiore à"
 
 #. IDS_FILTER_OP_BETWEEN
-#: Merge.rc:5760
+#: Merge.rc:5761
 msgid "Between"
 msgstr "Trà"
 
 #. IDS_FILTER_OP_NOT_BETWEEN
-#: Merge.rc:5761
+#: Merge.rc:5762
 msgid "Not Between"
 msgstr "Micca trà"
 
 #. IDS_FILTER_OP_CONTAINS
-#: Merge.rc:5762
+#: Merge.rc:5763
 msgid "Contains"
 msgstr "Cuntene"
 
 #. IDS_FILTER_OP_NOT_CONTAINS
-#: Merge.rc:5763
+#: Merge.rc:5764
 msgid "Not Contains"
 msgstr "Ùn cuntene micca"
 
 #. IDS_FILTER_OP_RECONTAINS
-#: Merge.rc:5764
+#: Merge.rc:5765
 msgid "Contains (regex)"
 msgstr "Cuntene (regex)"
 
 #. IDS_FILTER_OP_NOT_RECONTAINS
-#: Merge.rc:5765
+#: Merge.rc:5766
 msgid "Not Contains (regex)"
 msgstr "Ùn cuntene micca (regex)"
 
 #. IDS_FILTER_OP_LIKE
-#: Merge.rc:5766
+#: Merge.rc:5767
 msgid "Match (wildcard)"
 msgstr "Currisponde (caratteru genericu)"
 
 #. IDS_FILTER_OP_NOT_LIKE
-#: Merge.rc:5767
+#: Merge.rc:5768
 msgid "Not match (wildcard)"
 msgstr "Ùn currisponde (caratteru genericu)"
 
 #. IDS_FILTER_OP_MATCHES
-#: Merge.rc:5768
+#: Merge.rc:5769
 msgid "Match (regex)"
 msgstr "Currisponde (espressione regex)"
 
 #. IDS_FILTER_OP_NOT_MATCHES
-#: Merge.rc:5769
+#: Merge.rc:5770
 msgid "Not match (regex)"
 msgstr "Ùn currisponde (espressione regex)"
 
 #. IDS_COLORMODE_LIGHT
-#: Merge.rc:5774
+#: Merge.rc:5775
 msgid "Light"
 msgstr "Chjaru"
 
 #. IDS_COLORMODE_DARK
-#: Merge.rc:5775
+#: Merge.rc:5776
 msgid "Dark"
 msgstr "Scuru"
 
 #. IDS_COLORMODE_FOLLOWSYSTEM
-#: Merge.rc:5776
+#: Merge.rc:5777
 msgid "Follow system"
 msgstr "Seguità u sistema"
 
 #. IDS_EXAMPLE
-#: Merge.rc:5781
+#: Merge.rc:5782
 #, c-format
 msgid "e.g. %1"
 msgstr "p.i. %1"
 
 #. IDS_DETECTED_PREVIOUS_CRASH
-#: Merge.rc:5786
+#: Merge.rc:5787
 msgid "WinMerge detected a previous crash. Please report this if possible."
 msgstr "WinMerge hà scupertu un accidente scorsu. S’ella hè pussibule, ci vole à riferiscelu."
 
 #. IDS_REGEX_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5791
+#: Merge.rc:5792
 msgid ""
 "# Regex replacement list\r\n"
 "# Format: regex<TAB>replacement\r\n"
@@ -8873,7 +8878,7 @@ msgstr ""
 "(\\d{4})-(\\d{2})-(\\d{2})\t$1_$2_$3\\r\n"
 
 #. IDS_STRING_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5792
+#: Merge.rc:5793
 msgid ""
 "# Replacement list\r\n"
 "# Format: search<TAB>replacement\r\n"
@@ -8890,22 +8895,22 @@ msgstr ""
 "da2\tà2\\r\n"
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_ONLY
-#: Merge.rc:5797
+#: Merge.rc:5798
 msgid "Built-in only"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_FIRST
-#: Merge.rc:5798
+#: Merge.rc:5799
 msgid "Built-in first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_FIRST
-#: Merge.rc:5799
+#: Merge.rc:5800
 msgid "Tree-sitter first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_ONLY
-#: Merge.rc:5800
+#: Merge.rc:5801
 msgid "Tree-sitter only"
 msgstr ""
 

--- a/Translations/WinMerge/Croatian.po
+++ b/Translations/WinMerge/Croatian.po
@@ -21,7 +21,7 @@ msgstr ""
 "X-Poedit-Country: CROATIA\n"
 
 #. LANGUAGE, SUBLANGUAGE
-#: Merge.rc:26 Merge.rc:59 Merge.rc:5817
+#: Merge.rc:26 Merge.rc:59 Merge.rc:5818
 #, c-format
 msgid "LANG_ENGLISH, SUBLANG_ENGLISH_US"
 msgstr "LANG_CROATIAN, SUBLANG_DEFAULT"
@@ -238,7 +238,7 @@ msgid "Auto-Fit All Columns"
 msgstr ""
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN
-#: Merge.rc:153 Merge.rc:5645
+#: Merge.rc:153 Merge.rc:5646
 msgid "&Filter by This Column"
 msgstr ""
 
@@ -304,7 +304,7 @@ msgid "&Previous Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_NEXTPAGE
-#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5678
+#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5679
 #, c-format
 msgid "&Next Page"
 msgstr ""
@@ -710,7 +710,7 @@ msgid "&Huge"
 msgstr ""
 
 #. IDS_VIEW_MENU_BAR
-#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5713
+#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5714
 msgid "Men&u Bar"
 msgstr ""
 
@@ -4566,7 +4566,7 @@ msgid "Items compared:"
 msgstr "Stavki uspoređeno:"
 
 #. IDS_PREVIEWBAR_CLOSE
-#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5684
+#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5685
 #, c-format
 msgid "&Close"
 msgstr "&Zatvori"
@@ -8893,447 +8893,452 @@ msgstr ""
 msgid "2nd and 3rd"
 msgstr ""
 
+#. IDS_PLUGIN_CTRL_CLICK
+#: Merge.rc:5635
+msgid "(Ctrl+Click to add to pipeline)"
+msgstr ""
+
 #. IDS_FILTER_APPLIED
-#: Merge.rc:5639
+#: Merge.rc:5640
 msgid "Filter applied"
 msgstr ""
 
 #. IDS_FILTERMENU_COMPARE
-#: Merge.rc:5644
+#: Merge.rc:5645
 #, c-format
 msgid "Compare %1"
 msgstr ""
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN2
-#: Merge.rc:5646
+#: Merge.rc:5647
 msgid "&Filter by This Column..."
 msgstr ""
 
 #. IDS_CLIPBOARDHISTORY_TIME
-#: Merge.rc:5651
+#: Merge.rc:5652
 #, c-format
 msgid "Clipboard at %s"
 msgstr ""
 
 #. IDS_CLIPBOARDHISTORY_DISABLED
-#: Merge.rc:5652
+#: Merge.rc:5653
 msgid "Clipboard history disabled.\r\nEnable: Windows logo key + V, then Turn on."
 msgstr ""
 
-#: Merge.rc:5654
+#: Merge.rc:5655
 msgid "This system does not support clipboard history."
 msgstr ""
 
-#: Merge.rc:5656
+#: Merge.rc:5657
 msgid "32-bit WinMerge does not support Clipboard Compare"
 msgstr ""
 
 #. IDS_WEBVIEW2_RUNTIME_NOT_INSTALLED
-#: Merge.rc:5661
+#: Merge.rc:5662
 msgid "WebView2 runtime not installed. Download it?"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_TEXT_COMPARE
-#: Merge.rc:5666
+#: Merge.rc:5667
 msgid "New Text Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_TABLE_COMPARE
-#: Merge.rc:5667
+#: Merge.rc:5668
 msgid "New Table Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_BINARY_COMPARE
-#: Merge.rc:5668
+#: Merge.rc:5669
 msgid "New Binary Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_IMAGE_COMPARE
-#: Merge.rc:5669
+#: Merge.rc:5670
 msgid "New Image Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_WEBPAGE_COMPARE
-#: Merge.rc:5670
+#: Merge.rc:5671
 msgid "New Webpage Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_FOLDER_COMPARE
-#: Merge.rc:5671
+#: Merge.rc:5672
 msgid "New Folder Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_CLIPBOARD_COMPARE
-#: Merge.rc:5672
+#: Merge.rc:5673
 msgid "Clipboard Compare"
 msgstr ""
 
 #. IDS_PREVIEWBAR_PRINT
-#: Merge.rc:5677
+#: Merge.rc:5678
 msgid "&Print..."
 msgstr ""
 
 #. IDS_PREVIEWBAR_PREVPAGE
-#: Merge.rc:5679
+#: Merge.rc:5680
 msgid "Pre&v Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_TWOPAGE
-#: Merge.rc:5680
+#: Merge.rc:5681
 msgid "&Two Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_ONEPAGE
-#: Merge.rc:5681
+#: Merge.rc:5682
 msgid "&One Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_ZOOMIN
-#: Merge.rc:5682
+#: Merge.rc:5683
 msgid "Zoom &In"
 msgstr ""
 
 #. IDS_PREVIEWBAR_ZOOMOUT
-#: Merge.rc:5683
+#: Merge.rc:5684
 msgid "Zoom &Out"
 msgstr ""
 
 #. IDS_WEBPAGE_COMPARING
-#: Merge.rc:5689
+#: Merge.rc:5690
 msgid "Comparing..."
 msgstr ""
 
 #. IDS_WEBPAGE_ZOOM
-#: Merge.rc:5690
+#: Merge.rc:5691
 msgid "Zoom:"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_DIFFHUNK
-#: Merge.rc:5695
+#: Merge.rc:5696
 msgid "Diff hunk"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_INLINE
-#: Merge.rc:5696
+#: Merge.rc:5697
 msgid "Inline diff"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_LINE
-#: Merge.rc:5697
+#: Merge.rc:5698
 msgid "Line"
 msgstr ""
 
-#: Merge.rc:5698
+#: Merge.rc:5699
 msgid "Character"
 msgstr ""
 
 #. ID_MICE_PREVDIFF
-#: Merge.rc:5703
+#: Merge.rc:5704
 msgid "\nPrevious Difference (Alt+Up)\n(Right Button+Wheel Up)\n(Alt+Wheel Up)"
 msgstr ""
 
 #. ID_MICE_NEXTDIFF
-#: Merge.rc:5704
+#: Merge.rc:5705
 msgid "\nNext Difference (Alt+Down)\n(Right Button+Wheel Down)\n(Alt+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_L2R
-#: Merge.rc:5705
+#: Merge.rc:5706
 msgid "\nCopy to Right (Alt+Right)\n(Right Button+Wheel Right)\n(Alt+Wheel Right)\n(Alt+Shift+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_R2L
-#: Merge.rc:5706
+#: Merge.rc:5707
 msgid "\nCopy to Left (Alt+Left)\n(Right Button+Wheel Left)\n(Alt+Wheel Left)\n(Alt+Shift+Wheel Up)"
 msgstr ""
 
 #. ID_MICE_L2RNEXT
-#: Merge.rc:5707
+#: Merge.rc:5708
 msgid "\nCopy to Right and Advance (Ctrl+Alt+Right)\n(Ctrl+Alt+Wheel Right)\n(Ctrl+Alt+Shift+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_R2LNEXT
-#: Merge.rc:5708
+#: Merge.rc:5709
 msgid "\nCopy to Left and Advance (Ctrl+Alt+Left)\n(Ctrl+Alt+Wheel Left)\n(Ctrl+Alt+Shift+Wheel Up)"
 msgstr ""
 
 #. IDS_LOG_COMPARING_2
-#: Merge.rc:5718
+#: Merge.rc:5719
 #, c-format
 msgid "Comparing %1 with %2"
 msgstr ""
 
 #. IDS_LOG_COMPARING_3
-#: Merge.rc:5719
+#: Merge.rc:5720
 #, c-format
 msgid "Comparing %1 with %2 and %3"
 msgstr ""
 
 #. IDS_LOG_COMPARE_COMPLETED
-#: Merge.rc:5720
+#: Merge.rc:5721
 msgid "Comparison completed"
 msgstr ""
 
 #. IDS_LOG_COMPARE_ERROR_2
-#: Merge.rc:5721
+#: Merge.rc:5722
 #, c-format
 msgid "Failed to compare %1 with %2: "
 msgstr ""
 
 #. IDS_LOG_COMPARE_ERROR_3
-#: Merge.rc:5722
+#: Merge.rc:5723
 #, c-format
 msgid "Failed to compare %1 with %2 and %3: "
 msgstr ""
 
 #. IDS_LOG_FILE_SAVED
-#: Merge.rc:5723
+#: Merge.rc:5724
 msgid "File saved"
 msgstr ""
 
 #. IDS_LOG_COPYING_FILES
-#: Merge.rc:5724
+#: Merge.rc:5725
 msgid "Copying files..."
 msgstr ""
 
 #. IDS_LOG_MOVING_FILES
-#: Merge.rc:5725
+#: Merge.rc:5726
 msgid "Moving files..."
 msgstr ""
 
 #. IDS_LOG_DELETING_FILES
-#: Merge.rc:5726
+#: Merge.rc:5727
 msgid "Deleting files..."
 msgstr ""
 
 #. IDS_LOG_RECYCLEBIN
-#: Merge.rc:5727
+#: Merge.rc:5728
 msgid "Recycle Bin"
 msgstr ""
 
 #. IDS_LOG_PERMANENTLY_DELETED
-#: Merge.rc:5728
+#: Merge.rc:5729
 msgid "Permanently deleted"
 msgstr ""
 
 #. IDS_LOG_FILEOPERATION_COMPLETED
-#: Merge.rc:5729
+#: Merge.rc:5730
 msgid "File operation completed successfully"
 msgstr ""
 
 #. IDS_LOG_FILEOPERATION_CANCELED
-#: Merge.rc:5730
+#: Merge.rc:5731
 msgid "File operation canceled"
 msgstr ""
 
 #. IDS_FILTER_ERROR_NO_ERROR
-#: Merge.rc:5735
+#: Merge.rc:5736
 msgid "No error"
 msgstr ""
 
 #. IDS_FILTER_ERROR_EMPTY_EXPRESSION
-#: Merge.rc:5736
+#: Merge.rc:5737
 msgid "Filter expression is empty"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNKNOWN_CHAR
-#: Merge.rc:5737
+#: Merge.rc:5738
 msgid "Unknown character in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNTERMINATED_STRING
-#: Merge.rc:5738
+#: Merge.rc:5739
 msgid "Unterminated string literal"
 msgstr ""
 
 #. IDS_FILTER_ERROR_SYNTAX_ERROR
-#: Merge.rc:5739
+#: Merge.rc:5740
 msgid "Syntax error in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_PARSE_FAILURE
-#: Merge.rc:5740
+#: Merge.rc:5741
 msgid "Failed to parse filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_LITERAL
-#: Merge.rc:5741
+#: Merge.rc:5742
 msgid "Invalid literal value"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_REGULAR_EXPRESSION
-#: Merge.rc:5742
+#: Merge.rc:5743
 msgid "Invalid regular expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNDEFINED_IDENTIFIER
-#: Merge.rc:5743
+#: Merge.rc:5744
 msgid "Undefined identifier"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_ARGUMENT_COUNT
-#: Merge.rc:5744
+#: Merge.rc:5745
 msgid "Invalid number of arguments"
 msgstr ""
 
 #. IDS_FILTER_ERROR_FILTER_NAME_NOT_FOUND
-#: Merge.rc:5745
+#: Merge.rc:5746
 msgid "Filter name not found"
 msgstr ""
 
 #. IDS_FILTER_ERROR_DIVIDE_BY_ZERO
-#: Merge.rc:5746
+#: Merge.rc:5747
 msgid "Division by zero in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNKNOWN_ERROR
-#: Merge.rc:5747
+#: Merge.rc:5748
 msgid "Unknown error"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_PROPERTY_NAME
-#: Merge.rc:5748
+#: Merge.rc:5749
 msgid "Invalid property name"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_DIRECTIVE
-#: Merge.rc:5749
+#: Merge.rc:5750
 msgid "Invalid directive"
 msgstr ""
 
 #. IDS_FILTER_OP_EQUALS
-#: Merge.rc:5754
+#: Merge.rc:5755
 msgid "Equals"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_EQUALS
-#: Merge.rc:5755
+#: Merge.rc:5756
 msgid "Does not equal"
 msgstr ""
 
 #. IDS_FILTER_OP_LESS_THAN
-#: Merge.rc:5756
+#: Merge.rc:5757
 msgid "Less than"
 msgstr ""
 
 #. IDS_FILTER_OP_LESS_EQUAL
-#: Merge.rc:5757
+#: Merge.rc:5758
 msgid "Less than or equal to"
 msgstr ""
 
 #. IDS_FILTER_OP_GREATER_EQUAL
-#: Merge.rc:5758
+#: Merge.rc:5759
 msgid "Greater than or equal to"
 msgstr ""
 
 #. IDS_FILTER_OP_GREATER_THAN
-#: Merge.rc:5759
+#: Merge.rc:5760
 msgid "Greater than"
 msgstr ""
 
 #. IDS_FILTER_OP_BETWEEN
-#: Merge.rc:5760
+#: Merge.rc:5761
 msgid "Between"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_BETWEEN
-#: Merge.rc:5761
+#: Merge.rc:5762
 msgid "Not Between"
 msgstr ""
 
 #. IDS_FILTER_OP_CONTAINS
-#: Merge.rc:5762
+#: Merge.rc:5763
 msgid "Contains"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_CONTAINS
-#: Merge.rc:5763
+#: Merge.rc:5764
 msgid "Not Contains"
 msgstr ""
 
 #. IDS_FILTER_OP_RECONTAINS
-#: Merge.rc:5764
+#: Merge.rc:5765
 msgid "Contains (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_RECONTAINS
-#: Merge.rc:5765
+#: Merge.rc:5766
 msgid "Not Contains (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_LIKE
-#: Merge.rc:5766
+#: Merge.rc:5767
 msgid "Match (wildcard)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_LIKE
-#: Merge.rc:5767
+#: Merge.rc:5768
 msgid "Not match (wildcard)"
 msgstr ""
 
 #. IDS_FILTER_OP_MATCHES
-#: Merge.rc:5768
+#: Merge.rc:5769
 msgid "Match (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_MATCHES
-#: Merge.rc:5769
+#: Merge.rc:5770
 msgid "Not match (regex)"
 msgstr ""
 
 #. IDS_COLORMODE_LIGHT
-#: Merge.rc:5774
+#: Merge.rc:5775
 msgid "Light"
 msgstr ""
 
 #. IDS_COLORMODE_DARK
-#: Merge.rc:5775
+#: Merge.rc:5776
 msgid "Dark"
 msgstr ""
 
 #. IDS_COLORMODE_FOLLOWSYSTEM
-#: Merge.rc:5776
+#: Merge.rc:5777
 msgid "Follow system"
 msgstr ""
 
 #. IDS_EXAMPLE
-#: Merge.rc:5781
+#: Merge.rc:5782
 #, c-format
 msgid "e.g. %1"
 msgstr ""
 
 #. IDS_DETECTED_PREVIOUS_CRASH
-#: Merge.rc:5786
+#: Merge.rc:5787
 msgid "WinMerge detected a previous crash. Please report this if possible."
 msgstr ""
 
 #. IDS_REGEX_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5791
+#: Merge.rc:5792
 msgid "# Regex replacement list\r\n# Format: regex<TAB>replacement\r\n# Backreferences like $1, $2 are supported\r\n\r\n(\\d{4})-(\\d{2})-(\\d{2})\t$1_$2_$3\r\n"
 msgstr ""
 
 #. IDS_STRING_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5792
+#: Merge.rc:5793
 msgid "# Replacement list\r\n# Format: search<TAB>replacement\r\n# Lines starting with # are ignored\r\n\r\nfrom1\tto1\r\nfrom2\tto2\r\n"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_ONLY
-#: Merge.rc:5797
+#: Merge.rc:5798
 msgid "Built-in only"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_FIRST
-#: Merge.rc:5798
+#: Merge.rc:5799
 msgid "Built-in first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_FIRST
-#: Merge.rc:5799
+#: Merge.rc:5800
 msgid "Tree-sitter first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_ONLY
-#: Merge.rc:5800
+#: Merge.rc:5801
 msgid "Tree-sitter only"
 msgstr ""
 

--- a/Translations/WinMerge/Czech.po
+++ b/Translations/WinMerge/Czech.po
@@ -21,7 +21,7 @@ msgstr ""
 "X-Poedit-Basepath: ../../Src/\n"
 
 #. LANGUAGE, SUBLANGUAGE
-#: Merge.rc:26 Merge.rc:59 Merge.rc:5817
+#: Merge.rc:26 Merge.rc:59 Merge.rc:5818
 #, c-format
 msgid "LANG_ENGLISH, SUBLANG_ENGLISH_US"
 msgstr "LANG_CZECH, SUBLANG_DEFAULT"
@@ -238,7 +238,7 @@ msgid "Auto-Fit All Columns"
 msgstr ""
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN
-#: Merge.rc:153 Merge.rc:5645
+#: Merge.rc:153 Merge.rc:5646
 msgid "&Filter by This Column"
 msgstr ""
 
@@ -304,7 +304,7 @@ msgid "&Previous Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_NEXTPAGE
-#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5678
+#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5679
 #, c-format
 msgid "&Next Page"
 msgstr ""
@@ -710,7 +710,7 @@ msgid "&Huge"
 msgstr ""
 
 #. IDS_VIEW_MENU_BAR
-#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5713
+#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5714
 msgid "Men&u Bar"
 msgstr ""
 
@@ -4568,7 +4568,7 @@ msgid "Items compared:"
 msgstr "Porovnáno:"
 
 #. IDS_PREVIEWBAR_CLOSE
-#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5684
+#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5685
 #, c-format
 msgid "&Close"
 msgstr "&Zavřít"
@@ -8839,447 +8839,452 @@ msgstr ""
 msgid "2nd and 3rd"
 msgstr ""
 
+#. IDS_PLUGIN_CTRL_CLICK
+#: Merge.rc:5635
+msgid "(Ctrl+Click to add to pipeline)"
+msgstr ""
+
 #. IDS_FILTER_APPLIED
-#: Merge.rc:5639
+#: Merge.rc:5640
 msgid "Filter applied"
 msgstr ""
 
 #. IDS_FILTERMENU_COMPARE
-#: Merge.rc:5644
+#: Merge.rc:5645
 #, c-format
 msgid "Compare %1"
 msgstr ""
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN2
-#: Merge.rc:5646
+#: Merge.rc:5647
 msgid "&Filter by This Column..."
 msgstr ""
 
 #. IDS_CLIPBOARDHISTORY_TIME
-#: Merge.rc:5651
+#: Merge.rc:5652
 #, c-format
 msgid "Clipboard at %s"
 msgstr ""
 
 #. IDS_CLIPBOARDHISTORY_DISABLED
-#: Merge.rc:5652
+#: Merge.rc:5653
 msgid "Clipboard history disabled.\r\nEnable: Windows logo key + V, then Turn on."
 msgstr ""
 
-#: Merge.rc:5654
+#: Merge.rc:5655
 msgid "This system does not support clipboard history."
 msgstr ""
 
-#: Merge.rc:5656
+#: Merge.rc:5657
 msgid "32-bit WinMerge does not support Clipboard Compare"
 msgstr ""
 
 #. IDS_WEBVIEW2_RUNTIME_NOT_INSTALLED
-#: Merge.rc:5661
+#: Merge.rc:5662
 msgid "WebView2 runtime not installed. Download it?"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_TEXT_COMPARE
-#: Merge.rc:5666
+#: Merge.rc:5667
 msgid "New Text Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_TABLE_COMPARE
-#: Merge.rc:5667
+#: Merge.rc:5668
 msgid "New Table Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_BINARY_COMPARE
-#: Merge.rc:5668
+#: Merge.rc:5669
 msgid "New Binary Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_IMAGE_COMPARE
-#: Merge.rc:5669
+#: Merge.rc:5670
 msgid "New Image Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_WEBPAGE_COMPARE
-#: Merge.rc:5670
+#: Merge.rc:5671
 msgid "New Webpage Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_FOLDER_COMPARE
-#: Merge.rc:5671
+#: Merge.rc:5672
 msgid "New Folder Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_CLIPBOARD_COMPARE
-#: Merge.rc:5672
+#: Merge.rc:5673
 msgid "Clipboard Compare"
 msgstr ""
 
 #. IDS_PREVIEWBAR_PRINT
-#: Merge.rc:5677
+#: Merge.rc:5678
 msgid "&Print..."
 msgstr ""
 
 #. IDS_PREVIEWBAR_PREVPAGE
-#: Merge.rc:5679
+#: Merge.rc:5680
 msgid "Pre&v Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_TWOPAGE
-#: Merge.rc:5680
+#: Merge.rc:5681
 msgid "&Two Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_ONEPAGE
-#: Merge.rc:5681
+#: Merge.rc:5682
 msgid "&One Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_ZOOMIN
-#: Merge.rc:5682
+#: Merge.rc:5683
 msgid "Zoom &In"
 msgstr ""
 
 #. IDS_PREVIEWBAR_ZOOMOUT
-#: Merge.rc:5683
+#: Merge.rc:5684
 msgid "Zoom &Out"
 msgstr ""
 
 #. IDS_WEBPAGE_COMPARING
-#: Merge.rc:5689
+#: Merge.rc:5690
 msgid "Comparing..."
 msgstr ""
 
 #. IDS_WEBPAGE_ZOOM
-#: Merge.rc:5690
+#: Merge.rc:5691
 msgid "Zoom:"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_DIFFHUNK
-#: Merge.rc:5695
+#: Merge.rc:5696
 msgid "Diff hunk"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_INLINE
-#: Merge.rc:5696
+#: Merge.rc:5697
 msgid "Inline diff"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_LINE
-#: Merge.rc:5697
+#: Merge.rc:5698
 msgid "Line"
 msgstr ""
 
-#: Merge.rc:5698
+#: Merge.rc:5699
 msgid "Character"
 msgstr ""
 
 #. ID_MICE_PREVDIFF
-#: Merge.rc:5703
+#: Merge.rc:5704
 msgid "\nPrevious Difference (Alt+Up)\n(Right Button+Wheel Up)\n(Alt+Wheel Up)"
 msgstr ""
 
 #. ID_MICE_NEXTDIFF
-#: Merge.rc:5704
+#: Merge.rc:5705
 msgid "\nNext Difference (Alt+Down)\n(Right Button+Wheel Down)\n(Alt+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_L2R
-#: Merge.rc:5705
+#: Merge.rc:5706
 msgid "\nCopy to Right (Alt+Right)\n(Right Button+Wheel Right)\n(Alt+Wheel Right)\n(Alt+Shift+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_R2L
-#: Merge.rc:5706
+#: Merge.rc:5707
 msgid "\nCopy to Left (Alt+Left)\n(Right Button+Wheel Left)\n(Alt+Wheel Left)\n(Alt+Shift+Wheel Up)"
 msgstr ""
 
 #. ID_MICE_L2RNEXT
-#: Merge.rc:5707
+#: Merge.rc:5708
 msgid "\nCopy to Right and Advance (Ctrl+Alt+Right)\n(Ctrl+Alt+Wheel Right)\n(Ctrl+Alt+Shift+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_R2LNEXT
-#: Merge.rc:5708
+#: Merge.rc:5709
 msgid "\nCopy to Left and Advance (Ctrl+Alt+Left)\n(Ctrl+Alt+Wheel Left)\n(Ctrl+Alt+Shift+Wheel Up)"
 msgstr ""
 
 #. IDS_LOG_COMPARING_2
-#: Merge.rc:5718
+#: Merge.rc:5719
 #, c-format
 msgid "Comparing %1 with %2"
 msgstr ""
 
 #. IDS_LOG_COMPARING_3
-#: Merge.rc:5719
+#: Merge.rc:5720
 #, c-format
 msgid "Comparing %1 with %2 and %3"
 msgstr ""
 
 #. IDS_LOG_COMPARE_COMPLETED
-#: Merge.rc:5720
+#: Merge.rc:5721
 msgid "Comparison completed"
 msgstr ""
 
 #. IDS_LOG_COMPARE_ERROR_2
-#: Merge.rc:5721
+#: Merge.rc:5722
 #, c-format
 msgid "Failed to compare %1 with %2: "
 msgstr ""
 
 #. IDS_LOG_COMPARE_ERROR_3
-#: Merge.rc:5722
+#: Merge.rc:5723
 #, c-format
 msgid "Failed to compare %1 with %2 and %3: "
 msgstr ""
 
 #. IDS_LOG_FILE_SAVED
-#: Merge.rc:5723
+#: Merge.rc:5724
 msgid "File saved"
 msgstr ""
 
 #. IDS_LOG_COPYING_FILES
-#: Merge.rc:5724
+#: Merge.rc:5725
 msgid "Copying files..."
 msgstr ""
 
 #. IDS_LOG_MOVING_FILES
-#: Merge.rc:5725
+#: Merge.rc:5726
 msgid "Moving files..."
 msgstr ""
 
 #. IDS_LOG_DELETING_FILES
-#: Merge.rc:5726
+#: Merge.rc:5727
 msgid "Deleting files..."
 msgstr ""
 
 #. IDS_LOG_RECYCLEBIN
-#: Merge.rc:5727
+#: Merge.rc:5728
 msgid "Recycle Bin"
 msgstr ""
 
 #. IDS_LOG_PERMANENTLY_DELETED
-#: Merge.rc:5728
+#: Merge.rc:5729
 msgid "Permanently deleted"
 msgstr ""
 
 #. IDS_LOG_FILEOPERATION_COMPLETED
-#: Merge.rc:5729
+#: Merge.rc:5730
 msgid "File operation completed successfully"
 msgstr ""
 
 #. IDS_LOG_FILEOPERATION_CANCELED
-#: Merge.rc:5730
+#: Merge.rc:5731
 msgid "File operation canceled"
 msgstr ""
 
 #. IDS_FILTER_ERROR_NO_ERROR
-#: Merge.rc:5735
+#: Merge.rc:5736
 msgid "No error"
 msgstr ""
 
 #. IDS_FILTER_ERROR_EMPTY_EXPRESSION
-#: Merge.rc:5736
+#: Merge.rc:5737
 msgid "Filter expression is empty"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNKNOWN_CHAR
-#: Merge.rc:5737
+#: Merge.rc:5738
 msgid "Unknown character in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNTERMINATED_STRING
-#: Merge.rc:5738
+#: Merge.rc:5739
 msgid "Unterminated string literal"
 msgstr ""
 
 #. IDS_FILTER_ERROR_SYNTAX_ERROR
-#: Merge.rc:5739
+#: Merge.rc:5740
 msgid "Syntax error in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_PARSE_FAILURE
-#: Merge.rc:5740
+#: Merge.rc:5741
 msgid "Failed to parse filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_LITERAL
-#: Merge.rc:5741
+#: Merge.rc:5742
 msgid "Invalid literal value"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_REGULAR_EXPRESSION
-#: Merge.rc:5742
+#: Merge.rc:5743
 msgid "Invalid regular expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNDEFINED_IDENTIFIER
-#: Merge.rc:5743
+#: Merge.rc:5744
 msgid "Undefined identifier"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_ARGUMENT_COUNT
-#: Merge.rc:5744
+#: Merge.rc:5745
 msgid "Invalid number of arguments"
 msgstr ""
 
 #. IDS_FILTER_ERROR_FILTER_NAME_NOT_FOUND
-#: Merge.rc:5745
+#: Merge.rc:5746
 msgid "Filter name not found"
 msgstr ""
 
 #. IDS_FILTER_ERROR_DIVIDE_BY_ZERO
-#: Merge.rc:5746
+#: Merge.rc:5747
 msgid "Division by zero in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNKNOWN_ERROR
-#: Merge.rc:5747
+#: Merge.rc:5748
 msgid "Unknown error"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_PROPERTY_NAME
-#: Merge.rc:5748
+#: Merge.rc:5749
 msgid "Invalid property name"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_DIRECTIVE
-#: Merge.rc:5749
+#: Merge.rc:5750
 msgid "Invalid directive"
 msgstr ""
 
 #. IDS_FILTER_OP_EQUALS
-#: Merge.rc:5754
+#: Merge.rc:5755
 msgid "Equals"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_EQUALS
-#: Merge.rc:5755
+#: Merge.rc:5756
 msgid "Does not equal"
 msgstr ""
 
 #. IDS_FILTER_OP_LESS_THAN
-#: Merge.rc:5756
+#: Merge.rc:5757
 msgid "Less than"
 msgstr ""
 
 #. IDS_FILTER_OP_LESS_EQUAL
-#: Merge.rc:5757
+#: Merge.rc:5758
 msgid "Less than or equal to"
 msgstr ""
 
 #. IDS_FILTER_OP_GREATER_EQUAL
-#: Merge.rc:5758
+#: Merge.rc:5759
 msgid "Greater than or equal to"
 msgstr ""
 
 #. IDS_FILTER_OP_GREATER_THAN
-#: Merge.rc:5759
+#: Merge.rc:5760
 msgid "Greater than"
 msgstr ""
 
 #. IDS_FILTER_OP_BETWEEN
-#: Merge.rc:5760
+#: Merge.rc:5761
 msgid "Between"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_BETWEEN
-#: Merge.rc:5761
+#: Merge.rc:5762
 msgid "Not Between"
 msgstr ""
 
 #. IDS_FILTER_OP_CONTAINS
-#: Merge.rc:5762
+#: Merge.rc:5763
 msgid "Contains"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_CONTAINS
-#: Merge.rc:5763
+#: Merge.rc:5764
 msgid "Not Contains"
 msgstr ""
 
 #. IDS_FILTER_OP_RECONTAINS
-#: Merge.rc:5764
+#: Merge.rc:5765
 msgid "Contains (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_RECONTAINS
-#: Merge.rc:5765
+#: Merge.rc:5766
 msgid "Not Contains (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_LIKE
-#: Merge.rc:5766
+#: Merge.rc:5767
 msgid "Match (wildcard)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_LIKE
-#: Merge.rc:5767
+#: Merge.rc:5768
 msgid "Not match (wildcard)"
 msgstr ""
 
 #. IDS_FILTER_OP_MATCHES
-#: Merge.rc:5768
+#: Merge.rc:5769
 msgid "Match (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_MATCHES
-#: Merge.rc:5769
+#: Merge.rc:5770
 msgid "Not match (regex)"
 msgstr ""
 
 #. IDS_COLORMODE_LIGHT
-#: Merge.rc:5774
+#: Merge.rc:5775
 msgid "Light"
 msgstr ""
 
 #. IDS_COLORMODE_DARK
-#: Merge.rc:5775
+#: Merge.rc:5776
 msgid "Dark"
 msgstr ""
 
 #. IDS_COLORMODE_FOLLOWSYSTEM
-#: Merge.rc:5776
+#: Merge.rc:5777
 msgid "Follow system"
 msgstr ""
 
 #. IDS_EXAMPLE
-#: Merge.rc:5781
+#: Merge.rc:5782
 #, c-format
 msgid "e.g. %1"
 msgstr ""
 
 #. IDS_DETECTED_PREVIOUS_CRASH
-#: Merge.rc:5786
+#: Merge.rc:5787
 msgid "WinMerge detected a previous crash. Please report this if possible."
 msgstr ""
 
 #. IDS_REGEX_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5791
+#: Merge.rc:5792
 msgid "# Regex replacement list\r\n# Format: regex<TAB>replacement\r\n# Backreferences like $1, $2 are supported\r\n\r\n(\\d{4})-(\\d{2})-(\\d{2})\t$1_$2_$3\r\n"
 msgstr ""
 
 #. IDS_STRING_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5792
+#: Merge.rc:5793
 msgid "# Replacement list\r\n# Format: search<TAB>replacement\r\n# Lines starting with # are ignored\r\n\r\nfrom1\tto1\r\nfrom2\tto2\r\n"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_ONLY
-#: Merge.rc:5797
+#: Merge.rc:5798
 msgid "Built-in only"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_FIRST
-#: Merge.rc:5798
+#: Merge.rc:5799
 msgid "Built-in first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_FIRST
-#: Merge.rc:5799
+#: Merge.rc:5800
 msgid "Tree-sitter first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_ONLY
-#: Merge.rc:5800
+#: Merge.rc:5801
 msgid "Tree-sitter only"
 msgstr ""
 

--- a/Translations/WinMerge/Danish.po
+++ b/Translations/WinMerge/Danish.po
@@ -22,7 +22,7 @@ msgstr ""
 "X-Generator: Poedit 1.5.4\n"
 
 #. LANGUAGE, SUBLANGUAGE
-#: Merge.rc:26 Merge.rc:59 Merge.rc:5817
+#: Merge.rc:26 Merge.rc:59 Merge.rc:5818
 #, c-format
 msgid "LANG_ENGLISH, SUBLANG_ENGLISH_US"
 msgstr "LANG_DANISH, SUBLANG_DEFAULT"
@@ -239,7 +239,7 @@ msgid "Auto-Fit All Columns"
 msgstr ""
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN
-#: Merge.rc:153 Merge.rc:5645
+#: Merge.rc:153 Merge.rc:5646
 msgid "&Filter by This Column"
 msgstr ""
 
@@ -305,7 +305,7 @@ msgid "&Previous Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_NEXTPAGE
-#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5678
+#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5679
 #, c-format
 msgid "&Next Page"
 msgstr ""
@@ -711,7 +711,7 @@ msgid "&Huge"
 msgstr ""
 
 #. IDS_VIEW_MENU_BAR
-#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5713
+#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5714
 msgid "Men&u Bar"
 msgstr ""
 
@@ -4569,7 +4569,7 @@ msgid "Items compared:"
 msgstr "Emner sammenlignet:"
 
 #. IDS_PREVIEWBAR_CLOSE
-#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5684
+#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5685
 #, c-format
 msgid "&Close"
 msgstr "&Luk"
@@ -8923,447 +8923,452 @@ msgstr ""
 msgid "2nd and 3rd"
 msgstr ""
 
+#. IDS_PLUGIN_CTRL_CLICK
+#: Merge.rc:5635
+msgid "(Ctrl+Click to add to pipeline)"
+msgstr ""
+
 #. IDS_FILTER_APPLIED
-#: Merge.rc:5639
+#: Merge.rc:5640
 msgid "Filter applied"
 msgstr ""
 
 #. IDS_FILTERMENU_COMPARE
-#: Merge.rc:5644
+#: Merge.rc:5645
 #, c-format
 msgid "Compare %1"
 msgstr ""
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN2
-#: Merge.rc:5646
+#: Merge.rc:5647
 msgid "&Filter by This Column..."
 msgstr ""
 
 #. IDS_CLIPBOARDHISTORY_TIME
-#: Merge.rc:5651
+#: Merge.rc:5652
 #, c-format
 msgid "Clipboard at %s"
 msgstr ""
 
 #. IDS_CLIPBOARDHISTORY_DISABLED
-#: Merge.rc:5652
+#: Merge.rc:5653
 msgid "Clipboard history disabled.\r\nEnable: Windows logo key + V, then Turn on."
 msgstr ""
 
-#: Merge.rc:5654
+#: Merge.rc:5655
 msgid "This system does not support clipboard history."
 msgstr ""
 
-#: Merge.rc:5656
+#: Merge.rc:5657
 msgid "32-bit WinMerge does not support Clipboard Compare"
 msgstr ""
 
 #. IDS_WEBVIEW2_RUNTIME_NOT_INSTALLED
-#: Merge.rc:5661
+#: Merge.rc:5662
 msgid "WebView2 runtime not installed. Download it?"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_TEXT_COMPARE
-#: Merge.rc:5666
+#: Merge.rc:5667
 msgid "New Text Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_TABLE_COMPARE
-#: Merge.rc:5667
+#: Merge.rc:5668
 msgid "New Table Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_BINARY_COMPARE
-#: Merge.rc:5668
+#: Merge.rc:5669
 msgid "New Binary Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_IMAGE_COMPARE
-#: Merge.rc:5669
+#: Merge.rc:5670
 msgid "New Image Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_WEBPAGE_COMPARE
-#: Merge.rc:5670
+#: Merge.rc:5671
 msgid "New Webpage Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_FOLDER_COMPARE
-#: Merge.rc:5671
+#: Merge.rc:5672
 msgid "New Folder Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_CLIPBOARD_COMPARE
-#: Merge.rc:5672
+#: Merge.rc:5673
 msgid "Clipboard Compare"
 msgstr ""
 
 #. IDS_PREVIEWBAR_PRINT
-#: Merge.rc:5677
+#: Merge.rc:5678
 msgid "&Print..."
 msgstr ""
 
 #. IDS_PREVIEWBAR_PREVPAGE
-#: Merge.rc:5679
+#: Merge.rc:5680
 msgid "Pre&v Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_TWOPAGE
-#: Merge.rc:5680
+#: Merge.rc:5681
 msgid "&Two Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_ONEPAGE
-#: Merge.rc:5681
+#: Merge.rc:5682
 msgid "&One Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_ZOOMIN
-#: Merge.rc:5682
+#: Merge.rc:5683
 msgid "Zoom &In"
 msgstr ""
 
 #. IDS_PREVIEWBAR_ZOOMOUT
-#: Merge.rc:5683
+#: Merge.rc:5684
 msgid "Zoom &Out"
 msgstr ""
 
 #. IDS_WEBPAGE_COMPARING
-#: Merge.rc:5689
+#: Merge.rc:5690
 msgid "Comparing..."
 msgstr ""
 
 #. IDS_WEBPAGE_ZOOM
-#: Merge.rc:5690
+#: Merge.rc:5691
 msgid "Zoom:"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_DIFFHUNK
-#: Merge.rc:5695
+#: Merge.rc:5696
 msgid "Diff hunk"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_INLINE
-#: Merge.rc:5696
+#: Merge.rc:5697
 msgid "Inline diff"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_LINE
-#: Merge.rc:5697
+#: Merge.rc:5698
 msgid "Line"
 msgstr ""
 
-#: Merge.rc:5698
+#: Merge.rc:5699
 msgid "Character"
 msgstr ""
 
 #. ID_MICE_PREVDIFF
-#: Merge.rc:5703
+#: Merge.rc:5704
 msgid "\nPrevious Difference (Alt+Up)\n(Right Button+Wheel Up)\n(Alt+Wheel Up)"
 msgstr ""
 
 #. ID_MICE_NEXTDIFF
-#: Merge.rc:5704
+#: Merge.rc:5705
 msgid "\nNext Difference (Alt+Down)\n(Right Button+Wheel Down)\n(Alt+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_L2R
-#: Merge.rc:5705
+#: Merge.rc:5706
 msgid "\nCopy to Right (Alt+Right)\n(Right Button+Wheel Right)\n(Alt+Wheel Right)\n(Alt+Shift+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_R2L
-#: Merge.rc:5706
+#: Merge.rc:5707
 msgid "\nCopy to Left (Alt+Left)\n(Right Button+Wheel Left)\n(Alt+Wheel Left)\n(Alt+Shift+Wheel Up)"
 msgstr ""
 
 #. ID_MICE_L2RNEXT
-#: Merge.rc:5707
+#: Merge.rc:5708
 msgid "\nCopy to Right and Advance (Ctrl+Alt+Right)\n(Ctrl+Alt+Wheel Right)\n(Ctrl+Alt+Shift+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_R2LNEXT
-#: Merge.rc:5708
+#: Merge.rc:5709
 msgid "\nCopy to Left and Advance (Ctrl+Alt+Left)\n(Ctrl+Alt+Wheel Left)\n(Ctrl+Alt+Shift+Wheel Up)"
 msgstr ""
 
 #. IDS_LOG_COMPARING_2
-#: Merge.rc:5718
+#: Merge.rc:5719
 #, c-format
 msgid "Comparing %1 with %2"
 msgstr ""
 
 #. IDS_LOG_COMPARING_3
-#: Merge.rc:5719
+#: Merge.rc:5720
 #, c-format
 msgid "Comparing %1 with %2 and %3"
 msgstr ""
 
 #. IDS_LOG_COMPARE_COMPLETED
-#: Merge.rc:5720
+#: Merge.rc:5721
 msgid "Comparison completed"
 msgstr ""
 
 #. IDS_LOG_COMPARE_ERROR_2
-#: Merge.rc:5721
+#: Merge.rc:5722
 #, c-format
 msgid "Failed to compare %1 with %2: "
 msgstr ""
 
 #. IDS_LOG_COMPARE_ERROR_3
-#: Merge.rc:5722
+#: Merge.rc:5723
 #, c-format
 msgid "Failed to compare %1 with %2 and %3: "
 msgstr ""
 
 #. IDS_LOG_FILE_SAVED
-#: Merge.rc:5723
+#: Merge.rc:5724
 msgid "File saved"
 msgstr ""
 
 #. IDS_LOG_COPYING_FILES
-#: Merge.rc:5724
+#: Merge.rc:5725
 msgid "Copying files..."
 msgstr ""
 
 #. IDS_LOG_MOVING_FILES
-#: Merge.rc:5725
+#: Merge.rc:5726
 msgid "Moving files..."
 msgstr ""
 
 #. IDS_LOG_DELETING_FILES
-#: Merge.rc:5726
+#: Merge.rc:5727
 msgid "Deleting files..."
 msgstr ""
 
 #. IDS_LOG_RECYCLEBIN
-#: Merge.rc:5727
+#: Merge.rc:5728
 msgid "Recycle Bin"
 msgstr ""
 
 #. IDS_LOG_PERMANENTLY_DELETED
-#: Merge.rc:5728
+#: Merge.rc:5729
 msgid "Permanently deleted"
 msgstr ""
 
 #. IDS_LOG_FILEOPERATION_COMPLETED
-#: Merge.rc:5729
+#: Merge.rc:5730
 msgid "File operation completed successfully"
 msgstr ""
 
 #. IDS_LOG_FILEOPERATION_CANCELED
-#: Merge.rc:5730
+#: Merge.rc:5731
 msgid "File operation canceled"
 msgstr ""
 
 #. IDS_FILTER_ERROR_NO_ERROR
-#: Merge.rc:5735
+#: Merge.rc:5736
 msgid "No error"
 msgstr ""
 
 #. IDS_FILTER_ERROR_EMPTY_EXPRESSION
-#: Merge.rc:5736
+#: Merge.rc:5737
 msgid "Filter expression is empty"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNKNOWN_CHAR
-#: Merge.rc:5737
+#: Merge.rc:5738
 msgid "Unknown character in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNTERMINATED_STRING
-#: Merge.rc:5738
+#: Merge.rc:5739
 msgid "Unterminated string literal"
 msgstr ""
 
 #. IDS_FILTER_ERROR_SYNTAX_ERROR
-#: Merge.rc:5739
+#: Merge.rc:5740
 msgid "Syntax error in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_PARSE_FAILURE
-#: Merge.rc:5740
+#: Merge.rc:5741
 msgid "Failed to parse filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_LITERAL
-#: Merge.rc:5741
+#: Merge.rc:5742
 msgid "Invalid literal value"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_REGULAR_EXPRESSION
-#: Merge.rc:5742
+#: Merge.rc:5743
 msgid "Invalid regular expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNDEFINED_IDENTIFIER
-#: Merge.rc:5743
+#: Merge.rc:5744
 msgid "Undefined identifier"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_ARGUMENT_COUNT
-#: Merge.rc:5744
+#: Merge.rc:5745
 msgid "Invalid number of arguments"
 msgstr ""
 
 #. IDS_FILTER_ERROR_FILTER_NAME_NOT_FOUND
-#: Merge.rc:5745
+#: Merge.rc:5746
 msgid "Filter name not found"
 msgstr ""
 
 #. IDS_FILTER_ERROR_DIVIDE_BY_ZERO
-#: Merge.rc:5746
+#: Merge.rc:5747
 msgid "Division by zero in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNKNOWN_ERROR
-#: Merge.rc:5747
+#: Merge.rc:5748
 msgid "Unknown error"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_PROPERTY_NAME
-#: Merge.rc:5748
+#: Merge.rc:5749
 msgid "Invalid property name"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_DIRECTIVE
-#: Merge.rc:5749
+#: Merge.rc:5750
 msgid "Invalid directive"
 msgstr ""
 
 #. IDS_FILTER_OP_EQUALS
-#: Merge.rc:5754
+#: Merge.rc:5755
 msgid "Equals"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_EQUALS
-#: Merge.rc:5755
+#: Merge.rc:5756
 msgid "Does not equal"
 msgstr ""
 
 #. IDS_FILTER_OP_LESS_THAN
-#: Merge.rc:5756
+#: Merge.rc:5757
 msgid "Less than"
 msgstr ""
 
 #. IDS_FILTER_OP_LESS_EQUAL
-#: Merge.rc:5757
+#: Merge.rc:5758
 msgid "Less than or equal to"
 msgstr ""
 
 #. IDS_FILTER_OP_GREATER_EQUAL
-#: Merge.rc:5758
+#: Merge.rc:5759
 msgid "Greater than or equal to"
 msgstr ""
 
 #. IDS_FILTER_OP_GREATER_THAN
-#: Merge.rc:5759
+#: Merge.rc:5760
 msgid "Greater than"
 msgstr ""
 
 #. IDS_FILTER_OP_BETWEEN
-#: Merge.rc:5760
+#: Merge.rc:5761
 msgid "Between"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_BETWEEN
-#: Merge.rc:5761
+#: Merge.rc:5762
 msgid "Not Between"
 msgstr ""
 
 #. IDS_FILTER_OP_CONTAINS
-#: Merge.rc:5762
+#: Merge.rc:5763
 msgid "Contains"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_CONTAINS
-#: Merge.rc:5763
+#: Merge.rc:5764
 msgid "Not Contains"
 msgstr ""
 
 #. IDS_FILTER_OP_RECONTAINS
-#: Merge.rc:5764
+#: Merge.rc:5765
 msgid "Contains (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_RECONTAINS
-#: Merge.rc:5765
+#: Merge.rc:5766
 msgid "Not Contains (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_LIKE
-#: Merge.rc:5766
+#: Merge.rc:5767
 msgid "Match (wildcard)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_LIKE
-#: Merge.rc:5767
+#: Merge.rc:5768
 msgid "Not match (wildcard)"
 msgstr ""
 
 #. IDS_FILTER_OP_MATCHES
-#: Merge.rc:5768
+#: Merge.rc:5769
 msgid "Match (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_MATCHES
-#: Merge.rc:5769
+#: Merge.rc:5770
 msgid "Not match (regex)"
 msgstr ""
 
 #. IDS_COLORMODE_LIGHT
-#: Merge.rc:5774
+#: Merge.rc:5775
 msgid "Light"
 msgstr ""
 
 #. IDS_COLORMODE_DARK
-#: Merge.rc:5775
+#: Merge.rc:5776
 msgid "Dark"
 msgstr ""
 
 #. IDS_COLORMODE_FOLLOWSYSTEM
-#: Merge.rc:5776
+#: Merge.rc:5777
 msgid "Follow system"
 msgstr ""
 
 #. IDS_EXAMPLE
-#: Merge.rc:5781
+#: Merge.rc:5782
 #, c-format
 msgid "e.g. %1"
 msgstr ""
 
 #. IDS_DETECTED_PREVIOUS_CRASH
-#: Merge.rc:5786
+#: Merge.rc:5787
 msgid "WinMerge detected a previous crash. Please report this if possible."
 msgstr ""
 
 #. IDS_REGEX_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5791
+#: Merge.rc:5792
 msgid "# Regex replacement list\r\n# Format: regex<TAB>replacement\r\n# Backreferences like $1, $2 are supported\r\n\r\n(\\d{4})-(\\d{2})-(\\d{2})\t$1_$2_$3\r\n"
 msgstr ""
 
 #. IDS_STRING_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5792
+#: Merge.rc:5793
 msgid "# Replacement list\r\n# Format: search<TAB>replacement\r\n# Lines starting with # are ignored\r\n\r\nfrom1\tto1\r\nfrom2\tto2\r\n"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_ONLY
-#: Merge.rc:5797
+#: Merge.rc:5798
 msgid "Built-in only"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_FIRST
-#: Merge.rc:5798
+#: Merge.rc:5799
 msgid "Built-in first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_FIRST
-#: Merge.rc:5799
+#: Merge.rc:5800
 msgid "Tree-sitter first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_ONLY
-#: Merge.rc:5800
+#: Merge.rc:5801
 msgid "Tree-sitter only"
 msgstr ""
 

--- a/Translations/WinMerge/Dutch.po
+++ b/Translations/WinMerge/Dutch.po
@@ -21,7 +21,7 @@ msgstr ""
 "X-Poedit-SourceCharset: UTF-8\n"
 
 #. LANGUAGE, SUBLANGUAGE
-#: Merge.rc:26 Merge.rc:59 Merge.rc:5817
+#: Merge.rc:26 Merge.rc:59 Merge.rc:5818
 msgid "LANG_ENGLISH, SUBLANG_ENGLISH_US"
 msgstr "LANG_DUTCH, SUBLANG_DUTCH"
 
@@ -228,7 +228,7 @@ msgid "Auto-Fit All Columns"
 msgstr "Alle kolommen automatisch aanpassen"
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN
-#: Merge.rc:153 Merge.rc:5645
+#: Merge.rc:153 Merge.rc:5646
 msgid "&Filter by This Column"
 msgstr ""
 
@@ -289,7 +289,7 @@ msgid "&Previous Page"
 msgstr "Vorige pagina"
 
 #. IDS_PREVIEWBAR_NEXTPAGE
-#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5678
+#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5679
 msgid "&Next Page"
 msgstr "Volgende pagina"
 
@@ -662,7 +662,7 @@ msgid "&Huge"
 msgstr "Enorm"
 
 #. IDS_VIEW_MENU_BAR
-#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5713
+#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5714
 msgid "Men&u Bar"
 msgstr ""
 
@@ -4197,7 +4197,7 @@ msgid "Items compared:"
 msgstr "Items vergeleken:"
 
 #. IDS_PREVIEWBAR_CLOSE
-#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5684
+#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5685
 msgid "&Close"
 msgstr "Sluiten"
 
@@ -8369,30 +8369,35 @@ msgstr ""
 msgid "2nd and 3rd"
 msgstr ""
 
+#. IDS_PLUGIN_CTRL_CLICK
+#: Merge.rc:5635
+msgid "(Ctrl+Click to add to pipeline)"
+msgstr ""
+
 #. IDS_FILTER_APPLIED
-#: Merge.rc:5639
+#: Merge.rc:5640
 msgid "Filter applied"
 msgstr "Filter toegepast"
 
 #. IDS_FILTERMENU_COMPARE
-#: Merge.rc:5644
+#: Merge.rc:5645
 #, c-format
 msgid "Compare %1"
 msgstr ""
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN2
-#: Merge.rc:5646
+#: Merge.rc:5647
 msgid "&Filter by This Column..."
 msgstr ""
 
 #. IDS_CLIPBOARDHISTORY_TIME
-#: Merge.rc:5651
+#: Merge.rc:5652
 #, c-format
 msgid "Clipboard at %s"
 msgstr "Klembord op %s"
 
 #. IDS_CLIPBOARDHISTORY_DISABLED
-#: Merge.rc:5652
+#: Merge.rc:5653
 msgid ""
 "Clipboard history disabled.\r\n"
 "Enable: Windows logo key + V, then Turn on."
@@ -8400,115 +8405,115 @@ msgstr ""
 "De klembordgeschiedenis is uitgeschakeld.\n"
 "Om de klembordgeschiedenis in te schakelen, drukt u op de Windows-logotoets + V en klikt u vervolgens op de knop Inschakelen."
 
-#: Merge.rc:5654
+#: Merge.rc:5655
 msgid "This system does not support clipboard history."
 msgstr "Dit systeem ondersteunt geen klembordgeschiedenis."
 
-#: Merge.rc:5656
+#: Merge.rc:5657
 msgid "32-bit WinMerge does not support Clipboard Compare"
 msgstr "De 32-bit-versie van WinMerge ondersteunt geen klembordvergelijking"
 
 #. IDS_WEBVIEW2_RUNTIME_NOT_INSTALLED
-#: Merge.rc:5661
+#: Merge.rc:5662
 msgid "WebView2 runtime not installed. Download it?"
 msgstr "WebView2-runtime is niet geïnstalleerd. Wilt u het downloaden?"
 
 #. IDS_JUMPLIST_NEW_TEXT_COMPARE
-#: Merge.rc:5666
+#: Merge.rc:5667
 msgid "New Text Compare"
 msgstr "Nieuwe tekstvergelijking"
 
 #. IDS_JUMPLIST_NEW_TABLE_COMPARE
-#: Merge.rc:5667
+#: Merge.rc:5668
 msgid "New Table Compare"
 msgstr "Nieuwe tabelvergelijking"
 
 #. IDS_JUMPLIST_NEW_BINARY_COMPARE
-#: Merge.rc:5668
+#: Merge.rc:5669
 msgid "New Binary Compare"
 msgstr "Nieuwe binaire vergelijking"
 
 #. IDS_JUMPLIST_NEW_IMAGE_COMPARE
-#: Merge.rc:5669
+#: Merge.rc:5670
 msgid "New Image Compare"
 msgstr "Nieuwe afbeeldingsvergelijking"
 
 #. IDS_JUMPLIST_NEW_WEBPAGE_COMPARE
-#: Merge.rc:5670
+#: Merge.rc:5671
 msgid "New Webpage Compare"
 msgstr "Nieuwe webpagina-vergelijking"
 
 #. IDS_JUMPLIST_NEW_FOLDER_COMPARE
-#: Merge.rc:5671
+#: Merge.rc:5672
 msgid "New Folder Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_CLIPBOARD_COMPARE
-#: Merge.rc:5672
+#: Merge.rc:5673
 msgid "Clipboard Compare"
 msgstr "Klembordvergelijking"
 
 #. IDS_PREVIEWBAR_PRINT
-#: Merge.rc:5677
+#: Merge.rc:5678
 msgid "&Print..."
 msgstr "Afdrukken..."
 
 #. IDS_PREVIEWBAR_PREVPAGE
-#: Merge.rc:5679
+#: Merge.rc:5680
 msgid "Pre&v Page"
 msgstr "Vorige pagina"
 
 #. IDS_PREVIEWBAR_TWOPAGE
-#: Merge.rc:5680
+#: Merge.rc:5681
 msgid "&Two Page"
 msgstr "Twee pagina's"
 
 #. IDS_PREVIEWBAR_ONEPAGE
-#: Merge.rc:5681
+#: Merge.rc:5682
 msgid "&One Page"
 msgstr "Eén pagina"
 
 #. IDS_PREVIEWBAR_ZOOMIN
-#: Merge.rc:5682
+#: Merge.rc:5683
 msgid "Zoom &In"
 msgstr "Inzoomen"
 
 #. IDS_PREVIEWBAR_ZOOMOUT
-#: Merge.rc:5683
+#: Merge.rc:5684
 msgid "Zoom &Out"
 msgstr "Uitzoomen"
 
 #. IDS_WEBPAGE_COMPARING
-#: Merge.rc:5689
+#: Merge.rc:5690
 msgid "Comparing..."
 msgstr "Vergelijken..."
 
 #. IDS_WEBPAGE_ZOOM
-#: Merge.rc:5690
+#: Merge.rc:5691
 msgid "Zoom:"
 msgstr "Zoomen:"
 
 #. IDS_COPY_GRANULARITY_DIFFHUNK
-#: Merge.rc:5695
+#: Merge.rc:5696
 msgid "Diff hunk"
 msgstr "Verschil-hunk"
 
 #. IDS_COPY_GRANULARITY_INLINE
-#: Merge.rc:5696
+#: Merge.rc:5697
 msgid "Inline diff"
 msgstr "Inline-verschil"
 
 #. IDS_COPY_GRANULARITY_LINE
-#: Merge.rc:5697
+#: Merge.rc:5698
 msgid "Line"
 msgstr "Regel"
 
-#: Merge.rc:5698
+#: Merge.rc:5699
 msgid "Character"
 msgstr "Teken"
 
 #. ID_MICE_PREVDIFF
-#: Merge.rc:5703
+#: Merge.rc:5704
 msgid ""
 "\n"
 "Previous Difference (Alt+Up)\n"
@@ -8521,7 +8526,7 @@ msgstr ""
 "(Alt+Wiel omhoog)"
 
 #. ID_MICE_NEXTDIFF
-#: Merge.rc:5704
+#: Merge.rc:5705
 msgid ""
 "\n"
 "Next Difference (Alt+Down)\n"
@@ -8534,7 +8539,7 @@ msgstr ""
 "(Alt+Wiel omlaag)"
 
 #. ID_MICE_L2R
-#: Merge.rc:5705
+#: Merge.rc:5706
 msgid ""
 "\n"
 "Copy to Right (Alt+Right)\n"
@@ -8549,7 +8554,7 @@ msgstr ""
 "(Alt+Shift+Wiel omlaag)"
 
 #. ID_MICE_R2L
-#: Merge.rc:5706
+#: Merge.rc:5707
 msgid ""
 "\n"
 "Copy to Left (Alt+Left)\n"
@@ -8564,7 +8569,7 @@ msgstr ""
 "(Alt+Shift+Wiel omhoog)"
 
 #. ID_MICE_L2RNEXT
-#: Merge.rc:5707
+#: Merge.rc:5708
 msgid ""
 "\n"
 "Copy to Right and Advance (Ctrl+Alt+Right)\n"
@@ -8577,7 +8582,7 @@ msgstr ""
 "(Ctrl+Alt+Shift+Wiel omlaag)"
 
 #. ID_MICE_R2LNEXT
-#: Merge.rc:5708
+#: Merge.rc:5709
 msgid ""
 "\n"
 "Copy to Left and Advance (Ctrl+Alt+Left)\n"
@@ -8590,282 +8595,282 @@ msgstr ""
 "(Ctrl+Alt+Shift+Wiel omhoog)"
 
 #. IDS_LOG_COMPARING_2
-#: Merge.rc:5718
+#: Merge.rc:5719
 #, c-format
 msgid "Comparing %1 with %2"
 msgstr ""
 
 #. IDS_LOG_COMPARING_3
-#: Merge.rc:5719
+#: Merge.rc:5720
 #, c-format
 msgid "Comparing %1 with %2 and %3"
 msgstr ""
 
 #. IDS_LOG_COMPARE_COMPLETED
-#: Merge.rc:5720
+#: Merge.rc:5721
 msgid "Comparison completed"
 msgstr ""
 
 #. IDS_LOG_COMPARE_ERROR_2
-#: Merge.rc:5721
+#: Merge.rc:5722
 #, c-format
 msgid "Failed to compare %1 with %2: "
 msgstr ""
 
 #. IDS_LOG_COMPARE_ERROR_3
-#: Merge.rc:5722
+#: Merge.rc:5723
 #, c-format
 msgid "Failed to compare %1 with %2 and %3: "
 msgstr ""
 
 #. IDS_LOG_FILE_SAVED
-#: Merge.rc:5723
+#: Merge.rc:5724
 msgid "File saved"
 msgstr ""
 
 #. IDS_LOG_COPYING_FILES
-#: Merge.rc:5724
+#: Merge.rc:5725
 msgid "Copying files..."
 msgstr ""
 
 #. IDS_LOG_MOVING_FILES
-#: Merge.rc:5725
+#: Merge.rc:5726
 msgid "Moving files..."
 msgstr ""
 
 #. IDS_LOG_DELETING_FILES
-#: Merge.rc:5726
+#: Merge.rc:5727
 msgid "Deleting files..."
 msgstr ""
 
 #. IDS_LOG_RECYCLEBIN
-#: Merge.rc:5727
+#: Merge.rc:5728
 msgid "Recycle Bin"
 msgstr ""
 
 #. IDS_LOG_PERMANENTLY_DELETED
-#: Merge.rc:5728
+#: Merge.rc:5729
 msgid "Permanently deleted"
 msgstr ""
 
 #. IDS_LOG_FILEOPERATION_COMPLETED
-#: Merge.rc:5729
+#: Merge.rc:5730
 msgid "File operation completed successfully"
 msgstr ""
 
 #. IDS_LOG_FILEOPERATION_CANCELED
-#: Merge.rc:5730
+#: Merge.rc:5731
 msgid "File operation canceled"
 msgstr ""
 
 #. IDS_FILTER_ERROR_NO_ERROR
-#: Merge.rc:5735
+#: Merge.rc:5736
 msgid "No error"
 msgstr ""
 
 #. IDS_FILTER_ERROR_EMPTY_EXPRESSION
-#: Merge.rc:5736
+#: Merge.rc:5737
 msgid "Filter expression is empty"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNKNOWN_CHAR
-#: Merge.rc:5737
+#: Merge.rc:5738
 msgid "Unknown character in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNTERMINATED_STRING
-#: Merge.rc:5738
+#: Merge.rc:5739
 msgid "Unterminated string literal"
 msgstr ""
 
 #. IDS_FILTER_ERROR_SYNTAX_ERROR
-#: Merge.rc:5739
+#: Merge.rc:5740
 msgid "Syntax error in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_PARSE_FAILURE
-#: Merge.rc:5740
+#: Merge.rc:5741
 msgid "Failed to parse filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_LITERAL
-#: Merge.rc:5741
+#: Merge.rc:5742
 msgid "Invalid literal value"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_REGULAR_EXPRESSION
-#: Merge.rc:5742
+#: Merge.rc:5743
 msgid "Invalid regular expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNDEFINED_IDENTIFIER
-#: Merge.rc:5743
+#: Merge.rc:5744
 msgid "Undefined identifier"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_ARGUMENT_COUNT
-#: Merge.rc:5744
+#: Merge.rc:5745
 msgid "Invalid number of arguments"
 msgstr ""
 
 #. IDS_FILTER_ERROR_FILTER_NAME_NOT_FOUND
-#: Merge.rc:5745
+#: Merge.rc:5746
 msgid "Filter name not found"
 msgstr ""
 
 #. IDS_FILTER_ERROR_DIVIDE_BY_ZERO
-#: Merge.rc:5746
+#: Merge.rc:5747
 msgid "Division by zero in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNKNOWN_ERROR
-#: Merge.rc:5747
+#: Merge.rc:5748
 msgid "Unknown error"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_PROPERTY_NAME
-#: Merge.rc:5748
+#: Merge.rc:5749
 msgid "Invalid property name"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_DIRECTIVE
-#: Merge.rc:5749
+#: Merge.rc:5750
 msgid "Invalid directive"
 msgstr ""
 
 #. IDS_FILTER_OP_EQUALS
-#: Merge.rc:5754
+#: Merge.rc:5755
 msgid "Equals"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_EQUALS
-#: Merge.rc:5755
+#: Merge.rc:5756
 msgid "Does not equal"
 msgstr ""
 
 #. IDS_FILTER_OP_LESS_THAN
-#: Merge.rc:5756
+#: Merge.rc:5757
 msgid "Less than"
 msgstr ""
 
 #. IDS_FILTER_OP_LESS_EQUAL
-#: Merge.rc:5757
+#: Merge.rc:5758
 msgid "Less than or equal to"
 msgstr ""
 
 #. IDS_FILTER_OP_GREATER_EQUAL
-#: Merge.rc:5758
+#: Merge.rc:5759
 msgid "Greater than or equal to"
 msgstr ""
 
 #. IDS_FILTER_OP_GREATER_THAN
-#: Merge.rc:5759
+#: Merge.rc:5760
 msgid "Greater than"
 msgstr ""
 
 #. IDS_FILTER_OP_BETWEEN
-#: Merge.rc:5760
+#: Merge.rc:5761
 msgid "Between"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_BETWEEN
-#: Merge.rc:5761
+#: Merge.rc:5762
 msgid "Not Between"
 msgstr ""
 
 #. IDS_FILTER_OP_CONTAINS
-#: Merge.rc:5762
+#: Merge.rc:5763
 msgid "Contains"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_CONTAINS
-#: Merge.rc:5763
+#: Merge.rc:5764
 msgid "Not Contains"
 msgstr ""
 
 #. IDS_FILTER_OP_RECONTAINS
-#: Merge.rc:5764
+#: Merge.rc:5765
 msgid "Contains (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_RECONTAINS
-#: Merge.rc:5765
+#: Merge.rc:5766
 msgid "Not Contains (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_LIKE
-#: Merge.rc:5766
+#: Merge.rc:5767
 msgid "Match (wildcard)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_LIKE
-#: Merge.rc:5767
+#: Merge.rc:5768
 msgid "Not match (wildcard)"
 msgstr ""
 
 #. IDS_FILTER_OP_MATCHES
-#: Merge.rc:5768
+#: Merge.rc:5769
 msgid "Match (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_MATCHES
-#: Merge.rc:5769
+#: Merge.rc:5770
 msgid "Not match (regex)"
 msgstr ""
 
 #. IDS_COLORMODE_LIGHT
-#: Merge.rc:5774
+#: Merge.rc:5775
 msgid "Light"
 msgstr ""
 
 #. IDS_COLORMODE_DARK
-#: Merge.rc:5775
+#: Merge.rc:5776
 msgid "Dark"
 msgstr ""
 
 #. IDS_COLORMODE_FOLLOWSYSTEM
-#: Merge.rc:5776
+#: Merge.rc:5777
 msgid "Follow system"
 msgstr ""
 
 #. IDS_EXAMPLE
-#: Merge.rc:5781
+#: Merge.rc:5782
 #, c-format
 msgid "e.g. %1"
 msgstr ""
 
 #. IDS_DETECTED_PREVIOUS_CRASH
-#: Merge.rc:5786
+#: Merge.rc:5787
 msgid "WinMerge detected a previous crash. Please report this if possible."
 msgstr ""
 
 #. IDS_REGEX_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5791
+#: Merge.rc:5792
 msgid "# Regex replacement list\r\n# Format: regex<TAB>replacement\r\n# Backreferences like $1, $2 are supported\r\n\r\n(\\d{4})-(\\d{2})-(\\d{2})\t$1_$2_$3\r\n"
 msgstr ""
 
 #. IDS_STRING_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5792
+#: Merge.rc:5793
 msgid "# Replacement list\r\n# Format: search<TAB>replacement\r\n# Lines starting with # are ignored\r\n\r\nfrom1\tto1\r\nfrom2\tto2\r\n"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_ONLY
-#: Merge.rc:5797
+#: Merge.rc:5798
 msgid "Built-in only"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_FIRST
-#: Merge.rc:5798
+#: Merge.rc:5799
 msgid "Built-in first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_FIRST
-#: Merge.rc:5799
+#: Merge.rc:5800
 msgid "Tree-sitter first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_ONLY
-#: Merge.rc:5800
+#: Merge.rc:5801
 msgid "Tree-sitter only"
 msgstr ""
 

--- a/Translations/WinMerge/English.pot
+++ b/Translations/WinMerge/English.pot
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: WinMerge\n"
 "Report-Msgid-Bugs-To: https://github.com/WinMerge/winmerge/issues/\n"
-"POT-Creation-Date: 2026-07-26 02:22+0000\n"
+"POT-Creation-Date: 2026-08-08 23:06+0000\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: English <winmerge-translate@lists.sourceforge.net>\n"
@@ -17,7 +17,7 @@ msgstr ""
 "X-Poedit-Basepath: ../../Src/\n"
 
 #. LANGUAGE, SUBLANGUAGE
-#: Merge.rc:26 Merge.rc:59 Merge.rc:5817
+#: Merge.rc:26 Merge.rc:59 Merge.rc:5818
 msgid "LANG_ENGLISH, SUBLANG_ENGLISH_US"
 msgstr ""
 
@@ -224,7 +224,7 @@ msgid "Auto-Fit All Columns"
 msgstr ""
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN
-#: Merge.rc:153 Merge.rc:5645
+#: Merge.rc:153 Merge.rc:5646
 msgid "&Filter by This Column"
 msgstr ""
 
@@ -285,7 +285,7 @@ msgid "&Previous Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_NEXTPAGE
-#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5678
+#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5679
 msgid "&Next Page"
 msgstr ""
 
@@ -658,7 +658,7 @@ msgid "&Huge"
 msgstr ""
 
 #. IDS_VIEW_MENU_BAR
-#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5713
+#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5714
 msgid "Men&u Bar"
 msgstr ""
 
@@ -4183,7 +4183,7 @@ msgid "Items compared:"
 msgstr ""
 
 #. IDS_PREVIEWBAR_CLOSE
-#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5684
+#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5685
 msgid "&Close"
 msgstr ""
 
@@ -7996,447 +7996,452 @@ msgstr ""
 msgid "2nd and 3rd"
 msgstr ""
 
+#. IDS_PLUGIN_CTRL_CLICK
+#: Merge.rc:5635
+msgid "(Ctrl+Click to add to pipeline)"
+msgstr ""
+
 #. IDS_FILTER_APPLIED
-#: Merge.rc:5639
+#: Merge.rc:5640
 msgid "Filter applied"
 msgstr ""
 
 #. IDS_FILTERMENU_COMPARE
-#: Merge.rc:5644
+#: Merge.rc:5645
 #, c-format
 msgid "Compare %1"
 msgstr ""
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN2
-#: Merge.rc:5646
+#: Merge.rc:5647
 msgid "&Filter by This Column..."
 msgstr ""
 
 #. IDS_CLIPBOARDHISTORY_TIME
-#: Merge.rc:5651
+#: Merge.rc:5652
 #, c-format
 msgid "Clipboard at %s"
 msgstr ""
 
 #. IDS_CLIPBOARDHISTORY_DISABLED
-#: Merge.rc:5652
+#: Merge.rc:5653
 msgid "Clipboard history disabled.\r\nEnable: Windows logo key + V, then Turn on."
 msgstr ""
 
-#: Merge.rc:5654
+#: Merge.rc:5655
 msgid "This system does not support clipboard history."
 msgstr ""
 
-#: Merge.rc:5656
+#: Merge.rc:5657
 msgid "32-bit WinMerge does not support Clipboard Compare"
 msgstr ""
 
 #. IDS_WEBVIEW2_RUNTIME_NOT_INSTALLED
-#: Merge.rc:5661
+#: Merge.rc:5662
 msgid "WebView2 runtime not installed. Download it?"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_TEXT_COMPARE
-#: Merge.rc:5666
+#: Merge.rc:5667
 msgid "New Text Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_TABLE_COMPARE
-#: Merge.rc:5667
+#: Merge.rc:5668
 msgid "New Table Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_BINARY_COMPARE
-#: Merge.rc:5668
+#: Merge.rc:5669
 msgid "New Binary Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_IMAGE_COMPARE
-#: Merge.rc:5669
+#: Merge.rc:5670
 msgid "New Image Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_WEBPAGE_COMPARE
-#: Merge.rc:5670
+#: Merge.rc:5671
 msgid "New Webpage Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_FOLDER_COMPARE
-#: Merge.rc:5671
+#: Merge.rc:5672
 msgid "New Folder Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_CLIPBOARD_COMPARE
-#: Merge.rc:5672
+#: Merge.rc:5673
 msgid "Clipboard Compare"
 msgstr ""
 
 #. IDS_PREVIEWBAR_PRINT
-#: Merge.rc:5677
+#: Merge.rc:5678
 msgid "&Print..."
 msgstr ""
 
 #. IDS_PREVIEWBAR_PREVPAGE
-#: Merge.rc:5679
+#: Merge.rc:5680
 msgid "Pre&v Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_TWOPAGE
-#: Merge.rc:5680
+#: Merge.rc:5681
 msgid "&Two Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_ONEPAGE
-#: Merge.rc:5681
+#: Merge.rc:5682
 msgid "&One Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_ZOOMIN
-#: Merge.rc:5682
+#: Merge.rc:5683
 msgid "Zoom &In"
 msgstr ""
 
 #. IDS_PREVIEWBAR_ZOOMOUT
-#: Merge.rc:5683
+#: Merge.rc:5684
 msgid "Zoom &Out"
 msgstr ""
 
 #. IDS_WEBPAGE_COMPARING
-#: Merge.rc:5689
+#: Merge.rc:5690
 msgid "Comparing..."
 msgstr ""
 
 #. IDS_WEBPAGE_ZOOM
-#: Merge.rc:5690
+#: Merge.rc:5691
 msgid "Zoom:"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_DIFFHUNK
-#: Merge.rc:5695
+#: Merge.rc:5696
 msgid "Diff hunk"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_INLINE
-#: Merge.rc:5696
+#: Merge.rc:5697
 msgid "Inline diff"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_LINE
-#: Merge.rc:5697
+#: Merge.rc:5698
 msgid "Line"
 msgstr ""
 
-#: Merge.rc:5698
+#: Merge.rc:5699
 msgid "Character"
 msgstr ""
 
 #. ID_MICE_PREVDIFF
-#: Merge.rc:5703
+#: Merge.rc:5704
 msgid "\nPrevious Difference (Alt+Up)\n(Right Button+Wheel Up)\n(Alt+Wheel Up)"
 msgstr ""
 
 #. ID_MICE_NEXTDIFF
-#: Merge.rc:5704
+#: Merge.rc:5705
 msgid "\nNext Difference (Alt+Down)\n(Right Button+Wheel Down)\n(Alt+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_L2R
-#: Merge.rc:5705
+#: Merge.rc:5706
 msgid "\nCopy to Right (Alt+Right)\n(Right Button+Wheel Right)\n(Alt+Wheel Right)\n(Alt+Shift+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_R2L
-#: Merge.rc:5706
+#: Merge.rc:5707
 msgid "\nCopy to Left (Alt+Left)\n(Right Button+Wheel Left)\n(Alt+Wheel Left)\n(Alt+Shift+Wheel Up)"
 msgstr ""
 
 #. ID_MICE_L2RNEXT
-#: Merge.rc:5707
+#: Merge.rc:5708
 msgid "\nCopy to Right and Advance (Ctrl+Alt+Right)\n(Ctrl+Alt+Wheel Right)\n(Ctrl+Alt+Shift+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_R2LNEXT
-#: Merge.rc:5708
+#: Merge.rc:5709
 msgid "\nCopy to Left and Advance (Ctrl+Alt+Left)\n(Ctrl+Alt+Wheel Left)\n(Ctrl+Alt+Shift+Wheel Up)"
 msgstr ""
 
 #. IDS_LOG_COMPARING_2
-#: Merge.rc:5718
+#: Merge.rc:5719
 #, c-format
 msgid "Comparing %1 with %2"
 msgstr ""
 
 #. IDS_LOG_COMPARING_3
-#: Merge.rc:5719
+#: Merge.rc:5720
 #, c-format
 msgid "Comparing %1 with %2 and %3"
 msgstr ""
 
 #. IDS_LOG_COMPARE_COMPLETED
-#: Merge.rc:5720
+#: Merge.rc:5721
 msgid "Comparison completed"
 msgstr ""
 
 #. IDS_LOG_COMPARE_ERROR_2
-#: Merge.rc:5721
+#: Merge.rc:5722
 #, c-format
 msgid "Failed to compare %1 with %2: "
 msgstr ""
 
 #. IDS_LOG_COMPARE_ERROR_3
-#: Merge.rc:5722
+#: Merge.rc:5723
 #, c-format
 msgid "Failed to compare %1 with %2 and %3: "
 msgstr ""
 
 #. IDS_LOG_FILE_SAVED
-#: Merge.rc:5723
+#: Merge.rc:5724
 msgid "File saved"
 msgstr ""
 
 #. IDS_LOG_COPYING_FILES
-#: Merge.rc:5724
+#: Merge.rc:5725
 msgid "Copying files..."
 msgstr ""
 
 #. IDS_LOG_MOVING_FILES
-#: Merge.rc:5725
+#: Merge.rc:5726
 msgid "Moving files..."
 msgstr ""
 
 #. IDS_LOG_DELETING_FILES
-#: Merge.rc:5726
+#: Merge.rc:5727
 msgid "Deleting files..."
 msgstr ""
 
 #. IDS_LOG_RECYCLEBIN
-#: Merge.rc:5727
+#: Merge.rc:5728
 msgid "Recycle Bin"
 msgstr ""
 
 #. IDS_LOG_PERMANENTLY_DELETED
-#: Merge.rc:5728
+#: Merge.rc:5729
 msgid "Permanently deleted"
 msgstr ""
 
 #. IDS_LOG_FILEOPERATION_COMPLETED
-#: Merge.rc:5729
+#: Merge.rc:5730
 msgid "File operation completed successfully"
 msgstr ""
 
 #. IDS_LOG_FILEOPERATION_CANCELED
-#: Merge.rc:5730
+#: Merge.rc:5731
 msgid "File operation canceled"
 msgstr ""
 
 #. IDS_FILTER_ERROR_NO_ERROR
-#: Merge.rc:5735
+#: Merge.rc:5736
 msgid "No error"
 msgstr ""
 
 #. IDS_FILTER_ERROR_EMPTY_EXPRESSION
-#: Merge.rc:5736
+#: Merge.rc:5737
 msgid "Filter expression is empty"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNKNOWN_CHAR
-#: Merge.rc:5737
+#: Merge.rc:5738
 msgid "Unknown character in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNTERMINATED_STRING
-#: Merge.rc:5738
+#: Merge.rc:5739
 msgid "Unterminated string literal"
 msgstr ""
 
 #. IDS_FILTER_ERROR_SYNTAX_ERROR
-#: Merge.rc:5739
+#: Merge.rc:5740
 msgid "Syntax error in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_PARSE_FAILURE
-#: Merge.rc:5740
+#: Merge.rc:5741
 msgid "Failed to parse filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_LITERAL
-#: Merge.rc:5741
+#: Merge.rc:5742
 msgid "Invalid literal value"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_REGULAR_EXPRESSION
-#: Merge.rc:5742
+#: Merge.rc:5743
 msgid "Invalid regular expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNDEFINED_IDENTIFIER
-#: Merge.rc:5743
+#: Merge.rc:5744
 msgid "Undefined identifier"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_ARGUMENT_COUNT
-#: Merge.rc:5744
+#: Merge.rc:5745
 msgid "Invalid number of arguments"
 msgstr ""
 
 #. IDS_FILTER_ERROR_FILTER_NAME_NOT_FOUND
-#: Merge.rc:5745
+#: Merge.rc:5746
 msgid "Filter name not found"
 msgstr ""
 
 #. IDS_FILTER_ERROR_DIVIDE_BY_ZERO
-#: Merge.rc:5746
+#: Merge.rc:5747
 msgid "Division by zero in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNKNOWN_ERROR
-#: Merge.rc:5747
+#: Merge.rc:5748
 msgid "Unknown error"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_PROPERTY_NAME
-#: Merge.rc:5748
+#: Merge.rc:5749
 msgid "Invalid property name"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_DIRECTIVE
-#: Merge.rc:5749
+#: Merge.rc:5750
 msgid "Invalid directive"
 msgstr ""
 
 #. IDS_FILTER_OP_EQUALS
-#: Merge.rc:5754
+#: Merge.rc:5755
 msgid "Equals"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_EQUALS
-#: Merge.rc:5755
+#: Merge.rc:5756
 msgid "Does not equal"
 msgstr ""
 
 #. IDS_FILTER_OP_LESS_THAN
-#: Merge.rc:5756
+#: Merge.rc:5757
 msgid "Less than"
 msgstr ""
 
 #. IDS_FILTER_OP_LESS_EQUAL
-#: Merge.rc:5757
+#: Merge.rc:5758
 msgid "Less than or equal to"
 msgstr ""
 
 #. IDS_FILTER_OP_GREATER_EQUAL
-#: Merge.rc:5758
+#: Merge.rc:5759
 msgid "Greater than or equal to"
 msgstr ""
 
 #. IDS_FILTER_OP_GREATER_THAN
-#: Merge.rc:5759
+#: Merge.rc:5760
 msgid "Greater than"
 msgstr ""
 
 #. IDS_FILTER_OP_BETWEEN
-#: Merge.rc:5760
+#: Merge.rc:5761
 msgid "Between"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_BETWEEN
-#: Merge.rc:5761
+#: Merge.rc:5762
 msgid "Not Between"
 msgstr ""
 
 #. IDS_FILTER_OP_CONTAINS
-#: Merge.rc:5762
+#: Merge.rc:5763
 msgid "Contains"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_CONTAINS
-#: Merge.rc:5763
+#: Merge.rc:5764
 msgid "Not Contains"
 msgstr ""
 
 #. IDS_FILTER_OP_RECONTAINS
-#: Merge.rc:5764
+#: Merge.rc:5765
 msgid "Contains (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_RECONTAINS
-#: Merge.rc:5765
+#: Merge.rc:5766
 msgid "Not Contains (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_LIKE
-#: Merge.rc:5766
+#: Merge.rc:5767
 msgid "Match (wildcard)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_LIKE
-#: Merge.rc:5767
+#: Merge.rc:5768
 msgid "Not match (wildcard)"
 msgstr ""
 
 #. IDS_FILTER_OP_MATCHES
-#: Merge.rc:5768
+#: Merge.rc:5769
 msgid "Match (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_MATCHES
-#: Merge.rc:5769
+#: Merge.rc:5770
 msgid "Not match (regex)"
 msgstr ""
 
 #. IDS_COLORMODE_LIGHT
-#: Merge.rc:5774
+#: Merge.rc:5775
 msgid "Light"
 msgstr ""
 
 #. IDS_COLORMODE_DARK
-#: Merge.rc:5775
+#: Merge.rc:5776
 msgid "Dark"
 msgstr ""
 
 #. IDS_COLORMODE_FOLLOWSYSTEM
-#: Merge.rc:5776
+#: Merge.rc:5777
 msgid "Follow system"
 msgstr ""
 
 #. IDS_EXAMPLE
-#: Merge.rc:5781
+#: Merge.rc:5782
 #, c-format
 msgid "e.g. %1"
 msgstr ""
 
 #. IDS_DETECTED_PREVIOUS_CRASH
-#: Merge.rc:5786
+#: Merge.rc:5787
 msgid "WinMerge detected a previous crash. Please report this if possible."
 msgstr ""
 
 #. IDS_REGEX_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5791
+#: Merge.rc:5792
 msgid "# Regex replacement list\r\n# Format: regex<TAB>replacement\r\n# Backreferences like $1, $2 are supported\r\n\r\n(\\d{4})-(\\d{2})-(\\d{2})\t$1_$2_$3\r\n"
 msgstr ""
 
 #. IDS_STRING_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5792
+#: Merge.rc:5793
 msgid "# Replacement list\r\n# Format: search<TAB>replacement\r\n# Lines starting with # are ignored\r\n\r\nfrom1\tto1\r\nfrom2\tto2\r\n"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_ONLY
-#: Merge.rc:5797
+#: Merge.rc:5798
 msgid "Built-in only"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_FIRST
-#: Merge.rc:5798
+#: Merge.rc:5799
 msgid "Built-in first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_FIRST
-#: Merge.rc:5799
+#: Merge.rc:5800
 msgid "Tree-sitter first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_ONLY
-#: Merge.rc:5800
+#: Merge.rc:5801
 msgid "Tree-sitter only"
 msgstr ""
 

--- a/Translations/WinMerge/Finnish.po
+++ b/Translations/WinMerge/Finnish.po
@@ -22,7 +22,7 @@ msgstr ""
 "X-Generator: Poedit 3.1.1\n"
 
 #. LANGUAGE, SUBLANGUAGE
-#: Merge.rc:26 Merge.rc:59 Merge.rc:5817
+#: Merge.rc:26 Merge.rc:59 Merge.rc:5818
 msgid "LANG_ENGLISH, SUBLANG_ENGLISH_US"
 msgstr "LANG_FINNISH, SUBLANG_DEFAULT"
 
@@ -230,7 +230,7 @@ msgid "Auto-Fit All Columns"
 msgstr "Sovita kaikki sarakkeet automaattisesti"
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN
-#: Merge.rc:153 Merge.rc:5645
+#: Merge.rc:153 Merge.rc:5646
 msgid "&Filter by This Column"
 msgstr ""
 
@@ -291,7 +291,7 @@ msgid "&Previous Page"
 msgstr "E&dellinen sivu"
 
 #. IDS_PREVIEWBAR_NEXTPAGE
-#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5678
+#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5679
 msgid "&Next Page"
 msgstr "Seu&raava sivu"
 
@@ -664,7 +664,7 @@ msgid "&Huge"
 msgstr "&Valtava"
 
 #. IDS_VIEW_MENU_BAR
-#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5713
+#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5714
 msgid "Men&u Bar"
 msgstr ""
 
@@ -4198,7 +4198,7 @@ msgid "Items compared:"
 msgstr "Verratut kohteet:"
 
 #. IDS_PREVIEWBAR_CLOSE
-#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5684
+#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5685
 msgid "&Close"
 msgstr "Sulje"
 
@@ -8332,447 +8332,452 @@ msgstr ""
 msgid "2nd and 3rd"
 msgstr ""
 
+#. IDS_PLUGIN_CTRL_CLICK
+#: Merge.rc:5635
+msgid "(Ctrl+Click to add to pipeline)"
+msgstr ""
+
 #. IDS_FILTER_APPLIED
-#: Merge.rc:5639
+#: Merge.rc:5640
 msgid "Filter applied"
 msgstr "Sovellettu suodatin"
 
 #. IDS_FILTERMENU_COMPARE
-#: Merge.rc:5644
+#: Merge.rc:5645
 #, c-format
 msgid "Compare %1"
 msgstr ""
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN2
-#: Merge.rc:5646
+#: Merge.rc:5647
 msgid "&Filter by This Column..."
 msgstr ""
 
 #. IDS_CLIPBOARDHISTORY_TIME
-#: Merge.rc:5651
+#: Merge.rc:5652
 #, c-format
 msgid "Clipboard at %s"
 msgstr "Leikepöytä %s"
 
 #. IDS_CLIPBOARDHISTORY_DISABLED
-#: Merge.rc:5652
+#: Merge.rc:5653
 msgid "Clipboard history disabled.\r\nEnable: Windows logo key + V, then Turn on."
 msgstr ""
 
-#: Merge.rc:5654
+#: Merge.rc:5655
 msgid "This system does not support clipboard history."
 msgstr "Tämä järjestelmä ei tue leikepöydän historiaa."
 
-#: Merge.rc:5656
+#: Merge.rc:5657
 msgid "32-bit WinMerge does not support Clipboard Compare"
 msgstr "WinMergen 32-bittinen versio ei tue leikepöytävertailua"
 
 #. IDS_WEBVIEW2_RUNTIME_NOT_INSTALLED
-#: Merge.rc:5661
+#: Merge.rc:5662
 msgid "WebView2 runtime not installed. Download it?"
 msgstr "WebView2-runtimea ei ole asennettu. Haluatko ladata sen?"
 
 #. IDS_JUMPLIST_NEW_TEXT_COMPARE
-#: Merge.rc:5666
+#: Merge.rc:5667
 msgid "New Text Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_TABLE_COMPARE
-#: Merge.rc:5667
+#: Merge.rc:5668
 msgid "New Table Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_BINARY_COMPARE
-#: Merge.rc:5668
+#: Merge.rc:5669
 msgid "New Binary Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_IMAGE_COMPARE
-#: Merge.rc:5669
+#: Merge.rc:5670
 msgid "New Image Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_WEBPAGE_COMPARE
-#: Merge.rc:5670
+#: Merge.rc:5671
 msgid "New Webpage Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_FOLDER_COMPARE
-#: Merge.rc:5671
+#: Merge.rc:5672
 msgid "New Folder Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_CLIPBOARD_COMPARE
-#: Merge.rc:5672
+#: Merge.rc:5673
 msgid "Clipboard Compare"
 msgstr ""
 
 #. IDS_PREVIEWBAR_PRINT
-#: Merge.rc:5677
+#: Merge.rc:5678
 msgid "&Print..."
 msgstr ""
 
 #. IDS_PREVIEWBAR_PREVPAGE
-#: Merge.rc:5679
+#: Merge.rc:5680
 msgid "Pre&v Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_TWOPAGE
-#: Merge.rc:5680
+#: Merge.rc:5681
 msgid "&Two Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_ONEPAGE
-#: Merge.rc:5681
+#: Merge.rc:5682
 msgid "&One Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_ZOOMIN
-#: Merge.rc:5682
+#: Merge.rc:5683
 msgid "Zoom &In"
 msgstr ""
 
 #. IDS_PREVIEWBAR_ZOOMOUT
-#: Merge.rc:5683
+#: Merge.rc:5684
 msgid "Zoom &Out"
 msgstr ""
 
 #. IDS_WEBPAGE_COMPARING
-#: Merge.rc:5689
+#: Merge.rc:5690
 msgid "Comparing..."
 msgstr ""
 
 #. IDS_WEBPAGE_ZOOM
-#: Merge.rc:5690
+#: Merge.rc:5691
 msgid "Zoom:"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_DIFFHUNK
-#: Merge.rc:5695
+#: Merge.rc:5696
 msgid "Diff hunk"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_INLINE
-#: Merge.rc:5696
+#: Merge.rc:5697
 msgid "Inline diff"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_LINE
-#: Merge.rc:5697
+#: Merge.rc:5698
 msgid "Line"
 msgstr ""
 
-#: Merge.rc:5698
+#: Merge.rc:5699
 msgid "Character"
 msgstr ""
 
 #. ID_MICE_PREVDIFF
-#: Merge.rc:5703
+#: Merge.rc:5704
 msgid "\nPrevious Difference (Alt+Up)\n(Right Button+Wheel Up)\n(Alt+Wheel Up)"
 msgstr ""
 
 #. ID_MICE_NEXTDIFF
-#: Merge.rc:5704
+#: Merge.rc:5705
 msgid "\nNext Difference (Alt+Down)\n(Right Button+Wheel Down)\n(Alt+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_L2R
-#: Merge.rc:5705
+#: Merge.rc:5706
 msgid "\nCopy to Right (Alt+Right)\n(Right Button+Wheel Right)\n(Alt+Wheel Right)\n(Alt+Shift+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_R2L
-#: Merge.rc:5706
+#: Merge.rc:5707
 msgid "\nCopy to Left (Alt+Left)\n(Right Button+Wheel Left)\n(Alt+Wheel Left)\n(Alt+Shift+Wheel Up)"
 msgstr ""
 
 #. ID_MICE_L2RNEXT
-#: Merge.rc:5707
+#: Merge.rc:5708
 msgid "\nCopy to Right and Advance (Ctrl+Alt+Right)\n(Ctrl+Alt+Wheel Right)\n(Ctrl+Alt+Shift+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_R2LNEXT
-#: Merge.rc:5708
+#: Merge.rc:5709
 msgid "\nCopy to Left and Advance (Ctrl+Alt+Left)\n(Ctrl+Alt+Wheel Left)\n(Ctrl+Alt+Shift+Wheel Up)"
 msgstr ""
 
 #. IDS_LOG_COMPARING_2
-#: Merge.rc:5718
+#: Merge.rc:5719
 #, c-format
 msgid "Comparing %1 with %2"
 msgstr ""
 
 #. IDS_LOG_COMPARING_3
-#: Merge.rc:5719
+#: Merge.rc:5720
 #, c-format
 msgid "Comparing %1 with %2 and %3"
 msgstr ""
 
 #. IDS_LOG_COMPARE_COMPLETED
-#: Merge.rc:5720
+#: Merge.rc:5721
 msgid "Comparison completed"
 msgstr ""
 
 #. IDS_LOG_COMPARE_ERROR_2
-#: Merge.rc:5721
+#: Merge.rc:5722
 #, c-format
 msgid "Failed to compare %1 with %2: "
 msgstr ""
 
 #. IDS_LOG_COMPARE_ERROR_3
-#: Merge.rc:5722
+#: Merge.rc:5723
 #, c-format
 msgid "Failed to compare %1 with %2 and %3: "
 msgstr ""
 
 #. IDS_LOG_FILE_SAVED
-#: Merge.rc:5723
+#: Merge.rc:5724
 msgid "File saved"
 msgstr ""
 
 #. IDS_LOG_COPYING_FILES
-#: Merge.rc:5724
+#: Merge.rc:5725
 msgid "Copying files..."
 msgstr ""
 
 #. IDS_LOG_MOVING_FILES
-#: Merge.rc:5725
+#: Merge.rc:5726
 msgid "Moving files..."
 msgstr ""
 
 #. IDS_LOG_DELETING_FILES
-#: Merge.rc:5726
+#: Merge.rc:5727
 msgid "Deleting files..."
 msgstr ""
 
 #. IDS_LOG_RECYCLEBIN
-#: Merge.rc:5727
+#: Merge.rc:5728
 msgid "Recycle Bin"
 msgstr ""
 
 #. IDS_LOG_PERMANENTLY_DELETED
-#: Merge.rc:5728
+#: Merge.rc:5729
 msgid "Permanently deleted"
 msgstr ""
 
 #. IDS_LOG_FILEOPERATION_COMPLETED
-#: Merge.rc:5729
+#: Merge.rc:5730
 msgid "File operation completed successfully"
 msgstr ""
 
 #. IDS_LOG_FILEOPERATION_CANCELED
-#: Merge.rc:5730
+#: Merge.rc:5731
 msgid "File operation canceled"
 msgstr ""
 
 #. IDS_FILTER_ERROR_NO_ERROR
-#: Merge.rc:5735
+#: Merge.rc:5736
 msgid "No error"
 msgstr ""
 
 #. IDS_FILTER_ERROR_EMPTY_EXPRESSION
-#: Merge.rc:5736
+#: Merge.rc:5737
 msgid "Filter expression is empty"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNKNOWN_CHAR
-#: Merge.rc:5737
+#: Merge.rc:5738
 msgid "Unknown character in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNTERMINATED_STRING
-#: Merge.rc:5738
+#: Merge.rc:5739
 msgid "Unterminated string literal"
 msgstr ""
 
 #. IDS_FILTER_ERROR_SYNTAX_ERROR
-#: Merge.rc:5739
+#: Merge.rc:5740
 msgid "Syntax error in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_PARSE_FAILURE
-#: Merge.rc:5740
+#: Merge.rc:5741
 msgid "Failed to parse filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_LITERAL
-#: Merge.rc:5741
+#: Merge.rc:5742
 msgid "Invalid literal value"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_REGULAR_EXPRESSION
-#: Merge.rc:5742
+#: Merge.rc:5743
 msgid "Invalid regular expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNDEFINED_IDENTIFIER
-#: Merge.rc:5743
+#: Merge.rc:5744
 msgid "Undefined identifier"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_ARGUMENT_COUNT
-#: Merge.rc:5744
+#: Merge.rc:5745
 msgid "Invalid number of arguments"
 msgstr ""
 
 #. IDS_FILTER_ERROR_FILTER_NAME_NOT_FOUND
-#: Merge.rc:5745
+#: Merge.rc:5746
 msgid "Filter name not found"
 msgstr ""
 
 #. IDS_FILTER_ERROR_DIVIDE_BY_ZERO
-#: Merge.rc:5746
+#: Merge.rc:5747
 msgid "Division by zero in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNKNOWN_ERROR
-#: Merge.rc:5747
+#: Merge.rc:5748
 msgid "Unknown error"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_PROPERTY_NAME
-#: Merge.rc:5748
+#: Merge.rc:5749
 msgid "Invalid property name"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_DIRECTIVE
-#: Merge.rc:5749
+#: Merge.rc:5750
 msgid "Invalid directive"
 msgstr ""
 
 #. IDS_FILTER_OP_EQUALS
-#: Merge.rc:5754
+#: Merge.rc:5755
 msgid "Equals"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_EQUALS
-#: Merge.rc:5755
+#: Merge.rc:5756
 msgid "Does not equal"
 msgstr ""
 
 #. IDS_FILTER_OP_LESS_THAN
-#: Merge.rc:5756
+#: Merge.rc:5757
 msgid "Less than"
 msgstr ""
 
 #. IDS_FILTER_OP_LESS_EQUAL
-#: Merge.rc:5757
+#: Merge.rc:5758
 msgid "Less than or equal to"
 msgstr ""
 
 #. IDS_FILTER_OP_GREATER_EQUAL
-#: Merge.rc:5758
+#: Merge.rc:5759
 msgid "Greater than or equal to"
 msgstr ""
 
 #. IDS_FILTER_OP_GREATER_THAN
-#: Merge.rc:5759
+#: Merge.rc:5760
 msgid "Greater than"
 msgstr ""
 
 #. IDS_FILTER_OP_BETWEEN
-#: Merge.rc:5760
+#: Merge.rc:5761
 msgid "Between"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_BETWEEN
-#: Merge.rc:5761
+#: Merge.rc:5762
 msgid "Not Between"
 msgstr ""
 
 #. IDS_FILTER_OP_CONTAINS
-#: Merge.rc:5762
+#: Merge.rc:5763
 msgid "Contains"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_CONTAINS
-#: Merge.rc:5763
+#: Merge.rc:5764
 msgid "Not Contains"
 msgstr ""
 
 #. IDS_FILTER_OP_RECONTAINS
-#: Merge.rc:5764
+#: Merge.rc:5765
 msgid "Contains (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_RECONTAINS
-#: Merge.rc:5765
+#: Merge.rc:5766
 msgid "Not Contains (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_LIKE
-#: Merge.rc:5766
+#: Merge.rc:5767
 msgid "Match (wildcard)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_LIKE
-#: Merge.rc:5767
+#: Merge.rc:5768
 msgid "Not match (wildcard)"
 msgstr ""
 
 #. IDS_FILTER_OP_MATCHES
-#: Merge.rc:5768
+#: Merge.rc:5769
 msgid "Match (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_MATCHES
-#: Merge.rc:5769
+#: Merge.rc:5770
 msgid "Not match (regex)"
 msgstr ""
 
 #. IDS_COLORMODE_LIGHT
-#: Merge.rc:5774
+#: Merge.rc:5775
 msgid "Light"
 msgstr ""
 
 #. IDS_COLORMODE_DARK
-#: Merge.rc:5775
+#: Merge.rc:5776
 msgid "Dark"
 msgstr ""
 
 #. IDS_COLORMODE_FOLLOWSYSTEM
-#: Merge.rc:5776
+#: Merge.rc:5777
 msgid "Follow system"
 msgstr ""
 
 #. IDS_EXAMPLE
-#: Merge.rc:5781
+#: Merge.rc:5782
 #, c-format
 msgid "e.g. %1"
 msgstr ""
 
 #. IDS_DETECTED_PREVIOUS_CRASH
-#: Merge.rc:5786
+#: Merge.rc:5787
 msgid "WinMerge detected a previous crash. Please report this if possible."
 msgstr ""
 
 #. IDS_REGEX_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5791
+#: Merge.rc:5792
 msgid "# Regex replacement list\r\n# Format: regex<TAB>replacement\r\n# Backreferences like $1, $2 are supported\r\n\r\n(\\d{4})-(\\d{2})-(\\d{2})\t$1_$2_$3\r\n"
 msgstr ""
 
 #. IDS_STRING_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5792
+#: Merge.rc:5793
 msgid "# Replacement list\r\n# Format: search<TAB>replacement\r\n# Lines starting with # are ignored\r\n\r\nfrom1\tto1\r\nfrom2\tto2\r\n"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_ONLY
-#: Merge.rc:5797
+#: Merge.rc:5798
 msgid "Built-in only"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_FIRST
-#: Merge.rc:5798
+#: Merge.rc:5799
 msgid "Built-in first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_FIRST
-#: Merge.rc:5799
+#: Merge.rc:5800
 msgid "Tree-sitter first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_ONLY
-#: Merge.rc:5800
+#: Merge.rc:5801
 msgid "Tree-sitter only"
 msgstr ""
 

--- a/Translations/WinMerge/French.po
+++ b/Translations/WinMerge/French.po
@@ -30,7 +30,7 @@ msgstr ""
 "X-Poedit-Basepath: ../../Src\n"
 
 #. LANGUAGE, SUBLANGUAGE
-#: Merge.rc:26 Merge.rc:59 Merge.rc:5817
+#: Merge.rc:26 Merge.rc:59 Merge.rc:5818
 msgid "LANG_ENGLISH, SUBLANG_ENGLISH_US"
 msgstr "LANG_FRENCH, SUBLANG_FRENCH"
 
@@ -237,7 +237,7 @@ msgid "Auto-Fit All Columns"
 msgstr "Ajuster automatiquement toutes les colonnes"
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN
-#: Merge.rc:153 Merge.rc:5645
+#: Merge.rc:153 Merge.rc:5646
 msgid "&Filter by This Column"
 msgstr "&Filtrer par cette colonne"
 
@@ -298,7 +298,7 @@ msgid "&Previous Page"
 msgstr "Page &précédente"
 
 #. IDS_PREVIEWBAR_NEXTPAGE
-#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5678
+#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5679
 msgid "&Next Page"
 msgstr "Page &suivante"
 
@@ -671,7 +671,7 @@ msgid "&Huge"
 msgstr "&Très grande"
 
 #. IDS_VIEW_MENU_BAR
-#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5713
+#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5714
 msgid "Men&u Bar"
 msgstr "Barre de men&u"
 
@@ -4198,7 +4198,7 @@ msgid "Items compared:"
 msgstr "Éléments comparés :"
 
 #. IDS_PREVIEWBAR_CLOSE
-#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5684
+#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5685
 msgid "&Close"
 msgstr "&Fermer"
 
@@ -8398,30 +8398,35 @@ msgstr "1er et 3ème"
 msgid "2nd and 3rd"
 msgstr "2ème et 3ème"
 
+#. IDS_PLUGIN_CTRL_CLICK
+#: Merge.rc:5635
+msgid "(Ctrl+Click to add to pipeline)"
+msgstr ""
+
 #. IDS_FILTER_APPLIED
-#: Merge.rc:5639
+#: Merge.rc:5640
 msgid "Filter applied"
 msgstr "Filtre appliqué"
 
 #. IDS_FILTERMENU_COMPARE
-#: Merge.rc:5644
+#: Merge.rc:5645
 #, c-format
 msgid "Compare %1"
 msgstr "Comparer %1"
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN2
-#: Merge.rc:5646
+#: Merge.rc:5647
 msgid "&Filter by This Column..."
 msgstr "&Filtrer par cette colonne..."
 
 #. IDS_CLIPBOARDHISTORY_TIME
-#: Merge.rc:5651
+#: Merge.rc:5652
 #, c-format
 msgid "Clipboard at %s"
 msgstr "Presse-papiers à %s"
 
 #. IDS_CLIPBOARDHISTORY_DISABLED
-#: Merge.rc:5652
+#: Merge.rc:5653
 msgid ""
 "Clipboard history disabled.\r\n"
 "Enable: Windows logo key + V, then Turn on."
@@ -8429,115 +8434,115 @@ msgstr ""
 "L'historique du presse-papiers est désactivé.\r\n"
 "Pour l'activer : appuyez sur la touche de logo Windows + V, puis cliquez sur Activer."
 
-#: Merge.rc:5654
+#: Merge.rc:5655
 msgid "This system does not support clipboard history."
 msgstr "Ce système ne prend pas en charge l'historique du presse-papiers."
 
-#: Merge.rc:5656
+#: Merge.rc:5657
 msgid "32-bit WinMerge does not support Clipboard Compare"
 msgstr "La version 32 bits de WinMerge ne prend pas en charge la comparaison du presse-papiers"
 
 #. IDS_WEBVIEW2_RUNTIME_NOT_INSTALLED
-#: Merge.rc:5661
+#: Merge.rc:5662
 msgid "WebView2 runtime not installed. Download it?"
 msgstr "Le runtime WebView2 n'est pas installé. Voulez-vous le télécharger ?"
 
 #. IDS_JUMPLIST_NEW_TEXT_COMPARE
-#: Merge.rc:5666
+#: Merge.rc:5667
 msgid "New Text Compare"
 msgstr "Nouvelle comparaison de texte"
 
 #. IDS_JUMPLIST_NEW_TABLE_COMPARE
-#: Merge.rc:5667
+#: Merge.rc:5668
 msgid "New Table Compare"
 msgstr "Nouvelle comparaison de tableau"
 
 #. IDS_JUMPLIST_NEW_BINARY_COMPARE
-#: Merge.rc:5668
+#: Merge.rc:5669
 msgid "New Binary Compare"
 msgstr "Nouvelle comparaison de binaire"
 
 #. IDS_JUMPLIST_NEW_IMAGE_COMPARE
-#: Merge.rc:5669
+#: Merge.rc:5670
 msgid "New Image Compare"
 msgstr "Nouvelle comparaison d'image"
 
 #. IDS_JUMPLIST_NEW_WEBPAGE_COMPARE
-#: Merge.rc:5670
+#: Merge.rc:5671
 msgid "New Webpage Compare"
 msgstr "Nouvelle comparaison de page Web"
 
 #. IDS_JUMPLIST_NEW_FOLDER_COMPARE
-#: Merge.rc:5671
+#: Merge.rc:5672
 msgid "New Folder Compare"
 msgstr "Comparer le nouveau dossier"
 
 #. IDS_JUMPLIST_CLIPBOARD_COMPARE
-#: Merge.rc:5672
+#: Merge.rc:5673
 msgid "Clipboard Compare"
 msgstr "Comparer le presse-papiers"
 
 #. IDS_PREVIEWBAR_PRINT
-#: Merge.rc:5677
+#: Merge.rc:5678
 msgid "&Print..."
 msgstr "Im&primer..."
 
 #. IDS_PREVIEWBAR_PREVPAGE
-#: Merge.rc:5679
+#: Merge.rc:5680
 msgid "Pre&v Page"
 msgstr "Page pré&c."
 
 #. IDS_PREVIEWBAR_TWOPAGE
-#: Merge.rc:5680
+#: Merge.rc:5681
 msgid "&Two Page"
 msgstr "&Deux pages"
 
 #. IDS_PREVIEWBAR_ONEPAGE
-#: Merge.rc:5681
+#: Merge.rc:5682
 msgid "&One Page"
 msgstr "&Une page"
 
 #. IDS_PREVIEWBAR_ZOOMIN
-#: Merge.rc:5682
+#: Merge.rc:5683
 msgid "Zoom &In"
 msgstr "Zoom a&vant"
 
 #. IDS_PREVIEWBAR_ZOOMOUT
-#: Merge.rc:5683
+#: Merge.rc:5684
 msgid "Zoom &Out"
 msgstr "Zoom a&rrière"
 
 #. IDS_WEBPAGE_COMPARING
-#: Merge.rc:5689
+#: Merge.rc:5690
 msgid "Comparing..."
 msgstr "Comparaison en cours..."
 
 #. IDS_WEBPAGE_ZOOM
-#: Merge.rc:5690
+#: Merge.rc:5691
 msgid "Zoom:"
 msgstr "Zoom  :"
 
 #. IDS_COPY_GRANULARITY_DIFFHUNK
-#: Merge.rc:5695
+#: Merge.rc:5696
 msgid "Diff hunk"
 msgstr "Différence en bloc"
 
 #. IDS_COPY_GRANULARITY_INLINE
-#: Merge.rc:5696
+#: Merge.rc:5697
 msgid "Inline diff"
 msgstr "Différence en ligne"
 
 #. IDS_COPY_GRANULARITY_LINE
-#: Merge.rc:5697
+#: Merge.rc:5698
 msgid "Line"
 msgstr "Ligne"
 
-#: Merge.rc:5698
+#: Merge.rc:5699
 msgid "Character"
 msgstr "Caractère"
 
 #. ID_MICE_PREVDIFF
-#: Merge.rc:5703
+#: Merge.rc:5704
 msgid ""
 "\n"
 "Previous Difference (Alt+Up)\n"
@@ -8550,7 +8555,7 @@ msgstr ""
 "(Alt+Molette vers le haut)"
 
 #. ID_MICE_NEXTDIFF
-#: Merge.rc:5704
+#: Merge.rc:5705
 msgid ""
 "\n"
 "Next Difference (Alt+Down)\n"
@@ -8563,7 +8568,7 @@ msgstr ""
 "(Alt+Molette vers le bas)"
 
 #. ID_MICE_L2R
-#: Merge.rc:5705
+#: Merge.rc:5706
 msgid ""
 "\n"
 "Copy to Right (Alt+Right)\n"
@@ -8578,7 +8583,7 @@ msgstr ""
 "(Alt+Maj+Molette vers le bas)"
 
 #. ID_MICE_R2L
-#: Merge.rc:5706
+#: Merge.rc:5707
 msgid ""
 "\n"
 "Copy to Left (Alt+Left)\n"
@@ -8593,7 +8598,7 @@ msgstr ""
 "(Alt+Maj+Molette haut)"
 
 #. ID_MICE_L2RNEXT
-#: Merge.rc:5707
+#: Merge.rc:5708
 msgid ""
 "\n"
 "Copy to Right and Advance (Ctrl+Alt+Right)\n"
@@ -8606,7 +8611,7 @@ msgstr ""
 "(Ctrl+Alt+Maj+Molette vers le bas)"
 
 #. ID_MICE_R2LNEXT
-#: Merge.rc:5708
+#: Merge.rc:5709
 msgid ""
 "\n"
 "Copy to Left and Advance (Ctrl+Alt+Left)\n"
@@ -8619,257 +8624,257 @@ msgstr ""
 "(Ctrl+Alt+Maj+Molette haut)"
 
 #. IDS_LOG_COMPARING_2
-#: Merge.rc:5718
+#: Merge.rc:5719
 #, c-format
 msgid "Comparing %1 with %2"
 msgstr "Comparaison de %1 avec %2"
 
 #. IDS_LOG_COMPARING_3
-#: Merge.rc:5719
+#: Merge.rc:5720
 #, c-format
 msgid "Comparing %1 with %2 and %3"
 msgstr "Comparaison de %1 avec %2 et %3"
 
 #. IDS_LOG_COMPARE_COMPLETED
-#: Merge.rc:5720
+#: Merge.rc:5721
 msgid "Comparison completed"
 msgstr "Comparaison terminée"
 
 #. IDS_LOG_COMPARE_ERROR_2
-#: Merge.rc:5721
+#: Merge.rc:5722
 #, c-format
 msgid "Failed to compare %1 with %2: "
 msgstr "Échec de la comparaison de %1 avec %2 : "
 
 #. IDS_LOG_COMPARE_ERROR_3
-#: Merge.rc:5722
+#: Merge.rc:5723
 #, c-format
 msgid "Failed to compare %1 with %2 and %3: "
 msgstr "Échec de la comparaison de %1 avec %2 et %3 : "
 
 #. IDS_LOG_FILE_SAVED
-#: Merge.rc:5723
+#: Merge.rc:5724
 msgid "File saved"
 msgstr "Fichier enregistré"
 
 #. IDS_LOG_COPYING_FILES
-#: Merge.rc:5724
+#: Merge.rc:5725
 msgid "Copying files..."
 msgstr "Copie de fichiers en cours..."
 
 #. IDS_LOG_MOVING_FILES
-#: Merge.rc:5725
+#: Merge.rc:5726
 msgid "Moving files..."
 msgstr "Déplacement de fichiers en cours..."
 
 #. IDS_LOG_DELETING_FILES
-#: Merge.rc:5726
+#: Merge.rc:5727
 msgid "Deleting files..."
 msgstr "Suppression de fichiers en cours..."
 
 #. IDS_LOG_RECYCLEBIN
-#: Merge.rc:5727
+#: Merge.rc:5728
 msgid "Recycle Bin"
 msgstr "Corbeille"
 
 #. IDS_LOG_PERMANENTLY_DELETED
-#: Merge.rc:5728
+#: Merge.rc:5729
 msgid "Permanently deleted"
 msgstr "Supprimé définitivement"
 
 #. IDS_LOG_FILEOPERATION_COMPLETED
-#: Merge.rc:5729
+#: Merge.rc:5730
 msgid "File operation completed successfully"
 msgstr "L'opération sur le fichier s'est déroulé avec succès"
 
 #. IDS_LOG_FILEOPERATION_CANCELED
-#: Merge.rc:5730
+#: Merge.rc:5731
 msgid "File operation canceled"
 msgstr "L'opération sur le fichier a été annulée"
 
 #. IDS_FILTER_ERROR_NO_ERROR
-#: Merge.rc:5735
+#: Merge.rc:5736
 msgid "No error"
 msgstr "Aucune erreur"
 
 #. IDS_FILTER_ERROR_EMPTY_EXPRESSION
-#: Merge.rc:5736
+#: Merge.rc:5737
 msgid "Filter expression is empty"
 msgstr "L'expression de filtre est vide"
 
 #. IDS_FILTER_ERROR_UNKNOWN_CHAR
-#: Merge.rc:5737
+#: Merge.rc:5738
 msgid "Unknown character in filter expression"
 msgstr "Caractère inconnu dans l'expression du filtre"
 
 #. IDS_FILTER_ERROR_UNTERMINATED_STRING
-#: Merge.rc:5738
+#: Merge.rc:5739
 msgid "Unterminated string literal"
 msgstr "Littéral de chaîne non terminé"
 
 #. IDS_FILTER_ERROR_SYNTAX_ERROR
-#: Merge.rc:5739
+#: Merge.rc:5740
 msgid "Syntax error in filter expression"
 msgstr "Erreur de syntaxe dans l'expression du filtre"
 
 #. IDS_FILTER_ERROR_PARSE_FAILURE
-#: Merge.rc:5740
+#: Merge.rc:5741
 msgid "Failed to parse filter expression"
 msgstr "Échec de l'analyse de l'expression du filtre"
 
 #. IDS_FILTER_ERROR_INVALID_LITERAL
-#: Merge.rc:5741
+#: Merge.rc:5742
 msgid "Invalid literal value"
 msgstr "Valeur littérale non valide"
 
 #. IDS_FILTER_ERROR_INVALID_REGULAR_EXPRESSION
-#: Merge.rc:5742
+#: Merge.rc:5743
 msgid "Invalid regular expression"
 msgstr "Expression régulière invalide"
 
 #. IDS_FILTER_ERROR_UNDEFINED_IDENTIFIER
-#: Merge.rc:5743
+#: Merge.rc:5744
 msgid "Undefined identifier"
 msgstr "Identifiant non défini"
 
 #. IDS_FILTER_ERROR_INVALID_ARGUMENT_COUNT
-#: Merge.rc:5744
+#: Merge.rc:5745
 msgid "Invalid number of arguments"
 msgstr "Nombre d'arguments invalide"
 
 #. IDS_FILTER_ERROR_FILTER_NAME_NOT_FOUND
-#: Merge.rc:5745
+#: Merge.rc:5746
 msgid "Filter name not found"
 msgstr "Nom du filtre introuvable"
 
 #. IDS_FILTER_ERROR_DIVIDE_BY_ZERO
-#: Merge.rc:5746
+#: Merge.rc:5747
 msgid "Division by zero in filter expression"
 msgstr "Division par zéro dans l'expression du filtre"
 
 #. IDS_FILTER_ERROR_UNKNOWN_ERROR
-#: Merge.rc:5747
+#: Merge.rc:5748
 msgid "Unknown error"
 msgstr "Erreur inconnue"
 
 #. IDS_FILTER_ERROR_INVALID_PROPERTY_NAME
-#: Merge.rc:5748
+#: Merge.rc:5749
 msgid "Invalid property name"
 msgstr "Nom de propriété invalide"
 
 #. IDS_FILTER_ERROR_INVALID_DIRECTIVE
-#: Merge.rc:5749
+#: Merge.rc:5750
 msgid "Invalid directive"
 msgstr "Directive invalide"
 
 #. IDS_FILTER_OP_EQUALS
-#: Merge.rc:5754
+#: Merge.rc:5755
 msgid "Equals"
 msgstr "Égal"
 
 #. IDS_FILTER_OP_NOT_EQUALS
-#: Merge.rc:5755
+#: Merge.rc:5756
 msgid "Does not equal"
 msgstr "N'est pas égal"
 
 #. IDS_FILTER_OP_LESS_THAN
-#: Merge.rc:5756
+#: Merge.rc:5757
 msgid "Less than"
 msgstr "Inférieur à"
 
 #. IDS_FILTER_OP_LESS_EQUAL
-#: Merge.rc:5757
+#: Merge.rc:5758
 msgid "Less than or equal to"
 msgstr "Inférieur ou égal à"
 
 #. IDS_FILTER_OP_GREATER_EQUAL
-#: Merge.rc:5758
+#: Merge.rc:5759
 msgid "Greater than or equal to"
 msgstr "Supérieur ou égal à"
 
 #. IDS_FILTER_OP_GREATER_THAN
-#: Merge.rc:5759
+#: Merge.rc:5760
 msgid "Greater than"
 msgstr "Supérieur à"
 
 #. IDS_FILTER_OP_BETWEEN
-#: Merge.rc:5760
+#: Merge.rc:5761
 msgid "Between"
 msgstr "Entre"
 
 #. IDS_FILTER_OP_NOT_BETWEEN
-#: Merge.rc:5761
+#: Merge.rc:5762
 msgid "Not Between"
 msgstr "Pas entre"
 
 #. IDS_FILTER_OP_CONTAINS
-#: Merge.rc:5762
+#: Merge.rc:5763
 msgid "Contains"
 msgstr "Contient"
 
 #. IDS_FILTER_OP_NOT_CONTAINS
-#: Merge.rc:5763
+#: Merge.rc:5764
 msgid "Not Contains"
 msgstr "Ne contient pas"
 
 #. IDS_FILTER_OP_RECONTAINS
-#: Merge.rc:5764
+#: Merge.rc:5765
 msgid "Contains (regex)"
 msgstr "Contient (regex)"
 
 #. IDS_FILTER_OP_NOT_RECONTAINS
-#: Merge.rc:5765
+#: Merge.rc:5766
 msgid "Not Contains (regex)"
 msgstr "Ne contient pas (regex)"
 
 #. IDS_FILTER_OP_LIKE
-#: Merge.rc:5766
+#: Merge.rc:5767
 msgid "Match (wildcard)"
 msgstr "Correspond (caractère générique)"
 
 #. IDS_FILTER_OP_NOT_LIKE
-#: Merge.rc:5767
+#: Merge.rc:5768
 msgid "Not match (wildcard)"
 msgstr "Ne correspond pas (caractère générique)"
 
 #. IDS_FILTER_OP_MATCHES
-#: Merge.rc:5768
+#: Merge.rc:5769
 msgid "Match (regex)"
 msgstr "Correspond (regex)"
 
 #. IDS_FILTER_OP_NOT_MATCHES
-#: Merge.rc:5769
+#: Merge.rc:5770
 msgid "Not match (regex)"
 msgstr "Ne correspond pas (regex)"
 
 #. IDS_COLORMODE_LIGHT
-#: Merge.rc:5774
+#: Merge.rc:5775
 msgid "Light"
 msgstr "Clair"
 
 #. IDS_COLORMODE_DARK
-#: Merge.rc:5775
+#: Merge.rc:5776
 msgid "Dark"
 msgstr "Foncé"
 
 #. IDS_COLORMODE_FOLLOWSYSTEM
-#: Merge.rc:5776
+#: Merge.rc:5777
 msgid "Follow system"
 msgstr "Suivre le système"
 
 #. IDS_EXAMPLE
-#: Merge.rc:5781
+#: Merge.rc:5782
 #, c-format
 msgid "e.g. %1"
 msgstr "p. ex. %1"
 
 #. IDS_DETECTED_PREVIOUS_CRASH
-#: Merge.rc:5786
+#: Merge.rc:5787
 msgid "WinMerge detected a previous crash. Please report this if possible."
 msgstr "WinMerge a détecté un plantage précédent. Veuillez le signaler si possible."
 
 #. IDS_REGEX_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5791
+#: Merge.rc:5792
 msgid ""
 "# Regex replacement list\r\n"
 "# Format: regex<TAB>replacement\r\n"
@@ -8885,7 +8890,7 @@ msgstr ""
 "\v\n"
 
 #. IDS_STRING_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5792
+#: Merge.rc:5793
 msgid ""
 "# Replacement list\r\n"
 "# Format: search<TAB>replacement\r\n"
@@ -8902,22 +8907,22 @@ msgstr ""
 "\v\n"
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_ONLY
-#: Merge.rc:5797
+#: Merge.rc:5798
 msgid "Built-in only"
 msgstr "Intégré uniquement"
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_FIRST
-#: Merge.rc:5798
+#: Merge.rc:5799
 msgid "Built-in first"
 msgstr "Intégré en premier"
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_FIRST
-#: Merge.rc:5799
+#: Merge.rc:5800
 msgid "Tree-sitter first"
 msgstr "Tree-sitter en premier"
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_ONLY
-#: Merge.rc:5800
+#: Merge.rc:5801
 msgid "Tree-sitter only"
 msgstr "Tree-sitter uniquement"
 

--- a/Translations/WinMerge/Galician.po
+++ b/Translations/WinMerge/Galician.po
@@ -24,7 +24,7 @@ msgstr ""
 "X-Generator: Poedit 3.4.1\n"
 
 #. LANGUAGE, SUBLANGUAGE
-#: Merge.rc:26 Merge.rc:59 Merge.rc:5817
+#: Merge.rc:26 Merge.rc:59 Merge.rc:5818
 msgid "LANG_ENGLISH, SUBLANG_ENGLISH_US"
 msgstr "LANG_GALICIAN, SUBLANG_DEFAULT"
 
@@ -231,7 +231,7 @@ msgid "Auto-Fit All Columns"
 msgstr "Auto axustar todas as columnas"
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN
-#: Merge.rc:153 Merge.rc:5645
+#: Merge.rc:153 Merge.rc:5646
 msgid "&Filter by This Column"
 msgstr ""
 
@@ -292,7 +292,7 @@ msgid "&Previous Page"
 msgstr "&Páxina anterior"
 
 #. IDS_PREVIEWBAR_NEXTPAGE
-#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5678
+#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5679
 msgid "&Next Page"
 msgstr "Páxi&na seguinte"
 
@@ -665,7 +665,7 @@ msgid "&Huge"
 msgstr "&Enorme"
 
 #. IDS_VIEW_MENU_BAR
-#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5713
+#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5714
 msgid "Men&u Bar"
 msgstr ""
 
@@ -4190,7 +4190,7 @@ msgid "Items compared:"
 msgstr "Elementos comparados:"
 
 #. IDS_PREVIEWBAR_CLOSE
-#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5684
+#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5685
 msgid "&Close"
 msgstr "Pe&char"
 
@@ -8331,30 +8331,35 @@ msgstr ""
 msgid "2nd and 3rd"
 msgstr ""
 
+#. IDS_PLUGIN_CTRL_CLICK
+#: Merge.rc:5635
+msgid "(Ctrl+Click to add to pipeline)"
+msgstr ""
+
 #. IDS_FILTER_APPLIED
-#: Merge.rc:5639
+#: Merge.rc:5640
 msgid "Filter applied"
 msgstr "Filtro aplicado"
 
 #. IDS_FILTERMENU_COMPARE
-#: Merge.rc:5644
+#: Merge.rc:5645
 #, c-format
 msgid "Compare %1"
 msgstr ""
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN2
-#: Merge.rc:5646
+#: Merge.rc:5647
 msgid "&Filter by This Column..."
 msgstr ""
 
 #. IDS_CLIPBOARDHISTORY_TIME
-#: Merge.rc:5651
+#: Merge.rc:5652
 #, c-format
 msgid "Clipboard at %s"
 msgstr "Portapapeis en %s"
 
 #. IDS_CLIPBOARDHISTORY_DISABLED
-#: Merge.rc:5652
+#: Merge.rc:5653
 msgid ""
 "Clipboard history disabled.\r\n"
 "Enable: Windows logo key + V, then Turn on."
@@ -8362,420 +8367,420 @@ msgstr ""
 "O historial do portapapeis está desactivado.\r\n"
 "Para habilitar o historial do portapapeis, prema na tecla do logo de Windows + V e logo no botón Activar."
 
-#: Merge.rc:5654
+#: Merge.rc:5655
 msgid "This system does not support clipboard history."
 msgstr "Este sistema non soporta o historial do portapapeis."
 
-#: Merge.rc:5656
+#: Merge.rc:5657
 msgid "32-bit WinMerge does not support Clipboard Compare"
 msgstr "A versión de 32 bit de WinMerge non soporta a comparación de portapapeis"
 
 #. IDS_WEBVIEW2_RUNTIME_NOT_INSTALLED
-#: Merge.rc:5661
+#: Merge.rc:5662
 msgid "WebView2 runtime not installed. Download it?"
 msgstr "O runtime WebView2 non está instalado. Quere descargalo?"
 
 #. IDS_JUMPLIST_NEW_TEXT_COMPARE
-#: Merge.rc:5666
+#: Merge.rc:5667
 msgid "New Text Compare"
 msgstr "Nova comparación de texto"
 
 #. IDS_JUMPLIST_NEW_TABLE_COMPARE
-#: Merge.rc:5667
+#: Merge.rc:5668
 msgid "New Table Compare"
 msgstr "Nova comparación de táboa"
 
 #. IDS_JUMPLIST_NEW_BINARY_COMPARE
-#: Merge.rc:5668
+#: Merge.rc:5669
 msgid "New Binary Compare"
 msgstr "Nova comparación binaria"
 
 #. IDS_JUMPLIST_NEW_IMAGE_COMPARE
-#: Merge.rc:5669
+#: Merge.rc:5670
 msgid "New Image Compare"
 msgstr "Nova comparación de imaxe"
 
 #. IDS_JUMPLIST_NEW_WEBPAGE_COMPARE
-#: Merge.rc:5670
+#: Merge.rc:5671
 msgid "New Webpage Compare"
 msgstr "Nova comparación de páxina web"
 
 #. IDS_JUMPLIST_NEW_FOLDER_COMPARE
-#: Merge.rc:5671
+#: Merge.rc:5672
 msgid "New Folder Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_CLIPBOARD_COMPARE
-#: Merge.rc:5672
+#: Merge.rc:5673
 msgid "Clipboard Compare"
 msgstr "Comparar de portapapeis"
 
 #. IDS_PREVIEWBAR_PRINT
-#: Merge.rc:5677
+#: Merge.rc:5678
 msgid "&Print..."
 msgstr "Im&primir..."
 
 #. IDS_PREVIEWBAR_PREVPAGE
-#: Merge.rc:5679
+#: Merge.rc:5680
 msgid "Pre&v Page"
 msgstr "Páxina an&terior"
 
 #. IDS_PREVIEWBAR_TWOPAGE
-#: Merge.rc:5680
+#: Merge.rc:5681
 msgid "&Two Page"
 msgstr "&Dúas páxinas"
 
 #. IDS_PREVIEWBAR_ONEPAGE
-#: Merge.rc:5681
+#: Merge.rc:5682
 msgid "&One Page"
 msgstr "Un&ha páxina"
 
 #. IDS_PREVIEWBAR_ZOOMIN
-#: Merge.rc:5682
+#: Merge.rc:5683
 msgid "Zoom &In"
 msgstr "Aumentar &zoom"
 
 #. IDS_PREVIEWBAR_ZOOMOUT
-#: Merge.rc:5683
+#: Merge.rc:5684
 msgid "Zoom &Out"
 msgstr "Reducir z&oom"
 
 #. IDS_WEBPAGE_COMPARING
-#: Merge.rc:5689
+#: Merge.rc:5690
 msgid "Comparing..."
 msgstr ""
 
 #. IDS_WEBPAGE_ZOOM
-#: Merge.rc:5690
+#: Merge.rc:5691
 msgid "Zoom:"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_DIFFHUNK
-#: Merge.rc:5695
+#: Merge.rc:5696
 msgid "Diff hunk"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_INLINE
-#: Merge.rc:5696
+#: Merge.rc:5697
 msgid "Inline diff"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_LINE
-#: Merge.rc:5697
+#: Merge.rc:5698
 msgid "Line"
 msgstr ""
 
-#: Merge.rc:5698
+#: Merge.rc:5699
 msgid "Character"
 msgstr ""
 
 #. ID_MICE_PREVDIFF
-#: Merge.rc:5703
+#: Merge.rc:5704
 msgid "\nPrevious Difference (Alt+Up)\n(Right Button+Wheel Up)\n(Alt+Wheel Up)"
 msgstr ""
 
 #. ID_MICE_NEXTDIFF
-#: Merge.rc:5704
+#: Merge.rc:5705
 msgid "\nNext Difference (Alt+Down)\n(Right Button+Wheel Down)\n(Alt+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_L2R
-#: Merge.rc:5705
+#: Merge.rc:5706
 msgid "\nCopy to Right (Alt+Right)\n(Right Button+Wheel Right)\n(Alt+Wheel Right)\n(Alt+Shift+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_R2L
-#: Merge.rc:5706
+#: Merge.rc:5707
 msgid "\nCopy to Left (Alt+Left)\n(Right Button+Wheel Left)\n(Alt+Wheel Left)\n(Alt+Shift+Wheel Up)"
 msgstr ""
 
 #. ID_MICE_L2RNEXT
-#: Merge.rc:5707
+#: Merge.rc:5708
 msgid "\nCopy to Right and Advance (Ctrl+Alt+Right)\n(Ctrl+Alt+Wheel Right)\n(Ctrl+Alt+Shift+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_R2LNEXT
-#: Merge.rc:5708
+#: Merge.rc:5709
 msgid "\nCopy to Left and Advance (Ctrl+Alt+Left)\n(Ctrl+Alt+Wheel Left)\n(Ctrl+Alt+Shift+Wheel Up)"
 msgstr ""
 
 #. IDS_LOG_COMPARING_2
-#: Merge.rc:5718
+#: Merge.rc:5719
 #, c-format
 msgid "Comparing %1 with %2"
 msgstr ""
 
 #. IDS_LOG_COMPARING_3
-#: Merge.rc:5719
+#: Merge.rc:5720
 #, c-format
 msgid "Comparing %1 with %2 and %3"
 msgstr ""
 
 #. IDS_LOG_COMPARE_COMPLETED
-#: Merge.rc:5720
+#: Merge.rc:5721
 msgid "Comparison completed"
 msgstr ""
 
 #. IDS_LOG_COMPARE_ERROR_2
-#: Merge.rc:5721
+#: Merge.rc:5722
 #, c-format
 msgid "Failed to compare %1 with %2: "
 msgstr ""
 
 #. IDS_LOG_COMPARE_ERROR_3
-#: Merge.rc:5722
+#: Merge.rc:5723
 #, c-format
 msgid "Failed to compare %1 with %2 and %3: "
 msgstr ""
 
 #. IDS_LOG_FILE_SAVED
-#: Merge.rc:5723
+#: Merge.rc:5724
 msgid "File saved"
 msgstr ""
 
 #. IDS_LOG_COPYING_FILES
-#: Merge.rc:5724
+#: Merge.rc:5725
 msgid "Copying files..."
 msgstr ""
 
 #. IDS_LOG_MOVING_FILES
-#: Merge.rc:5725
+#: Merge.rc:5726
 msgid "Moving files..."
 msgstr ""
 
 #. IDS_LOG_DELETING_FILES
-#: Merge.rc:5726
+#: Merge.rc:5727
 msgid "Deleting files..."
 msgstr ""
 
 #. IDS_LOG_RECYCLEBIN
-#: Merge.rc:5727
+#: Merge.rc:5728
 msgid "Recycle Bin"
 msgstr ""
 
 #. IDS_LOG_PERMANENTLY_DELETED
-#: Merge.rc:5728
+#: Merge.rc:5729
 msgid "Permanently deleted"
 msgstr ""
 
 #. IDS_LOG_FILEOPERATION_COMPLETED
-#: Merge.rc:5729
+#: Merge.rc:5730
 msgid "File operation completed successfully"
 msgstr ""
 
 #. IDS_LOG_FILEOPERATION_CANCELED
-#: Merge.rc:5730
+#: Merge.rc:5731
 msgid "File operation canceled"
 msgstr ""
 
 #. IDS_FILTER_ERROR_NO_ERROR
-#: Merge.rc:5735
+#: Merge.rc:5736
 msgid "No error"
 msgstr ""
 
 #. IDS_FILTER_ERROR_EMPTY_EXPRESSION
-#: Merge.rc:5736
+#: Merge.rc:5737
 msgid "Filter expression is empty"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNKNOWN_CHAR
-#: Merge.rc:5737
+#: Merge.rc:5738
 msgid "Unknown character in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNTERMINATED_STRING
-#: Merge.rc:5738
+#: Merge.rc:5739
 msgid "Unterminated string literal"
 msgstr ""
 
 #. IDS_FILTER_ERROR_SYNTAX_ERROR
-#: Merge.rc:5739
+#: Merge.rc:5740
 msgid "Syntax error in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_PARSE_FAILURE
-#: Merge.rc:5740
+#: Merge.rc:5741
 msgid "Failed to parse filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_LITERAL
-#: Merge.rc:5741
+#: Merge.rc:5742
 msgid "Invalid literal value"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_REGULAR_EXPRESSION
-#: Merge.rc:5742
+#: Merge.rc:5743
 msgid "Invalid regular expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNDEFINED_IDENTIFIER
-#: Merge.rc:5743
+#: Merge.rc:5744
 msgid "Undefined identifier"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_ARGUMENT_COUNT
-#: Merge.rc:5744
+#: Merge.rc:5745
 msgid "Invalid number of arguments"
 msgstr ""
 
 #. IDS_FILTER_ERROR_FILTER_NAME_NOT_FOUND
-#: Merge.rc:5745
+#: Merge.rc:5746
 msgid "Filter name not found"
 msgstr ""
 
 #. IDS_FILTER_ERROR_DIVIDE_BY_ZERO
-#: Merge.rc:5746
+#: Merge.rc:5747
 msgid "Division by zero in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNKNOWN_ERROR
-#: Merge.rc:5747
+#: Merge.rc:5748
 msgid "Unknown error"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_PROPERTY_NAME
-#: Merge.rc:5748
+#: Merge.rc:5749
 msgid "Invalid property name"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_DIRECTIVE
-#: Merge.rc:5749
+#: Merge.rc:5750
 msgid "Invalid directive"
 msgstr ""
 
 #. IDS_FILTER_OP_EQUALS
-#: Merge.rc:5754
+#: Merge.rc:5755
 msgid "Equals"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_EQUALS
-#: Merge.rc:5755
+#: Merge.rc:5756
 msgid "Does not equal"
 msgstr ""
 
 #. IDS_FILTER_OP_LESS_THAN
-#: Merge.rc:5756
+#: Merge.rc:5757
 msgid "Less than"
 msgstr ""
 
 #. IDS_FILTER_OP_LESS_EQUAL
-#: Merge.rc:5757
+#: Merge.rc:5758
 msgid "Less than or equal to"
 msgstr ""
 
 #. IDS_FILTER_OP_GREATER_EQUAL
-#: Merge.rc:5758
+#: Merge.rc:5759
 msgid "Greater than or equal to"
 msgstr ""
 
 #. IDS_FILTER_OP_GREATER_THAN
-#: Merge.rc:5759
+#: Merge.rc:5760
 msgid "Greater than"
 msgstr ""
 
 #. IDS_FILTER_OP_BETWEEN
-#: Merge.rc:5760
+#: Merge.rc:5761
 msgid "Between"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_BETWEEN
-#: Merge.rc:5761
+#: Merge.rc:5762
 msgid "Not Between"
 msgstr ""
 
 #. IDS_FILTER_OP_CONTAINS
-#: Merge.rc:5762
+#: Merge.rc:5763
 msgid "Contains"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_CONTAINS
-#: Merge.rc:5763
+#: Merge.rc:5764
 msgid "Not Contains"
 msgstr ""
 
 #. IDS_FILTER_OP_RECONTAINS
-#: Merge.rc:5764
+#: Merge.rc:5765
 msgid "Contains (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_RECONTAINS
-#: Merge.rc:5765
+#: Merge.rc:5766
 msgid "Not Contains (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_LIKE
-#: Merge.rc:5766
+#: Merge.rc:5767
 msgid "Match (wildcard)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_LIKE
-#: Merge.rc:5767
+#: Merge.rc:5768
 msgid "Not match (wildcard)"
 msgstr ""
 
 #. IDS_FILTER_OP_MATCHES
-#: Merge.rc:5768
+#: Merge.rc:5769
 msgid "Match (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_MATCHES
-#: Merge.rc:5769
+#: Merge.rc:5770
 msgid "Not match (regex)"
 msgstr ""
 
 #. IDS_COLORMODE_LIGHT
-#: Merge.rc:5774
+#: Merge.rc:5775
 msgid "Light"
 msgstr ""
 
 #. IDS_COLORMODE_DARK
-#: Merge.rc:5775
+#: Merge.rc:5776
 msgid "Dark"
 msgstr ""
 
 #. IDS_COLORMODE_FOLLOWSYSTEM
-#: Merge.rc:5776
+#: Merge.rc:5777
 msgid "Follow system"
 msgstr ""
 
 #. IDS_EXAMPLE
-#: Merge.rc:5781
+#: Merge.rc:5782
 #, c-format
 msgid "e.g. %1"
 msgstr ""
 
 #. IDS_DETECTED_PREVIOUS_CRASH
-#: Merge.rc:5786
+#: Merge.rc:5787
 msgid "WinMerge detected a previous crash. Please report this if possible."
 msgstr ""
 
 #. IDS_REGEX_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5791
+#: Merge.rc:5792
 msgid "# Regex replacement list\r\n# Format: regex<TAB>replacement\r\n# Backreferences like $1, $2 are supported\r\n\r\n(\\d{4})-(\\d{2})-(\\d{2})\t$1_$2_$3\r\n"
 msgstr ""
 
 #. IDS_STRING_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5792
+#: Merge.rc:5793
 msgid "# Replacement list\r\n# Format: search<TAB>replacement\r\n# Lines starting with # are ignored\r\n\r\nfrom1\tto1\r\nfrom2\tto2\r\n"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_ONLY
-#: Merge.rc:5797
+#: Merge.rc:5798
 msgid "Built-in only"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_FIRST
-#: Merge.rc:5798
+#: Merge.rc:5799
 msgid "Built-in first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_FIRST
-#: Merge.rc:5799
+#: Merge.rc:5800
 msgid "Tree-sitter first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_ONLY
-#: Merge.rc:5800
+#: Merge.rc:5801
 msgid "Tree-sitter only"
 msgstr ""
 

--- a/Translations/WinMerge/German.po
+++ b/Translations/WinMerge/German.po
@@ -26,7 +26,7 @@ msgstr ""
 "X-Poedit-Basepath: ../../Src\n"
 
 #. LANGUAGE, SUBLANGUAGE
-#: Merge.rc:26 Merge.rc:59 Merge.rc:5817
+#: Merge.rc:26 Merge.rc:59 Merge.rc:5818
 #, c-format
 msgid "LANG_ENGLISH, SUBLANG_ENGLISH_US"
 msgstr "LANG_GERMAN, SUBLANG_GERMAN"
@@ -243,7 +243,7 @@ msgid "Auto-Fit All Columns"
 msgstr "Alle Spalten automatisch anpassen"
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN
-#: Merge.rc:153 Merge.rc:5645
+#: Merge.rc:153 Merge.rc:5646
 msgid "&Filter by This Column"
 msgstr "Nach dieser Spalte &filtern"
 
@@ -309,7 +309,7 @@ msgid "&Previous Page"
 msgstr "&Vorherige Seite"
 
 #. IDS_PREVIEWBAR_NEXTPAGE
-#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5678
+#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5679
 #, c-format
 msgid "&Next Page"
 msgstr "&Nächste Seite"
@@ -715,7 +715,7 @@ msgid "&Huge"
 msgstr "&Riesig"
 
 #. IDS_VIEW_MENU_BAR
-#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5713
+#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5714
 msgid "Men&u Bar"
 msgstr "Men&üleiste"
 
@@ -4578,7 +4578,7 @@ msgid "Items compared:"
 msgstr "Objekte verglichen:"
 
 #. IDS_PREVIEWBAR_CLOSE
-#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5684
+#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5685
 #, c-format
 msgid "&Close"
 msgstr "&Schließen"
@@ -9129,30 +9129,35 @@ msgstr "1. und 3."
 msgid "2nd and 3rd"
 msgstr "2. und 3."
 
+#. IDS_PLUGIN_CTRL_CLICK
+#: Merge.rc:5635
+msgid "(Ctrl+Click to add to pipeline)"
+msgstr ""
+
 #. IDS_FILTER_APPLIED
-#: Merge.rc:5639
+#: Merge.rc:5640
 msgid "Filter applied"
 msgstr "Angewandter Filter"
 
 #. IDS_FILTERMENU_COMPARE
-#: Merge.rc:5644
+#: Merge.rc:5645
 #, c-format
 msgid "Compare %1"
 msgstr "Vergleiche %1"
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN2
-#: Merge.rc:5646
+#: Merge.rc:5647
 msgid "&Filter by This Column..."
 msgstr "Nach dieser Spalte &filtern..."
 
 #. IDS_CLIPBOARDHISTORY_TIME
-#: Merge.rc:5651
+#: Merge.rc:5652
 #, c-format
 msgid "Clipboard at %s"
 msgstr "Zwischenablage am %s"
 
 #. IDS_CLIPBOARDHISTORY_DISABLED
-#: Merge.rc:5652
+#: Merge.rc:5653
 msgid ""
 "Clipboard history disabled.\r\n"
 "Enable: Windows logo key + V, then Turn on."
@@ -9160,115 +9165,115 @@ msgstr ""
 "Der Zwischenablageverlauf ist deaktiviert.\r\n"
 "Um den Zwischenablageverlauf zu aktivieren, betätigen Sie 'Windows+V' und klicken dann auf die Schaltfläche 'Einschalten'."
 
-#: Merge.rc:5654
+#: Merge.rc:5655
 msgid "This system does not support clipboard history."
 msgstr "Dieses System unterstützt keinen Zwischenablageverlauf."
 
-#: Merge.rc:5656
+#: Merge.rc:5657
 msgid "32-bit WinMerge does not support Clipboard Compare"
 msgstr "Die 32-Bit-Version von WinMerge unterstützt den Zwischenablagevergleich nicht"
 
 #. IDS_WEBVIEW2_RUNTIME_NOT_INSTALLED
-#: Merge.rc:5661
+#: Merge.rc:5662
 msgid "WebView2 runtime not installed. Download it?"
 msgstr "WebView2-Laufzeitumgebung ist nicht installiert. Möchten Sie sie herunterladen?"
 
 #. IDS_JUMPLIST_NEW_TEXT_COMPARE
-#: Merge.rc:5666
+#: Merge.rc:5667
 msgid "New Text Compare"
 msgstr "Neuer Textvergleich"
 
 #. IDS_JUMPLIST_NEW_TABLE_COMPARE
-#: Merge.rc:5667
+#: Merge.rc:5668
 msgid "New Table Compare"
 msgstr "Neuer Tabellenvergleich"
 
 #. IDS_JUMPLIST_NEW_BINARY_COMPARE
-#: Merge.rc:5668
+#: Merge.rc:5669
 msgid "New Binary Compare"
 msgstr "Neuer Binärvergleich"
 
 #. IDS_JUMPLIST_NEW_IMAGE_COMPARE
-#: Merge.rc:5669
+#: Merge.rc:5670
 msgid "New Image Compare"
 msgstr "Neuer Bildvergleich"
 
 #. IDS_JUMPLIST_NEW_WEBPAGE_COMPARE
-#: Merge.rc:5670
+#: Merge.rc:5671
 msgid "New Webpage Compare"
 msgstr "Neuer Webseitenvergleich"
 
 #. IDS_JUMPLIST_NEW_FOLDER_COMPARE
-#: Merge.rc:5671
+#: Merge.rc:5672
 msgid "New Folder Compare"
 msgstr "Neuer Ordnervergleich"
 
 #. IDS_JUMPLIST_CLIPBOARD_COMPARE
-#: Merge.rc:5672
+#: Merge.rc:5673
 msgid "Clipboard Compare"
 msgstr "Zwischenablage vergleichen"
 
 #. IDS_PREVIEWBAR_PRINT
-#: Merge.rc:5677
+#: Merge.rc:5678
 msgid "&Print..."
 msgstr "&Drucken"
 
 #. IDS_PREVIEWBAR_PREVPAGE
-#: Merge.rc:5679
+#: Merge.rc:5680
 msgid "Pre&v Page"
 msgstr "&Vorige Seite"
 
 #. IDS_PREVIEWBAR_TWOPAGE
-#: Merge.rc:5680
+#: Merge.rc:5681
 msgid "&Two Page"
 msgstr "&Zwei Seiten"
 
 #. IDS_PREVIEWBAR_ONEPAGE
-#: Merge.rc:5681
+#: Merge.rc:5682
 msgid "&One Page"
 msgstr "&Eine Seite"
 
 #. IDS_PREVIEWBAR_ZOOMIN
-#: Merge.rc:5682
+#: Merge.rc:5683
 msgid "Zoom &In"
 msgstr "Here&inzoomen"
 
 #. IDS_PREVIEWBAR_ZOOMOUT
-#: Merge.rc:5683
+#: Merge.rc:5684
 msgid "Zoom &Out"
 msgstr "Hera&uszoomen"
 
 #. IDS_WEBPAGE_COMPARING
-#: Merge.rc:5689
+#: Merge.rc:5690
 msgid "Comparing..."
 msgstr "Vergleichen..."
 
 #. IDS_WEBPAGE_ZOOM
-#: Merge.rc:5690
+#: Merge.rc:5691
 msgid "Zoom:"
 msgstr "Zoom:"
 
 #. IDS_COPY_GRANULARITY_DIFFHUNK
-#: Merge.rc:5695
+#: Merge.rc:5696
 msgid "Diff hunk"
 msgstr "Diff-Hunk"
 
 #. IDS_COPY_GRANULARITY_INLINE
-#: Merge.rc:5696
+#: Merge.rc:5697
 msgid "Inline diff"
 msgstr "Zeilenuntersciede"
 
 #. IDS_COPY_GRANULARITY_LINE
-#: Merge.rc:5697
+#: Merge.rc:5698
 msgid "Line"
 msgstr "Zeile"
 
-#: Merge.rc:5698
+#: Merge.rc:5699
 msgid "Character"
 msgstr "Zeichen"
 
 #. ID_MICE_PREVDIFF
-#: Merge.rc:5703
+#: Merge.rc:5704
 msgid ""
 "\n"
 "Previous Difference (Alt+Up)\n"
@@ -9281,7 +9286,7 @@ msgstr ""
 "(Alt+Mausrad Hoch)"
 
 #. ID_MICE_NEXTDIFF
-#: Merge.rc:5704
+#: Merge.rc:5705
 msgid ""
 "\n"
 "Next Difference (Alt+Down)\n"
@@ -9294,7 +9299,7 @@ msgstr ""
 "(Alt+Mausrad Runter)"
 
 #. ID_MICE_L2R
-#: Merge.rc:5705
+#: Merge.rc:5706
 msgid ""
 "\n"
 "Copy to Right (Alt+Right)\n"
@@ -9309,7 +9314,7 @@ msgstr ""
 "(Alt+Umschalt+Mausrad Runter)"
 
 #. ID_MICE_R2L
-#: Merge.rc:5706
+#: Merge.rc:5707
 msgid ""
 "\n"
 "Copy to Left (Alt+Left)\n"
@@ -9324,7 +9329,7 @@ msgstr ""
 "(Alt+Umschalt+Mausrad Hoch)"
 
 #. ID_MICE_L2RNEXT
-#: Merge.rc:5707
+#: Merge.rc:5708
 msgid ""
 "\n"
 "Copy to Right and Advance (Ctrl+Alt+Right)\n"
@@ -9337,7 +9342,7 @@ msgstr ""
 "(Strg+Alt+Umschalt+Mausrad Runter)"
 
 #. ID_MICE_R2LNEXT
-#: Merge.rc:5708
+#: Merge.rc:5709
 msgid ""
 "\n"
 "Copy to Left and Advance (Ctrl+Alt+Left)\n"
@@ -9350,257 +9355,257 @@ msgstr ""
 "(Strg+Alt+Umschalt+Mausrad Hoch)"
 
 #. IDS_LOG_COMPARING_2
-#: Merge.rc:5718
+#: Merge.rc:5719
 #, c-format
 msgid "Comparing %1 with %2"
 msgstr "Vergleich von %1 mit %2"
 
 #. IDS_LOG_COMPARING_3
-#: Merge.rc:5719
+#: Merge.rc:5720
 #, c-format
 msgid "Comparing %1 with %2 and %3"
 msgstr "Vergleich von %1 mit %2 und %3"
 
 #. IDS_LOG_COMPARE_COMPLETED
-#: Merge.rc:5720
+#: Merge.rc:5721
 msgid "Comparison completed"
 msgstr "Vergleich abgeschlossen"
 
 #. IDS_LOG_COMPARE_ERROR_2
-#: Merge.rc:5721
+#: Merge.rc:5722
 #, c-format
 msgid "Failed to compare %1 with %2: "
 msgstr "Der Vergleich von %1 mit %2 ist fehlgeschlagen:"
 
 #. IDS_LOG_COMPARE_ERROR_3
-#: Merge.rc:5722
+#: Merge.rc:5723
 #, c-format
 msgid "Failed to compare %1 with %2 and %3: "
 msgstr "Der Vergleich von %1 mit %2 und %3 ist fehlgeschlagen:"
 
 #. IDS_LOG_FILE_SAVED
-#: Merge.rc:5723
+#: Merge.rc:5724
 msgid "File saved"
 msgstr "Datei gespeichert"
 
 #. IDS_LOG_COPYING_FILES
-#: Merge.rc:5724
+#: Merge.rc:5725
 msgid "Copying files..."
 msgstr "Dateien werden kopiert..."
 
 #. IDS_LOG_MOVING_FILES
-#: Merge.rc:5725
+#: Merge.rc:5726
 msgid "Moving files..."
 msgstr "Dateien werden verschoben ..."
 
 #. IDS_LOG_DELETING_FILES
-#: Merge.rc:5726
+#: Merge.rc:5727
 msgid "Deleting files..."
 msgstr "Dateien werden gelöscht..."
 
 #. IDS_LOG_RECYCLEBIN
-#: Merge.rc:5727
+#: Merge.rc:5728
 msgid "Recycle Bin"
 msgstr "Papierkorb"
 
 #. IDS_LOG_PERMANENTLY_DELETED
-#: Merge.rc:5728
+#: Merge.rc:5729
 msgid "Permanently deleted"
 msgstr "Dauerhaft gelöscht"
 
 #. IDS_LOG_FILEOPERATION_COMPLETED
-#: Merge.rc:5729
+#: Merge.rc:5730
 msgid "File operation completed successfully"
 msgstr "Dateioperation erfolgreich abgeschlossen"
 
 #. IDS_LOG_FILEOPERATION_CANCELED
-#: Merge.rc:5730
+#: Merge.rc:5731
 msgid "File operation canceled"
 msgstr "Dateioperation abgebrochen"
 
 #. IDS_FILTER_ERROR_NO_ERROR
-#: Merge.rc:5735
+#: Merge.rc:5736
 msgid "No error"
 msgstr "Kein Fehler"
 
 #. IDS_FILTER_ERROR_EMPTY_EXPRESSION
-#: Merge.rc:5736
+#: Merge.rc:5737
 msgid "Filter expression is empty"
 msgstr "Filterausdruck ist leer"
 
 #. IDS_FILTER_ERROR_UNKNOWN_CHAR
-#: Merge.rc:5737
+#: Merge.rc:5738
 msgid "Unknown character in filter expression"
 msgstr "Unbekanntes Zeichen im Filterausdruck"
 
 #. IDS_FILTER_ERROR_UNTERMINATED_STRING
-#: Merge.rc:5738
+#: Merge.rc:5739
 msgid "Unterminated string literal"
 msgstr "Zeichenfolgenliteral ohne Ende"
 
 #. IDS_FILTER_ERROR_SYNTAX_ERROR
-#: Merge.rc:5739
+#: Merge.rc:5740
 msgid "Syntax error in filter expression"
 msgstr "Syntaxfehler im Filterausdruck"
 
 #. IDS_FILTER_ERROR_PARSE_FAILURE
-#: Merge.rc:5740
+#: Merge.rc:5741
 msgid "Failed to parse filter expression"
 msgstr "Filterausdruck konnte nicht geparst werden"
 
 #. IDS_FILTER_ERROR_INVALID_LITERAL
-#: Merge.rc:5741
+#: Merge.rc:5742
 msgid "Invalid literal value"
 msgstr "Ungültiger literaler Wert"
 
 #. IDS_FILTER_ERROR_INVALID_REGULAR_EXPRESSION
-#: Merge.rc:5742
+#: Merge.rc:5743
 msgid "Invalid regular expression"
 msgstr "Ungültiger regulärer Ausdruck"
 
 #. IDS_FILTER_ERROR_UNDEFINED_IDENTIFIER
-#: Merge.rc:5743
+#: Merge.rc:5744
 msgid "Undefined identifier"
 msgstr "Undefinierter Bezeichner"
 
 #. IDS_FILTER_ERROR_INVALID_ARGUMENT_COUNT
-#: Merge.rc:5744
+#: Merge.rc:5745
 msgid "Invalid number of arguments"
 msgstr "Ungültige Anzahl von Argumenten"
 
 #. IDS_FILTER_ERROR_FILTER_NAME_NOT_FOUND
-#: Merge.rc:5745
+#: Merge.rc:5746
 msgid "Filter name not found"
 msgstr "Filtername nicht gefunden"
 
 #. IDS_FILTER_ERROR_DIVIDE_BY_ZERO
-#: Merge.rc:5746
+#: Merge.rc:5747
 msgid "Division by zero in filter expression"
 msgstr "Division durch Null im Filterausdruck"
 
 #. IDS_FILTER_ERROR_UNKNOWN_ERROR
-#: Merge.rc:5747
+#: Merge.rc:5748
 msgid "Unknown error"
 msgstr "Unbekannter Fehler"
 
 #. IDS_FILTER_ERROR_INVALID_PROPERTY_NAME
-#: Merge.rc:5748
+#: Merge.rc:5749
 msgid "Invalid property name"
 msgstr "Ungültiger Eigenschaftsname"
 
 #. IDS_FILTER_ERROR_INVALID_DIRECTIVE
-#: Merge.rc:5749
+#: Merge.rc:5750
 msgid "Invalid directive"
 msgstr "Ungültige Anweisung"
 
 #. IDS_FILTER_OP_EQUALS
-#: Merge.rc:5754
+#: Merge.rc:5755
 msgid "Equals"
 msgstr "Ist gleich"
 
 #. IDS_FILTER_OP_NOT_EQUALS
-#: Merge.rc:5755
+#: Merge.rc:5756
 msgid "Does not equal"
 msgstr "Ist nicht gleich"
 
 #. IDS_FILTER_OP_LESS_THAN
-#: Merge.rc:5756
+#: Merge.rc:5757
 msgid "Less than"
 msgstr "Weniger als"
 
 #. IDS_FILTER_OP_LESS_EQUAL
-#: Merge.rc:5757
+#: Merge.rc:5758
 msgid "Less than or equal to"
 msgstr "Kleiner oder gleich"
 
 #. IDS_FILTER_OP_GREATER_EQUAL
-#: Merge.rc:5758
+#: Merge.rc:5759
 msgid "Greater than or equal to"
 msgstr "Größer oder gleich"
 
 #. IDS_FILTER_OP_GREATER_THAN
-#: Merge.rc:5759
+#: Merge.rc:5760
 msgid "Greater than"
 msgstr "Größer als"
 
 #. IDS_FILTER_OP_BETWEEN
-#: Merge.rc:5760
+#: Merge.rc:5761
 msgid "Between"
 msgstr "Zwischen"
 
 #. IDS_FILTER_OP_NOT_BETWEEN
-#: Merge.rc:5761
+#: Merge.rc:5762
 msgid "Not Between"
 msgstr "Nicht zwischen"
 
 #. IDS_FILTER_OP_CONTAINS
-#: Merge.rc:5762
+#: Merge.rc:5763
 msgid "Contains"
 msgstr "Enthält"
 
 #. IDS_FILTER_OP_NOT_CONTAINS
-#: Merge.rc:5763
+#: Merge.rc:5764
 msgid "Not Contains"
 msgstr "Enthält nicht"
 
 #. IDS_FILTER_OP_RECONTAINS
-#: Merge.rc:5764
+#: Merge.rc:5765
 msgid "Contains (regex)"
 msgstr "Enthält (Regex)"
 
 #. IDS_FILTER_OP_NOT_RECONTAINS
-#: Merge.rc:5765
+#: Merge.rc:5766
 msgid "Not Contains (regex)"
 msgstr "Enthält nicht (Regex)"
 
 #. IDS_FILTER_OP_LIKE
-#: Merge.rc:5766
+#: Merge.rc:5767
 msgid "Match (wildcard)"
 msgstr "Entspricht (Platzhalter)"
 
 #. IDS_FILTER_OP_NOT_LIKE
-#: Merge.rc:5767
+#: Merge.rc:5768
 msgid "Not match (wildcard)"
 msgstr "Entspricht nicht (Platzhalter)"
 
 #. IDS_FILTER_OP_MATCHES
-#: Merge.rc:5768
+#: Merge.rc:5769
 msgid "Match (regex)"
 msgstr "Entspricht (Regex)"
 
 #. IDS_FILTER_OP_NOT_MATCHES
-#: Merge.rc:5769
+#: Merge.rc:5770
 msgid "Not match (regex)"
 msgstr "Entspricht nicht (Regex)"
 
 #. IDS_COLORMODE_LIGHT
-#: Merge.rc:5774
+#: Merge.rc:5775
 msgid "Light"
 msgstr "Hell"
 
 #. IDS_COLORMODE_DARK
-#: Merge.rc:5775
+#: Merge.rc:5776
 msgid "Dark"
 msgstr "Dunkel"
 
 #. IDS_COLORMODE_FOLLOWSYSTEM
-#: Merge.rc:5776
+#: Merge.rc:5777
 msgid "Follow system"
 msgstr "Systemeinstellung verwenden"
 
 #. IDS_EXAMPLE
-#: Merge.rc:5781
+#: Merge.rc:5782
 #, c-format
 msgid "e.g. %1"
 msgstr "z. B. %1"
 
 #. IDS_DETECTED_PREVIOUS_CRASH
-#: Merge.rc:5786
+#: Merge.rc:5787
 msgid "WinMerge detected a previous crash. Please report this if possible."
 msgstr "WinMerge hat einen vorherigen Absturz festgestellt. Bitte melden Sie ihn, wenn möglich."
 
 #. IDS_REGEX_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5791
+#: Merge.rc:5792
 msgid ""
 "# Regex replacement list\r\n"
 "# Format: regex<TAB>replacement\r\n"
@@ -9615,7 +9620,7 @@ msgstr ""
 "(\\d{4})-(\\d{2})-(\\d{2})\t$1_$2_$3\r\n"
 
 #. IDS_STRING_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5792
+#: Merge.rc:5793
 msgid ""
 "# Replacement list\r\n"
 "# Format: search<TAB>replacement\r\n"
@@ -9632,22 +9637,22 @@ msgstr ""
 "von2\tzu2\r\n"
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_ONLY
-#: Merge.rc:5797
+#: Merge.rc:5798
 msgid "Built-in only"
 msgstr "Nur integrierte"
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_FIRST
-#: Merge.rc:5798
+#: Merge.rc:5799
 msgid "Built-in first"
 msgstr "Integrierte zuerst"
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_FIRST
-#: Merge.rc:5799
+#: Merge.rc:5800
 msgid "Tree-sitter first"
 msgstr "Tree-sitter zuerst"
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_ONLY
-#: Merge.rc:5800
+#: Merge.rc:5801
 msgid "Tree-sitter only"
 msgstr "Nur Tree-sitter"
 

--- a/Translations/WinMerge/Greek.po
+++ b/Translations/WinMerge/Greek.po
@@ -20,7 +20,7 @@ msgstr ""
 "X-Poedit-Basepath: ../../Src/\n"
 
 #. LANGUAGE, SUBLANGUAGE
-#: Merge.rc:26 Merge.rc:59 Merge.rc:5817
+#: Merge.rc:26 Merge.rc:59 Merge.rc:5818
 #, c-format
 msgid "LANG_ENGLISH, SUBLANG_ENGLISH_US"
 msgstr "LANG_GREEK, SUBLANG_DEFAULT"
@@ -237,7 +237,7 @@ msgid "Auto-Fit All Columns"
 msgstr ""
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN
-#: Merge.rc:153 Merge.rc:5645
+#: Merge.rc:153 Merge.rc:5646
 msgid "&Filter by This Column"
 msgstr ""
 
@@ -303,7 +303,7 @@ msgid "&Previous Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_NEXTPAGE
-#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5678
+#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5679
 #, c-format
 msgid "&Next Page"
 msgstr ""
@@ -709,7 +709,7 @@ msgid "&Huge"
 msgstr ""
 
 #. IDS_VIEW_MENU_BAR
-#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5713
+#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5714
 msgid "Men&u Bar"
 msgstr ""
 
@@ -4565,7 +4565,7 @@ msgid "Items compared:"
 msgstr "Συγκριθέντα αντικείμενα:"
 
 #. IDS_PREVIEWBAR_CLOSE
-#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5684
+#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5685
 #, c-format
 msgid "&Close"
 msgstr "Κ&λείσιμο"
@@ -8876,447 +8876,452 @@ msgstr ""
 msgid "2nd and 3rd"
 msgstr ""
 
+#. IDS_PLUGIN_CTRL_CLICK
+#: Merge.rc:5635
+msgid "(Ctrl+Click to add to pipeline)"
+msgstr ""
+
 #. IDS_FILTER_APPLIED
-#: Merge.rc:5639
+#: Merge.rc:5640
 msgid "Filter applied"
 msgstr ""
 
 #. IDS_FILTERMENU_COMPARE
-#: Merge.rc:5644
+#: Merge.rc:5645
 #, c-format
 msgid "Compare %1"
 msgstr ""
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN2
-#: Merge.rc:5646
+#: Merge.rc:5647
 msgid "&Filter by This Column..."
 msgstr ""
 
 #. IDS_CLIPBOARDHISTORY_TIME
-#: Merge.rc:5651
+#: Merge.rc:5652
 #, c-format
 msgid "Clipboard at %s"
 msgstr ""
 
 #. IDS_CLIPBOARDHISTORY_DISABLED
-#: Merge.rc:5652
+#: Merge.rc:5653
 msgid "Clipboard history disabled.\r\nEnable: Windows logo key + V, then Turn on."
 msgstr ""
 
-#: Merge.rc:5654
+#: Merge.rc:5655
 msgid "This system does not support clipboard history."
 msgstr ""
 
-#: Merge.rc:5656
+#: Merge.rc:5657
 msgid "32-bit WinMerge does not support Clipboard Compare"
 msgstr ""
 
 #. IDS_WEBVIEW2_RUNTIME_NOT_INSTALLED
-#: Merge.rc:5661
+#: Merge.rc:5662
 msgid "WebView2 runtime not installed. Download it?"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_TEXT_COMPARE
-#: Merge.rc:5666
+#: Merge.rc:5667
 msgid "New Text Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_TABLE_COMPARE
-#: Merge.rc:5667
+#: Merge.rc:5668
 msgid "New Table Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_BINARY_COMPARE
-#: Merge.rc:5668
+#: Merge.rc:5669
 msgid "New Binary Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_IMAGE_COMPARE
-#: Merge.rc:5669
+#: Merge.rc:5670
 msgid "New Image Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_WEBPAGE_COMPARE
-#: Merge.rc:5670
+#: Merge.rc:5671
 msgid "New Webpage Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_FOLDER_COMPARE
-#: Merge.rc:5671
+#: Merge.rc:5672
 msgid "New Folder Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_CLIPBOARD_COMPARE
-#: Merge.rc:5672
+#: Merge.rc:5673
 msgid "Clipboard Compare"
 msgstr ""
 
 #. IDS_PREVIEWBAR_PRINT
-#: Merge.rc:5677
+#: Merge.rc:5678
 msgid "&Print..."
 msgstr ""
 
 #. IDS_PREVIEWBAR_PREVPAGE
-#: Merge.rc:5679
+#: Merge.rc:5680
 msgid "Pre&v Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_TWOPAGE
-#: Merge.rc:5680
+#: Merge.rc:5681
 msgid "&Two Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_ONEPAGE
-#: Merge.rc:5681
+#: Merge.rc:5682
 msgid "&One Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_ZOOMIN
-#: Merge.rc:5682
+#: Merge.rc:5683
 msgid "Zoom &In"
 msgstr ""
 
 #. IDS_PREVIEWBAR_ZOOMOUT
-#: Merge.rc:5683
+#: Merge.rc:5684
 msgid "Zoom &Out"
 msgstr ""
 
 #. IDS_WEBPAGE_COMPARING
-#: Merge.rc:5689
+#: Merge.rc:5690
 msgid "Comparing..."
 msgstr ""
 
 #. IDS_WEBPAGE_ZOOM
-#: Merge.rc:5690
+#: Merge.rc:5691
 msgid "Zoom:"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_DIFFHUNK
-#: Merge.rc:5695
+#: Merge.rc:5696
 msgid "Diff hunk"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_INLINE
-#: Merge.rc:5696
+#: Merge.rc:5697
 msgid "Inline diff"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_LINE
-#: Merge.rc:5697
+#: Merge.rc:5698
 msgid "Line"
 msgstr ""
 
-#: Merge.rc:5698
+#: Merge.rc:5699
 msgid "Character"
 msgstr ""
 
 #. ID_MICE_PREVDIFF
-#: Merge.rc:5703
+#: Merge.rc:5704
 msgid "\nPrevious Difference (Alt+Up)\n(Right Button+Wheel Up)\n(Alt+Wheel Up)"
 msgstr ""
 
 #. ID_MICE_NEXTDIFF
-#: Merge.rc:5704
+#: Merge.rc:5705
 msgid "\nNext Difference (Alt+Down)\n(Right Button+Wheel Down)\n(Alt+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_L2R
-#: Merge.rc:5705
+#: Merge.rc:5706
 msgid "\nCopy to Right (Alt+Right)\n(Right Button+Wheel Right)\n(Alt+Wheel Right)\n(Alt+Shift+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_R2L
-#: Merge.rc:5706
+#: Merge.rc:5707
 msgid "\nCopy to Left (Alt+Left)\n(Right Button+Wheel Left)\n(Alt+Wheel Left)\n(Alt+Shift+Wheel Up)"
 msgstr ""
 
 #. ID_MICE_L2RNEXT
-#: Merge.rc:5707
+#: Merge.rc:5708
 msgid "\nCopy to Right and Advance (Ctrl+Alt+Right)\n(Ctrl+Alt+Wheel Right)\n(Ctrl+Alt+Shift+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_R2LNEXT
-#: Merge.rc:5708
+#: Merge.rc:5709
 msgid "\nCopy to Left and Advance (Ctrl+Alt+Left)\n(Ctrl+Alt+Wheel Left)\n(Ctrl+Alt+Shift+Wheel Up)"
 msgstr ""
 
 #. IDS_LOG_COMPARING_2
-#: Merge.rc:5718
+#: Merge.rc:5719
 #, c-format
 msgid "Comparing %1 with %2"
 msgstr ""
 
 #. IDS_LOG_COMPARING_3
-#: Merge.rc:5719
+#: Merge.rc:5720
 #, c-format
 msgid "Comparing %1 with %2 and %3"
 msgstr ""
 
 #. IDS_LOG_COMPARE_COMPLETED
-#: Merge.rc:5720
+#: Merge.rc:5721
 msgid "Comparison completed"
 msgstr ""
 
 #. IDS_LOG_COMPARE_ERROR_2
-#: Merge.rc:5721
+#: Merge.rc:5722
 #, c-format
 msgid "Failed to compare %1 with %2: "
 msgstr ""
 
 #. IDS_LOG_COMPARE_ERROR_3
-#: Merge.rc:5722
+#: Merge.rc:5723
 #, c-format
 msgid "Failed to compare %1 with %2 and %3: "
 msgstr ""
 
 #. IDS_LOG_FILE_SAVED
-#: Merge.rc:5723
+#: Merge.rc:5724
 msgid "File saved"
 msgstr ""
 
 #. IDS_LOG_COPYING_FILES
-#: Merge.rc:5724
+#: Merge.rc:5725
 msgid "Copying files..."
 msgstr ""
 
 #. IDS_LOG_MOVING_FILES
-#: Merge.rc:5725
+#: Merge.rc:5726
 msgid "Moving files..."
 msgstr ""
 
 #. IDS_LOG_DELETING_FILES
-#: Merge.rc:5726
+#: Merge.rc:5727
 msgid "Deleting files..."
 msgstr ""
 
 #. IDS_LOG_RECYCLEBIN
-#: Merge.rc:5727
+#: Merge.rc:5728
 msgid "Recycle Bin"
 msgstr ""
 
 #. IDS_LOG_PERMANENTLY_DELETED
-#: Merge.rc:5728
+#: Merge.rc:5729
 msgid "Permanently deleted"
 msgstr ""
 
 #. IDS_LOG_FILEOPERATION_COMPLETED
-#: Merge.rc:5729
+#: Merge.rc:5730
 msgid "File operation completed successfully"
 msgstr ""
 
 #. IDS_LOG_FILEOPERATION_CANCELED
-#: Merge.rc:5730
+#: Merge.rc:5731
 msgid "File operation canceled"
 msgstr ""
 
 #. IDS_FILTER_ERROR_NO_ERROR
-#: Merge.rc:5735
+#: Merge.rc:5736
 msgid "No error"
 msgstr ""
 
 #. IDS_FILTER_ERROR_EMPTY_EXPRESSION
-#: Merge.rc:5736
+#: Merge.rc:5737
 msgid "Filter expression is empty"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNKNOWN_CHAR
-#: Merge.rc:5737
+#: Merge.rc:5738
 msgid "Unknown character in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNTERMINATED_STRING
-#: Merge.rc:5738
+#: Merge.rc:5739
 msgid "Unterminated string literal"
 msgstr ""
 
 #. IDS_FILTER_ERROR_SYNTAX_ERROR
-#: Merge.rc:5739
+#: Merge.rc:5740
 msgid "Syntax error in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_PARSE_FAILURE
-#: Merge.rc:5740
+#: Merge.rc:5741
 msgid "Failed to parse filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_LITERAL
-#: Merge.rc:5741
+#: Merge.rc:5742
 msgid "Invalid literal value"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_REGULAR_EXPRESSION
-#: Merge.rc:5742
+#: Merge.rc:5743
 msgid "Invalid regular expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNDEFINED_IDENTIFIER
-#: Merge.rc:5743
+#: Merge.rc:5744
 msgid "Undefined identifier"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_ARGUMENT_COUNT
-#: Merge.rc:5744
+#: Merge.rc:5745
 msgid "Invalid number of arguments"
 msgstr ""
 
 #. IDS_FILTER_ERROR_FILTER_NAME_NOT_FOUND
-#: Merge.rc:5745
+#: Merge.rc:5746
 msgid "Filter name not found"
 msgstr ""
 
 #. IDS_FILTER_ERROR_DIVIDE_BY_ZERO
-#: Merge.rc:5746
+#: Merge.rc:5747
 msgid "Division by zero in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNKNOWN_ERROR
-#: Merge.rc:5747
+#: Merge.rc:5748
 msgid "Unknown error"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_PROPERTY_NAME
-#: Merge.rc:5748
+#: Merge.rc:5749
 msgid "Invalid property name"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_DIRECTIVE
-#: Merge.rc:5749
+#: Merge.rc:5750
 msgid "Invalid directive"
 msgstr ""
 
 #. IDS_FILTER_OP_EQUALS
-#: Merge.rc:5754
+#: Merge.rc:5755
 msgid "Equals"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_EQUALS
-#: Merge.rc:5755
+#: Merge.rc:5756
 msgid "Does not equal"
 msgstr ""
 
 #. IDS_FILTER_OP_LESS_THAN
-#: Merge.rc:5756
+#: Merge.rc:5757
 msgid "Less than"
 msgstr ""
 
 #. IDS_FILTER_OP_LESS_EQUAL
-#: Merge.rc:5757
+#: Merge.rc:5758
 msgid "Less than or equal to"
 msgstr ""
 
 #. IDS_FILTER_OP_GREATER_EQUAL
-#: Merge.rc:5758
+#: Merge.rc:5759
 msgid "Greater than or equal to"
 msgstr ""
 
 #. IDS_FILTER_OP_GREATER_THAN
-#: Merge.rc:5759
+#: Merge.rc:5760
 msgid "Greater than"
 msgstr ""
 
 #. IDS_FILTER_OP_BETWEEN
-#: Merge.rc:5760
+#: Merge.rc:5761
 msgid "Between"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_BETWEEN
-#: Merge.rc:5761
+#: Merge.rc:5762
 msgid "Not Between"
 msgstr ""
 
 #. IDS_FILTER_OP_CONTAINS
-#: Merge.rc:5762
+#: Merge.rc:5763
 msgid "Contains"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_CONTAINS
-#: Merge.rc:5763
+#: Merge.rc:5764
 msgid "Not Contains"
 msgstr ""
 
 #. IDS_FILTER_OP_RECONTAINS
-#: Merge.rc:5764
+#: Merge.rc:5765
 msgid "Contains (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_RECONTAINS
-#: Merge.rc:5765
+#: Merge.rc:5766
 msgid "Not Contains (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_LIKE
-#: Merge.rc:5766
+#: Merge.rc:5767
 msgid "Match (wildcard)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_LIKE
-#: Merge.rc:5767
+#: Merge.rc:5768
 msgid "Not match (wildcard)"
 msgstr ""
 
 #. IDS_FILTER_OP_MATCHES
-#: Merge.rc:5768
+#: Merge.rc:5769
 msgid "Match (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_MATCHES
-#: Merge.rc:5769
+#: Merge.rc:5770
 msgid "Not match (regex)"
 msgstr ""
 
 #. IDS_COLORMODE_LIGHT
-#: Merge.rc:5774
+#: Merge.rc:5775
 msgid "Light"
 msgstr ""
 
 #. IDS_COLORMODE_DARK
-#: Merge.rc:5775
+#: Merge.rc:5776
 msgid "Dark"
 msgstr ""
 
 #. IDS_COLORMODE_FOLLOWSYSTEM
-#: Merge.rc:5776
+#: Merge.rc:5777
 msgid "Follow system"
 msgstr ""
 
 #. IDS_EXAMPLE
-#: Merge.rc:5781
+#: Merge.rc:5782
 #, c-format
 msgid "e.g. %1"
 msgstr ""
 
 #. IDS_DETECTED_PREVIOUS_CRASH
-#: Merge.rc:5786
+#: Merge.rc:5787
 msgid "WinMerge detected a previous crash. Please report this if possible."
 msgstr ""
 
 #. IDS_REGEX_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5791
+#: Merge.rc:5792
 msgid "# Regex replacement list\r\n# Format: regex<TAB>replacement\r\n# Backreferences like $1, $2 are supported\r\n\r\n(\\d{4})-(\\d{2})-(\\d{2})\t$1_$2_$3\r\n"
 msgstr ""
 
 #. IDS_STRING_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5792
+#: Merge.rc:5793
 msgid "# Replacement list\r\n# Format: search<TAB>replacement\r\n# Lines starting with # are ignored\r\n\r\nfrom1\tto1\r\nfrom2\tto2\r\n"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_ONLY
-#: Merge.rc:5797
+#: Merge.rc:5798
 msgid "Built-in only"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_FIRST
-#: Merge.rc:5798
+#: Merge.rc:5799
 msgid "Built-in first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_FIRST
-#: Merge.rc:5799
+#: Merge.rc:5800
 msgid "Tree-sitter first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_ONLY
-#: Merge.rc:5800
+#: Merge.rc:5801
 msgid "Tree-sitter only"
 msgstr ""
 

--- a/Translations/WinMerge/Hebrew.po
+++ b/Translations/WinMerge/Hebrew.po
@@ -21,7 +21,7 @@ msgstr ""
 "X-Generator: Poedit 3.5\n"
 
 #. LANGUAGE, SUBLANGUAGE
-#: Merge.rc:26 Merge.rc:59 Merge.rc:5817
+#: Merge.rc:26 Merge.rc:59 Merge.rc:5818
 msgid "LANG_ENGLISH, SUBLANG_ENGLISH_US"
 msgstr "LANG_HEBREW, SUBLANG_HEBREW_ISRAEL"
 
@@ -228,7 +228,7 @@ msgid "Auto-Fit All Columns"
 msgstr "התאם אוטומטית את כל העמודות"
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN
-#: Merge.rc:153 Merge.rc:5645
+#: Merge.rc:153 Merge.rc:5646
 msgid "&Filter by This Column"
 msgstr ""
 
@@ -289,7 +289,7 @@ msgid "&Previous Page"
 msgstr "עמוד קודם"
 
 #. IDS_PREVIEWBAR_NEXTPAGE
-#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5678
+#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5679
 msgid "&Next Page"
 msgstr "עמוד הבא"
 
@@ -662,7 +662,7 @@ msgid "&Huge"
 msgstr "ענק"
 
 #. IDS_VIEW_MENU_BAR
-#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5713
+#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5714
 msgid "Men&u Bar"
 msgstr "סרגל תפריטים"
 
@@ -4187,7 +4187,7 @@ msgid "Items compared:"
 msgstr "פריטים שהושוו:"
 
 #. IDS_PREVIEWBAR_CLOSE
-#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5684
+#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5685
 msgid "&Close"
 msgstr "סגור"
 
@@ -8196,30 +8196,35 @@ msgstr "ראשון ושלישי"
 msgid "2nd and 3rd"
 msgstr "שני ושלישי"
 
+#. IDS_PLUGIN_CTRL_CLICK
+#: Merge.rc:5635
+msgid "(Ctrl+Click to add to pipeline)"
+msgstr ""
+
 #. IDS_FILTER_APPLIED
-#: Merge.rc:5639
+#: Merge.rc:5640
 msgid "Filter applied"
 msgstr "המסנן הופעל"
 
 #. IDS_FILTERMENU_COMPARE
-#: Merge.rc:5644
+#: Merge.rc:5645
 #, c-format
 msgid "Compare %1"
 msgstr ""
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN2
-#: Merge.rc:5646
+#: Merge.rc:5647
 msgid "&Filter by This Column..."
 msgstr ""
 
 #. IDS_CLIPBOARDHISTORY_TIME
-#: Merge.rc:5651
+#: Merge.rc:5652
 #, c-format
 msgid "Clipboard at %s"
 msgstr "לוח גזירים ב-%s"
 
 #. IDS_CLIPBOARDHISTORY_DISABLED
-#: Merge.rc:5652
+#: Merge.rc:5653
 msgid ""
 "Clipboard history disabled.\r\n"
 "Enable: Windows logo key + V, then Turn on."
@@ -8227,115 +8232,115 @@ msgstr ""
 "היסטוריית לוח גזירים מושבתת.\r\n"
 "כדי להפעיל אותה, לחץ על מקש Windows + V ולאחר מכן לחץ על כפתור 'הפעל'."
 
-#: Merge.rc:5654
+#: Merge.rc:5655
 msgid "This system does not support clipboard history."
 msgstr "מערכת זו אינה תומכת בהיסטוריית לוח גזירים."
 
-#: Merge.rc:5656
+#: Merge.rc:5657
 msgid "32-bit WinMerge does not support Clipboard Compare"
 msgstr "גרסת 32 ביט של WinMerge אינה תומכת בהשוואת לוח גזירים"
 
 #. IDS_WEBVIEW2_RUNTIME_NOT_INSTALLED
-#: Merge.rc:5661
+#: Merge.rc:5662
 msgid "WebView2 runtime not installed. Download it?"
 msgstr "WebView2 Runtime אינו מותקן. האם ברצונך להוריד אותו?"
 
 #. IDS_JUMPLIST_NEW_TEXT_COMPARE
-#: Merge.rc:5666
+#: Merge.rc:5667
 msgid "New Text Compare"
 msgstr "השוואת טקסט חדשה"
 
 #. IDS_JUMPLIST_NEW_TABLE_COMPARE
-#: Merge.rc:5667
+#: Merge.rc:5668
 msgid "New Table Compare"
 msgstr "השוואת טבלה חדשה"
 
 #. IDS_JUMPLIST_NEW_BINARY_COMPARE
-#: Merge.rc:5668
+#: Merge.rc:5669
 msgid "New Binary Compare"
 msgstr "השוואה בינארית חדשה"
 
 #. IDS_JUMPLIST_NEW_IMAGE_COMPARE
-#: Merge.rc:5669
+#: Merge.rc:5670
 msgid "New Image Compare"
 msgstr "השוואת תמונה חדשה"
 
 #. IDS_JUMPLIST_NEW_WEBPAGE_COMPARE
-#: Merge.rc:5670
+#: Merge.rc:5671
 msgid "New Webpage Compare"
 msgstr "השוואת דף אינטרנט חדשה"
 
 #. IDS_JUMPLIST_NEW_FOLDER_COMPARE
-#: Merge.rc:5671
+#: Merge.rc:5672
 msgid "New Folder Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_CLIPBOARD_COMPARE
-#: Merge.rc:5672
+#: Merge.rc:5673
 msgid "Clipboard Compare"
 msgstr "השוואת לוח גזירים"
 
 #. IDS_PREVIEWBAR_PRINT
-#: Merge.rc:5677
+#: Merge.rc:5678
 msgid "&Print..."
 msgstr "&הדפס..."
 
 #. IDS_PREVIEWBAR_PREVPAGE
-#: Merge.rc:5679
+#: Merge.rc:5680
 msgid "Pre&v Page"
 msgstr "עמוד קו&דם"
 
 #. IDS_PREVIEWBAR_TWOPAGE
-#: Merge.rc:5680
+#: Merge.rc:5681
 msgid "&Two Page"
 msgstr "&שני עמודים"
 
 #. IDS_PREVIEWBAR_ONEPAGE
-#: Merge.rc:5681
+#: Merge.rc:5682
 msgid "&One Page"
 msgstr "&עמוד אחד"
 
 #. IDS_PREVIEWBAR_ZOOMIN
-#: Merge.rc:5682
+#: Merge.rc:5683
 msgid "Zoom &In"
 msgstr "התקרבות &פנימה"
 
 #. IDS_PREVIEWBAR_ZOOMOUT
-#: Merge.rc:5683
+#: Merge.rc:5684
 msgid "Zoom &Out"
 msgstr "התרחקות &החוצה"
 
 #. IDS_WEBPAGE_COMPARING
-#: Merge.rc:5689
+#: Merge.rc:5690
 msgid "Comparing..."
 msgstr "משווה..."
 
 #. IDS_WEBPAGE_ZOOM
-#: Merge.rc:5690
+#: Merge.rc:5691
 msgid "Zoom:"
 msgstr "התקרבות:"
 
 #. IDS_COPY_GRANULARITY_DIFFHUNK
-#: Merge.rc:5695
+#: Merge.rc:5696
 msgid "Diff hunk"
 msgstr "גוש הבדלים"
 
 #. IDS_COPY_GRANULARITY_INLINE
-#: Merge.rc:5696
+#: Merge.rc:5697
 msgid "Inline diff"
 msgstr "הבדלים פנימיים"
 
 #. IDS_COPY_GRANULARITY_LINE
-#: Merge.rc:5697
+#: Merge.rc:5698
 msgid "Line"
 msgstr "שורה"
 
-#: Merge.rc:5698
+#: Merge.rc:5699
 msgid "Character"
 msgstr "תו"
 
 #. ID_MICE_PREVDIFF
-#: Merge.rc:5703
+#: Merge.rc:5704
 msgid ""
 "\n"
 "Previous Difference (Alt+Up)\n"
@@ -8348,7 +8353,7 @@ msgstr ""
 "(Alt+גלגלת למעלה)"
 
 #. ID_MICE_NEXTDIFF
-#: Merge.rc:5704
+#: Merge.rc:5705
 msgid ""
 "\n"
 "Next Difference (Alt+Down)\n"
@@ -8361,7 +8366,7 @@ msgstr ""
 "(Alt+גלגלת למטה)"
 
 #. ID_MICE_L2R
-#: Merge.rc:5705
+#: Merge.rc:5706
 msgid ""
 "\n"
 "Copy to Right (Alt+Right)\n"
@@ -8376,7 +8381,7 @@ msgstr ""
 "(Alt+Shift+גלגלת למטה)"
 
 #. ID_MICE_R2L
-#: Merge.rc:5706
+#: Merge.rc:5707
 msgid ""
 "\n"
 "Copy to Left (Alt+Left)\n"
@@ -8391,7 +8396,7 @@ msgstr ""
 "(Alt+Shift+גלגלת למעלה)"
 
 #. ID_MICE_L2RNEXT
-#: Merge.rc:5707
+#: Merge.rc:5708
 msgid ""
 "\n"
 "Copy to Right and Advance (Ctrl+Alt+Right)\n"
@@ -8404,7 +8409,7 @@ msgstr ""
 "(Ctrl+Alt+Shift+גלגלת למטה)"
 
 #. ID_MICE_R2LNEXT
-#: Merge.rc:5708
+#: Merge.rc:5709
 msgid ""
 "\n"
 "Copy to Left and Advance (Ctrl+Alt+Left)\n"
@@ -8417,282 +8422,282 @@ msgstr ""
 "(Ctrl+Alt+Shift+גלגלת למעלה)"
 
 #. IDS_LOG_COMPARING_2
-#: Merge.rc:5718
+#: Merge.rc:5719
 #, c-format
 msgid "Comparing %1 with %2"
 msgstr ""
 
 #. IDS_LOG_COMPARING_3
-#: Merge.rc:5719
+#: Merge.rc:5720
 #, c-format
 msgid "Comparing %1 with %2 and %3"
 msgstr ""
 
 #. IDS_LOG_COMPARE_COMPLETED
-#: Merge.rc:5720
+#: Merge.rc:5721
 msgid "Comparison completed"
 msgstr ""
 
 #. IDS_LOG_COMPARE_ERROR_2
-#: Merge.rc:5721
+#: Merge.rc:5722
 #, c-format
 msgid "Failed to compare %1 with %2: "
 msgstr ""
 
 #. IDS_LOG_COMPARE_ERROR_3
-#: Merge.rc:5722
+#: Merge.rc:5723
 #, c-format
 msgid "Failed to compare %1 with %2 and %3: "
 msgstr ""
 
 #. IDS_LOG_FILE_SAVED
-#: Merge.rc:5723
+#: Merge.rc:5724
 msgid "File saved"
 msgstr ""
 
 #. IDS_LOG_COPYING_FILES
-#: Merge.rc:5724
+#: Merge.rc:5725
 msgid "Copying files..."
 msgstr ""
 
 #. IDS_LOG_MOVING_FILES
-#: Merge.rc:5725
+#: Merge.rc:5726
 msgid "Moving files..."
 msgstr ""
 
 #. IDS_LOG_DELETING_FILES
-#: Merge.rc:5726
+#: Merge.rc:5727
 msgid "Deleting files..."
 msgstr ""
 
 #. IDS_LOG_RECYCLEBIN
-#: Merge.rc:5727
+#: Merge.rc:5728
 msgid "Recycle Bin"
 msgstr ""
 
 #. IDS_LOG_PERMANENTLY_DELETED
-#: Merge.rc:5728
+#: Merge.rc:5729
 msgid "Permanently deleted"
 msgstr ""
 
 #. IDS_LOG_FILEOPERATION_COMPLETED
-#: Merge.rc:5729
+#: Merge.rc:5730
 msgid "File operation completed successfully"
 msgstr ""
 
 #. IDS_LOG_FILEOPERATION_CANCELED
-#: Merge.rc:5730
+#: Merge.rc:5731
 msgid "File operation canceled"
 msgstr ""
 
 #. IDS_FILTER_ERROR_NO_ERROR
-#: Merge.rc:5735
+#: Merge.rc:5736
 msgid "No error"
 msgstr ""
 
 #. IDS_FILTER_ERROR_EMPTY_EXPRESSION
-#: Merge.rc:5736
+#: Merge.rc:5737
 msgid "Filter expression is empty"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNKNOWN_CHAR
-#: Merge.rc:5737
+#: Merge.rc:5738
 msgid "Unknown character in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNTERMINATED_STRING
-#: Merge.rc:5738
+#: Merge.rc:5739
 msgid "Unterminated string literal"
 msgstr ""
 
 #. IDS_FILTER_ERROR_SYNTAX_ERROR
-#: Merge.rc:5739
+#: Merge.rc:5740
 msgid "Syntax error in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_PARSE_FAILURE
-#: Merge.rc:5740
+#: Merge.rc:5741
 msgid "Failed to parse filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_LITERAL
-#: Merge.rc:5741
+#: Merge.rc:5742
 msgid "Invalid literal value"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_REGULAR_EXPRESSION
-#: Merge.rc:5742
+#: Merge.rc:5743
 msgid "Invalid regular expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNDEFINED_IDENTIFIER
-#: Merge.rc:5743
+#: Merge.rc:5744
 msgid "Undefined identifier"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_ARGUMENT_COUNT
-#: Merge.rc:5744
+#: Merge.rc:5745
 msgid "Invalid number of arguments"
 msgstr ""
 
 #. IDS_FILTER_ERROR_FILTER_NAME_NOT_FOUND
-#: Merge.rc:5745
+#: Merge.rc:5746
 msgid "Filter name not found"
 msgstr ""
 
 #. IDS_FILTER_ERROR_DIVIDE_BY_ZERO
-#: Merge.rc:5746
+#: Merge.rc:5747
 msgid "Division by zero in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNKNOWN_ERROR
-#: Merge.rc:5747
+#: Merge.rc:5748
 msgid "Unknown error"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_PROPERTY_NAME
-#: Merge.rc:5748
+#: Merge.rc:5749
 msgid "Invalid property name"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_DIRECTIVE
-#: Merge.rc:5749
+#: Merge.rc:5750
 msgid "Invalid directive"
 msgstr ""
 
 #. IDS_FILTER_OP_EQUALS
-#: Merge.rc:5754
+#: Merge.rc:5755
 msgid "Equals"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_EQUALS
-#: Merge.rc:5755
+#: Merge.rc:5756
 msgid "Does not equal"
 msgstr ""
 
 #. IDS_FILTER_OP_LESS_THAN
-#: Merge.rc:5756
+#: Merge.rc:5757
 msgid "Less than"
 msgstr ""
 
 #. IDS_FILTER_OP_LESS_EQUAL
-#: Merge.rc:5757
+#: Merge.rc:5758
 msgid "Less than or equal to"
 msgstr ""
 
 #. IDS_FILTER_OP_GREATER_EQUAL
-#: Merge.rc:5758
+#: Merge.rc:5759
 msgid "Greater than or equal to"
 msgstr ""
 
 #. IDS_FILTER_OP_GREATER_THAN
-#: Merge.rc:5759
+#: Merge.rc:5760
 msgid "Greater than"
 msgstr ""
 
 #. IDS_FILTER_OP_BETWEEN
-#: Merge.rc:5760
+#: Merge.rc:5761
 msgid "Between"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_BETWEEN
-#: Merge.rc:5761
+#: Merge.rc:5762
 msgid "Not Between"
 msgstr ""
 
 #. IDS_FILTER_OP_CONTAINS
-#: Merge.rc:5762
+#: Merge.rc:5763
 msgid "Contains"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_CONTAINS
-#: Merge.rc:5763
+#: Merge.rc:5764
 msgid "Not Contains"
 msgstr ""
 
 #. IDS_FILTER_OP_RECONTAINS
-#: Merge.rc:5764
+#: Merge.rc:5765
 msgid "Contains (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_RECONTAINS
-#: Merge.rc:5765
+#: Merge.rc:5766
 msgid "Not Contains (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_LIKE
-#: Merge.rc:5766
+#: Merge.rc:5767
 msgid "Match (wildcard)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_LIKE
-#: Merge.rc:5767
+#: Merge.rc:5768
 msgid "Not match (wildcard)"
 msgstr ""
 
 #. IDS_FILTER_OP_MATCHES
-#: Merge.rc:5768
+#: Merge.rc:5769
 msgid "Match (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_MATCHES
-#: Merge.rc:5769
+#: Merge.rc:5770
 msgid "Not match (regex)"
 msgstr ""
 
 #. IDS_COLORMODE_LIGHT
-#: Merge.rc:5774
+#: Merge.rc:5775
 msgid "Light"
 msgstr ""
 
 #. IDS_COLORMODE_DARK
-#: Merge.rc:5775
+#: Merge.rc:5776
 msgid "Dark"
 msgstr ""
 
 #. IDS_COLORMODE_FOLLOWSYSTEM
-#: Merge.rc:5776
+#: Merge.rc:5777
 msgid "Follow system"
 msgstr ""
 
 #. IDS_EXAMPLE
-#: Merge.rc:5781
+#: Merge.rc:5782
 #, c-format
 msgid "e.g. %1"
 msgstr ""
 
 #. IDS_DETECTED_PREVIOUS_CRASH
-#: Merge.rc:5786
+#: Merge.rc:5787
 msgid "WinMerge detected a previous crash. Please report this if possible."
 msgstr ""
 
 #. IDS_REGEX_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5791
+#: Merge.rc:5792
 msgid "# Regex replacement list\r\n# Format: regex<TAB>replacement\r\n# Backreferences like $1, $2 are supported\r\n\r\n(\\d{4})-(\\d{2})-(\\d{2})\t$1_$2_$3\r\n"
 msgstr ""
 
 #. IDS_STRING_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5792
+#: Merge.rc:5793
 msgid "# Replacement list\r\n# Format: search<TAB>replacement\r\n# Lines starting with # are ignored\r\n\r\nfrom1\tto1\r\nfrom2\tto2\r\n"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_ONLY
-#: Merge.rc:5797
+#: Merge.rc:5798
 msgid "Built-in only"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_FIRST
-#: Merge.rc:5798
+#: Merge.rc:5799
 msgid "Built-in first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_FIRST
-#: Merge.rc:5799
+#: Merge.rc:5800
 msgid "Tree-sitter first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_ONLY
-#: Merge.rc:5800
+#: Merge.rc:5801
 msgid "Tree-sitter only"
 msgstr ""
 

--- a/Translations/WinMerge/Hungarian.po
+++ b/Translations/WinMerge/Hungarian.po
@@ -23,7 +23,7 @@ msgstr ""
 "X-Generator: Poedit 2.4.2\n"
 
 #. LANGUAGE, SUBLANGUAGE
-#: Merge.rc:26 Merge.rc:59 Merge.rc:5817
+#: Merge.rc:26 Merge.rc:59 Merge.rc:5818
 #, c-format
 msgid "LANG_ENGLISH, SUBLANG_ENGLISH_US"
 msgstr "LANG_HUNGARIAN, SUBLANG_DEFAULT"
@@ -240,7 +240,7 @@ msgid "Auto-Fit All Columns"
 msgstr "Minden oszlop automatikus illeszkedése"
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN
-#: Merge.rc:153 Merge.rc:5645
+#: Merge.rc:153 Merge.rc:5646
 msgid "&Filter by This Column"
 msgstr "&Szűrés ezen oszlop alapján"
 
@@ -306,7 +306,7 @@ msgid "&Previous Page"
 msgstr "Előző oldal"
 
 #. IDS_PREVIEWBAR_NEXTPAGE
-#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5678
+#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5679
 #, c-format
 msgid "&Next Page"
 msgstr "Következő oldal"
@@ -712,7 +712,7 @@ msgid "&Huge"
 msgstr "Hatalmas"
 
 #. IDS_VIEW_MENU_BAR
-#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5713
+#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5714
 msgid "Men&u Bar"
 msgstr "Menü sáv"
 
@@ -4568,7 +4568,7 @@ msgid "Items compared:"
 msgstr "Összehasonlított elemek:"
 
 #. IDS_PREVIEWBAR_CLOSE
-#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5684
+#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5685
 #, c-format
 msgid "&Close"
 msgstr "&Bezárás"
@@ -8990,447 +8990,452 @@ msgstr "1. és 3."
 msgid "2nd and 3rd"
 msgstr "2. és 3."
 
+#. IDS_PLUGIN_CTRL_CLICK
+#: Merge.rc:5635
+msgid "(Ctrl+Click to add to pipeline)"
+msgstr ""
+
 #. IDS_FILTER_APPLIED
-#: Merge.rc:5639
+#: Merge.rc:5640
 msgid "Filter applied"
 msgstr "Szűrő alkalmazva"
 
 #. IDS_FILTERMENU_COMPARE
-#: Merge.rc:5644
+#: Merge.rc:5645
 #, c-format
 msgid "Compare %1"
 msgstr "Összehasonlítás %1"
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN2
-#: Merge.rc:5646
+#: Merge.rc:5647
 msgid "&Filter by This Column..."
 msgstr "&Szűrés ezen oszlop alapján..."
 
 #. IDS_CLIPBOARDHISTORY_TIME
-#: Merge.rc:5651
+#: Merge.rc:5652
 #, c-format
 msgid "Clipboard at %s"
 msgstr "Vágólap itt: %s"
 
 #. IDS_CLIPBOARDHISTORY_DISABLED
-#: Merge.rc:5652
+#: Merge.rc:5653
 msgid "Clipboard history disabled.\r\nEnable: Windows logo key + V, then Turn on."
 msgstr "Vágólap előzmények letiltva.\r\nAz engedélyezéshez nyomd meg a Win+V gombokat, majd kattints a bekapcsolás gombra"
 
-#: Merge.rc:5654
+#: Merge.rc:5655
 msgid "This system does not support clipboard history."
 msgstr "Ez a rendszer nem támogatja a vágólap előzményeket"
 
-#: Merge.rc:5656
+#: Merge.rc:5657
 msgid "32-bit WinMerge does not support Clipboard Compare"
 msgstr "A WinMerge 32 bites verziója nem támogatja a vágólap összehasonlítást"
 
 #. IDS_WEBVIEW2_RUNTIME_NOT_INSTALLED
-#: Merge.rc:5661
+#: Merge.rc:5662
 msgid "WebView2 runtime not installed. Download it?"
 msgstr "A WebView2 runtime nincs telepítve. Le akarod tölteni?"
 
 #. IDS_JUMPLIST_NEW_TEXT_COMPARE
-#: Merge.rc:5666
+#: Merge.rc:5667
 msgid "New Text Compare"
 msgstr "Új szöveg összehasonlítás"
 
 #. IDS_JUMPLIST_NEW_TABLE_COMPARE
-#: Merge.rc:5667
+#: Merge.rc:5668
 msgid "New Table Compare"
 msgstr "Új táblázat összehasonlítás"
 
 #. IDS_JUMPLIST_NEW_BINARY_COMPARE
-#: Merge.rc:5668
+#: Merge.rc:5669
 msgid "New Binary Compare"
 msgstr "Új bináris összehasonlítás"
 
 #. IDS_JUMPLIST_NEW_IMAGE_COMPARE
-#: Merge.rc:5669
+#: Merge.rc:5670
 msgid "New Image Compare"
 msgstr "Új kép összehasonlítás"
 
 #. IDS_JUMPLIST_NEW_WEBPAGE_COMPARE
-#: Merge.rc:5670
+#: Merge.rc:5671
 msgid "New Webpage Compare"
 msgstr "Új weboldal összehasonlítás"
 
 #. IDS_JUMPLIST_NEW_FOLDER_COMPARE
-#: Merge.rc:5671
+#: Merge.rc:5672
 msgid "New Folder Compare"
 msgstr "Új mappa összehasonlítás"
 
 #. IDS_JUMPLIST_CLIPBOARD_COMPARE
-#: Merge.rc:5672
+#: Merge.rc:5673
 msgid "Clipboard Compare"
 msgstr "Vágólap összehasonlítás"
 
 #. IDS_PREVIEWBAR_PRINT
-#: Merge.rc:5677
+#: Merge.rc:5678
 msgid "&Print..."
 msgstr "&Nyomtatás..."
 
 #. IDS_PREVIEWBAR_PREVPAGE
-#: Merge.rc:5679
+#: Merge.rc:5680
 msgid "Pre&v Page"
 msgstr "Kö&vetkező oldal"
 
 #. IDS_PREVIEWBAR_TWOPAGE
-#: Merge.rc:5680
+#: Merge.rc:5681
 msgid "&Two Page"
 msgstr "&Két oldal"
 
 #. IDS_PREVIEWBAR_ONEPAGE
-#: Merge.rc:5681
+#: Merge.rc:5682
 msgid "&One Page"
 msgstr "&Egy oldal"
 
 #. IDS_PREVIEWBAR_ZOOMIN
-#: Merge.rc:5682
+#: Merge.rc:5683
 msgid "Zoom &In"
 msgstr "&Nagyítás"
 
 #. IDS_PREVIEWBAR_ZOOMOUT
-#: Merge.rc:5683
+#: Merge.rc:5684
 msgid "Zoom &Out"
 msgstr "K&icsinyítés"
 
 #. IDS_WEBPAGE_COMPARING
-#: Merge.rc:5689
+#: Merge.rc:5690
 msgid "Comparing..."
 msgstr "Összehasonlítás..."
 
 #. IDS_WEBPAGE_ZOOM
-#: Merge.rc:5690
+#: Merge.rc:5691
 msgid "Zoom:"
 msgstr "Nagyítás:"
 
 #. IDS_COPY_GRANULARITY_DIFFHUNK
-#: Merge.rc:5695
+#: Merge.rc:5696
 msgid "Diff hunk"
 msgstr "Különb.nagyság"
 
 #. IDS_COPY_GRANULARITY_INLINE
-#: Merge.rc:5696
+#: Merge.rc:5697
 msgid "Inline diff"
 msgstr "Soron belüli kül."
 
 #. IDS_COPY_GRANULARITY_LINE
-#: Merge.rc:5697
+#: Merge.rc:5698
 msgid "Line"
 msgstr "Sor"
 
-#: Merge.rc:5698
+#: Merge.rc:5699
 msgid "Character"
 msgstr "Karakter"
 
 #. ID_MICE_PREVDIFF
-#: Merge.rc:5703
+#: Merge.rc:5704
 msgid "\nPrevious Difference (Alt+Up)\n(Right Button+Wheel Up)\n(Alt+Wheel Up)"
 msgstr "\nElőző különbség (Alt+fel)\n(Jobb gomb+görgő fel)\n(Alt+görgő fel)"
 
 #. ID_MICE_NEXTDIFF
-#: Merge.rc:5704
+#: Merge.rc:5705
 msgid "\nNext Difference (Alt+Down)\n(Right Button+Wheel Down)\n(Alt+Wheel Down)"
 msgstr "\nKövetkező különbség (Alt+le)\n(Jobb gomb+görgő le)\n(Alt+görgő le)"
 
 #. ID_MICE_L2R
-#: Merge.rc:5705
+#: Merge.rc:5706
 msgid "\nCopy to Right (Alt+Right)\n(Right Button+Wheel Right)\n(Alt+Wheel Right)\n(Alt+Shift+Wheel Down)"
 msgstr "\nMásolás jobbra (Alt+jobbra)\n(Jobb gomb+görgő jobbra)\n(Alt+görgő jobbra)\n(Alt+Shift+görgő le)"
 
 #. ID_MICE_R2L
-#: Merge.rc:5706
+#: Merge.rc:5707
 msgid "\nCopy to Left (Alt+Left)\n(Right Button+Wheel Left)\n(Alt+Wheel Left)\n(Alt+Shift+Wheel Up)"
 msgstr "\nMásolás balra (Alt+balra)\n(Jobb gomb+görgő balra)\n(Alt+görgő balra)\n(Alt+Shift+görgő fel)"
 
 #. ID_MICE_L2RNEXT
-#: Merge.rc:5707
+#: Merge.rc:5708
 msgid "\nCopy to Right and Advance (Ctrl+Alt+Right)\n(Ctrl+Alt+Wheel Right)\n(Ctrl+Alt+Shift+Wheel Down)"
 msgstr "\nMásolás jobbra és előre (Ctrl+Alt+jobbra)\n(Ctrl+Alt+görgő jobbra)\n(Ctrl+Alt+Shift+görgő le)"
 
 #. ID_MICE_R2LNEXT
-#: Merge.rc:5708
+#: Merge.rc:5709
 msgid "\nCopy to Left and Advance (Ctrl+Alt+Left)\n(Ctrl+Alt+Wheel Left)\n(Ctrl+Alt+Shift+Wheel Up)"
 msgstr "\nMásolás balra és előre (Ctrl+Alt+balra)\n(Ctrl+Alt+görgő balra)\n(Ctrl+Alt+Shift+görgő fel)"
 
 #. IDS_LOG_COMPARING_2
-#: Merge.rc:5718
+#: Merge.rc:5719
 #, c-format
 msgid "Comparing %1 with %2"
 msgstr "%1 összehasonlítása ezzel: %2"
 
 #. IDS_LOG_COMPARING_3
-#: Merge.rc:5719
+#: Merge.rc:5720
 #, c-format
 msgid "Comparing %1 with %2 and %3"
 msgstr "%1 összehasonlítása ezekkel: %2 és %3"
 
 #. IDS_LOG_COMPARE_COMPLETED
-#: Merge.rc:5720
+#: Merge.rc:5721
 msgid "Comparison completed"
 msgstr "Összehasonlítás kész"
 
 #. IDS_LOG_COMPARE_ERROR_2
-#: Merge.rc:5721
+#: Merge.rc:5722
 #, c-format
 msgid "Failed to compare %1 with %2: "
 msgstr "Nem sikerült %1 összehasonlítása ezzel: %2"
 
 #. IDS_LOG_COMPARE_ERROR_3
-#: Merge.rc:5722
+#: Merge.rc:5723
 #, c-format
 msgid "Failed to compare %1 with %2 and %3: "
 msgstr "Nem sikerült %1 összehasonlítása ezekkel: %2 és %3"
 
 #. IDS_LOG_FILE_SAVED
-#: Merge.rc:5723
+#: Merge.rc:5724
 msgid "File saved"
 msgstr "Fájl mentve"
 
 #. IDS_LOG_COPYING_FILES
-#: Merge.rc:5724
+#: Merge.rc:5725
 msgid "Copying files..."
 msgstr "Fájlok másolása..."
 
 #. IDS_LOG_MOVING_FILES
-#: Merge.rc:5725
+#: Merge.rc:5726
 msgid "Moving files..."
 msgstr "Fájlok áthelyezése..."
 
 #. IDS_LOG_DELETING_FILES
-#: Merge.rc:5726
+#: Merge.rc:5727
 msgid "Deleting files..."
 msgstr "Fájlok törlése..."
 
 #. IDS_LOG_RECYCLEBIN
-#: Merge.rc:5727
+#: Merge.rc:5728
 msgid "Recycle Bin"
 msgstr "Lomtár"
 
 #. IDS_LOG_PERMANENTLY_DELETED
-#: Merge.rc:5728
+#: Merge.rc:5729
 msgid "Permanently deleted"
 msgstr "Véglegesen törölve"
 
 #. IDS_LOG_FILEOPERATION_COMPLETED
-#: Merge.rc:5729
+#: Merge.rc:5730
 msgid "File operation completed successfully"
 msgstr "A fájlművelet sikeresen befejeződött"
 
 #. IDS_LOG_FILEOPERATION_CANCELED
-#: Merge.rc:5730
+#: Merge.rc:5731
 msgid "File operation canceled"
 msgstr "A fájlművelet megszakítva"
 
 #. IDS_FILTER_ERROR_NO_ERROR
-#: Merge.rc:5735
+#: Merge.rc:5736
 msgid "No error"
 msgstr "Nincs hiba"
 
 #. IDS_FILTER_ERROR_EMPTY_EXPRESSION
-#: Merge.rc:5736
+#: Merge.rc:5737
 msgid "Filter expression is empty"
 msgstr "A szűrőkifejezés üres"
 
 #. IDS_FILTER_ERROR_UNKNOWN_CHAR
-#: Merge.rc:5737
+#: Merge.rc:5738
 msgid "Unknown character in filter expression"
 msgstr "Ismeretlen karakter a szűrőkifejezésben"
 
 #. IDS_FILTER_ERROR_UNTERMINATED_STRING
-#: Merge.rc:5738
+#: Merge.rc:5739
 msgid "Unterminated string literal"
 msgstr "Le nem zárt szting literális"
 
 #. IDS_FILTER_ERROR_SYNTAX_ERROR
-#: Merge.rc:5739
+#: Merge.rc:5740
 msgid "Syntax error in filter expression"
 msgstr "Szintaxishiba a szűrőkifejezésben"
 
 #. IDS_FILTER_ERROR_PARSE_FAILURE
-#: Merge.rc:5740
+#: Merge.rc:5741
 msgid "Failed to parse filter expression"
 msgstr "Nem sikerült elemezni a szűrőkifejezést"
 
 #. IDS_FILTER_ERROR_INVALID_LITERAL
-#: Merge.rc:5741
+#: Merge.rc:5742
 msgid "Invalid literal value"
 msgstr "Érvénytelen literális érték"
 
 #. IDS_FILTER_ERROR_INVALID_REGULAR_EXPRESSION
-#: Merge.rc:5742
+#: Merge.rc:5743
 msgid "Invalid regular expression"
 msgstr "Érvénytelen reguláris kifejezés"
 
 #. IDS_FILTER_ERROR_UNDEFINED_IDENTIFIER
-#: Merge.rc:5743
+#: Merge.rc:5744
 msgid "Undefined identifier"
 msgstr "Meghatározatlan azonosító"
 
 #. IDS_FILTER_ERROR_INVALID_ARGUMENT_COUNT
-#: Merge.rc:5744
+#: Merge.rc:5745
 msgid "Invalid number of arguments"
 msgstr "Érvénytelen számú argumentum"
 
 #. IDS_FILTER_ERROR_FILTER_NAME_NOT_FOUND
-#: Merge.rc:5745
+#: Merge.rc:5746
 msgid "Filter name not found"
 msgstr "A szűrő neve nem található"
 
 #. IDS_FILTER_ERROR_DIVIDE_BY_ZERO
-#: Merge.rc:5746
+#: Merge.rc:5747
 msgid "Division by zero in filter expression"
 msgstr "Nullával való osztás a szűrőkifejezésben"
 
 #. IDS_FILTER_ERROR_UNKNOWN_ERROR
-#: Merge.rc:5747
+#: Merge.rc:5748
 msgid "Unknown error"
 msgstr "Ismeretlen hiba"
 
 #. IDS_FILTER_ERROR_INVALID_PROPERTY_NAME
-#: Merge.rc:5748
+#: Merge.rc:5749
 msgid "Invalid property name"
 msgstr "Érvénytelen tulajdonságnév"
 
 #. IDS_FILTER_ERROR_INVALID_DIRECTIVE
-#: Merge.rc:5749
+#: Merge.rc:5750
 msgid "Invalid directive"
 msgstr "Érvénytelen utasítás"
 
 #. IDS_FILTER_OP_EQUALS
-#: Merge.rc:5754
+#: Merge.rc:5755
 msgid "Equals"
 msgstr "Egyenlők"
 
 #. IDS_FILTER_OP_NOT_EQUALS
-#: Merge.rc:5755
+#: Merge.rc:5756
 msgid "Does not equal"
 msgstr "Nem egyenlő"
 
 #. IDS_FILTER_OP_LESS_THAN
-#: Merge.rc:5756
+#: Merge.rc:5757
 msgid "Less than"
 msgstr "Kevesebb, mint"
 
 #. IDS_FILTER_OP_LESS_EQUAL
-#: Merge.rc:5757
+#: Merge.rc:5758
 msgid "Less than or equal to"
 msgstr "Kevesebb vagy egyenlő, mint"
 
 #. IDS_FILTER_OP_GREATER_EQUAL
-#: Merge.rc:5758
+#: Merge.rc:5759
 msgid "Greater than or equal to"
 msgstr "Nagyobb vagy egyenlő, mint"
 
 #. IDS_FILTER_OP_GREATER_THAN
-#: Merge.rc:5759
+#: Merge.rc:5760
 msgid "Greater than"
 msgstr "Nagyobb , mint"
 
 #. IDS_FILTER_OP_BETWEEN
-#: Merge.rc:5760
+#: Merge.rc:5761
 msgid "Between"
 msgstr "Ezek között"
 
 #. IDS_FILTER_OP_NOT_BETWEEN
-#: Merge.rc:5761
+#: Merge.rc:5762
 msgid "Not Between"
 msgstr "Nem ezek között"
 
 #. IDS_FILTER_OP_CONTAINS
-#: Merge.rc:5762
+#: Merge.rc:5763
 msgid "Contains"
 msgstr "Tartalmazza"
 
 #. IDS_FILTER_OP_NOT_CONTAINS
-#: Merge.rc:5763
+#: Merge.rc:5764
 msgid "Not Contains"
 msgstr "Nem tartalmazza"
 
 #. IDS_FILTER_OP_RECONTAINS
-#: Merge.rc:5764
+#: Merge.rc:5765
 msgid "Contains (regex)"
 msgstr "Tartalmazza (regex)"
 
 #. IDS_FILTER_OP_NOT_RECONTAINS
-#: Merge.rc:5765
+#: Merge.rc:5766
 msgid "Not Contains (regex)"
 msgstr "Nem tartalmazza (regex)"
 
 #. IDS_FILTER_OP_LIKE
-#: Merge.rc:5766
+#: Merge.rc:5767
 msgid "Match (wildcard)"
 msgstr "Egyezés (helyettesítő karakter)"
 
 #. IDS_FILTER_OP_NOT_LIKE
-#: Merge.rc:5767
+#: Merge.rc:5768
 msgid "Not match (wildcard)"
 msgstr "Nem egyezik (helyettesítő karakter)"
 
 #. IDS_FILTER_OP_MATCHES
-#: Merge.rc:5768
+#: Merge.rc:5769
 msgid "Match (regex)"
 msgstr "Egyezés (regex)"
 
 #. IDS_FILTER_OP_NOT_MATCHES
-#: Merge.rc:5769
+#: Merge.rc:5770
 msgid "Not match (regex)"
 msgstr "Nem egyezik (regex)"
 
 #. IDS_COLORMODE_LIGHT
-#: Merge.rc:5774
+#: Merge.rc:5775
 msgid "Light"
 msgstr "Világos"
 
 #. IDS_COLORMODE_DARK
-#: Merge.rc:5775
+#: Merge.rc:5776
 msgid "Dark"
 msgstr "Sötét"
 
 #. IDS_COLORMODE_FOLLOWSYSTEM
-#: Merge.rc:5776
+#: Merge.rc:5777
 msgid "Follow system"
 msgstr "Rendszert követi"
 
 #. IDS_EXAMPLE
-#: Merge.rc:5781
+#: Merge.rc:5782
 #, c-format
 msgid "e.g. %1"
 msgstr "pl %1"
 
 #. IDS_DETECTED_PREVIOUS_CRASH
-#: Merge.rc:5786
+#: Merge.rc:5787
 msgid "WinMerge detected a previous crash. Please report this if possible."
 msgstr "A WinMerge egy korábbi összeomlást észlelt. Kérjük, jelentse ezt, ha lehetséges."
 
 #. IDS_REGEX_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5791
+#: Merge.rc:5792
 msgid "# Regex replacement list\r\n# Format: regex<TAB>replacement\r\n# Backreferences like $1, $2 are supported\r\n\r\n(\\d{4})-(\\d{2})-(\\d{2})\t$1_$2_$3\r\n"
 msgstr "# Regex helyettesítési lista\r\n# Formátum: regex<TAB>csere\r\n# A $1 és $2-hez hasonló visszahivatkozások támogatottak\r\n\r\n(\\d{4})-(\\d{2})-(\\d{2})\t$1_$2_$3\r\n"
 
 #. IDS_STRING_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5792
+#: Merge.rc:5793
 msgid "# Replacement list\r\n# Format: search<TAB>replacement\r\n# Lines starting with # are ignored\r\n\r\nfrom1\tto1\r\nfrom2\tto2\r\n"
 msgstr "# Cserelista\r\n# Formátum: search<TAB>replacement\r\n# A # karakterrel kezdődő sorokat figyelmen kívül hagyja\r\n\r\n1-től 1-ig\r\n2-től 2-ig\r\n"
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_ONLY
-#: Merge.rc:5797
+#: Merge.rc:5798
 msgid "Built-in only"
 msgstr "Csak beépített"
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_FIRST
-#: Merge.rc:5798
+#: Merge.rc:5799
 msgid "Built-in first"
 msgstr "Beépített először"
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_FIRST
-#: Merge.rc:5799
+#: Merge.rc:5800
 msgid "Tree-sitter first"
 msgstr "Tree-sitter először"
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_ONLY
-#: Merge.rc:5800
+#: Merge.rc:5801
 msgid "Tree-sitter only"
 msgstr "Tree-sitter csak"
 

--- a/Translations/WinMerge/Italian.po
+++ b/Translations/WinMerge/Italian.po
@@ -24,7 +24,7 @@ msgstr ""
 "X-Poedit-SourceCharset: UTF-8\n"
 
 #. LANGUAGE, SUBLANGUAGE
-#: Merge.rc:26 Merge.rc:59 Merge.rc:5817
+#: Merge.rc:26 Merge.rc:59 Merge.rc:5818
 msgid "LANG_ENGLISH, SUBLANG_ENGLISH_US"
 msgstr "LANG_ITALIAN, SUBLANG_ITALIAN"
 
@@ -231,7 +231,7 @@ msgid "Auto-Fit All Columns"
 msgstr "Adatta tutte le colonne"
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN
-#: Merge.rc:153 Merge.rc:5645
+#: Merge.rc:153 Merge.rc:5646
 msgid "&Filter by This Column"
 msgstr "&Filtra in base a questa colonna"
 
@@ -292,7 +292,7 @@ msgid "&Previous Page"
 msgstr "Pagina &precedente"
 
 #. IDS_PREVIEWBAR_NEXTPAGE
-#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5678
+#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5679
 msgid "&Next Page"
 msgstr "Pagina s&uccessiva"
 
@@ -665,7 +665,7 @@ msgid "&Huge"
 msgstr "&Gigantesca"
 
 #. IDS_VIEW_MENU_BAR
-#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5713
+#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5714
 msgid "Men&u Bar"
 msgstr "Barra men&u"
 
@@ -4201,7 +4201,7 @@ msgid "Items compared:"
 msgstr "Elementi confrontati:"
 
 #. IDS_PREVIEWBAR_CLOSE
-#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5684
+#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5685
 msgid "&Close"
 msgstr "&Chiudi"
 
@@ -8434,30 +8434,35 @@ msgstr "Primo e terzo"
 msgid "2nd and 3rd"
 msgstr "Secondo e terzo"
 
+#. IDS_PLUGIN_CTRL_CLICK
+#: Merge.rc:5635
+msgid "(Ctrl+Click to add to pipeline)"
+msgstr ""
+
 #. IDS_FILTER_APPLIED
-#: Merge.rc:5639
+#: Merge.rc:5640
 msgid "Filter applied"
 msgstr "Filtro applicato"
 
 #. IDS_FILTERMENU_COMPARE
-#: Merge.rc:5644
+#: Merge.rc:5645
 #, c-format
 msgid "Compare %1"
 msgstr "Confronta %1"
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN2
-#: Merge.rc:5646
+#: Merge.rc:5647
 msgid "&Filter by This Column..."
 msgstr "&Filtra in base a questa colonna..."
 
 #. IDS_CLIPBOARDHISTORY_TIME
-#: Merge.rc:5651
+#: Merge.rc:5652
 #, c-format
 msgid "Clipboard at %s"
 msgstr "Appunti in %s"
 
 #. IDS_CLIPBOARDHISTORY_DISABLED
-#: Merge.rc:5652
+#: Merge.rc:5653
 msgid ""
 "Clipboard history disabled.\r\n"
 "Enable: Windows logo key + V, then Turn on."
@@ -8466,118 +8471,118 @@ msgstr ""
 "Per abilitare la cronologia degli appunti, premi il tasto Logo Windows + V, "
 "quindi fai clic sul pulsante Attiva."
 
-#: Merge.rc:5654
+#: Merge.rc:5655
 msgid "This system does not support clipboard history."
 msgstr "Questo sistema non supporta la cronologia degli appunti."
 
-#: Merge.rc:5656
+#: Merge.rc:5657
 msgid "32-bit WinMerge does not support Clipboard Compare"
 msgstr ""
 "La versione di WinMerge a 32 bit non supporta il confronto degli appunti"
 
 #. IDS_WEBVIEW2_RUNTIME_NOT_INSTALLED
-#: Merge.rc:5661
+#: Merge.rc:5662
 msgid "WebView2 runtime not installed. Download it?"
 msgstr ""
 "Il runtime WebView2 non è installato.\n"
 "Vuoi scaricarlo?"
 
 #. IDS_JUMPLIST_NEW_TEXT_COMPARE
-#: Merge.rc:5666
+#: Merge.rc:5667
 msgid "New Text Compare"
 msgstr "Nuovo confronto testo"
 
 #. IDS_JUMPLIST_NEW_TABLE_COMPARE
-#: Merge.rc:5667
+#: Merge.rc:5668
 msgid "New Table Compare"
 msgstr "Nuova confronto tabella"
 
 #. IDS_JUMPLIST_NEW_BINARY_COMPARE
-#: Merge.rc:5668
+#: Merge.rc:5669
 msgid "New Binary Compare"
 msgstr "Nuovo confronto binario"
 
 #. IDS_JUMPLIST_NEW_IMAGE_COMPARE
-#: Merge.rc:5669
+#: Merge.rc:5670
 msgid "New Image Compare"
 msgstr "Nuovo confronto immagine"
 
 #. IDS_JUMPLIST_NEW_WEBPAGE_COMPARE
-#: Merge.rc:5670
+#: Merge.rc:5671
 msgid "New Webpage Compare"
 msgstr "Nuovo confronto pagina web"
 
 #. IDS_JUMPLIST_NEW_FOLDER_COMPARE
-#: Merge.rc:5671
+#: Merge.rc:5672
 msgid "New Folder Compare"
 msgstr "Nuovo confronto cartella"
 
 #. IDS_JUMPLIST_CLIPBOARD_COMPARE
-#: Merge.rc:5672
+#: Merge.rc:5673
 msgid "Clipboard Compare"
 msgstr "Confronto appunti"
 
 #. IDS_PREVIEWBAR_PRINT
-#: Merge.rc:5677
+#: Merge.rc:5678
 msgid "&Print..."
 msgstr "Stam&pa...."
 
 #. IDS_PREVIEWBAR_PREVPAGE
-#: Merge.rc:5679
+#: Merge.rc:5680
 msgid "Pre&v Page"
 msgstr "Pagina &prec"
 
 #. IDS_PREVIEWBAR_TWOPAGE
-#: Merge.rc:5680
+#: Merge.rc:5681
 msgid "&Two Page"
 msgstr "&Due pagine"
 
 #. IDS_PREVIEWBAR_ONEPAGE
-#: Merge.rc:5681
+#: Merge.rc:5682
 msgid "&One Page"
 msgstr "&Una pagina"
 
 #. IDS_PREVIEWBAR_ZOOMIN
-#: Merge.rc:5682
+#: Merge.rc:5683
 msgid "Zoom &In"
 msgstr "Zoom +"
 
 #. IDS_PREVIEWBAR_ZOOMOUT
-#: Merge.rc:5683
+#: Merge.rc:5684
 msgid "Zoom &Out"
 msgstr "Zoom &-"
 
 #. IDS_WEBPAGE_COMPARING
-#: Merge.rc:5689
+#: Merge.rc:5690
 msgid "Comparing..."
 msgstr "Confronto..."
 
 #. IDS_WEBPAGE_ZOOM
-#: Merge.rc:5690
+#: Merge.rc:5691
 msgid "Zoom:"
 msgstr "Zoom:"
 
 #. IDS_COPY_GRANULARITY_DIFFHUNK
-#: Merge.rc:5695
+#: Merge.rc:5696
 msgid "Diff hunk"
 msgstr "Segmento diff"
 
 #. IDS_COPY_GRANULARITY_INLINE
-#: Merge.rc:5696
+#: Merge.rc:5697
 msgid "Inline diff"
 msgstr "Diff. in linea"
 
 #. IDS_COPY_GRANULARITY_LINE
-#: Merge.rc:5697
+#: Merge.rc:5698
 msgid "Line"
 msgstr "Linea"
 
-#: Merge.rc:5698
+#: Merge.rc:5699
 msgid "Character"
 msgstr "Carattere"
 
 #. ID_MICE_PREVDIFF
-#: Merge.rc:5703
+#: Merge.rc:5704
 msgid ""
 "\n"
 "Previous Difference (Alt+Up)\n"
@@ -8590,7 +8595,7 @@ msgstr ""
 "(Alt+Rotellina Su)"
 
 #. ID_MICE_NEXTDIFF
-#: Merge.rc:5704
+#: Merge.rc:5705
 msgid ""
 "\n"
 "Next Difference (Alt+Down)\n"
@@ -8603,7 +8608,7 @@ msgstr ""
 "(Alt+Rotellina Giù)"
 
 #. ID_MICE_L2R
-#: Merge.rc:5705
+#: Merge.rc:5706
 msgid ""
 "\n"
 "Copy to Right (Alt+Right)\n"
@@ -8618,7 +8623,7 @@ msgstr ""
 "(Alt+Maiusc+Rotellina giù)"
 
 #. ID_MICE_R2L
-#: Merge.rc:5706
+#: Merge.rc:5707
 msgid ""
 "\n"
 "Copy to Left (Alt+Left)\n"
@@ -8633,7 +8638,7 @@ msgstr ""
 "(Alt+Maiusc+Rotellina su)"
 
 #. ID_MICE_L2RNEXT
-#: Merge.rc:5707
+#: Merge.rc:5708
 msgid ""
 "\n"
 "Copy to Right and Advance (Ctrl+Alt+Right)\n"
@@ -8646,7 +8651,7 @@ msgstr ""
 "(Ctrl+Alt+Maiusc+Rotella Giù)"
 
 #. ID_MICE_R2LNEXT
-#: Merge.rc:5708
+#: Merge.rc:5709
 msgid ""
 "\n"
 "Copy to Left and Advance (Ctrl+Alt+Left)\n"
@@ -8659,282 +8664,282 @@ msgstr ""
 "(Ctrl+Alt+Maiusc+Rotellina Su)"
 
 #. IDS_LOG_COMPARING_2
-#: Merge.rc:5718
+#: Merge.rc:5719
 #, c-format
 msgid "Comparing %1 with %2"
 msgstr "Confronto %1 con %2"
 
 #. IDS_LOG_COMPARING_3
-#: Merge.rc:5719
+#: Merge.rc:5720
 #, c-format
 msgid "Comparing %1 with %2 and %3"
 msgstr "Confronto %1 con %2 e %3"
 
 #. IDS_LOG_COMPARE_COMPLETED
-#: Merge.rc:5720
+#: Merge.rc:5721
 msgid "Comparison completed"
 msgstr "Confronto completato"
 
 #. IDS_LOG_COMPARE_ERROR_2
-#: Merge.rc:5721
+#: Merge.rc:5722
 #, c-format
 msgid "Failed to compare %1 with %2: "
 msgstr "Impossibile confrontare %1 con %2: "
 
 #. IDS_LOG_COMPARE_ERROR_3
-#: Merge.rc:5722
+#: Merge.rc:5723
 #, c-format
 msgid "Failed to compare %1 with %2 and %3: "
 msgstr "Impossibile confrontare %1 con %2 e %3: "
 
 #. IDS_LOG_FILE_SAVED
-#: Merge.rc:5723
+#: Merge.rc:5724
 msgid "File saved"
 msgstr "File salvato"
 
 #. IDS_LOG_COPYING_FILES
-#: Merge.rc:5724
+#: Merge.rc:5725
 msgid "Copying files..."
 msgstr "Copia file..."
 
 #. IDS_LOG_MOVING_FILES
-#: Merge.rc:5725
+#: Merge.rc:5726
 msgid "Moving files..."
 msgstr "Spostamento file..."
 
 #. IDS_LOG_DELETING_FILES
-#: Merge.rc:5726
+#: Merge.rc:5727
 msgid "Deleting files..."
 msgstr "Eliminazione file..."
 
 #. IDS_LOG_RECYCLEBIN
-#: Merge.rc:5727
+#: Merge.rc:5728
 msgid "Recycle Bin"
 msgstr "Cestino"
 
 #. IDS_LOG_PERMANENTLY_DELETED
-#: Merge.rc:5728
+#: Merge.rc:5729
 msgid "Permanently deleted"
 msgstr "Permanentemente eliminati"
 
 #. IDS_LOG_FILEOPERATION_COMPLETED
-#: Merge.rc:5729
+#: Merge.rc:5730
 msgid "File operation completed successfully"
 msgstr "Operazione file completata correttamente"
 
 #. IDS_LOG_FILEOPERATION_CANCELED
-#: Merge.rc:5730
+#: Merge.rc:5731
 msgid "File operation canceled"
 msgstr "Operazione file annullata"
 
 #. IDS_FILTER_ERROR_NO_ERROR
-#: Merge.rc:5735
+#: Merge.rc:5736
 msgid "No error"
 msgstr "Nessun errore"
 
 #. IDS_FILTER_ERROR_EMPTY_EXPRESSION
-#: Merge.rc:5736
+#: Merge.rc:5737
 msgid "Filter expression is empty"
 msgstr "L'espressione filtro è vuota"
 
 #. IDS_FILTER_ERROR_UNKNOWN_CHAR
-#: Merge.rc:5737
+#: Merge.rc:5738
 msgid "Unknown character in filter expression"
 msgstr "Carattere sconosciuto nell'espressione filtro"
 
 #. IDS_FILTER_ERROR_UNTERMINATED_STRING
-#: Merge.rc:5738
+#: Merge.rc:5739
 msgid "Unterminated string literal"
 msgstr "Stringa letterale non terminata"
 
 #. IDS_FILTER_ERROR_SYNTAX_ERROR
-#: Merge.rc:5739
+#: Merge.rc:5740
 msgid "Syntax error in filter expression"
 msgstr "Errore di sintassi nell'espressione filtro"
 
 #. IDS_FILTER_ERROR_PARSE_FAILURE
-#: Merge.rc:5740
+#: Merge.rc:5741
 msgid "Failed to parse filter expression"
 msgstr "Impossibile analizzare l'espressione filtro"
 
 #. IDS_FILTER_ERROR_INVALID_LITERAL
-#: Merge.rc:5741
+#: Merge.rc:5742
 msgid "Invalid literal value"
 msgstr "Valore letterale non valido"
 
 #. IDS_FILTER_ERROR_INVALID_REGULAR_EXPRESSION
-#: Merge.rc:5742
+#: Merge.rc:5743
 msgid "Invalid regular expression"
 msgstr "Espressione regolare non valida"
 
 #. IDS_FILTER_ERROR_UNDEFINED_IDENTIFIER
-#: Merge.rc:5743
+#: Merge.rc:5744
 msgid "Undefined identifier"
 msgstr "Identificatore non definito"
 
 #. IDS_FILTER_ERROR_INVALID_ARGUMENT_COUNT
-#: Merge.rc:5744
+#: Merge.rc:5745
 msgid "Invalid number of arguments"
 msgstr "Numero di argomenti non valido"
 
 #. IDS_FILTER_ERROR_FILTER_NAME_NOT_FOUND
-#: Merge.rc:5745
+#: Merge.rc:5746
 msgid "Filter name not found"
 msgstr "Nome filtro non trovato"
 
 #. IDS_FILTER_ERROR_DIVIDE_BY_ZERO
-#: Merge.rc:5746
+#: Merge.rc:5747
 msgid "Division by zero in filter expression"
 msgstr "Divisione per zero nell'espressione filtro"
 
 #. IDS_FILTER_ERROR_UNKNOWN_ERROR
-#: Merge.rc:5747
+#: Merge.rc:5748
 msgid "Unknown error"
 msgstr "Errore sconosciuto"
 
 #. IDS_FILTER_ERROR_INVALID_PROPERTY_NAME
-#: Merge.rc:5748
+#: Merge.rc:5749
 msgid "Invalid property name"
 msgstr "Nome proprietà non valido"
 
 #. IDS_FILTER_ERROR_INVALID_DIRECTIVE
-#: Merge.rc:5749
+#: Merge.rc:5750
 msgid "Invalid directive"
 msgstr "Direttiva non valida"
 
 #. IDS_FILTER_OP_EQUALS
-#: Merge.rc:5754
+#: Merge.rc:5755
 msgid "Equals"
 msgstr "Uguale"
 
 #. IDS_FILTER_OP_NOT_EQUALS
-#: Merge.rc:5755
+#: Merge.rc:5756
 msgid "Does not equal"
 msgstr "Non uguale"
 
 #. IDS_FILTER_OP_LESS_THAN
-#: Merge.rc:5756
+#: Merge.rc:5757
 msgid "Less than"
 msgstr "Inferiore a"
 
 #. IDS_FILTER_OP_LESS_EQUAL
-#: Merge.rc:5757
+#: Merge.rc:5758
 msgid "Less than or equal to"
 msgstr "Inferiore a o uguale a"
 
 #. IDS_FILTER_OP_GREATER_EQUAL
-#: Merge.rc:5758
+#: Merge.rc:5759
 msgid "Greater than or equal to"
 msgstr "Maggiore di o uguale a"
 
 #. IDS_FILTER_OP_GREATER_THAN
-#: Merge.rc:5759
+#: Merge.rc:5760
 msgid "Greater than"
 msgstr "Maggiore di"
 
 #. IDS_FILTER_OP_BETWEEN
-#: Merge.rc:5760
+#: Merge.rc:5761
 msgid "Between"
 msgstr "Tra"
 
 #. IDS_FILTER_OP_NOT_BETWEEN
-#: Merge.rc:5761
+#: Merge.rc:5762
 msgid "Not Between"
 msgstr "Non tra"
 
 #. IDS_FILTER_OP_CONTAINS
-#: Merge.rc:5762
+#: Merge.rc:5763
 msgid "Contains"
 msgstr "Contiene"
 
 #. IDS_FILTER_OP_NOT_CONTAINS
-#: Merge.rc:5763
+#: Merge.rc:5764
 msgid "Not Contains"
 msgstr "Non contiene"
 
 #. IDS_FILTER_OP_RECONTAINS
-#: Merge.rc:5764
+#: Merge.rc:5765
 msgid "Contains (regex)"
 msgstr "Contiene (regx)"
 
 #. IDS_FILTER_OP_NOT_RECONTAINS
-#: Merge.rc:5765
+#: Merge.rc:5766
 msgid "Not Contains (regex)"
 msgstr "Non contiene (regex)"
 
 #. IDS_FILTER_OP_LIKE
-#: Merge.rc:5766
+#: Merge.rc:5767
 msgid "Match (wildcard)"
 msgstr "Corrispondenza (carattere jolly)"
 
 #. IDS_FILTER_OP_NOT_LIKE
-#: Merge.rc:5767
+#: Merge.rc:5768
 msgid "Not match (wildcard)"
 msgstr "Non corrispondenza (carattere jolly)"
 
 #. IDS_FILTER_OP_MATCHES
-#: Merge.rc:5768
+#: Merge.rc:5769
 msgid "Match (regex)"
 msgstr "Corrispondenza (regex)"
 
 #. IDS_FILTER_OP_NOT_MATCHES
-#: Merge.rc:5769
+#: Merge.rc:5770
 msgid "Not match (regex)"
 msgstr "Non corrispondenza (regex)"
 
 #. IDS_COLORMODE_LIGHT
-#: Merge.rc:5774
+#: Merge.rc:5775
 msgid "Light"
 msgstr "Chiaro"
 
 #. IDS_COLORMODE_DARK
-#: Merge.rc:5775
+#: Merge.rc:5776
 msgid "Dark"
 msgstr "Scuro"
 
 #. IDS_COLORMODE_FOLLOWSYSTEM
-#: Merge.rc:5776
+#: Merge.rc:5777
 msgid "Follow system"
 msgstr "Sistema"
 
 #. IDS_EXAMPLE
-#: Merge.rc:5781
+#: Merge.rc:5782
 #, c-format
 msgid "e.g. %1"
 msgstr "es. %1"
 
 #. IDS_DETECTED_PREVIOUS_CRASH
-#: Merge.rc:5786
+#: Merge.rc:5787
 msgid "WinMerge detected a previous crash. Please report this if possible."
 msgstr "WinMerge ha rilevato un precedente arresto anomalo. Se possibile, segnalalo."
 
 #. IDS_REGEX_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5791
+#: Merge.rc:5792
 msgid "# Regex replacement list\r\n# Format: regex<TAB>replacement\r\n# Backreferences like $1, $2 are supported\r\n\r\n(\\d{4})-(\\d{2})-(\\d{2})\t$1_$2_$3\r\n"
 msgstr "# Elenco sostituzione Regex\r\n# Formato: regex<TAB>sostituzione\r\n# Sono supportati riferimenti all'indietro come $1, $2\r\n\r\n(\\d{4})-(\\d{2})-(\\d{2})\t$1_$2_$3\r\n"
 
 #. IDS_STRING_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5792
+#: Merge.rc:5793
 msgid "# Replacement list\r\n# Format: search<TAB>replacement\r\n# Lines starting with # are ignored\r\n\r\nfrom1\tto1\r\nfrom2\tto2\r\n"
 msgstr "# Elenco sostituzioni\r\n# Formato: ricerca<TAB>sostituzione\r\n# Le righe che iniziano con # verranno ignorate\r\n\r\nda1\ta1\r\nda2\ta2\r\n"
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_ONLY
-#: Merge.rc:5797
+#: Merge.rc:5798
 msgid "Built-in only"
 msgstr "Solo integrati"
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_FIRST
-#: Merge.rc:5798
+#: Merge.rc:5799
 msgid "Built-in first"
 msgstr "Prima integrati"
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_FIRST
-#: Merge.rc:5799
+#: Merge.rc:5800
 msgid "Tree-sitter first"
 msgstr "Prima tree-sitter"
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_ONLY
-#: Merge.rc:5800
+#: Merge.rc:5801
 msgid "Tree-sitter only"
 msgstr "Solo tree-sitter"
 

--- a/Translations/WinMerge/Japanese.po
+++ b/Translations/WinMerge/Japanese.po
@@ -22,7 +22,7 @@ msgstr ""
 "X-Generator: Poedit 3.9\n"
 
 #. LANGUAGE, SUBLANGUAGE
-#: Merge.rc:26 Merge.rc:59 Merge.rc:5817
+#: Merge.rc:26 Merge.rc:59 Merge.rc:5818
 msgid "LANG_ENGLISH, SUBLANG_ENGLISH_US"
 msgstr "LANG_JAPANESE, SUBLANG_DEFAULT"
 
@@ -229,7 +229,7 @@ msgid "Auto-Fit All Columns"
 msgstr "全列幅を自動調整する"
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN
-#: Merge.rc:153 Merge.rc:5645
+#: Merge.rc:153 Merge.rc:5646
 msgid "&Filter by This Column"
 msgstr "この列でフィルター(&F)"
 
@@ -290,7 +290,7 @@ msgid "&Previous Page"
 msgstr "前ページ(&P)"
 
 #. IDS_PREVIEWBAR_NEXTPAGE
-#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5678
+#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5679
 msgid "&Next Page"
 msgstr "次ページ(&N)"
 
@@ -663,7 +663,7 @@ msgid "&Huge"
 msgstr "特大(&H)"
 
 #. IDS_VIEW_MENU_BAR
-#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5713
+#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5714
 msgid "Men&u Bar"
 msgstr "メニューバー(&U)"
 
@@ -4192,7 +4192,7 @@ msgid "Items compared:"
 msgstr "比較した項目:"
 
 #. IDS_PREVIEWBAR_CLOSE
-#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5684
+#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5685
 msgid "&Close"
 msgstr "閉じる(&C)"
 
@@ -8395,30 +8395,35 @@ msgstr "1番目と3番目"
 msgid "2nd and 3rd"
 msgstr "2番目と3番目"
 
+#. IDS_PLUGIN_CTRL_CLICK
+#: Merge.rc:5635
+msgid "(Ctrl+Click to add to pipeline)"
+msgstr "(Ctrl+クリックでパイプラインに追加)"
+
 #. IDS_FILTER_APPLIED
-#: Merge.rc:5639
+#: Merge.rc:5640
 msgid "Filter applied"
 msgstr "フィルター適用"
 
 #. IDS_FILTERMENU_COMPARE
-#: Merge.rc:5644
+#: Merge.rc:5645
 #, c-format
 msgid "Compare %1"
 msgstr "%1 を比較"
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN2
-#: Merge.rc:5646
+#: Merge.rc:5647
 msgid "&Filter by This Column..."
 msgstr "この列でフィルター(&F)..."
 
 #. IDS_CLIPBOARDHISTORY_TIME
-#: Merge.rc:5651
+#: Merge.rc:5652
 #, c-format
 msgid "Clipboard at %s"
 msgstr "クリップボード %s"
 
 #. IDS_CLIPBOARDHISTORY_DISABLED
-#: Merge.rc:5652
+#: Merge.rc:5653
 msgid ""
 "Clipboard history disabled.\r\n"
 "Enable: Windows logo key + V, then Turn on."
@@ -8426,115 +8431,115 @@ msgstr ""
 "クリップボード履歴が無効になっています。\r\n"
 "クリップボード履歴を有効にするには、Windows キー + V を押下後、[有効にする] ボタンをクリックしてください。"
 
-#: Merge.rc:5654
+#: Merge.rc:5655
 msgid "This system does not support clipboard history."
 msgstr "このシステムではクリップボード履歴はサポートされていません。"
 
-#: Merge.rc:5656
+#: Merge.rc:5657
 msgid "32-bit WinMerge does not support Clipboard Compare"
 msgstr "32bit版 WinMerge ではクリップボード比較はサポートされていません。"
 
 #. IDS_WEBVIEW2_RUNTIME_NOT_INSTALLED
-#: Merge.rc:5661
+#: Merge.rc:5662
 msgid "WebView2 runtime not installed. Download it?"
 msgstr "WebView2 ランタイムがインストールされていません。ダウンロードしますか?"
 
 #. IDS_JUMPLIST_NEW_TEXT_COMPARE
-#: Merge.rc:5666
+#: Merge.rc:5667
 msgid "New Text Compare"
 msgstr "新規テキスト比較"
 
 #. IDS_JUMPLIST_NEW_TABLE_COMPARE
-#: Merge.rc:5667
+#: Merge.rc:5668
 msgid "New Table Compare"
 msgstr "新規テーブル比較"
 
 #. IDS_JUMPLIST_NEW_BINARY_COMPARE
-#: Merge.rc:5668
+#: Merge.rc:5669
 msgid "New Binary Compare"
 msgstr "新規バイナリ比較"
 
 #. IDS_JUMPLIST_NEW_IMAGE_COMPARE
-#: Merge.rc:5669
+#: Merge.rc:5670
 msgid "New Image Compare"
 msgstr "新規画像比較"
 
 #. IDS_JUMPLIST_NEW_WEBPAGE_COMPARE
-#: Merge.rc:5670
+#: Merge.rc:5671
 msgid "New Webpage Compare"
 msgstr "新規Webページ比較"
 
 #. IDS_JUMPLIST_NEW_FOLDER_COMPARE
-#: Merge.rc:5671
+#: Merge.rc:5672
 msgid "New Folder Compare"
 msgstr "新規フォルダー比較"
 
 #. IDS_JUMPLIST_CLIPBOARD_COMPARE
-#: Merge.rc:5672
+#: Merge.rc:5673
 msgid "Clipboard Compare"
 msgstr "クリップボード比較"
 
 #. IDS_PREVIEWBAR_PRINT
-#: Merge.rc:5677
+#: Merge.rc:5678
 msgid "&Print..."
 msgstr "印刷(&P)..."
 
 #. IDS_PREVIEWBAR_PREVPAGE
-#: Merge.rc:5679
+#: Merge.rc:5680
 msgid "Pre&v Page"
 msgstr "前ページ(&V)"
 
 #. IDS_PREVIEWBAR_TWOPAGE
-#: Merge.rc:5680
+#: Merge.rc:5681
 msgid "&Two Page"
 msgstr "2ページ(&T)"
 
 #. IDS_PREVIEWBAR_ONEPAGE
-#: Merge.rc:5681
+#: Merge.rc:5682
 msgid "&One Page"
 msgstr "1ページ(&O)"
 
 #. IDS_PREVIEWBAR_ZOOMIN
-#: Merge.rc:5682
+#: Merge.rc:5683
 msgid "Zoom &In"
 msgstr "拡大(&I)"
 
 #. IDS_PREVIEWBAR_ZOOMOUT
-#: Merge.rc:5683
+#: Merge.rc:5684
 msgid "Zoom &Out"
 msgstr "縮小(&O)"
 
 #. IDS_WEBPAGE_COMPARING
-#: Merge.rc:5689
+#: Merge.rc:5690
 msgid "Comparing..."
 msgstr "比較しています..."
 
 #. IDS_WEBPAGE_ZOOM
-#: Merge.rc:5690
+#: Merge.rc:5691
 msgid "Zoom:"
 msgstr "拡大率:"
 
 #. IDS_COPY_GRANULARITY_DIFFHUNK
-#: Merge.rc:5695
+#: Merge.rc:5696
 msgid "Diff hunk"
 msgstr "差異ブロック"
 
 #. IDS_COPY_GRANULARITY_INLINE
-#: Merge.rc:5696
+#: Merge.rc:5697
 msgid "Inline diff"
 msgstr "行内差異"
 
 #. IDS_COPY_GRANULARITY_LINE
-#: Merge.rc:5697
+#: Merge.rc:5698
 msgid "Line"
 msgstr "行"
 
-#: Merge.rc:5698
+#: Merge.rc:5699
 msgid "Character"
 msgstr "文字"
 
 #. ID_MICE_PREVDIFF
-#: Merge.rc:5703
+#: Merge.rc:5704
 msgid ""
 "\n"
 "Previous Difference (Alt+Up)\n"
@@ -8547,7 +8552,7 @@ msgstr ""
 "(Alt+Wheel Up)"
 
 #. ID_MICE_NEXTDIFF
-#: Merge.rc:5704
+#: Merge.rc:5705
 msgid ""
 "\n"
 "Next Difference (Alt+Down)\n"
@@ -8560,7 +8565,7 @@ msgstr ""
 "(Alt+Wheel Down)"
 
 #. ID_MICE_L2R
-#: Merge.rc:5705
+#: Merge.rc:5706
 msgid ""
 "\n"
 "Copy to Right (Alt+Right)\n"
@@ -8575,7 +8580,7 @@ msgstr ""
 "(Alt+Shift+Wheel Down)"
 
 #. ID_MICE_R2L
-#: Merge.rc:5706
+#: Merge.rc:5707
 msgid ""
 "\n"
 "Copy to Left (Alt+Left)\n"
@@ -8590,7 +8595,7 @@ msgstr ""
 "(Alt+Shift+Wheel Up)"
 
 #. ID_MICE_L2RNEXT
-#: Merge.rc:5707
+#: Merge.rc:5708
 msgid ""
 "\n"
 "Copy to Right and Advance (Ctrl+Alt+Right)\n"
@@ -8603,7 +8608,7 @@ msgstr ""
 "(Ctrl+Alt+Shift+Wheel Down)"
 
 #. ID_MICE_R2LNEXT
-#: Merge.rc:5708
+#: Merge.rc:5709
 msgid ""
 "\n"
 "Copy to Left and Advance (Ctrl+Alt+Left)\n"
@@ -8616,257 +8621,257 @@ msgstr ""
 "(Ctrl+Alt+Shift+Wheel Up)"
 
 #. IDS_LOG_COMPARING_2
-#: Merge.rc:5718
+#: Merge.rc:5719
 #, c-format
 msgid "Comparing %1 with %2"
 msgstr "%1 と %2 を比較しています"
 
 #. IDS_LOG_COMPARING_3
-#: Merge.rc:5719
+#: Merge.rc:5720
 #, c-format
 msgid "Comparing %1 with %2 and %3"
 msgstr "%1 と %2 と %3 を比較しています"
 
 #. IDS_LOG_COMPARE_COMPLETED
-#: Merge.rc:5720
+#: Merge.rc:5721
 msgid "Comparison completed"
 msgstr "比較が完了しました"
 
 #. IDS_LOG_COMPARE_ERROR_2
-#: Merge.rc:5721
+#: Merge.rc:5722
 #, c-format
 msgid "Failed to compare %1 with %2: "
 msgstr "%1 と %2 の比較に失敗しました: "
 
 #. IDS_LOG_COMPARE_ERROR_3
-#: Merge.rc:5722
+#: Merge.rc:5723
 #, c-format
 msgid "Failed to compare %1 with %2 and %3: "
 msgstr "%1 と %2 と %3 の比較に失敗しました: "
 
 #. IDS_LOG_FILE_SAVED
-#: Merge.rc:5723
+#: Merge.rc:5724
 msgid "File saved"
 msgstr "ファイルが保存されました"
 
 #. IDS_LOG_COPYING_FILES
-#: Merge.rc:5724
+#: Merge.rc:5725
 msgid "Copying files..."
 msgstr "ファイルをコピーしています..."
 
 #. IDS_LOG_MOVING_FILES
-#: Merge.rc:5725
+#: Merge.rc:5726
 msgid "Moving files..."
 msgstr "ファイルを移動しています..."
 
 #. IDS_LOG_DELETING_FILES
-#: Merge.rc:5726
+#: Merge.rc:5727
 msgid "Deleting files..."
 msgstr "ファイルを削除しています..."
 
 #. IDS_LOG_RECYCLEBIN
-#: Merge.rc:5727
+#: Merge.rc:5728
 msgid "Recycle Bin"
 msgstr "ゴミ箱"
 
 #. IDS_LOG_PERMANENTLY_DELETED
-#: Merge.rc:5728
+#: Merge.rc:5729
 msgid "Permanently deleted"
 msgstr "完全に削除"
 
 #. IDS_LOG_FILEOPERATION_COMPLETED
-#: Merge.rc:5729
+#: Merge.rc:5730
 msgid "File operation completed successfully"
 msgstr "ファイル操作が正常に完了しました"
 
 #. IDS_LOG_FILEOPERATION_CANCELED
-#: Merge.rc:5730
+#: Merge.rc:5731
 msgid "File operation canceled"
 msgstr "ファイル操作がキャンセルされました"
 
 #. IDS_FILTER_ERROR_NO_ERROR
-#: Merge.rc:5735
+#: Merge.rc:5736
 msgid "No error"
 msgstr "エラーはありません"
 
 #. IDS_FILTER_ERROR_EMPTY_EXPRESSION
-#: Merge.rc:5736
+#: Merge.rc:5737
 msgid "Filter expression is empty"
 msgstr "フィルター式が空です"
 
 #. IDS_FILTER_ERROR_UNKNOWN_CHAR
-#: Merge.rc:5737
+#: Merge.rc:5738
 msgid "Unknown character in filter expression"
 msgstr "フィルター式に不明な文字があります"
 
 #. IDS_FILTER_ERROR_UNTERMINATED_STRING
-#: Merge.rc:5738
+#: Merge.rc:5739
 msgid "Unterminated string literal"
 msgstr "文字列リテラルが閉じられていません"
 
 #. IDS_FILTER_ERROR_SYNTAX_ERROR
-#: Merge.rc:5739
+#: Merge.rc:5740
 msgid "Syntax error in filter expression"
 msgstr "フィルター式の構文エラーです"
 
 #. IDS_FILTER_ERROR_PARSE_FAILURE
-#: Merge.rc:5740
+#: Merge.rc:5741
 msgid "Failed to parse filter expression"
 msgstr "フィルター式の解析に失敗しました"
 
 #. IDS_FILTER_ERROR_INVALID_LITERAL
-#: Merge.rc:5741
+#: Merge.rc:5742
 msgid "Invalid literal value"
 msgstr "無効なリテラル値です"
 
 #. IDS_FILTER_ERROR_INVALID_REGULAR_EXPRESSION
-#: Merge.rc:5742
+#: Merge.rc:5743
 msgid "Invalid regular expression"
 msgstr "無効な正規表現です"
 
 #. IDS_FILTER_ERROR_UNDEFINED_IDENTIFIER
-#: Merge.rc:5743
+#: Merge.rc:5744
 msgid "Undefined identifier"
 msgstr "未定義の識別子です"
 
 #. IDS_FILTER_ERROR_INVALID_ARGUMENT_COUNT
-#: Merge.rc:5744
+#: Merge.rc:5745
 msgid "Invalid number of arguments"
 msgstr "引数の数が正しくありません"
 
 #. IDS_FILTER_ERROR_FILTER_NAME_NOT_FOUND
-#: Merge.rc:5745
+#: Merge.rc:5746
 msgid "Filter name not found"
 msgstr "フィルター名が見つかりません"
 
 #. IDS_FILTER_ERROR_DIVIDE_BY_ZERO
-#: Merge.rc:5746
+#: Merge.rc:5747
 msgid "Division by zero in filter expression"
 msgstr "フィルター式で0による除算が行われました"
 
 #. IDS_FILTER_ERROR_UNKNOWN_ERROR
-#: Merge.rc:5747
+#: Merge.rc:5748
 msgid "Unknown error"
 msgstr "不明なエラーです"
 
 #. IDS_FILTER_ERROR_INVALID_PROPERTY_NAME
-#: Merge.rc:5748
+#: Merge.rc:5749
 msgid "Invalid property name"
 msgstr "無効なプロパティ名です"
 
 #. IDS_FILTER_ERROR_INVALID_DIRECTIVE
-#: Merge.rc:5749
+#: Merge.rc:5750
 msgid "Invalid directive"
 msgstr "無効なディレクティブです"
 
 #. IDS_FILTER_OP_EQUALS
-#: Merge.rc:5754
+#: Merge.rc:5755
 msgid "Equals"
 msgstr "等しい"
 
 #. IDS_FILTER_OP_NOT_EQUALS
-#: Merge.rc:5755
+#: Merge.rc:5756
 msgid "Does not equal"
 msgstr "等しくない"
 
 #. IDS_FILTER_OP_LESS_THAN
-#: Merge.rc:5756
+#: Merge.rc:5757
 msgid "Less than"
 msgstr "より小さい"
 
 #. IDS_FILTER_OP_LESS_EQUAL
-#: Merge.rc:5757
+#: Merge.rc:5758
 msgid "Less than or equal to"
 msgstr "以下"
 
 #. IDS_FILTER_OP_GREATER_EQUAL
-#: Merge.rc:5758
+#: Merge.rc:5759
 msgid "Greater than or equal to"
 msgstr "以上"
 
 #. IDS_FILTER_OP_GREATER_THAN
-#: Merge.rc:5759
+#: Merge.rc:5760
 msgid "Greater than"
 msgstr "より大きい"
 
 #. IDS_FILTER_OP_BETWEEN
-#: Merge.rc:5760
+#: Merge.rc:5761
 msgid "Between"
 msgstr "範囲内"
 
 #. IDS_FILTER_OP_NOT_BETWEEN
-#: Merge.rc:5761
+#: Merge.rc:5762
 msgid "Not Between"
 msgstr "範囲外"
 
 #. IDS_FILTER_OP_CONTAINS
-#: Merge.rc:5762
+#: Merge.rc:5763
 msgid "Contains"
 msgstr "含む"
 
 #. IDS_FILTER_OP_NOT_CONTAINS
-#: Merge.rc:5763
+#: Merge.rc:5764
 msgid "Not Contains"
 msgstr "含まない"
 
 #. IDS_FILTER_OP_RECONTAINS
-#: Merge.rc:5764
+#: Merge.rc:5765
 msgid "Contains (regex)"
 msgstr "含む(正規表現)"
 
 #. IDS_FILTER_OP_NOT_RECONTAINS
-#: Merge.rc:5765
+#: Merge.rc:5766
 msgid "Not Contains (regex)"
 msgstr "含まない(正規表現)"
 
 #. IDS_FILTER_OP_LIKE
-#: Merge.rc:5766
+#: Merge.rc:5767
 msgid "Match (wildcard)"
 msgstr "一致(ワイルドカード)"
 
 #. IDS_FILTER_OP_NOT_LIKE
-#: Merge.rc:5767
+#: Merge.rc:5768
 msgid "Not match (wildcard)"
 msgstr "不一致(ワイルドカード)"
 
 #. IDS_FILTER_OP_MATCHES
-#: Merge.rc:5768
+#: Merge.rc:5769
 msgid "Match (regex)"
 msgstr "一致(正規表現)"
 
 #. IDS_FILTER_OP_NOT_MATCHES
-#: Merge.rc:5769
+#: Merge.rc:5770
 msgid "Not match (regex)"
 msgstr "不一致(正規表現)"
 
 #. IDS_COLORMODE_LIGHT
-#: Merge.rc:5774
+#: Merge.rc:5775
 msgid "Light"
 msgstr "ライト"
 
 #. IDS_COLORMODE_DARK
-#: Merge.rc:5775
+#: Merge.rc:5776
 msgid "Dark"
 msgstr "ダーク"
 
 #. IDS_COLORMODE_FOLLOWSYSTEM
-#: Merge.rc:5776
+#: Merge.rc:5777
 msgid "Follow system"
 msgstr "システムに従う"
 
 #. IDS_EXAMPLE
-#: Merge.rc:5781
+#: Merge.rc:5782
 #, c-format
 msgid "e.g. %1"
 msgstr "例: %1"
 
 #. IDS_DETECTED_PREVIOUS_CRASH
-#: Merge.rc:5786
+#: Merge.rc:5787
 msgid "WinMerge detected a previous crash. Please report this if possible."
 msgstr "以前の WinMerge のクラッシュを検出しました。可能であればご報告ください。"
 
 #. IDS_REGEX_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5791
+#: Merge.rc:5792
 msgid ""
 "# Regex replacement list\r\n"
 "# Format: regex<TAB>replacement\r\n"
@@ -8881,7 +8886,7 @@ msgstr ""
 "(\\d{4})-(\\d{2})-(\\d{2})\t$1_$2_$3\r\n"
 
 #. IDS_STRING_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5792
+#: Merge.rc:5793
 msgid ""
 "# Replacement list\r\n"
 "# Format: search<TAB>replacement\r\n"
@@ -8898,22 +8903,22 @@ msgstr ""
 "from2\tto2\r\n"
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_ONLY
-#: Merge.rc:5797
+#: Merge.rc:5798
 msgid "Built-in only"
 msgstr "組み込みのみ使用"
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_FIRST
-#: Merge.rc:5798
+#: Merge.rc:5799
 msgid "Built-in first"
 msgstr "組み込みを優先"
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_FIRST
-#: Merge.rc:5799
+#: Merge.rc:5800
 msgid "Tree-sitter first"
 msgstr "Tree-sitter を優先"
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_ONLY
-#: Merge.rc:5800
+#: Merge.rc:5801
 msgid "Tree-sitter only"
 msgstr "Tree-sitter のみ使用"
 

--- a/Translations/WinMerge/Korean.po
+++ b/Translations/WinMerge/Korean.po
@@ -30,7 +30,7 @@ msgstr ""
 "X-Poedit-Bookmarks: 308,-1,-1,-1,-1,-1,-1,-1,-1,-1\n"
 
 #. LANGUAGE, SUBLANGUAGE
-#: Merge.rc:26 Merge.rc:59 Merge.rc:5817
+#: Merge.rc:26 Merge.rc:59 Merge.rc:5818
 #, c-format
 msgid "LANG_ENGLISH, SUBLANG_ENGLISH_US"
 msgstr "LANG_KOREAN, SUBLANG_DEFAULT"
@@ -247,7 +247,7 @@ msgid "Auto-Fit All Columns"
 msgstr "모든 열 자동 맞춤"
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN
-#: Merge.rc:153 Merge.rc:5645
+#: Merge.rc:153 Merge.rc:5646
 msgid "&Filter by This Column"
 msgstr "이 열로 필터링(&F)"
 
@@ -313,7 +313,7 @@ msgid "&Previous Page"
 msgstr "이전 페이지(&P)"
 
 #. IDS_PREVIEWBAR_NEXTPAGE
-#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5678
+#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5679
 #, c-format
 msgid "&Next Page"
 msgstr "다음 페이지(&N)"
@@ -719,7 +719,7 @@ msgid "&Huge"
 msgstr "매우 크게(&H)"
 
 #. IDS_VIEW_MENU_BAR
-#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5713
+#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5714
 msgid "Men&u Bar"
 msgstr "메뉴 표시줄(&U)"
 
@@ -4575,7 +4575,7 @@ msgid "Items compared:"
 msgstr "비교된 항목:"
 
 #. IDS_PREVIEWBAR_CLOSE
-#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5684
+#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5685
 #, c-format
 msgid "&Close"
 msgstr "닫기(&C)"
@@ -9120,30 +9120,35 @@ msgstr "척 번째 및 세번째"
 msgid "2nd and 3rd"
 msgstr "두 번째 및 세번째"
 
+#. IDS_PLUGIN_CTRL_CLICK
+#: Merge.rc:5635
+msgid "(Ctrl+Click to add to pipeline)"
+msgstr ""
+
 #. IDS_FILTER_APPLIED
-#: Merge.rc:5639
+#: Merge.rc:5640
 msgid "Filter applied"
 msgstr "필터 적용됨"
 
 #. IDS_FILTERMENU_COMPARE
-#: Merge.rc:5644
+#: Merge.rc:5645
 #, c-format
 msgid "Compare %1"
 msgstr "비교 %1"
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN2
-#: Merge.rc:5646
+#: Merge.rc:5647
 msgid "&Filter by This Column..."
 msgstr "이 열로 필터링(&F)..."
 
 #. IDS_CLIPBOARDHISTORY_TIME
-#: Merge.rc:5651
+#: Merge.rc:5652
 #, c-format
 msgid "Clipboard at %s"
 msgstr "%s의 클립보드"
 
 #. IDS_CLIPBOARDHISTORY_DISABLED
-#: Merge.rc:5652
+#: Merge.rc:5653
 msgid ""
 "Clipboard history disabled.\r\n"
 "Enable: Windows logo key + V, then Turn on."
@@ -9151,115 +9156,115 @@ msgstr ""
 "클립보드 기록울 사용할 수 없습니다.\r\n"
 "사용함: Windows 로고 키 + V를 누른 다음 켭니다."
 
-#: Merge.rc:5654
+#: Merge.rc:5655
 msgid "This system does not support clipboard history."
 msgstr "이 시스템은 클립보드 기록을 지원하지 않습니다."
 
-#: Merge.rc:5656
+#: Merge.rc:5657
 msgid "32-bit WinMerge does not support Clipboard Compare"
 msgstr "32비트 버전의 WinMerge는 클립보드 비교를 지원하지 않습니다"
 
 #. IDS_WEBVIEW2_RUNTIME_NOT_INSTALLED
-#: Merge.rc:5661
+#: Merge.rc:5662
 msgid "WebView2 runtime not installed. Download it?"
 msgstr "WebView2 런타임이 설치되지 않았습니다. 다운로드하시겠습니까?"
 
 #. IDS_JUMPLIST_NEW_TEXT_COMPARE
-#: Merge.rc:5666
+#: Merge.rc:5667
 msgid "New Text Compare"
 msgstr "새 텍스트 비교"
 
 #. IDS_JUMPLIST_NEW_TABLE_COMPARE
-#: Merge.rc:5667
+#: Merge.rc:5668
 msgid "New Table Compare"
 msgstr "새 테이블 비교"
 
 #. IDS_JUMPLIST_NEW_BINARY_COMPARE
-#: Merge.rc:5668
+#: Merge.rc:5669
 msgid "New Binary Compare"
 msgstr "새 바이너리 비교"
 
 #. IDS_JUMPLIST_NEW_IMAGE_COMPARE
-#: Merge.rc:5669
+#: Merge.rc:5670
 msgid "New Image Compare"
 msgstr "새 이미지 비교"
 
 #. IDS_JUMPLIST_NEW_WEBPAGE_COMPARE
-#: Merge.rc:5670
+#: Merge.rc:5671
 msgid "New Webpage Compare"
 msgstr "새 웹 페이지 비교"
 
 #. IDS_JUMPLIST_NEW_FOLDER_COMPARE
-#: Merge.rc:5671
+#: Merge.rc:5672
 msgid "New Folder Compare"
 msgstr "새 폴더 비교"
 
 #. IDS_JUMPLIST_CLIPBOARD_COMPARE
-#: Merge.rc:5672
+#: Merge.rc:5673
 msgid "Clipboard Compare"
 msgstr "클립보드 비교"
 
 #. IDS_PREVIEWBAR_PRINT
-#: Merge.rc:5677
+#: Merge.rc:5678
 msgid "&Print..."
 msgstr "인쇄(&P)..."
 
 #. IDS_PREVIEWBAR_PREVPAGE
-#: Merge.rc:5679
+#: Merge.rc:5680
 msgid "Pre&v Page"
 msgstr "이전 페이지(&V)"
 
 #. IDS_PREVIEWBAR_TWOPAGE
-#: Merge.rc:5680
+#: Merge.rc:5681
 msgid "&Two Page"
 msgstr "2 페이지(&T)"
 
 #. IDS_PREVIEWBAR_ONEPAGE
-#: Merge.rc:5681
+#: Merge.rc:5682
 msgid "&One Page"
 msgstr "1 페이지(&O)"
 
 #. IDS_PREVIEWBAR_ZOOMIN
-#: Merge.rc:5682
+#: Merge.rc:5683
 msgid "Zoom &In"
 msgstr "확대(&I)"
 
 #. IDS_PREVIEWBAR_ZOOMOUT
-#: Merge.rc:5683
+#: Merge.rc:5684
 msgid "Zoom &Out"
 msgstr "축소(&O)"
 
 #. IDS_WEBPAGE_COMPARING
-#: Merge.rc:5689
+#: Merge.rc:5690
 msgid "Comparing..."
 msgstr "비교 중..."
 
 #. IDS_WEBPAGE_ZOOM
-#: Merge.rc:5690
+#: Merge.rc:5691
 msgid "Zoom:"
 msgstr "확대/축소:"
 
 #. IDS_COPY_GRANULARITY_DIFFHUNK
-#: Merge.rc:5695
+#: Merge.rc:5696
 msgid "Diff hunk"
 msgstr "차이 덩어리"
 
 #. IDS_COPY_GRANULARITY_INLINE
-#: Merge.rc:5696
+#: Merge.rc:5697
 msgid "Inline diff"
 msgstr "인라인 차이"
 
 #. IDS_COPY_GRANULARITY_LINE
-#: Merge.rc:5697
+#: Merge.rc:5698
 msgid "Line"
 msgstr "줄"
 
-#: Merge.rc:5698
+#: Merge.rc:5699
 msgid "Character"
 msgstr "문자"
 
 #. ID_MICE_PREVDIFF
-#: Merge.rc:5703
+#: Merge.rc:5704
 msgid ""
 "\n"
 "Previous Difference (Alt+Up)\n"
@@ -9272,7 +9277,7 @@ msgstr ""
 "(Alt+휠 ⭡)"
 
 #. ID_MICE_NEXTDIFF
-#: Merge.rc:5704
+#: Merge.rc:5705
 msgid ""
 "\n"
 "Next Difference (Alt+Down)\n"
@@ -9285,7 +9290,7 @@ msgstr ""
 "(Alt+휠 ⭣)"
 
 #. ID_MICE_L2R
-#: Merge.rc:5705
+#: Merge.rc:5706
 msgid ""
 "\n"
 "Copy to Right (Alt+Right)\n"
@@ -9300,7 +9305,7 @@ msgstr ""
 "(Alt+Shift+휠 ⭣)"
 
 #. ID_MICE_R2L
-#: Merge.rc:5706
+#: Merge.rc:5707
 msgid ""
 "\n"
 "Copy to Left (Alt+Left)\n"
@@ -9315,7 +9320,7 @@ msgstr ""
 "(Alt+Shift+휠 ⭡)"
 
 #. ID_MICE_L2RNEXT
-#: Merge.rc:5707
+#: Merge.rc:5708
 msgid ""
 "\n"
 "Copy to Right and Advance (Ctrl+Alt+Right)\n"
@@ -9328,7 +9333,7 @@ msgstr ""
 "(Ctrl+Alt+Shift+휠 ⭣)"
 
 #. ID_MICE_R2LNEXT
-#: Merge.rc:5708
+#: Merge.rc:5709
 msgid ""
 "\n"
 "Copy to Left and Advance (Ctrl+Alt+Left)\n"
@@ -9341,257 +9346,257 @@ msgstr ""
 "(Ctrl+Alt+Shift+휠 ⭡)"
 
 #. IDS_LOG_COMPARING_2
-#: Merge.rc:5718
+#: Merge.rc:5719
 #, c-format
 msgid "Comparing %1 with %2"
 msgstr "%1과 %2 비교"
 
 #. IDS_LOG_COMPARING_3
-#: Merge.rc:5719
+#: Merge.rc:5720
 #, c-format
 msgid "Comparing %1 with %2 and %3"
 msgstr "%1과 %2 및 %3 비교"
 
 #. IDS_LOG_COMPARE_COMPLETED
-#: Merge.rc:5720
+#: Merge.rc:5721
 msgid "Comparison completed"
 msgstr "비교 완료"
 
 #. IDS_LOG_COMPARE_ERROR_2
-#: Merge.rc:5721
+#: Merge.rc:5722
 #, c-format
 msgid "Failed to compare %1 with %2: "
 msgstr "%1과 %2를 비교하지 못했습니다: "
 
 #. IDS_LOG_COMPARE_ERROR_3
-#: Merge.rc:5722
+#: Merge.rc:5723
 #, c-format
 msgid "Failed to compare %1 with %2 and %3: "
 msgstr "%1과 %2 및 %3을 비교하지 못했습니다: "
 
 #. IDS_LOG_FILE_SAVED
-#: Merge.rc:5723
+#: Merge.rc:5724
 msgid "File saved"
 msgstr "파일이 저장되었습니다"
 
 #. IDS_LOG_COPYING_FILES
-#: Merge.rc:5724
+#: Merge.rc:5725
 msgid "Copying files..."
 msgstr "파일 복사 중..."
 
 #. IDS_LOG_MOVING_FILES
-#: Merge.rc:5725
+#: Merge.rc:5726
 msgid "Moving files..."
 msgstr "파일 이동 중..."
 
 #. IDS_LOG_DELETING_FILES
-#: Merge.rc:5726
+#: Merge.rc:5727
 msgid "Deleting files..."
 msgstr "파일 삭제 중..."
 
 #. IDS_LOG_RECYCLEBIN
-#: Merge.rc:5727
+#: Merge.rc:5728
 msgid "Recycle Bin"
 msgstr "휴지통"
 
 #. IDS_LOG_PERMANENTLY_DELETED
-#: Merge.rc:5728
+#: Merge.rc:5729
 msgid "Permanently deleted"
 msgstr "영구 삭제"
 
 #. IDS_LOG_FILEOPERATION_COMPLETED
-#: Merge.rc:5729
+#: Merge.rc:5730
 msgid "File operation completed successfully"
 msgstr "파일 작업이 성공적으로 완료되었습니다"
 
 #. IDS_LOG_FILEOPERATION_CANCELED
-#: Merge.rc:5730
+#: Merge.rc:5731
 msgid "File operation canceled"
 msgstr "파일 작업이 취소되었습니다"
 
 #. IDS_FILTER_ERROR_NO_ERROR
-#: Merge.rc:5735
+#: Merge.rc:5736
 msgid "No error"
 msgstr "오류 없음"
 
 #. IDS_FILTER_ERROR_EMPTY_EXPRESSION
-#: Merge.rc:5736
+#: Merge.rc:5737
 msgid "Filter expression is empty"
 msgstr "필터 표현식이 비어 있습니다"
 
 #. IDS_FILTER_ERROR_UNKNOWN_CHAR
-#: Merge.rc:5737
+#: Merge.rc:5738
 msgid "Unknown character in filter expression"
 msgstr "필터 표현식에서 알 수 없는 문자"
 
 #. IDS_FILTER_ERROR_UNTERMINATED_STRING
-#: Merge.rc:5738
+#: Merge.rc:5739
 msgid "Unterminated string literal"
 msgstr "종료되지 않은 문자열 리터럴"
 
 #. IDS_FILTER_ERROR_SYNTAX_ERROR
-#: Merge.rc:5739
+#: Merge.rc:5740
 msgid "Syntax error in filter expression"
 msgstr "필터 표현식의 구문 오류"
 
 #. IDS_FILTER_ERROR_PARSE_FAILURE
-#: Merge.rc:5740
+#: Merge.rc:5741
 msgid "Failed to parse filter expression"
 msgstr "필터 표현식을 구문 분석하지 못했습니다"
 
 #. IDS_FILTER_ERROR_INVALID_LITERAL
-#: Merge.rc:5741
+#: Merge.rc:5742
 msgid "Invalid literal value"
 msgstr "잘못된 문자 그대로의 값"
 
 #. IDS_FILTER_ERROR_INVALID_REGULAR_EXPRESSION
-#: Merge.rc:5742
+#: Merge.rc:5743
 msgid "Invalid regular expression"
 msgstr "잘못된 정규 표현식"
 
 #. IDS_FILTER_ERROR_UNDEFINED_IDENTIFIER
-#: Merge.rc:5743
+#: Merge.rc:5744
 msgid "Undefined identifier"
 msgstr "정의되지 않은 식별자"
 
 #. IDS_FILTER_ERROR_INVALID_ARGUMENT_COUNT
-#: Merge.rc:5744
+#: Merge.rc:5745
 msgid "Invalid number of arguments"
 msgstr "인수 수가 잘못되었습니다"
 
 #. IDS_FILTER_ERROR_FILTER_NAME_NOT_FOUND
-#: Merge.rc:5745
+#: Merge.rc:5746
 msgid "Filter name not found"
 msgstr "필터 이름을 찾을 수 없습니다"
 
 #. IDS_FILTER_ERROR_DIVIDE_BY_ZERO
-#: Merge.rc:5746
+#: Merge.rc:5747
 msgid "Division by zero in filter expression"
 msgstr "필터 표현식에서 0으로 나눕니다"
 
 #. IDS_FILTER_ERROR_UNKNOWN_ERROR
-#: Merge.rc:5747
+#: Merge.rc:5748
 msgid "Unknown error"
 msgstr "알 수 없는 오류"
 
 #. IDS_FILTER_ERROR_INVALID_PROPERTY_NAME
-#: Merge.rc:5748
+#: Merge.rc:5749
 msgid "Invalid property name"
 msgstr "잘못된 속성 이름"
 
 #. IDS_FILTER_ERROR_INVALID_DIRECTIVE
-#: Merge.rc:5749
+#: Merge.rc:5750
 msgid "Invalid directive"
 msgstr "잘못된 지침"
 
 #. IDS_FILTER_OP_EQUALS
-#: Merge.rc:5754
+#: Merge.rc:5755
 msgid "Equals"
 msgstr "같음"
 
 #. IDS_FILTER_OP_NOT_EQUALS
-#: Merge.rc:5755
+#: Merge.rc:5756
 msgid "Does not equal"
 msgstr "같지 않음"
 
 #. IDS_FILTER_OP_LESS_THAN
-#: Merge.rc:5756
+#: Merge.rc:5757
 msgid "Less than"
 msgstr "보다 적은"
 
 #. IDS_FILTER_OP_LESS_EQUAL
-#: Merge.rc:5757
+#: Merge.rc:5758
 msgid "Less than or equal to"
 msgstr "작거나 같음"
 
 #. IDS_FILTER_OP_GREATER_EQUAL
-#: Merge.rc:5758
+#: Merge.rc:5759
 msgid "Greater than or equal to"
 msgstr "크거나 같음"
 
 #. IDS_FILTER_OP_GREATER_THAN
-#: Merge.rc:5759
+#: Merge.rc:5760
 msgid "Greater than"
 msgstr "보다 적은"
 
 #. IDS_FILTER_OP_BETWEEN
-#: Merge.rc:5760
+#: Merge.rc:5761
 msgid "Between"
 msgstr "사이에"
 
 #. IDS_FILTER_OP_NOT_BETWEEN
-#: Merge.rc:5761
+#: Merge.rc:5762
 msgid "Not Between"
 msgstr "사이가 아님"
 
 #. IDS_FILTER_OP_CONTAINS
-#: Merge.rc:5762
+#: Merge.rc:5763
 msgid "Contains"
 msgstr "포함"
 
 #. IDS_FILTER_OP_NOT_CONTAINS
-#: Merge.rc:5763
+#: Merge.rc:5764
 msgid "Not Contains"
 msgstr "포함하지 않음"
 
 #. IDS_FILTER_OP_RECONTAINS
-#: Merge.rc:5764
+#: Merge.rc:5765
 msgid "Contains (regex)"
 msgstr "포함 (정규식)"
 
 #. IDS_FILTER_OP_NOT_RECONTAINS
-#: Merge.rc:5765
+#: Merge.rc:5766
 msgid "Not Contains (regex)"
 msgstr "포함하지 않음 (정규식)"
 
 #. IDS_FILTER_OP_LIKE
-#: Merge.rc:5766
+#: Merge.rc:5767
 msgid "Match (wildcard)"
 msgstr "일치 (와일드카드)"
 
 #. IDS_FILTER_OP_NOT_LIKE
-#: Merge.rc:5767
+#: Merge.rc:5768
 msgid "Not match (wildcard)"
 msgstr "일치하지 않음 (와일드카드)"
 
 #. IDS_FILTER_OP_MATCHES
-#: Merge.rc:5768
+#: Merge.rc:5769
 msgid "Match (regex)"
 msgstr "일치 (정규 표현식)"
 
 #. IDS_FILTER_OP_NOT_MATCHES
-#: Merge.rc:5769
+#: Merge.rc:5770
 msgid "Not match (regex)"
 msgstr "일치하지 않음 (정규 표현식)"
 
 #. IDS_COLORMODE_LIGHT
-#: Merge.rc:5774
+#: Merge.rc:5775
 msgid "Light"
 msgstr "밝은"
 
 #. IDS_COLORMODE_DARK
-#: Merge.rc:5775
+#: Merge.rc:5776
 msgid "Dark"
 msgstr "어두운"
 
 #. IDS_COLORMODE_FOLLOWSYSTEM
-#: Merge.rc:5776
+#: Merge.rc:5777
 msgid "Follow system"
 msgstr "시스템을 따름"
 
 #. IDS_EXAMPLE
-#: Merge.rc:5781
+#: Merge.rc:5782
 #, c-format
 msgid "e.g. %1"
 msgstr "예: %1"
 
 #. IDS_DETECTED_PREVIOUS_CRASH
-#: Merge.rc:5786
+#: Merge.rc:5787
 msgid "WinMerge detected a previous crash. Please report this if possible."
 msgstr "WinMerge가 이전 충돌을 감지했습니다. 가능하다면 이를 보고해 주세요."
 
 #. IDS_REGEX_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5791
+#: Merge.rc:5792
 msgid ""
 "# Regex replacement list\r\n"
 "# Format: regex<TAB>replacement\r\n"
@@ -9606,7 +9611,7 @@ msgstr ""
 "(\\d{4})-(\\d{2})-(\\d{2})\t$1_$2_$3\r\n"
 
 #. IDS_STRING_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5792
+#: Merge.rc:5793
 msgid ""
 "# Replacement list\r\n"
 "# Format: search<TAB>replacement\r\n"
@@ -9623,22 +9628,22 @@ msgstr ""
 "2부터\t2까지\r\n"
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_ONLY
-#: Merge.rc:5797
+#: Merge.rc:5798
 msgid "Built-in only"
 msgstr "내장만"
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_FIRST
-#: Merge.rc:5798
+#: Merge.rc:5799
 msgid "Built-in first"
 msgstr "내장 우선"
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_FIRST
-#: Merge.rc:5799
+#: Merge.rc:5800
 msgid "Tree-sitter first"
 msgstr "트리 시터 우선"
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_ONLY
-#: Merge.rc:5800
+#: Merge.rc:5801
 msgid "Tree-sitter only"
 msgstr "트리 시터만"
 

--- a/Translations/WinMerge/Lithuanian.po
+++ b/Translations/WinMerge/Lithuanian.po
@@ -23,7 +23,7 @@ msgstr ""
 "X-Generator: Poedit 3.9.1\n"
 
 #. LANGUAGE, SUBLANGUAGE
-#: Merge.rc:26 Merge.rc:59 Merge.rc:5817
+#: Merge.rc:26 Merge.rc:59 Merge.rc:5818
 msgid "LANG_ENGLISH, SUBLANG_ENGLISH_US"
 msgstr "LANG_LITHUANIAN, SUBLANG_DEFAULT"
 
@@ -230,7 +230,7 @@ msgid "Auto-Fit All Columns"
 msgstr "Automatiškai talpinti visus stulpelius"
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN
-#: Merge.rc:153 Merge.rc:5645
+#: Merge.rc:153 Merge.rc:5646
 msgid "&Filter by This Column"
 msgstr "&Filtruoti pagal šį stulpelį"
 
@@ -291,7 +291,7 @@ msgid "&Previous Page"
 msgstr "&Praeitas psl."
 
 #. IDS_PREVIEWBAR_NEXTPAGE
-#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5678
+#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5679
 msgid "&Next Page"
 msgstr "&Kitas psl."
 
@@ -664,7 +664,7 @@ msgid "&Huge"
 msgstr "&Milžiniški mygtukai"
 
 #. IDS_VIEW_MENU_BAR
-#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5713
+#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5714
 msgid "Men&u Bar"
 msgstr "Meni&u juosta"
 
@@ -4189,7 +4189,7 @@ msgid "Items compared:"
 msgstr "Elementų palyginta:"
 
 #. IDS_PREVIEWBAR_CLOSE
-#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5684
+#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5685
 msgid "&Close"
 msgstr "&Užverti"
 
@@ -8001,447 +8001,452 @@ msgstr "1-ą ir 3-ą"
 msgid "2nd and 3rd"
 msgstr "2-ą ir 3-ą"
 
+#. IDS_PLUGIN_CTRL_CLICK
+#: Merge.rc:5635
+msgid "(Ctrl+Click to add to pipeline)"
+msgstr ""
+
 #. IDS_FILTER_APPLIED
-#: Merge.rc:5639
+#: Merge.rc:5640
 msgid "Filter applied"
 msgstr "Pritaikytas filtras"
 
 #. IDS_FILTERMENU_COMPARE
-#: Merge.rc:5644
+#: Merge.rc:5645
 #, c-format
 msgid "Compare %1"
 msgstr "Palyginti %1"
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN2
-#: Merge.rc:5646
+#: Merge.rc:5647
 msgid "&Filter by This Column..."
 msgstr "&Filtruoti pagal šį stulpelį..."
 
 #. IDS_CLIPBOARDHISTORY_TIME
-#: Merge.rc:5651
+#: Merge.rc:5652
 #, c-format
 msgid "Clipboard at %s"
 msgstr "Mainų sritis %s"
 
 #. IDS_CLIPBOARDHISTORY_DISABLED
-#: Merge.rc:5652
+#: Merge.rc:5653
 msgid "Clipboard history disabled.\r\nEnable: Windows logo key + V, then Turn on."
 msgstr "Mainų srities istorijos funkcionalumas išjungtas.\r\nNorėdami įjungti, paspauskite Win+V klavišus ir tada „Įjungti“ mygtuką."
 
-#: Merge.rc:5654
+#: Merge.rc:5655
 msgid "This system does not support clipboard history."
 msgstr "Ši sistema nepalaiko mainų srities istorijos."
 
-#: Merge.rc:5656
+#: Merge.rc:5657
 msgid "32-bit WinMerge does not support Clipboard Compare"
 msgstr "32 bitų „WinMerge“ versija nepalaiko lyginimo mainų srityje"
 
 #. IDS_WEBVIEW2_RUNTIME_NOT_INSTALLED
-#: Merge.rc:5661
+#: Merge.rc:5662
 msgid "WebView2 runtime not installed. Download it?"
 msgstr "„WebView2“ vykdymo aplinka neįdiegta. Norite ją parsisiųsti?"
 
 #. IDS_JUMPLIST_NEW_TEXT_COMPARE
-#: Merge.rc:5666
+#: Merge.rc:5667
 msgid "New Text Compare"
 msgstr "Naujas teksto palyginimas"
 
 #. IDS_JUMPLIST_NEW_TABLE_COMPARE
-#: Merge.rc:5667
+#: Merge.rc:5668
 msgid "New Table Compare"
 msgstr "Naujas lentelių palyginimas"
 
 #. IDS_JUMPLIST_NEW_BINARY_COMPARE
-#: Merge.rc:5668
+#: Merge.rc:5669
 msgid "New Binary Compare"
 msgstr "Naujas binarinių failų palyginimas"
 
 #. IDS_JUMPLIST_NEW_IMAGE_COMPARE
-#: Merge.rc:5669
+#: Merge.rc:5670
 msgid "New Image Compare"
 msgstr "Naujas vaizdų palyginimas"
 
 #. IDS_JUMPLIST_NEW_WEBPAGE_COMPARE
-#: Merge.rc:5670
+#: Merge.rc:5671
 msgid "New Webpage Compare"
 msgstr "Naujas tinklapių palyginimas"
 
 #. IDS_JUMPLIST_NEW_FOLDER_COMPARE
-#: Merge.rc:5671
+#: Merge.rc:5672
 msgid "New Folder Compare"
 msgstr "Naujas katalogų oalyginimas"
 
 #. IDS_JUMPLIST_CLIPBOARD_COMPARE
-#: Merge.rc:5672
+#: Merge.rc:5673
 msgid "Clipboard Compare"
 msgstr "Mainų srities palyginimas"
 
 #. IDS_PREVIEWBAR_PRINT
-#: Merge.rc:5677
+#: Merge.rc:5678
 msgid "&Print..."
 msgstr "S&pausdinti..."
 
 #. IDS_PREVIEWBAR_PREVPAGE
-#: Merge.rc:5679
+#: Merge.rc:5680
 msgid "Pre&v Page"
 msgstr "P&raeitas psl."
 
 #. IDS_PREVIEWBAR_TWOPAGE
-#: Merge.rc:5680
+#: Merge.rc:5681
 msgid "&Two Page"
 msgstr "&2 psl."
 
 #. IDS_PREVIEWBAR_ONEPAGE
-#: Merge.rc:5681
+#: Merge.rc:5682
 msgid "&One Page"
 msgstr "&1 psl."
 
 #. IDS_PREVIEWBAR_ZOOMIN
-#: Merge.rc:5682
+#: Merge.rc:5683
 msgid "Zoom &In"
 msgstr "Did&inti"
 
 #. IDS_PREVIEWBAR_ZOOMOUT
-#: Merge.rc:5683
+#: Merge.rc:5684
 msgid "Zoom &Out"
 msgstr "Mažin&ti"
 
 #. IDS_WEBPAGE_COMPARING
-#: Merge.rc:5689
+#: Merge.rc:5690
 msgid "Comparing..."
 msgstr "Lygina..."
 
 #. IDS_WEBPAGE_ZOOM
-#: Merge.rc:5690
+#: Merge.rc:5691
 msgid "Zoom:"
 msgstr "Mastelis:"
 
 #. IDS_COPY_GRANULARITY_DIFFHUNK
-#: Merge.rc:5695
+#: Merge.rc:5696
 msgid "Diff hunk"
 msgstr "Skirt. bloke"
 
 #. IDS_COPY_GRANULARITY_INLINE
-#: Merge.rc:5696
+#: Merge.rc:5697
 msgid "Inline diff"
 msgstr "Skirt. eilutėje"
 
 #. IDS_COPY_GRANULARITY_LINE
-#: Merge.rc:5697
+#: Merge.rc:5698
 msgid "Line"
 msgstr "Eilutė"
 
-#: Merge.rc:5698
+#: Merge.rc:5699
 msgid "Character"
 msgstr "Simbolis"
 
 #. ID_MICE_PREVDIFF
-#: Merge.rc:5703
+#: Merge.rc:5704
 msgid "\nPrevious Difference (Alt+Up)\n(Right Button+Wheel Up)\n(Alt+Wheel Up)"
 msgstr "\nPraeitas skirtumas (Alt+Up)\n(Right Button+Wheel Up)\n(Alt+Wheel Up)"
 
 #. ID_MICE_NEXTDIFF
-#: Merge.rc:5704
+#: Merge.rc:5705
 msgid "\nNext Difference (Alt+Down)\n(Right Button+Wheel Down)\n(Alt+Wheel Down)"
 msgstr "\nKitas skirtumas (Alt+Down)\n(Right Button+Wheel Down)\n(Alt+Wheel Down)"
 
 #. ID_MICE_L2R
-#: Merge.rc:5705
+#: Merge.rc:5706
 msgid "\nCopy to Right (Alt+Right)\n(Right Button+Wheel Right)\n(Alt+Wheel Right)\n(Alt+Shift+Wheel Down)"
 msgstr "\nKopijuoti į dešinę (Alt+Right)\n(Right Button+Wheel Right)\n(Alt+Wheel Right)\n(Alt+Shift+Wheel Down)"
 
 #. ID_MICE_R2L
-#: Merge.rc:5706
+#: Merge.rc:5707
 msgid "\nCopy to Left (Alt+Left)\n(Right Button+Wheel Left)\n(Alt+Wheel Left)\n(Alt+Shift+Wheel Up)"
 msgstr "\nKopijuoti į kairę (Alt+Left)\n(Right Button+Wheel Left)\n(Alt+Wheel Left)\n(Alt+Shift+Wheel Up)"
 
 #. ID_MICE_L2RNEXT
-#: Merge.rc:5707
+#: Merge.rc:5708
 msgid "\nCopy to Right and Advance (Ctrl+Alt+Right)\n(Ctrl+Alt+Wheel Right)\n(Ctrl+Alt+Shift+Wheel Down)"
 msgstr "\nKopijuoti į dešinę ir Daugiau (Ctrl+Alt+Right)\n(Ctrl+Alt+Wheel Right)\n(Ctrl+Alt+Shift+Wheel Down)"
 
 #. ID_MICE_R2LNEXT
-#: Merge.rc:5708
+#: Merge.rc:5709
 msgid "\nCopy to Left and Advance (Ctrl+Alt+Left)\n(Ctrl+Alt+Wheel Left)\n(Ctrl+Alt+Shift+Wheel Up)"
 msgstr "\nKopijuoti į kairę ir Daugiau (Ctrl+Alt+Left)\n(Ctrl+Alt+Wheel Left)\n(Ctrl+Alt+Shift+Wheel Up)"
 
 #. IDS_LOG_COMPARING_2
-#: Merge.rc:5718
+#: Merge.rc:5719
 #, c-format
 msgid "Comparing %1 with %2"
 msgstr "Lyginama %1 su %2"
 
 #. IDS_LOG_COMPARING_3
-#: Merge.rc:5719
+#: Merge.rc:5720
 #, c-format
 msgid "Comparing %1 with %2 and %3"
 msgstr "Lyginama %1 su %2 ir %3"
 
 #. IDS_LOG_COMPARE_COMPLETED
-#: Merge.rc:5720
+#: Merge.rc:5721
 msgid "Comparison completed"
 msgstr "Palyginimas baigtas"
 
 #. IDS_LOG_COMPARE_ERROR_2
-#: Merge.rc:5721
+#: Merge.rc:5722
 #, c-format
 msgid "Failed to compare %1 with %2: "
 msgstr "Nepavyko %1 ir %2 palyginimas: "
 
 #. IDS_LOG_COMPARE_ERROR_3
-#: Merge.rc:5722
+#: Merge.rc:5723
 #, c-format
 msgid "Failed to compare %1 with %2 and %3: "
 msgstr "Nepavyko %1, %2 ir %3 palyginimas: "
 
 #. IDS_LOG_FILE_SAVED
-#: Merge.rc:5723
+#: Merge.rc:5724
 msgid "File saved"
 msgstr "Failas išsaugotas"
 
 #. IDS_LOG_COPYING_FILES
-#: Merge.rc:5724
+#: Merge.rc:5725
 msgid "Copying files..."
 msgstr "Failų kopijavimas..."
 
 #. IDS_LOG_MOVING_FILES
-#: Merge.rc:5725
+#: Merge.rc:5726
 msgid "Moving files..."
 msgstr "Failų perkėlimas..."
 
 #. IDS_LOG_DELETING_FILES
-#: Merge.rc:5726
+#: Merge.rc:5727
 msgid "Deleting files..."
 msgstr "Failų trynimas..."
 
 #. IDS_LOG_RECYCLEBIN
-#: Merge.rc:5727
+#: Merge.rc:5728
 msgid "Recycle Bin"
 msgstr "Šiukšliadėžė"
 
 #. IDS_LOG_PERMANENTLY_DELETED
-#: Merge.rc:5728
+#: Merge.rc:5729
 msgid "Permanently deleted"
 msgstr "Ištrinta visam laikui"
 
 #. IDS_LOG_FILEOPERATION_COMPLETED
-#: Merge.rc:5729
+#: Merge.rc:5730
 msgid "File operation completed successfully"
 msgstr "Failo operacija baigta sėkmingai"
 
 #. IDS_LOG_FILEOPERATION_CANCELED
-#: Merge.rc:5730
+#: Merge.rc:5731
 msgid "File operation canceled"
 msgstr "Failo operacija atšaukta"
 
 #. IDS_FILTER_ERROR_NO_ERROR
-#: Merge.rc:5735
+#: Merge.rc:5736
 msgid "No error"
 msgstr "Klaidų nėra"
 
 #. IDS_FILTER_ERROR_EMPTY_EXPRESSION
-#: Merge.rc:5736
+#: Merge.rc:5737
 msgid "Filter expression is empty"
 msgstr "Filtro išraiška tuščia"
 
 #. IDS_FILTER_ERROR_UNKNOWN_CHAR
-#: Merge.rc:5737
+#: Merge.rc:5738
 msgid "Unknown character in filter expression"
 msgstr "Nežinomas simbolis filtro išraiškoje"
 
 #. IDS_FILTER_ERROR_UNTERMINATED_STRING
-#: Merge.rc:5738
+#: Merge.rc:5739
 msgid "Unterminated string literal"
 msgstr "Neužbaigta eilutės tiesioginė išraiška"
 
 #. IDS_FILTER_ERROR_SYNTAX_ERROR
-#: Merge.rc:5739
+#: Merge.rc:5740
 msgid "Syntax error in filter expression"
 msgstr "Sintaksės klaida filtro išraiškoje"
 
 #. IDS_FILTER_ERROR_PARSE_FAILURE
-#: Merge.rc:5740
+#: Merge.rc:5741
 msgid "Failed to parse filter expression"
 msgstr "Nepavyko išanalizuoti filtro išraiškos"
 
 #. IDS_FILTER_ERROR_INVALID_LITERAL
-#: Merge.rc:5741
+#: Merge.rc:5742
 msgid "Invalid literal value"
 msgstr "Klaidinga tiesioginės išraiškos reikšmė"
 
 #. IDS_FILTER_ERROR_INVALID_REGULAR_EXPRESSION
-#: Merge.rc:5742
+#: Merge.rc:5743
 msgid "Invalid regular expression"
 msgstr "Klaidinga reguliarioji išraiška"
 
 #. IDS_FILTER_ERROR_UNDEFINED_IDENTIFIER
-#: Merge.rc:5743
+#: Merge.rc:5744
 msgid "Undefined identifier"
 msgstr "Neapibrėžtas identifikatorius"
 
 #. IDS_FILTER_ERROR_INVALID_ARGUMENT_COUNT
-#: Merge.rc:5744
+#: Merge.rc:5745
 msgid "Invalid number of arguments"
 msgstr "Neteisingas argumentų skaičius"
 
 #. IDS_FILTER_ERROR_FILTER_NAME_NOT_FOUND
-#: Merge.rc:5745
+#: Merge.rc:5746
 msgid "Filter name not found"
 msgstr "Filtro pavadinimas nerastas"
 
 #. IDS_FILTER_ERROR_DIVIDE_BY_ZERO
-#: Merge.rc:5746
+#: Merge.rc:5747
 msgid "Division by zero in filter expression"
 msgstr "Dalyba iš nulio filtro išraiškoje"
 
 #. IDS_FILTER_ERROR_UNKNOWN_ERROR
-#: Merge.rc:5747
+#: Merge.rc:5748
 msgid "Unknown error"
 msgstr "Nežinoma klaida"
 
 #. IDS_FILTER_ERROR_INVALID_PROPERTY_NAME
-#: Merge.rc:5748
+#: Merge.rc:5749
 msgid "Invalid property name"
 msgstr "Netinkamas ypatybės pavadinimas"
 
 #. IDS_FILTER_ERROR_INVALID_DIRECTIVE
-#: Merge.rc:5749
+#: Merge.rc:5750
 msgid "Invalid directive"
 msgstr "Netinkama direktyva"
 
 #. IDS_FILTER_OP_EQUALS
-#: Merge.rc:5754
+#: Merge.rc:5755
 msgid "Equals"
 msgstr "Lygu"
 
 #. IDS_FILTER_OP_NOT_EQUALS
-#: Merge.rc:5755
+#: Merge.rc:5756
 msgid "Does not equal"
 msgstr "Nelygu"
 
 #. IDS_FILTER_OP_LESS_THAN
-#: Merge.rc:5756
+#: Merge.rc:5757
 msgid "Less than"
 msgstr "Mažiau nei"
 
 #. IDS_FILTER_OP_LESS_EQUAL
-#: Merge.rc:5757
+#: Merge.rc:5758
 msgid "Less than or equal to"
 msgstr "Mažiau arba lygu"
 
 #. IDS_FILTER_OP_GREATER_EQUAL
-#: Merge.rc:5758
+#: Merge.rc:5759
 msgid "Greater than or equal to"
 msgstr "Daugiau arba lygu"
 
 #. IDS_FILTER_OP_GREATER_THAN
-#: Merge.rc:5759
+#: Merge.rc:5760
 msgid "Greater than"
 msgstr "Daugiau nei"
 
 #. IDS_FILTER_OP_BETWEEN
-#: Merge.rc:5760
+#: Merge.rc:5761
 msgid "Between"
 msgstr "Tarp"
 
 #. IDS_FILTER_OP_NOT_BETWEEN
-#: Merge.rc:5761
+#: Merge.rc:5762
 msgid "Not Between"
 msgstr "Ne tarp"
 
 #. IDS_FILTER_OP_CONTAINS
-#: Merge.rc:5762
+#: Merge.rc:5763
 msgid "Contains"
 msgstr "Turi"
 
 #. IDS_FILTER_OP_NOT_CONTAINS
-#: Merge.rc:5763
+#: Merge.rc:5764
 msgid "Not Contains"
 msgstr "Neturi"
 
 #. IDS_FILTER_OP_RECONTAINS
-#: Merge.rc:5764
+#: Merge.rc:5765
 msgid "Contains (regex)"
 msgstr "Turi (regex)"
 
 #. IDS_FILTER_OP_NOT_RECONTAINS
-#: Merge.rc:5765
+#: Merge.rc:5766
 msgid "Not Contains (regex)"
 msgstr "Neturi (regex)"
 
 #. IDS_FILTER_OP_LIKE
-#: Merge.rc:5766
+#: Merge.rc:5767
 msgid "Match (wildcard)"
 msgstr "Sutampa (wildcard)"
 
 #. IDS_FILTER_OP_NOT_LIKE
-#: Merge.rc:5767
+#: Merge.rc:5768
 msgid "Not match (wildcard)"
 msgstr "Nesutampa (wildcard)"
 
 #. IDS_FILTER_OP_MATCHES
-#: Merge.rc:5768
+#: Merge.rc:5769
 msgid "Match (regex)"
 msgstr "Sutampa (regex)"
 
 #. IDS_FILTER_OP_NOT_MATCHES
-#: Merge.rc:5769
+#: Merge.rc:5770
 msgid "Not match (regex)"
 msgstr "Nesutampa (regex)"
 
 #. IDS_COLORMODE_LIGHT
-#: Merge.rc:5774
+#: Merge.rc:5775
 msgid "Light"
 msgstr "Šviesi schema"
 
 #. IDS_COLORMODE_DARK
-#: Merge.rc:5775
+#: Merge.rc:5776
 msgid "Dark"
 msgstr "Tamsi schema"
 
 #. IDS_COLORMODE_FOLLOWSYSTEM
-#: Merge.rc:5776
+#: Merge.rc:5777
 msgid "Follow system"
 msgstr "Kaip sistemos"
 
 #. IDS_EXAMPLE
-#: Merge.rc:5781
+#: Merge.rc:5782
 #, c-format
 msgid "e.g. %1"
 msgstr "pvz. %1"
 
 #. IDS_DETECTED_PREVIOUS_CRASH
-#: Merge.rc:5786
+#: Merge.rc:5787
 msgid "WinMerge detected a previous crash. Please report this if possible."
 msgstr "„WinMerge“ aptiko, kad buvo gedimas. Jei įmanoma, praneškite apie tai."
 
 #. IDS_REGEX_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5791
+#: Merge.rc:5792
 msgid "# Regex replacement list\r\n# Format: regex<TAB>replacement\r\n# Backreferences like $1, $2 are supported\r\n\r\n(\\d{4})-(\\d{2})-(\\d{2})\t$1_$2_$3\r\n"
 msgstr "# Regex pakeitimų sąrašas\r\n# Formatas: regex<TAB>replacement\r\n# Backreferences like $1, $2 are supported\r\n\r\n(\\d{4})-(\\d{2})-(\\d{2})\t$1_$2_$3\r\n"
 
 #. IDS_STRING_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5792
+#: Merge.rc:5793
 msgid "# Replacement list\r\n# Format: search<TAB>replacement\r\n# Lines starting with # are ignored\r\n\r\nfrom1\tto1\r\nfrom2\tto2\r\n"
 msgstr "# Pakeitimų sąrašas\r\n# Formatas: search<TAB>replacement\r\n# Lines starting with # are ignored\r\n\r\nfrom1\tto1\r\nfrom2\tto2\r\n"
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_ONLY
-#: Merge.rc:5797
+#: Merge.rc:5798
 msgid "Built-in only"
 msgstr "Tik įtaisytasis"
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_FIRST
-#: Merge.rc:5798
+#: Merge.rc:5799
 msgid "Built-in first"
 msgstr "Pirmiausia įtaisytasis"
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_FIRST
-#: Merge.rc:5799
+#: Merge.rc:5800
 msgid "Tree-sitter first"
 msgstr "Pirmiausia „Tree-sitter“"
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_ONLY
-#: Merge.rc:5800
+#: Merge.rc:5801
 msgid "Tree-sitter only"
 msgstr "Tik „Tree-sitter“"
 

--- a/Translations/WinMerge/Norwegian.po
+++ b/Translations/WinMerge/Norwegian.po
@@ -22,7 +22,7 @@ msgstr ""
 "X-Generator: Poedit 3.0.1\n"
 
 #. LANGUAGE, SUBLANGUAGE
-#: Merge.rc:26 Merge.rc:59 Merge.rc:5817
+#: Merge.rc:26 Merge.rc:59 Merge.rc:5818
 msgid "LANG_ENGLISH, SUBLANG_ENGLISH_US"
 msgstr "LANG_NORWEGIAN, SUBLANG_DEFAULT"
 
@@ -229,7 +229,7 @@ msgid "Auto-Fit All Columns"
 msgstr ""
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN
-#: Merge.rc:153 Merge.rc:5645
+#: Merge.rc:153 Merge.rc:5646
 msgid "&Filter by This Column"
 msgstr ""
 
@@ -290,7 +290,7 @@ msgid "&Previous Page"
 msgstr "&Forrige side"
 
 #. IDS_PREVIEWBAR_NEXTPAGE
-#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5678
+#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5679
 msgid "&Next Page"
 msgstr "&Neste side"
 
@@ -663,7 +663,7 @@ msgid "&Huge"
 msgstr ""
 
 #. IDS_VIEW_MENU_BAR
-#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5713
+#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5714
 msgid "Men&u Bar"
 msgstr ""
 
@@ -4194,7 +4194,7 @@ msgid "Items compared:"
 msgstr "Objekter sammenlignet:"
 
 #. IDS_PREVIEWBAR_CLOSE
-#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5684
+#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5685
 msgid "&Close"
 msgstr "&Lukk"
 
@@ -8306,447 +8306,452 @@ msgstr ""
 msgid "2nd and 3rd"
 msgstr ""
 
+#. IDS_PLUGIN_CTRL_CLICK
+#: Merge.rc:5635
+msgid "(Ctrl+Click to add to pipeline)"
+msgstr ""
+
 #. IDS_FILTER_APPLIED
-#: Merge.rc:5639
+#: Merge.rc:5640
 msgid "Filter applied"
 msgstr ""
 
 #. IDS_FILTERMENU_COMPARE
-#: Merge.rc:5644
+#: Merge.rc:5645
 #, c-format
 msgid "Compare %1"
 msgstr ""
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN2
-#: Merge.rc:5646
+#: Merge.rc:5647
 msgid "&Filter by This Column..."
 msgstr ""
 
 #. IDS_CLIPBOARDHISTORY_TIME
-#: Merge.rc:5651
+#: Merge.rc:5652
 #, c-format
 msgid "Clipboard at %s"
 msgstr ""
 
 #. IDS_CLIPBOARDHISTORY_DISABLED
-#: Merge.rc:5652
+#: Merge.rc:5653
 msgid "Clipboard history disabled.\r\nEnable: Windows logo key + V, then Turn on."
 msgstr ""
 
-#: Merge.rc:5654
+#: Merge.rc:5655
 msgid "This system does not support clipboard history."
 msgstr ""
 
-#: Merge.rc:5656
+#: Merge.rc:5657
 msgid "32-bit WinMerge does not support Clipboard Compare"
 msgstr ""
 
 #. IDS_WEBVIEW2_RUNTIME_NOT_INSTALLED
-#: Merge.rc:5661
+#: Merge.rc:5662
 msgid "WebView2 runtime not installed. Download it?"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_TEXT_COMPARE
-#: Merge.rc:5666
+#: Merge.rc:5667
 msgid "New Text Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_TABLE_COMPARE
-#: Merge.rc:5667
+#: Merge.rc:5668
 msgid "New Table Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_BINARY_COMPARE
-#: Merge.rc:5668
+#: Merge.rc:5669
 msgid "New Binary Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_IMAGE_COMPARE
-#: Merge.rc:5669
+#: Merge.rc:5670
 msgid "New Image Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_WEBPAGE_COMPARE
-#: Merge.rc:5670
+#: Merge.rc:5671
 msgid "New Webpage Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_FOLDER_COMPARE
-#: Merge.rc:5671
+#: Merge.rc:5672
 msgid "New Folder Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_CLIPBOARD_COMPARE
-#: Merge.rc:5672
+#: Merge.rc:5673
 msgid "Clipboard Compare"
 msgstr ""
 
 #. IDS_PREVIEWBAR_PRINT
-#: Merge.rc:5677
+#: Merge.rc:5678
 msgid "&Print..."
 msgstr ""
 
 #. IDS_PREVIEWBAR_PREVPAGE
-#: Merge.rc:5679
+#: Merge.rc:5680
 msgid "Pre&v Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_TWOPAGE
-#: Merge.rc:5680
+#: Merge.rc:5681
 msgid "&Two Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_ONEPAGE
-#: Merge.rc:5681
+#: Merge.rc:5682
 msgid "&One Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_ZOOMIN
-#: Merge.rc:5682
+#: Merge.rc:5683
 msgid "Zoom &In"
 msgstr ""
 
 #. IDS_PREVIEWBAR_ZOOMOUT
-#: Merge.rc:5683
+#: Merge.rc:5684
 msgid "Zoom &Out"
 msgstr ""
 
 #. IDS_WEBPAGE_COMPARING
-#: Merge.rc:5689
+#: Merge.rc:5690
 msgid "Comparing..."
 msgstr ""
 
 #. IDS_WEBPAGE_ZOOM
-#: Merge.rc:5690
+#: Merge.rc:5691
 msgid "Zoom:"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_DIFFHUNK
-#: Merge.rc:5695
+#: Merge.rc:5696
 msgid "Diff hunk"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_INLINE
-#: Merge.rc:5696
+#: Merge.rc:5697
 msgid "Inline diff"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_LINE
-#: Merge.rc:5697
+#: Merge.rc:5698
 msgid "Line"
 msgstr ""
 
-#: Merge.rc:5698
+#: Merge.rc:5699
 msgid "Character"
 msgstr ""
 
 #. ID_MICE_PREVDIFF
-#: Merge.rc:5703
+#: Merge.rc:5704
 msgid "\nPrevious Difference (Alt+Up)\n(Right Button+Wheel Up)\n(Alt+Wheel Up)"
 msgstr ""
 
 #. ID_MICE_NEXTDIFF
-#: Merge.rc:5704
+#: Merge.rc:5705
 msgid "\nNext Difference (Alt+Down)\n(Right Button+Wheel Down)\n(Alt+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_L2R
-#: Merge.rc:5705
+#: Merge.rc:5706
 msgid "\nCopy to Right (Alt+Right)\n(Right Button+Wheel Right)\n(Alt+Wheel Right)\n(Alt+Shift+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_R2L
-#: Merge.rc:5706
+#: Merge.rc:5707
 msgid "\nCopy to Left (Alt+Left)\n(Right Button+Wheel Left)\n(Alt+Wheel Left)\n(Alt+Shift+Wheel Up)"
 msgstr ""
 
 #. ID_MICE_L2RNEXT
-#: Merge.rc:5707
+#: Merge.rc:5708
 msgid "\nCopy to Right and Advance (Ctrl+Alt+Right)\n(Ctrl+Alt+Wheel Right)\n(Ctrl+Alt+Shift+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_R2LNEXT
-#: Merge.rc:5708
+#: Merge.rc:5709
 msgid "\nCopy to Left and Advance (Ctrl+Alt+Left)\n(Ctrl+Alt+Wheel Left)\n(Ctrl+Alt+Shift+Wheel Up)"
 msgstr ""
 
 #. IDS_LOG_COMPARING_2
-#: Merge.rc:5718
+#: Merge.rc:5719
 #, c-format
 msgid "Comparing %1 with %2"
 msgstr ""
 
 #. IDS_LOG_COMPARING_3
-#: Merge.rc:5719
+#: Merge.rc:5720
 #, c-format
 msgid "Comparing %1 with %2 and %3"
 msgstr ""
 
 #. IDS_LOG_COMPARE_COMPLETED
-#: Merge.rc:5720
+#: Merge.rc:5721
 msgid "Comparison completed"
 msgstr ""
 
 #. IDS_LOG_COMPARE_ERROR_2
-#: Merge.rc:5721
+#: Merge.rc:5722
 #, c-format
 msgid "Failed to compare %1 with %2: "
 msgstr ""
 
 #. IDS_LOG_COMPARE_ERROR_3
-#: Merge.rc:5722
+#: Merge.rc:5723
 #, c-format
 msgid "Failed to compare %1 with %2 and %3: "
 msgstr ""
 
 #. IDS_LOG_FILE_SAVED
-#: Merge.rc:5723
+#: Merge.rc:5724
 msgid "File saved"
 msgstr ""
 
 #. IDS_LOG_COPYING_FILES
-#: Merge.rc:5724
+#: Merge.rc:5725
 msgid "Copying files..."
 msgstr ""
 
 #. IDS_LOG_MOVING_FILES
-#: Merge.rc:5725
+#: Merge.rc:5726
 msgid "Moving files..."
 msgstr ""
 
 #. IDS_LOG_DELETING_FILES
-#: Merge.rc:5726
+#: Merge.rc:5727
 msgid "Deleting files..."
 msgstr ""
 
 #. IDS_LOG_RECYCLEBIN
-#: Merge.rc:5727
+#: Merge.rc:5728
 msgid "Recycle Bin"
 msgstr ""
 
 #. IDS_LOG_PERMANENTLY_DELETED
-#: Merge.rc:5728
+#: Merge.rc:5729
 msgid "Permanently deleted"
 msgstr ""
 
 #. IDS_LOG_FILEOPERATION_COMPLETED
-#: Merge.rc:5729
+#: Merge.rc:5730
 msgid "File operation completed successfully"
 msgstr ""
 
 #. IDS_LOG_FILEOPERATION_CANCELED
-#: Merge.rc:5730
+#: Merge.rc:5731
 msgid "File operation canceled"
 msgstr ""
 
 #. IDS_FILTER_ERROR_NO_ERROR
-#: Merge.rc:5735
+#: Merge.rc:5736
 msgid "No error"
 msgstr ""
 
 #. IDS_FILTER_ERROR_EMPTY_EXPRESSION
-#: Merge.rc:5736
+#: Merge.rc:5737
 msgid "Filter expression is empty"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNKNOWN_CHAR
-#: Merge.rc:5737
+#: Merge.rc:5738
 msgid "Unknown character in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNTERMINATED_STRING
-#: Merge.rc:5738
+#: Merge.rc:5739
 msgid "Unterminated string literal"
 msgstr ""
 
 #. IDS_FILTER_ERROR_SYNTAX_ERROR
-#: Merge.rc:5739
+#: Merge.rc:5740
 msgid "Syntax error in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_PARSE_FAILURE
-#: Merge.rc:5740
+#: Merge.rc:5741
 msgid "Failed to parse filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_LITERAL
-#: Merge.rc:5741
+#: Merge.rc:5742
 msgid "Invalid literal value"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_REGULAR_EXPRESSION
-#: Merge.rc:5742
+#: Merge.rc:5743
 msgid "Invalid regular expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNDEFINED_IDENTIFIER
-#: Merge.rc:5743
+#: Merge.rc:5744
 msgid "Undefined identifier"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_ARGUMENT_COUNT
-#: Merge.rc:5744
+#: Merge.rc:5745
 msgid "Invalid number of arguments"
 msgstr ""
 
 #. IDS_FILTER_ERROR_FILTER_NAME_NOT_FOUND
-#: Merge.rc:5745
+#: Merge.rc:5746
 msgid "Filter name not found"
 msgstr ""
 
 #. IDS_FILTER_ERROR_DIVIDE_BY_ZERO
-#: Merge.rc:5746
+#: Merge.rc:5747
 msgid "Division by zero in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNKNOWN_ERROR
-#: Merge.rc:5747
+#: Merge.rc:5748
 msgid "Unknown error"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_PROPERTY_NAME
-#: Merge.rc:5748
+#: Merge.rc:5749
 msgid "Invalid property name"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_DIRECTIVE
-#: Merge.rc:5749
+#: Merge.rc:5750
 msgid "Invalid directive"
 msgstr ""
 
 #. IDS_FILTER_OP_EQUALS
-#: Merge.rc:5754
+#: Merge.rc:5755
 msgid "Equals"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_EQUALS
-#: Merge.rc:5755
+#: Merge.rc:5756
 msgid "Does not equal"
 msgstr ""
 
 #. IDS_FILTER_OP_LESS_THAN
-#: Merge.rc:5756
+#: Merge.rc:5757
 msgid "Less than"
 msgstr ""
 
 #. IDS_FILTER_OP_LESS_EQUAL
-#: Merge.rc:5757
+#: Merge.rc:5758
 msgid "Less than or equal to"
 msgstr ""
 
 #. IDS_FILTER_OP_GREATER_EQUAL
-#: Merge.rc:5758
+#: Merge.rc:5759
 msgid "Greater than or equal to"
 msgstr ""
 
 #. IDS_FILTER_OP_GREATER_THAN
-#: Merge.rc:5759
+#: Merge.rc:5760
 msgid "Greater than"
 msgstr ""
 
 #. IDS_FILTER_OP_BETWEEN
-#: Merge.rc:5760
+#: Merge.rc:5761
 msgid "Between"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_BETWEEN
-#: Merge.rc:5761
+#: Merge.rc:5762
 msgid "Not Between"
 msgstr ""
 
 #. IDS_FILTER_OP_CONTAINS
-#: Merge.rc:5762
+#: Merge.rc:5763
 msgid "Contains"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_CONTAINS
-#: Merge.rc:5763
+#: Merge.rc:5764
 msgid "Not Contains"
 msgstr ""
 
 #. IDS_FILTER_OP_RECONTAINS
-#: Merge.rc:5764
+#: Merge.rc:5765
 msgid "Contains (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_RECONTAINS
-#: Merge.rc:5765
+#: Merge.rc:5766
 msgid "Not Contains (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_LIKE
-#: Merge.rc:5766
+#: Merge.rc:5767
 msgid "Match (wildcard)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_LIKE
-#: Merge.rc:5767
+#: Merge.rc:5768
 msgid "Not match (wildcard)"
 msgstr ""
 
 #. IDS_FILTER_OP_MATCHES
-#: Merge.rc:5768
+#: Merge.rc:5769
 msgid "Match (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_MATCHES
-#: Merge.rc:5769
+#: Merge.rc:5770
 msgid "Not match (regex)"
 msgstr ""
 
 #. IDS_COLORMODE_LIGHT
-#: Merge.rc:5774
+#: Merge.rc:5775
 msgid "Light"
 msgstr ""
 
 #. IDS_COLORMODE_DARK
-#: Merge.rc:5775
+#: Merge.rc:5776
 msgid "Dark"
 msgstr ""
 
 #. IDS_COLORMODE_FOLLOWSYSTEM
-#: Merge.rc:5776
+#: Merge.rc:5777
 msgid "Follow system"
 msgstr ""
 
 #. IDS_EXAMPLE
-#: Merge.rc:5781
+#: Merge.rc:5782
 #, c-format
 msgid "e.g. %1"
 msgstr ""
 
 #. IDS_DETECTED_PREVIOUS_CRASH
-#: Merge.rc:5786
+#: Merge.rc:5787
 msgid "WinMerge detected a previous crash. Please report this if possible."
 msgstr ""
 
 #. IDS_REGEX_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5791
+#: Merge.rc:5792
 msgid "# Regex replacement list\r\n# Format: regex<TAB>replacement\r\n# Backreferences like $1, $2 are supported\r\n\r\n(\\d{4})-(\\d{2})-(\\d{2})\t$1_$2_$3\r\n"
 msgstr ""
 
 #. IDS_STRING_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5792
+#: Merge.rc:5793
 msgid "# Replacement list\r\n# Format: search<TAB>replacement\r\n# Lines starting with # are ignored\r\n\r\nfrom1\tto1\r\nfrom2\tto2\r\n"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_ONLY
-#: Merge.rc:5797
+#: Merge.rc:5798
 msgid "Built-in only"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_FIRST
-#: Merge.rc:5798
+#: Merge.rc:5799
 msgid "Built-in first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_FIRST
-#: Merge.rc:5799
+#: Merge.rc:5800
 msgid "Tree-sitter first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_ONLY
-#: Merge.rc:5800
+#: Merge.rc:5801
 msgid "Tree-sitter only"
 msgstr ""
 

--- a/Translations/WinMerge/Persian.po
+++ b/Translations/WinMerge/Persian.po
@@ -22,7 +22,7 @@ msgstr ""
 "X-Generator: Poedit 1.5.7\n"
 
 #. LANGUAGE, SUBLANGUAGE
-#: Merge.rc:26 Merge.rc:59 Merge.rc:5817
+#: Merge.rc:26 Merge.rc:59 Merge.rc:5818
 #, c-format
 msgid "LANG_ENGLISH, SUBLANG_ENGLISH_US"
 msgstr "LANG_FARSI, SUBLANG_DEFAULT"
@@ -239,7 +239,7 @@ msgid "Auto-Fit All Columns"
 msgstr ""
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN
-#: Merge.rc:153 Merge.rc:5645
+#: Merge.rc:153 Merge.rc:5646
 msgid "&Filter by This Column"
 msgstr ""
 
@@ -305,7 +305,7 @@ msgid "&Previous Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_NEXTPAGE
-#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5678
+#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5679
 #, c-format
 msgid "&Next Page"
 msgstr ""
@@ -711,7 +711,7 @@ msgid "&Huge"
 msgstr ""
 
 #. IDS_VIEW_MENU_BAR
-#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5713
+#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5714
 msgid "Men&u Bar"
 msgstr ""
 
@@ -4571,7 +4571,7 @@ msgid "Items compared:"
 msgstr " موارد مقايسه شده : "
 
 #. IDS_PREVIEWBAR_CLOSE
-#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5684
+#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5685
 #, c-format
 msgid "&Close"
 msgstr "&C بستن "
@@ -8933,447 +8933,452 @@ msgstr ""
 msgid "2nd and 3rd"
 msgstr ""
 
+#. IDS_PLUGIN_CTRL_CLICK
+#: Merge.rc:5635
+msgid "(Ctrl+Click to add to pipeline)"
+msgstr ""
+
 #. IDS_FILTER_APPLIED
-#: Merge.rc:5639
+#: Merge.rc:5640
 msgid "Filter applied"
 msgstr ""
 
 #. IDS_FILTERMENU_COMPARE
-#: Merge.rc:5644
+#: Merge.rc:5645
 #, c-format
 msgid "Compare %1"
 msgstr ""
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN2
-#: Merge.rc:5646
+#: Merge.rc:5647
 msgid "&Filter by This Column..."
 msgstr ""
 
 #. IDS_CLIPBOARDHISTORY_TIME
-#: Merge.rc:5651
+#: Merge.rc:5652
 #, c-format
 msgid "Clipboard at %s"
 msgstr ""
 
 #. IDS_CLIPBOARDHISTORY_DISABLED
-#: Merge.rc:5652
+#: Merge.rc:5653
 msgid "Clipboard history disabled.\r\nEnable: Windows logo key + V, then Turn on."
 msgstr ""
 
-#: Merge.rc:5654
+#: Merge.rc:5655
 msgid "This system does not support clipboard history."
 msgstr ""
 
-#: Merge.rc:5656
+#: Merge.rc:5657
 msgid "32-bit WinMerge does not support Clipboard Compare"
 msgstr ""
 
 #. IDS_WEBVIEW2_RUNTIME_NOT_INSTALLED
-#: Merge.rc:5661
+#: Merge.rc:5662
 msgid "WebView2 runtime not installed. Download it?"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_TEXT_COMPARE
-#: Merge.rc:5666
+#: Merge.rc:5667
 msgid "New Text Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_TABLE_COMPARE
-#: Merge.rc:5667
+#: Merge.rc:5668
 msgid "New Table Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_BINARY_COMPARE
-#: Merge.rc:5668
+#: Merge.rc:5669
 msgid "New Binary Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_IMAGE_COMPARE
-#: Merge.rc:5669
+#: Merge.rc:5670
 msgid "New Image Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_WEBPAGE_COMPARE
-#: Merge.rc:5670
+#: Merge.rc:5671
 msgid "New Webpage Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_FOLDER_COMPARE
-#: Merge.rc:5671
+#: Merge.rc:5672
 msgid "New Folder Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_CLIPBOARD_COMPARE
-#: Merge.rc:5672
+#: Merge.rc:5673
 msgid "Clipboard Compare"
 msgstr ""
 
 #. IDS_PREVIEWBAR_PRINT
-#: Merge.rc:5677
+#: Merge.rc:5678
 msgid "&Print..."
 msgstr ""
 
 #. IDS_PREVIEWBAR_PREVPAGE
-#: Merge.rc:5679
+#: Merge.rc:5680
 msgid "Pre&v Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_TWOPAGE
-#: Merge.rc:5680
+#: Merge.rc:5681
 msgid "&Two Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_ONEPAGE
-#: Merge.rc:5681
+#: Merge.rc:5682
 msgid "&One Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_ZOOMIN
-#: Merge.rc:5682
+#: Merge.rc:5683
 msgid "Zoom &In"
 msgstr ""
 
 #. IDS_PREVIEWBAR_ZOOMOUT
-#: Merge.rc:5683
+#: Merge.rc:5684
 msgid "Zoom &Out"
 msgstr ""
 
 #. IDS_WEBPAGE_COMPARING
-#: Merge.rc:5689
+#: Merge.rc:5690
 msgid "Comparing..."
 msgstr ""
 
 #. IDS_WEBPAGE_ZOOM
-#: Merge.rc:5690
+#: Merge.rc:5691
 msgid "Zoom:"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_DIFFHUNK
-#: Merge.rc:5695
+#: Merge.rc:5696
 msgid "Diff hunk"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_INLINE
-#: Merge.rc:5696
+#: Merge.rc:5697
 msgid "Inline diff"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_LINE
-#: Merge.rc:5697
+#: Merge.rc:5698
 msgid "Line"
 msgstr ""
 
-#: Merge.rc:5698
+#: Merge.rc:5699
 msgid "Character"
 msgstr ""
 
 #. ID_MICE_PREVDIFF
-#: Merge.rc:5703
+#: Merge.rc:5704
 msgid "\nPrevious Difference (Alt+Up)\n(Right Button+Wheel Up)\n(Alt+Wheel Up)"
 msgstr ""
 
 #. ID_MICE_NEXTDIFF
-#: Merge.rc:5704
+#: Merge.rc:5705
 msgid "\nNext Difference (Alt+Down)\n(Right Button+Wheel Down)\n(Alt+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_L2R
-#: Merge.rc:5705
+#: Merge.rc:5706
 msgid "\nCopy to Right (Alt+Right)\n(Right Button+Wheel Right)\n(Alt+Wheel Right)\n(Alt+Shift+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_R2L
-#: Merge.rc:5706
+#: Merge.rc:5707
 msgid "\nCopy to Left (Alt+Left)\n(Right Button+Wheel Left)\n(Alt+Wheel Left)\n(Alt+Shift+Wheel Up)"
 msgstr ""
 
 #. ID_MICE_L2RNEXT
-#: Merge.rc:5707
+#: Merge.rc:5708
 msgid "\nCopy to Right and Advance (Ctrl+Alt+Right)\n(Ctrl+Alt+Wheel Right)\n(Ctrl+Alt+Shift+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_R2LNEXT
-#: Merge.rc:5708
+#: Merge.rc:5709
 msgid "\nCopy to Left and Advance (Ctrl+Alt+Left)\n(Ctrl+Alt+Wheel Left)\n(Ctrl+Alt+Shift+Wheel Up)"
 msgstr ""
 
 #. IDS_LOG_COMPARING_2
-#: Merge.rc:5718
+#: Merge.rc:5719
 #, c-format
 msgid "Comparing %1 with %2"
 msgstr ""
 
 #. IDS_LOG_COMPARING_3
-#: Merge.rc:5719
+#: Merge.rc:5720
 #, c-format
 msgid "Comparing %1 with %2 and %3"
 msgstr ""
 
 #. IDS_LOG_COMPARE_COMPLETED
-#: Merge.rc:5720
+#: Merge.rc:5721
 msgid "Comparison completed"
 msgstr ""
 
 #. IDS_LOG_COMPARE_ERROR_2
-#: Merge.rc:5721
+#: Merge.rc:5722
 #, c-format
 msgid "Failed to compare %1 with %2: "
 msgstr ""
 
 #. IDS_LOG_COMPARE_ERROR_3
-#: Merge.rc:5722
+#: Merge.rc:5723
 #, c-format
 msgid "Failed to compare %1 with %2 and %3: "
 msgstr ""
 
 #. IDS_LOG_FILE_SAVED
-#: Merge.rc:5723
+#: Merge.rc:5724
 msgid "File saved"
 msgstr ""
 
 #. IDS_LOG_COPYING_FILES
-#: Merge.rc:5724
+#: Merge.rc:5725
 msgid "Copying files..."
 msgstr ""
 
 #. IDS_LOG_MOVING_FILES
-#: Merge.rc:5725
+#: Merge.rc:5726
 msgid "Moving files..."
 msgstr ""
 
 #. IDS_LOG_DELETING_FILES
-#: Merge.rc:5726
+#: Merge.rc:5727
 msgid "Deleting files..."
 msgstr ""
 
 #. IDS_LOG_RECYCLEBIN
-#: Merge.rc:5727
+#: Merge.rc:5728
 msgid "Recycle Bin"
 msgstr ""
 
 #. IDS_LOG_PERMANENTLY_DELETED
-#: Merge.rc:5728
+#: Merge.rc:5729
 msgid "Permanently deleted"
 msgstr ""
 
 #. IDS_LOG_FILEOPERATION_COMPLETED
-#: Merge.rc:5729
+#: Merge.rc:5730
 msgid "File operation completed successfully"
 msgstr ""
 
 #. IDS_LOG_FILEOPERATION_CANCELED
-#: Merge.rc:5730
+#: Merge.rc:5731
 msgid "File operation canceled"
 msgstr ""
 
 #. IDS_FILTER_ERROR_NO_ERROR
-#: Merge.rc:5735
+#: Merge.rc:5736
 msgid "No error"
 msgstr ""
 
 #. IDS_FILTER_ERROR_EMPTY_EXPRESSION
-#: Merge.rc:5736
+#: Merge.rc:5737
 msgid "Filter expression is empty"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNKNOWN_CHAR
-#: Merge.rc:5737
+#: Merge.rc:5738
 msgid "Unknown character in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNTERMINATED_STRING
-#: Merge.rc:5738
+#: Merge.rc:5739
 msgid "Unterminated string literal"
 msgstr ""
 
 #. IDS_FILTER_ERROR_SYNTAX_ERROR
-#: Merge.rc:5739
+#: Merge.rc:5740
 msgid "Syntax error in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_PARSE_FAILURE
-#: Merge.rc:5740
+#: Merge.rc:5741
 msgid "Failed to parse filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_LITERAL
-#: Merge.rc:5741
+#: Merge.rc:5742
 msgid "Invalid literal value"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_REGULAR_EXPRESSION
-#: Merge.rc:5742
+#: Merge.rc:5743
 msgid "Invalid regular expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNDEFINED_IDENTIFIER
-#: Merge.rc:5743
+#: Merge.rc:5744
 msgid "Undefined identifier"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_ARGUMENT_COUNT
-#: Merge.rc:5744
+#: Merge.rc:5745
 msgid "Invalid number of arguments"
 msgstr ""
 
 #. IDS_FILTER_ERROR_FILTER_NAME_NOT_FOUND
-#: Merge.rc:5745
+#: Merge.rc:5746
 msgid "Filter name not found"
 msgstr ""
 
 #. IDS_FILTER_ERROR_DIVIDE_BY_ZERO
-#: Merge.rc:5746
+#: Merge.rc:5747
 msgid "Division by zero in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNKNOWN_ERROR
-#: Merge.rc:5747
+#: Merge.rc:5748
 msgid "Unknown error"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_PROPERTY_NAME
-#: Merge.rc:5748
+#: Merge.rc:5749
 msgid "Invalid property name"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_DIRECTIVE
-#: Merge.rc:5749
+#: Merge.rc:5750
 msgid "Invalid directive"
 msgstr ""
 
 #. IDS_FILTER_OP_EQUALS
-#: Merge.rc:5754
+#: Merge.rc:5755
 msgid "Equals"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_EQUALS
-#: Merge.rc:5755
+#: Merge.rc:5756
 msgid "Does not equal"
 msgstr ""
 
 #. IDS_FILTER_OP_LESS_THAN
-#: Merge.rc:5756
+#: Merge.rc:5757
 msgid "Less than"
 msgstr ""
 
 #. IDS_FILTER_OP_LESS_EQUAL
-#: Merge.rc:5757
+#: Merge.rc:5758
 msgid "Less than or equal to"
 msgstr ""
 
 #. IDS_FILTER_OP_GREATER_EQUAL
-#: Merge.rc:5758
+#: Merge.rc:5759
 msgid "Greater than or equal to"
 msgstr ""
 
 #. IDS_FILTER_OP_GREATER_THAN
-#: Merge.rc:5759
+#: Merge.rc:5760
 msgid "Greater than"
 msgstr ""
 
 #. IDS_FILTER_OP_BETWEEN
-#: Merge.rc:5760
+#: Merge.rc:5761
 msgid "Between"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_BETWEEN
-#: Merge.rc:5761
+#: Merge.rc:5762
 msgid "Not Between"
 msgstr ""
 
 #. IDS_FILTER_OP_CONTAINS
-#: Merge.rc:5762
+#: Merge.rc:5763
 msgid "Contains"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_CONTAINS
-#: Merge.rc:5763
+#: Merge.rc:5764
 msgid "Not Contains"
 msgstr ""
 
 #. IDS_FILTER_OP_RECONTAINS
-#: Merge.rc:5764
+#: Merge.rc:5765
 msgid "Contains (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_RECONTAINS
-#: Merge.rc:5765
+#: Merge.rc:5766
 msgid "Not Contains (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_LIKE
-#: Merge.rc:5766
+#: Merge.rc:5767
 msgid "Match (wildcard)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_LIKE
-#: Merge.rc:5767
+#: Merge.rc:5768
 msgid "Not match (wildcard)"
 msgstr ""
 
 #. IDS_FILTER_OP_MATCHES
-#: Merge.rc:5768
+#: Merge.rc:5769
 msgid "Match (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_MATCHES
-#: Merge.rc:5769
+#: Merge.rc:5770
 msgid "Not match (regex)"
 msgstr ""
 
 #. IDS_COLORMODE_LIGHT
-#: Merge.rc:5774
+#: Merge.rc:5775
 msgid "Light"
 msgstr ""
 
 #. IDS_COLORMODE_DARK
-#: Merge.rc:5775
+#: Merge.rc:5776
 msgid "Dark"
 msgstr ""
 
 #. IDS_COLORMODE_FOLLOWSYSTEM
-#: Merge.rc:5776
+#: Merge.rc:5777
 msgid "Follow system"
 msgstr ""
 
 #. IDS_EXAMPLE
-#: Merge.rc:5781
+#: Merge.rc:5782
 #, c-format
 msgid "e.g. %1"
 msgstr ""
 
 #. IDS_DETECTED_PREVIOUS_CRASH
-#: Merge.rc:5786
+#: Merge.rc:5787
 msgid "WinMerge detected a previous crash. Please report this if possible."
 msgstr ""
 
 #. IDS_REGEX_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5791
+#: Merge.rc:5792
 msgid "# Regex replacement list\r\n# Format: regex<TAB>replacement\r\n# Backreferences like $1, $2 are supported\r\n\r\n(\\d{4})-(\\d{2})-(\\d{2})\t$1_$2_$3\r\n"
 msgstr ""
 
 #. IDS_STRING_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5792
+#: Merge.rc:5793
 msgid "# Replacement list\r\n# Format: search<TAB>replacement\r\n# Lines starting with # are ignored\r\n\r\nfrom1\tto1\r\nfrom2\tto2\r\n"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_ONLY
-#: Merge.rc:5797
+#: Merge.rc:5798
 msgid "Built-in only"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_FIRST
-#: Merge.rc:5798
+#: Merge.rc:5799
 msgid "Built-in first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_FIRST
-#: Merge.rc:5799
+#: Merge.rc:5800
 msgid "Tree-sitter first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_ONLY
-#: Merge.rc:5800
+#: Merge.rc:5801
 msgid "Tree-sitter only"
 msgstr ""
 

--- a/Translations/WinMerge/Polish.po
+++ b/Translations/WinMerge/Polish.po
@@ -24,7 +24,7 @@ msgstr ""
 "X-Poedit-Basepath: ../../Src/\n"
 
 #. LANGUAGE, SUBLANGUAGE
-#: Merge.rc:26 Merge.rc:59 Merge.rc:5817
+#: Merge.rc:26 Merge.rc:59 Merge.rc:5818
 msgid "LANG_ENGLISH, SUBLANG_ENGLISH_US"
 msgstr "LANG_POLISH, SUBLANG_DEFAULT"
 
@@ -231,7 +231,7 @@ msgid "Auto-Fit All Columns"
 msgstr "Automatycznie dopasuj wszystkie kolumny"
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN
-#: Merge.rc:153 Merge.rc:5645
+#: Merge.rc:153 Merge.rc:5646
 msgid "&Filter by This Column"
 msgstr "Filtruj według tej kolumny"
 
@@ -292,7 +292,7 @@ msgid "&Previous Page"
 msgstr "Poprzednia strona"
 
 #. IDS_PREVIEWBAR_NEXTPAGE
-#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5678
+#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5679
 msgid "&Next Page"
 msgstr "Następna strona"
 
@@ -665,7 +665,7 @@ msgid "&Huge"
 msgstr "Ogromny"
 
 #. IDS_VIEW_MENU_BAR
-#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5713
+#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5714
 msgid "Men&u Bar"
 msgstr "Pasek menu"
 
@@ -4190,7 +4190,7 @@ msgid "Items compared:"
 msgstr "Porównano elementów:"
 
 #. IDS_PREVIEWBAR_CLOSE
-#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5684
+#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5685
 msgid "&Close"
 msgstr "Zamknij"
 
@@ -8002,447 +8002,452 @@ msgstr "1 i 3"
 msgid "2nd and 3rd"
 msgstr "2 i 3"
 
+#. IDS_PLUGIN_CTRL_CLICK
+#: Merge.rc:5635
+msgid "(Ctrl+Click to add to pipeline)"
+msgstr ""
+
 #. IDS_FILTER_APPLIED
-#: Merge.rc:5639
+#: Merge.rc:5640
 msgid "Filter applied"
 msgstr "Zastosowano filtr"
 
 #. IDS_FILTERMENU_COMPARE
-#: Merge.rc:5644
+#: Merge.rc:5645
 #, c-format
 msgid "Compare %1"
 msgstr "Porównaj %1"
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN2
-#: Merge.rc:5646
+#: Merge.rc:5647
 msgid "&Filter by This Column..."
 msgstr "Filtruj według tej kolumny..."
 
 #. IDS_CLIPBOARDHISTORY_TIME
-#: Merge.rc:5651
+#: Merge.rc:5652
 #, c-format
 msgid "Clipboard at %s"
 msgstr "Schowek w %s"
 
 #. IDS_CLIPBOARDHISTORY_DISABLED
-#: Merge.rc:5652
+#: Merge.rc:5653
 msgid "Clipboard history disabled.\r\nEnable: Windows logo key + V, then Turn on."
 msgstr "Historia schowka jest wyłączona.\r\nAby włączyć historię schowka, naciśnij klawisz logo Windows + V, a następnie kliknij przycisk Włącz."
 
-#: Merge.rc:5654
+#: Merge.rc:5655
 msgid "This system does not support clipboard history."
 msgstr "Ten system nie obsługuje historii schowka."
 
-#: Merge.rc:5656
+#: Merge.rc:5657
 msgid "32-bit WinMerge does not support Clipboard Compare"
 msgstr "32-bitowa wersja programu WinMerge nie obsługuje funkcji porównywania schowka"
 
 #. IDS_WEBVIEW2_RUNTIME_NOT_INSTALLED
-#: Merge.rc:5661
+#: Merge.rc:5662
 msgid "WebView2 runtime not installed. Download it?"
 msgstr "WebView2 Runtime nie został zainstalowany. Pobrać go?"
 
 #. IDS_JUMPLIST_NEW_TEXT_COMPARE
-#: Merge.rc:5666
+#: Merge.rc:5667
 msgid "New Text Compare"
 msgstr "Porównaj nowy tekst"
 
 #. IDS_JUMPLIST_NEW_TABLE_COMPARE
-#: Merge.rc:5667
+#: Merge.rc:5668
 msgid "New Table Compare"
 msgstr "Porównaj nową tabelę"
 
 #. IDS_JUMPLIST_NEW_BINARY_COMPARE
-#: Merge.rc:5668
+#: Merge.rc:5669
 msgid "New Binary Compare"
 msgstr "Porównaj nowe pliki binarne"
 
 #. IDS_JUMPLIST_NEW_IMAGE_COMPARE
-#: Merge.rc:5669
+#: Merge.rc:5670
 msgid "New Image Compare"
 msgstr "Porównaj nowy obraz"
 
 #. IDS_JUMPLIST_NEW_WEBPAGE_COMPARE
-#: Merge.rc:5670
+#: Merge.rc:5671
 msgid "New Webpage Compare"
 msgstr "Porównaj nową stronę internetową"
 
 #. IDS_JUMPLIST_NEW_FOLDER_COMPARE
-#: Merge.rc:5671
+#: Merge.rc:5672
 msgid "New Folder Compare"
 msgstr "Porównaj nowy folder"
 
 #. IDS_JUMPLIST_CLIPBOARD_COMPARE
-#: Merge.rc:5672
+#: Merge.rc:5673
 msgid "Clipboard Compare"
 msgstr "Porównaj schowek"
 
 #. IDS_PREVIEWBAR_PRINT
-#: Merge.rc:5677
+#: Merge.rc:5678
 msgid "&Print..."
 msgstr "Drukuj..."
 
 #. IDS_PREVIEWBAR_PREVPAGE
-#: Merge.rc:5679
+#: Merge.rc:5680
 msgid "Pre&v Page"
 msgstr "Poprzednia strona"
 
 #. IDS_PREVIEWBAR_TWOPAGE
-#: Merge.rc:5680
+#: Merge.rc:5681
 msgid "&Two Page"
 msgstr "Dwie strony"
 
 #. IDS_PREVIEWBAR_ONEPAGE
-#: Merge.rc:5681
+#: Merge.rc:5682
 msgid "&One Page"
 msgstr "Jedna strona"
 
 #. IDS_PREVIEWBAR_ZOOMIN
-#: Merge.rc:5682
+#: Merge.rc:5683
 msgid "Zoom &In"
 msgstr "Powiększ"
 
 #. IDS_PREVIEWBAR_ZOOMOUT
-#: Merge.rc:5683
+#: Merge.rc:5684
 msgid "Zoom &Out"
 msgstr "Pomniejsz"
 
 #. IDS_WEBPAGE_COMPARING
-#: Merge.rc:5689
+#: Merge.rc:5690
 msgid "Comparing..."
 msgstr "Porównywanie..."
 
 #. IDS_WEBPAGE_ZOOM
-#: Merge.rc:5690
+#: Merge.rc:5691
 msgid "Zoom:"
 msgstr "Powiększenie:"
 
 #. IDS_COPY_GRANULARITY_DIFFHUNK
-#: Merge.rc:5695
+#: Merge.rc:5696
 msgid "Diff hunk"
 msgstr "Fragment różnicy"
 
 #. IDS_COPY_GRANULARITY_INLINE
-#: Merge.rc:5696
+#: Merge.rc:5697
 msgid "Inline diff"
 msgstr "Różnica w linii"
 
 #. IDS_COPY_GRANULARITY_LINE
-#: Merge.rc:5697
+#: Merge.rc:5698
 msgid "Line"
 msgstr "Wiersz"
 
-#: Merge.rc:5698
+#: Merge.rc:5699
 msgid "Character"
 msgstr "Znak"
 
 #. ID_MICE_PREVDIFF
-#: Merge.rc:5703
+#: Merge.rc:5704
 msgid "\nPrevious Difference (Alt+Up)\n(Right Button+Wheel Up)\n(Alt+Wheel Up)"
 msgstr "\nPoprzednia różnica (Alt+Klawisz w górę)\n(Prawy przycisk+Kółko w górę)\n(Alt+Kółko w górę)"
 
 #. ID_MICE_NEXTDIFF
-#: Merge.rc:5704
+#: Merge.rc:5705
 msgid "\nNext Difference (Alt+Down)\n(Right Button+Wheel Down)\n(Alt+Wheel Down)"
 msgstr "\nNastępna różnica (Alt+Klawisz w dół)\n(Prawy przycisk+Kółko w dół)\n(Alt+Kółko w dół"
 
 #. ID_MICE_L2R
-#: Merge.rc:5705
+#: Merge.rc:5706
 msgid "\nCopy to Right (Alt+Right)\n(Right Button+Wheel Right)\n(Alt+Wheel Right)\n(Alt+Shift+Wheel Down)"
 msgstr "\nKopiuj do prawej (Alt+Prawo)\n(Prawy przycisk+Kółko w prawo)\n(Alt+Kółko w prawo)\n(Alt+Shift+Kółko w dół)"
 
 #. ID_MICE_R2L
-#: Merge.rc:5706
+#: Merge.rc:5707
 msgid "\nCopy to Left (Alt+Left)\n(Right Button+Wheel Left)\n(Alt+Wheel Left)\n(Alt+Shift+Wheel Up)"
 msgstr "\nKopiuj do lewej (Alt+Lewo)\n(Prawy przycisk+Kółko w lewo)\n(Alt+Kółko w lewo)\n(Alt+Shift+Kółko w górę)"
 
 #. ID_MICE_L2RNEXT
-#: Merge.rc:5707
+#: Merge.rc:5708
 msgid "\nCopy to Right and Advance (Ctrl+Alt+Right)\n(Ctrl+Alt+Wheel Right)\n(Ctrl+Alt+Shift+Wheel Down)"
 msgstr "\nKopiuj do prawej i przejdź dalej (Ctrl+Alt+Prawo)\n(Ctrl+Alt+Kółko w prawo)\n(Ctrl+Alt+Shift+Kółko w dół)"
 
 #. ID_MICE_R2LNEXT
-#: Merge.rc:5708
+#: Merge.rc:5709
 msgid "\nCopy to Left and Advance (Ctrl+Alt+Left)\n(Ctrl+Alt+Wheel Left)\n(Ctrl+Alt+Shift+Wheel Up)"
 msgstr "\nKopiuj do lewej i przejdź dalej (Ctrl+Alt+Lewo)\n(Ctrl+Alt+Kółko w lewo)\n(Ctrl+Alt+Shift+Kółko w górę)"
 
 #. IDS_LOG_COMPARING_2
-#: Merge.rc:5718
+#: Merge.rc:5719
 #, c-format
 msgid "Comparing %1 with %2"
 msgstr "Porównywanie %1 z %2"
 
 #. IDS_LOG_COMPARING_3
-#: Merge.rc:5719
+#: Merge.rc:5720
 #, c-format
 msgid "Comparing %1 with %2 and %3"
 msgstr "Porównywanie %1 z %2 i %3"
 
 #. IDS_LOG_COMPARE_COMPLETED
-#: Merge.rc:5720
+#: Merge.rc:5721
 msgid "Comparison completed"
 msgstr "Porównywanie zakończone"
 
 #. IDS_LOG_COMPARE_ERROR_2
-#: Merge.rc:5721
+#: Merge.rc:5722
 #, c-format
 msgid "Failed to compare %1 with %2: "
 msgstr "Nie udało się porównać %1 z %2: "
 
 #. IDS_LOG_COMPARE_ERROR_3
-#: Merge.rc:5722
+#: Merge.rc:5723
 #, c-format
 msgid "Failed to compare %1 with %2 and %3: "
 msgstr "Nie udało się porównać %1 z %2 i %3: "
 
 #. IDS_LOG_FILE_SAVED
-#: Merge.rc:5723
+#: Merge.rc:5724
 msgid "File saved"
 msgstr "Plik został zapisany"
 
 #. IDS_LOG_COPYING_FILES
-#: Merge.rc:5724
+#: Merge.rc:5725
 msgid "Copying files..."
 msgstr "Kopiowanie plików..."
 
 #. IDS_LOG_MOVING_FILES
-#: Merge.rc:5725
+#: Merge.rc:5726
 msgid "Moving files..."
 msgstr "Przenoszenie plików..."
 
 #. IDS_LOG_DELETING_FILES
-#: Merge.rc:5726
+#: Merge.rc:5727
 msgid "Deleting files..."
 msgstr "Usuwanie plików..."
 
 #. IDS_LOG_RECYCLEBIN
-#: Merge.rc:5727
+#: Merge.rc:5728
 msgid "Recycle Bin"
 msgstr "Kosz"
 
 #. IDS_LOG_PERMANENTLY_DELETED
-#: Merge.rc:5728
+#: Merge.rc:5729
 msgid "Permanently deleted"
 msgstr "Trwale usunięty"
 
 #. IDS_LOG_FILEOPERATION_COMPLETED
-#: Merge.rc:5729
+#: Merge.rc:5730
 msgid "File operation completed successfully"
 msgstr "Operacja na pliku zakończona pomyślnie"
 
 #. IDS_LOG_FILEOPERATION_CANCELED
-#: Merge.rc:5730
+#: Merge.rc:5731
 msgid "File operation canceled"
 msgstr "Operacja na pliku została anulowana"
 
 #. IDS_FILTER_ERROR_NO_ERROR
-#: Merge.rc:5735
+#: Merge.rc:5736
 msgid "No error"
 msgstr "Brak błędu"
 
 #. IDS_FILTER_ERROR_EMPTY_EXPRESSION
-#: Merge.rc:5736
+#: Merge.rc:5737
 msgid "Filter expression is empty"
 msgstr "Wyrażenie filtrujące jest puste"
 
 #. IDS_FILTER_ERROR_UNKNOWN_CHAR
-#: Merge.rc:5737
+#: Merge.rc:5738
 msgid "Unknown character in filter expression"
 msgstr "Nieznany znak w wyrażeniu filtrującym"
 
 #. IDS_FILTER_ERROR_UNTERMINATED_STRING
-#: Merge.rc:5738
+#: Merge.rc:5739
 msgid "Unterminated string literal"
 msgstr "Niezakończony literał łańcuchowy"
 
 #. IDS_FILTER_ERROR_SYNTAX_ERROR
-#: Merge.rc:5739
+#: Merge.rc:5740
 msgid "Syntax error in filter expression"
 msgstr "Błąd składni w wyrażeniu filtrującym"
 
 #. IDS_FILTER_ERROR_PARSE_FAILURE
-#: Merge.rc:5740
+#: Merge.rc:5741
 msgid "Failed to parse filter expression"
 msgstr "Nie udało się przeanalizować wyrażenia filtrującego"
 
 #. IDS_FILTER_ERROR_INVALID_LITERAL
-#: Merge.rc:5741
+#: Merge.rc:5742
 msgid "Invalid literal value"
 msgstr "Nieprawidłowa wartość literału"
 
 #. IDS_FILTER_ERROR_INVALID_REGULAR_EXPRESSION
-#: Merge.rc:5742
+#: Merge.rc:5743
 msgid "Invalid regular expression"
 msgstr "Nieprawidłowe wyrażenie regularne"
 
 #. IDS_FILTER_ERROR_UNDEFINED_IDENTIFIER
-#: Merge.rc:5743
+#: Merge.rc:5744
 msgid "Undefined identifier"
 msgstr "Nieokreślony identyfikator"
 
 #. IDS_FILTER_ERROR_INVALID_ARGUMENT_COUNT
-#: Merge.rc:5744
+#: Merge.rc:5745
 msgid "Invalid number of arguments"
 msgstr "Nieprawidłowa liczba argumentów"
 
 #. IDS_FILTER_ERROR_FILTER_NAME_NOT_FOUND
-#: Merge.rc:5745
+#: Merge.rc:5746
 msgid "Filter name not found"
 msgstr "Nie znaleziono nazwy filtra"
 
 #. IDS_FILTER_ERROR_DIVIDE_BY_ZERO
-#: Merge.rc:5746
+#: Merge.rc:5747
 msgid "Division by zero in filter expression"
 msgstr "Dzielenie przez zero w wyrażeniu filtrującym"
 
 #. IDS_FILTER_ERROR_UNKNOWN_ERROR
-#: Merge.rc:5747
+#: Merge.rc:5748
 msgid "Unknown error"
 msgstr "Nieznany błąd"
 
 #. IDS_FILTER_ERROR_INVALID_PROPERTY_NAME
-#: Merge.rc:5748
+#: Merge.rc:5749
 msgid "Invalid property name"
 msgstr "Nieprawidłowa nazwa właściwości"
 
 #. IDS_FILTER_ERROR_INVALID_DIRECTIVE
-#: Merge.rc:5749
+#: Merge.rc:5750
 msgid "Invalid directive"
 msgstr "Nieprawidłowa dyrektywa"
 
 #. IDS_FILTER_OP_EQUALS
-#: Merge.rc:5754
+#: Merge.rc:5755
 msgid "Equals"
 msgstr "Równe"
 
 #. IDS_FILTER_OP_NOT_EQUALS
-#: Merge.rc:5755
+#: Merge.rc:5756
 msgid "Does not equal"
 msgstr "Nierówne"
 
 #. IDS_FILTER_OP_LESS_THAN
-#: Merge.rc:5756
+#: Merge.rc:5757
 msgid "Less than"
 msgstr "Mniejsze niż"
 
 #. IDS_FILTER_OP_LESS_EQUAL
-#: Merge.rc:5757
+#: Merge.rc:5758
 msgid "Less than or equal to"
 msgstr "Mniejsze lub równe"
 
 #. IDS_FILTER_OP_GREATER_EQUAL
-#: Merge.rc:5758
+#: Merge.rc:5759
 msgid "Greater than or equal to"
 msgstr "Większe lub równe"
 
 #. IDS_FILTER_OP_GREATER_THAN
-#: Merge.rc:5759
+#: Merge.rc:5760
 msgid "Greater than"
 msgstr "Większe niż"
 
 #. IDS_FILTER_OP_BETWEEN
-#: Merge.rc:5760
+#: Merge.rc:5761
 msgid "Between"
 msgstr "Między"
 
 #. IDS_FILTER_OP_NOT_BETWEEN
-#: Merge.rc:5761
+#: Merge.rc:5762
 msgid "Not Between"
 msgstr "Nie między"
 
 #. IDS_FILTER_OP_CONTAINS
-#: Merge.rc:5762
+#: Merge.rc:5763
 msgid "Contains"
 msgstr "Zawiera"
 
 #. IDS_FILTER_OP_NOT_CONTAINS
-#: Merge.rc:5763
+#: Merge.rc:5764
 msgid "Not Contains"
 msgstr "Nie zawiera"
 
 #. IDS_FILTER_OP_RECONTAINS
-#: Merge.rc:5764
+#: Merge.rc:5765
 msgid "Contains (regex)"
 msgstr "Zawiera (wyrażenie regularne)"
 
 #. IDS_FILTER_OP_NOT_RECONTAINS
-#: Merge.rc:5765
+#: Merge.rc:5766
 msgid "Not Contains (regex)"
 msgstr "Nie zawiera (wyrażenie regularne)"
 
 #. IDS_FILTER_OP_LIKE
-#: Merge.rc:5766
+#: Merge.rc:5767
 msgid "Match (wildcard)"
 msgstr "Dopasuj (symbol wieloznaczny)"
 
 #. IDS_FILTER_OP_NOT_LIKE
-#: Merge.rc:5767
+#: Merge.rc:5768
 msgid "Not match (wildcard)"
 msgstr "Nie dopasuj (symbol wieloznaczny)"
 
 #. IDS_FILTER_OP_MATCHES
-#: Merge.rc:5768
+#: Merge.rc:5769
 msgid "Match (regex)"
 msgstr "Dopasuj (wyrażenie regularne)"
 
 #. IDS_FILTER_OP_NOT_MATCHES
-#: Merge.rc:5769
+#: Merge.rc:5770
 msgid "Not match (regex)"
 msgstr "Nie dopasuj (wyrażenie regularne)"
 
 #. IDS_COLORMODE_LIGHT
-#: Merge.rc:5774
+#: Merge.rc:5775
 msgid "Light"
 msgstr "Jasny"
 
 #. IDS_COLORMODE_DARK
-#: Merge.rc:5775
+#: Merge.rc:5776
 msgid "Dark"
 msgstr "Ciemny"
 
 #. IDS_COLORMODE_FOLLOWSYSTEM
-#: Merge.rc:5776
+#: Merge.rc:5777
 msgid "Follow system"
 msgstr "Systemowy"
 
 #. IDS_EXAMPLE
-#: Merge.rc:5781
+#: Merge.rc:5782
 #, c-format
 msgid "e.g. %1"
 msgstr "np. %1"
 
 #. IDS_DETECTED_PREVIOUS_CRASH
-#: Merge.rc:5786
+#: Merge.rc:5787
 msgid "WinMerge detected a previous crash. Please report this if possible."
 msgstr "WinMerge wykrył błąd krytyczny podczas ostatniej sesji. Prosimy o zgłoszenie tego faktu, jeśli to możliwe."
 
 #. IDS_REGEX_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5791
+#: Merge.rc:5792
 msgid "# Regex replacement list\r\n# Format: regex<TAB>replacement\r\n# Backreferences like $1, $2 are supported\r\n\r\n(\\d{4})-(\\d{2})-(\\d{2})\t$1_$2_$3\r\n"
 msgstr "# Lista zastąpionych wyrażeń regularnych\r\n# Format: wyrażenie regularne<TAB>zastąpienie\r\n# Obsługiwane są odwołania wsteczne, takie jak $1, $2\r\n\r\n(\\d{4})-(\\d{2})-(\\d{2})\t$1_$2_$3\r\n"
 
 #. IDS_STRING_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5792
+#: Merge.rc:5793
 msgid "# Replacement list\r\n# Format: search<TAB>replacement\r\n# Lines starting with # are ignored\r\n\r\nfrom1\tto1\r\nfrom2\tto2\r\n"
 msgstr "# Lista zastąpionych\r\n# Format: szukaj<TAB>zastąpienie\r\n# Linie zaczynające się od # są ignorowane\r\n\r\nfrom1\tto1\r\nfrom2\tto2\r\n"
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_ONLY
-#: Merge.rc:5797
+#: Merge.rc:5798
 msgid "Built-in only"
 msgstr "Tylko wbudowane"
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_FIRST
-#: Merge.rc:5798
+#: Merge.rc:5799
 msgid "Built-in first"
 msgstr "Najpierw wbudowane"
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_FIRST
-#: Merge.rc:5799
+#: Merge.rc:5800
 msgid "Tree-sitter first"
 msgstr "Najpierw Tree-sitter"
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_ONLY
-#: Merge.rc:5800
+#: Merge.rc:5801
 msgid "Tree-sitter only"
 msgstr "Tylko Tree-sitter"
 

--- a/Translations/WinMerge/Portuguese.po
+++ b/Translations/WinMerge/Portuguese.po
@@ -24,7 +24,7 @@ msgstr ""
 "X-Generator: Poedit 3.9\n"
 
 #. LANGUAGE, SUBLANGUAGE
-#: Merge.rc:26 Merge.rc:59 Merge.rc:5817
+#: Merge.rc:26 Merge.rc:59 Merge.rc:5818
 msgid "LANG_ENGLISH, SUBLANG_ENGLISH_US"
 msgstr "LANG_PORTUGUESE, SUBLANG_PORTUGUESE"
 
@@ -231,7 +231,7 @@ msgid "Auto-Fit All Columns"
 msgstr "Ajustar automaticamente todas as colunas"
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN
-#: Merge.rc:153 Merge.rc:5645
+#: Merge.rc:153 Merge.rc:5646
 msgid "&Filter by This Column"
 msgstr "&Filtrar por esta coluna"
 
@@ -292,7 +292,7 @@ msgid "&Previous Page"
 msgstr "&Página anterior"
 
 #. IDS_PREVIEWBAR_NEXTPAGE
-#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5678
+#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5679
 msgid "&Next Page"
 msgstr "&Página seguinte"
 
@@ -665,7 +665,7 @@ msgid "&Huge"
 msgstr "&Enorme"
 
 #. IDS_VIEW_MENU_BAR
-#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5713
+#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5714
 msgid "Men&u Bar"
 msgstr "Barra de men&us"
 
@@ -4190,7 +4190,7 @@ msgid "Items compared:"
 msgstr "Itens comparados:"
 
 #. IDS_PREVIEWBAR_CLOSE
-#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5684
+#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5685
 msgid "&Close"
 msgstr "Fechar"
 
@@ -8397,30 +8397,35 @@ msgstr "1.º e 3.º"
 msgid "2nd and 3rd"
 msgstr "2.º e 3.º"
 
+#. IDS_PLUGIN_CTRL_CLICK
+#: Merge.rc:5635
+msgid "(Ctrl+Click to add to pipeline)"
+msgstr ""
+
 #. IDS_FILTER_APPLIED
-#: Merge.rc:5639
+#: Merge.rc:5640
 msgid "Filter applied"
 msgstr "Filtro aplicado"
 
 #. IDS_FILTERMENU_COMPARE
-#: Merge.rc:5644
+#: Merge.rc:5645
 #, c-format
 msgid "Compare %1"
 msgstr "Comparar %1"
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN2
-#: Merge.rc:5646
+#: Merge.rc:5647
 msgid "&Filter by This Column..."
 msgstr "&Filtrar por esta coluna..."
 
 #. IDS_CLIPBOARDHISTORY_TIME
-#: Merge.rc:5651
+#: Merge.rc:5652
 #, c-format
 msgid "Clipboard at %s"
 msgstr "Área de transferência em %s"
 
 #. IDS_CLIPBOARDHISTORY_DISABLED
-#: Merge.rc:5652
+#: Merge.rc:5653
 msgid ""
 "Clipboard history disabled.\r\n"
 "Enable: Windows logo key + V, then Turn on."
@@ -8428,115 +8433,115 @@ msgstr ""
 "O histórico da área de transferência está desativado.\r\n"
 "Para ativar o histórico da área de transferência, prima a tecla do logotipo do Windows + V e clique no botão Ativar."
 
-#: Merge.rc:5654
+#: Merge.rc:5655
 msgid "This system does not support clipboard history."
 msgstr "Este sistema não suporta o histórico da área de transferência."
 
-#: Merge.rc:5656
+#: Merge.rc:5657
 msgid "32-bit WinMerge does not support Clipboard Compare"
 msgstr "A versão de 32 bits do WinMerge não suporta a comparação da área de transferência"
 
 #. IDS_WEBVIEW2_RUNTIME_NOT_INSTALLED
-#: Merge.rc:5661
+#: Merge.rc:5662
 msgid "WebView2 runtime not installed. Download it?"
 msgstr "O runtime WebView2 não está instalado. Quer transferi-lo?"
 
 #. IDS_JUMPLIST_NEW_TEXT_COMPARE
-#: Merge.rc:5666
+#: Merge.rc:5667
 msgid "New Text Compare"
 msgstr "Nova comparação de textos"
 
 #. IDS_JUMPLIST_NEW_TABLE_COMPARE
-#: Merge.rc:5667
+#: Merge.rc:5668
 msgid "New Table Compare"
 msgstr "Nova comparação de tabelas"
 
 #. IDS_JUMPLIST_NEW_BINARY_COMPARE
-#: Merge.rc:5668
+#: Merge.rc:5669
 msgid "New Binary Compare"
 msgstr "Nova comparação de binários"
 
 #. IDS_JUMPLIST_NEW_IMAGE_COMPARE
-#: Merge.rc:5669
+#: Merge.rc:5670
 msgid "New Image Compare"
 msgstr "Nova comparação de imagens"
 
 #. IDS_JUMPLIST_NEW_WEBPAGE_COMPARE
-#: Merge.rc:5670
+#: Merge.rc:5671
 msgid "New Webpage Compare"
 msgstr "Nova comparação de páginas web"
 
 #. IDS_JUMPLIST_NEW_FOLDER_COMPARE
-#: Merge.rc:5671
+#: Merge.rc:5672
 msgid "New Folder Compare"
 msgstr "Nova comparação de pastas"
 
 #. IDS_JUMPLIST_CLIPBOARD_COMPARE
-#: Merge.rc:5672
+#: Merge.rc:5673
 msgid "Clipboard Compare"
 msgstr "Comparação da área de transferência"
 
 #. IDS_PREVIEWBAR_PRINT
-#: Merge.rc:5677
+#: Merge.rc:5678
 msgid "&Print..."
 msgstr "&Imprimir..."
 
 #. IDS_PREVIEWBAR_PREVPAGE
-#: Merge.rc:5679
+#: Merge.rc:5680
 msgid "Pre&v Page"
 msgstr "Pré-&visualizar página"
 
 #. IDS_PREVIEWBAR_TWOPAGE
-#: Merge.rc:5680
+#: Merge.rc:5681
 msgid "&Two Page"
 msgstr "&Duas páginas"
 
 #. IDS_PREVIEWBAR_ONEPAGE
-#: Merge.rc:5681
+#: Merge.rc:5682
 msgid "&One Page"
 msgstr "&Uma página"
 
 #. IDS_PREVIEWBAR_ZOOMIN
-#: Merge.rc:5682
+#: Merge.rc:5683
 msgid "Zoom &In"
 msgstr "&Ampliar"
 
 #. IDS_PREVIEWBAR_ZOOMOUT
-#: Merge.rc:5683
+#: Merge.rc:5684
 msgid "Zoom &Out"
 msgstr "&Reduzir"
 
 #. IDS_WEBPAGE_COMPARING
-#: Merge.rc:5689
+#: Merge.rc:5690
 msgid "Comparing..."
 msgstr "A comparar..."
 
 #. IDS_WEBPAGE_ZOOM
-#: Merge.rc:5690
+#: Merge.rc:5691
 msgid "Zoom:"
 msgstr "Zoom:"
 
 #. IDS_COPY_GRANULARITY_DIFFHUNK
-#: Merge.rc:5695
+#: Merge.rc:5696
 msgid "Diff hunk"
 msgstr "Diferenciar pedaço"
 
 #. IDS_COPY_GRANULARITY_INLINE
-#: Merge.rc:5696
+#: Merge.rc:5697
 msgid "Inline diff"
 msgstr "Diferença em linha"
 
 #. IDS_COPY_GRANULARITY_LINE
-#: Merge.rc:5697
+#: Merge.rc:5698
 msgid "Line"
 msgstr "Linha"
 
-#: Merge.rc:5698
+#: Merge.rc:5699
 msgid "Character"
 msgstr "Caráter"
 
 #. ID_MICE_PREVDIFF
-#: Merge.rc:5703
+#: Merge.rc:5704
 msgid ""
 "\n"
 "Previous Difference (Alt+Up)\n"
@@ -8549,7 +8554,7 @@ msgstr ""
 "(Alt+Roda para cima)"
 
 #. ID_MICE_NEXTDIFF
-#: Merge.rc:5704
+#: Merge.rc:5705
 msgid ""
 "\n"
 "Next Difference (Alt+Down)\n"
@@ -8562,7 +8567,7 @@ msgstr ""
 "(Alt+Roda para baixo)"
 
 #. ID_MICE_L2R
-#: Merge.rc:5705
+#: Merge.rc:5706
 msgid ""
 "\n"
 "Copy to Right (Alt+Right)\n"
@@ -8577,7 +8582,7 @@ msgstr ""
 "(Alt+Shift+Roda para baixo)"
 
 #. ID_MICE_R2L
-#: Merge.rc:5706
+#: Merge.rc:5707
 msgid ""
 "\n"
 "Copy to Left (Alt+Left)\n"
@@ -8592,7 +8597,7 @@ msgstr ""
 "(Alt+Shift+Roda para cima)"
 
 #. ID_MICE_L2RNEXT
-#: Merge.rc:5707
+#: Merge.rc:5708
 msgid ""
 "\n"
 "Copy to Right and Advance (Ctrl+Alt+Right)\n"
@@ -8605,7 +8610,7 @@ msgstr ""
 "(Ctrl+Alt+Shift+Roda para baixo)"
 
 #. ID_MICE_R2LNEXT
-#: Merge.rc:5708
+#: Merge.rc:5709
 msgid ""
 "\n"
 "Copy to Left and Advance (Ctrl+Alt+Left)\n"
@@ -8618,257 +8623,257 @@ msgstr ""
 "(Ctrl+Alt+Shift+Roda para cima)"
 
 #. IDS_LOG_COMPARING_2
-#: Merge.rc:5718
+#: Merge.rc:5719
 #, c-format
 msgid "Comparing %1 with %2"
 msgstr "A comparar %1 com %2"
 
 #. IDS_LOG_COMPARING_3
-#: Merge.rc:5719
+#: Merge.rc:5720
 #, c-format
 msgid "Comparing %1 with %2 and %3"
 msgstr "A comparar %1 com %2 e %3"
 
 #. IDS_LOG_COMPARE_COMPLETED
-#: Merge.rc:5720
+#: Merge.rc:5721
 msgid "Comparison completed"
 msgstr "Comparação concluída"
 
 #. IDS_LOG_COMPARE_ERROR_2
-#: Merge.rc:5721
+#: Merge.rc:5722
 #, c-format
 msgid "Failed to compare %1 with %2: "
 msgstr "Falha ao comparar %1 com %2: "
 
 #. IDS_LOG_COMPARE_ERROR_3
-#: Merge.rc:5722
+#: Merge.rc:5723
 #, c-format
 msgid "Failed to compare %1 with %2 and %3: "
 msgstr "Falha ao comparar %1 com %2 e %3: "
 
 #. IDS_LOG_FILE_SAVED
-#: Merge.rc:5723
+#: Merge.rc:5724
 msgid "File saved"
 msgstr "Ficheiro guardado"
 
 #. IDS_LOG_COPYING_FILES
-#: Merge.rc:5724
+#: Merge.rc:5725
 msgid "Copying files..."
 msgstr "A copiar ficheiros..."
 
 #. IDS_LOG_MOVING_FILES
-#: Merge.rc:5725
+#: Merge.rc:5726
 msgid "Moving files..."
 msgstr "A mover ficheiros..."
 
 #. IDS_LOG_DELETING_FILES
-#: Merge.rc:5726
+#: Merge.rc:5727
 msgid "Deleting files..."
 msgstr "A eliminar ficheiros..."
 
 #. IDS_LOG_RECYCLEBIN
-#: Merge.rc:5727
+#: Merge.rc:5728
 msgid "Recycle Bin"
 msgstr "Reciclagem"
 
 #. IDS_LOG_PERMANENTLY_DELETED
-#: Merge.rc:5728
+#: Merge.rc:5729
 msgid "Permanently deleted"
 msgstr "Eliminado permanentemente"
 
 #. IDS_LOG_FILEOPERATION_COMPLETED
-#: Merge.rc:5729
+#: Merge.rc:5730
 msgid "File operation completed successfully"
 msgstr "Operação de ficheiros concluída com sucesso"
 
 #. IDS_LOG_FILEOPERATION_CANCELED
-#: Merge.rc:5730
+#: Merge.rc:5731
 msgid "File operation canceled"
 msgstr "Operação de ficheiros cancelada"
 
 #. IDS_FILTER_ERROR_NO_ERROR
-#: Merge.rc:5735
+#: Merge.rc:5736
 msgid "No error"
 msgstr "Sem erros"
 
 #. IDS_FILTER_ERROR_EMPTY_EXPRESSION
-#: Merge.rc:5736
+#: Merge.rc:5737
 msgid "Filter expression is empty"
 msgstr "A expressão de filtro está vazia"
 
 #. IDS_FILTER_ERROR_UNKNOWN_CHAR
-#: Merge.rc:5737
+#: Merge.rc:5738
 msgid "Unknown character in filter expression"
 msgstr "Caracter desconhecido na expressão de filtro"
 
 #. IDS_FILTER_ERROR_UNTERMINATED_STRING
-#: Merge.rc:5738
+#: Merge.rc:5739
 msgid "Unterminated string literal"
 msgstr "Sequência de caracteres sem terminação"
 
 #. IDS_FILTER_ERROR_SYNTAX_ERROR
-#: Merge.rc:5739
+#: Merge.rc:5740
 msgid "Syntax error in filter expression"
 msgstr "Erro de sintaxe na expressão do filtro"
 
 #. IDS_FILTER_ERROR_PARSE_FAILURE
-#: Merge.rc:5740
+#: Merge.rc:5741
 msgid "Failed to parse filter expression"
 msgstr "Falha ao analisar a expressão do filtro"
 
 #. IDS_FILTER_ERROR_INVALID_LITERAL
-#: Merge.rc:5741
+#: Merge.rc:5742
 msgid "Invalid literal value"
 msgstr "Valor literal inválido"
 
 #. IDS_FILTER_ERROR_INVALID_REGULAR_EXPRESSION
-#: Merge.rc:5742
+#: Merge.rc:5743
 msgid "Invalid regular expression"
 msgstr "Expressão regular inválida"
 
 #. IDS_FILTER_ERROR_UNDEFINED_IDENTIFIER
-#: Merge.rc:5743
+#: Merge.rc:5744
 msgid "Undefined identifier"
 msgstr "Identificador indefinido"
 
 #. IDS_FILTER_ERROR_INVALID_ARGUMENT_COUNT
-#: Merge.rc:5744
+#: Merge.rc:5745
 msgid "Invalid number of arguments"
 msgstr "Número de argumentos inválido"
 
 #. IDS_FILTER_ERROR_FILTER_NAME_NOT_FOUND
-#: Merge.rc:5745
+#: Merge.rc:5746
 msgid "Filter name not found"
 msgstr "Nome de filtro não encontrado"
 
 #. IDS_FILTER_ERROR_DIVIDE_BY_ZERO
-#: Merge.rc:5746
+#: Merge.rc:5747
 msgid "Division by zero in filter expression"
 msgstr "Divisão por zero em expressão de filtro"
 
 #. IDS_FILTER_ERROR_UNKNOWN_ERROR
-#: Merge.rc:5747
+#: Merge.rc:5748
 msgid "Unknown error"
 msgstr "Erro desconhecido"
 
 #. IDS_FILTER_ERROR_INVALID_PROPERTY_NAME
-#: Merge.rc:5748
+#: Merge.rc:5749
 msgid "Invalid property name"
 msgstr "Nome de propriedade inválido"
 
 #. IDS_FILTER_ERROR_INVALID_DIRECTIVE
-#: Merge.rc:5749
+#: Merge.rc:5750
 msgid "Invalid directive"
 msgstr "Diretiva inválida"
 
 #. IDS_FILTER_OP_EQUALS
-#: Merge.rc:5754
+#: Merge.rc:5755
 msgid "Equals"
 msgstr "Igual a"
 
 #. IDS_FILTER_OP_NOT_EQUALS
-#: Merge.rc:5755
+#: Merge.rc:5756
 msgid "Does not equal"
 msgstr "Não é igual a"
 
 #. IDS_FILTER_OP_LESS_THAN
-#: Merge.rc:5756
+#: Merge.rc:5757
 msgid "Less than"
 msgstr "Menor que"
 
 #. IDS_FILTER_OP_LESS_EQUAL
-#: Merge.rc:5757
+#: Merge.rc:5758
 msgid "Less than or equal to"
 msgstr "Menor ou igual a"
 
 #. IDS_FILTER_OP_GREATER_EQUAL
-#: Merge.rc:5758
+#: Merge.rc:5759
 msgid "Greater than or equal to"
 msgstr "Maior ou igual a"
 
 #. IDS_FILTER_OP_GREATER_THAN
-#: Merge.rc:5759
+#: Merge.rc:5760
 msgid "Greater than"
 msgstr "Maior que"
 
 #. IDS_FILTER_OP_BETWEEN
-#: Merge.rc:5760
+#: Merge.rc:5761
 msgid "Between"
 msgstr "Entre"
 
 #. IDS_FILTER_OP_NOT_BETWEEN
-#: Merge.rc:5761
+#: Merge.rc:5762
 msgid "Not Between"
 msgstr "Não é entre"
 
 #. IDS_FILTER_OP_CONTAINS
-#: Merge.rc:5762
+#: Merge.rc:5763
 msgid "Contains"
 msgstr "Contém"
 
 #. IDS_FILTER_OP_NOT_CONTAINS
-#: Merge.rc:5763
+#: Merge.rc:5764
 msgid "Not Contains"
 msgstr "Não contém"
 
 #. IDS_FILTER_OP_RECONTAINS
-#: Merge.rc:5764
+#: Merge.rc:5765
 msgid "Contains (regex)"
 msgstr "Contém (regex)"
 
 #. IDS_FILTER_OP_NOT_RECONTAINS
-#: Merge.rc:5765
+#: Merge.rc:5766
 msgid "Not Contains (regex)"
 msgstr "Não contém (regex)"
 
 #. IDS_FILTER_OP_LIKE
-#: Merge.rc:5766
+#: Merge.rc:5767
 msgid "Match (wildcard)"
 msgstr "Correspondência (caractere)"
 
 #. IDS_FILTER_OP_NOT_LIKE
-#: Merge.rc:5767
+#: Merge.rc:5768
 msgid "Not match (wildcard)"
 msgstr "Sem correspondência (caractere)"
 
 #. IDS_FILTER_OP_MATCHES
-#: Merge.rc:5768
+#: Merge.rc:5769
 msgid "Match (regex)"
 msgstr "Correspondência (regex)"
 
 #. IDS_FILTER_OP_NOT_MATCHES
-#: Merge.rc:5769
+#: Merge.rc:5770
 msgid "Not match (regex)"
 msgstr "Sem correspondência (regex)"
 
 #. IDS_COLORMODE_LIGHT
-#: Merge.rc:5774
+#: Merge.rc:5775
 msgid "Light"
 msgstr "Claro"
 
 #. IDS_COLORMODE_DARK
-#: Merge.rc:5775
+#: Merge.rc:5776
 msgid "Dark"
 msgstr "Escuro"
 
 #. IDS_COLORMODE_FOLLOWSYSTEM
-#: Merge.rc:5776
+#: Merge.rc:5777
 msgid "Follow system"
 msgstr "Seguir o sistema"
 
 #. IDS_EXAMPLE
-#: Merge.rc:5781
+#: Merge.rc:5782
 #, c-format
 msgid "e.g. %1"
 msgstr "por exemplo, %1"
 
 #. IDS_DETECTED_PREVIOUS_CRASH
-#: Merge.rc:5786
+#: Merge.rc:5787
 msgid "WinMerge detected a previous crash. Please report this if possible."
 msgstr "O WinMerge detetou uma falha anterior. Se possível, informe-nos sobre isso."
 
 #. IDS_REGEX_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5791
+#: Merge.rc:5792
 msgid ""
 "# Regex replacement list\r\n"
 "# Format: regex<TAB>replacement\r\n"
@@ -8883,7 +8888,7 @@ msgstr ""
 "(\\d{4})-(\\d{2})-(\\d{2})\t$1_$2_$3\r\n"
 
 #. IDS_STRING_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5792
+#: Merge.rc:5793
 msgid ""
 "# Replacement list\r\n"
 "# Format: search<TAB>replacement\r\n"
@@ -8900,22 +8905,22 @@ msgstr ""
 "de2\tpara2\r\n"
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_ONLY
-#: Merge.rc:5797
+#: Merge.rc:5798
 msgid "Built-in only"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_FIRST
-#: Merge.rc:5798
+#: Merge.rc:5799
 msgid "Built-in first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_FIRST
-#: Merge.rc:5799
+#: Merge.rc:5800
 msgid "Tree-sitter first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_ONLY
-#: Merge.rc:5800
+#: Merge.rc:5801
 msgid "Tree-sitter only"
 msgstr ""
 

--- a/Translations/WinMerge/Romanian.po
+++ b/Translations/WinMerge/Romanian.po
@@ -22,7 +22,7 @@ msgstr ""
 "X-Generator: Poedit 3.4.1\n"
 
 #. LANGUAGE, SUBLANGUAGE
-#: Merge.rc:26 Merge.rc:59 Merge.rc:5817
+#: Merge.rc:26 Merge.rc:59 Merge.rc:5818
 msgid "LANG_ENGLISH, SUBLANG_ENGLISH_US"
 msgstr "LANG_ROMANIAN, SUBLANG_DEFAULT"
 
@@ -229,7 +229,7 @@ msgid "Auto-Fit All Columns"
 msgstr "Ajustează automat toate coloanele"
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN
-#: Merge.rc:153 Merge.rc:5645
+#: Merge.rc:153 Merge.rc:5646
 msgid "&Filter by This Column"
 msgstr ""
 
@@ -290,7 +290,7 @@ msgid "&Previous Page"
 msgstr "Pagina &precedentă"
 
 #. IDS_PREVIEWBAR_NEXTPAGE
-#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5678
+#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5679
 msgid "&Next Page"
 msgstr "Pagina următoare"
 
@@ -663,7 +663,7 @@ msgid "&Huge"
 msgstr "Uriaș"
 
 #. IDS_VIEW_MENU_BAR
-#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5713
+#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5714
 msgid "Men&u Bar"
 msgstr ""
 
@@ -4198,7 +4198,7 @@ msgid "Items compared:"
 msgstr "Elemente comparate:"
 
 #. IDS_PREVIEWBAR_CLOSE
-#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5684
+#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5685
 msgid "&Close"
 msgstr "În&chide"
 
@@ -8380,450 +8380,455 @@ msgstr ""
 msgid "2nd and 3rd"
 msgstr ""
 
+#. IDS_PLUGIN_CTRL_CLICK
+#: Merge.rc:5635
+msgid "(Ctrl+Click to add to pipeline)"
+msgstr ""
+
 #. IDS_FILTER_APPLIED
-#: Merge.rc:5639
+#: Merge.rc:5640
 msgid "Filter applied"
 msgstr "Filtru aplicat"
 
 #. IDS_FILTERMENU_COMPARE
-#: Merge.rc:5644
+#: Merge.rc:5645
 #, c-format
 msgid "Compare %1"
 msgstr ""
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN2
-#: Merge.rc:5646
+#: Merge.rc:5647
 msgid "&Filter by This Column..."
 msgstr ""
 
 #. IDS_CLIPBOARDHISTORY_TIME
-#: Merge.rc:5651
+#: Merge.rc:5652
 #, c-format
 msgid "Clipboard at %s"
 msgstr "Clipboard la %s"
 
 #. IDS_CLIPBOARDHISTORY_DISABLED
-#: Merge.rc:5652
+#: Merge.rc:5653
 msgid "Clipboard history disabled.\r\nEnable: Windows logo key + V, then Turn on."
 msgstr ""
 "Istoricul clipboard-ului este deactivat.\r\n"
 "Pentru a activa istoricul clipboard-ului, apăsați tasta logo Windows + V, "
 "apoi apăsați butonul Porniți."
 
-#: Merge.rc:5654
+#: Merge.rc:5655
 msgid "This system does not support clipboard history."
 msgstr "Acest sistem nu suportă istoricul clipboard-ului."
 
-#: Merge.rc:5656
+#: Merge.rc:5657
 msgid "32-bit WinMerge does not support Clipboard Compare"
 msgstr "Versiunea pe 32 biți WinMerge nu suportă Comparare clipboard"
 
 #. IDS_WEBVIEW2_RUNTIME_NOT_INSTALLED
-#: Merge.rc:5661
+#: Merge.rc:5662
 msgid "WebView2 runtime not installed. Download it?"
 msgstr "Runtime-ul WebView2 nu este instalat. Doriți să-l descărcați?"
 
 #. IDS_JUMPLIST_NEW_TEXT_COMPARE
-#: Merge.rc:5666
+#: Merge.rc:5667
 msgid "New Text Compare"
 msgstr "Comparare text nouă"
 
 #. IDS_JUMPLIST_NEW_TABLE_COMPARE
-#: Merge.rc:5667
+#: Merge.rc:5668
 msgid "New Table Compare"
 msgstr "Comparare tabel nouă"
 
 #. IDS_JUMPLIST_NEW_BINARY_COMPARE
-#: Merge.rc:5668
+#: Merge.rc:5669
 msgid "New Binary Compare"
 msgstr "Comparare binară nouă"
 
 #. IDS_JUMPLIST_NEW_IMAGE_COMPARE
-#: Merge.rc:5669
+#: Merge.rc:5670
 msgid "New Image Compare"
 msgstr "Comparare imagine nouă"
 
 #. IDS_JUMPLIST_NEW_WEBPAGE_COMPARE
-#: Merge.rc:5670
+#: Merge.rc:5671
 msgid "New Webpage Compare"
 msgstr "Comparare pagină web nouă"
 
 #. IDS_JUMPLIST_NEW_FOLDER_COMPARE
-#: Merge.rc:5671
+#: Merge.rc:5672
 msgid "New Folder Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_CLIPBOARD_COMPARE
-#: Merge.rc:5672
+#: Merge.rc:5673
 msgid "Clipboard Compare"
 msgstr "Comparare clipboard"
 
 #. IDS_PREVIEWBAR_PRINT
-#: Merge.rc:5677
+#: Merge.rc:5678
 msgid "&Print..."
 msgstr ""
 
 #. IDS_PREVIEWBAR_PREVPAGE
-#: Merge.rc:5679
+#: Merge.rc:5680
 msgid "Pre&v Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_TWOPAGE
-#: Merge.rc:5680
+#: Merge.rc:5681
 msgid "&Two Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_ONEPAGE
-#: Merge.rc:5681
+#: Merge.rc:5682
 msgid "&One Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_ZOOMIN
-#: Merge.rc:5682
+#: Merge.rc:5683
 msgid "Zoom &In"
 msgstr ""
 
 #. IDS_PREVIEWBAR_ZOOMOUT
-#: Merge.rc:5683
+#: Merge.rc:5684
 msgid "Zoom &Out"
 msgstr ""
 
 #. IDS_WEBPAGE_COMPARING
-#: Merge.rc:5689
+#: Merge.rc:5690
 msgid "Comparing..."
 msgstr ""
 
 #. IDS_WEBPAGE_ZOOM
-#: Merge.rc:5690
+#: Merge.rc:5691
 msgid "Zoom:"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_DIFFHUNK
-#: Merge.rc:5695
+#: Merge.rc:5696
 msgid "Diff hunk"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_INLINE
-#: Merge.rc:5696
+#: Merge.rc:5697
 msgid "Inline diff"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_LINE
-#: Merge.rc:5697
+#: Merge.rc:5698
 msgid "Line"
 msgstr ""
 
-#: Merge.rc:5698
+#: Merge.rc:5699
 msgid "Character"
 msgstr ""
 
 #. ID_MICE_PREVDIFF
-#: Merge.rc:5703
+#: Merge.rc:5704
 msgid "\nPrevious Difference (Alt+Up)\n(Right Button+Wheel Up)\n(Alt+Wheel Up)"
 msgstr ""
 
 #. ID_MICE_NEXTDIFF
-#: Merge.rc:5704
+#: Merge.rc:5705
 msgid "\nNext Difference (Alt+Down)\n(Right Button+Wheel Down)\n(Alt+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_L2R
-#: Merge.rc:5705
+#: Merge.rc:5706
 msgid "\nCopy to Right (Alt+Right)\n(Right Button+Wheel Right)\n(Alt+Wheel Right)\n(Alt+Shift+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_R2L
-#: Merge.rc:5706
+#: Merge.rc:5707
 msgid "\nCopy to Left (Alt+Left)\n(Right Button+Wheel Left)\n(Alt+Wheel Left)\n(Alt+Shift+Wheel Up)"
 msgstr ""
 
 #. ID_MICE_L2RNEXT
-#: Merge.rc:5707
+#: Merge.rc:5708
 msgid "\nCopy to Right and Advance (Ctrl+Alt+Right)\n(Ctrl+Alt+Wheel Right)\n(Ctrl+Alt+Shift+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_R2LNEXT
-#: Merge.rc:5708
+#: Merge.rc:5709
 msgid "\nCopy to Left and Advance (Ctrl+Alt+Left)\n(Ctrl+Alt+Wheel Left)\n(Ctrl+Alt+Shift+Wheel Up)"
 msgstr ""
 
 #. IDS_LOG_COMPARING_2
-#: Merge.rc:5718
+#: Merge.rc:5719
 #, c-format
 msgid "Comparing %1 with %2"
 msgstr ""
 
 #. IDS_LOG_COMPARING_3
-#: Merge.rc:5719
+#: Merge.rc:5720
 #, c-format
 msgid "Comparing %1 with %2 and %3"
 msgstr ""
 
 #. IDS_LOG_COMPARE_COMPLETED
-#: Merge.rc:5720
+#: Merge.rc:5721
 msgid "Comparison completed"
 msgstr ""
 
 #. IDS_LOG_COMPARE_ERROR_2
-#: Merge.rc:5721
+#: Merge.rc:5722
 #, c-format
 msgid "Failed to compare %1 with %2: "
 msgstr ""
 
 #. IDS_LOG_COMPARE_ERROR_3
-#: Merge.rc:5722
+#: Merge.rc:5723
 #, c-format
 msgid "Failed to compare %1 with %2 and %3: "
 msgstr ""
 
 #. IDS_LOG_FILE_SAVED
-#: Merge.rc:5723
+#: Merge.rc:5724
 msgid "File saved"
 msgstr ""
 
 #. IDS_LOG_COPYING_FILES
-#: Merge.rc:5724
+#: Merge.rc:5725
 msgid "Copying files..."
 msgstr ""
 
 #. IDS_LOG_MOVING_FILES
-#: Merge.rc:5725
+#: Merge.rc:5726
 msgid "Moving files..."
 msgstr ""
 
 #. IDS_LOG_DELETING_FILES
-#: Merge.rc:5726
+#: Merge.rc:5727
 msgid "Deleting files..."
 msgstr ""
 
 #. IDS_LOG_RECYCLEBIN
-#: Merge.rc:5727
+#: Merge.rc:5728
 msgid "Recycle Bin"
 msgstr ""
 
 #. IDS_LOG_PERMANENTLY_DELETED
-#: Merge.rc:5728
+#: Merge.rc:5729
 msgid "Permanently deleted"
 msgstr ""
 
 #. IDS_LOG_FILEOPERATION_COMPLETED
-#: Merge.rc:5729
+#: Merge.rc:5730
 msgid "File operation completed successfully"
 msgstr ""
 
 #. IDS_LOG_FILEOPERATION_CANCELED
-#: Merge.rc:5730
+#: Merge.rc:5731
 msgid "File operation canceled"
 msgstr ""
 
 #. IDS_FILTER_ERROR_NO_ERROR
-#: Merge.rc:5735
+#: Merge.rc:5736
 msgid "No error"
 msgstr ""
 
 #. IDS_FILTER_ERROR_EMPTY_EXPRESSION
-#: Merge.rc:5736
+#: Merge.rc:5737
 msgid "Filter expression is empty"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNKNOWN_CHAR
-#: Merge.rc:5737
+#: Merge.rc:5738
 msgid "Unknown character in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNTERMINATED_STRING
-#: Merge.rc:5738
+#: Merge.rc:5739
 msgid "Unterminated string literal"
 msgstr ""
 
 #. IDS_FILTER_ERROR_SYNTAX_ERROR
-#: Merge.rc:5739
+#: Merge.rc:5740
 msgid "Syntax error in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_PARSE_FAILURE
-#: Merge.rc:5740
+#: Merge.rc:5741
 msgid "Failed to parse filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_LITERAL
-#: Merge.rc:5741
+#: Merge.rc:5742
 msgid "Invalid literal value"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_REGULAR_EXPRESSION
-#: Merge.rc:5742
+#: Merge.rc:5743
 msgid "Invalid regular expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNDEFINED_IDENTIFIER
-#: Merge.rc:5743
+#: Merge.rc:5744
 msgid "Undefined identifier"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_ARGUMENT_COUNT
-#: Merge.rc:5744
+#: Merge.rc:5745
 msgid "Invalid number of arguments"
 msgstr ""
 
 #. IDS_FILTER_ERROR_FILTER_NAME_NOT_FOUND
-#: Merge.rc:5745
+#: Merge.rc:5746
 msgid "Filter name not found"
 msgstr ""
 
 #. IDS_FILTER_ERROR_DIVIDE_BY_ZERO
-#: Merge.rc:5746
+#: Merge.rc:5747
 msgid "Division by zero in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNKNOWN_ERROR
-#: Merge.rc:5747
+#: Merge.rc:5748
 msgid "Unknown error"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_PROPERTY_NAME
-#: Merge.rc:5748
+#: Merge.rc:5749
 msgid "Invalid property name"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_DIRECTIVE
-#: Merge.rc:5749
+#: Merge.rc:5750
 msgid "Invalid directive"
 msgstr ""
 
 #. IDS_FILTER_OP_EQUALS
-#: Merge.rc:5754
+#: Merge.rc:5755
 msgid "Equals"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_EQUALS
-#: Merge.rc:5755
+#: Merge.rc:5756
 msgid "Does not equal"
 msgstr ""
 
 #. IDS_FILTER_OP_LESS_THAN
-#: Merge.rc:5756
+#: Merge.rc:5757
 msgid "Less than"
 msgstr ""
 
 #. IDS_FILTER_OP_LESS_EQUAL
-#: Merge.rc:5757
+#: Merge.rc:5758
 msgid "Less than or equal to"
 msgstr ""
 
 #. IDS_FILTER_OP_GREATER_EQUAL
-#: Merge.rc:5758
+#: Merge.rc:5759
 msgid "Greater than or equal to"
 msgstr ""
 
 #. IDS_FILTER_OP_GREATER_THAN
-#: Merge.rc:5759
+#: Merge.rc:5760
 msgid "Greater than"
 msgstr ""
 
 #. IDS_FILTER_OP_BETWEEN
-#: Merge.rc:5760
+#: Merge.rc:5761
 msgid "Between"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_BETWEEN
-#: Merge.rc:5761
+#: Merge.rc:5762
 msgid "Not Between"
 msgstr ""
 
 #. IDS_FILTER_OP_CONTAINS
-#: Merge.rc:5762
+#: Merge.rc:5763
 msgid "Contains"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_CONTAINS
-#: Merge.rc:5763
+#: Merge.rc:5764
 msgid "Not Contains"
 msgstr ""
 
 #. IDS_FILTER_OP_RECONTAINS
-#: Merge.rc:5764
+#: Merge.rc:5765
 msgid "Contains (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_RECONTAINS
-#: Merge.rc:5765
+#: Merge.rc:5766
 msgid "Not Contains (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_LIKE
-#: Merge.rc:5766
+#: Merge.rc:5767
 msgid "Match (wildcard)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_LIKE
-#: Merge.rc:5767
+#: Merge.rc:5768
 msgid "Not match (wildcard)"
 msgstr ""
 
 #. IDS_FILTER_OP_MATCHES
-#: Merge.rc:5768
+#: Merge.rc:5769
 msgid "Match (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_MATCHES
-#: Merge.rc:5769
+#: Merge.rc:5770
 msgid "Not match (regex)"
 msgstr ""
 
 #. IDS_COLORMODE_LIGHT
-#: Merge.rc:5774
+#: Merge.rc:5775
 msgid "Light"
 msgstr ""
 
 #. IDS_COLORMODE_DARK
-#: Merge.rc:5775
+#: Merge.rc:5776
 msgid "Dark"
 msgstr ""
 
 #. IDS_COLORMODE_FOLLOWSYSTEM
-#: Merge.rc:5776
+#: Merge.rc:5777
 msgid "Follow system"
 msgstr ""
 
 #. IDS_EXAMPLE
-#: Merge.rc:5781
+#: Merge.rc:5782
 #, c-format
 msgid "e.g. %1"
 msgstr ""
 
 #. IDS_DETECTED_PREVIOUS_CRASH
-#: Merge.rc:5786
+#: Merge.rc:5787
 msgid "WinMerge detected a previous crash. Please report this if possible."
 msgstr ""
 
 #. IDS_REGEX_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5791
+#: Merge.rc:5792
 msgid "# Regex replacement list\r\n# Format: regex<TAB>replacement\r\n# Backreferences like $1, $2 are supported\r\n\r\n(\\d{4})-(\\d{2})-(\\d{2})\t$1_$2_$3\r\n"
 msgstr ""
 
 #. IDS_STRING_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5792
+#: Merge.rc:5793
 msgid "# Replacement list\r\n# Format: search<TAB>replacement\r\n# Lines starting with # are ignored\r\n\r\nfrom1\tto1\r\nfrom2\tto2\r\n"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_ONLY
-#: Merge.rc:5797
+#: Merge.rc:5798
 msgid "Built-in only"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_FIRST
-#: Merge.rc:5798
+#: Merge.rc:5799
 msgid "Built-in first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_FIRST
-#: Merge.rc:5799
+#: Merge.rc:5800
 msgid "Tree-sitter first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_ONLY
-#: Merge.rc:5800
+#: Merge.rc:5801
 msgid "Tree-sitter only"
 msgstr ""
 

--- a/Translations/WinMerge/Russian.po
+++ b/Translations/WinMerge/Russian.po
@@ -25,7 +25,7 @@ msgstr ""
 "X-Poedit-Country: RUSSIAN FEDERATION\n"
 
 #. LANGUAGE, SUBLANGUAGE
-#: Merge.rc:26 Merge.rc:59 Merge.rc:5817
+#: Merge.rc:26 Merge.rc:59 Merge.rc:5818
 msgid "LANG_ENGLISH, SUBLANG_ENGLISH_US"
 msgstr "LANG_RUSSIAN, SUBLANG_DEFAULT"
 
@@ -232,7 +232,7 @@ msgid "Auto-Fit All Columns"
 msgstr "Автоширина столбцов"
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN
-#: Merge.rc:153 Merge.rc:5645
+#: Merge.rc:153 Merge.rc:5646
 msgid "&Filter by This Column"
 msgstr "Фильтр по этому столбцу"
 
@@ -293,7 +293,7 @@ msgid "&Previous Page"
 msgstr "Предыдущая страница"
 
 #. IDS_PREVIEWBAR_NEXTPAGE
-#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5678
+#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5679
 msgid "&Next Page"
 msgstr "Следующая страница"
 
@@ -666,7 +666,7 @@ msgid "&Huge"
 msgstr "&Огромные значки"
 
 #. IDS_VIEW_MENU_BAR
-#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5713
+#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5714
 msgid "Men&u Bar"
 msgstr "Панель меню"
 
@@ -4191,7 +4191,7 @@ msgid "Items compared:"
 msgstr "Обработано:"
 
 #. IDS_PREVIEWBAR_CLOSE
-#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5684
+#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5685
 msgid "&Close"
 msgstr "&Закрыть"
 
@@ -8003,447 +8003,452 @@ msgstr "1-й и 3-й"
 msgid "2nd and 3rd"
 msgstr "2-й и 3-й"
 
+#. IDS_PLUGIN_CTRL_CLICK
+#: Merge.rc:5635
+msgid "(Ctrl+Click to add to pipeline)"
+msgstr ""
+
 #. IDS_FILTER_APPLIED
-#: Merge.rc:5639
+#: Merge.rc:5640
 msgid "Filter applied"
 msgstr "Фильтр применен"
 
 #. IDS_FILTERMENU_COMPARE
-#: Merge.rc:5644
+#: Merge.rc:5645
 #, c-format
 msgid "Compare %1"
 msgstr "Сравнить %1"
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN2
-#: Merge.rc:5646
+#: Merge.rc:5647
 msgid "&Filter by This Column..."
 msgstr "Фильтр по этому столбцу..."
 
 #. IDS_CLIPBOARDHISTORY_TIME
-#: Merge.rc:5651
+#: Merge.rc:5652
 #, c-format
 msgid "Clipboard at %s"
 msgstr "Буфер обмена в %s"
 
 #. IDS_CLIPBOARDHISTORY_DISABLED
-#: Merge.rc:5652
+#: Merge.rc:5653
 msgid "Clipboard history disabled.\r\nEnable: Windows logo key + V, then Turn on."
 msgstr "История буфера обмена отключена.\r\nЧтобы включить историю буфера обмена, нажмите Win+V, а затем кнопку 'включить'."
 
-#: Merge.rc:5654
+#: Merge.rc:5655
 msgid "This system does not support clipboard history."
 msgstr "Эта система не поддерживает историю буфера обмена."
 
-#: Merge.rc:5656
+#: Merge.rc:5657
 msgid "32-bit WinMerge does not support Clipboard Compare"
 msgstr "32-битная версия WinMerge не поддерживает Сравнение буфера обмена"
 
 #. IDS_WEBVIEW2_RUNTIME_NOT_INSTALLED
-#: Merge.rc:5661
+#: Merge.rc:5662
 msgid "WebView2 runtime not installed. Download it?"
 msgstr "Не установлена среда выполнения WebView2. Загрузить?"
 
 #. IDS_JUMPLIST_NEW_TEXT_COMPARE
-#: Merge.rc:5666
+#: Merge.rc:5667
 msgid "New Text Compare"
 msgstr "Создать сравнение текста"
 
 #. IDS_JUMPLIST_NEW_TABLE_COMPARE
-#: Merge.rc:5667
+#: Merge.rc:5668
 msgid "New Table Compare"
 msgstr "Создать сравнение таблиц"
 
 #. IDS_JUMPLIST_NEW_BINARY_COMPARE
-#: Merge.rc:5668
+#: Merge.rc:5669
 msgid "New Binary Compare"
 msgstr "Создать двоичное сравнение"
 
 #. IDS_JUMPLIST_NEW_IMAGE_COMPARE
-#: Merge.rc:5669
+#: Merge.rc:5670
 msgid "New Image Compare"
 msgstr "Создать сравнение изображений"
 
 #. IDS_JUMPLIST_NEW_WEBPAGE_COMPARE
-#: Merge.rc:5670
+#: Merge.rc:5671
 msgid "New Webpage Compare"
 msgstr "Создать сравнение веб-страниц"
 
 #. IDS_JUMPLIST_NEW_FOLDER_COMPARE
-#: Merge.rc:5671
+#: Merge.rc:5672
 msgid "New Folder Compare"
 msgstr "Создать сравнение папок"
 
 #. IDS_JUMPLIST_CLIPBOARD_COMPARE
-#: Merge.rc:5672
+#: Merge.rc:5673
 msgid "Clipboard Compare"
 msgstr "Сравнение буфера обмена"
 
 #. IDS_PREVIEWBAR_PRINT
-#: Merge.rc:5677
+#: Merge.rc:5678
 msgid "&Print..."
 msgstr "Печать..."
 
 #. IDS_PREVIEWBAR_PREVPAGE
-#: Merge.rc:5679
+#: Merge.rc:5680
 msgid "Pre&v Page"
 msgstr "Предыдущая страница"
 
 #. IDS_PREVIEWBAR_TWOPAGE
-#: Merge.rc:5680
+#: Merge.rc:5681
 msgid "&Two Page"
 msgstr "Две страницы"
 
 #. IDS_PREVIEWBAR_ONEPAGE
-#: Merge.rc:5681
+#: Merge.rc:5682
 msgid "&One Page"
 msgstr "Одна страница"
 
 #. IDS_PREVIEWBAR_ZOOMIN
-#: Merge.rc:5682
+#: Merge.rc:5683
 msgid "Zoom &In"
 msgstr "Увеличить"
 
 #. IDS_PREVIEWBAR_ZOOMOUT
-#: Merge.rc:5683
+#: Merge.rc:5684
 msgid "Zoom &Out"
 msgstr "Уменьшить"
 
 #. IDS_WEBPAGE_COMPARING
-#: Merge.rc:5689
+#: Merge.rc:5690
 msgid "Comparing..."
 msgstr "Сравнение..."
 
 #. IDS_WEBPAGE_ZOOM
-#: Merge.rc:5690
+#: Merge.rc:5691
 msgid "Zoom:"
 msgstr "Масштаб:"
 
 #. IDS_COPY_GRANULARITY_DIFFHUNK
-#: Merge.rc:5695
+#: Merge.rc:5696
 msgid "Diff hunk"
 msgstr "Отличающийся кусок"
 
 #. IDS_COPY_GRANULARITY_INLINE
-#: Merge.rc:5696
+#: Merge.rc:5697
 msgid "Inline diff"
 msgstr "Встроенное отличие"
 
 #. IDS_COPY_GRANULARITY_LINE
-#: Merge.rc:5697
+#: Merge.rc:5698
 msgid "Line"
 msgstr "Строка"
 
-#: Merge.rc:5698
+#: Merge.rc:5699
 msgid "Character"
 msgstr "Символ"
 
 #. ID_MICE_PREVDIFF
-#: Merge.rc:5703
+#: Merge.rc:5704
 msgid "\nPrevious Difference (Alt+Up)\n(Right Button+Wheel Up)\n(Alt+Wheel Up)"
 msgstr "\nПредыдущее отличие (Alt+Up)\n(Правая кнопка+Колесо вверх)\n(Alt+Колесо вверх)"
 
 #. ID_MICE_NEXTDIFF
-#: Merge.rc:5704
+#: Merge.rc:5705
 msgid "\nNext Difference (Alt+Down)\n(Right Button+Wheel Down)\n(Alt+Wheel Down)"
 msgstr "\nСледующее отличие (Alt+Down)\n(Правая кнопка+Колесо вниз)\n(Alt+Колесо вниз)"
 
 #. ID_MICE_L2R
-#: Merge.rc:5705
+#: Merge.rc:5706
 msgid "\nCopy to Right (Alt+Right)\n(Right Button+Wheel Right)\n(Alt+Wheel Right)\n(Alt+Shift+Wheel Down)"
 msgstr "\nКопировать направо (Alt+Right)\n(Правая кнопка+Колесо вправо)\n(Alt+Колесо вправо)\n(Alt+Shift+Колесо вниз)"
 
 #. ID_MICE_R2L
-#: Merge.rc:5706
+#: Merge.rc:5707
 msgid "\nCopy to Left (Alt+Left)\n(Right Button+Wheel Left)\n(Alt+Wheel Left)\n(Alt+Shift+Wheel Up)"
 msgstr "\nКопировать налево (Alt+Left)\n(Правая кнопка+Колесо влево)\n(Alt+Колесо влево)\n(Alt+Shift+Колесо вверх)"
 
 #. ID_MICE_L2RNEXT
-#: Merge.rc:5707
+#: Merge.rc:5708
 msgid "\nCopy to Right and Advance (Ctrl+Alt+Right)\n(Ctrl+Alt+Wheel Right)\n(Ctrl+Alt+Shift+Wheel Down)"
 msgstr "\nКопировать направо и перейти (Ctrl+Alt+Right)\n(Ctrl+Alt+Колесо вправо)\n(Ctrl+Alt+Shift+Колесо вниз)"
 
 #. ID_MICE_R2LNEXT
-#: Merge.rc:5708
+#: Merge.rc:5709
 msgid "\nCopy to Left and Advance (Ctrl+Alt+Left)\n(Ctrl+Alt+Wheel Left)\n(Ctrl+Alt+Shift+Wheel Up)"
 msgstr "\nКопировать налево и перейти (Ctrl+Alt+Left)\n(Ctrl+Alt+Колесо влево)\n(Ctrl+Alt+Shift+Колесо вверх)"
 
 #. IDS_LOG_COMPARING_2
-#: Merge.rc:5718
+#: Merge.rc:5719
 #, c-format
 msgid "Comparing %1 with %2"
 msgstr "Сравнение %1 с %2"
 
 #. IDS_LOG_COMPARING_3
-#: Merge.rc:5719
+#: Merge.rc:5720
 #, c-format
 msgid "Comparing %1 with %2 and %3"
 msgstr "Сравнение %1 с %2 и %3"
 
 #. IDS_LOG_COMPARE_COMPLETED
-#: Merge.rc:5720
+#: Merge.rc:5721
 msgid "Comparison completed"
 msgstr "Сравнение завершено"
 
 #. IDS_LOG_COMPARE_ERROR_2
-#: Merge.rc:5721
+#: Merge.rc:5722
 #, c-format
 msgid "Failed to compare %1 with %2: "
 msgstr "Не удалось сравнить %1 с %2: "
 
 #. IDS_LOG_COMPARE_ERROR_3
-#: Merge.rc:5722
+#: Merge.rc:5723
 #, c-format
 msgid "Failed to compare %1 with %2 and %3: "
 msgstr "Не удалось сравнить %1 с %2 и %3: "
 
 #. IDS_LOG_FILE_SAVED
-#: Merge.rc:5723
+#: Merge.rc:5724
 msgid "File saved"
 msgstr "Файл сохранен"
 
 #. IDS_LOG_COPYING_FILES
-#: Merge.rc:5724
+#: Merge.rc:5725
 msgid "Copying files..."
 msgstr "Копирование файлов..."
 
 #. IDS_LOG_MOVING_FILES
-#: Merge.rc:5725
+#: Merge.rc:5726
 msgid "Moving files..."
 msgstr "Перемещение файлов..."
 
 #. IDS_LOG_DELETING_FILES
-#: Merge.rc:5726
+#: Merge.rc:5727
 msgid "Deleting files..."
 msgstr "Удаление файлов..."
 
 #. IDS_LOG_RECYCLEBIN
-#: Merge.rc:5727
+#: Merge.rc:5728
 msgid "Recycle Bin"
 msgstr "Корзина"
 
 #. IDS_LOG_PERMANENTLY_DELETED
-#: Merge.rc:5728
+#: Merge.rc:5729
 msgid "Permanently deleted"
 msgstr "Удалено без возможности восстановления"
 
 #. IDS_LOG_FILEOPERATION_COMPLETED
-#: Merge.rc:5729
+#: Merge.rc:5730
 msgid "File operation completed successfully"
 msgstr "Файловая операция успешно завершена"
 
 #. IDS_LOG_FILEOPERATION_CANCELED
-#: Merge.rc:5730
+#: Merge.rc:5731
 msgid "File operation canceled"
 msgstr "Файловая операция отменена"
 
 #. IDS_FILTER_ERROR_NO_ERROR
-#: Merge.rc:5735
+#: Merge.rc:5736
 msgid "No error"
 msgstr "Ошибок нет"
 
 #. IDS_FILTER_ERROR_EMPTY_EXPRESSION
-#: Merge.rc:5736
+#: Merge.rc:5737
 msgid "Filter expression is empty"
 msgstr "Пустое выражение фильтра"
 
 #. IDS_FILTER_ERROR_UNKNOWN_CHAR
-#: Merge.rc:5737
+#: Merge.rc:5738
 msgid "Unknown character in filter expression"
 msgstr "Неизвестный символ в выражении фильтра"
 
 #. IDS_FILTER_ERROR_UNTERMINATED_STRING
-#: Merge.rc:5738
+#: Merge.rc:5739
 msgid "Unterminated string literal"
 msgstr "Незаконченный литерал"
 
 #. IDS_FILTER_ERROR_SYNTAX_ERROR
-#: Merge.rc:5739
+#: Merge.rc:5740
 msgid "Syntax error in filter expression"
 msgstr "Синтаксическая ошибка в выражении фильтра"
 
 #. IDS_FILTER_ERROR_PARSE_FAILURE
-#: Merge.rc:5740
+#: Merge.rc:5741
 msgid "Failed to parse filter expression"
 msgstr "Не удалось разобрать выражение фильтра"
 
 #. IDS_FILTER_ERROR_INVALID_LITERAL
-#: Merge.rc:5741
+#: Merge.rc:5742
 msgid "Invalid literal value"
 msgstr "Неверное значение литерала"
 
 #. IDS_FILTER_ERROR_INVALID_REGULAR_EXPRESSION
-#: Merge.rc:5742
+#: Merge.rc:5743
 msgid "Invalid regular expression"
 msgstr "Неверное регулярное выражение"
 
 #. IDS_FILTER_ERROR_UNDEFINED_IDENTIFIER
-#: Merge.rc:5743
+#: Merge.rc:5744
 msgid "Undefined identifier"
 msgstr "Неопределенный идентификатор"
 
 #. IDS_FILTER_ERROR_INVALID_ARGUMENT_COUNT
-#: Merge.rc:5744
+#: Merge.rc:5745
 msgid "Invalid number of arguments"
 msgstr "Неверное количество аргументов"
 
 #. IDS_FILTER_ERROR_FILTER_NAME_NOT_FOUND
-#: Merge.rc:5745
+#: Merge.rc:5746
 msgid "Filter name not found"
 msgstr "Не найдено имя фильтра "
 
 #. IDS_FILTER_ERROR_DIVIDE_BY_ZERO
-#: Merge.rc:5746
+#: Merge.rc:5747
 msgid "Division by zero in filter expression"
 msgstr "Деление на ноль в выражении фильтра"
 
 #. IDS_FILTER_ERROR_UNKNOWN_ERROR
-#: Merge.rc:5747
+#: Merge.rc:5748
 msgid "Unknown error"
 msgstr "Неизвестная ошибка"
 
 #. IDS_FILTER_ERROR_INVALID_PROPERTY_NAME
-#: Merge.rc:5748
+#: Merge.rc:5749
 msgid "Invalid property name"
 msgstr "Неверное имя свойства"
 
 #. IDS_FILTER_ERROR_INVALID_DIRECTIVE
-#: Merge.rc:5749
+#: Merge.rc:5750
 msgid "Invalid directive"
 msgstr "Неверная директива"
 
 #. IDS_FILTER_OP_EQUALS
-#: Merge.rc:5754
+#: Merge.rc:5755
 msgid "Equals"
 msgstr "Равно"
 
 #. IDS_FILTER_OP_NOT_EQUALS
-#: Merge.rc:5755
+#: Merge.rc:5756
 msgid "Does not equal"
 msgstr "Не равно"
 
 #. IDS_FILTER_OP_LESS_THAN
-#: Merge.rc:5756
+#: Merge.rc:5757
 msgid "Less than"
 msgstr "Меньше чем"
 
 #. IDS_FILTER_OP_LESS_EQUAL
-#: Merge.rc:5757
+#: Merge.rc:5758
 msgid "Less than or equal to"
 msgstr "Меньше или равно"
 
 #. IDS_FILTER_OP_GREATER_EQUAL
-#: Merge.rc:5758
+#: Merge.rc:5759
 msgid "Greater than or equal to"
 msgstr "Больше или равно"
 
 #. IDS_FILTER_OP_GREATER_THAN
-#: Merge.rc:5759
+#: Merge.rc:5760
 msgid "Greater than"
 msgstr "Больше чем"
 
 #. IDS_FILTER_OP_BETWEEN
-#: Merge.rc:5760
+#: Merge.rc:5761
 msgid "Between"
 msgstr "Между"
 
 #. IDS_FILTER_OP_NOT_BETWEEN
-#: Merge.rc:5761
+#: Merge.rc:5762
 msgid "Not Between"
 msgstr "Не между"
 
 #. IDS_FILTER_OP_CONTAINS
-#: Merge.rc:5762
+#: Merge.rc:5763
 msgid "Contains"
 msgstr "Содержит"
 
 #. IDS_FILTER_OP_NOT_CONTAINS
-#: Merge.rc:5763
+#: Merge.rc:5764
 msgid "Not Contains"
 msgstr "Не содержит"
 
 #. IDS_FILTER_OP_RECONTAINS
-#: Merge.rc:5764
+#: Merge.rc:5765
 msgid "Contains (regex)"
 msgstr "Содержит (regex)"
 
 #. IDS_FILTER_OP_NOT_RECONTAINS
-#: Merge.rc:5765
+#: Merge.rc:5766
 msgid "Not Contains (regex)"
 msgstr "Не содержит (regex)"
 
 #. IDS_FILTER_OP_LIKE
-#: Merge.rc:5766
+#: Merge.rc:5767
 msgid "Match (wildcard)"
 msgstr "Совпадение (маска)"
 
 #. IDS_FILTER_OP_NOT_LIKE
-#: Merge.rc:5767
+#: Merge.rc:5768
 msgid "Not match (wildcard)"
 msgstr "Несовпадение (маска)"
 
 #. IDS_FILTER_OP_MATCHES
-#: Merge.rc:5768
+#: Merge.rc:5769
 msgid "Match (regex)"
 msgstr "Совпадение (regex)"
 
 #. IDS_FILTER_OP_NOT_MATCHES
-#: Merge.rc:5769
+#: Merge.rc:5770
 msgid "Not match (regex)"
 msgstr "Несовпадение (regex)"
 
 #. IDS_COLORMODE_LIGHT
-#: Merge.rc:5774
+#: Merge.rc:5775
 msgid "Light"
 msgstr "Светлый"
 
 #. IDS_COLORMODE_DARK
-#: Merge.rc:5775
+#: Merge.rc:5776
 msgid "Dark"
 msgstr "Тёмный"
 
 #. IDS_COLORMODE_FOLLOWSYSTEM
-#: Merge.rc:5776
+#: Merge.rc:5777
 msgid "Follow system"
 msgstr "Системный"
 
 #. IDS_EXAMPLE
-#: Merge.rc:5781
+#: Merge.rc:5782
 #, c-format
 msgid "e.g. %1"
 msgstr "например, %1"
 
 #. IDS_DETECTED_PREVIOUS_CRASH
-#: Merge.rc:5786
+#: Merge.rc:5787
 msgid "WinMerge detected a previous crash. Please report this if possible."
 msgstr "WinMerge обнаружил предыдущий сбой. Пожалуйста, сообщите о нём, если это возможно."
 
 #. IDS_REGEX_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5791
+#: Merge.rc:5792
 msgid "# Regex replacement list\r\n# Format: regex<TAB>replacement\r\n# Backreferences like $1, $2 are supported\r\n\r\n(\\d{4})-(\\d{2})-(\\d{2})\t$1_$2_$3\r\n"
 msgstr "# Список замены регулярных выражений\r\n# Формат: регулярное выражение<TAB>замена\r\n# Поддерживаются обратные ссылки типа $1, $2\r\n\r\n(\\d{4})-(\\d{2})-(\\d{2})\t$1_$2_$3\r\n"
 
 #. IDS_STRING_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5792
+#: Merge.rc:5793
 msgid "# Replacement list\r\n# Format: search<TAB>replacement\r\n# Lines starting with # are ignored\r\n\r\nfrom1\tto1\r\nfrom2\tto2\r\n"
 msgstr "# Список замены\r\n# Формат: поиск<TAB>замена\r\n# Строки, начинающиеся с #, игнорируются\r\n\r\nот1\tдо1\r\nот2\tдо2\r\n"
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_ONLY
-#: Merge.rc:5797
+#: Merge.rc:5798
 msgid "Built-in only"
 msgstr "Только встроенный"
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_FIRST
-#: Merge.rc:5798
+#: Merge.rc:5799
 msgid "Built-in first"
 msgstr "Сначала встроенный"
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_FIRST
-#: Merge.rc:5799
+#: Merge.rc:5800
 msgid "Tree-sitter first"
 msgstr "Сначала Tree-sitter"
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_ONLY
-#: Merge.rc:5800
+#: Merge.rc:5801
 msgid "Tree-sitter only"
 msgstr "Только Tree-sitter"
 

--- a/Translations/WinMerge/Serbian.po
+++ b/Translations/WinMerge/Serbian.po
@@ -20,7 +20,7 @@ msgstr ""
 "X-Poedit-Basepath: ../../Src/\n"
 
 #. LANGUAGE, SUBLANGUAGE
-#: Merge.rc:26 Merge.rc:59 Merge.rc:5817
+#: Merge.rc:26 Merge.rc:59 Merge.rc:5818
 #, c-format
 msgid "LANG_ENGLISH, SUBLANG_ENGLISH_US"
 msgstr "LANG_SERBIAN, SUBLANG_SERBIAN_CYRILLIC"
@@ -237,7 +237,7 @@ msgid "Auto-Fit All Columns"
 msgstr ""
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN
-#: Merge.rc:153 Merge.rc:5645
+#: Merge.rc:153 Merge.rc:5646
 msgid "&Filter by This Column"
 msgstr ""
 
@@ -303,7 +303,7 @@ msgid "&Previous Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_NEXTPAGE
-#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5678
+#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5679
 #, c-format
 msgid "&Next Page"
 msgstr ""
@@ -708,7 +708,7 @@ msgid "&Huge"
 msgstr ""
 
 #. IDS_VIEW_MENU_BAR
-#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5713
+#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5714
 msgid "Men&u Bar"
 msgstr ""
 
@@ -4549,7 +4549,7 @@ msgid "Items compared:"
 msgstr "Поређење ставки:"
 
 #. IDS_PREVIEWBAR_CLOSE
-#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5684
+#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5685
 #, c-format
 msgid "&Close"
 msgstr "&Затвори"
@@ -8865,447 +8865,452 @@ msgstr ""
 msgid "2nd and 3rd"
 msgstr ""
 
+#. IDS_PLUGIN_CTRL_CLICK
+#: Merge.rc:5635
+msgid "(Ctrl+Click to add to pipeline)"
+msgstr ""
+
 #. IDS_FILTER_APPLIED
-#: Merge.rc:5639
+#: Merge.rc:5640
 msgid "Filter applied"
 msgstr ""
 
 #. IDS_FILTERMENU_COMPARE
-#: Merge.rc:5644
+#: Merge.rc:5645
 #, c-format
 msgid "Compare %1"
 msgstr ""
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN2
-#: Merge.rc:5646
+#: Merge.rc:5647
 msgid "&Filter by This Column..."
 msgstr ""
 
 #. IDS_CLIPBOARDHISTORY_TIME
-#: Merge.rc:5651
+#: Merge.rc:5652
 #, c-format
 msgid "Clipboard at %s"
 msgstr ""
 
 #. IDS_CLIPBOARDHISTORY_DISABLED
-#: Merge.rc:5652
+#: Merge.rc:5653
 msgid "Clipboard history disabled.\r\nEnable: Windows logo key + V, then Turn on."
 msgstr ""
 
-#: Merge.rc:5654
+#: Merge.rc:5655
 msgid "This system does not support clipboard history."
 msgstr ""
 
-#: Merge.rc:5656
+#: Merge.rc:5657
 msgid "32-bit WinMerge does not support Clipboard Compare"
 msgstr ""
 
 #. IDS_WEBVIEW2_RUNTIME_NOT_INSTALLED
-#: Merge.rc:5661
+#: Merge.rc:5662
 msgid "WebView2 runtime not installed. Download it?"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_TEXT_COMPARE
-#: Merge.rc:5666
+#: Merge.rc:5667
 msgid "New Text Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_TABLE_COMPARE
-#: Merge.rc:5667
+#: Merge.rc:5668
 msgid "New Table Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_BINARY_COMPARE
-#: Merge.rc:5668
+#: Merge.rc:5669
 msgid "New Binary Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_IMAGE_COMPARE
-#: Merge.rc:5669
+#: Merge.rc:5670
 msgid "New Image Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_WEBPAGE_COMPARE
-#: Merge.rc:5670
+#: Merge.rc:5671
 msgid "New Webpage Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_FOLDER_COMPARE
-#: Merge.rc:5671
+#: Merge.rc:5672
 msgid "New Folder Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_CLIPBOARD_COMPARE
-#: Merge.rc:5672
+#: Merge.rc:5673
 msgid "Clipboard Compare"
 msgstr ""
 
 #. IDS_PREVIEWBAR_PRINT
-#: Merge.rc:5677
+#: Merge.rc:5678
 msgid "&Print..."
 msgstr ""
 
 #. IDS_PREVIEWBAR_PREVPAGE
-#: Merge.rc:5679
+#: Merge.rc:5680
 msgid "Pre&v Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_TWOPAGE
-#: Merge.rc:5680
+#: Merge.rc:5681
 msgid "&Two Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_ONEPAGE
-#: Merge.rc:5681
+#: Merge.rc:5682
 msgid "&One Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_ZOOMIN
-#: Merge.rc:5682
+#: Merge.rc:5683
 msgid "Zoom &In"
 msgstr ""
 
 #. IDS_PREVIEWBAR_ZOOMOUT
-#: Merge.rc:5683
+#: Merge.rc:5684
 msgid "Zoom &Out"
 msgstr ""
 
 #. IDS_WEBPAGE_COMPARING
-#: Merge.rc:5689
+#: Merge.rc:5690
 msgid "Comparing..."
 msgstr ""
 
 #. IDS_WEBPAGE_ZOOM
-#: Merge.rc:5690
+#: Merge.rc:5691
 msgid "Zoom:"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_DIFFHUNK
-#: Merge.rc:5695
+#: Merge.rc:5696
 msgid "Diff hunk"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_INLINE
-#: Merge.rc:5696
+#: Merge.rc:5697
 msgid "Inline diff"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_LINE
-#: Merge.rc:5697
+#: Merge.rc:5698
 msgid "Line"
 msgstr ""
 
-#: Merge.rc:5698
+#: Merge.rc:5699
 msgid "Character"
 msgstr ""
 
 #. ID_MICE_PREVDIFF
-#: Merge.rc:5703
+#: Merge.rc:5704
 msgid "\nPrevious Difference (Alt+Up)\n(Right Button+Wheel Up)\n(Alt+Wheel Up)"
 msgstr ""
 
 #. ID_MICE_NEXTDIFF
-#: Merge.rc:5704
+#: Merge.rc:5705
 msgid "\nNext Difference (Alt+Down)\n(Right Button+Wheel Down)\n(Alt+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_L2R
-#: Merge.rc:5705
+#: Merge.rc:5706
 msgid "\nCopy to Right (Alt+Right)\n(Right Button+Wheel Right)\n(Alt+Wheel Right)\n(Alt+Shift+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_R2L
-#: Merge.rc:5706
+#: Merge.rc:5707
 msgid "\nCopy to Left (Alt+Left)\n(Right Button+Wheel Left)\n(Alt+Wheel Left)\n(Alt+Shift+Wheel Up)"
 msgstr ""
 
 #. ID_MICE_L2RNEXT
-#: Merge.rc:5707
+#: Merge.rc:5708
 msgid "\nCopy to Right and Advance (Ctrl+Alt+Right)\n(Ctrl+Alt+Wheel Right)\n(Ctrl+Alt+Shift+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_R2LNEXT
-#: Merge.rc:5708
+#: Merge.rc:5709
 msgid "\nCopy to Left and Advance (Ctrl+Alt+Left)\n(Ctrl+Alt+Wheel Left)\n(Ctrl+Alt+Shift+Wheel Up)"
 msgstr ""
 
 #. IDS_LOG_COMPARING_2
-#: Merge.rc:5718
+#: Merge.rc:5719
 #, c-format
 msgid "Comparing %1 with %2"
 msgstr ""
 
 #. IDS_LOG_COMPARING_3
-#: Merge.rc:5719
+#: Merge.rc:5720
 #, c-format
 msgid "Comparing %1 with %2 and %3"
 msgstr ""
 
 #. IDS_LOG_COMPARE_COMPLETED
-#: Merge.rc:5720
+#: Merge.rc:5721
 msgid "Comparison completed"
 msgstr ""
 
 #. IDS_LOG_COMPARE_ERROR_2
-#: Merge.rc:5721
+#: Merge.rc:5722
 #, c-format
 msgid "Failed to compare %1 with %2: "
 msgstr ""
 
 #. IDS_LOG_COMPARE_ERROR_3
-#: Merge.rc:5722
+#: Merge.rc:5723
 #, c-format
 msgid "Failed to compare %1 with %2 and %3: "
 msgstr ""
 
 #. IDS_LOG_FILE_SAVED
-#: Merge.rc:5723
+#: Merge.rc:5724
 msgid "File saved"
 msgstr ""
 
 #. IDS_LOG_COPYING_FILES
-#: Merge.rc:5724
+#: Merge.rc:5725
 msgid "Copying files..."
 msgstr ""
 
 #. IDS_LOG_MOVING_FILES
-#: Merge.rc:5725
+#: Merge.rc:5726
 msgid "Moving files..."
 msgstr ""
 
 #. IDS_LOG_DELETING_FILES
-#: Merge.rc:5726
+#: Merge.rc:5727
 msgid "Deleting files..."
 msgstr ""
 
 #. IDS_LOG_RECYCLEBIN
-#: Merge.rc:5727
+#: Merge.rc:5728
 msgid "Recycle Bin"
 msgstr ""
 
 #. IDS_LOG_PERMANENTLY_DELETED
-#: Merge.rc:5728
+#: Merge.rc:5729
 msgid "Permanently deleted"
 msgstr ""
 
 #. IDS_LOG_FILEOPERATION_COMPLETED
-#: Merge.rc:5729
+#: Merge.rc:5730
 msgid "File operation completed successfully"
 msgstr ""
 
 #. IDS_LOG_FILEOPERATION_CANCELED
-#: Merge.rc:5730
+#: Merge.rc:5731
 msgid "File operation canceled"
 msgstr ""
 
 #. IDS_FILTER_ERROR_NO_ERROR
-#: Merge.rc:5735
+#: Merge.rc:5736
 msgid "No error"
 msgstr ""
 
 #. IDS_FILTER_ERROR_EMPTY_EXPRESSION
-#: Merge.rc:5736
+#: Merge.rc:5737
 msgid "Filter expression is empty"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNKNOWN_CHAR
-#: Merge.rc:5737
+#: Merge.rc:5738
 msgid "Unknown character in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNTERMINATED_STRING
-#: Merge.rc:5738
+#: Merge.rc:5739
 msgid "Unterminated string literal"
 msgstr ""
 
 #. IDS_FILTER_ERROR_SYNTAX_ERROR
-#: Merge.rc:5739
+#: Merge.rc:5740
 msgid "Syntax error in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_PARSE_FAILURE
-#: Merge.rc:5740
+#: Merge.rc:5741
 msgid "Failed to parse filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_LITERAL
-#: Merge.rc:5741
+#: Merge.rc:5742
 msgid "Invalid literal value"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_REGULAR_EXPRESSION
-#: Merge.rc:5742
+#: Merge.rc:5743
 msgid "Invalid regular expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNDEFINED_IDENTIFIER
-#: Merge.rc:5743
+#: Merge.rc:5744
 msgid "Undefined identifier"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_ARGUMENT_COUNT
-#: Merge.rc:5744
+#: Merge.rc:5745
 msgid "Invalid number of arguments"
 msgstr ""
 
 #. IDS_FILTER_ERROR_FILTER_NAME_NOT_FOUND
-#: Merge.rc:5745
+#: Merge.rc:5746
 msgid "Filter name not found"
 msgstr ""
 
 #. IDS_FILTER_ERROR_DIVIDE_BY_ZERO
-#: Merge.rc:5746
+#: Merge.rc:5747
 msgid "Division by zero in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNKNOWN_ERROR
-#: Merge.rc:5747
+#: Merge.rc:5748
 msgid "Unknown error"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_PROPERTY_NAME
-#: Merge.rc:5748
+#: Merge.rc:5749
 msgid "Invalid property name"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_DIRECTIVE
-#: Merge.rc:5749
+#: Merge.rc:5750
 msgid "Invalid directive"
 msgstr ""
 
 #. IDS_FILTER_OP_EQUALS
-#: Merge.rc:5754
+#: Merge.rc:5755
 msgid "Equals"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_EQUALS
-#: Merge.rc:5755
+#: Merge.rc:5756
 msgid "Does not equal"
 msgstr ""
 
 #. IDS_FILTER_OP_LESS_THAN
-#: Merge.rc:5756
+#: Merge.rc:5757
 msgid "Less than"
 msgstr ""
 
 #. IDS_FILTER_OP_LESS_EQUAL
-#: Merge.rc:5757
+#: Merge.rc:5758
 msgid "Less than or equal to"
 msgstr ""
 
 #. IDS_FILTER_OP_GREATER_EQUAL
-#: Merge.rc:5758
+#: Merge.rc:5759
 msgid "Greater than or equal to"
 msgstr ""
 
 #. IDS_FILTER_OP_GREATER_THAN
-#: Merge.rc:5759
+#: Merge.rc:5760
 msgid "Greater than"
 msgstr ""
 
 #. IDS_FILTER_OP_BETWEEN
-#: Merge.rc:5760
+#: Merge.rc:5761
 msgid "Between"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_BETWEEN
-#: Merge.rc:5761
+#: Merge.rc:5762
 msgid "Not Between"
 msgstr ""
 
 #. IDS_FILTER_OP_CONTAINS
-#: Merge.rc:5762
+#: Merge.rc:5763
 msgid "Contains"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_CONTAINS
-#: Merge.rc:5763
+#: Merge.rc:5764
 msgid "Not Contains"
 msgstr ""
 
 #. IDS_FILTER_OP_RECONTAINS
-#: Merge.rc:5764
+#: Merge.rc:5765
 msgid "Contains (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_RECONTAINS
-#: Merge.rc:5765
+#: Merge.rc:5766
 msgid "Not Contains (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_LIKE
-#: Merge.rc:5766
+#: Merge.rc:5767
 msgid "Match (wildcard)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_LIKE
-#: Merge.rc:5767
+#: Merge.rc:5768
 msgid "Not match (wildcard)"
 msgstr ""
 
 #. IDS_FILTER_OP_MATCHES
-#: Merge.rc:5768
+#: Merge.rc:5769
 msgid "Match (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_MATCHES
-#: Merge.rc:5769
+#: Merge.rc:5770
 msgid "Not match (regex)"
 msgstr ""
 
 #. IDS_COLORMODE_LIGHT
-#: Merge.rc:5774
+#: Merge.rc:5775
 msgid "Light"
 msgstr ""
 
 #. IDS_COLORMODE_DARK
-#: Merge.rc:5775
+#: Merge.rc:5776
 msgid "Dark"
 msgstr ""
 
 #. IDS_COLORMODE_FOLLOWSYSTEM
-#: Merge.rc:5776
+#: Merge.rc:5777
 msgid "Follow system"
 msgstr ""
 
 #. IDS_EXAMPLE
-#: Merge.rc:5781
+#: Merge.rc:5782
 #, c-format
 msgid "e.g. %1"
 msgstr ""
 
 #. IDS_DETECTED_PREVIOUS_CRASH
-#: Merge.rc:5786
+#: Merge.rc:5787
 msgid "WinMerge detected a previous crash. Please report this if possible."
 msgstr ""
 
 #. IDS_REGEX_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5791
+#: Merge.rc:5792
 msgid "# Regex replacement list\r\n# Format: regex<TAB>replacement\r\n# Backreferences like $1, $2 are supported\r\n\r\n(\\d{4})-(\\d{2})-(\\d{2})\t$1_$2_$3\r\n"
 msgstr ""
 
 #. IDS_STRING_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5792
+#: Merge.rc:5793
 msgid "# Replacement list\r\n# Format: search<TAB>replacement\r\n# Lines starting with # are ignored\r\n\r\nfrom1\tto1\r\nfrom2\tto2\r\n"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_ONLY
-#: Merge.rc:5797
+#: Merge.rc:5798
 msgid "Built-in only"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_FIRST
-#: Merge.rc:5798
+#: Merge.rc:5799
 msgid "Built-in first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_FIRST
-#: Merge.rc:5799
+#: Merge.rc:5800
 msgid "Tree-sitter first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_ONLY
-#: Merge.rc:5800
+#: Merge.rc:5801
 msgid "Tree-sitter only"
 msgstr ""
 

--- a/Translations/WinMerge/Sinhala.po
+++ b/Translations/WinMerge/Sinhala.po
@@ -21,7 +21,7 @@ msgstr ""
 "X-Poedit-Country: SRI LANKA\n"
 
 #. LANGUAGE, SUBLANGUAGE
-#: Merge.rc:26 Merge.rc:59 Merge.rc:5817
+#: Merge.rc:26 Merge.rc:59 Merge.rc:5818
 #, c-format
 msgid "LANG_ENGLISH, SUBLANG_ENGLISH_US"
 msgstr "LANG_SINHALESE, SUBLANG_DEFAULT"
@@ -238,7 +238,7 @@ msgid "Auto-Fit All Columns"
 msgstr ""
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN
-#: Merge.rc:153 Merge.rc:5645
+#: Merge.rc:153 Merge.rc:5646
 msgid "&Filter by This Column"
 msgstr ""
 
@@ -304,7 +304,7 @@ msgid "&Previous Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_NEXTPAGE
-#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5678
+#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5679
 #, c-format
 msgid "&Next Page"
 msgstr ""
@@ -710,7 +710,7 @@ msgid "&Huge"
 msgstr ""
 
 #. IDS_VIEW_MENU_BAR
-#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5713
+#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5714
 msgid "Men&u Bar"
 msgstr ""
 
@@ -4566,7 +4566,7 @@ msgid "Items compared:"
 msgstr "සැසඳූ අයිතම:"
 
 #. IDS_PREVIEWBAR_CLOSE
-#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5684
+#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5685
 #, c-format
 msgid "&Close"
 msgstr "වසන්න"
@@ -8894,447 +8894,452 @@ msgstr ""
 msgid "2nd and 3rd"
 msgstr ""
 
+#. IDS_PLUGIN_CTRL_CLICK
+#: Merge.rc:5635
+msgid "(Ctrl+Click to add to pipeline)"
+msgstr ""
+
 #. IDS_FILTER_APPLIED
-#: Merge.rc:5639
+#: Merge.rc:5640
 msgid "Filter applied"
 msgstr ""
 
 #. IDS_FILTERMENU_COMPARE
-#: Merge.rc:5644
+#: Merge.rc:5645
 #, c-format
 msgid "Compare %1"
 msgstr ""
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN2
-#: Merge.rc:5646
+#: Merge.rc:5647
 msgid "&Filter by This Column..."
 msgstr ""
 
 #. IDS_CLIPBOARDHISTORY_TIME
-#: Merge.rc:5651
+#: Merge.rc:5652
 #, c-format
 msgid "Clipboard at %s"
 msgstr ""
 
 #. IDS_CLIPBOARDHISTORY_DISABLED
-#: Merge.rc:5652
+#: Merge.rc:5653
 msgid "Clipboard history disabled.\r\nEnable: Windows logo key + V, then Turn on."
 msgstr ""
 
-#: Merge.rc:5654
+#: Merge.rc:5655
 msgid "This system does not support clipboard history."
 msgstr ""
 
-#: Merge.rc:5656
+#: Merge.rc:5657
 msgid "32-bit WinMerge does not support Clipboard Compare"
 msgstr ""
 
 #. IDS_WEBVIEW2_RUNTIME_NOT_INSTALLED
-#: Merge.rc:5661
+#: Merge.rc:5662
 msgid "WebView2 runtime not installed. Download it?"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_TEXT_COMPARE
-#: Merge.rc:5666
+#: Merge.rc:5667
 msgid "New Text Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_TABLE_COMPARE
-#: Merge.rc:5667
+#: Merge.rc:5668
 msgid "New Table Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_BINARY_COMPARE
-#: Merge.rc:5668
+#: Merge.rc:5669
 msgid "New Binary Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_IMAGE_COMPARE
-#: Merge.rc:5669
+#: Merge.rc:5670
 msgid "New Image Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_WEBPAGE_COMPARE
-#: Merge.rc:5670
+#: Merge.rc:5671
 msgid "New Webpage Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_FOLDER_COMPARE
-#: Merge.rc:5671
+#: Merge.rc:5672
 msgid "New Folder Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_CLIPBOARD_COMPARE
-#: Merge.rc:5672
+#: Merge.rc:5673
 msgid "Clipboard Compare"
 msgstr ""
 
 #. IDS_PREVIEWBAR_PRINT
-#: Merge.rc:5677
+#: Merge.rc:5678
 msgid "&Print..."
 msgstr ""
 
 #. IDS_PREVIEWBAR_PREVPAGE
-#: Merge.rc:5679
+#: Merge.rc:5680
 msgid "Pre&v Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_TWOPAGE
-#: Merge.rc:5680
+#: Merge.rc:5681
 msgid "&Two Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_ONEPAGE
-#: Merge.rc:5681
+#: Merge.rc:5682
 msgid "&One Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_ZOOMIN
-#: Merge.rc:5682
+#: Merge.rc:5683
 msgid "Zoom &In"
 msgstr ""
 
 #. IDS_PREVIEWBAR_ZOOMOUT
-#: Merge.rc:5683
+#: Merge.rc:5684
 msgid "Zoom &Out"
 msgstr ""
 
 #. IDS_WEBPAGE_COMPARING
-#: Merge.rc:5689
+#: Merge.rc:5690
 msgid "Comparing..."
 msgstr ""
 
 #. IDS_WEBPAGE_ZOOM
-#: Merge.rc:5690
+#: Merge.rc:5691
 msgid "Zoom:"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_DIFFHUNK
-#: Merge.rc:5695
+#: Merge.rc:5696
 msgid "Diff hunk"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_INLINE
-#: Merge.rc:5696
+#: Merge.rc:5697
 msgid "Inline diff"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_LINE
-#: Merge.rc:5697
+#: Merge.rc:5698
 msgid "Line"
 msgstr ""
 
-#: Merge.rc:5698
+#: Merge.rc:5699
 msgid "Character"
 msgstr ""
 
 #. ID_MICE_PREVDIFF
-#: Merge.rc:5703
+#: Merge.rc:5704
 msgid "\nPrevious Difference (Alt+Up)\n(Right Button+Wheel Up)\n(Alt+Wheel Up)"
 msgstr ""
 
 #. ID_MICE_NEXTDIFF
-#: Merge.rc:5704
+#: Merge.rc:5705
 msgid "\nNext Difference (Alt+Down)\n(Right Button+Wheel Down)\n(Alt+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_L2R
-#: Merge.rc:5705
+#: Merge.rc:5706
 msgid "\nCopy to Right (Alt+Right)\n(Right Button+Wheel Right)\n(Alt+Wheel Right)\n(Alt+Shift+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_R2L
-#: Merge.rc:5706
+#: Merge.rc:5707
 msgid "\nCopy to Left (Alt+Left)\n(Right Button+Wheel Left)\n(Alt+Wheel Left)\n(Alt+Shift+Wheel Up)"
 msgstr ""
 
 #. ID_MICE_L2RNEXT
-#: Merge.rc:5707
+#: Merge.rc:5708
 msgid "\nCopy to Right and Advance (Ctrl+Alt+Right)\n(Ctrl+Alt+Wheel Right)\n(Ctrl+Alt+Shift+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_R2LNEXT
-#: Merge.rc:5708
+#: Merge.rc:5709
 msgid "\nCopy to Left and Advance (Ctrl+Alt+Left)\n(Ctrl+Alt+Wheel Left)\n(Ctrl+Alt+Shift+Wheel Up)"
 msgstr ""
 
 #. IDS_LOG_COMPARING_2
-#: Merge.rc:5718
+#: Merge.rc:5719
 #, c-format
 msgid "Comparing %1 with %2"
 msgstr ""
 
 #. IDS_LOG_COMPARING_3
-#: Merge.rc:5719
+#: Merge.rc:5720
 #, c-format
 msgid "Comparing %1 with %2 and %3"
 msgstr ""
 
 #. IDS_LOG_COMPARE_COMPLETED
-#: Merge.rc:5720
+#: Merge.rc:5721
 msgid "Comparison completed"
 msgstr ""
 
 #. IDS_LOG_COMPARE_ERROR_2
-#: Merge.rc:5721
+#: Merge.rc:5722
 #, c-format
 msgid "Failed to compare %1 with %2: "
 msgstr ""
 
 #. IDS_LOG_COMPARE_ERROR_3
-#: Merge.rc:5722
+#: Merge.rc:5723
 #, c-format
 msgid "Failed to compare %1 with %2 and %3: "
 msgstr ""
 
 #. IDS_LOG_FILE_SAVED
-#: Merge.rc:5723
+#: Merge.rc:5724
 msgid "File saved"
 msgstr ""
 
 #. IDS_LOG_COPYING_FILES
-#: Merge.rc:5724
+#: Merge.rc:5725
 msgid "Copying files..."
 msgstr ""
 
 #. IDS_LOG_MOVING_FILES
-#: Merge.rc:5725
+#: Merge.rc:5726
 msgid "Moving files..."
 msgstr ""
 
 #. IDS_LOG_DELETING_FILES
-#: Merge.rc:5726
+#: Merge.rc:5727
 msgid "Deleting files..."
 msgstr ""
 
 #. IDS_LOG_RECYCLEBIN
-#: Merge.rc:5727
+#: Merge.rc:5728
 msgid "Recycle Bin"
 msgstr ""
 
 #. IDS_LOG_PERMANENTLY_DELETED
-#: Merge.rc:5728
+#: Merge.rc:5729
 msgid "Permanently deleted"
 msgstr ""
 
 #. IDS_LOG_FILEOPERATION_COMPLETED
-#: Merge.rc:5729
+#: Merge.rc:5730
 msgid "File operation completed successfully"
 msgstr ""
 
 #. IDS_LOG_FILEOPERATION_CANCELED
-#: Merge.rc:5730
+#: Merge.rc:5731
 msgid "File operation canceled"
 msgstr ""
 
 #. IDS_FILTER_ERROR_NO_ERROR
-#: Merge.rc:5735
+#: Merge.rc:5736
 msgid "No error"
 msgstr ""
 
 #. IDS_FILTER_ERROR_EMPTY_EXPRESSION
-#: Merge.rc:5736
+#: Merge.rc:5737
 msgid "Filter expression is empty"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNKNOWN_CHAR
-#: Merge.rc:5737
+#: Merge.rc:5738
 msgid "Unknown character in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNTERMINATED_STRING
-#: Merge.rc:5738
+#: Merge.rc:5739
 msgid "Unterminated string literal"
 msgstr ""
 
 #. IDS_FILTER_ERROR_SYNTAX_ERROR
-#: Merge.rc:5739
+#: Merge.rc:5740
 msgid "Syntax error in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_PARSE_FAILURE
-#: Merge.rc:5740
+#: Merge.rc:5741
 msgid "Failed to parse filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_LITERAL
-#: Merge.rc:5741
+#: Merge.rc:5742
 msgid "Invalid literal value"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_REGULAR_EXPRESSION
-#: Merge.rc:5742
+#: Merge.rc:5743
 msgid "Invalid regular expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNDEFINED_IDENTIFIER
-#: Merge.rc:5743
+#: Merge.rc:5744
 msgid "Undefined identifier"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_ARGUMENT_COUNT
-#: Merge.rc:5744
+#: Merge.rc:5745
 msgid "Invalid number of arguments"
 msgstr ""
 
 #. IDS_FILTER_ERROR_FILTER_NAME_NOT_FOUND
-#: Merge.rc:5745
+#: Merge.rc:5746
 msgid "Filter name not found"
 msgstr ""
 
 #. IDS_FILTER_ERROR_DIVIDE_BY_ZERO
-#: Merge.rc:5746
+#: Merge.rc:5747
 msgid "Division by zero in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNKNOWN_ERROR
-#: Merge.rc:5747
+#: Merge.rc:5748
 msgid "Unknown error"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_PROPERTY_NAME
-#: Merge.rc:5748
+#: Merge.rc:5749
 msgid "Invalid property name"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_DIRECTIVE
-#: Merge.rc:5749
+#: Merge.rc:5750
 msgid "Invalid directive"
 msgstr ""
 
 #. IDS_FILTER_OP_EQUALS
-#: Merge.rc:5754
+#: Merge.rc:5755
 msgid "Equals"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_EQUALS
-#: Merge.rc:5755
+#: Merge.rc:5756
 msgid "Does not equal"
 msgstr ""
 
 #. IDS_FILTER_OP_LESS_THAN
-#: Merge.rc:5756
+#: Merge.rc:5757
 msgid "Less than"
 msgstr ""
 
 #. IDS_FILTER_OP_LESS_EQUAL
-#: Merge.rc:5757
+#: Merge.rc:5758
 msgid "Less than or equal to"
 msgstr ""
 
 #. IDS_FILTER_OP_GREATER_EQUAL
-#: Merge.rc:5758
+#: Merge.rc:5759
 msgid "Greater than or equal to"
 msgstr ""
 
 #. IDS_FILTER_OP_GREATER_THAN
-#: Merge.rc:5759
+#: Merge.rc:5760
 msgid "Greater than"
 msgstr ""
 
 #. IDS_FILTER_OP_BETWEEN
-#: Merge.rc:5760
+#: Merge.rc:5761
 msgid "Between"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_BETWEEN
-#: Merge.rc:5761
+#: Merge.rc:5762
 msgid "Not Between"
 msgstr ""
 
 #. IDS_FILTER_OP_CONTAINS
-#: Merge.rc:5762
+#: Merge.rc:5763
 msgid "Contains"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_CONTAINS
-#: Merge.rc:5763
+#: Merge.rc:5764
 msgid "Not Contains"
 msgstr ""
 
 #. IDS_FILTER_OP_RECONTAINS
-#: Merge.rc:5764
+#: Merge.rc:5765
 msgid "Contains (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_RECONTAINS
-#: Merge.rc:5765
+#: Merge.rc:5766
 msgid "Not Contains (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_LIKE
-#: Merge.rc:5766
+#: Merge.rc:5767
 msgid "Match (wildcard)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_LIKE
-#: Merge.rc:5767
+#: Merge.rc:5768
 msgid "Not match (wildcard)"
 msgstr ""
 
 #. IDS_FILTER_OP_MATCHES
-#: Merge.rc:5768
+#: Merge.rc:5769
 msgid "Match (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_MATCHES
-#: Merge.rc:5769
+#: Merge.rc:5770
 msgid "Not match (regex)"
 msgstr ""
 
 #. IDS_COLORMODE_LIGHT
-#: Merge.rc:5774
+#: Merge.rc:5775
 msgid "Light"
 msgstr ""
 
 #. IDS_COLORMODE_DARK
-#: Merge.rc:5775
+#: Merge.rc:5776
 msgid "Dark"
 msgstr ""
 
 #. IDS_COLORMODE_FOLLOWSYSTEM
-#: Merge.rc:5776
+#: Merge.rc:5777
 msgid "Follow system"
 msgstr ""
 
 #. IDS_EXAMPLE
-#: Merge.rc:5781
+#: Merge.rc:5782
 #, c-format
 msgid "e.g. %1"
 msgstr ""
 
 #. IDS_DETECTED_PREVIOUS_CRASH
-#: Merge.rc:5786
+#: Merge.rc:5787
 msgid "WinMerge detected a previous crash. Please report this if possible."
 msgstr ""
 
 #. IDS_REGEX_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5791
+#: Merge.rc:5792
 msgid "# Regex replacement list\r\n# Format: regex<TAB>replacement\r\n# Backreferences like $1, $2 are supported\r\n\r\n(\\d{4})-(\\d{2})-(\\d{2})\t$1_$2_$3\r\n"
 msgstr ""
 
 #. IDS_STRING_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5792
+#: Merge.rc:5793
 msgid "# Replacement list\r\n# Format: search<TAB>replacement\r\n# Lines starting with # are ignored\r\n\r\nfrom1\tto1\r\nfrom2\tto2\r\n"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_ONLY
-#: Merge.rc:5797
+#: Merge.rc:5798
 msgid "Built-in only"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_FIRST
-#: Merge.rc:5798
+#: Merge.rc:5799
 msgid "Built-in first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_FIRST
-#: Merge.rc:5799
+#: Merge.rc:5800
 msgid "Tree-sitter first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_ONLY
-#: Merge.rc:5800
+#: Merge.rc:5801
 msgid "Tree-sitter only"
 msgstr ""
 

--- a/Translations/WinMerge/Slovak.po
+++ b/Translations/WinMerge/Slovak.po
@@ -23,7 +23,7 @@ msgstr ""
 "X-Generator: Poedit 3.0.1\n"
 
 #. LANGUAGE, SUBLANGUAGE
-#: Merge.rc:26 Merge.rc:59 Merge.rc:5817
+#: Merge.rc:26 Merge.rc:59 Merge.rc:5818
 msgid "LANG_ENGLISH, SUBLANG_ENGLISH_US"
 msgstr "LANG_SLOVAK, SUBLANG_DEFAULT"
 
@@ -230,7 +230,7 @@ msgid "Auto-Fit All Columns"
 msgstr ""
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN
-#: Merge.rc:153 Merge.rc:5645
+#: Merge.rc:153 Merge.rc:5646
 msgid "&Filter by This Column"
 msgstr ""
 
@@ -291,7 +291,7 @@ msgid "&Previous Page"
 msgstr "&Predošlá stránka"
 
 #. IDS_PREVIEWBAR_NEXTPAGE
-#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5678
+#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5679
 msgid "&Next Page"
 msgstr "Ď&alšia stránka"
 
@@ -664,7 +664,7 @@ msgid "&Huge"
 msgstr "&Obrovská"
 
 #. IDS_VIEW_MENU_BAR
-#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5713
+#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5714
 msgid "Men&u Bar"
 msgstr ""
 
@@ -4189,7 +4189,7 @@ msgid "Items compared:"
 msgstr "Porovnané položky:"
 
 #. IDS_PREVIEWBAR_CLOSE
-#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5684
+#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5685
 msgid "&Close"
 msgstr "&Zatvoriť"
 
@@ -8306,30 +8306,35 @@ msgstr ""
 msgid "2nd and 3rd"
 msgstr ""
 
+#. IDS_PLUGIN_CTRL_CLICK
+#: Merge.rc:5635
+msgid "(Ctrl+Click to add to pipeline)"
+msgstr ""
+
 #. IDS_FILTER_APPLIED
-#: Merge.rc:5639
+#: Merge.rc:5640
 msgid "Filter applied"
 msgstr "Použitý filter"
 
 #. IDS_FILTERMENU_COMPARE
-#: Merge.rc:5644
+#: Merge.rc:5645
 #, c-format
 msgid "Compare %1"
 msgstr ""
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN2
-#: Merge.rc:5646
+#: Merge.rc:5647
 msgid "&Filter by This Column..."
 msgstr ""
 
 #. IDS_CLIPBOARDHISTORY_TIME
-#: Merge.rc:5651
+#: Merge.rc:5652
 #, c-format
 msgid "Clipboard at %s"
 msgstr "Schránka na %s"
 
 #. IDS_CLIPBOARDHISTORY_DISABLED
-#: Merge.rc:5652
+#: Merge.rc:5653
 msgid ""
 "Clipboard history disabled.\r\n"
 "Enable: Windows logo key + V, then Turn on."
@@ -8337,420 +8342,420 @@ msgstr ""
 "História schránky je vypnutá.\r\n"
 "Ak chcete zapnúť históriu schránky, stlačte kláves s logom Windows + V a potom kliknite na tlačidlo Zapnúť."
 
-#: Merge.rc:5654
+#: Merge.rc:5655
 msgid "This system does not support clipboard history."
 msgstr "Tento systém nepodporuje históriu schránky."
 
-#: Merge.rc:5656
+#: Merge.rc:5657
 msgid "32-bit WinMerge does not support Clipboard Compare"
 msgstr "32-bitová verzia WinMerge nepodporuje porovnávanie schránky"
 
 #. IDS_WEBVIEW2_RUNTIME_NOT_INSTALLED
-#: Merge.rc:5661
+#: Merge.rc:5662
 msgid "WebView2 runtime not installed. Download it?"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_TEXT_COMPARE
-#: Merge.rc:5666
+#: Merge.rc:5667
 msgid "New Text Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_TABLE_COMPARE
-#: Merge.rc:5667
+#: Merge.rc:5668
 msgid "New Table Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_BINARY_COMPARE
-#: Merge.rc:5668
+#: Merge.rc:5669
 msgid "New Binary Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_IMAGE_COMPARE
-#: Merge.rc:5669
+#: Merge.rc:5670
 msgid "New Image Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_WEBPAGE_COMPARE
-#: Merge.rc:5670
+#: Merge.rc:5671
 msgid "New Webpage Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_FOLDER_COMPARE
-#: Merge.rc:5671
+#: Merge.rc:5672
 msgid "New Folder Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_CLIPBOARD_COMPARE
-#: Merge.rc:5672
+#: Merge.rc:5673
 msgid "Clipboard Compare"
 msgstr ""
 
 #. IDS_PREVIEWBAR_PRINT
-#: Merge.rc:5677
+#: Merge.rc:5678
 msgid "&Print..."
 msgstr ""
 
 #. IDS_PREVIEWBAR_PREVPAGE
-#: Merge.rc:5679
+#: Merge.rc:5680
 msgid "Pre&v Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_TWOPAGE
-#: Merge.rc:5680
+#: Merge.rc:5681
 msgid "&Two Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_ONEPAGE
-#: Merge.rc:5681
+#: Merge.rc:5682
 msgid "&One Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_ZOOMIN
-#: Merge.rc:5682
+#: Merge.rc:5683
 msgid "Zoom &In"
 msgstr ""
 
 #. IDS_PREVIEWBAR_ZOOMOUT
-#: Merge.rc:5683
+#: Merge.rc:5684
 msgid "Zoom &Out"
 msgstr ""
 
 #. IDS_WEBPAGE_COMPARING
-#: Merge.rc:5689
+#: Merge.rc:5690
 msgid "Comparing..."
 msgstr ""
 
 #. IDS_WEBPAGE_ZOOM
-#: Merge.rc:5690
+#: Merge.rc:5691
 msgid "Zoom:"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_DIFFHUNK
-#: Merge.rc:5695
+#: Merge.rc:5696
 msgid "Diff hunk"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_INLINE
-#: Merge.rc:5696
+#: Merge.rc:5697
 msgid "Inline diff"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_LINE
-#: Merge.rc:5697
+#: Merge.rc:5698
 msgid "Line"
 msgstr ""
 
-#: Merge.rc:5698
+#: Merge.rc:5699
 msgid "Character"
 msgstr ""
 
 #. ID_MICE_PREVDIFF
-#: Merge.rc:5703
+#: Merge.rc:5704
 msgid "\nPrevious Difference (Alt+Up)\n(Right Button+Wheel Up)\n(Alt+Wheel Up)"
 msgstr ""
 
 #. ID_MICE_NEXTDIFF
-#: Merge.rc:5704
+#: Merge.rc:5705
 msgid "\nNext Difference (Alt+Down)\n(Right Button+Wheel Down)\n(Alt+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_L2R
-#: Merge.rc:5705
+#: Merge.rc:5706
 msgid "\nCopy to Right (Alt+Right)\n(Right Button+Wheel Right)\n(Alt+Wheel Right)\n(Alt+Shift+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_R2L
-#: Merge.rc:5706
+#: Merge.rc:5707
 msgid "\nCopy to Left (Alt+Left)\n(Right Button+Wheel Left)\n(Alt+Wheel Left)\n(Alt+Shift+Wheel Up)"
 msgstr ""
 
 #. ID_MICE_L2RNEXT
-#: Merge.rc:5707
+#: Merge.rc:5708
 msgid "\nCopy to Right and Advance (Ctrl+Alt+Right)\n(Ctrl+Alt+Wheel Right)\n(Ctrl+Alt+Shift+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_R2LNEXT
-#: Merge.rc:5708
+#: Merge.rc:5709
 msgid "\nCopy to Left and Advance (Ctrl+Alt+Left)\n(Ctrl+Alt+Wheel Left)\n(Ctrl+Alt+Shift+Wheel Up)"
 msgstr ""
 
 #. IDS_LOG_COMPARING_2
-#: Merge.rc:5718
+#: Merge.rc:5719
 #, c-format
 msgid "Comparing %1 with %2"
 msgstr ""
 
 #. IDS_LOG_COMPARING_3
-#: Merge.rc:5719
+#: Merge.rc:5720
 #, c-format
 msgid "Comparing %1 with %2 and %3"
 msgstr ""
 
 #. IDS_LOG_COMPARE_COMPLETED
-#: Merge.rc:5720
+#: Merge.rc:5721
 msgid "Comparison completed"
 msgstr ""
 
 #. IDS_LOG_COMPARE_ERROR_2
-#: Merge.rc:5721
+#: Merge.rc:5722
 #, c-format
 msgid "Failed to compare %1 with %2: "
 msgstr ""
 
 #. IDS_LOG_COMPARE_ERROR_3
-#: Merge.rc:5722
+#: Merge.rc:5723
 #, c-format
 msgid "Failed to compare %1 with %2 and %3: "
 msgstr ""
 
 #. IDS_LOG_FILE_SAVED
-#: Merge.rc:5723
+#: Merge.rc:5724
 msgid "File saved"
 msgstr ""
 
 #. IDS_LOG_COPYING_FILES
-#: Merge.rc:5724
+#: Merge.rc:5725
 msgid "Copying files..."
 msgstr ""
 
 #. IDS_LOG_MOVING_FILES
-#: Merge.rc:5725
+#: Merge.rc:5726
 msgid "Moving files..."
 msgstr ""
 
 #. IDS_LOG_DELETING_FILES
-#: Merge.rc:5726
+#: Merge.rc:5727
 msgid "Deleting files..."
 msgstr ""
 
 #. IDS_LOG_RECYCLEBIN
-#: Merge.rc:5727
+#: Merge.rc:5728
 msgid "Recycle Bin"
 msgstr ""
 
 #. IDS_LOG_PERMANENTLY_DELETED
-#: Merge.rc:5728
+#: Merge.rc:5729
 msgid "Permanently deleted"
 msgstr ""
 
 #. IDS_LOG_FILEOPERATION_COMPLETED
-#: Merge.rc:5729
+#: Merge.rc:5730
 msgid "File operation completed successfully"
 msgstr ""
 
 #. IDS_LOG_FILEOPERATION_CANCELED
-#: Merge.rc:5730
+#: Merge.rc:5731
 msgid "File operation canceled"
 msgstr ""
 
 #. IDS_FILTER_ERROR_NO_ERROR
-#: Merge.rc:5735
+#: Merge.rc:5736
 msgid "No error"
 msgstr ""
 
 #. IDS_FILTER_ERROR_EMPTY_EXPRESSION
-#: Merge.rc:5736
+#: Merge.rc:5737
 msgid "Filter expression is empty"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNKNOWN_CHAR
-#: Merge.rc:5737
+#: Merge.rc:5738
 msgid "Unknown character in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNTERMINATED_STRING
-#: Merge.rc:5738
+#: Merge.rc:5739
 msgid "Unterminated string literal"
 msgstr ""
 
 #. IDS_FILTER_ERROR_SYNTAX_ERROR
-#: Merge.rc:5739
+#: Merge.rc:5740
 msgid "Syntax error in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_PARSE_FAILURE
-#: Merge.rc:5740
+#: Merge.rc:5741
 msgid "Failed to parse filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_LITERAL
-#: Merge.rc:5741
+#: Merge.rc:5742
 msgid "Invalid literal value"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_REGULAR_EXPRESSION
-#: Merge.rc:5742
+#: Merge.rc:5743
 msgid "Invalid regular expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNDEFINED_IDENTIFIER
-#: Merge.rc:5743
+#: Merge.rc:5744
 msgid "Undefined identifier"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_ARGUMENT_COUNT
-#: Merge.rc:5744
+#: Merge.rc:5745
 msgid "Invalid number of arguments"
 msgstr ""
 
 #. IDS_FILTER_ERROR_FILTER_NAME_NOT_FOUND
-#: Merge.rc:5745
+#: Merge.rc:5746
 msgid "Filter name not found"
 msgstr ""
 
 #. IDS_FILTER_ERROR_DIVIDE_BY_ZERO
-#: Merge.rc:5746
+#: Merge.rc:5747
 msgid "Division by zero in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNKNOWN_ERROR
-#: Merge.rc:5747
+#: Merge.rc:5748
 msgid "Unknown error"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_PROPERTY_NAME
-#: Merge.rc:5748
+#: Merge.rc:5749
 msgid "Invalid property name"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_DIRECTIVE
-#: Merge.rc:5749
+#: Merge.rc:5750
 msgid "Invalid directive"
 msgstr ""
 
 #. IDS_FILTER_OP_EQUALS
-#: Merge.rc:5754
+#: Merge.rc:5755
 msgid "Equals"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_EQUALS
-#: Merge.rc:5755
+#: Merge.rc:5756
 msgid "Does not equal"
 msgstr ""
 
 #. IDS_FILTER_OP_LESS_THAN
-#: Merge.rc:5756
+#: Merge.rc:5757
 msgid "Less than"
 msgstr ""
 
 #. IDS_FILTER_OP_LESS_EQUAL
-#: Merge.rc:5757
+#: Merge.rc:5758
 msgid "Less than or equal to"
 msgstr ""
 
 #. IDS_FILTER_OP_GREATER_EQUAL
-#: Merge.rc:5758
+#: Merge.rc:5759
 msgid "Greater than or equal to"
 msgstr ""
 
 #. IDS_FILTER_OP_GREATER_THAN
-#: Merge.rc:5759
+#: Merge.rc:5760
 msgid "Greater than"
 msgstr ""
 
 #. IDS_FILTER_OP_BETWEEN
-#: Merge.rc:5760
+#: Merge.rc:5761
 msgid "Between"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_BETWEEN
-#: Merge.rc:5761
+#: Merge.rc:5762
 msgid "Not Between"
 msgstr ""
 
 #. IDS_FILTER_OP_CONTAINS
-#: Merge.rc:5762
+#: Merge.rc:5763
 msgid "Contains"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_CONTAINS
-#: Merge.rc:5763
+#: Merge.rc:5764
 msgid "Not Contains"
 msgstr ""
 
 #. IDS_FILTER_OP_RECONTAINS
-#: Merge.rc:5764
+#: Merge.rc:5765
 msgid "Contains (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_RECONTAINS
-#: Merge.rc:5765
+#: Merge.rc:5766
 msgid "Not Contains (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_LIKE
-#: Merge.rc:5766
+#: Merge.rc:5767
 msgid "Match (wildcard)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_LIKE
-#: Merge.rc:5767
+#: Merge.rc:5768
 msgid "Not match (wildcard)"
 msgstr ""
 
 #. IDS_FILTER_OP_MATCHES
-#: Merge.rc:5768
+#: Merge.rc:5769
 msgid "Match (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_MATCHES
-#: Merge.rc:5769
+#: Merge.rc:5770
 msgid "Not match (regex)"
 msgstr ""
 
 #. IDS_COLORMODE_LIGHT
-#: Merge.rc:5774
+#: Merge.rc:5775
 msgid "Light"
 msgstr ""
 
 #. IDS_COLORMODE_DARK
-#: Merge.rc:5775
+#: Merge.rc:5776
 msgid "Dark"
 msgstr ""
 
 #. IDS_COLORMODE_FOLLOWSYSTEM
-#: Merge.rc:5776
+#: Merge.rc:5777
 msgid "Follow system"
 msgstr ""
 
 #. IDS_EXAMPLE
-#: Merge.rc:5781
+#: Merge.rc:5782
 #, c-format
 msgid "e.g. %1"
 msgstr ""
 
 #. IDS_DETECTED_PREVIOUS_CRASH
-#: Merge.rc:5786
+#: Merge.rc:5787
 msgid "WinMerge detected a previous crash. Please report this if possible."
 msgstr ""
 
 #. IDS_REGEX_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5791
+#: Merge.rc:5792
 msgid "# Regex replacement list\r\n# Format: regex<TAB>replacement\r\n# Backreferences like $1, $2 are supported\r\n\r\n(\\d{4})-(\\d{2})-(\\d{2})\t$1_$2_$3\r\n"
 msgstr ""
 
 #. IDS_STRING_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5792
+#: Merge.rc:5793
 msgid "# Replacement list\r\n# Format: search<TAB>replacement\r\n# Lines starting with # are ignored\r\n\r\nfrom1\tto1\r\nfrom2\tto2\r\n"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_ONLY
-#: Merge.rc:5797
+#: Merge.rc:5798
 msgid "Built-in only"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_FIRST
-#: Merge.rc:5798
+#: Merge.rc:5799
 msgid "Built-in first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_FIRST
-#: Merge.rc:5799
+#: Merge.rc:5800
 msgid "Tree-sitter first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_ONLY
-#: Merge.rc:5800
+#: Merge.rc:5801
 msgid "Tree-sitter only"
 msgstr ""
 

--- a/Translations/WinMerge/Slovenian.po
+++ b/Translations/WinMerge/Slovenian.po
@@ -23,7 +23,7 @@ msgstr ""
 "X-Generator: Poedit 3.4.2\n"
 
 #. LANGUAGE, SUBLANGUAGE
-#: Merge.rc:26 Merge.rc:59 Merge.rc:5817
+#: Merge.rc:26 Merge.rc:59 Merge.rc:5818
 msgid "LANG_ENGLISH, SUBLANG_ENGLISH_US"
 msgstr "LANG_SLOVENIAN, SUBLANG_SLOVENIAN"
 
@@ -230,7 +230,7 @@ msgid "Auto-Fit All Columns"
 msgstr "Samodejno prilagodi vse stolpce"
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN
-#: Merge.rc:153 Merge.rc:5645
+#: Merge.rc:153 Merge.rc:5646
 msgid "&Filter by This Column"
 msgstr ""
 
@@ -291,7 +291,7 @@ msgid "&Previous Page"
 msgstr "&Prejšnja stran"
 
 #. IDS_PREVIEWBAR_NEXTPAGE
-#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5678
+#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5679
 msgid "&Next Page"
 msgstr "&Naslednja stran"
 
@@ -664,7 +664,7 @@ msgid "&Huge"
 msgstr "O&gromne"
 
 #. IDS_VIEW_MENU_BAR
-#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5713
+#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5714
 msgid "Men&u Bar"
 msgstr ""
 
@@ -4189,7 +4189,7 @@ msgid "Items compared:"
 msgstr "Primerjanih vnosov:"
 
 #. IDS_PREVIEWBAR_CLOSE
-#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5684
+#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5685
 msgid "&Close"
 msgstr "&Zapri"
 
@@ -8329,30 +8329,35 @@ msgstr ""
 msgid "2nd and 3rd"
 msgstr ""
 
+#. IDS_PLUGIN_CTRL_CLICK
+#: Merge.rc:5635
+msgid "(Ctrl+Click to add to pipeline)"
+msgstr ""
+
 #. IDS_FILTER_APPLIED
-#: Merge.rc:5639
+#: Merge.rc:5640
 msgid "Filter applied"
 msgstr "Filter je uporabljen"
 
 #. IDS_FILTERMENU_COMPARE
-#: Merge.rc:5644
+#: Merge.rc:5645
 #, c-format
 msgid "Compare %1"
 msgstr ""
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN2
-#: Merge.rc:5646
+#: Merge.rc:5647
 msgid "&Filter by This Column..."
 msgstr ""
 
 #. IDS_CLIPBOARDHISTORY_TIME
-#: Merge.rc:5651
+#: Merge.rc:5652
 #, c-format
 msgid "Clipboard at %s"
 msgstr "Odložišče na %s"
 
 #. IDS_CLIPBOARDHISTORY_DISABLED
-#: Merge.rc:5652
+#: Merge.rc:5653
 msgid ""
 "Clipboard history disabled.\r\n"
 "Enable: Windows logo key + V, then Turn on."
@@ -8360,420 +8365,420 @@ msgstr ""
 "Zgodovina odložišča je onemogočena.\r\n"
 "Za omogočanje zgodovine odložišča, pritisnite tipko z logotipom Windows + V in nato kliknite gumb Vklopi."
 
-#: Merge.rc:5654
+#: Merge.rc:5655
 msgid "This system does not support clipboard history."
 msgstr "Ta sistem ne podpira zgodovine odložišča."
 
-#: Merge.rc:5656
+#: Merge.rc:5657
 msgid "32-bit WinMerge does not support Clipboard Compare"
 msgstr "32-bitna različica WinMerge ne podpira primerjave odložišča"
 
 #. IDS_WEBVIEW2_RUNTIME_NOT_INSTALLED
-#: Merge.rc:5661
+#: Merge.rc:5662
 msgid "WebView2 runtime not installed. Download it?"
 msgstr "Izvajalski čas WebView2 ni nameščen. Ali ga želite prenesti?"
 
 #. IDS_JUMPLIST_NEW_TEXT_COMPARE
-#: Merge.rc:5666
+#: Merge.rc:5667
 msgid "New Text Compare"
 msgstr "Primerjava novega besedila"
 
 #. IDS_JUMPLIST_NEW_TABLE_COMPARE
-#: Merge.rc:5667
+#: Merge.rc:5668
 msgid "New Table Compare"
 msgstr "Primerjava nove tabele"
 
 #. IDS_JUMPLIST_NEW_BINARY_COMPARE
-#: Merge.rc:5668
+#: Merge.rc:5669
 msgid "New Binary Compare"
 msgstr "Primerjava nove dvojiške"
 
 #. IDS_JUMPLIST_NEW_IMAGE_COMPARE
-#: Merge.rc:5669
+#: Merge.rc:5670
 msgid "New Image Compare"
 msgstr "Primerjava nove slike"
 
 #. IDS_JUMPLIST_NEW_WEBPAGE_COMPARE
-#: Merge.rc:5670
+#: Merge.rc:5671
 msgid "New Webpage Compare"
 msgstr "Primerjava nove spletne strani"
 
 #. IDS_JUMPLIST_NEW_FOLDER_COMPARE
-#: Merge.rc:5671
+#: Merge.rc:5672
 msgid "New Folder Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_CLIPBOARD_COMPARE
-#: Merge.rc:5672
+#: Merge.rc:5673
 msgid "Clipboard Compare"
 msgstr "Primerjava odložišča"
 
 #. IDS_PREVIEWBAR_PRINT
-#: Merge.rc:5677
+#: Merge.rc:5678
 msgid "&Print..."
 msgstr "Na&tisni..."
 
 #. IDS_PREVIEWBAR_PREVPAGE
-#: Merge.rc:5679
+#: Merge.rc:5680
 msgid "Pre&v Page"
 msgstr "Pre&jšnja stran"
 
 #. IDS_PREVIEWBAR_TWOPAGE
-#: Merge.rc:5680
+#: Merge.rc:5681
 msgid "&Two Page"
 msgstr "&Dve strani"
 
 #. IDS_PREVIEWBAR_ONEPAGE
-#: Merge.rc:5681
+#: Merge.rc:5682
 msgid "&One Page"
 msgstr "&Ena stran"
 
 #. IDS_PREVIEWBAR_ZOOMIN
-#: Merge.rc:5682
+#: Merge.rc:5683
 msgid "Zoom &In"
 msgstr "Po&večaj"
 
 #. IDS_PREVIEWBAR_ZOOMOUT
-#: Merge.rc:5683
+#: Merge.rc:5684
 msgid "Zoom &Out"
 msgstr "Pom&njšaj"
 
 #. IDS_WEBPAGE_COMPARING
-#: Merge.rc:5689
+#: Merge.rc:5690
 msgid "Comparing..."
 msgstr "Primerjanje..."
 
 #. IDS_WEBPAGE_ZOOM
-#: Merge.rc:5690
+#: Merge.rc:5691
 msgid "Zoom:"
 msgstr "Povečava:"
 
 #. IDS_COPY_GRANULARITY_DIFFHUNK
-#: Merge.rc:5695
+#: Merge.rc:5696
 msgid "Diff hunk"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_INLINE
-#: Merge.rc:5696
+#: Merge.rc:5697
 msgid "Inline diff"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_LINE
-#: Merge.rc:5697
+#: Merge.rc:5698
 msgid "Line"
 msgstr ""
 
-#: Merge.rc:5698
+#: Merge.rc:5699
 msgid "Character"
 msgstr ""
 
 #. ID_MICE_PREVDIFF
-#: Merge.rc:5703
+#: Merge.rc:5704
 msgid "\nPrevious Difference (Alt+Up)\n(Right Button+Wheel Up)\n(Alt+Wheel Up)"
 msgstr ""
 
 #. ID_MICE_NEXTDIFF
-#: Merge.rc:5704
+#: Merge.rc:5705
 msgid "\nNext Difference (Alt+Down)\n(Right Button+Wheel Down)\n(Alt+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_L2R
-#: Merge.rc:5705
+#: Merge.rc:5706
 msgid "\nCopy to Right (Alt+Right)\n(Right Button+Wheel Right)\n(Alt+Wheel Right)\n(Alt+Shift+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_R2L
-#: Merge.rc:5706
+#: Merge.rc:5707
 msgid "\nCopy to Left (Alt+Left)\n(Right Button+Wheel Left)\n(Alt+Wheel Left)\n(Alt+Shift+Wheel Up)"
 msgstr ""
 
 #. ID_MICE_L2RNEXT
-#: Merge.rc:5707
+#: Merge.rc:5708
 msgid "\nCopy to Right and Advance (Ctrl+Alt+Right)\n(Ctrl+Alt+Wheel Right)\n(Ctrl+Alt+Shift+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_R2LNEXT
-#: Merge.rc:5708
+#: Merge.rc:5709
 msgid "\nCopy to Left and Advance (Ctrl+Alt+Left)\n(Ctrl+Alt+Wheel Left)\n(Ctrl+Alt+Shift+Wheel Up)"
 msgstr ""
 
 #. IDS_LOG_COMPARING_2
-#: Merge.rc:5718
+#: Merge.rc:5719
 #, c-format
 msgid "Comparing %1 with %2"
 msgstr ""
 
 #. IDS_LOG_COMPARING_3
-#: Merge.rc:5719
+#: Merge.rc:5720
 #, c-format
 msgid "Comparing %1 with %2 and %3"
 msgstr ""
 
 #. IDS_LOG_COMPARE_COMPLETED
-#: Merge.rc:5720
+#: Merge.rc:5721
 msgid "Comparison completed"
 msgstr ""
 
 #. IDS_LOG_COMPARE_ERROR_2
-#: Merge.rc:5721
+#: Merge.rc:5722
 #, c-format
 msgid "Failed to compare %1 with %2: "
 msgstr ""
 
 #. IDS_LOG_COMPARE_ERROR_3
-#: Merge.rc:5722
+#: Merge.rc:5723
 #, c-format
 msgid "Failed to compare %1 with %2 and %3: "
 msgstr ""
 
 #. IDS_LOG_FILE_SAVED
-#: Merge.rc:5723
+#: Merge.rc:5724
 msgid "File saved"
 msgstr ""
 
 #. IDS_LOG_COPYING_FILES
-#: Merge.rc:5724
+#: Merge.rc:5725
 msgid "Copying files..."
 msgstr ""
 
 #. IDS_LOG_MOVING_FILES
-#: Merge.rc:5725
+#: Merge.rc:5726
 msgid "Moving files..."
 msgstr ""
 
 #. IDS_LOG_DELETING_FILES
-#: Merge.rc:5726
+#: Merge.rc:5727
 msgid "Deleting files..."
 msgstr ""
 
 #. IDS_LOG_RECYCLEBIN
-#: Merge.rc:5727
+#: Merge.rc:5728
 msgid "Recycle Bin"
 msgstr ""
 
 #. IDS_LOG_PERMANENTLY_DELETED
-#: Merge.rc:5728
+#: Merge.rc:5729
 msgid "Permanently deleted"
 msgstr ""
 
 #. IDS_LOG_FILEOPERATION_COMPLETED
-#: Merge.rc:5729
+#: Merge.rc:5730
 msgid "File operation completed successfully"
 msgstr ""
 
 #. IDS_LOG_FILEOPERATION_CANCELED
-#: Merge.rc:5730
+#: Merge.rc:5731
 msgid "File operation canceled"
 msgstr ""
 
 #. IDS_FILTER_ERROR_NO_ERROR
-#: Merge.rc:5735
+#: Merge.rc:5736
 msgid "No error"
 msgstr ""
 
 #. IDS_FILTER_ERROR_EMPTY_EXPRESSION
-#: Merge.rc:5736
+#: Merge.rc:5737
 msgid "Filter expression is empty"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNKNOWN_CHAR
-#: Merge.rc:5737
+#: Merge.rc:5738
 msgid "Unknown character in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNTERMINATED_STRING
-#: Merge.rc:5738
+#: Merge.rc:5739
 msgid "Unterminated string literal"
 msgstr ""
 
 #. IDS_FILTER_ERROR_SYNTAX_ERROR
-#: Merge.rc:5739
+#: Merge.rc:5740
 msgid "Syntax error in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_PARSE_FAILURE
-#: Merge.rc:5740
+#: Merge.rc:5741
 msgid "Failed to parse filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_LITERAL
-#: Merge.rc:5741
+#: Merge.rc:5742
 msgid "Invalid literal value"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_REGULAR_EXPRESSION
-#: Merge.rc:5742
+#: Merge.rc:5743
 msgid "Invalid regular expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNDEFINED_IDENTIFIER
-#: Merge.rc:5743
+#: Merge.rc:5744
 msgid "Undefined identifier"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_ARGUMENT_COUNT
-#: Merge.rc:5744
+#: Merge.rc:5745
 msgid "Invalid number of arguments"
 msgstr ""
 
 #. IDS_FILTER_ERROR_FILTER_NAME_NOT_FOUND
-#: Merge.rc:5745
+#: Merge.rc:5746
 msgid "Filter name not found"
 msgstr ""
 
 #. IDS_FILTER_ERROR_DIVIDE_BY_ZERO
-#: Merge.rc:5746
+#: Merge.rc:5747
 msgid "Division by zero in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNKNOWN_ERROR
-#: Merge.rc:5747
+#: Merge.rc:5748
 msgid "Unknown error"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_PROPERTY_NAME
-#: Merge.rc:5748
+#: Merge.rc:5749
 msgid "Invalid property name"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_DIRECTIVE
-#: Merge.rc:5749
+#: Merge.rc:5750
 msgid "Invalid directive"
 msgstr ""
 
 #. IDS_FILTER_OP_EQUALS
-#: Merge.rc:5754
+#: Merge.rc:5755
 msgid "Equals"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_EQUALS
-#: Merge.rc:5755
+#: Merge.rc:5756
 msgid "Does not equal"
 msgstr ""
 
 #. IDS_FILTER_OP_LESS_THAN
-#: Merge.rc:5756
+#: Merge.rc:5757
 msgid "Less than"
 msgstr ""
 
 #. IDS_FILTER_OP_LESS_EQUAL
-#: Merge.rc:5757
+#: Merge.rc:5758
 msgid "Less than or equal to"
 msgstr ""
 
 #. IDS_FILTER_OP_GREATER_EQUAL
-#: Merge.rc:5758
+#: Merge.rc:5759
 msgid "Greater than or equal to"
 msgstr ""
 
 #. IDS_FILTER_OP_GREATER_THAN
-#: Merge.rc:5759
+#: Merge.rc:5760
 msgid "Greater than"
 msgstr ""
 
 #. IDS_FILTER_OP_BETWEEN
-#: Merge.rc:5760
+#: Merge.rc:5761
 msgid "Between"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_BETWEEN
-#: Merge.rc:5761
+#: Merge.rc:5762
 msgid "Not Between"
 msgstr ""
 
 #. IDS_FILTER_OP_CONTAINS
-#: Merge.rc:5762
+#: Merge.rc:5763
 msgid "Contains"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_CONTAINS
-#: Merge.rc:5763
+#: Merge.rc:5764
 msgid "Not Contains"
 msgstr ""
 
 #. IDS_FILTER_OP_RECONTAINS
-#: Merge.rc:5764
+#: Merge.rc:5765
 msgid "Contains (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_RECONTAINS
-#: Merge.rc:5765
+#: Merge.rc:5766
 msgid "Not Contains (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_LIKE
-#: Merge.rc:5766
+#: Merge.rc:5767
 msgid "Match (wildcard)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_LIKE
-#: Merge.rc:5767
+#: Merge.rc:5768
 msgid "Not match (wildcard)"
 msgstr ""
 
 #. IDS_FILTER_OP_MATCHES
-#: Merge.rc:5768
+#: Merge.rc:5769
 msgid "Match (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_MATCHES
-#: Merge.rc:5769
+#: Merge.rc:5770
 msgid "Not match (regex)"
 msgstr ""
 
 #. IDS_COLORMODE_LIGHT
-#: Merge.rc:5774
+#: Merge.rc:5775
 msgid "Light"
 msgstr ""
 
 #. IDS_COLORMODE_DARK
-#: Merge.rc:5775
+#: Merge.rc:5776
 msgid "Dark"
 msgstr ""
 
 #. IDS_COLORMODE_FOLLOWSYSTEM
-#: Merge.rc:5776
+#: Merge.rc:5777
 msgid "Follow system"
 msgstr ""
 
 #. IDS_EXAMPLE
-#: Merge.rc:5781
+#: Merge.rc:5782
 #, c-format
 msgid "e.g. %1"
 msgstr ""
 
 #. IDS_DETECTED_PREVIOUS_CRASH
-#: Merge.rc:5786
+#: Merge.rc:5787
 msgid "WinMerge detected a previous crash. Please report this if possible."
 msgstr ""
 
 #. IDS_REGEX_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5791
+#: Merge.rc:5792
 msgid "# Regex replacement list\r\n# Format: regex<TAB>replacement\r\n# Backreferences like $1, $2 are supported\r\n\r\n(\\d{4})-(\\d{2})-(\\d{2})\t$1_$2_$3\r\n"
 msgstr ""
 
 #. IDS_STRING_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5792
+#: Merge.rc:5793
 msgid "# Replacement list\r\n# Format: search<TAB>replacement\r\n# Lines starting with # are ignored\r\n\r\nfrom1\tto1\r\nfrom2\tto2\r\n"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_ONLY
-#: Merge.rc:5797
+#: Merge.rc:5798
 msgid "Built-in only"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_FIRST
-#: Merge.rc:5798
+#: Merge.rc:5799
 msgid "Built-in first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_FIRST
-#: Merge.rc:5799
+#: Merge.rc:5800
 msgid "Tree-sitter first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_ONLY
-#: Merge.rc:5800
+#: Merge.rc:5801
 msgid "Tree-sitter only"
 msgstr ""
 

--- a/Translations/WinMerge/Spanish.po
+++ b/Translations/WinMerge/Spanish.po
@@ -26,7 +26,7 @@ msgstr ""
 "X-Generator: Poedit 3.9\n"
 
 #. LANGUAGE, SUBLANGUAGE
-#: Merge.rc:26 Merge.rc:59 Merge.rc:5817
+#: Merge.rc:26 Merge.rc:59 Merge.rc:5818
 msgid "LANG_ENGLISH, SUBLANG_ENGLISH_US"
 msgstr "LANG_SPANISH, SUBLANG_SPANISH_MODERN"
 
@@ -233,7 +233,7 @@ msgid "Auto-Fit All Columns"
 msgstr "Autoajustar todas las columnas"
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN
-#: Merge.rc:153 Merge.rc:5645
+#: Merge.rc:153 Merge.rc:5646
 msgid "&Filter by This Column"
 msgstr "&Filtrar por esta columna"
 
@@ -294,7 +294,7 @@ msgid "&Previous Page"
 msgstr "&Página anterior"
 
 #. IDS_PREVIEWBAR_NEXTPAGE
-#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5678
+#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5679
 msgid "&Next Page"
 msgstr "Pági&na siguiente"
 
@@ -667,7 +667,7 @@ msgid "&Huge"
 msgstr "&Enorme"
 
 #. IDS_VIEW_MENU_BAR
-#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5713
+#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5714
 msgid "Men&u Bar"
 msgstr "Barra de men&ús"
 
@@ -4192,7 +4192,7 @@ msgid "Items compared:"
 msgstr "Elementos comparados:"
 
 #. IDS_PREVIEWBAR_CLOSE
-#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5684
+#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5685
 msgid "&Close"
 msgstr "&Cerrar"
 
@@ -8395,30 +8395,35 @@ msgstr "1.º y 3.º"
 msgid "2nd and 3rd"
 msgstr "2.º y 3.º"
 
+#. IDS_PLUGIN_CTRL_CLICK
+#: Merge.rc:5635
+msgid "(Ctrl+Click to add to pipeline)"
+msgstr ""
+
 #. IDS_FILTER_APPLIED
-#: Merge.rc:5639
+#: Merge.rc:5640
 msgid "Filter applied"
 msgstr "Filtro aplicado"
 
 #. IDS_FILTERMENU_COMPARE
-#: Merge.rc:5644
+#: Merge.rc:5645
 #, c-format
 msgid "Compare %1"
 msgstr "Comparar %1"
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN2
-#: Merge.rc:5646
+#: Merge.rc:5647
 msgid "&Filter by This Column..."
 msgstr "&Filtrar por esta columna..."
 
 #. IDS_CLIPBOARDHISTORY_TIME
-#: Merge.rc:5651
+#: Merge.rc:5652
 #, c-format
 msgid "Clipboard at %s"
 msgstr "Portapapeles en %s"
 
 #. IDS_CLIPBOARDHISTORY_DISABLED
-#: Merge.rc:5652
+#: Merge.rc:5653
 msgid ""
 "Clipboard history disabled.\r\n"
 "Enable: Windows logo key + V, then Turn on."
@@ -8426,115 +8431,115 @@ msgstr ""
 "El historial del Portapapeles está deshabilitado.\r\n"
 "Para habilitarlo, presione la tecla Windows + V y luego presione el botón Activar."
 
-#: Merge.rc:5654
+#: Merge.rc:5655
 msgid "This system does not support clipboard history."
 msgstr "Este sistema no soporta historial del Portapapeles."
 
-#: Merge.rc:5656
+#: Merge.rc:5657
 msgid "32-bit WinMerge does not support Clipboard Compare"
 msgstr "La versión de 32 bits de WinMerge no soporta comparación de Portapapeles"
 
 #. IDS_WEBVIEW2_RUNTIME_NOT_INSTALLED
-#: Merge.rc:5661
+#: Merge.rc:5662
 msgid "WebView2 runtime not installed. Download it?"
 msgstr "WebView2 Runtime no está instalado. ¿Desea descargarlo?"
 
 #. IDS_JUMPLIST_NEW_TEXT_COMPARE
-#: Merge.rc:5666
+#: Merge.rc:5667
 msgid "New Text Compare"
 msgstr "Nueva comparación de texto"
 
 #. IDS_JUMPLIST_NEW_TABLE_COMPARE
-#: Merge.rc:5667
+#: Merge.rc:5668
 msgid "New Table Compare"
 msgstr "Nueva comparación de tabla"
 
 #. IDS_JUMPLIST_NEW_BINARY_COMPARE
-#: Merge.rc:5668
+#: Merge.rc:5669
 msgid "New Binary Compare"
 msgstr "Nueva comparación binaria"
 
 #. IDS_JUMPLIST_NEW_IMAGE_COMPARE
-#: Merge.rc:5669
+#: Merge.rc:5670
 msgid "New Image Compare"
 msgstr "Nueva comparación de imágen"
 
 #. IDS_JUMPLIST_NEW_WEBPAGE_COMPARE
-#: Merge.rc:5670
+#: Merge.rc:5671
 msgid "New Webpage Compare"
 msgstr "Nueva comparación de página web"
 
 #. IDS_JUMPLIST_NEW_FOLDER_COMPARE
-#: Merge.rc:5671
+#: Merge.rc:5672
 msgid "New Folder Compare"
 msgstr "Nueva comparación de carpetas"
 
 #. IDS_JUMPLIST_CLIPBOARD_COMPARE
-#: Merge.rc:5672
+#: Merge.rc:5673
 msgid "Clipboard Compare"
 msgstr "Nueva comparación de Portapapeles"
 
 #. IDS_PREVIEWBAR_PRINT
-#: Merge.rc:5677
+#: Merge.rc:5678
 msgid "&Print..."
 msgstr "Im&primir..."
 
 #. IDS_PREVIEWBAR_PREVPAGE
-#: Merge.rc:5679
+#: Merge.rc:5680
 msgid "Pre&v Page"
 msgstr "Página an&terior"
 
 #. IDS_PREVIEWBAR_TWOPAGE
-#: Merge.rc:5680
+#: Merge.rc:5681
 msgid "&Two Page"
 msgstr "&Dos páginas"
 
 #. IDS_PREVIEWBAR_ONEPAGE
-#: Merge.rc:5681
+#: Merge.rc:5682
 msgid "&One Page"
 msgstr "Un&a página"
 
 #. IDS_PREVIEWBAR_ZOOMIN
-#: Merge.rc:5682
+#: Merge.rc:5683
 msgid "Zoom &In"
 msgstr "Aumentar &zoom"
 
 #. IDS_PREVIEWBAR_ZOOMOUT
-#: Merge.rc:5683
+#: Merge.rc:5684
 msgid "Zoom &Out"
 msgstr "Reducir z&oom"
 
 #. IDS_WEBPAGE_COMPARING
-#: Merge.rc:5689
+#: Merge.rc:5690
 msgid "Comparing..."
 msgstr "Comparando..."
 
 #. IDS_WEBPAGE_ZOOM
-#: Merge.rc:5690
+#: Merge.rc:5691
 msgid "Zoom:"
 msgstr "Ampliar:"
 
 #. IDS_COPY_GRANULARITY_DIFFHUNK
-#: Merge.rc:5695
+#: Merge.rc:5696
 msgid "Diff hunk"
 msgstr "Fragmentos de diferencias"
 
 #. IDS_COPY_GRANULARITY_INLINE
-#: Merge.rc:5696
+#: Merge.rc:5697
 msgid "Inline diff"
 msgstr "Diferencia en línea"
 
 #. IDS_COPY_GRANULARITY_LINE
-#: Merge.rc:5697
+#: Merge.rc:5698
 msgid "Line"
 msgstr "Línea"
 
-#: Merge.rc:5698
+#: Merge.rc:5699
 msgid "Character"
 msgstr "Carácter"
 
 #. ID_MICE_PREVDIFF
-#: Merge.rc:5703
+#: Merge.rc:5704
 msgid ""
 "\n"
 "Previous Difference (Alt+Up)\n"
@@ -8547,7 +8552,7 @@ msgstr ""
 "(Alt+Rueda adelante)"
 
 #. ID_MICE_NEXTDIFF
-#: Merge.rc:5704
+#: Merge.rc:5705
 msgid ""
 "\n"
 "Next Difference (Alt+Down)\n"
@@ -8560,7 +8565,7 @@ msgstr ""
 "(Alt+Rueda atrás)"
 
 #. ID_MICE_L2R
-#: Merge.rc:5705
+#: Merge.rc:5706
 msgid ""
 "\n"
 "Copy to Right (Alt+Right)\n"
@@ -8575,7 +8580,7 @@ msgstr ""
 "(Alt+Mayús+Rueda atrás)"
 
 #. ID_MICE_R2L
-#: Merge.rc:5706
+#: Merge.rc:5707
 msgid ""
 "\n"
 "Copy to Left (Alt+Left)\n"
@@ -8590,7 +8595,7 @@ msgstr ""
 "(Alt+Mayús+Rueda adelante)"
 
 #. ID_MICE_L2RNEXT
-#: Merge.rc:5707
+#: Merge.rc:5708
 msgid ""
 "\n"
 "Copy to Right and Advance (Ctrl+Alt+Right)\n"
@@ -8603,7 +8608,7 @@ msgstr ""
 "(Ctrl+Alt+Mayús+Rueda atrás)"
 
 #. ID_MICE_R2LNEXT
-#: Merge.rc:5708
+#: Merge.rc:5709
 msgid ""
 "\n"
 "Copy to Left and Advance (Ctrl+Alt+Left)\n"
@@ -8616,257 +8621,257 @@ msgstr ""
 "(Ctrl+Alt+Mayús+Rueda adelante)"
 
 #. IDS_LOG_COMPARING_2
-#: Merge.rc:5718
+#: Merge.rc:5719
 #, c-format
 msgid "Comparing %1 with %2"
 msgstr "Comparando %1 con %2"
 
 #. IDS_LOG_COMPARING_3
-#: Merge.rc:5719
+#: Merge.rc:5720
 #, c-format
 msgid "Comparing %1 with %2 and %3"
 msgstr "Comparando %1 con %2 y %3"
 
 #. IDS_LOG_COMPARE_COMPLETED
-#: Merge.rc:5720
+#: Merge.rc:5721
 msgid "Comparison completed"
 msgstr "Comparación completada"
 
 #. IDS_LOG_COMPARE_ERROR_2
-#: Merge.rc:5721
+#: Merge.rc:5722
 #, c-format
 msgid "Failed to compare %1 with %2: "
 msgstr "No se ha podido comparar %1 con %2: "
 
 #. IDS_LOG_COMPARE_ERROR_3
-#: Merge.rc:5722
+#: Merge.rc:5723
 #, c-format
 msgid "Failed to compare %1 with %2 and %3: "
 msgstr "No se ha podido comparar %1 con %2 y %3: "
 
 #. IDS_LOG_FILE_SAVED
-#: Merge.rc:5723
+#: Merge.rc:5724
 msgid "File saved"
 msgstr "Archivo guardado"
 
 #. IDS_LOG_COPYING_FILES
-#: Merge.rc:5724
+#: Merge.rc:5725
 msgid "Copying files..."
 msgstr "Copiando archivos..."
 
 #. IDS_LOG_MOVING_FILES
-#: Merge.rc:5725
+#: Merge.rc:5726
 msgid "Moving files..."
 msgstr "Moviendo archivos..."
 
 #. IDS_LOG_DELETING_FILES
-#: Merge.rc:5726
+#: Merge.rc:5727
 msgid "Deleting files..."
 msgstr "Eliminando archivos..."
 
 #. IDS_LOG_RECYCLEBIN
-#: Merge.rc:5727
+#: Merge.rc:5728
 msgid "Recycle Bin"
 msgstr "Papelera de reciclaje"
 
 #. IDS_LOG_PERMANENTLY_DELETED
-#: Merge.rc:5728
+#: Merge.rc:5729
 msgid "Permanently deleted"
 msgstr "Eliminado permanentemente"
 
 #. IDS_LOG_FILEOPERATION_COMPLETED
-#: Merge.rc:5729
+#: Merge.rc:5730
 msgid "File operation completed successfully"
 msgstr "Operación de archivo completada correctamente"
 
 #. IDS_LOG_FILEOPERATION_CANCELED
-#: Merge.rc:5730
+#: Merge.rc:5731
 msgid "File operation canceled"
 msgstr "Operación de archivo cancelada"
 
 #. IDS_FILTER_ERROR_NO_ERROR
-#: Merge.rc:5735
+#: Merge.rc:5736
 msgid "No error"
 msgstr "Sin errores"
 
 #. IDS_FILTER_ERROR_EMPTY_EXPRESSION
-#: Merge.rc:5736
+#: Merge.rc:5737
 msgid "Filter expression is empty"
 msgstr "La expresión del filtro está vacía"
 
 #. IDS_FILTER_ERROR_UNKNOWN_CHAR
-#: Merge.rc:5737
+#: Merge.rc:5738
 msgid "Unknown character in filter expression"
 msgstr "Carácter desconocido en la expresión del filtro"
 
 #. IDS_FILTER_ERROR_UNTERMINATED_STRING
-#: Merge.rc:5738
+#: Merge.rc:5739
 msgid "Unterminated string literal"
 msgstr "Literal de cadena sin terminar"
 
 #. IDS_FILTER_ERROR_SYNTAX_ERROR
-#: Merge.rc:5739
+#: Merge.rc:5740
 msgid "Syntax error in filter expression"
 msgstr "Error de sintaxis en la expresión del filtro"
 
 #. IDS_FILTER_ERROR_PARSE_FAILURE
-#: Merge.rc:5740
+#: Merge.rc:5741
 msgid "Failed to parse filter expression"
 msgstr "No se pudo analizar la expresión del filtro"
 
 #. IDS_FILTER_ERROR_INVALID_LITERAL
-#: Merge.rc:5741
+#: Merge.rc:5742
 msgid "Invalid literal value"
 msgstr "Valor literal no válido"
 
 #. IDS_FILTER_ERROR_INVALID_REGULAR_EXPRESSION
-#: Merge.rc:5742
+#: Merge.rc:5743
 msgid "Invalid regular expression"
 msgstr "Expresión regular no válida"
 
 #. IDS_FILTER_ERROR_UNDEFINED_IDENTIFIER
-#: Merge.rc:5743
+#: Merge.rc:5744
 msgid "Undefined identifier"
 msgstr "Identificador no definido"
 
 #. IDS_FILTER_ERROR_INVALID_ARGUMENT_COUNT
-#: Merge.rc:5744
+#: Merge.rc:5745
 msgid "Invalid number of arguments"
 msgstr "Número de argumentos no válido"
 
 #. IDS_FILTER_ERROR_FILTER_NAME_NOT_FOUND
-#: Merge.rc:5745
+#: Merge.rc:5746
 msgid "Filter name not found"
 msgstr "Nombre de filtro no encontrado"
 
 #. IDS_FILTER_ERROR_DIVIDE_BY_ZERO
-#: Merge.rc:5746
+#: Merge.rc:5747
 msgid "Division by zero in filter expression"
 msgstr "División por cero en la expresión del filtro"
 
 #. IDS_FILTER_ERROR_UNKNOWN_ERROR
-#: Merge.rc:5747
+#: Merge.rc:5748
 msgid "Unknown error"
 msgstr "Error desconocido"
 
 #. IDS_FILTER_ERROR_INVALID_PROPERTY_NAME
-#: Merge.rc:5748
+#: Merge.rc:5749
 msgid "Invalid property name"
 msgstr "Nombre de propiedad no válido"
 
 #. IDS_FILTER_ERROR_INVALID_DIRECTIVE
-#: Merge.rc:5749
+#: Merge.rc:5750
 msgid "Invalid directive"
 msgstr "Directiva no válida"
 
 #. IDS_FILTER_OP_EQUALS
-#: Merge.rc:5754
+#: Merge.rc:5755
 msgid "Equals"
 msgstr "Iguales"
 
 #. IDS_FILTER_OP_NOT_EQUALS
-#: Merge.rc:5755
+#: Merge.rc:5756
 msgid "Does not equal"
 msgstr "No es igual"
 
 #. IDS_FILTER_OP_LESS_THAN
-#: Merge.rc:5756
+#: Merge.rc:5757
 msgid "Less than"
 msgstr "Menor que"
 
 #. IDS_FILTER_OP_LESS_EQUAL
-#: Merge.rc:5757
+#: Merge.rc:5758
 msgid "Less than or equal to"
 msgstr "Menor o igual que"
 
 #. IDS_FILTER_OP_GREATER_EQUAL
-#: Merge.rc:5758
+#: Merge.rc:5759
 msgid "Greater than or equal to"
 msgstr "Mayor o igual que"
 
 #. IDS_FILTER_OP_GREATER_THAN
-#: Merge.rc:5759
+#: Merge.rc:5760
 msgid "Greater than"
 msgstr "Mayor que"
 
 #. IDS_FILTER_OP_BETWEEN
-#: Merge.rc:5760
+#: Merge.rc:5761
 msgid "Between"
 msgstr "Entre"
 
 #. IDS_FILTER_OP_NOT_BETWEEN
-#: Merge.rc:5761
+#: Merge.rc:5762
 msgid "Not Between"
 msgstr "No entre"
 
 #. IDS_FILTER_OP_CONTAINS
-#: Merge.rc:5762
+#: Merge.rc:5763
 msgid "Contains"
 msgstr "Contiene"
 
 #. IDS_FILTER_OP_NOT_CONTAINS
-#: Merge.rc:5763
+#: Merge.rc:5764
 msgid "Not Contains"
 msgstr "No contiene"
 
 #. IDS_FILTER_OP_RECONTAINS
-#: Merge.rc:5764
+#: Merge.rc:5765
 msgid "Contains (regex)"
 msgstr "Contiene (regex)"
 
 #. IDS_FILTER_OP_NOT_RECONTAINS
-#: Merge.rc:5765
+#: Merge.rc:5766
 msgid "Not Contains (regex)"
 msgstr "No contiene (regex)"
 
 #. IDS_FILTER_OP_LIKE
-#: Merge.rc:5766
+#: Merge.rc:5767
 msgid "Match (wildcard)"
 msgstr "Coincide (comodín)"
 
 #. IDS_FILTER_OP_NOT_LIKE
-#: Merge.rc:5767
+#: Merge.rc:5768
 msgid "Not match (wildcard)"
 msgstr "No coincide (comodín)"
 
 #. IDS_FILTER_OP_MATCHES
-#: Merge.rc:5768
+#: Merge.rc:5769
 msgid "Match (regex)"
 msgstr "Coincide (expresión regular)"
 
 #. IDS_FILTER_OP_NOT_MATCHES
-#: Merge.rc:5769
+#: Merge.rc:5770
 msgid "Not match (regex)"
 msgstr "No coincide (expresión regular)"
 
 #. IDS_COLORMODE_LIGHT
-#: Merge.rc:5774
+#: Merge.rc:5775
 msgid "Light"
 msgstr "Claro"
 
 #. IDS_COLORMODE_DARK
-#: Merge.rc:5775
+#: Merge.rc:5776
 msgid "Dark"
 msgstr "Oscuro"
 
 #. IDS_COLORMODE_FOLLOWSYSTEM
-#: Merge.rc:5776
+#: Merge.rc:5777
 msgid "Follow system"
 msgstr "Según el sistema"
 
 #. IDS_EXAMPLE
-#: Merge.rc:5781
+#: Merge.rc:5782
 #, c-format
 msgid "e.g. %1"
 msgstr "ejemplo %1"
 
 #. IDS_DETECTED_PREVIOUS_CRASH
-#: Merge.rc:5786
+#: Merge.rc:5787
 msgid "WinMerge detected a previous crash. Please report this if possible."
 msgstr "WinMerge ha detectado un fallo anterior. Si es posible, por favor, infórmenos de ello."
 
 #. IDS_REGEX_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5791
+#: Merge.rc:5792
 msgid ""
 "# Regex replacement list\r\n"
 "# Format: regex<TAB>replacement\r\n"
@@ -8881,7 +8886,7 @@ msgstr ""
 "(\\d{4})-(\\d{2})-(\\d{2})\t$1_$2_$3\r\n"
 
 #. IDS_STRING_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5792
+#: Merge.rc:5793
 msgid ""
 "# Replacement list\r\n"
 "# Format: search<TAB>replacement\r\n"
@@ -8898,22 +8903,22 @@ msgstr ""
 "desde2\thasta2\r\n"
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_ONLY
-#: Merge.rc:5797
+#: Merge.rc:5798
 msgid "Built-in only"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_FIRST
-#: Merge.rc:5798
+#: Merge.rc:5799
 msgid "Built-in first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_FIRST
-#: Merge.rc:5799
+#: Merge.rc:5800
 msgid "Tree-sitter first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_ONLY
-#: Merge.rc:5800
+#: Merge.rc:5801
 msgid "Tree-sitter only"
 msgstr ""
 

--- a/Translations/WinMerge/Swedish.po
+++ b/Translations/WinMerge/Swedish.po
@@ -26,7 +26,7 @@ msgstr ""
 "X-Generator: Poedit 3.7\n"
 
 #. LANGUAGE, SUBLANGUAGE
-#: Merge.rc:26 Merge.rc:59 Merge.rc:5817
+#: Merge.rc:26 Merge.rc:59 Merge.rc:5818
 msgid "LANG_ENGLISH, SUBLANG_ENGLISH_US"
 msgstr "LANG_SWEDISH, SUBLANG_DEFAULT"
 
@@ -233,7 +233,7 @@ msgid "Auto-Fit All Columns"
 msgstr "Automatisk passning för alla kolumner"
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN
-#: Merge.rc:153 Merge.rc:5645
+#: Merge.rc:153 Merge.rc:5646
 msgid "&Filter by This Column"
 msgstr ""
 
@@ -294,7 +294,7 @@ msgid "&Previous Page"
 msgstr "Föregående sida"
 
 #. IDS_PREVIEWBAR_NEXTPAGE
-#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5678
+#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5679
 msgid "&Next Page"
 msgstr "Nästa sida"
 
@@ -667,7 +667,7 @@ msgid "&Huge"
 msgstr "Enorm"
 
 #. IDS_VIEW_MENU_BAR
-#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5713
+#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5714
 msgid "Men&u Bar"
 msgstr "Menyrad"
 
@@ -4192,7 +4192,7 @@ msgid "Items compared:"
 msgstr "Jämförda objekt:"
 
 #. IDS_PREVIEWBAR_CLOSE
-#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5684
+#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5685
 msgid "&Close"
 msgstr "Stäng"
 
@@ -8364,30 +8364,35 @@ msgstr "Första och Tredje"
 msgid "2nd and 3rd"
 msgstr "Andra och Tredje"
 
+#. IDS_PLUGIN_CTRL_CLICK
+#: Merge.rc:5635
+msgid "(Ctrl+Click to add to pipeline)"
+msgstr ""
+
 #. IDS_FILTER_APPLIED
-#: Merge.rc:5639
+#: Merge.rc:5640
 msgid "Filter applied"
 msgstr "Filter verkställt"
 
 #. IDS_FILTERMENU_COMPARE
-#: Merge.rc:5644
+#: Merge.rc:5645
 #, c-format
 msgid "Compare %1"
 msgstr ""
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN2
-#: Merge.rc:5646
+#: Merge.rc:5647
 msgid "&Filter by This Column..."
 msgstr ""
 
 #. IDS_CLIPBOARDHISTORY_TIME
-#: Merge.rc:5651
+#: Merge.rc:5652
 #, c-format
 msgid "Clipboard at %s"
 msgstr "Klippbordet vid %s"
 
 #. IDS_CLIPBOARDHISTORY_DISABLED
-#: Merge.rc:5652
+#: Merge.rc:5653
 msgid ""
 "Clipboard history disabled.\r\n"
 "Enable: Windows logo key + V, then Turn on."
@@ -8395,115 +8400,115 @@ msgstr ""
 "Klippbordshistorik är inaktiverat.\r\n"
 "\" För att aktivera Klippbordshistorik, tryck på Windows-tangenten + V och klicka på Aktivera.."
 
-#: Merge.rc:5654
+#: Merge.rc:5655
 msgid "This system does not support clipboard history."
 msgstr "Det här systemet stöder inte Klippbordshistorik."
 
-#: Merge.rc:5656
+#: Merge.rc:5657
 msgid "32-bit WinMerge does not support Clipboard Compare"
 msgstr "32-bitarsversionen av WinMerge stöder inte jämförelse med Klippbordet"
 
 #. IDS_WEBVIEW2_RUNTIME_NOT_INSTALLED
-#: Merge.rc:5661
+#: Merge.rc:5662
 msgid "WebView2 runtime not installed. Download it?"
 msgstr "Körbara filer för WebView2 är inte installerade. Vill du ladda ned det?"
 
 #. IDS_JUMPLIST_NEW_TEXT_COMPARE
-#: Merge.rc:5666
+#: Merge.rc:5667
 msgid "New Text Compare"
 msgstr "Ny Textjämförelse"
 
 #. IDS_JUMPLIST_NEW_TABLE_COMPARE
-#: Merge.rc:5667
+#: Merge.rc:5668
 msgid "New Table Compare"
 msgstr "Ny tabelljämförelse"
 
 #. IDS_JUMPLIST_NEW_BINARY_COMPARE
-#: Merge.rc:5668
+#: Merge.rc:5669
 msgid "New Binary Compare"
 msgstr "Ny binär jämförelse"
 
 #. IDS_JUMPLIST_NEW_IMAGE_COMPARE
-#: Merge.rc:5669
+#: Merge.rc:5670
 msgid "New Image Compare"
 msgstr "Ny bildjämförelse"
 
 #. IDS_JUMPLIST_NEW_WEBPAGE_COMPARE
-#: Merge.rc:5670
+#: Merge.rc:5671
 msgid "New Webpage Compare"
 msgstr "Ny Webbsidojämförelse"
 
 #. IDS_JUMPLIST_NEW_FOLDER_COMPARE
-#: Merge.rc:5671
+#: Merge.rc:5672
 msgid "New Folder Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_CLIPBOARD_COMPARE
-#: Merge.rc:5672
+#: Merge.rc:5673
 msgid "Clipboard Compare"
 msgstr "Klippbordsjämförelse"
 
 #. IDS_PREVIEWBAR_PRINT
-#: Merge.rc:5677
+#: Merge.rc:5678
 msgid "&Print..."
 msgstr "Skriv ut..."
 
 #. IDS_PREVIEWBAR_PREVPAGE
-#: Merge.rc:5679
+#: Merge.rc:5680
 msgid "Pre&v Page"
 msgstr "Förra sidan"
 
 #. IDS_PREVIEWBAR_TWOPAGE
-#: Merge.rc:5680
+#: Merge.rc:5681
 msgid "&Two Page"
 msgstr "Två sidor"
 
 #. IDS_PREVIEWBAR_ONEPAGE
-#: Merge.rc:5681
+#: Merge.rc:5682
 msgid "&One Page"
 msgstr "En sida"
 
 #. IDS_PREVIEWBAR_ZOOMIN
-#: Merge.rc:5682
+#: Merge.rc:5683
 msgid "Zoom &In"
 msgstr "Zooma in"
 
 #. IDS_PREVIEWBAR_ZOOMOUT
-#: Merge.rc:5683
+#: Merge.rc:5684
 msgid "Zoom &Out"
 msgstr "Zooma ut"
 
 #. IDS_WEBPAGE_COMPARING
-#: Merge.rc:5689
+#: Merge.rc:5690
 msgid "Comparing..."
 msgstr "Jämför..."
 
 #. IDS_WEBPAGE_ZOOM
-#: Merge.rc:5690
+#: Merge.rc:5691
 msgid "Zoom:"
 msgstr "Zooma:"
 
 #. IDS_COPY_GRANULARITY_DIFFHUNK
-#: Merge.rc:5695
+#: Merge.rc:5696
 msgid "Diff hunk"
 msgstr "Skillnadsmassa"
 
 #. IDS_COPY_GRANULARITY_INLINE
-#: Merge.rc:5696
+#: Merge.rc:5697
 msgid "Inline diff"
 msgstr "Inlineskillnad"
 
 #. IDS_COPY_GRANULARITY_LINE
-#: Merge.rc:5697
+#: Merge.rc:5698
 msgid "Line"
 msgstr "Rad"
 
-#: Merge.rc:5698
+#: Merge.rc:5699
 msgid "Character"
 msgstr "Tecken"
 
 #. ID_MICE_PREVDIFF
-#: Merge.rc:5703
+#: Merge.rc:5704
 msgid ""
 "\n"
 "Previous Difference (Alt+Up)\n"
@@ -8516,7 +8521,7 @@ msgstr ""
 "(Alt+Hjul Upp)"
 
 #. ID_MICE_NEXTDIFF
-#: Merge.rc:5704
+#: Merge.rc:5705
 msgid ""
 "\n"
 "Next Difference (Alt+Down)\n"
@@ -8529,7 +8534,7 @@ msgstr ""
 "(Alt+Hjul Ner)"
 
 #. ID_MICE_L2R
-#: Merge.rc:5705
+#: Merge.rc:5706
 msgid ""
 "\n"
 "Copy to Right (Alt+Right)\n"
@@ -8544,7 +8549,7 @@ msgstr ""
 "(Alt+Shift+Hjul Ner)"
 
 #. ID_MICE_R2L
-#: Merge.rc:5706
+#: Merge.rc:5707
 msgid ""
 "\n"
 "Copy to Left (Alt+Left)\n"
@@ -8559,7 +8564,7 @@ msgstr ""
 "(Alt+Shift+Hjul Upp)"
 
 #. ID_MICE_L2RNEXT
-#: Merge.rc:5707
+#: Merge.rc:5708
 msgid ""
 "\n"
 "Copy to Right and Advance (Ctrl+Alt+Right)\n"
@@ -8572,7 +8577,7 @@ msgstr ""
 "(Ctrl+Alt+Shift+Hjul Ner)"
 
 #. ID_MICE_R2LNEXT
-#: Merge.rc:5708
+#: Merge.rc:5709
 msgid ""
 "\n"
 "Copy to Left and Advance (Ctrl+Alt+Left)\n"
@@ -8585,282 +8590,282 @@ msgstr ""
 "(Ctrl+Alt+Shift+Hjul Upp)"
 
 #. IDS_LOG_COMPARING_2
-#: Merge.rc:5718
+#: Merge.rc:5719
 #, c-format
 msgid "Comparing %1 with %2"
 msgstr "Jämför %1 med %2"
 
 #. IDS_LOG_COMPARING_3
-#: Merge.rc:5719
+#: Merge.rc:5720
 #, c-format
 msgid "Comparing %1 with %2 and %3"
 msgstr "Jämför %1 med %2 och %3"
 
 #. IDS_LOG_COMPARE_COMPLETED
-#: Merge.rc:5720
+#: Merge.rc:5721
 msgid "Comparison completed"
 msgstr "Jämförelse färdig"
 
 #. IDS_LOG_COMPARE_ERROR_2
-#: Merge.rc:5721
+#: Merge.rc:5722
 #, c-format
 msgid "Failed to compare %1 with %2: "
 msgstr "Kunde inte jämföra %1 med %2: "
 
 #. IDS_LOG_COMPARE_ERROR_3
-#: Merge.rc:5722
+#: Merge.rc:5723
 #, c-format
 msgid "Failed to compare %1 with %2 and %3: "
 msgstr "Kunde inte jämföra %1 med %2 och %3: "
 
 #. IDS_LOG_FILE_SAVED
-#: Merge.rc:5723
+#: Merge.rc:5724
 msgid "File saved"
 msgstr "Fil sparad"
 
 #. IDS_LOG_COPYING_FILES
-#: Merge.rc:5724
+#: Merge.rc:5725
 msgid "Copying files..."
 msgstr "Kopierar filer..."
 
 #. IDS_LOG_MOVING_FILES
-#: Merge.rc:5725
+#: Merge.rc:5726
 msgid "Moving files..."
 msgstr "Flyttar filer..."
 
 #. IDS_LOG_DELETING_FILES
-#: Merge.rc:5726
+#: Merge.rc:5727
 msgid "Deleting files..."
 msgstr "Tar bort filer..."
 
 #. IDS_LOG_RECYCLEBIN
-#: Merge.rc:5727
+#: Merge.rc:5728
 msgid "Recycle Bin"
 msgstr "Papperskorg"
 
 #. IDS_LOG_PERMANENTLY_DELETED
-#: Merge.rc:5728
+#: Merge.rc:5729
 msgid "Permanently deleted"
 msgstr "Permanent borttagen"
 
 #. IDS_LOG_FILEOPERATION_COMPLETED
-#: Merge.rc:5729
+#: Merge.rc:5730
 msgid "File operation completed successfully"
 msgstr "Filoperation framgångsrikt gjord"
 
 #. IDS_LOG_FILEOPERATION_CANCELED
-#: Merge.rc:5730
+#: Merge.rc:5731
 msgid "File operation canceled"
 msgstr "Filoperation avbruten"
 
 #. IDS_FILTER_ERROR_NO_ERROR
-#: Merge.rc:5735
+#: Merge.rc:5736
 msgid "No error"
 msgstr "Inget fel"
 
 #. IDS_FILTER_ERROR_EMPTY_EXPRESSION
-#: Merge.rc:5736
+#: Merge.rc:5737
 msgid "Filter expression is empty"
 msgstr "Filteruttrycket är tomt"
 
 #. IDS_FILTER_ERROR_UNKNOWN_CHAR
-#: Merge.rc:5737
+#: Merge.rc:5738
 msgid "Unknown character in filter expression"
 msgstr "Okänt tecken i filteruttryck"
 
 #. IDS_FILTER_ERROR_UNTERMINATED_STRING
-#: Merge.rc:5738
+#: Merge.rc:5739
 msgid "Unterminated string literal"
 msgstr "Oavslutad litterär text"
 
 #. IDS_FILTER_ERROR_SYNTAX_ERROR
-#: Merge.rc:5739
+#: Merge.rc:5740
 msgid "Syntax error in filter expression"
 msgstr "Syntaxfel i filteruttryck"
 
 #. IDS_FILTER_ERROR_PARSE_FAILURE
-#: Merge.rc:5740
+#: Merge.rc:5741
 msgid "Failed to parse filter expression"
 msgstr "Kunde inte tolka filteruttryck"
 
 #. IDS_FILTER_ERROR_INVALID_LITERAL
-#: Merge.rc:5741
+#: Merge.rc:5742
 msgid "Invalid literal value"
 msgstr "Ogiltigt litterärt värde"
 
 #. IDS_FILTER_ERROR_INVALID_REGULAR_EXPRESSION
-#: Merge.rc:5742
+#: Merge.rc:5743
 msgid "Invalid regular expression"
 msgstr "Ogiltigt reguljärt uttryck"
 
 #. IDS_FILTER_ERROR_UNDEFINED_IDENTIFIER
-#: Merge.rc:5743
+#: Merge.rc:5744
 msgid "Undefined identifier"
 msgstr "Odefinierad identifierare"
 
 #. IDS_FILTER_ERROR_INVALID_ARGUMENT_COUNT
-#: Merge.rc:5744
+#: Merge.rc:5745
 msgid "Invalid number of arguments"
 msgstr ""
 
 #. IDS_FILTER_ERROR_FILTER_NAME_NOT_FOUND
-#: Merge.rc:5745
+#: Merge.rc:5746
 msgid "Filter name not found"
 msgstr "Filternamn hittades inte"
 
 #. IDS_FILTER_ERROR_DIVIDE_BY_ZERO
-#: Merge.rc:5746
+#: Merge.rc:5747
 msgid "Division by zero in filter expression"
 msgstr "Division med noll i filteruttryck"
 
 #. IDS_FILTER_ERROR_UNKNOWN_ERROR
-#: Merge.rc:5747
+#: Merge.rc:5748
 msgid "Unknown error"
 msgstr "Okänt fel"
 
 #. IDS_FILTER_ERROR_INVALID_PROPERTY_NAME
-#: Merge.rc:5748
+#: Merge.rc:5749
 msgid "Invalid property name"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_DIRECTIVE
-#: Merge.rc:5749
+#: Merge.rc:5750
 msgid "Invalid directive"
 msgstr ""
 
 #. IDS_FILTER_OP_EQUALS
-#: Merge.rc:5754
+#: Merge.rc:5755
 msgid "Equals"
 msgstr "Lika med"
 
 #. IDS_FILTER_OP_NOT_EQUALS
-#: Merge.rc:5755
+#: Merge.rc:5756
 msgid "Does not equal"
 msgstr "Inte lika med"
 
 #. IDS_FILTER_OP_LESS_THAN
-#: Merge.rc:5756
+#: Merge.rc:5757
 msgid "Less than"
 msgstr "Mindre än"
 
 #. IDS_FILTER_OP_LESS_EQUAL
-#: Merge.rc:5757
+#: Merge.rc:5758
 msgid "Less than or equal to"
 msgstr "Mindre än eller lika med"
 
 #. IDS_FILTER_OP_GREATER_EQUAL
-#: Merge.rc:5758
+#: Merge.rc:5759
 msgid "Greater than or equal to"
 msgstr "Större än eller lika med"
 
 #. IDS_FILTER_OP_GREATER_THAN
-#: Merge.rc:5759
+#: Merge.rc:5760
 msgid "Greater than"
 msgstr "Större än"
 
 #. IDS_FILTER_OP_BETWEEN
-#: Merge.rc:5760
+#: Merge.rc:5761
 msgid "Between"
 msgstr "Mellan"
 
 #. IDS_FILTER_OP_NOT_BETWEEN
-#: Merge.rc:5761
+#: Merge.rc:5762
 msgid "Not Between"
 msgstr "Inte mellan"
 
 #. IDS_FILTER_OP_CONTAINS
-#: Merge.rc:5762
+#: Merge.rc:5763
 msgid "Contains"
 msgstr "Innehåller"
 
 #. IDS_FILTER_OP_NOT_CONTAINS
-#: Merge.rc:5763
+#: Merge.rc:5764
 msgid "Not Contains"
 msgstr "Innehåller inte"
 
 #. IDS_FILTER_OP_RECONTAINS
-#: Merge.rc:5764
+#: Merge.rc:5765
 msgid "Contains (regex)"
 msgstr "Innehåller (RegExp)"
 
 #. IDS_FILTER_OP_NOT_RECONTAINS
-#: Merge.rc:5765
+#: Merge.rc:5766
 msgid "Not Contains (regex)"
 msgstr "Innehåller inte (RegExp)"
 
 #. IDS_FILTER_OP_LIKE
-#: Merge.rc:5766
+#: Merge.rc:5767
 msgid "Match (wildcard)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_LIKE
-#: Merge.rc:5767
+#: Merge.rc:5768
 msgid "Not match (wildcard)"
 msgstr ""
 
 #. IDS_FILTER_OP_MATCHES
-#: Merge.rc:5768
+#: Merge.rc:5769
 msgid "Match (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_MATCHES
-#: Merge.rc:5769
+#: Merge.rc:5770
 msgid "Not match (regex)"
 msgstr ""
 
 #. IDS_COLORMODE_LIGHT
-#: Merge.rc:5774
+#: Merge.rc:5775
 msgid "Light"
 msgstr "Ljus"
 
 #. IDS_COLORMODE_DARK
-#: Merge.rc:5775
+#: Merge.rc:5776
 msgid "Dark"
 msgstr "Mörk"
 
 #. IDS_COLORMODE_FOLLOWSYSTEM
-#: Merge.rc:5776
+#: Merge.rc:5777
 msgid "Follow system"
 msgstr "Följ system"
 
 #. IDS_EXAMPLE
-#: Merge.rc:5781
+#: Merge.rc:5782
 #, c-format
 msgid "e.g. %1"
 msgstr ""
 
 #. IDS_DETECTED_PREVIOUS_CRASH
-#: Merge.rc:5786
+#: Merge.rc:5787
 msgid "WinMerge detected a previous crash. Please report this if possible."
 msgstr ""
 
 #. IDS_REGEX_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5791
+#: Merge.rc:5792
 msgid "# Regex replacement list\r\n# Format: regex<TAB>replacement\r\n# Backreferences like $1, $2 are supported\r\n\r\n(\\d{4})-(\\d{2})-(\\d{2})\t$1_$2_$3\r\n"
 msgstr ""
 
 #. IDS_STRING_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5792
+#: Merge.rc:5793
 msgid "# Replacement list\r\n# Format: search<TAB>replacement\r\n# Lines starting with # are ignored\r\n\r\nfrom1\tto1\r\nfrom2\tto2\r\n"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_ONLY
-#: Merge.rc:5797
+#: Merge.rc:5798
 msgid "Built-in only"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_FIRST
-#: Merge.rc:5798
+#: Merge.rc:5799
 msgid "Built-in first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_FIRST
-#: Merge.rc:5799
+#: Merge.rc:5800
 msgid "Tree-sitter first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_ONLY
-#: Merge.rc:5800
+#: Merge.rc:5801
 msgid "Tree-sitter only"
 msgstr ""
 

--- a/Translations/WinMerge/Tamil.po
+++ b/Translations/WinMerge/Tamil.po
@@ -21,7 +21,7 @@ msgstr ""
 "X-Poedit-SourceCharset: UTF-8\n"
 
 #. LANGUAGE, SUBLANGUAGE
-#: Merge.rc:26 Merge.rc:59 Merge.rc:5817
+#: Merge.rc:26 Merge.rc:59 Merge.rc:5818
 msgid "LANG_ENGLISH, SUBLANG_ENGLISH_US"
 msgstr "LANG_TAMIL, SUBLANG_TAMIL_INDIA"
 
@@ -237,7 +237,7 @@ msgid "Auto-Fit All Columns"
 msgstr "அனைத்து நெடுவரிசைகளையும் தானாக பொருத்து"
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN
-#: Merge.rc:153 Merge.rc:5645
+#: Merge.rc:153 Merge.rc:5646
 msgid "&Filter by This Column"
 msgstr ""
 
@@ -298,7 +298,7 @@ msgid "&Previous Page"
 msgstr "முந்தைய பக்கம்"
 
 #. IDS_PREVIEWBAR_NEXTPAGE
-#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5678
+#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5679
 msgid "&Next Page"
 msgstr "அடுத்த பக்கம்"
 
@@ -671,7 +671,7 @@ msgid "&Huge"
 msgstr "பெரிய"
 
 #. IDS_VIEW_MENU_BAR
-#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5713
+#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5714
 msgid "Men&u Bar"
 msgstr "பட்டியல் பட்டி"
 
@@ -4209,7 +4209,7 @@ msgid "Items compared:"
 msgstr "ஒப்பிடப்பட்ட உருப்படிகள்:"
 
 #. IDS_PREVIEWBAR_CLOSE
-#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5684
+#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5685
 msgid "&Close"
 msgstr "மூடு"
 
@@ -8425,30 +8425,35 @@ msgstr "1 மற்றும் 3 வது"
 msgid "2nd and 3rd"
 msgstr "2 மற்றும் 3 வது"
 
+#. IDS_PLUGIN_CTRL_CLICK
+#: Merge.rc:5635
+msgid "(Ctrl+Click to add to pipeline)"
+msgstr ""
+
 #. IDS_FILTER_APPLIED
-#: Merge.rc:5639
+#: Merge.rc:5640
 msgid "Filter applied"
 msgstr "வடிகட்டி பயன்படுத்தப்பட்டது"
 
 #. IDS_FILTERMENU_COMPARE
-#: Merge.rc:5644
+#: Merge.rc:5645
 #, c-format
 msgid "Compare %1"
 msgstr ""
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN2
-#: Merge.rc:5646
+#: Merge.rc:5647
 msgid "&Filter by This Column..."
 msgstr ""
 
 #. IDS_CLIPBOARDHISTORY_TIME
-#: Merge.rc:5651
+#: Merge.rc:5652
 #, c-format
 msgid "Clipboard at %s"
 msgstr "%s இல் இடைநிலைப்பலகை"
 
 #. IDS_CLIPBOARDHISTORY_DISABLED
-#: Merge.rc:5652
+#: Merge.rc:5653
 msgid ""
 "Clipboard history disabled.\r\n"
 "Enable: Windows logo key + V, then Turn on."
@@ -8456,117 +8461,117 @@ msgstr ""
 "இடைநிலைப்பலகை வரலாறு முடக்கப்பட்டுள்ளது.\r\n"
 "இடைநிலைப்பலகை வரலாற்றை இயக்க, சாளரங்கள் சின்னம் + V ஐ அழுத்தி, பின்னர் இயக்கு பொத்தானைக் சொடுக்கவும்."
 
-#: Merge.rc:5654
+#: Merge.rc:5655
 msgid "This system does not support clipboard history."
 msgstr "இந்த அமைப்பு இடைநிலைப்பலகை வரலாற்றை ஆதரிக்காது."
 
-#: Merge.rc:5656
+#: Merge.rc:5657
 msgid "32-bit WinMerge does not support Clipboard Compare"
 msgstr "சாளரொன்றிணையின் 32-இரும பதிப்பு இடைநிலைப்பலகை ஒப்பீட்டை ஆதரிக்கவில்லை"
 
 #. IDS_WEBVIEW2_RUNTIME_NOT_INSTALLED
-#: Merge.rc:5661
+#: Merge.rc:5662
 msgid "WebView2 runtime not installed. Download it?"
 msgstr ""
 "வலைக்காட்சி2 இயக்கநேரம் நிறுவப்படவில்லை. நீங்கள் அதைப் பதிவிறக்க "
 "விரும்புகிறீர்களா?"
 
 #. IDS_JUMPLIST_NEW_TEXT_COMPARE
-#: Merge.rc:5666
+#: Merge.rc:5667
 msgid "New Text Compare"
 msgstr "புதிய உரை ஒப்பிடுக"
 
 #. IDS_JUMPLIST_NEW_TABLE_COMPARE
-#: Merge.rc:5667
+#: Merge.rc:5668
 msgid "New Table Compare"
 msgstr "புதிய அட்டவணை ஒப்பிடுக"
 
 #. IDS_JUMPLIST_NEW_BINARY_COMPARE
-#: Merge.rc:5668
+#: Merge.rc:5669
 msgid "New Binary Compare"
 msgstr "புதிய இருமம் ஒப்பீடு"
 
 #. IDS_JUMPLIST_NEW_IMAGE_COMPARE
-#: Merge.rc:5669
+#: Merge.rc:5670
 msgid "New Image Compare"
 msgstr "புதிய படம் ஒப்பிடுக"
 
 #. IDS_JUMPLIST_NEW_WEBPAGE_COMPARE
-#: Merge.rc:5670
+#: Merge.rc:5671
 msgid "New Webpage Compare"
 msgstr "புதிய வலைப்பக்கம் ஒப்பிடுக"
 
 #. IDS_JUMPLIST_NEW_FOLDER_COMPARE
-#: Merge.rc:5671
+#: Merge.rc:5672
 msgid "New Folder Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_CLIPBOARD_COMPARE
-#: Merge.rc:5672
+#: Merge.rc:5673
 msgid "Clipboard Compare"
 msgstr "இடைநிலைப்பலகை ஒப்பிடுக"
 
 #. IDS_PREVIEWBAR_PRINT
-#: Merge.rc:5677
+#: Merge.rc:5678
 msgid "&Print..."
 msgstr "அச்சிடு... (&p)"
 
 #. IDS_PREVIEWBAR_PREVPAGE
-#: Merge.rc:5679
+#: Merge.rc:5680
 msgid "Pre&v Page"
 msgstr "முன் & வி பக்கம்"
 
 #. IDS_PREVIEWBAR_TWOPAGE
-#: Merge.rc:5680
+#: Merge.rc:5681
 msgid "&Two Page"
 msgstr "& இரண்டு பக்கம்"
 
 #. IDS_PREVIEWBAR_ONEPAGE
-#: Merge.rc:5681
+#: Merge.rc:5682
 msgid "&One Page"
 msgstr "ஒரு பக்கம்"
 
 #. IDS_PREVIEWBAR_ZOOMIN
-#: Merge.rc:5682
+#: Merge.rc:5683
 msgid "Zoom &In"
 msgstr "சூம் & இன்"
 
 #. IDS_PREVIEWBAR_ZOOMOUT
-#: Merge.rc:5683
+#: Merge.rc:5684
 msgid "Zoom &Out"
 msgstr "பெரிதாக்கவும்"
 
 #. IDS_WEBPAGE_COMPARING
-#: Merge.rc:5689
+#: Merge.rc:5690
 msgid "Comparing..."
 msgstr "ஒப்பிடுவது ..."
 
 #. IDS_WEBPAGE_ZOOM
-#: Merge.rc:5690
+#: Merge.rc:5691
 msgid "Zoom:"
 msgstr "சூம்:"
 
 #. IDS_COPY_GRANULARITY_DIFFHUNK
-#: Merge.rc:5695
+#: Merge.rc:5696
 msgid "Diff hunk"
 msgstr "வேறு கொத்து"
 
 #. IDS_COPY_GRANULARITY_INLINE
-#: Merge.rc:5696
+#: Merge.rc:5697
 msgid "Inline diff"
 msgstr "உள்வரி வேறுபாடு"
 
 #. IDS_COPY_GRANULARITY_LINE
-#: Merge.rc:5697
+#: Merge.rc:5698
 msgid "Line"
 msgstr "வரி"
 
-#: Merge.rc:5698
+#: Merge.rc:5699
 msgid "Character"
 msgstr "எழுத்து"
 
 #. ID_MICE_PREVDIFF
-#: Merge.rc:5703
+#: Merge.rc:5704
 msgid ""
 "\n"
 "Previous Difference (Alt+Up)\n"
@@ -8579,7 +8584,7 @@ msgstr ""
 "(Alt+வீல் அப்)"
 
 #. ID_MICE_NEXTDIFF
-#: Merge.rc:5704
+#: Merge.rc:5705
 msgid ""
 "\n"
 "Next Difference (Alt+Down)\n"
@@ -8592,7 +8597,7 @@ msgstr ""
 "(Alt+வீல் டவுன்)"
 
 #. ID_MICE_L2R
-#: Merge.rc:5705
+#: Merge.rc:5706
 msgid ""
 "\n"
 "Copy to Right (Alt+Right)\n"
@@ -8607,7 +8612,7 @@ msgstr ""
 "(Alt+Shift+Wheel Down)"
 
 #. ID_MICE_R2L
-#: Merge.rc:5706
+#: Merge.rc:5707
 msgid ""
 "\n"
 "Copy to Left (Alt+Left)\n"
@@ -8622,7 +8627,7 @@ msgstr ""
 "(Alt+Shift+Wheel UP)"
 
 #. ID_MICE_L2RNEXT
-#: Merge.rc:5707
+#: Merge.rc:5708
 msgid ""
 "\n"
 "Copy to Right and Advance (Ctrl+Alt+Right)\n"
@@ -8635,7 +8640,7 @@ msgstr ""
 "(Ctrl+Alt+Shift+Wheel Town)"
 
 #. ID_MICE_R2LNEXT
-#: Merge.rc:5708
+#: Merge.rc:5709
 msgid ""
 "\n"
 "Copy to Left and Advance (Ctrl+Alt+Left)\n"
@@ -8648,282 +8653,282 @@ msgstr ""
 "(Ctrl+alt+shift+wheel Up)"
 
 #. IDS_LOG_COMPARING_2
-#: Merge.rc:5718
+#: Merge.rc:5719
 #, c-format
 msgid "Comparing %1 with %2"
 msgstr "%1 ஐ %2 உடன் ஒப்பிடுகிறது"
 
 #. IDS_LOG_COMPARING_3
-#: Merge.rc:5719
+#: Merge.rc:5720
 #, c-format
 msgid "Comparing %1 with %2 and %3"
 msgstr "%1 ஐ %2 மற்றும் %3 உடன் ஒப்பிடுகிறது"
 
 #. IDS_LOG_COMPARE_COMPLETED
-#: Merge.rc:5720
+#: Merge.rc:5721
 msgid "Comparison completed"
 msgstr "ஒப்பீடு முடிந்தது"
 
 #. IDS_LOG_COMPARE_ERROR_2
-#: Merge.rc:5721
+#: Merge.rc:5722
 #, c-format
 msgid "Failed to compare %1 with %2: "
 msgstr "%1 ஐ %2 உடன் ஒப்பிடுவதில் தோல்வி:"
 
 #. IDS_LOG_COMPARE_ERROR_3
-#: Merge.rc:5722
+#: Merge.rc:5723
 #, c-format
 msgid "Failed to compare %1 with %2 and %3: "
 msgstr "%1 ஐ %2 மற்றும் %3 உடன் ஒப்பிடுவதில் தோல்வி:"
 
 #. IDS_LOG_FILE_SAVED
-#: Merge.rc:5723
+#: Merge.rc:5724
 msgid "File saved"
 msgstr "கோப்பு சேமிக்கப்பட்டது"
 
 #. IDS_LOG_COPYING_FILES
-#: Merge.rc:5724
+#: Merge.rc:5725
 msgid "Copying files..."
 msgstr "கோப்புகளை நகலெடுக்கிறது..."
 
 #. IDS_LOG_MOVING_FILES
-#: Merge.rc:5725
+#: Merge.rc:5726
 msgid "Moving files..."
 msgstr "நகரும் கோப்புகள் ..."
 
 #. IDS_LOG_DELETING_FILES
-#: Merge.rc:5726
+#: Merge.rc:5727
 msgid "Deleting files..."
 msgstr "கோப்புகளை நீக்குதல் ..."
 
 #. IDS_LOG_RECYCLEBIN
-#: Merge.rc:5727
+#: Merge.rc:5728
 msgid "Recycle Bin"
 msgstr "மறுசுழற்சி தொட்டி"
 
 #. IDS_LOG_PERMANENTLY_DELETED
-#: Merge.rc:5728
+#: Merge.rc:5729
 msgid "Permanently deleted"
 msgstr "நிரந்தரமாக நீக்கப்பட்டது"
 
 #. IDS_LOG_FILEOPERATION_COMPLETED
-#: Merge.rc:5729
+#: Merge.rc:5730
 msgid "File operation completed successfully"
 msgstr "கோப்பு செயல்பாடு வெற்றிகரமாக முடிந்தது"
 
 #. IDS_LOG_FILEOPERATION_CANCELED
-#: Merge.rc:5730
+#: Merge.rc:5731
 msgid "File operation canceled"
 msgstr "கோப்பு செயல்பாடு கைவிடப்பட்டது"
 
 #. IDS_FILTER_ERROR_NO_ERROR
-#: Merge.rc:5735
+#: Merge.rc:5736
 msgid "No error"
 msgstr ""
 
 #. IDS_FILTER_ERROR_EMPTY_EXPRESSION
-#: Merge.rc:5736
+#: Merge.rc:5737
 msgid "Filter expression is empty"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNKNOWN_CHAR
-#: Merge.rc:5737
+#: Merge.rc:5738
 msgid "Unknown character in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNTERMINATED_STRING
-#: Merge.rc:5738
+#: Merge.rc:5739
 msgid "Unterminated string literal"
 msgstr ""
 
 #. IDS_FILTER_ERROR_SYNTAX_ERROR
-#: Merge.rc:5739
+#: Merge.rc:5740
 msgid "Syntax error in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_PARSE_FAILURE
-#: Merge.rc:5740
+#: Merge.rc:5741
 msgid "Failed to parse filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_LITERAL
-#: Merge.rc:5741
+#: Merge.rc:5742
 msgid "Invalid literal value"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_REGULAR_EXPRESSION
-#: Merge.rc:5742
+#: Merge.rc:5743
 msgid "Invalid regular expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNDEFINED_IDENTIFIER
-#: Merge.rc:5743
+#: Merge.rc:5744
 msgid "Undefined identifier"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_ARGUMENT_COUNT
-#: Merge.rc:5744
+#: Merge.rc:5745
 msgid "Invalid number of arguments"
 msgstr ""
 
 #. IDS_FILTER_ERROR_FILTER_NAME_NOT_FOUND
-#: Merge.rc:5745
+#: Merge.rc:5746
 msgid "Filter name not found"
 msgstr ""
 
 #. IDS_FILTER_ERROR_DIVIDE_BY_ZERO
-#: Merge.rc:5746
+#: Merge.rc:5747
 msgid "Division by zero in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNKNOWN_ERROR
-#: Merge.rc:5747
+#: Merge.rc:5748
 msgid "Unknown error"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_PROPERTY_NAME
-#: Merge.rc:5748
+#: Merge.rc:5749
 msgid "Invalid property name"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_DIRECTIVE
-#: Merge.rc:5749
+#: Merge.rc:5750
 msgid "Invalid directive"
 msgstr ""
 
 #. IDS_FILTER_OP_EQUALS
-#: Merge.rc:5754
+#: Merge.rc:5755
 msgid "Equals"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_EQUALS
-#: Merge.rc:5755
+#: Merge.rc:5756
 msgid "Does not equal"
 msgstr ""
 
 #. IDS_FILTER_OP_LESS_THAN
-#: Merge.rc:5756
+#: Merge.rc:5757
 msgid "Less than"
 msgstr ""
 
 #. IDS_FILTER_OP_LESS_EQUAL
-#: Merge.rc:5757
+#: Merge.rc:5758
 msgid "Less than or equal to"
 msgstr ""
 
 #. IDS_FILTER_OP_GREATER_EQUAL
-#: Merge.rc:5758
+#: Merge.rc:5759
 msgid "Greater than or equal to"
 msgstr ""
 
 #. IDS_FILTER_OP_GREATER_THAN
-#: Merge.rc:5759
+#: Merge.rc:5760
 msgid "Greater than"
 msgstr ""
 
 #. IDS_FILTER_OP_BETWEEN
-#: Merge.rc:5760
+#: Merge.rc:5761
 msgid "Between"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_BETWEEN
-#: Merge.rc:5761
+#: Merge.rc:5762
 msgid "Not Between"
 msgstr ""
 
 #. IDS_FILTER_OP_CONTAINS
-#: Merge.rc:5762
+#: Merge.rc:5763
 msgid "Contains"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_CONTAINS
-#: Merge.rc:5763
+#: Merge.rc:5764
 msgid "Not Contains"
 msgstr ""
 
 #. IDS_FILTER_OP_RECONTAINS
-#: Merge.rc:5764
+#: Merge.rc:5765
 msgid "Contains (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_RECONTAINS
-#: Merge.rc:5765
+#: Merge.rc:5766
 msgid "Not Contains (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_LIKE
-#: Merge.rc:5766
+#: Merge.rc:5767
 msgid "Match (wildcard)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_LIKE
-#: Merge.rc:5767
+#: Merge.rc:5768
 msgid "Not match (wildcard)"
 msgstr ""
 
 #. IDS_FILTER_OP_MATCHES
-#: Merge.rc:5768
+#: Merge.rc:5769
 msgid "Match (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_MATCHES
-#: Merge.rc:5769
+#: Merge.rc:5770
 msgid "Not match (regex)"
 msgstr ""
 
 #. IDS_COLORMODE_LIGHT
-#: Merge.rc:5774
+#: Merge.rc:5775
 msgid "Light"
 msgstr ""
 
 #. IDS_COLORMODE_DARK
-#: Merge.rc:5775
+#: Merge.rc:5776
 msgid "Dark"
 msgstr ""
 
 #. IDS_COLORMODE_FOLLOWSYSTEM
-#: Merge.rc:5776
+#: Merge.rc:5777
 msgid "Follow system"
 msgstr ""
 
 #. IDS_EXAMPLE
-#: Merge.rc:5781
+#: Merge.rc:5782
 #, c-format
 msgid "e.g. %1"
 msgstr ""
 
 #. IDS_DETECTED_PREVIOUS_CRASH
-#: Merge.rc:5786
+#: Merge.rc:5787
 msgid "WinMerge detected a previous crash. Please report this if possible."
 msgstr ""
 
 #. IDS_REGEX_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5791
+#: Merge.rc:5792
 msgid "# Regex replacement list\r\n# Format: regex<TAB>replacement\r\n# Backreferences like $1, $2 are supported\r\n\r\n(\\d{4})-(\\d{2})-(\\d{2})\t$1_$2_$3\r\n"
 msgstr ""
 
 #. IDS_STRING_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5792
+#: Merge.rc:5793
 msgid "# Replacement list\r\n# Format: search<TAB>replacement\r\n# Lines starting with # are ignored\r\n\r\nfrom1\tto1\r\nfrom2\tto2\r\n"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_ONLY
-#: Merge.rc:5797
+#: Merge.rc:5798
 msgid "Built-in only"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_FIRST
-#: Merge.rc:5798
+#: Merge.rc:5799
 msgid "Built-in first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_FIRST
-#: Merge.rc:5799
+#: Merge.rc:5800
 msgid "Tree-sitter first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_ONLY
-#: Merge.rc:5800
+#: Merge.rc:5801
 msgid "Tree-sitter only"
 msgstr ""
 

--- a/Translations/WinMerge/Turkish.po
+++ b/Translations/WinMerge/Turkish.po
@@ -24,7 +24,7 @@ msgstr ""
 "X-Generator: Poedit 3.9\n"
 
 #. LANGUAGE, SUBLANGUAGE
-#: Merge.rc:26 Merge.rc:59 Merge.rc:5817
+#: Merge.rc:26 Merge.rc:59 Merge.rc:5818
 msgid "LANG_ENGLISH, SUBLANG_ENGLISH_US"
 msgstr "LANG_TURKISH, SUBLANG_DEFAULT"
 
@@ -231,7 +231,7 @@ msgid "Auto-Fit All Columns"
 msgstr "Tüm sütunlar otomatik sığdırılsın"
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN
-#: Merge.rc:153 Merge.rc:5645
+#: Merge.rc:153 Merge.rc:5646
 msgid "&Filter by This Column"
 msgstr "Bu sütuna göre &filtrele"
 
@@ -292,7 +292,7 @@ msgid "&Previous Page"
 msgstr "Ö&nceki sayfa"
 
 #. IDS_PREVIEWBAR_NEXTPAGE
-#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5678
+#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5679
 msgid "&Next Page"
 msgstr "So&nraki sayfa"
 
@@ -665,7 +665,7 @@ msgid "&Huge"
 msgstr "Çok &büyük"
 
 #. IDS_VIEW_MENU_BAR
-#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5713
+#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5714
 msgid "Men&u Bar"
 msgstr "Me&nü çubuğu"
 
@@ -4190,7 +4190,7 @@ msgid "Items compared:"
 msgstr "Karşılaştırılan öge:"
 
 #. IDS_PREVIEWBAR_CLOSE
-#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5684
+#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5685
 msgid "&Close"
 msgstr "&Kapat"
 
@@ -8408,30 +8408,35 @@ msgstr "Birinci ve üçüncü"
 msgid "2nd and 3rd"
 msgstr "İkinci ve üçüncü"
 
+#. IDS_PLUGIN_CTRL_CLICK
+#: Merge.rc:5635
+msgid "(Ctrl+Click to add to pipeline)"
+msgstr ""
+
 #. IDS_FILTER_APPLIED
-#: Merge.rc:5639
+#: Merge.rc:5640
 msgid "Filter applied"
 msgstr "Filtre uygulandı"
 
 #. IDS_FILTERMENU_COMPARE
-#: Merge.rc:5644
+#: Merge.rc:5645
 #, c-format
 msgid "Compare %1"
 msgstr "%1’i karşılaştır"
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN2
-#: Merge.rc:5646
+#: Merge.rc:5647
 msgid "&Filter by This Column..."
 msgstr "Bu sütuna göre &filtrele..."
 
 #. IDS_CLIPBOARDHISTORY_TIME
-#: Merge.rc:5651
+#: Merge.rc:5652
 #, c-format
 msgid "Clipboard at %s"
 msgstr "%s zamanındaki pano"
 
 #. IDS_CLIPBOARDHISTORY_DISABLED
-#: Merge.rc:5652
+#: Merge.rc:5653
 msgid ""
 "Clipboard history disabled.\r\n"
 "Enable: Windows logo key + V, then Turn on."
@@ -8439,115 +8444,115 @@ msgstr ""
 "Pano geçmişi devre dışı bırakılmış.\r\n"
 "Pano geçmişini etkinleştirmek için, Windows + V tuşlarına basıp açılan pencerede Aç üzerine tıklayın."
 
-#: Merge.rc:5654
+#: Merge.rc:5655
 msgid "This system does not support clipboard history."
 msgstr "Bu sistemde pano geçmişi özelliği yok."
 
-#: Merge.rc:5656
+#: Merge.rc:5657
 msgid "32-bit WinMerge does not support Clipboard Compare"
 msgstr "32-bit WinMerge sürümünde pano karşılaştırma özelliği yok"
 
 #. IDS_WEBVIEW2_RUNTIME_NOT_INSTALLED
-#: Merge.rc:5661
+#: Merge.rc:5662
 msgid "WebView2 runtime not installed. Download it?"
 msgstr "WebView2 çalıştırıcı bulunamadı. İndirmek ister misiniz?"
 
 #. IDS_JUMPLIST_NEW_TEXT_COMPARE
-#: Merge.rc:5666
+#: Merge.rc:5667
 msgid "New Text Compare"
 msgstr "Yeni metin karşılaştırması"
 
 #. IDS_JUMPLIST_NEW_TABLE_COMPARE
-#: Merge.rc:5667
+#: Merge.rc:5668
 msgid "New Table Compare"
 msgstr "Yeni tablo karşılaştırması"
 
 #. IDS_JUMPLIST_NEW_BINARY_COMPARE
-#: Merge.rc:5668
+#: Merge.rc:5669
 msgid "New Binary Compare"
 msgstr "Yeni binary karşılaştırması"
 
 #. IDS_JUMPLIST_NEW_IMAGE_COMPARE
-#: Merge.rc:5669
+#: Merge.rc:5670
 msgid "New Image Compare"
 msgstr "Yeni görsel karşılaştırması"
 
 #. IDS_JUMPLIST_NEW_WEBPAGE_COMPARE
-#: Merge.rc:5670
+#: Merge.rc:5671
 msgid "New Webpage Compare"
 msgstr "Yeni site sayfası karşılaştırması"
 
 #. IDS_JUMPLIST_NEW_FOLDER_COMPARE
-#: Merge.rc:5671
+#: Merge.rc:5672
 msgid "New Folder Compare"
 msgstr "Yeni klasör karşılaştırması"
 
 #. IDS_JUMPLIST_CLIPBOARD_COMPARE
-#: Merge.rc:5672
+#: Merge.rc:5673
 msgid "Clipboard Compare"
 msgstr "Pano karşılaştırması"
 
 #. IDS_PREVIEWBAR_PRINT
-#: Merge.rc:5677
+#: Merge.rc:5678
 msgid "&Print..."
 msgstr "&Yazdır..."
 
 #. IDS_PREVIEWBAR_PREVPAGE
-#: Merge.rc:5679
+#: Merge.rc:5680
 msgid "Pre&v Page"
 msgstr "Ö&nceki sayfa"
 
 #. IDS_PREVIEWBAR_TWOPAGE
-#: Merge.rc:5680
+#: Merge.rc:5681
 msgid "&Two Page"
 msgstr "İ&ki sayfa"
 
 #. IDS_PREVIEWBAR_ONEPAGE
-#: Merge.rc:5681
+#: Merge.rc:5682
 msgid "&One Page"
 msgstr "&Bir sayfa"
 
 #. IDS_PREVIEWBAR_ZOOMIN
-#: Merge.rc:5682
+#: Merge.rc:5683
 msgid "Zoom &In"
 msgstr "Y&akınlaştır"
 
 #. IDS_PREVIEWBAR_ZOOMOUT
-#: Merge.rc:5683
+#: Merge.rc:5684
 msgid "Zoom &Out"
 msgstr "&Uzaklaştır"
 
 #. IDS_WEBPAGE_COMPARING
-#: Merge.rc:5689
+#: Merge.rc:5690
 msgid "Comparing..."
 msgstr "Karşılaştırılıyor..."
 
 #. IDS_WEBPAGE_ZOOM
-#: Merge.rc:5690
+#: Merge.rc:5691
 msgid "Zoom:"
 msgstr "Yakınlaştıma:"
 
 #. IDS_COPY_GRANULARITY_DIFFHUNK
-#: Merge.rc:5695
+#: Merge.rc:5696
 msgid "Diff hunk"
 msgstr "Fark parçası"
 
 #. IDS_COPY_GRANULARITY_INLINE
-#: Merge.rc:5696
+#: Merge.rc:5697
 msgid "Inline diff"
 msgstr "Satır arası fark"
 
 #. IDS_COPY_GRANULARITY_LINE
-#: Merge.rc:5697
+#: Merge.rc:5698
 msgid "Line"
 msgstr "Satır"
 
-#: Merge.rc:5698
+#: Merge.rc:5699
 msgid "Character"
 msgstr "Karakter"
 
 #. ID_MICE_PREVDIFF
-#: Merge.rc:5703
+#: Merge.rc:5704
 msgid ""
 "\n"
 "Previous Difference (Alt+Up)\n"
@@ -8560,7 +8565,7 @@ msgstr ""
 "(Alt+Tekerlek Yukarı)"
 
 #. ID_MICE_NEXTDIFF
-#: Merge.rc:5704
+#: Merge.rc:5705
 msgid ""
 "\n"
 "Next Difference (Alt+Down)\n"
@@ -8573,7 +8578,7 @@ msgstr ""
 "(Alt+Tekerlek Aşağı)"
 
 #. ID_MICE_L2R
-#: Merge.rc:5705
+#: Merge.rc:5706
 msgid ""
 "\n"
 "Copy to Right (Alt+Right)\n"
@@ -8588,7 +8593,7 @@ msgstr ""
 "(Alt+Shift+Tekerlek Aşağı)"
 
 #. ID_MICE_R2L
-#: Merge.rc:5706
+#: Merge.rc:5707
 msgid ""
 "\n"
 "Copy to Left (Alt+Left)\n"
@@ -8603,7 +8608,7 @@ msgstr ""
 "(Alt+Shift+Tekerlek Yukarı)"
 
 #. ID_MICE_L2RNEXT
-#: Merge.rc:5707
+#: Merge.rc:5708
 msgid ""
 "\n"
 "Copy to Right and Advance (Ctrl+Alt+Right)\n"
@@ -8616,7 +8621,7 @@ msgstr ""
 "(Ctrl+Alt+Shift+Tekerlek Aşağı)"
 
 #. ID_MICE_R2LNEXT
-#: Merge.rc:5708
+#: Merge.rc:5709
 msgid ""
 "\n"
 "Copy to Left and Advance (Ctrl+Alt+Left)\n"
@@ -8629,257 +8634,257 @@ msgstr ""
 "(Ctrl+Alt+Shift+Tekerlek Yukarı)"
 
 #. IDS_LOG_COMPARING_2
-#: Merge.rc:5718
+#: Merge.rc:5719
 #, c-format
 msgid "Comparing %1 with %2"
 msgstr "%1 ile %2 karşılaştırılıyor"
 
 #. IDS_LOG_COMPARING_3
-#: Merge.rc:5719
+#: Merge.rc:5720
 #, c-format
 msgid "Comparing %1 with %2 and %3"
 msgstr "%1 ile %2 ve %3 ile karşılaştırılıyor"
 
 #. IDS_LOG_COMPARE_COMPLETED
-#: Merge.rc:5720
+#: Merge.rc:5721
 msgid "Comparison completed"
 msgstr "Karşılaştırma tamamlandı"
 
 #. IDS_LOG_COMPARE_ERROR_2
-#: Merge.rc:5721
+#: Merge.rc:5722
 #, c-format
 msgid "Failed to compare %1 with %2: "
 msgstr "%1 ile %2 karşılaştırılamadı: "
 
 #. IDS_LOG_COMPARE_ERROR_3
-#: Merge.rc:5722
+#: Merge.rc:5723
 #, c-format
 msgid "Failed to compare %1 with %2 and %3: "
 msgstr "%1 ile %2 ve %3 karşılaştırılamadı: "
 
 #. IDS_LOG_FILE_SAVED
-#: Merge.rc:5723
+#: Merge.rc:5724
 msgid "File saved"
 msgstr "Dosya kaydedildi"
 
 #. IDS_LOG_COPYING_FILES
-#: Merge.rc:5724
+#: Merge.rc:5725
 msgid "Copying files..."
 msgstr "Dosyalar kopyalanıyor..."
 
 #. IDS_LOG_MOVING_FILES
-#: Merge.rc:5725
+#: Merge.rc:5726
 msgid "Moving files..."
 msgstr "Dosyalar taşınıyor..."
 
 #. IDS_LOG_DELETING_FILES
-#: Merge.rc:5726
+#: Merge.rc:5727
 msgid "Deleting files..."
 msgstr "Dosyalar siliniyor..."
 
 #. IDS_LOG_RECYCLEBIN
-#: Merge.rc:5727
+#: Merge.rc:5728
 msgid "Recycle Bin"
 msgstr "Geri Dönüşüm Kutusu"
 
 #. IDS_LOG_PERMANENTLY_DELETED
-#: Merge.rc:5728
+#: Merge.rc:5729
 msgid "Permanently deleted"
 msgstr "Kalıcı olarak silindi"
 
 #. IDS_LOG_FILEOPERATION_COMPLETED
-#: Merge.rc:5729
+#: Merge.rc:5730
 msgid "File operation completed successfully"
 msgstr "Dosya işlemi başarıyla tamamlandı"
 
 #. IDS_LOG_FILEOPERATION_CANCELED
-#: Merge.rc:5730
+#: Merge.rc:5731
 msgid "File operation canceled"
 msgstr "Dosya işlemi iptal edildi"
 
 #. IDS_FILTER_ERROR_NO_ERROR
-#: Merge.rc:5735
+#: Merge.rc:5736
 msgid "No error"
 msgstr "Hata yok"
 
 #. IDS_FILTER_ERROR_EMPTY_EXPRESSION
-#: Merge.rc:5736
+#: Merge.rc:5737
 msgid "Filter expression is empty"
 msgstr "Filtre ifadesi boş"
 
 #. IDS_FILTER_ERROR_UNKNOWN_CHAR
-#: Merge.rc:5737
+#: Merge.rc:5738
 msgid "Unknown character in filter expression"
 msgstr "Filtre ifadesinde bilinmeyen karakter"
 
 #. IDS_FILTER_ERROR_UNTERMINATED_STRING
-#: Merge.rc:5738
+#: Merge.rc:5739
 msgid "Unterminated string literal"
 msgstr "Sonlandırılmamış dize sabiti"
 
 #. IDS_FILTER_ERROR_SYNTAX_ERROR
-#: Merge.rc:5739
+#: Merge.rc:5740
 msgid "Syntax error in filter expression"
 msgstr "Filtre ifadesinde söz dizimi hatası"
 
 #. IDS_FILTER_ERROR_PARSE_FAILURE
-#: Merge.rc:5740
+#: Merge.rc:5741
 msgid "Failed to parse filter expression"
 msgstr "Filtre ifadesi ayrıştırılamadı"
 
 #. IDS_FILTER_ERROR_INVALID_LITERAL
-#: Merge.rc:5741
+#: Merge.rc:5742
 msgid "Invalid literal value"
 msgstr "Geçersiz sabit değer"
 
 #. IDS_FILTER_ERROR_INVALID_REGULAR_EXPRESSION
-#: Merge.rc:5742
+#: Merge.rc:5743
 msgid "Invalid regular expression"
 msgstr "Geçersiz düzenli ifade"
 
 #. IDS_FILTER_ERROR_UNDEFINED_IDENTIFIER
-#: Merge.rc:5743
+#: Merge.rc:5744
 msgid "Undefined identifier"
 msgstr "Tanımsız tanımlayıcı"
 
 #. IDS_FILTER_ERROR_INVALID_ARGUMENT_COUNT
-#: Merge.rc:5744
+#: Merge.rc:5745
 msgid "Invalid number of arguments"
 msgstr "Geçersiz değişken sayısı"
 
 #. IDS_FILTER_ERROR_FILTER_NAME_NOT_FOUND
-#: Merge.rc:5745
+#: Merge.rc:5746
 msgid "Filter name not found"
 msgstr "Filtre adı bulunamadı"
 
 #. IDS_FILTER_ERROR_DIVIDE_BY_ZERO
-#: Merge.rc:5746
+#: Merge.rc:5747
 msgid "Division by zero in filter expression"
 msgstr "Filtre ifadesinde sıfıra bölme işlemi"
 
 #. IDS_FILTER_ERROR_UNKNOWN_ERROR
-#: Merge.rc:5747
+#: Merge.rc:5748
 msgid "Unknown error"
 msgstr "Bilinmeyen hata"
 
 #. IDS_FILTER_ERROR_INVALID_PROPERTY_NAME
-#: Merge.rc:5748
+#: Merge.rc:5749
 msgid "Invalid property name"
 msgstr "Geçersiz özellik adı"
 
 #. IDS_FILTER_ERROR_INVALID_DIRECTIVE
-#: Merge.rc:5749
+#: Merge.rc:5750
 msgid "Invalid directive"
 msgstr "Geçersiz yönerge"
 
 #. IDS_FILTER_OP_EQUALS
-#: Merge.rc:5754
+#: Merge.rc:5755
 msgid "Equals"
 msgstr "Eşittir"
 
 #. IDS_FILTER_OP_NOT_EQUALS
-#: Merge.rc:5755
+#: Merge.rc:5756
 msgid "Does not equal"
 msgstr "Eşit değil"
 
 #. IDS_FILTER_OP_LESS_THAN
-#: Merge.rc:5756
+#: Merge.rc:5757
 msgid "Less than"
 msgstr "Daha az"
 
 #. IDS_FILTER_OP_LESS_EQUAL
-#: Merge.rc:5757
+#: Merge.rc:5758
 msgid "Less than or equal to"
 msgstr "Küçük veya eşit"
 
 #. IDS_FILTER_OP_GREATER_EQUAL
-#: Merge.rc:5758
+#: Merge.rc:5759
 msgid "Greater than or equal to"
 msgstr "Büyük veya eşit"
 
 #. IDS_FILTER_OP_GREATER_THAN
-#: Merge.rc:5759
+#: Merge.rc:5760
 msgid "Greater than"
 msgstr "Daha büyük"
 
 #. IDS_FILTER_OP_BETWEEN
-#: Merge.rc:5760
+#: Merge.rc:5761
 msgid "Between"
 msgstr "Arasında"
 
 #. IDS_FILTER_OP_NOT_BETWEEN
-#: Merge.rc:5761
+#: Merge.rc:5762
 msgid "Not Between"
 msgstr "Arasında değil"
 
 #. IDS_FILTER_OP_CONTAINS
-#: Merge.rc:5762
+#: Merge.rc:5763
 msgid "Contains"
 msgstr "İçerir"
 
 #. IDS_FILTER_OP_NOT_CONTAINS
-#: Merge.rc:5763
+#: Merge.rc:5764
 msgid "Not Contains"
 msgstr "İçermez"
 
 #. IDS_FILTER_OP_RECONTAINS
-#: Merge.rc:5764
+#: Merge.rc:5765
 msgid "Contains (regex)"
 msgstr "İçerir (regex)"
 
 #. IDS_FILTER_OP_NOT_RECONTAINS
-#: Merge.rc:5765
+#: Merge.rc:5766
 msgid "Not Contains (regex)"
 msgstr "İçermez (regex)"
 
 #. IDS_FILTER_OP_LIKE
-#: Merge.rc:5766
+#: Merge.rc:5767
 msgid "Match (wildcard)"
 msgstr "Eşleştir (joker karakter)"
 
 #. IDS_FILTER_OP_NOT_LIKE
-#: Merge.rc:5767
+#: Merge.rc:5768
 msgid "Not match (wildcard)"
 msgstr "Eşleşmez (joker karakter)"
 
 #. IDS_FILTER_OP_MATCHES
-#: Merge.rc:5768
+#: Merge.rc:5769
 msgid "Match (regex)"
 msgstr "Eşleştir (regex)"
 
 #. IDS_FILTER_OP_NOT_MATCHES
-#: Merge.rc:5769
+#: Merge.rc:5770
 msgid "Not match (regex)"
 msgstr "Eşleşmez (regex)"
 
 #. IDS_COLORMODE_LIGHT
-#: Merge.rc:5774
+#: Merge.rc:5775
 msgid "Light"
 msgstr "Aydınlık"
 
 #. IDS_COLORMODE_DARK
-#: Merge.rc:5775
+#: Merge.rc:5776
 msgid "Dark"
 msgstr "Karanlık"
 
 #. IDS_COLORMODE_FOLLOWSYSTEM
-#: Merge.rc:5776
+#: Merge.rc:5777
 msgid "Follow system"
 msgstr "Sistem ayarını seç"
 
 #. IDS_EXAMPLE
-#: Merge.rc:5781
+#: Merge.rc:5782
 #, c-format
 msgid "e.g. %1"
 msgstr "örn. %1"
 
 #. IDS_DETECTED_PREVIOUS_CRASH
-#: Merge.rc:5786
+#: Merge.rc:5787
 msgid "WinMerge detected a previous crash. Please report this if possible."
 msgstr "WinMerge, önceki bir çökme tespit etti. Mümkünse lütfen bunu bildirin."
 
 #. IDS_REGEX_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5791
+#: Merge.rc:5792
 msgid ""
 "# Regex replacement list\r\n"
 "# Format: regex<TAB>replacement\r\n"
@@ -8894,7 +8899,7 @@ msgstr ""
 "(\\d{4})-(\\d{2})-(\\d{2})\t$1_$2_$3\r\n"
 
 #. IDS_STRING_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5792
+#: Merge.rc:5793
 msgid ""
 "# Replacement list\r\n"
 "# Format: search<TAB>replacement\r\n"
@@ -8911,22 +8916,22 @@ msgstr ""
 "from2\tto2\r\n"
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_ONLY
-#: Merge.rc:5797
+#: Merge.rc:5798
 msgid "Built-in only"
 msgstr "Yalnızca yerleşik"
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_FIRST
-#: Merge.rc:5798
+#: Merge.rc:5799
 msgid "Built-in first"
 msgstr "Önce yerleşik olanlar"
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_FIRST
-#: Merge.rc:5799
+#: Merge.rc:5800
 msgid "Tree-sitter first"
 msgstr "Önce Tree-sitter"
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_ONLY
-#: Merge.rc:5800
+#: Merge.rc:5801
 msgid "Tree-sitter only"
 msgstr "Yalnızca Tree-sitter"
 

--- a/Translations/WinMerge/Ukrainian.po
+++ b/Translations/WinMerge/Ukrainian.po
@@ -23,7 +23,7 @@ msgstr ""
 "X-Generator: Poedit 3.8\n"
 
 #. LANGUAGE, SUBLANGUAGE
-#: Merge.rc:26 Merge.rc:59 Merge.rc:5817
+#: Merge.rc:26 Merge.rc:59 Merge.rc:5818
 msgid "LANG_ENGLISH, SUBLANG_ENGLISH_US"
 msgstr "LANG_UKRAINIAN, SUBLANG_DEFAULT"
 
@@ -230,7 +230,7 @@ msgid "Auto-Fit All Columns"
 msgstr "Автоширина стовпців"
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN
-#: Merge.rc:153 Merge.rc:5645
+#: Merge.rc:153 Merge.rc:5646
 msgid "&Filter by This Column"
 msgstr ""
 
@@ -291,7 +291,7 @@ msgid "&Previous Page"
 msgstr "&Попередня сторінка"
 
 #. IDS_PREVIEWBAR_NEXTPAGE
-#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5678
+#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5679
 msgid "&Next Page"
 msgstr "&Наступна сторінка"
 
@@ -664,7 +664,7 @@ msgid "&Huge"
 msgstr "&Величезні"
 
 #. IDS_VIEW_MENU_BAR
-#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5713
+#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5714
 msgid "Men&u Bar"
 msgstr "Рядок м&еню"
 
@@ -4189,7 +4189,7 @@ msgid "Items compared:"
 msgstr "Порівняно елементів:"
 
 #. IDS_PREVIEWBAR_CLOSE
-#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5684
+#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5685
 msgid "&Close"
 msgstr "&Закрити"
 
@@ -8376,30 +8376,35 @@ msgstr "1-й та 3-й"
 msgid "2nd and 3rd"
 msgstr "2-й та 3-й"
 
+#. IDS_PLUGIN_CTRL_CLICK
+#: Merge.rc:5635
+msgid "(Ctrl+Click to add to pipeline)"
+msgstr ""
+
 #. IDS_FILTER_APPLIED
-#: Merge.rc:5639
+#: Merge.rc:5640
 msgid "Filter applied"
 msgstr "Застосован Фільтр"
 
 #. IDS_FILTERMENU_COMPARE
-#: Merge.rc:5644
+#: Merge.rc:5645
 #, c-format
 msgid "Compare %1"
 msgstr "Порівняти %1"
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN2
-#: Merge.rc:5646
+#: Merge.rc:5647
 msgid "&Filter by This Column..."
 msgstr ""
 
 #. IDS_CLIPBOARDHISTORY_TIME
-#: Merge.rc:5651
+#: Merge.rc:5652
 #, c-format
 msgid "Clipboard at %s"
 msgstr "Буфера обміну в %s"
 
 #. IDS_CLIPBOARDHISTORY_DISABLED
-#: Merge.rc:5652
+#: Merge.rc:5653
 msgid ""
 "Clipboard history disabled.\r\n"
 "Enable: Windows logo key + V, then Turn on."
@@ -8407,115 +8412,115 @@ msgstr ""
 "Історію буфера обміну вимкнено.\r\n"
 "Увімкнути: Win + V, потім увімкнути."
 
-#: Merge.rc:5654
+#: Merge.rc:5655
 msgid "This system does not support clipboard history."
 msgstr "Ця сисмтема не підтримує історію буфера обміну."
 
-#: Merge.rc:5656
+#: Merge.rc:5657
 msgid "32-bit WinMerge does not support Clipboard Compare"
 msgstr "32-бітна версія WinMerge не підтримує порівняння з буфера обміну"
 
 #. IDS_WEBVIEW2_RUNTIME_NOT_INSTALLED
-#: Merge.rc:5661
+#: Merge.rc:5662
 msgid "WebView2 runtime not installed. Download it?"
 msgstr "Середовище виконання WebView2 не встановлено. Завантажити?"
 
 #. IDS_JUMPLIST_NEW_TEXT_COMPARE
-#: Merge.rc:5666
+#: Merge.rc:5667
 msgid "New Text Compare"
 msgstr "Нове порівняння тексту"
 
 #. IDS_JUMPLIST_NEW_TABLE_COMPARE
-#: Merge.rc:5667
+#: Merge.rc:5668
 msgid "New Table Compare"
 msgstr "Нове порівняння таблиць"
 
 #. IDS_JUMPLIST_NEW_BINARY_COMPARE
-#: Merge.rc:5668
+#: Merge.rc:5669
 msgid "New Binary Compare"
 msgstr "Нове двійкове порівняння"
 
 #. IDS_JUMPLIST_NEW_IMAGE_COMPARE
-#: Merge.rc:5669
+#: Merge.rc:5670
 msgid "New Image Compare"
 msgstr "Нове порівняння зображень"
 
 #. IDS_JUMPLIST_NEW_WEBPAGE_COMPARE
-#: Merge.rc:5670
+#: Merge.rc:5671
 msgid "New Webpage Compare"
 msgstr "Нове порівняння вебсторінки"
 
 #. IDS_JUMPLIST_NEW_FOLDER_COMPARE
-#: Merge.rc:5671
+#: Merge.rc:5672
 msgid "New Folder Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_CLIPBOARD_COMPARE
-#: Merge.rc:5672
+#: Merge.rc:5673
 msgid "Clipboard Compare"
 msgstr "Порівняння буфера обміну"
 
 #. IDS_PREVIEWBAR_PRINT
-#: Merge.rc:5677
+#: Merge.rc:5678
 msgid "&Print..."
 msgstr "&Друк..."
 
 #. IDS_PREVIEWBAR_PREVPAGE
-#: Merge.rc:5679
+#: Merge.rc:5680
 msgid "Pre&v Page"
 msgstr "Поп&ередня сторінка"
 
 #. IDS_PREVIEWBAR_TWOPAGE
-#: Merge.rc:5680
+#: Merge.rc:5681
 msgid "&Two Page"
 msgstr "&Дві сторінки"
 
 #. IDS_PREVIEWBAR_ONEPAGE
-#: Merge.rc:5681
+#: Merge.rc:5682
 msgid "&One Page"
 msgstr "&Одна сторінка"
 
 #. IDS_PREVIEWBAR_ZOOMIN
-#: Merge.rc:5682
+#: Merge.rc:5683
 msgid "Zoom &In"
 msgstr "Збільши&ти"
 
 #. IDS_PREVIEWBAR_ZOOMOUT
-#: Merge.rc:5683
+#: Merge.rc:5684
 msgid "Zoom &Out"
 msgstr "З&меншити масштаб"
 
 #. IDS_WEBPAGE_COMPARING
-#: Merge.rc:5689
+#: Merge.rc:5690
 msgid "Comparing..."
 msgstr "Порівняння..."
 
 #. IDS_WEBPAGE_ZOOM
-#: Merge.rc:5690
+#: Merge.rc:5691
 msgid "Zoom:"
 msgstr "Масштаб:"
 
 #. IDS_COPY_GRANULARITY_DIFFHUNK
-#: Merge.rc:5695
+#: Merge.rc:5696
 msgid "Diff hunk"
 msgstr "Блок відмінностей"
 
 #. IDS_COPY_GRANULARITY_INLINE
-#: Merge.rc:5696
+#: Merge.rc:5697
 msgid "Inline diff"
 msgstr "Відмінності у рядку"
 
 #. IDS_COPY_GRANULARITY_LINE
-#: Merge.rc:5697
+#: Merge.rc:5698
 msgid "Line"
 msgstr "Рядок"
 
-#: Merge.rc:5698
+#: Merge.rc:5699
 msgid "Character"
 msgstr "Символ"
 
 #. ID_MICE_PREVDIFF
-#: Merge.rc:5703
+#: Merge.rc:5704
 msgid ""
 "\n"
 "Previous Difference (Alt+Up)\n"
@@ -8528,7 +8533,7 @@ msgstr ""
 "(Alt+Wheel Up)"
 
 #. ID_MICE_NEXTDIFF
-#: Merge.rc:5704
+#: Merge.rc:5705
 msgid ""
 "\n"
 "Next Difference (Alt+Down)\n"
@@ -8540,7 +8545,7 @@ msgstr ""
 "(Alt+Wheel Down)"
 
 #. ID_MICE_L2R
-#: Merge.rc:5705
+#: Merge.rc:5706
 msgid ""
 "\n"
 "Copy to Right (Alt+Right)\n"
@@ -8555,7 +8560,7 @@ msgstr ""
 "(Alt+Shift+Wheel Down)"
 
 #. ID_MICE_R2L
-#: Merge.rc:5706
+#: Merge.rc:5707
 msgid ""
 "\n"
 "Copy to Left (Alt+Left)\n"
@@ -8570,7 +8575,7 @@ msgstr ""
 "(Alt+Shift+Wheel Up)"
 
 #. ID_MICE_L2RNEXT
-#: Merge.rc:5707
+#: Merge.rc:5708
 msgid ""
 "\n"
 "Copy to Right and Advance (Ctrl+Alt+Right)\n"
@@ -8583,7 +8588,7 @@ msgstr ""
 "(Ctrl+Alt+Shift+Wheel Down)"
 
 #. ID_MICE_R2LNEXT
-#: Merge.rc:5708
+#: Merge.rc:5709
 msgid ""
 "\n"
 "Copy to Left and Advance (Ctrl+Alt+Left)\n"
@@ -8596,282 +8601,282 @@ msgstr ""
 "(Ctrl+Alt+Shift+Wheel Up)"
 
 #. IDS_LOG_COMPARING_2
-#: Merge.rc:5718
+#: Merge.rc:5719
 #, c-format
 msgid "Comparing %1 with %2"
 msgstr "Порівняння  %1 з %2"
 
 #. IDS_LOG_COMPARING_3
-#: Merge.rc:5719
+#: Merge.rc:5720
 #, c-format
 msgid "Comparing %1 with %2 and %3"
 msgstr "Порівняння  %1 з %2 та %3"
 
 #. IDS_LOG_COMPARE_COMPLETED
-#: Merge.rc:5720
+#: Merge.rc:5721
 msgid "Comparison completed"
 msgstr "Порівняння завершено"
 
 #. IDS_LOG_COMPARE_ERROR_2
-#: Merge.rc:5721
+#: Merge.rc:5722
 #, c-format
 msgid "Failed to compare %1 with %2: "
 msgstr "Не вдалося порівняти %1 із %2: "
 
 #. IDS_LOG_COMPARE_ERROR_3
-#: Merge.rc:5722
+#: Merge.rc:5723
 #, c-format
 msgid "Failed to compare %1 with %2 and %3: "
 msgstr "Не вдалося порівняти %1 із %2 та %3: "
 
 #. IDS_LOG_FILE_SAVED
-#: Merge.rc:5723
+#: Merge.rc:5724
 msgid "File saved"
 msgstr "Файл збережено"
 
 #. IDS_LOG_COPYING_FILES
-#: Merge.rc:5724
+#: Merge.rc:5725
 msgid "Copying files..."
 msgstr "Копіювання файлів..."
 
 #. IDS_LOG_MOVING_FILES
-#: Merge.rc:5725
+#: Merge.rc:5726
 msgid "Moving files..."
 msgstr "Переміщення файлів..."
 
 #. IDS_LOG_DELETING_FILES
-#: Merge.rc:5726
+#: Merge.rc:5727
 msgid "Deleting files..."
 msgstr "Видалення файлів..."
 
 #. IDS_LOG_RECYCLEBIN
-#: Merge.rc:5727
+#: Merge.rc:5728
 msgid "Recycle Bin"
 msgstr "Кошик"
 
 #. IDS_LOG_PERMANENTLY_DELETED
-#: Merge.rc:5728
+#: Merge.rc:5729
 msgid "Permanently deleted"
 msgstr "Видалено остаточно"
 
 #. IDS_LOG_FILEOPERATION_COMPLETED
-#: Merge.rc:5729
+#: Merge.rc:5730
 msgid "File operation completed successfully"
 msgstr "Операція над файлами виконана успішно"
 
 #. IDS_LOG_FILEOPERATION_CANCELED
-#: Merge.rc:5730
+#: Merge.rc:5731
 msgid "File operation canceled"
 msgstr "Операція над файлами скасована"
 
 #. IDS_FILTER_ERROR_NO_ERROR
-#: Merge.rc:5735
+#: Merge.rc:5736
 msgid "No error"
 msgstr "Без помилок"
 
 #. IDS_FILTER_ERROR_EMPTY_EXPRESSION
-#: Merge.rc:5736
+#: Merge.rc:5737
 msgid "Filter expression is empty"
 msgstr "Вираз фільтра порожній"
 
 #. IDS_FILTER_ERROR_UNKNOWN_CHAR
-#: Merge.rc:5737
+#: Merge.rc:5738
 msgid "Unknown character in filter expression"
 msgstr "Невідомий символ у виразі фільтра"
 
 #. IDS_FILTER_ERROR_UNTERMINATED_STRING
-#: Merge.rc:5738
+#: Merge.rc:5739
 msgid "Unterminated string literal"
 msgstr "Незавершений рядковий літерал"
 
 #. IDS_FILTER_ERROR_SYNTAX_ERROR
-#: Merge.rc:5739
+#: Merge.rc:5740
 msgid "Syntax error in filter expression"
 msgstr "Синтаксична помилка у виразі фільтра"
 
 #. IDS_FILTER_ERROR_PARSE_FAILURE
-#: Merge.rc:5740
+#: Merge.rc:5741
 msgid "Failed to parse filter expression"
 msgstr "Не вдалося розібрати вираз фільтра"
 
 #. IDS_FILTER_ERROR_INVALID_LITERAL
-#: Merge.rc:5741
+#: Merge.rc:5742
 msgid "Invalid literal value"
 msgstr "Неприпустиме значення літерала"
 
 #. IDS_FILTER_ERROR_INVALID_REGULAR_EXPRESSION
-#: Merge.rc:5742
+#: Merge.rc:5743
 msgid "Invalid regular expression"
 msgstr "Неприпустимий регулярний вираз"
 
 #. IDS_FILTER_ERROR_UNDEFINED_IDENTIFIER
-#: Merge.rc:5743
+#: Merge.rc:5744
 msgid "Undefined identifier"
 msgstr "Невизначений ідентифікатор"
 
 #. IDS_FILTER_ERROR_INVALID_ARGUMENT_COUNT
-#: Merge.rc:5744
+#: Merge.rc:5745
 msgid "Invalid number of arguments"
 msgstr "Невірна кількість аргументів"
 
 #. IDS_FILTER_ERROR_FILTER_NAME_NOT_FOUND
-#: Merge.rc:5745
+#: Merge.rc:5746
 msgid "Filter name not found"
 msgstr "Ім'я фільтра не знайдено"
 
 #. IDS_FILTER_ERROR_DIVIDE_BY_ZERO
-#: Merge.rc:5746
+#: Merge.rc:5747
 msgid "Division by zero in filter expression"
 msgstr "Ділення на нуль у виразі фільтра"
 
 #. IDS_FILTER_ERROR_UNKNOWN_ERROR
-#: Merge.rc:5747
+#: Merge.rc:5748
 msgid "Unknown error"
 msgstr "Невідома помилка"
 
 #. IDS_FILTER_ERROR_INVALID_PROPERTY_NAME
-#: Merge.rc:5748
+#: Merge.rc:5749
 msgid "Invalid property name"
 msgstr "Неприпустимиа назва властивості"
 
 #. IDS_FILTER_ERROR_INVALID_DIRECTIVE
-#: Merge.rc:5749
+#: Merge.rc:5750
 msgid "Invalid directive"
 msgstr ""
 
 #. IDS_FILTER_OP_EQUALS
-#: Merge.rc:5754
+#: Merge.rc:5755
 msgid "Equals"
 msgstr "Дорівнює"
 
 #. IDS_FILTER_OP_NOT_EQUALS
-#: Merge.rc:5755
+#: Merge.rc:5756
 msgid "Does not equal"
 msgstr "Не дорівнює"
 
 #. IDS_FILTER_OP_LESS_THAN
-#: Merge.rc:5756
+#: Merge.rc:5757
 msgid "Less than"
 msgstr "Менше ніж"
 
 #. IDS_FILTER_OP_LESS_EQUAL
-#: Merge.rc:5757
+#: Merge.rc:5758
 msgid "Less than or equal to"
 msgstr "Менше або дорівнює"
 
 #. IDS_FILTER_OP_GREATER_EQUAL
-#: Merge.rc:5758
+#: Merge.rc:5759
 msgid "Greater than or equal to"
 msgstr "Більше або дорівнює"
 
 #. IDS_FILTER_OP_GREATER_THAN
-#: Merge.rc:5759
+#: Merge.rc:5760
 msgid "Greater than"
 msgstr "Більше ніж"
 
 #. IDS_FILTER_OP_BETWEEN
-#: Merge.rc:5760
+#: Merge.rc:5761
 msgid "Between"
 msgstr "В межах"
 
 #. IDS_FILTER_OP_NOT_BETWEEN
-#: Merge.rc:5761
+#: Merge.rc:5762
 msgid "Not Between"
 msgstr "Не в межах"
 
 #. IDS_FILTER_OP_CONTAINS
-#: Merge.rc:5762
+#: Merge.rc:5763
 msgid "Contains"
 msgstr "Містить"
 
 #. IDS_FILTER_OP_NOT_CONTAINS
-#: Merge.rc:5763
+#: Merge.rc:5764
 msgid "Not Contains"
 msgstr "Не містить"
 
 #. IDS_FILTER_OP_RECONTAINS
-#: Merge.rc:5764
+#: Merge.rc:5765
 msgid "Contains (regex)"
 msgstr "Містить (регулярний вираз)"
 
 #. IDS_FILTER_OP_NOT_RECONTAINS
-#: Merge.rc:5765
+#: Merge.rc:5766
 msgid "Not Contains (regex)"
 msgstr "Не містить (регулярний вираз)"
 
 #. IDS_FILTER_OP_LIKE
-#: Merge.rc:5766
+#: Merge.rc:5767
 msgid "Match (wildcard)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_LIKE
-#: Merge.rc:5767
+#: Merge.rc:5768
 msgid "Not match (wildcard)"
 msgstr ""
 
 #. IDS_FILTER_OP_MATCHES
-#: Merge.rc:5768
+#: Merge.rc:5769
 msgid "Match (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_MATCHES
-#: Merge.rc:5769
+#: Merge.rc:5770
 msgid "Not match (regex)"
 msgstr ""
 
 #. IDS_COLORMODE_LIGHT
-#: Merge.rc:5774
+#: Merge.rc:5775
 msgid "Light"
 msgstr "Світла"
 
 #. IDS_COLORMODE_DARK
-#: Merge.rc:5775
+#: Merge.rc:5776
 msgid "Dark"
 msgstr "Темна"
 
 #. IDS_COLORMODE_FOLLOWSYSTEM
-#: Merge.rc:5776
+#: Merge.rc:5777
 msgid "Follow system"
 msgstr "Як в системі"
 
 #. IDS_EXAMPLE
-#: Merge.rc:5781
+#: Merge.rc:5782
 #, c-format
 msgid "e.g. %1"
 msgstr ""
 
 #. IDS_DETECTED_PREVIOUS_CRASH
-#: Merge.rc:5786
+#: Merge.rc:5787
 msgid "WinMerge detected a previous crash. Please report this if possible."
 msgstr ""
 
 #. IDS_REGEX_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5791
+#: Merge.rc:5792
 msgid "# Regex replacement list\r\n# Format: regex<TAB>replacement\r\n# Backreferences like $1, $2 are supported\r\n\r\n(\\d{4})-(\\d{2})-(\\d{2})\t$1_$2_$3\r\n"
 msgstr ""
 
 #. IDS_STRING_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5792
+#: Merge.rc:5793
 msgid "# Replacement list\r\n# Format: search<TAB>replacement\r\n# Lines starting with # are ignored\r\n\r\nfrom1\tto1\r\nfrom2\tto2\r\n"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_ONLY
-#: Merge.rc:5797
+#: Merge.rc:5798
 msgid "Built-in only"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_FIRST
-#: Merge.rc:5798
+#: Merge.rc:5799
 msgid "Built-in first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_FIRST
-#: Merge.rc:5799
+#: Merge.rc:5800
 msgid "Tree-sitter first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_ONLY
-#: Merge.rc:5800
+#: Merge.rc:5801
 msgid "Tree-sitter only"
 msgstr ""
 

--- a/Translations/WinMerge/Vietnamese.po
+++ b/Translations/WinMerge/Vietnamese.po
@@ -23,7 +23,7 @@ msgstr ""
 "X-Source-Language: en\n"
 
 #. LANGUAGE, SUBLANGUAGE
-#: Merge.rc:26 Merge.rc:59 Merge.rc:5817
+#: Merge.rc:26 Merge.rc:59 Merge.rc:5818
 msgid "LANG_ENGLISH, SUBLANG_ENGLISH_US"
 msgstr "LANG_VIETNAMESE, SUBLANG_DEFAULT"
 
@@ -230,7 +230,7 @@ msgid "Auto-Fit All Columns"
 msgstr "Tự động khớp tất cả các cột"
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN
-#: Merge.rc:153 Merge.rc:5645
+#: Merge.rc:153 Merge.rc:5646
 msgid "&Filter by This Column"
 msgstr ""
 
@@ -291,7 +291,7 @@ msgid "&Previous Page"
 msgstr "Trang &trước"
 
 #. IDS_PREVIEWBAR_NEXTPAGE
-#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5678
+#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5679
 msgid "&Next Page"
 msgstr "Trang &sau"
 
@@ -664,7 +664,7 @@ msgid "&Huge"
 msgstr "&Khổng lồ"
 
 #. IDS_VIEW_MENU_BAR
-#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5713
+#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5714
 msgid "Men&u Bar"
 msgstr "Thanh &bảng chọn"
 
@@ -4197,7 +4197,7 @@ msgid "Items compared:"
 msgstr "Mục đã so sánh:"
 
 #. IDS_PREVIEWBAR_CLOSE
-#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5684
+#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5685
 msgid "&Close"
 msgstr "&Đóng"
 
@@ -8400,30 +8400,35 @@ msgstr "Thứ nhất và thứ 3"
 msgid "2nd and 3rd"
 msgstr "Thứ 2 và thứ 3"
 
+#. IDS_PLUGIN_CTRL_CLICK
+#: Merge.rc:5635
+msgid "(Ctrl+Click to add to pipeline)"
+msgstr ""
+
 #. IDS_FILTER_APPLIED
-#: Merge.rc:5639
+#: Merge.rc:5640
 msgid "Filter applied"
 msgstr "Đã áp dụng bộ lọc"
 
 #. IDS_FILTERMENU_COMPARE
-#: Merge.rc:5644
+#: Merge.rc:5645
 #, c-format
 msgid "Compare %1"
 msgstr "So sánh %1"
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN2
-#: Merge.rc:5646
+#: Merge.rc:5647
 msgid "&Filter by This Column..."
 msgstr ""
 
 #. IDS_CLIPBOARDHISTORY_TIME
-#: Merge.rc:5651
+#: Merge.rc:5652
 #, c-format
 msgid "Clipboard at %s"
 msgstr "Bảng tạm lúc %s"
 
 #. IDS_CLIPBOARDHISTORY_DISABLED
-#: Merge.rc:5652
+#: Merge.rc:5653
 msgid ""
 "Clipboard history disabled.\r\n"
 "Enable: Windows logo key + V, then Turn on."
@@ -8431,115 +8436,115 @@ msgstr ""
 "Lịch sử bảng tạm đã bị tắt.\r\n"
 "Bật: Phím Windows + V, sau đó chọn Bật (Turn on)."
 
-#: Merge.rc:5654
+#: Merge.rc:5655
 msgid "This system does not support clipboard history."
 msgstr "Hệ thống này không hỗ trợ lịch sử bảng tạm."
 
-#: Merge.rc:5656
+#: Merge.rc:5657
 msgid "32-bit WinMerge does not support Clipboard Compare"
 msgstr "WinMerge phiên bản 32-bit không hỗ trợ So sánh bảng tạm"
 
 #. IDS_WEBVIEW2_RUNTIME_NOT_INSTALLED
-#: Merge.rc:5661
+#: Merge.rc:5662
 msgid "WebView2 runtime not installed. Download it?"
 msgstr "Chưa cài đặt thời gian chạy (runtime) WebView2. Có tải xuống không?"
 
 #. IDS_JUMPLIST_NEW_TEXT_COMPARE
-#: Merge.rc:5666
+#: Merge.rc:5667
 msgid "New Text Compare"
 msgstr "So sánh văn bản mới"
 
 #. IDS_JUMPLIST_NEW_TABLE_COMPARE
-#: Merge.rc:5667
+#: Merge.rc:5668
 msgid "New Table Compare"
 msgstr "So sánh bảng mới"
 
 #. IDS_JUMPLIST_NEW_BINARY_COMPARE
-#: Merge.rc:5668
+#: Merge.rc:5669
 msgid "New Binary Compare"
 msgstr "So sánh nhị phân mới"
 
 #. IDS_JUMPLIST_NEW_IMAGE_COMPARE
-#: Merge.rc:5669
+#: Merge.rc:5670
 msgid "New Image Compare"
 msgstr "So sánh hình ảnh mới"
 
 #. IDS_JUMPLIST_NEW_WEBPAGE_COMPARE
-#: Merge.rc:5670
+#: Merge.rc:5671
 msgid "New Webpage Compare"
 msgstr "So sánh trang web mới"
 
 #. IDS_JUMPLIST_NEW_FOLDER_COMPARE
-#: Merge.rc:5671
+#: Merge.rc:5672
 msgid "New Folder Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_CLIPBOARD_COMPARE
-#: Merge.rc:5672
+#: Merge.rc:5673
 msgid "Clipboard Compare"
 msgstr "So sánh bảng tạm"
 
 #. IDS_PREVIEWBAR_PRINT
-#: Merge.rc:5677
+#: Merge.rc:5678
 msgid "&Print..."
 msgstr "In..."
 
 #. IDS_PREVIEWBAR_PREVPAGE
-#: Merge.rc:5679
+#: Merge.rc:5680
 msgid "Pre&v Page"
 msgstr "Trang trước"
 
 #. IDS_PREVIEWBAR_TWOPAGE
-#: Merge.rc:5680
+#: Merge.rc:5681
 msgid "&Two Page"
 msgstr "Hai trang"
 
 #. IDS_PREVIEWBAR_ONEPAGE
-#: Merge.rc:5681
+#: Merge.rc:5682
 msgid "&One Page"
 msgstr "Một trang"
 
 #. IDS_PREVIEWBAR_ZOOMIN
-#: Merge.rc:5682
+#: Merge.rc:5683
 msgid "Zoom &In"
 msgstr "Phóng to"
 
 #. IDS_PREVIEWBAR_ZOOMOUT
-#: Merge.rc:5683
+#: Merge.rc:5684
 msgid "Zoom &Out"
 msgstr "Thu nhỏ"
 
 #. IDS_WEBPAGE_COMPARING
-#: Merge.rc:5689
+#: Merge.rc:5690
 msgid "Comparing..."
 msgstr "Đang so sánh..."
 
 #. IDS_WEBPAGE_ZOOM
-#: Merge.rc:5690
+#: Merge.rc:5691
 msgid "Zoom:"
 msgstr "Thu phóng:"
 
 #. IDS_COPY_GRANULARITY_DIFFHUNK
-#: Merge.rc:5695
+#: Merge.rc:5696
 msgid "Diff hunk"
 msgstr "Khối khác biệt"
 
 #. IDS_COPY_GRANULARITY_INLINE
-#: Merge.rc:5696
+#: Merge.rc:5697
 msgid "Inline diff"
 msgstr "Khác biệt trên dòng"
 
 #. IDS_COPY_GRANULARITY_LINE
-#: Merge.rc:5697
+#: Merge.rc:5698
 msgid "Line"
 msgstr "Dòng"
 
-#: Merge.rc:5698
+#: Merge.rc:5699
 msgid "Character"
 msgstr "Kí tự"
 
 #. ID_MICE_PREVDIFF
-#: Merge.rc:5703
+#: Merge.rc:5704
 msgid ""
 "\n"
 "Previous Difference (Alt+Up)\n"
@@ -8552,7 +8557,7 @@ msgstr ""
 "(Alt+Cuộn lên)"
 
 #. ID_MICE_NEXTDIFF
-#: Merge.rc:5704
+#: Merge.rc:5705
 msgid ""
 "\n"
 "Next Difference (Alt+Down)\n"
@@ -8565,7 +8570,7 @@ msgstr ""
 "(Alt+Cuộn xuống)"
 
 #. ID_MICE_L2R
-#: Merge.rc:5705
+#: Merge.rc:5706
 msgid ""
 "\n"
 "Copy to Right (Alt+Right)\n"
@@ -8580,7 +8585,7 @@ msgstr ""
 "(Alt+Shift+Cuộn xuống)"
 
 #. ID_MICE_R2L
-#: Merge.rc:5706
+#: Merge.rc:5707
 msgid ""
 "\n"
 "Copy to Left (Alt+Left)\n"
@@ -8595,7 +8600,7 @@ msgstr ""
 "(Alt+Shift+Cuộn lên)"
 
 #. ID_MICE_L2RNEXT
-#: Merge.rc:5707
+#: Merge.rc:5708
 msgid ""
 "\n"
 "Copy to Right and Advance (Ctrl+Alt+Right)\n"
@@ -8608,7 +8613,7 @@ msgstr ""
 "(Ctrl+Alt+Shift+Cuộn xuống)"
 
 #. ID_MICE_R2LNEXT
-#: Merge.rc:5708
+#: Merge.rc:5709
 msgid ""
 "\n"
 "Copy to Left and Advance (Ctrl+Alt+Left)\n"
@@ -8621,282 +8626,282 @@ msgstr ""
 "(Ctrl+Alt+Shift+Cuộn lên)"
 
 #. IDS_LOG_COMPARING_2
-#: Merge.rc:5718
+#: Merge.rc:5719
 #, c-format
 msgid "Comparing %1 with %2"
 msgstr "Đang so sánh %1 với %2"
 
 #. IDS_LOG_COMPARING_3
-#: Merge.rc:5719
+#: Merge.rc:5720
 #, c-format
 msgid "Comparing %1 with %2 and %3"
 msgstr "Đang so sánh %1 với %2 và %3"
 
 #. IDS_LOG_COMPARE_COMPLETED
-#: Merge.rc:5720
+#: Merge.rc:5721
 msgid "Comparison completed"
 msgstr "So sánh hoàn tất"
 
 #. IDS_LOG_COMPARE_ERROR_2
-#: Merge.rc:5721
+#: Merge.rc:5722
 #, c-format
 msgid "Failed to compare %1 with %2: "
 msgstr "Không thể so sánh %1 với %2: "
 
 #. IDS_LOG_COMPARE_ERROR_3
-#: Merge.rc:5722
+#: Merge.rc:5723
 #, c-format
 msgid "Failed to compare %1 with %2 and %3: "
 msgstr "Không thể so sánh %1 với %2 và %3: "
 
 #. IDS_LOG_FILE_SAVED
-#: Merge.rc:5723
+#: Merge.rc:5724
 msgid "File saved"
 msgstr "Tệp đã được lưu"
 
 #. IDS_LOG_COPYING_FILES
-#: Merge.rc:5724
+#: Merge.rc:5725
 msgid "Copying files..."
 msgstr "Đang sao chép các tệp..."
 
 #. IDS_LOG_MOVING_FILES
-#: Merge.rc:5725
+#: Merge.rc:5726
 msgid "Moving files..."
 msgstr "Đang di chuyển các tệp..."
 
 #. IDS_LOG_DELETING_FILES
-#: Merge.rc:5726
+#: Merge.rc:5727
 msgid "Deleting files..."
 msgstr "Đang xoá các tệp..."
 
 #. IDS_LOG_RECYCLEBIN
-#: Merge.rc:5727
+#: Merge.rc:5728
 msgid "Recycle Bin"
 msgstr "Thùng rác"
 
 #. IDS_LOG_PERMANENTLY_DELETED
-#: Merge.rc:5728
+#: Merge.rc:5729
 msgid "Permanently deleted"
 msgstr "Đã xoá vĩnh viễn"
 
 #. IDS_LOG_FILEOPERATION_COMPLETED
-#: Merge.rc:5729
+#: Merge.rc:5730
 msgid "File operation completed successfully"
 msgstr "Thao tác tệp đã hoàn thành thành công"
 
 #. IDS_LOG_FILEOPERATION_CANCELED
-#: Merge.rc:5730
+#: Merge.rc:5731
 msgid "File operation canceled"
 msgstr "Thao tác tệp đã bị huỷ"
 
 #. IDS_FILTER_ERROR_NO_ERROR
-#: Merge.rc:5735
+#: Merge.rc:5736
 msgid "No error"
 msgstr "Không có lỗi"
 
 #. IDS_FILTER_ERROR_EMPTY_EXPRESSION
-#: Merge.rc:5736
+#: Merge.rc:5737
 msgid "Filter expression is empty"
 msgstr "Biểu thức bộ lọc trống"
 
 #. IDS_FILTER_ERROR_UNKNOWN_CHAR
-#: Merge.rc:5737
+#: Merge.rc:5738
 msgid "Unknown character in filter expression"
 msgstr "Kí tự không xác định trong biểu thức bộ lọc"
 
 #. IDS_FILTER_ERROR_UNTERMINATED_STRING
-#: Merge.rc:5738
+#: Merge.rc:5739
 msgid "Unterminated string literal"
 msgstr "Chuỗi văn bản chưa được kết thúc"
 
 #. IDS_FILTER_ERROR_SYNTAX_ERROR
-#: Merge.rc:5739
+#: Merge.rc:5740
 msgid "Syntax error in filter expression"
 msgstr "Lỗi cú pháp trong biểu thức bộ lọc"
 
 #. IDS_FILTER_ERROR_PARSE_FAILURE
-#: Merge.rc:5740
+#: Merge.rc:5741
 msgid "Failed to parse filter expression"
 msgstr "Không thể phân tích cú pháp biểu thức bộ lọc"
 
 #. IDS_FILTER_ERROR_INVALID_LITERAL
-#: Merge.rc:5741
+#: Merge.rc:5742
 msgid "Invalid literal value"
 msgstr "Giá trị hằng nguyên văn không hợp lệ"
 
 #. IDS_FILTER_ERROR_INVALID_REGULAR_EXPRESSION
-#: Merge.rc:5742
+#: Merge.rc:5743
 msgid "Invalid regular expression"
 msgstr "Biểu thức chính quy không hợp lệ"
 
 #. IDS_FILTER_ERROR_UNDEFINED_IDENTIFIER
-#: Merge.rc:5743
+#: Merge.rc:5744
 msgid "Undefined identifier"
 msgstr "Định danh chưa được định nghĩa"
 
 #. IDS_FILTER_ERROR_INVALID_ARGUMENT_COUNT
-#: Merge.rc:5744
+#: Merge.rc:5745
 msgid "Invalid number of arguments"
 msgstr "Số lượng đối số không hợp lệ"
 
 #. IDS_FILTER_ERROR_FILTER_NAME_NOT_FOUND
-#: Merge.rc:5745
+#: Merge.rc:5746
 msgid "Filter name not found"
 msgstr "Không tìm thấy tên bộ lọc"
 
 #. IDS_FILTER_ERROR_DIVIDE_BY_ZERO
-#: Merge.rc:5746
+#: Merge.rc:5747
 msgid "Division by zero in filter expression"
 msgstr "Lỗi chia cho số không trong biểu thức bộ lọc"
 
 #. IDS_FILTER_ERROR_UNKNOWN_ERROR
-#: Merge.rc:5747
+#: Merge.rc:5748
 msgid "Unknown error"
 msgstr "Lỗi không xác định"
 
 #. IDS_FILTER_ERROR_INVALID_PROPERTY_NAME
-#: Merge.rc:5748
+#: Merge.rc:5749
 msgid "Invalid property name"
 msgstr "Tên thuộc tính không hợp lệ"
 
 #. IDS_FILTER_ERROR_INVALID_DIRECTIVE
-#: Merge.rc:5749
+#: Merge.rc:5750
 msgid "Invalid directive"
 msgstr ""
 
 #. IDS_FILTER_OP_EQUALS
-#: Merge.rc:5754
+#: Merge.rc:5755
 msgid "Equals"
 msgstr "Bằng"
 
 #. IDS_FILTER_OP_NOT_EQUALS
-#: Merge.rc:5755
+#: Merge.rc:5756
 msgid "Does not equal"
 msgstr "Không bằng"
 
 #. IDS_FILTER_OP_LESS_THAN
-#: Merge.rc:5756
+#: Merge.rc:5757
 msgid "Less than"
 msgstr "Nhỏ hơn"
 
 #. IDS_FILTER_OP_LESS_EQUAL
-#: Merge.rc:5757
+#: Merge.rc:5758
 msgid "Less than or equal to"
 msgstr "Nhỏ hơn hoặc bằng"
 
 #. IDS_FILTER_OP_GREATER_EQUAL
-#: Merge.rc:5758
+#: Merge.rc:5759
 msgid "Greater than or equal to"
 msgstr "Lớn hơn hoặc bằng"
 
 #. IDS_FILTER_OP_GREATER_THAN
-#: Merge.rc:5759
+#: Merge.rc:5760
 msgid "Greater than"
 msgstr "Lớn hơn"
 
 #. IDS_FILTER_OP_BETWEEN
-#: Merge.rc:5760
+#: Merge.rc:5761
 msgid "Between"
 msgstr "Ở giữa"
 
 #. IDS_FILTER_OP_NOT_BETWEEN
-#: Merge.rc:5761
+#: Merge.rc:5762
 msgid "Not Between"
 msgstr "Không ở giữa"
 
 #. IDS_FILTER_OP_CONTAINS
-#: Merge.rc:5762
+#: Merge.rc:5763
 msgid "Contains"
 msgstr "Chứa"
 
 #. IDS_FILTER_OP_NOT_CONTAINS
-#: Merge.rc:5763
+#: Merge.rc:5764
 msgid "Not Contains"
 msgstr "Không chứa"
 
 #. IDS_FILTER_OP_RECONTAINS
-#: Merge.rc:5764
+#: Merge.rc:5765
 msgid "Contains (regex)"
 msgstr "Chứa (biểu thức chính quy)"
 
 #. IDS_FILTER_OP_NOT_RECONTAINS
-#: Merge.rc:5765
+#: Merge.rc:5766
 msgid "Not Contains (regex)"
 msgstr "Không chứa (biểu thức chính quy)"
 
 #. IDS_FILTER_OP_LIKE
-#: Merge.rc:5766
+#: Merge.rc:5767
 msgid "Match (wildcard)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_LIKE
-#: Merge.rc:5767
+#: Merge.rc:5768
 msgid "Not match (wildcard)"
 msgstr ""
 
 #. IDS_FILTER_OP_MATCHES
-#: Merge.rc:5768
+#: Merge.rc:5769
 msgid "Match (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_MATCHES
-#: Merge.rc:5769
+#: Merge.rc:5770
 msgid "Not match (regex)"
 msgstr ""
 
 #. IDS_COLORMODE_LIGHT
-#: Merge.rc:5774
+#: Merge.rc:5775
 msgid "Light"
 msgstr "Sáng"
 
 #. IDS_COLORMODE_DARK
-#: Merge.rc:5775
+#: Merge.rc:5776
 msgid "Dark"
 msgstr "Tối"
 
 #. IDS_COLORMODE_FOLLOWSYSTEM
-#: Merge.rc:5776
+#: Merge.rc:5777
 msgid "Follow system"
 msgstr "Theo hệ thống"
 
 #. IDS_EXAMPLE
-#: Merge.rc:5781
+#: Merge.rc:5782
 #, c-format
 msgid "e.g. %1"
 msgstr ""
 
 #. IDS_DETECTED_PREVIOUS_CRASH
-#: Merge.rc:5786
+#: Merge.rc:5787
 msgid "WinMerge detected a previous crash. Please report this if possible."
 msgstr ""
 
 #. IDS_REGEX_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5791
+#: Merge.rc:5792
 msgid "# Regex replacement list\r\n# Format: regex<TAB>replacement\r\n# Backreferences like $1, $2 are supported\r\n\r\n(\\d{4})-(\\d{2})-(\\d{2})\t$1_$2_$3\r\n"
 msgstr ""
 
 #. IDS_STRING_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5792
+#: Merge.rc:5793
 msgid "# Replacement list\r\n# Format: search<TAB>replacement\r\n# Lines starting with # are ignored\r\n\r\nfrom1\tto1\r\nfrom2\tto2\r\n"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_ONLY
-#: Merge.rc:5797
+#: Merge.rc:5798
 msgid "Built-in only"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_FIRST
-#: Merge.rc:5798
+#: Merge.rc:5799
 msgid "Built-in first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_FIRST
-#: Merge.rc:5799
+#: Merge.rc:5800
 msgid "Tree-sitter first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_ONLY
-#: Merge.rc:5800
+#: Merge.rc:5801
 msgid "Tree-sitter only"
 msgstr ""
 


### PR DESCRIPTION
### Summary

* Show the current plugin pipeline order in plugin menus.
* Support adding a plugin to the pipeline with Ctrl+Click.
* Unify plugin menu update handling for unpackers, prediffers, and editor scripts.
* Remove the old prediffer-specific menu handling.

<img width="529" height="522" alt="image" src="https://github.com/user-attachments/assets/84f24fc8-b645-4b57-b9e9-ca8e12a5cc49" />
