### PR TITLE
Make merge mode indicator clickable and reduce its width

### DIFF
--- a/Src/MainFrm.cpp
+++ b/Src/MainFrm.cpp
@@ -3758,9 +3758,9 @@ void CMainFrame::OnUpdateMergingMode(CCmdUI* pCmdUI)
  */
 void CMainFrame::OnUpdateMergingStatus(CCmdUI *pCmdUI)
 {
-	String text = _T("\u2191\u2193");
+	String text = theApp.GetMergingMode() ? _T("\u2191\u2193") : _T("Alt");
 	pCmdUI->SetText(text.c_str());
-	pCmdUI->Enable(theApp.GetMergingMode());
+	pCmdUI->Enable(true);
 }
 
 /**

--- a/Src/MainFrm.cpp
+++ b/Src/MainFrm.cpp
@@ -365,6 +365,9 @@ BEGIN_MESSAGE_MAP(CMainFrame, CMDIFrameWnd)
 	ON_COMMAND_RANGE(ID_DIFF_OPTIONS_COMPMETHOD_FULL_CONTENTS, ID_DIFF_OPTIONS_COMPMETHOD_EXISTENCE, OnCompareMethod)
 	ON_UPDATE_COMMAND_UI_RANGE(ID_DIFF_OPTIONS_COMPMETHOD_FULL_CONTENTS, ID_DIFF_OPTIONS_COMPMETHOD_EXISTENCE, OnUpdateCompareMethod)
 	// Status bar
+	ON_COMMAND(ID_FILE_MERGINGMODE, OnMergingMode)
+	ON_UPDATE_COMMAND_UI(ID_FILE_MERGINGMODE, OnUpdateMergingMode)
+	ON_UPDATE_COMMAND_UI(ID_STATUS_MERGINGMODE, OnUpdateMergingStatus)
 	ON_NOTIFY(NM_CLICK, AFX_IDW_STATUS_BAR, OnStatusBarClick)
 	ON_UPDATE_COMMAND_UI(ID_STATUS_PLUGIN, OnUpdatePluginName)
 	ON_UPDATE_COMMAND_UI(ID_STATUS_DIFFNUM, OnUpdateStatusNum)
@@ -506,8 +509,8 @@ int CMainFrame::OnCreate(LPCREATESTRUCT lpCreateStruct)
 	const int lpx = CClientDC(this).GetDeviceCaps(LOGPIXELSX);
 	auto pointToPixel = [lpx](int point) { return MulDiv(point, lpx, 72); };
 	m_wndStatusBar.SetPaneInfo(0, 0, SBPS_STRETCH | SBPS_NOBORDERS, 0);
-	m_wndStatusBar.SetPaneInfo(1, ID_STATUS_PLUGIN, SBPS_CLICKABLE, pointToPixel(225));
-	m_wndStatusBar.SetPaneInfo(2, ID_STATUS_MERGINGMODE, 0, pointToPixel(75)); 
+	m_wndStatusBar.SetPaneInfo(1, ID_STATUS_PLUGIN, SBPS_CLICKABLE, pointToPixel(285));
+	m_wndStatusBar.SetPaneInfo(2, ID_STATUS_MERGINGMODE, SBPS_CLICKABLE, pointToPixel(15)); 
 	m_wndStatusBar.SetPaneInfo(3, ID_STATUS_DIFFNUM, 0, pointToPixel(112)); 
 
 	if (!GetOptionsMgr()->GetBool(OPT_SHOW_STATUSBAR))
@@ -3729,6 +3732,38 @@ void CMainFrame::OnUpdateNoMRUs(CCmdUI* pCmdUI)
 }
 
 /**
+ * @brief Switch Merging/Editing mode and update
+ * buffer read-only states accordingly
+ */
+void CMainFrame::OnMergingMode()
+{
+	bool bMergingMode = theApp.GetMergingMode();
+
+	if (!bMergingMode)
+		I18n::MessageBox(IDS_MERGE_MODE, MB_ICONINFORMATION | MB_DONT_DISPLAY_AGAIN, IDS_MERGE_MODE);
+	theApp.SetMergingMode(!bMergingMode);
+}
+
+/**
+ * @brief Update Menuitem for Merging Mode
+ */
+void CMainFrame::OnUpdateMergingMode(CCmdUI* pCmdUI)
+{
+	pCmdUI->Enable(true);
+	pCmdUI->SetCheck(theApp.GetMergingMode());
+}
+
+/**
+ * @brief Update MergingMode UI in statusbar
+ */
+void CMainFrame::OnUpdateMergingStatus(CCmdUI *pCmdUI)
+{
+	String text = _T("\u2191\u2193");
+	pCmdUI->SetText(text.c_str());
+	pCmdUI->Enable(theApp.GetMergingMode());
+}
+
+/**
  * @brief Update plugin name
  * @param [in] pCmdUI UI component to update.
  */
@@ -3792,26 +3827,33 @@ void CMainFrame::OnStatusBarClick(NMHDR* pNMHDR, LRESULT* pResult)
 	int index = static_cast<int>(pNMMouse->dwItemSpec);
 	if (index < 0)
 		return;
-	CPoint point = pNMMouse->pt;
-	int subidx = m_wndStatusBar.HitTestSubPaneButton(index, point);
-	if (subidx < 0)
-		return;
-	if (auto pMergeDoc = GetActiveIMergeDoc())
+	if (index == 1)
 	{
-		PathContext paths;
-		for (int i = 0; i < pMergeDoc->GetFileCount(); ++i)
-			paths.SetPath(i, pMergeDoc->GetPath(i));
-		String filteredFilenames = strutils::join(paths.begin(), paths.end(), _T("|"));
-		std::vector<CRect> rects;
-		m_wndStatusBar.GetSubPaneButtonRects(index, rects);
-		CPoint pt = CPoint(rects[subidx].left, rects[subidx].top);
-		m_wndStatusBar.ClientToScreen(&pt);
-		if (subidx == 0)
-			PluginMenu::ShowMenu(pMergeDoc->GetUnpacker(), filteredFilenames, FileTransform::UnpackerEventNames,
-				PluginMenu::AddSelectMenu, ID_UNPACKERS_FIRST, pt.x, pt.y, this);
-		else if (subidx == 1)
-			PluginMenu::ShowMenu(pMergeDoc->GetPrediffer(), filteredFilenames, FileTransform::PredifferEventNames,
-				PluginMenu::FlattenMenu|PluginMenu::AddSelectMenu, ID_PREDIFFERS_FIRST, pt.x, pt.y, this);
+		CPoint point = pNMMouse->pt;
+		int subidx = m_wndStatusBar.HitTestSubPaneButton(index, point);
+		if (subidx < 0)
+			return;
+		if (auto pMergeDoc = GetActiveIMergeDoc())
+		{
+			PathContext paths;
+			for (int i = 0; i < pMergeDoc->GetFileCount(); ++i)
+				paths.SetPath(i, pMergeDoc->GetPath(i));
+			String filteredFilenames = strutils::join(paths.begin(), paths.end(), _T("|"));
+			std::vector<CRect> rects;
+			m_wndStatusBar.GetSubPaneButtonRects(index, rects);
+			CPoint pt = CPoint(rects[subidx].left, rects[subidx].top);
+			m_wndStatusBar.ClientToScreen(&pt);
+			if (subidx == 0)
+				PluginMenu::ShowMenu(pMergeDoc->GetUnpacker(), filteredFilenames, FileTransform::UnpackerEventNames,
+					PluginMenu::AddSelectMenu, ID_UNPACKERS_FIRST, pt.x, pt.y, this);
+			else if (subidx == 1)
+				PluginMenu::ShowMenu(pMergeDoc->GetPrediffer(), filteredFilenames, FileTransform::PredifferEventNames,
+					PluginMenu::FlattenMenu | PluginMenu::AddSelectMenu, ID_PREDIFFERS_FIRST, pt.x, pt.y, this);
+		}
+	}
+	else if (index == 2)
+	{
+		OnMergingMode();
 	}
 }
 

--- a/Src/MainFrm.h
+++ b/Src/MainFrm.h
@@ -494,7 +494,10 @@ protected:
 	afx_msg void OnViewOutputBar();
 	afx_msg void OnUpdateViewOutputBar(CCmdUI* pCmdUI);
 	afx_msg void OnSysCommand(UINT nID, LPARAM lParam);
-    afx_msg void OnSettingChange(UINT uFlags, LPCTSTR lpszSection);
+	afx_msg void OnSettingChange(UINT uFlags, LPCTSTR lpszSection);
+	afx_msg void OnMergingMode();
+	afx_msg void OnUpdateMergingMode(CCmdUI* pCmdUI);
+	afx_msg void OnUpdateMergingStatus(CCmdUI* pCmdUI);
 	afx_msg void OnStatusBarClick(NMHDR* pNMHDR, LRESULT* pResult);
 	//}}AFX_MSG
 	DECLARE_MESSAGE_MAP()

--- a/Src/Merge.cpp
+++ b/Src/Merge.cpp
@@ -93,9 +93,6 @@ BEGIN_MESSAGE_MAP(CMergeApp, CWinApp)
 	ON_COMMAND(ID_HELP, OnHelp)
 	ON_COMMAND_EX_RANGE(ID_FILE_PROJECT_MRU_FIRST, ID_FILE_PROJECT_MRU_LAST, OnOpenRecentFile)
 	ON_UPDATE_COMMAND_UI(ID_FILE_PROJECT_MRU_FIRST, CWinApp::OnUpdateRecentFileMenu)
-	ON_COMMAND(ID_FILE_MERGINGMODE, OnMergingMode)
-	ON_UPDATE_COMMAND_UI(ID_FILE_MERGINGMODE, OnUpdateMergingMode)
-	ON_UPDATE_COMMAND_UI(ID_STATUS_MERGINGMODE, OnUpdateMergingStatus)
 	ON_COMMAND(ID_FILE_PRINT_SETUP, CWinApp::OnFilePrintSetup)
 	//}}AFX_MSG_MAP
 	// Standard file based document commands
@@ -1705,44 +1702,12 @@ bool CMergeApp::GetMergingMode() const
 }
 
 /**
- * @brief Set doc to Merging/Editing mode
+ * @brief Set Merging/Editing mode
  */
 void CMergeApp::SetMergingMode(bool bMergingMode)
 {
 	m_bMergingMode = bMergingMode;
 	GetOptionsMgr()->SaveOption(OPT_MERGE_MODE, m_bMergingMode);
-}
-
-/**
- * @brief Switch Merging/Editing mode and update
- * buffer read-only states accordingly
- */
-void CMergeApp::OnMergingMode()
-{
-	bool bMergingMode = GetMergingMode();
-
-	if (!bMergingMode)
-		I18n::MessageBox(IDS_MERGE_MODE, MB_ICONINFORMATION | MB_DONT_DISPLAY_AGAIN, IDS_MERGE_MODE);
-	SetMergingMode(!bMergingMode);
-}
-
-/**
- * @brief Update Menuitem for Merging Mode
- */
-void CMergeApp::OnUpdateMergingMode(CCmdUI* pCmdUI)
-{
-	pCmdUI->Enable(true);
-	pCmdUI->SetCheck(GetMergingMode());
-}
-
-/**
- * @brief Update MergingMode UI in statusbar
- */
-void CMergeApp::OnUpdateMergingStatus(CCmdUI *pCmdUI)
-{
-	String text = I18n::LoadString(IDS_MERGEMODE_MERGING);
-	pCmdUI->SetText(text.c_str());
-	pCmdUI->Enable(GetMergingMode());
 }
 
 UINT CMergeApp::GetProfileInt(const tchar_t* lpszSection, const tchar_t* lpszEntry, int nDefault)

--- a/Src/Merge.h
+++ b/Src/Merge.h
@@ -174,9 +174,6 @@ protected:
 	afx_msg BOOL OnOpenRecentFile(UINT nID);
 	afx_msg void OnAppAbout();
 	afx_msg void OnHelp();
-	afx_msg void OnMergingMode();
-	afx_msg void OnUpdateMergingMode(CCmdUI* pCmdUI);
-	afx_msg void OnUpdateMergingStatus(CCmdUI* pCmdUI);
 	//}}AFX_MSG
 	DECLARE_MESSAGE_MAP()
 private:

--- a/Src/Merge.rc
+++ b/Src/Merge.rc
@@ -4731,7 +4731,6 @@ BEGIN
     IDS_EMPTY_LINE_STATUS_INFO "Line: %s"
     IDS_LINE_STATUS_INFO    "Ln: %s  Col: %d/%d  Ch: %d/%d"
     IDS_LINE_STATUS_INFO_SEL "  Sel: %d | %d"
-    IDS_MERGEMODE_MERGING   "Merge"
     IDS_DIFF_NUMBER_STATUS_FMT "Difference %1 of %2"
     IDS_NO_DIFF_SEL_FMT     "%1 Differences Found"
     IDS_1_DIFF_FOUND        "1 Difference Found"

--- a/Src/resource.h
+++ b/Src/resource.h
@@ -1745,7 +1745,6 @@
 #define IDS_LINE_STATUS_INFO_EOL        40832
 #define IDS_EMPTY_LINE_STATUS_INFO      40833
 #define IDS_LINE_STATUS_INFO            40834
-#define IDS_MERGEMODE_MERGING           40835
 #define IDS_DIFF_NUMBER_STATUS_FMT      40836
 #define IDS_NO_DIFF_SEL_FMT             40837
 #define IDS_1_DIFF_FOUND                40838

--- a/Translations/WinMerge/Arabic.po
+++ b/Translations/WinMerge/Arabic.po
@@ -24,7 +24,7 @@ msgstr ""
 "Language: ar_SA\n"
 
 #. LANGUAGE, SUBLANGUAGE
-#: Merge.rc:26 Merge.rc:59 Merge.rc:5818
+#: Merge.rc:26 Merge.rc:59 Merge.rc:5817
 msgid "LANG_ENGLISH, SUBLANG_ENGLISH_US"
 msgstr "LANG_ARABIC, SUBLANG_ARABIC_SAUDI_ARABIA"
 
@@ -166,7 +166,7 @@ msgstr "لغة نصية (سكريبت)"
 #. IDS_NO_EDIT_SCRIPTS
 #: Merge.rc:127 Merge.rc:352 Merge.rc:463 Merge.rc:673 Merge.rc:678
 #: Merge.rc:887 Merge.rc:899 Merge.rc:906 Merge.rc:963 Merge.rc:1210
-#: Merge.rc:5375
+#: Merge.rc:5374
 msgid "< Empty >"
 msgstr "<فارغ>"
 
@@ -231,7 +231,7 @@ msgid "Auto-Fit All Columns"
 msgstr ""
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN
-#: Merge.rc:153 Merge.rc:5646
+#: Merge.rc:153 Merge.rc:5645
 msgid "&Filter by This Column"
 msgstr ""
 
@@ -292,7 +292,7 @@ msgid "&Previous Page"
 msgstr "ال&صفحة السابقة"
 
 #. IDS_PREVIEWBAR_NEXTPAGE
-#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5679
+#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5678
 msgid "&Next Page"
 msgstr "الص&فحة التالية"
 
@@ -543,7 +543,7 @@ msgstr "ملف &ثنائي"
 #. IDS_IMAGE_MENU
 #: Merge.rc:329 Merge.rc:338 Merge.rc:432 Merge.rc:441 Merge.rc:609
 #: Merge.rc:618 Merge.rc:670 Merge.rc:960 Merge.rc:1187 Merge.rc:1200
-#: Merge.rc:5477
+#: Merge.rc:5476
 msgid "&Image"
 msgstr "&صورة"
 
@@ -665,7 +665,7 @@ msgid "&Huge"
 msgstr "&ضخم"
 
 #. IDS_VIEW_MENU_BAR
-#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5714
+#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5713
 msgid "Men&u Bar"
 msgstr ""
 
@@ -1320,7 +1320,7 @@ msgid "Lo&cation Pane"
 msgstr "الجزء الخاص &بالموقع"
 
 #. IDS_OUTPUTBAR_CAPTION
-#: Merge.rc:782 Merge.rc:5252
+#: Merge.rc:782 Merge.rc:5251
 msgid "Output Pane"
 msgstr ""
 
@@ -1583,55 +1583,55 @@ msgid "Co&mpare As"
 msgstr "مقارنة كـ"
 
 #. IDS_COPY_LEFT_TO_MIDDLE2
-#: Merge.rc:968 Merge.rc:980 Merge.rc:4852
+#: Merge.rc:968 Merge.rc:980 Merge.rc:4851
 #, c-format
 msgid "Left to Middle (%1 of %2)"
 msgstr "من اليسار إلى الوسط (%1 من %2)"
 
 #. IDS_COPY_LEFT_TO_RIGHT2
-#: Merge.rc:969 Merge.rc:981 Merge.rc:4851
+#: Merge.rc:969 Merge.rc:981 Merge.rc:4850
 #, c-format
 msgid "Left to Right (%1 of %2)"
 msgstr "من اليسار إلى اليمين (%1 من %2)"
 
 #. IDS_MOVE_LEFT_TO2
-#: Merge.rc:970 Merge.rc:982 Merge.rc:1045 Merge.rc:4863 Merge.rc:4892
+#: Merge.rc:970 Merge.rc:982 Merge.rc:1045 Merge.rc:4862 Merge.rc:4891
 #, c-format
 msgid "Left to... (%1 of %2)"
 msgstr "من اليسار إلى... (%1 من %2)"
 
 #. IDS_COPY_MIDDLE_TO_LEFT2
-#: Merge.rc:971 Merge.rc:983 Merge.rc:4849
+#: Merge.rc:971 Merge.rc:983 Merge.rc:4848
 #, c-format
 msgid "Middle to Left (%1 of %2)"
 msgstr "من الوسط إلى اليسار (%1 من %2)"
 
 #. IDS_COPY_MIDDLE_TO_RIGHT2
-#: Merge.rc:972 Merge.rc:984 Merge.rc:4850
+#: Merge.rc:972 Merge.rc:984 Merge.rc:4849
 #, c-format
 msgid "Middle to Right (%1 of %2)"
 msgstr "من الوسط إلى اليمين (%1 من %2)"
 
 #. IDS_MOVE_MIDDLE_TO2
-#: Merge.rc:973 Merge.rc:985 Merge.rc:1046 Merge.rc:4864 Merge.rc:4893
+#: Merge.rc:973 Merge.rc:985 Merge.rc:1046 Merge.rc:4863 Merge.rc:4892
 #, c-format
 msgid "Middle to... (%1 of %2)"
 msgstr "من الوسط إلى... (%1 من %2)"
 
 #. IDS_COPY_RIGHT_TO_MIDDLE2
-#: Merge.rc:974 Merge.rc:986 Merge.rc:4848
+#: Merge.rc:974 Merge.rc:986 Merge.rc:4847
 #, c-format
 msgid "Right to Middle (%1 of %2)"
 msgstr "من اليمين إلى الوسط (%1 من %2)"
 
 #. IDS_COPY_RIGHT_TO_LEFT2
-#: Merge.rc:975 Merge.rc:987 Merge.rc:4847
+#: Merge.rc:975 Merge.rc:987 Merge.rc:4846
 #, c-format
 msgid "Right to Left (%1 of %2)"
 msgstr "من اليمين إلى اليسار (%1 من %2)"
 
 #. IDS_MOVE_RIGHT_TO2
-#: Merge.rc:976 Merge.rc:988 Merge.rc:1047 Merge.rc:4865 Merge.rc:4894
+#: Merge.rc:976 Merge.rc:988 Merge.rc:1047 Merge.rc:4864 Merge.rc:4893
 #, c-format
 msgid "Right to... (%1 of %2)"
 msgstr "من اليمين إلى... (%1 من %2)"
@@ -1687,31 +1687,31 @@ msgid "Cop&y Paths"
 msgstr "نسخ المسارات"
 
 #. IDS_DEL_LEFT_FMT2
-#: Merge.rc:1026 Merge.rc:1035 Merge.rc:4880
+#: Merge.rc:1026 Merge.rc:1035 Merge.rc:4879
 #, c-format
 msgid "Left (%1 of %2)"
 msgstr "اليسار (%1 من %2)"
 
 #. IDS_DEL_MIDDLE_FMT2
-#: Merge.rc:1027 Merge.rc:1036 Merge.rc:4881
+#: Merge.rc:1027 Merge.rc:1036 Merge.rc:4880
 #, c-format
 msgid "Middle (%1 of %2)"
 msgstr "الوسط (%1 من %2)"
 
 #. IDS_DEL_RIGHT_FMT2
-#: Merge.rc:1028 Merge.rc:1037 Merge.rc:4882
+#: Merge.rc:1028 Merge.rc:1037 Merge.rc:4881
 #, c-format
 msgid "Right (%1 of %2)"
 msgstr "اليمين (%1 من %2)"
 
 #. IDS_DEL_BOTH_FMT2
-#: Merge.rc:1029 Merge.rc:1038 Merge.rc:4883
+#: Merge.rc:1029 Merge.rc:1038 Merge.rc:4882
 #, c-format
 msgid "Both (%1 of %2)"
 msgstr "كلاهما (%1 من %2)"
 
 #. IDS_DEL_ALL_FMT2
-#: Merge.rc:1030 Merge.rc:1039 Merge.rc:4888
+#: Merge.rc:1030 Merge.rc:1039 Merge.rc:4887
 #, c-format
 msgid "All (%1 of %2)"
 msgstr "الكل (%1 من %2)"
@@ -1737,19 +1737,19 @@ msgid "&Zip"
 msgstr "Zip"
 
 #. IDS_COPY_BOTH_TO2
-#: Merge.rc:1048 Merge.rc:4866
+#: Merge.rc:1048 Merge.rc:4865
 #, c-format
 msgid "Both to... (%1 of %2)"
 msgstr "كلاهما إلى...(%1 من %2)"
 
 #. IDS_COPY_ALL_TO2
-#: Merge.rc:1049 Merge.rc:4867
+#: Merge.rc:1049 Merge.rc:4866
 #, c-format
 msgid "All to... (%1 of %2)"
 msgstr "الكل إلى...(%1 من %2)"
 
 #. IDS_COPY_DIFFERENCES_TO2
-#: Merge.rc:1050 Merge.rc:4868
+#: Merge.rc:1050 Merge.rc:4867
 #, c-format
 msgid "Differences to... (%1 of %2)"
 msgstr "الاختلافات إلى...(%1 من %2)"
@@ -1816,12 +1816,12 @@ msgstr ""
 
 #. IDS_USERCHOICE_NONE
 #: Merge.rc:1088 Merge.rc:1094 Merge.rc:1836 Merge.rc:1840 Merge.rc:2031
-#: Merge.rc:2035 Merge.rc:5377
+#: Merge.rc:2035 Merge.rc:5376
 msgid "<None>"
 msgstr "<لا يوجد>"
 
 #. IDS_USERCHOICE_AUTOMATIC
-#: Merge.rc:1089 Merge.rc:1095 Merge.rc:5378
+#: Merge.rc:1089 Merge.rc:1095 Merge.rc:5377
 msgid "<Automatic>"
 msgstr "<تلقائي>"
 
@@ -2753,12 +2753,12 @@ msgid "Text files only"
 msgstr ""
 
 #. IDS_EOL_NONE
-#: Merge.rc:1667 Merge.rc:1918 Merge.rc:5304
+#: Merge.rc:1667 Merge.rc:1918 Merge.rc:5303
 msgid "None"
 msgstr "لا يوجد"
 
 #. IDS_EOL_MIXED
-#: Merge.rc:1668 Merge.rc:5299
+#: Merge.rc:1668 Merge.rc:5298
 msgid "Mixed"
 msgstr "مختلط"
 
@@ -3030,13 +3030,13 @@ msgstr ""
 
 #. IDS_DIFFERENT
 #: Merge.rc:1904 Merge.rc:1988 Merge.rc:2866 Merge.rc:3036 Merge.rc:3077
-#: Merge.rc:5058
+#: Merge.rc:5057
 msgid "Different"
 msgstr "الاختلاف"
 
 #. IDS_IDENTICAL
 #: Merge.rc:1905 Merge.rc:1989 Merge.rc:2865 Merge.rc:3055 Merge.rc:3116
-#: Merge.rc:5048
+#: Merge.rc:5047
 msgid "Identical"
 msgstr "متطابق"
 
@@ -3056,7 +3056,7 @@ msgid "Missing"
 msgstr ""
 
 #. IDS_MOVED
-#: Merge.rc:1910 Merge.rc:5076
+#: Merge.rc:1910 Merge.rc:5075
 msgid "Moved"
 msgstr ""
 
@@ -3792,7 +3792,7 @@ msgid "&Use custom system colors"
 msgstr ""
 
 #. IDS_PRPCAT_SYSTEM
-#: Merge.rc:2565 Merge.rc:4559 Merge.rc:4560 Merge.rc:5007
+#: Merge.rc:2565 Merge.rc:4559 Merge.rc:4560 Merge.rc:5006
 msgid "System"
 msgstr "النظام"
 
@@ -4194,7 +4194,7 @@ msgid "Items compared:"
 msgstr "العناصر التي تمت مقارنتها:"
 
 #. IDS_PREVIEWBAR_CLOSE
-#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5685
+#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5684
 msgid "&Close"
 msgstr "إ&غلاق"
 
@@ -4813,7 +4813,7 @@ msgid "A&ppend timestamp"
 msgstr "إلحق الطابع ال&زمني للملف"
 
 #. IDS_CONFIRM_COPY_CAPTION
-#: Merge.rc:3214 Merge.rc:4915
+#: Merge.rc:3214 Merge.rc:4914
 msgid "Confirm Copy"
 msgstr "تأكيد النسخ"
 
@@ -5050,7 +5050,7 @@ msgid "&Character Set..."
 msgstr "&مجموعة الرموز..."
 
 #. IDS_PRPCAT_IMAGE
-#: Merge.rc:3351 Merge.rc:4574 Merge.rc:5015
+#: Merge.rc:3351 Merge.rc:4574 Merge.rc:5014
 msgid "Image"
 msgstr "صورة"
 
@@ -5446,7 +5446,7 @@ msgid "Project"
 msgstr ""
 
 #. IDS_COLHDR_NSDIFFS
-#: Merge.rc:4566 Merge.rc:4990
+#: Merge.rc:4566 Merge.rc:4989
 msgid "Differences"
 msgstr "الاختلافات"
 
@@ -5595,12 +5595,12 @@ msgid "File Type"
 msgstr ""
 
 #. IDS_COLHDR_EXTENSION
-#: Merge.rc:4653 Merge.rc:4947
+#: Merge.rc:4653 Merge.rc:4946
 msgid "Extension"
 msgstr "الإمتداد"
 
 #. IDS_PRPCAT_MESSAGE
-#: Merge.rc:4659 Merge.rc:5019
+#: Merge.rc:4659 Merge.rc:5018
 msgid "Message"
 msgstr ""
 
@@ -5640,7 +5640,7 @@ msgid "Hidden Items"
 msgstr ""
 
 #. IDS_PLUGINSLIST_NAME
-#: Merge.rc:4680 Merge.rc:5311
+#: Merge.rc:4680 Merge.rc:5310
 msgid "Name"
 msgstr "الاسم"
 
@@ -5660,7 +5660,7 @@ msgid "[F] "
 msgstr "[F] "
 
 #. IDS_PLUGINSLIST_DESC
-#: Merge.rc:4684 Merge.rc:5313
+#: Merge.rc:4684 Merge.rc:5312
 msgid "Description"
 msgstr "الوصف"
 
@@ -5817,155 +5817,150 @@ msgstr "Ln: %s  Col: %d/%d  Ch: %d/%d"
 msgid "  Sel: %d | %d"
 msgstr ""
 
-#. IDS_MERGEMODE_MERGING
-#: Merge.rc:4734
-msgid "Merge"
-msgstr "دمج"
-
 #. IDS_DIFF_NUMBER_STATUS_FMT
-#: Merge.rc:4735
+#: Merge.rc:4734
 #, c-format
 msgid "Difference %1 of %2"
 msgstr "الاختلاف %1 من %2"
 
 #. IDS_NO_DIFF_SEL_FMT
-#: Merge.rc:4736
+#: Merge.rc:4735
 #, c-format
 msgid "%1 Differences Found"
 msgstr "%1 عدد الاختلافات التي تم العثور عليها"
 
 #. IDS_1_DIFF_FOUND
-#: Merge.rc:4737
+#: Merge.rc:4736
 msgid "1 Difference Found"
 msgstr "اختلاف واحد تم العثور عليه"
 
 #. IDS_NO_ERR_SEL_FMT
-#: Merge.rc:4738
+#: Merge.rc:4737
 #, c-format
 msgid "%1 Errors Found"
 msgstr ""
 
 #. IDS_1_ERR_FOUND
-#: Merge.rc:4739
+#: Merge.rc:4738
 msgid "1 Error Found"
 msgstr ""
 
 #. IDS_STATUSBAR_READONLY, Abbreviation from "Read Only"
-#: Merge.rc:4740
+#: Merge.rc:4739
 msgid "RO"
 msgstr "RO"
 
 #. IDS_DIRVIEW_STATUS_FMT_FOCUS
-#: Merge.rc:4746
+#: Merge.rc:4745
 #, c-format
 msgid "Item %1 of %2"
 msgstr "العنصر %1 من %2"
 
 #. IDS_DIRVIEW_STATUS_FMT_NOFOCUS
-#: Merge.rc:4747
+#: Merge.rc:4746
 #, c-format
 msgid "Items: %1"
 msgstr "العناصر: %1"
 
 #. IDS_DIRVIEW_STATUS_COMPARING
-#: Merge.rc:4748
+#: Merge.rc:4747
 msgid "Comparing items..."
 msgstr "يتم مقارنة العناصر..."
 
 #. IDS_ITEMS_PER_SEC
-#: Merge.rc:4749
+#: Merge.rc:4748
 #, c-format
 msgid "%.1f[items/sec]"
 msgstr ""
 
 #. IDS_ERROR_INCOMPARABLE
-#: Merge.rc:4755
+#: Merge.rc:4754
 msgid "Select two existing folders/files to compare."
 msgstr "اختر ملفين أو مجلدين للمقارنة."
 
 #. IDS_DIRSEL_TAG
-#: Merge.rc:4756
+#: Merge.rc:4755
 msgid "Folder Selection"
 msgstr "اختيار المجلد"
 
 #. IDS_OPEN_FILESDIRS
-#: Merge.rc:4757
+#: Merge.rc:4756
 msgid "Select two (or three) folders/files to compare."
 msgstr "اختر مجلدين (أو ثلاثة) أو ملفين (أو ثلاثة) للمقارنة."
 
 #. IDS_OPEN_LEFTINVALID
-#: Merge.rc:4758
+#: Merge.rc:4757
 msgid "Left (1st) path is invalid!"
 msgstr "المسار (الأول) الأيسر غير صالح!"
 
 #. IDS_OPEN_MIDDLEINVALID
-#: Merge.rc:4759
+#: Merge.rc:4758
 msgid "Middle (2nd) path is invalid!"
 msgstr "المسار (الثاني) الأوسط غير صالح!"
 
 #. IDS_OPEN_RIGHTINVALID2
-#: Merge.rc:4760
+#: Merge.rc:4759
 msgid "Right (2nd) path is invalid!"
 msgstr "المسار (الثاني) الأيمن غير صالح!"
 
 #. IDS_OPEN_RIGHTINVALID3
-#: Merge.rc:4761
+#: Merge.rc:4760
 msgid "Right (3rd) path is invalid!"
 msgstr "المسار (الثالث) الأيمن غير صالح!"
 
 #. IDS_OPEN_BOTHINVALID
-#: Merge.rc:4762
+#: Merge.rc:4761
 msgid "Both paths are invalid!"
 msgstr "المساران غير صالحين!"
 
-#: Merge.rc:4764
+#: Merge.rc:4763
 msgid "Left (1st) and Middle (2nd) paths are invalid!"
 msgstr "المساران الأيسر (الأول) والأوسط (الثاني) غير صالحين!"
 
 #. IDS_OPEN_LEFTRIGHTINVALID
-#: Merge.rc:4765
+#: Merge.rc:4764
 msgid "Left (1st) and Right (3rd) paths are invalid!"
 msgstr "المساران الأيسر (الأول) والأيمن (الثالث) غير صالحين!"
 
-#: Merge.rc:4767
+#: Merge.rc:4766
 msgid "Middle (2nd) and Right (3rd) paths are invalid!"
 msgstr "المساران الأوسط (الثاني) والأيمن (الثالث) غير صالحين!"
 
 #. IDS_OPEN_ALLINVALID
-#: Merge.rc:4768
+#: Merge.rc:4767
 msgid "All paths are invalid!"
 msgstr "كل المسارات غير صالحة!"
 
 #. IDS_OPEN_UNPACKERDISABLED
-#: Merge.rc:4769
+#: Merge.rc:4768
 msgid "Only enabled for file comparisons"
 msgstr "تم التفعيل لمقارنة الملفات فقط"
 
 #. IDS_OPEN_MISMATCH
-#: Merge.rc:4770
+#: Merge.rc:4769
 msgid "Cannot compare file and folder!"
 msgstr "لا يمكن إجراء المقارنة بين ملف ومجلد!"
 
 #. IDS_ERROR_FILE_NOT_FOUND
-#: Merge.rc:4776
+#: Merge.rc:4775
 #, c-format
 msgid "File not found: %1"
 msgstr "لم يتم العثور على الملف: %1"
 
 #. IDS_ERROR_FOLDER_NOT_FOUND
-#: Merge.rc:4777
+#: Merge.rc:4776
 #, c-format
 msgid "Folder not found: %1"
 msgstr ""
 
 #. IDS_ERROR_FILE_NOT_UNPACKED
-#: Merge.rc:4778
+#: Merge.rc:4777
 #, c-format
 msgid "File not unpacked: %1"
 msgstr "الملف لم يتم فك تحزيمة: %1"
 
 #. IDS_ERROR_FILEOPEN
-#: Merge.rc:4779
+#: Merge.rc:4778
 #, c-format
 msgid ""
 "Cannot open file\n"
@@ -5979,12 +5974,12 @@ msgstr ""
 "%2"
 
 #. IDS_ERROR_CONF_RESOLVE
-#: Merge.rc:4780
+#: Merge.rc:4779
 msgid "Failed to parse conflict file."
 msgstr "فشل في فحص الملف محل التضارب."
 
 #. IDS_NOT_CONFLICT_FILE
-#: Merge.rc:4781
+#: Merge.rc:4780
 #, c-format
 msgid "The file\n%1\nis not a conflict file."
 msgstr ""
@@ -5993,34 +5988,34 @@ msgstr ""
 "ليس محل تضارب."
 
 #. IDS_COMPARE_LARGE_FILES
-#: Merge.rc:4782
+#: Merge.rc:4781
 msgid "Comparing large files requires significant memory.\nShow only comparison results (not file contents)?"
 msgstr ""
 
 #. IDS_SAVE_AS_TITLE
-#: Merge.rc:4788
+#: Merge.rc:4787
 msgid "Save As"
 msgstr "الحفظ باسم"
 
 #. IDS_SAVE_FMT
-#: Merge.rc:4789
+#: Merge.rc:4788
 #, c-format
 msgid "Save changes to %1?"
 msgstr "حفظ التغييرات إلى %1؟"
 
 #. IDS_SAVEREADONLY_FMT
-#: Merge.rc:4790
+#: Merge.rc:4789
 #, c-format
 msgid "%1 is read-only. Override? Or 'No' to save as new filename?"
 msgstr ""
 "%1 للقراءة فقط. هل ترغب في تجاوز أمر القراءة فقط؟ (أختر لا للحفظ كملف جديد)"
 
 #. IDS_ERROR_BACKUP
-#: Merge.rc:4791
+#: Merge.rc:4790
 msgid "Error backing up file"
 msgstr "خطأ أثناء الحفظ الاحتياطي للملف"
 
-#: Merge.rc:4793
+#: Merge.rc:4792
 #, c-format
 msgid ""
 "Unable to backup original file:\n"
@@ -6034,7 +6029,7 @@ msgstr ""
 "هل ترغب بالاستمرار على أي حال؟"
 
 #. IDS_FILESAVE_FAILED
-#: Merge.rc:4794
+#: Merge.rc:4793
 #, c-format
 msgid "Saving file failed.\n%1\n%2\n\t- Use different filename (OK)\n\t- Abort (Cancel)?"
 msgstr ""
@@ -6045,7 +6040,7 @@ msgstr ""
 "\t- استخدام اسم ملف مختلف (أضغط على زر الموافقة)\n"
 "\t- إلغاء العملية الجارية (إضغط على زر الإلغاء)؟"
 
-#: Merge.rc:4796
+#: Merge.rc:4795
 #, c-format
 msgid "Plugin '%2' cannot pack changes to left file into '%1'.\n\nOriginal unchanged. Save unpacked version?"
 msgstr ""
@@ -6055,12 +6050,12 @@ msgstr ""
 "\n"
 "هل تريد حفظ النسخة التي تم فك تحزيمها إلى ملف آخر؟"
 
-#: Merge.rc:4798
+#: Merge.rc:4797
 #, c-format
 msgid "Plugin '%2' cannot pack changes to middle file into '%1'.\n\nOriginal unchanged. Save unpacked version?"
 msgstr ""
 
-#: Merge.rc:4800
+#: Merge.rc:4799
 #, c-format
 msgid "Plugin '%2' cannot pack changes to right file into '%1'.\n\nOriginal unchanged. Save unpacked version?"
 msgstr ""
@@ -6071,7 +6066,7 @@ msgstr ""
 "هل تريد حفظ النسخة التي تم فك تحزيمها إلى ملف آخر؟"
 
 #. IDS_FILECHANGED_ONDISK
-#: Merge.rc:4801
+#: Merge.rc:4800
 #, c-format
 msgid ""
 "Another application updated\n"
@@ -6088,7 +6083,7 @@ msgstr ""
 "البرنامج الآخر)؟"
 
 #. IDS_SAVEREADONLY_MULTI
-#: Merge.rc:4802
+#: Merge.rc:4801
 #, c-format
 msgid ""
 "%1\n"
@@ -6098,7 +6093,7 @@ msgstr ""
 "هو ملف للقراءة فقط. هل ترغب في تجاوز أمر القراءة فقط للعنصر؟"
 
 #. IDS_FILECHANGED_RESCAN
-#: Merge.rc:4803
+#: Merge.rc:4802
 #, c-format
 msgid "Another application updated\n%1\nsince last scan.\n\nReload?"
 msgstr ""
@@ -6109,22 +6104,22 @@ msgstr ""
 "هل ترغب في إعادة تحميل الملف؟"
 
 #. IDS_SAVE_LEFT_AS
-#: Merge.rc:4804
+#: Merge.rc:4803
 msgid "Save Left File As"
 msgstr "حفظ الملف الأيسر باسم"
 
 #. IDS_SAVE_MIDDLE_AS
-#: Merge.rc:4805
+#: Merge.rc:4804
 msgid "Save Middle File As"
 msgstr "حفظ الملف الأوسط باسم"
 
 #. IDS_SAVE_RIGHT_AS
-#: Merge.rc:4806
+#: Merge.rc:4805
 msgid "Save Right File As"
 msgstr "حفظ الملف الأيمن باسم"
 
 #. IDS_FILE_DISAPPEARED
-#: Merge.rc:4811
+#: Merge.rc:4810
 #, c-format
 msgid ""
 "File\n"
@@ -6136,7 +6131,7 @@ msgstr ""
 "أختفى. يرجى حفظ نسخ من الملف للإستمرر."
 
 #. IDS_VIEWS_OUTOFSYNC
-#: Merge.rc:4817
+#: Merge.rc:4816
 msgid ""
 "Cannot merge unsynched documents.\n"
 "\n"
@@ -6147,186 +6142,186 @@ msgstr ""
 "تحديث المستندات قبل الإستمرار."
 
 #. IDS_BREAK_ON_WHITESPACE
-#: Merge.rc:4822
+#: Merge.rc:4821
 msgid "Break at whitespace"
 msgstr "فصل بين العبارات باستخدام المسافات الخالية (whitespace)"
 
 #. IDS_BREAK_ON_PUNCTUATION
-#: Merge.rc:4823
+#: Merge.rc:4822
 msgid "Break at whitespace or punctuation"
 msgstr "فصل بين العبارات باستخدام المسافات الخالية أو علامات الترقيم"
 
 #. IDS_L2M
-#: Merge.rc:4829
+#: Merge.rc:4828
 msgid "Copy to &Middle\tAlt+Right"
 msgstr ""
 
 #. IDS_R2M
-#: Merge.rc:4830
+#: Merge.rc:4829
 msgid "Copy to &Middle\tAlt+Left"
 msgstr ""
 
 #. IDS_COPY_FROM_MIDDLE_R
-#: Merge.rc:4831
+#: Merge.rc:4830
 msgid "Copy from Middle\tAlt+Shift+Right"
 msgstr ""
 
 #. IDS_COPY_FROM_MIDDLE_L
-#: Merge.rc:4832
+#: Merge.rc:4831
 msgid "Copy from Middle\tAlt+Shift+Left"
 msgstr ""
 
 #. IDS_L2MNEXT
-#: Merge.rc:4833
+#: Merge.rc:4832
 msgid "Copy to Middle and Advance\tCtrl+Alt+Right"
 msgstr ""
 
 #. IDS_R2MNEXT
-#: Merge.rc:4834
+#: Merge.rc:4833
 msgid "Copy to Middle and Advance\tCtrl+Alt+Left"
 msgstr ""
 
 #. IDS_ALL_MIDDLE
-#: Merge.rc:4835
+#: Merge.rc:4834
 msgid "Copy All to Middle"
 msgstr ""
 
 #. IDS_COPY_RIGHT_TO_LEFT
-#: Merge.rc:4841
+#: Merge.rc:4840
 #, c-format
 msgid "Right to Left (%1)"
 msgstr "اليمين إلى اليسار (%1)"
 
 #. IDS_COPY_RIGHT_TO_MIDDLE
-#: Merge.rc:4842
+#: Merge.rc:4841
 #, c-format
 msgid "Right to Middle (%1)"
 msgstr "اليمين إلى الوسط (%1)"
 
 #. IDS_COPY_MIDDLE_TO_LEFT
-#: Merge.rc:4843
+#: Merge.rc:4842
 #, c-format
 msgid "Middle to Left (%1)"
 msgstr "الوسط إلى اليسار (%1)"
 
 #. IDS_COPY_MIDDLE_TO_RIGHT
-#: Merge.rc:4844
+#: Merge.rc:4843
 #, c-format
 msgid "Middle to Right (%1)"
 msgstr "الوسط إلى اليمين (%1)"
 
 #. IDS_COPY_LEFT_TO_RIGHT
-#: Merge.rc:4845
+#: Merge.rc:4844
 #, c-format
 msgid "Left to Right (%1)"
 msgstr "اليسار إلى اليمين (%1)"
 
 #. IDS_COPY_LEFT_TO_MIDDLE
-#: Merge.rc:4846
+#: Merge.rc:4845
 #, c-format
 msgid "Left to Middle (%1)"
 msgstr "اليسار إلى الوسط (%1)"
 
 #. IDS_MOVE_LEFT_TO
-#: Merge.rc:4857 Merge.rc:4889
+#: Merge.rc:4856 Merge.rc:4888
 #, c-format
 msgid "Left to... (%1)"
 msgstr "اليسار إلى...(%1)"
 
 #. IDS_MOVE_MIDDLE_TO
-#: Merge.rc:4858 Merge.rc:4890
+#: Merge.rc:4857 Merge.rc:4889
 #, c-format
 msgid "Middle to... (%1)"
 msgstr "الوسط إلى... (%1)"
 
 #. IDS_MOVE_RIGHT_TO
-#: Merge.rc:4859 Merge.rc:4891
+#: Merge.rc:4858 Merge.rc:4890
 #, c-format
 msgid "Right to... (%1)"
 msgstr "اليمين إلى... (%1)"
 
 #. IDS_COPY_BOTH_TO
-#: Merge.rc:4860
+#: Merge.rc:4859
 #, c-format
 msgid "Both to... (%1)"
 msgstr "كلاهما إلى... (%1)"
 
 #. IDS_COPY_ALL_TO
-#: Merge.rc:4861
+#: Merge.rc:4860
 #, c-format
 msgid "All to... (%1)"
 msgstr "الكل إلى... (%1)"
 
 #. IDS_COPY_DIFFERENCES_TO
-#: Merge.rc:4862
+#: Merge.rc:4861
 #, c-format
 msgid "Differences to... (%1)"
 msgstr "الاختلافات إلى... (%1)"
 
 #. IDS_ONLYDIFFITEMS_CONFIRM
-#: Merge.rc:4869
+#: Merge.rc:4868
 msgid "Some selected items are identical or skipped.\nProcess only items with differences?"
 msgstr ""
 
 #. IDS_DEL_LEFT_FMT
-#: Merge.rc:4875
+#: Merge.rc:4874
 #, c-format
 msgid "Left (%1)"
 msgstr "اليسار (%1)"
 
 #. IDS_DEL_MIDDLE_FMT
-#: Merge.rc:4876
+#: Merge.rc:4875
 #, c-format
 msgid "Middle (%1)"
 msgstr "الوسط (%1)"
 
 #. IDS_DEL_RIGHT_FMT
-#: Merge.rc:4877
+#: Merge.rc:4876
 #, c-format
 msgid "Right (%1)"
 msgstr "اليمين (%1)"
 
 #. IDS_DEL_BOTH_FMT
-#: Merge.rc:4878
+#: Merge.rc:4877
 #, c-format
 msgid "Both (%1)"
 msgstr "كلاهما (%1)"
 
 #. IDS_DEL_ALL_FMT
-#: Merge.rc:4879
+#: Merge.rc:4878
 #, c-format
 msgid "All (%1)"
 msgstr "الكل (%1)"
 
 #. IDS_SELECT_DEST_LEFT
-#: Merge.rc:4895
+#: Merge.rc:4894
 msgid "Left Side - Select Destination Folder:"
 msgstr "الجزء الأيسر - قم باختيار المجلد المستهدف:"
 
 #. IDS_SELECT_DEST_MIDDLE
-#: Merge.rc:4896
+#: Merge.rc:4895
 msgid "Middle Side - Select Destination Folder:"
 msgstr "الجزء الأوسط - قم باختيار المجلد المستهدف:"
 
 #. IDS_SELECT_DEST_RIGHT
-#: Merge.rc:4897
+#: Merge.rc:4896
 msgid "Right Side - Select Destination Folder:"
 msgstr "الجزء الأيمن - قم باختيار المجلد المستهدف:"
 
 #. IDS_FILES_AFFECTED_FMT
-#: Merge.rc:4898
+#: Merge.rc:4897
 #, c-format
 msgid "(%1 Files Affected)"
 msgstr "(%1 ملفات تأثرت)"
 
 #. IDS_FILES_AFFECTED_FMT2
-#: Merge.rc:4899
+#: Merge.rc:4898
 #, c-format
 msgid "(%1 of %2 Files Affected)"
 msgstr "(%1 من %2 ملفات تأثرت)"
 
 #. IDS_CONFIRM_DELETE_SINGLE
-#: Merge.rc:4905
+#: Merge.rc:4904
 #, c-format
 msgid ""
 "Are you sure you want to delete\n"
@@ -6338,18 +6333,18 @@ msgstr ""
 "%1؟"
 
 #. IDS_CONFIRM_SINGLE_COPY
-#: Merge.rc:4906
+#: Merge.rc:4905
 msgid "Are you sure you want to copy?"
 msgstr "هل أنت متأكد تريد نسخ:"
 
 #. IDS_CONFIRM_MULTIPLE_COPY
-#: Merge.rc:4907
+#: Merge.rc:4906
 #, c-format
 msgid "Are you sure you want to copy %d items?"
 msgstr "هل أنت متأكد أنك تريد نسخ %d عنصر:"
 
 #. IDS_DIRCMP_NOTSYNC
-#: Merge.rc:4908
+#: Merge.rc:4907
 #, c-format
 msgid ""
 "Operation aborted!\n"
@@ -6368,794 +6363,794 @@ msgstr ""
 "يرجى تحديث المقارنة."
 
 #. IDS_CONFIRM_SINGLE_MOVE
-#: Merge.rc:4913
+#: Merge.rc:4912
 msgid "Are you sure you want to move?"
 msgstr "هل أنت متأكد تريد نقل:"
 
 #. IDS_CONFIRM_MULTIPLE_MOVE
-#: Merge.rc:4914
+#: Merge.rc:4913
 #, c-format
 msgid "Are you sure you want to move %d items?"
 msgstr "هل أنت متأكد أنك تريد نقل %d عنصر:"
 
 #. IDS_CONFIRM_MOVE_CAPTION
-#: Merge.rc:4916
+#: Merge.rc:4915
 msgid "Confirm Move"
 msgstr "تأكيد الأمر"
 
-#: Merge.rc:4918
+#: Merge.rc:4917
 msgid "Close the folder comparison window?"
 msgstr ""
 "أنت على وشك إغلاق النافذة التي تقوم بالمقارنة بين المجلدات. هل أنت متأكد "
 "برغبتك في إغلاقها؟"
 
-#: Merge.rc:4920
+#: Merge.rc:4919
 msgid "Close the folder comparison window, which took a long time?"
 msgstr ""
 
 #. IDS_ERROR_INVALID_DIR_FILE_NAME
-#: Merge.rc:4921
+#: Merge.rc:4920
 msgid "The file or folder name is invalid."
 msgstr ""
 
 #. IDS_ERROR_EXECUTE_FILE
-#: Merge.rc:4927
+#: Merge.rc:4926
 #, c-format
 msgid "Failed to execute external editor: %1"
 msgstr "فشل في تشغيل المحرر الخارجي: %1"
 
 #. IDS_UNKNOWN_ARCHIVE_FORMAT
-#: Merge.rc:4933
+#: Merge.rc:4932
 msgid "Unknown archive format"
 msgstr "نوع أرشيف غير معروف"
 
-#: Merge.rc:4935
+#: Merge.rc:4934
 msgid "Failed to extract archive.\nCompare as text file?"
 msgstr ""
 
 #. IDS_COLHDR_FILENAME
-#: Merge.rc:4941
+#: Merge.rc:4940
 msgid "Filename"
 msgstr "اسم الملف"
 
 #. IDS_COLHDR_DIR
-#: Merge.rc:4942
+#: Merge.rc:4941
 msgctxt "DirView|ColumnHeader"
 msgid "Folder"
 msgstr "مجلد"
 
 #. IDS_COLHDR_RESULT
-#: Merge.rc:4943
+#: Merge.rc:4942
 msgid "Comparison Result"
 msgstr "نتيجة المقارنة"
 
 #. IDS_COLHDR_LTIMEM
-#: Merge.rc:4944
+#: Merge.rc:4943
 msgid "Left Date"
 msgstr "التاريخ في الجزء الأيسر"
 
 #. IDS_COLHDR_RTIMEM
-#: Merge.rc:4945
+#: Merge.rc:4944
 msgid "Right Date"
 msgstr "التاريخ في الجزء الأيمن"
 
 #. IDS_COLHDR_MTIMEM
-#: Merge.rc:4946
+#: Merge.rc:4945
 msgid "Middle Date"
 msgstr "التاريخ في الجزء الأوسط"
 
 #. IDS_COLHDR_LSIZE
-#: Merge.rc:4948
+#: Merge.rc:4947
 msgid "Left Size"
 msgstr "الحجم في الجزء الأيسر"
 
 #. IDS_COLHDR_RSIZE
-#: Merge.rc:4949
+#: Merge.rc:4948
 msgid "Right Size"
 msgstr "الحجم في الجزء الأيمن"
 
 #. IDS_COLHDR_MSIZE
-#: Merge.rc:4954
+#: Merge.rc:4953
 msgid "Middle Size"
 msgstr "الحجم في الجزء الأوسط"
 
 #. IDS_COLHDR_RSIZE_SHORT
-#: Merge.rc:4955
+#: Merge.rc:4954
 msgid "Right Size (Short)"
 msgstr "الحجم في الجزء الأيمن (مختصر)"
 
 #. IDS_COLHDR_LSIZE_SHORT
-#: Merge.rc:4956
+#: Merge.rc:4955
 msgid "Left Size (Short)"
 msgstr "الحجم في الجزء الأيسر (مختصر)"
 
 #. IDS_COLHDR_MSIZE_SHORT
-#: Merge.rc:4957
+#: Merge.rc:4956
 msgid "Middle Size (Short)"
 msgstr "الحجم في الجزء الأوسط (مختصر)"
 
 #. IDS_COLHDR_LTIMEC
-#: Merge.rc:4963
+#: Merge.rc:4962
 msgid "Left Creation Time"
 msgstr "وقت إنشاء الملف في الجزء الأيسر"
 
 #. IDS_COLHDR_RTIMEC
-#: Merge.rc:4964
+#: Merge.rc:4963
 msgid "Right Creation Time"
 msgstr "وقت إنشاء الملف في الجزء الأيمن"
 
 #. IDS_COLHDR_MTIMEC
-#: Merge.rc:4965
+#: Merge.rc:4964
 msgid "Middle Creation Time"
 msgstr "وقت إنشاء الملف في الجزء الأوسط"
 
 #. IDS_COLHDR_NEWER
-#: Merge.rc:4966
+#: Merge.rc:4965
 msgid "Newer File"
 msgstr "الملف الأحدث"
 
 #. IDS_COLHDR_LVERSION
-#: Merge.rc:4967
+#: Merge.rc:4966
 msgid "Left File Version"
 msgstr "نسخة الملف في الجزء الأيسر"
 
 #. IDS_COLHDR_RVERSION
-#: Merge.rc:4968
+#: Merge.rc:4967
 msgid "Right File Version"
 msgstr "نسخة الملف في الجزء الأيمن"
 
 #. IDS_COLHDR_MVERSION
-#: Merge.rc:4969
+#: Merge.rc:4968
 msgid "Middle File Version"
 msgstr "نسخة الملف في الجزء الأوسط"
 
 #. IDS_COLHDR_RESULT_ABBR
-#: Merge.rc:4970
+#: Merge.rc:4969
 msgid "Short Result"
 msgstr "النتائج المختصرة"
 
 #. IDS_COLHDR_LATTRIBUTES
-#: Merge.rc:4971
+#: Merge.rc:4970
 msgid "Left Attributes"
 msgstr "السمات في الجانب الأيسر"
 
 #. IDS_COLHDR_RATTRIBUTES
-#: Merge.rc:4972
+#: Merge.rc:4971
 msgid "Right Attributes"
 msgstr "السمات في الجانب الأيمن"
 
 #. IDS_COLHDR_MATTRIBUTES
-#: Merge.rc:4973
+#: Merge.rc:4972
 msgid "Middle Attributes"
 msgstr "السمات في الجانب الأوسط"
 
 #. IDS_COLHDR_LEOL_TYPE
-#: Merge.rc:4978
+#: Merge.rc:4977
 msgid "Left EOL"
 msgstr "نهاية السطر (EOL) في الجزء الأيسر"
 
 #. IDS_COLHDR_MEOL_TYPE
-#: Merge.rc:4979
+#: Merge.rc:4978
 msgid "Middle EOL"
 msgstr "نهاية السطر (EOL) في الجزء الأوسط"
 
 #. IDS_COLHDR_REOL_TYPE
-#: Merge.rc:4980
+#: Merge.rc:4979
 msgid "Right EOL"
 msgstr "نهاية السطر (EOL) في الجزء الأيمن"
 
 #. IDS_COLHDR_LENCODING
-#: Merge.rc:4986
+#: Merge.rc:4985
 msgid "Left Encoding"
 msgstr "نوع الترميز في الجزء الأيسر"
 
 #. IDS_COLHDR_RENCODING
-#: Merge.rc:4987
+#: Merge.rc:4986
 msgid "Right Encoding"
 msgstr "نوع الترميز في الجزء الأيمن"
 
 #. IDS_COLHDR_MENCODING
-#: Merge.rc:4988
+#: Merge.rc:4987
 msgid "Middle Encoding"
 msgstr "نوع الترميز في الجزء الأوسط"
 
 #. IDS_COLHDR_NIDIFFS
-#: Merge.rc:4989
+#: Merge.rc:4988
 msgid "Ignored Diff"
 msgstr "الاختلافات التي تم تجاهلها."
 
 #. IDS_COLHDR_BINARY
-#: Merge.rc:4991
+#: Merge.rc:4990
 msgctxt "DirView|ColumnHeader"
 msgid "Binary"
 msgstr "ثنائي"
 
 #. IDS_PLUGINS_TYPE_UNPACKER
-#: Merge.rc:4992 Merge.rc:5314
+#: Merge.rc:4991 Merge.rc:5313
 msgid "Unpacker"
 msgstr "فك الحزمة"
 
 #. IDS_PLUGIN_TYPE4
-#: Merge.rc:4993 Merge.rc:5315 Merge.rc:5622
+#: Merge.rc:4992 Merge.rc:5314 Merge.rc:5621
 msgid "Prediffer"
 msgstr "اختلافات مسبقة"
 
 #. IDS_COLHDR_LEFT
-#: Merge.rc:4994
+#: Merge.rc:4993
 msgid "Left"
 msgstr ""
 
 #. IDS_COLHDR_MIDDLE
-#: Merge.rc:4995
+#: Merge.rc:4994
 msgid "Middle"
 msgstr ""
 
 #. IDS_COLHDR_RIGHT
-#: Merge.rc:4996
+#: Merge.rc:4995
 msgid "Right"
 msgstr ""
 
 #. IDS_COLHDR_DIFF
-#: Merge.rc:4997
+#: Merge.rc:4996
 msgid "Diff"
 msgstr ""
 
 #. IDS_COLHDR_LEFT_DUPLICATE
-#: Merge.rc:4998
+#: Merge.rc:4997
 msgid "Left Duplicate Count"
 msgstr ""
 
 #. IDS_COLHDR_RIGHT_DUPLICATE
-#: Merge.rc:4999
+#: Merge.rc:4998
 msgid "Right Duplicate Count"
 msgstr ""
 
 #. IDS_COLHDR_MIDDLE_DUPLICATE
-#: Merge.rc:5000
+#: Merge.rc:4999
 msgid "Middle Duplicate Count"
 msgstr ""
 
 #. IDS_COLHDR_MOVE
-#: Merge.rc:5001
+#: Merge.rc:5000
 msgid "Move"
 msgstr ""
 
 #. IDS_PRPCAT_AUDIO
-#: Merge.rc:5008
+#: Merge.rc:5007
 msgid "Audio"
 msgstr ""
 
 #. IDS_PRPCAT_CALENDAR
-#: Merge.rc:5009
+#: Merge.rc:5008
 msgid "Calendar"
 msgstr ""
 
 #. IDS_PRPCAT_COMMUNICATION
-#: Merge.rc:5010
+#: Merge.rc:5009
 msgid "Communication"
 msgstr ""
 
 #. IDS_PRPCAT_CONTACT
-#: Merge.rc:5011
+#: Merge.rc:5010
 msgid "Contact"
 msgstr ""
 
 #. IDS_PRPCAT_DEVICES
-#: Merge.rc:5012
+#: Merge.rc:5011
 msgid "Devices"
 msgstr ""
 
 #. IDS_PRPCAT_DOCUMENT
-#: Merge.rc:5013
+#: Merge.rc:5012
 msgid "Document"
 msgstr ""
 
 #. IDS_PRPCAT_HOME
-#: Merge.rc:5014
+#: Merge.rc:5013
 msgid "Home"
 msgstr ""
 
 #. IDS_PRPCAT_JOURNAL
-#: Merge.rc:5016
+#: Merge.rc:5015
 msgid "Journal"
 msgstr ""
 
 #. IDS_PRPCAT_LINK
-#: Merge.rc:5017
+#: Merge.rc:5016
 msgid "Link"
 msgstr ""
 
 #. IDS_PRPCAT_MEDIA
-#: Merge.rc:5018
+#: Merge.rc:5017
 msgid "Media"
 msgstr ""
 
 #. IDS_PRPCAT_MUSIC
-#: Merge.rc:5020
+#: Merge.rc:5019
 msgid "Music"
 msgstr ""
 
 #. IDS_PRPCAT_NOTE
-#: Merge.rc:5021
+#: Merge.rc:5020
 msgid "Note"
 msgstr ""
 
 #. IDS_PRPCAT_PHOTO
-#: Merge.rc:5022
+#: Merge.rc:5021
 msgid "Photo"
 msgstr ""
 
 #. IDS_PRPCAT_RECORDEDTV
-#: Merge.rc:5023
+#: Merge.rc:5022
 msgid "RecordedTV"
 msgstr ""
 
 #. IDS_PRPCAT_SEARCH
-#: Merge.rc:5024
+#: Merge.rc:5023
 msgid "Search"
 msgstr ""
 
 #. IDS_PRPCAT_SECURITY
-#: Merge.rc:5025
+#: Merge.rc:5024
 msgid "Security"
 msgstr ""
 
 #. IDS_PRPCAT_SOFTWARE
-#: Merge.rc:5026
+#: Merge.rc:5025
 msgid "Software"
 msgstr ""
 
 #. IDS_PRPCAT_TASK
-#: Merge.rc:5027
+#: Merge.rc:5026
 msgid "Task"
 msgstr ""
 
 #. IDS_PRPCAT_VIDEO
-#: Merge.rc:5028
+#: Merge.rc:5027
 msgid "Video"
 msgstr ""
 
 #. IDS_PRPCAT_HASH
-#: Merge.rc:5029
+#: Merge.rc:5028
 msgid "Hash"
 msgstr ""
 
 #. IDS_CANT_COMPARE_FILES
-#: Merge.rc:5035
+#: Merge.rc:5034
 msgid "Unable to compare files"
 msgstr "لا يمكن مقارنة الملفات"
 
 #. IDS_ABORTED_ITEM
-#: Merge.rc:5036
+#: Merge.rc:5035
 msgid "Item aborted"
 msgstr "العنصر تم إلغاءه"
 
 #. IDS_FILE_SKIPPED
-#: Merge.rc:5037
+#: Merge.rc:5036
 msgid "File skipped"
 msgstr "تم تخطي الملف"
 
 #. IDS_DIR_SKIPPED
-#: Merge.rc:5038
+#: Merge.rc:5037
 msgid "Folder skipped"
 msgstr "تم تخطي المجلد"
 
 #. IDS_LEFT_ONLY_IN_FMT
-#: Merge.rc:5039
+#: Merge.rc:5038
 #, c-format
 msgid "Left only: %1"
 msgstr "في اليسار: %1 فقط"
 
 #. IDS_MIDDLE_ONLY_IN_FMT
-#: Merge.rc:5040
+#: Merge.rc:5039
 #, c-format
 msgid "Middle only: %1"
 msgstr "في الوسط: %1 فقط"
 
 #. IDS_RIGHT_ONLY_IN_FMT
-#: Merge.rc:5041
+#: Merge.rc:5040
 #, c-format
 msgid "Right only: %1"
 msgstr "في اليمين: %1 فقط"
 
 #. IDS_DOES_NOT_EXIST_IN_FMT
-#: Merge.rc:5042
+#: Merge.rc:5041
 #, c-format
 msgid "Does not exist in %1"
 msgstr "لا يوجد في %1"
 
 #. IDS_BIN_FILES_SAME
-#: Merge.rc:5043
+#: Merge.rc:5042
 msgid "Binary files are identical"
 msgstr "الملفات الثنائية متطابقة"
 
 #. IDS_BIN_FILES_DIFF
-#: Merge.rc:5049
+#: Merge.rc:5048
 msgid "Binary files are different"
 msgstr "الملفات الثنائية مختلفة"
 
 #. IDS_FILES_ARE_DIFFERENT
-#: Merge.rc:5050
+#: Merge.rc:5049
 msgid "Files are different"
 msgstr "الملفات مختلفة"
 
 #. IDS_FOLDERS_ARE_DIFFERENT
-#: Merge.rc:5051
+#: Merge.rc:5050
 msgid "Folders are different"
 msgstr "المجلدات مختلفة"
 
 #. IDS_LEFTONLY
-#: Merge.rc:5052
+#: Merge.rc:5051
 msgid "Left Only"
 msgstr "في اليسار فقط"
 
 #. IDS_RIGHTONLY
-#: Merge.rc:5053
+#: Merge.rc:5052
 msgid "Right Only"
 msgstr "في اليمين فقط"
 
 #. IDS_MIDDLEONLY
-#: Merge.rc:5054
+#: Merge.rc:5053
 msgid "Middle Only"
 msgstr "في الوسط فقط"
 
 #. IDS_NOITEMLEFT
-#: Merge.rc:5055
+#: Merge.rc:5054
 msgid "No item in left"
 msgstr "لا توجد عناصر في الجزء الأيسر"
 
 #. IDS_NOITEMRIGHT
-#: Merge.rc:5056
+#: Merge.rc:5055
 msgid "No item in right"
 msgstr "لا توجد عناصر في الجزء الأيمن"
 
 #. IDS_NOITEMMIDDLE
-#: Merge.rc:5057
+#: Merge.rc:5056
 msgid "No item in middle"
 msgstr "لا توجد عناصر في الجزء الأوسط"
 
 #. IDS_CMPRES_ERROR
-#: Merge.rc:5059
+#: Merge.rc:5058
 msgid "Error"
 msgstr "خطأ"
 
 #. IDS_TEXT_FILES_SAME
-#: Merge.rc:5060
+#: Merge.rc:5059
 msgid "Text files are identical"
 msgstr "الملفات النصية متطابقة"
 
 #. IDS_LEFTONLY_DIFF
-#: Merge.rc:5061
+#: Merge.rc:5060
 msgid " (Middle and right are identical)"
 msgstr " (الجزء الأوسط والجزء الأيمن متطابقان)"
 
 #. IDS_MIDDLEONLY_DIFF
-#: Merge.rc:5062
+#: Merge.rc:5061
 msgid " (Left and right are identical)"
 msgstr " (الجزء الأيسر والجزء الأيمن متطابقان)"
 
 #. IDS_RIGHTONLY_DIFF
-#: Merge.rc:5063
+#: Merge.rc:5062
 msgid " (Left and middle are identical)"
 msgstr " (الجزء الأيسر والجزء الأوسط متطابقان)"
 
 #. IDS_PATH_MISMATCH
-#: Merge.rc:5064
+#: Merge.rc:5063
 msgid " (paths differ)"
 msgstr ""
 
 #. IDS_TEXT_FILES_DIFF
-#: Merge.rc:5065
+#: Merge.rc:5064
 msgid "Text files are different"
 msgstr "الملفات النصية مختلفة"
 
 #. IDS_IMAGE_FILES_SAME
-#: Merge.rc:5066
+#: Merge.rc:5065
 msgid "Image files are identical"
 msgstr ""
 
 #. IDS_IMAGE_FILES_DIFF
-#: Merge.rc:5067
+#: Merge.rc:5066
 msgid "Image files are different"
 msgstr ""
 
 #. IDS_EXPR_DIFF
-#: Merge.rc:5068
+#: Merge.rc:5067
 #, c-format
 msgid "Files are different (expr: %1)"
 msgstr ""
 
 #. IDS_HASH_GROUP
-#: Merge.rc:5069
+#: Merge.rc:5068
 #, c-format
 msgid "Group%d"
 msgstr ""
 
 #. IDS_RENAME_MOVE_DETECTION_DISALBED
-#: Merge.rc:5070
+#: Merge.rc:5069
 msgctxt "Options dialog|Compare|Folder|Detect renames and moves"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_RENAME_MOVE_DETECTION_RENAME
-#: Merge.rc:5071
+#: Merge.rc:5070
 msgid "Detect renames"
 msgstr ""
 
 #. IDS_RENAME_MOVE_DETECTION_RENAME_MOVE
-#: Merge.rc:5072
+#: Merge.rc:5071
 msgid "Detect renames and moves"
 msgstr ""
 
 #. IDS_RENAME_MOVE_MERGE_MODE_RENAME
-#: Merge.rc:5073
+#: Merge.rc:5072
 msgid "Merge renames"
 msgstr ""
 
 #. IDS_RENAME_MOVE_MERGE_MODE_RENAME_MOVE
-#: Merge.rc:5074
+#: Merge.rc:5073
 msgid "Merge renames and moves"
 msgstr ""
 
 #. IDS_RENAMED
-#: Merge.rc:5075
+#: Merge.rc:5074
 msgid "Renamed"
 msgstr ""
 
 #. IDS_RENAMED_MOVED
-#: Merge.rc:5077
+#: Merge.rc:5076
 msgid "Renamed/Moved"
 msgstr ""
 
 #. IDS_RENAMED_MOVED_ITEMS
-#: Merge.rc:5078
+#: Merge.rc:5077
 #, c-format
 msgid "(%1 items)"
 msgstr ""
 
 #. IDS_RENAMED_MOVED_RESULT
-#: Merge.rc:5079
+#: Merge.rc:5078
 #, c-format
 msgid "%1 (set %2): "
 msgstr ""
 
 #. IDS_SWITCH_FLAT_MODE
-#: Merge.rc:5080
+#: Merge.rc:5079
 msgid "Some moved items have been merged.\nIn Tree Mode, these items may appear in positions that do not reflect the actual folder structure, which can be confusing.\nSwitch to Flat Mode?"
 msgstr ""
 
 #. IDS_ELAPSED_TIME
-#: Merge.rc:5086
+#: Merge.rc:5085
 #, c-format
 msgid "Elapsed time: %ld ms"
 msgstr "الوقت المنقضي: %ld م.ث"
 
 #. IDS_STATUS_SELITEM1
-#: Merge.rc:5087
+#: Merge.rc:5086
 msgid "1 item selected"
 msgstr "تم اختيار عنصر واحد"
 
 #. IDS_STATUS_SELITEMS
-#: Merge.rc:5088
+#: Merge.rc:5087
 #, c-format
 msgid "%1 items selected"
 msgstr "%1 عنصر تم اختياره"
 
 #. IDS_COLDESC_FILENAME
-#: Merge.rc:5094
+#: Merge.rc:5093
 msgid "Filename or folder name."
 msgstr "اسم الملف أو اسم المجلد."
 
 #. IDS_COLDESC_DIR
-#: Merge.rc:5095
+#: Merge.rc:5094
 msgid "Subfolder name when subfolders are included."
 msgstr "اسم المجلد الفرعي عند تضمين المجلدات الفرعية."
 
 #. IDS_COLDESC_RESULT
-#: Merge.rc:5096
+#: Merge.rc:5095
 msgid "Comparison result, long form."
 msgstr "نتيجة المقارنة، بالصيغة الطويلة."
 
 #. IDS_COLDESC_LTIMEM
-#: Merge.rc:5101
+#: Merge.rc:5100
 msgid "Left side modification date."
 msgstr "تاريخ التعديل في الجزء الأيسر."
 
 #. IDS_COLDESC_RTIMEM
-#: Merge.rc:5102
+#: Merge.rc:5101
 msgid "Right side modification date."
 msgstr "تاريخ التعديل في الجزء الأيمن."
 
 #. IDS_COLDESC_MTIMEM
-#: Merge.rc:5103
+#: Merge.rc:5102
 msgid "Middle side modification date."
 msgstr "تاريخ التعديل في الجزء الأوسط."
 
 #. IDS_COLDESC_EXTENSION
-#: Merge.rc:5104
+#: Merge.rc:5103
 msgid "File's extension."
 msgstr "إمتداد الملف."
 
 #. IDS_COLDESC_LSIZE
-#: Merge.rc:5105
+#: Merge.rc:5104
 msgid "Left file size in bytes."
 msgstr "حجم الملف بالبايت في الجزء الأيسر."
 
 #. IDS_COLDESC_RSIZE
-#: Merge.rc:5106
+#: Merge.rc:5105
 msgid "Right file size in bytes."
 msgstr "حجم الملف بالبايت في الجزء الأيمن."
 
 #. IDS_COLDESC_MSIZE
-#: Merge.rc:5107
+#: Merge.rc:5106
 msgid "Middle file size in bytes."
 msgstr "حجم الملف بالبايت في الجزء الأوسط."
 
 #. IDS_COLDESC_LSIZE_SHORT
-#: Merge.rc:5108
+#: Merge.rc:5107
 msgid "Left file size abbreviated."
 msgstr "حجم الملف بالبايت في الجزء الأيسر."
 
 #. IDS_COLDESC_RSIZE_SHORT
-#: Merge.rc:5109
+#: Merge.rc:5108
 msgid "Right file size abbreviated."
 msgstr "حجم الملف بالبايت في الجزء الأيمن."
 
 #. IDS_COLDESC_MSIZE_SHORT
-#: Merge.rc:5110
+#: Merge.rc:5109
 msgid "Middle file size abbreviated."
 msgstr "حجم الملف بالبايت في الجزء الأوسط."
 
 #. IDS_COLDESC_LTIMEC
-#: Merge.rc:5116
+#: Merge.rc:5115
 msgid "Left side creation time."
 msgstr "وقت إنشاء الملف في الجزء الأيسر."
 
 #. IDS_COLDESC_RTIMEC
-#: Merge.rc:5117
+#: Merge.rc:5116
 msgid "Right side creation time."
 msgstr "وقت إنشاء الملف في الجزء الأيمن."
 
 #. IDS_COLDESC_MTIMEC
-#: Merge.rc:5118
+#: Merge.rc:5117
 msgid "Middle side creation time."
 msgstr "وقت إنشاء الملف في الجزء الأوسط."
 
 #. IDS_COLDESC_NEWER
-#: Merge.rc:5119
+#: Merge.rc:5118
 msgid "Tells which side has newer modification date."
 msgstr "يحدد أي جانب لديه تاريخ تعديل أحدث."
 
 #. IDS_COLDESC_LVERSION
-#: Merge.rc:5120
+#: Merge.rc:5119
 msgid "Left side file version, only for some file types."
 msgstr "إصدار الملف في الجانب الأيسر، فقط لبعض أنواع الملفات."
 
 #. IDS_COLDESC_RVERSION
-#: Merge.rc:5121
+#: Merge.rc:5120
 msgid "Right side file version, only for some file types."
 msgstr "إصدار الملف في الجانب الأيمن، فقط لبعض أنواع الملفات."
 
 #. IDS_COLDESC_MVERSION
-#: Merge.rc:5126
+#: Merge.rc:5125
 msgid "Middle side file version, only for some file types."
 msgstr "إصدار الملف في الجانب الأوسط، فقط لبعض أنواع الملفات."
 
 #. IDS_COLDESC_RESULT_ABBR
-#: Merge.rc:5127
+#: Merge.rc:5126
 msgid "Short comparison result."
 msgstr "نتائج المقارنة المختصرة."
 
 #. IDS_COLDESC_LATTRIBUTES
-#: Merge.rc:5128
+#: Merge.rc:5127
 msgid "Left side attributes."
 msgstr "سمات الملف في الجزء الأيسر."
 
 #. IDS_COLDESC_RATTRIBUTES
-#: Merge.rc:5129
+#: Merge.rc:5128
 msgid "Right side attributes."
 msgstr "سمات الملف في الجزء الأيمن."
 
 #. IDS_COLDESC_MATTRIBUTES
-#: Merge.rc:5130
+#: Merge.rc:5129
 msgid "Middle side attributes."
 msgstr "سمات الملف في الجزء الأوسط."
 
 #. IDS_COLDESC_LEOL_TYPE
-#: Merge.rc:5131
+#: Merge.rc:5130
 msgid "Left side file EOL type."
 msgstr "نوع رمز نهاية السطر (EOL) في الجزء الأيسر."
 
 #. IDS_COLDESC_REOL_TYPE
-#: Merge.rc:5132
+#: Merge.rc:5131
 msgid "Right side file EOL type."
 msgstr "نوع رمز نهاية السطر (EOL) في الجزء الأيمن."
 
 #. IDS_COLDESC_MEOL_TYPE
-#: Merge.rc:5133
+#: Merge.rc:5132
 msgid "Middle side file EOL type."
 msgstr "نوع رمز نهاية السطر (EOL) في الجزء الأوسط."
 
 #. IDS_COLDESC_LENCODING
-#: Merge.rc:5139
+#: Merge.rc:5138
 msgid "Left side encoding."
 msgstr "ترميز الملف في الجزء الأيسر."
 
 #. IDS_COLDESC_RENCODING
-#: Merge.rc:5140
+#: Merge.rc:5139
 msgid "Right side encoding."
 msgstr "ترميز الملف في الجزء الأيمن."
 
 #. IDS_COLDESC_MENCODING
-#: Merge.rc:5141
+#: Merge.rc:5140
 msgid "Middle side encoding."
 msgstr "ترميز الملف في الجزء الأوسط."
 
 #. IDS_COLDESC_NIDIFFS
-#: Merge.rc:5142
+#: Merge.rc:5141
 msgid "Number of ignored differences in file. Ignored and cannot be merged."
 msgstr ""
 "عدد الاختلافات التي تم تجاهلها في الملف. هذه الاختلافات تم تجاهلها من قبل "
 "WinMerge ولا يمكن دمجها."
 
 #. IDS_COLDESC_NSDIFFS
-#: Merge.rc:5143
+#: Merge.rc:5142
 msgid "Number of differences in file (excluding ignored)."
 msgstr ""
 
 #. IDS_COLDESC_BINARY
-#: Merge.rc:5144
+#: Merge.rc:5143
 msgid "Shows an asterisk (*) if the file is binary."
 msgstr "ضع علامة النجمة (*) إذا كان الملف ثنائي."
 
 #. IDS_COLDESC_UNPACKER
-#: Merge.rc:5145
+#: Merge.rc:5144
 msgid "Unpacker plugin name or pipeline."
 msgstr ""
 
 #. IDS_COLDESC_PREDIFFER
-#: Merge.rc:5146
+#: Merge.rc:5145
 msgid "Prediffer plugin name or pipeline."
 msgstr ""
 
 #. IDS_DIRECTORY_REPORT_TITLE
-#: Merge.rc:5152
+#: Merge.rc:5151
 #, c-format
 msgid "Compare %1 with %2"
 msgstr "قارن بين %1 و %2"
 
 #. IDS_DIRECTORY_REPORT_TITLE3
-#: Merge.rc:5153
+#: Merge.rc:5152
 #, c-format
 msgid "Compare %1 with %2 and %3"
 msgstr ""
 
 #. IDS_REPORT_COMMALIST
-#: Merge.rc:5154
+#: Merge.rc:5153
 msgid "Comma-separated list"
 msgstr "قائمة مرتبة بالفاصلة"
 
 #. IDS_REPORT_TABLIST
-#: Merge.rc:5155
+#: Merge.rc:5154
 msgid "Tab-separated list"
 msgstr "قائمة مرتبة بالتاب (Tab)"
 
 #. IDS_REPORT_SIMPLEHTML
-#: Merge.rc:5156
+#: Merge.rc:5155
 msgid "Simple HTML"
 msgstr "HTML بسيط"
 
 #. IDS_REPORT_SIMPLEXML
-#: Merge.rc:5157
+#: Merge.rc:5156
 msgid "Simple XML"
 msgstr "XML بسيط"
 
-#: Merge.rc:5159
+#: Merge.rc:5158
 msgid "Report file already exists. Overwrite?"
 msgstr "ملف التقرير موجود مسبقا. هل تريد الكتابة فوق الملف الموجود؟"
 
 #. IDS_REPORT_ERROR
-#: Merge.rc:5164
+#: Merge.rc:5163
 #, c-format
 msgid ""
 "Error creating the report:\n"
@@ -7165,73 +7160,73 @@ msgstr ""
 "%1"
 
 #. IDS_REPORT_SUCCESS
-#: Merge.rc:5165
+#: Merge.rc:5164
 msgid "Report created successfully."
 msgstr "تم إنشاء التقرير بنجاح."
 
 #. IDS_SYNCPOINT_LASTBLOCK
-#: Merge.rc:5171
+#: Merge.rc:5170
 msgid "Cannot add a synchronization point at this line."
 msgstr ""
 
 #. IDS_FILE_TO_ITSELF
-#: Merge.rc:5177
+#: Merge.rc:5176
 msgid "Same file is opened in both panes."
 msgstr "تم فتح نفس الملف في كلا الخانتين."
 
 #. IDS_FILESSAME
-#: Merge.rc:5178
+#: Merge.rc:5177
 msgid "Selected files are identical."
 msgstr "الملفات التي تم اختيارها متطابقة."
 
 #. IDS_FILESSAME_CURCFG
-#: Merge.rc:5179
+#: Merge.rc:5178
 msgid "Selected files are identical (with current settings).\r\nChecking binary identity..."
 msgstr ""
 
 #. IDS_FILESSAME_BINERROR
-#: Merge.rc:5180
+#: Merge.rc:5179
 msgid "Selected files are identical (with current settings).\r\nBut binary comparison failed."
 msgstr ""
 
 #. IDS_FILESSAME_BINSAME
-#: Merge.rc:5181
+#: Merge.rc:5180
 msgid "Selected files are identical (binary match)."
 msgstr ""
 
 #. IDS_FILESSAME_BINDIFF
-#: Merge.rc:5182
+#: Merge.rc:5181
 msgid "Selected files are identical (with current settings).\r\nBut differ at the binary level."
 msgstr ""
 
 #. IDS_FILEERROR
-#: Merge.rc:5183
+#: Merge.rc:5182
 msgid "An error occurred while comparing files."
 msgstr "حدث خطأ أثناء مقارنة الملفات."
 
 #. IDS_TEMP_FILEERROR
-#: Merge.rc:5184
+#: Merge.rc:5183
 msgid ""
 "Could not create temporary files. Check your temporary path settings."
 msgstr "لا يمكن إنشاء ملفات مؤقتة. تحقق من إعدادات المسار الملفات المؤقتة."
 
 #. IDS_SUGGEST_IGNOREEOL
-#: Merge.rc:5185
+#: Merge.rc:5184
 msgid "Files use different EOL.\n\nTreat all EOL as equivalent?\n\nSet 'Ignore EOL differences (Windows/Unix/Mac)' in Compare section of Options."
 msgstr ""
 
 #. IDS_INVALID_DIRECTORY
-#: Merge.rc:5186
+#: Merge.rc:5185
 msgid "Selected folder is invalid."
 msgstr "المجلد الذي قمت باختياره غير صالح."
 
 #. IDS_CANNOT_OPEN_BINARYFILE
-#: Merge.rc:5187
+#: Merge.rc:5186
 msgid "Cannot open a binary file in Editor."
 msgstr "لا يمكن فتح الملف الثنائي من المحرر."
 
 #. IDS_CREATE_PAIR_FOLDER
-#: Merge.rc:5188
+#: Merge.rc:5187
 #, c-format
 msgid "Create matching folder:\n%1\non the other side and open?"
 msgstr ""
@@ -7242,41 +7237,41 @@ msgstr ""
 "في الجهة الأخرى وفتح هذه المجلدات؟"
 
 #. IDS_CONFIRM_COPY_ALL_DIFFS
-#: Merge.rc:5189
+#: Merge.rc:5188
 msgid "Copy all differences to other file?"
 msgstr ""
 
 #. IDS_MOVE_TO_NEXTFILE
-#: Merge.rc:5194
+#: Merge.rc:5193
 msgid "Move to next file?"
 msgstr "هل تريد الإنتقال إلى الملف التالي؟"
 
 #. IDS_MOVE_TO_PREVFILE
-#: Merge.rc:5195
+#: Merge.rc:5194
 msgid "Move to previous file?"
 msgstr "هل تريد العودة إلى الملف السابق؟"
 
 #. IDS_MOVE_TO_NEXTPAGE
-#: Merge.rc:5196
+#: Merge.rc:5195
 msgid "Move to next page?"
 msgstr "هل تريد الإنتقال إلى الصفحة التالية؟"
 
 #. IDS_MOVE_TO_PREVPAGE
-#: Merge.rc:5197
+#: Merge.rc:5196
 msgid "Move to previous page?"
 msgstr "هل تريد العودة إلى الصفحة السابقة؟"
 
 #. IDS_MOVE_TO_FIRSTFILE
-#: Merge.rc:5198
+#: Merge.rc:5197
 msgid "Move to first file?"
 msgstr ""
 
 #. IDS_MOVE_TO_LASTFILE
-#: Merge.rc:5199
+#: Merge.rc:5198
 msgid "Move to last file?"
 msgstr ""
 
-#: Merge.rc:5206
+#: Merge.rc:5205
 #, c-format
 msgid "Different codepages: left (cp%d), right (cp%d).\nDisplay in codepage (better display) or default Windows codepage (safer merging)?\n(Recommended: default Windows codepage)"
 msgstr ""
@@ -7287,53 +7282,53 @@ msgstr ""
 "هل ترغب في مع التعامل مع كلا الملفين باستخدام صفحة الترميز الافتراضية الخاصة "
 "بويندوز (ينصح بهذا الإجراء)؟"
 
-#: Merge.rc:5208
+#: Merge.rc:5207
 msgid "Information lost due to encoding errors: both files"
 msgstr "المعلومات فقدت بسبب أخطاء في الترميز: كلا الملفين"
 
-#: Merge.rc:5210
+#: Merge.rc:5209
 msgid "Information lost due to encoding errors: first file"
 msgstr "المعلومات فقدت بسبب أخطاء في الترميز: الملف الأول"
 
-#: Merge.rc:5212
+#: Merge.rc:5211
 msgid "Information lost due to encoding errors: second file"
 msgstr "المعلومات فقدت بسبب أخطاء في الترميز: الملف الثاني"
 
-#: Merge.rc:5214
+#: Merge.rc:5213
 msgid "Information lost due to encoding errors: third file"
 msgstr "المعلومات فقدت بسبب أخطاء في الترميز: الملف الثالث"
 
 #. IDS_LINEDIFF_NODIFF
-#: Merge.rc:5220
+#: Merge.rc:5219
 msgid "No difference"
 msgstr "لا اختلافات"
 
 #. IDS_LINEDIFF_NODIFF_CAPTION
-#: Merge.rc:5221
+#: Merge.rc:5220
 msgid "Line difference"
 msgstr "الاختلاف في السطر"
 
 #. IDS_NUM_REPLACED
-#: Merge.rc:5227
+#: Merge.rc:5226
 #, c-format
 msgid "Replaced %1 string(s)."
 msgstr "تم اتسبدال %1 سطر."
 
 #. IDS_EDIT_TEXT_NOT_FOUND
-#: Merge.rc:5228
+#: Merge.rc:5227
 #, c-format
 msgid "Cannot find string \"%s\"."
 msgstr "لا يمكن ايجاد السطر \"%s\"."
 
 #. IDS_MERGE_MODE
-#: Merge.rc:5234
+#: Merge.rc:5233
 msgid "Entering Merge Mode. Press F9 to turn off."
 msgstr ""
 "أنت الآن تدخل وضع الدمج. إذا كنت ترغب في إيقاف تشغيل وضع الدمج، قم بالضغط "
 "على المفتاح F9."
 
 #. IDS_AUTO_MERGE
-#: Merge.rc:5240
+#: Merge.rc:5239
 #, c-format
 msgid ""
 "Automatic merges: %1\n"
@@ -7343,89 +7338,89 @@ msgstr ""
 "عدد حالات التضارب التي تم حلها: %2"
 
 #. IDS_CODEPAGE_MERGED
-#: Merge.rc:5241
+#: Merge.rc:5240
 msgid "Codepage change merged."
 msgstr "التغيير في صحفة الترميز تم دمجها."
 
 #. IDS_CODEPAGE_CONFLICT
-#: Merge.rc:5242
+#: Merge.rc:5241
 msgid "Codepage changes are conflicting."
 msgstr "التغييرات في صفحة الترميز متضاربة."
 
 #. IDS_EOL_MERGED
-#: Merge.rc:5243
+#: Merge.rc:5242
 msgid "EOL change merged."
 msgstr "التغييرات في رمز آخر السطر (EOL) تم دمجه."
 
 #. IDS_EOL_CONFLICT
-#: Merge.rc:5244
+#: Merge.rc:5243
 msgid "EOL changes are conflicting."
 msgstr "التغييرات في رمز آخر السطر (EOL) متضاربة."
 
 #. IDS_LOCBAR_CAPTION
-#: Merge.rc:5250
+#: Merge.rc:5249
 msgid "Location Pane"
 msgstr "الجزء الخاص بالموقع"
 
 #. IDS_DIFFBAR_CAPTION
-#: Merge.rc:5251
+#: Merge.rc:5250
 msgid "Diff Pane"
 msgstr "الجزء الخاص بأداة مقارنة الملفات Diff"
 
 #. IDS_DIFF_SUCCEEDED
-#: Merge.rc:5258
+#: Merge.rc:5257
 msgid "Patch file written."
 msgstr "ملف التصحيح (Patch) تم كتابتة بنجاح."
 
 #. IDS_DIFF_FILEOVERWRITE
-#: Merge.rc:5259
+#: Merge.rc:5258
 msgid "Patch file already exists. Overwrite?"
 msgstr "ملف التصحيح موجود مسبقا. هل تريد الكتابة عليه؟"
 
 #. IDS_DIFF_SELECTEDFILES
-#: Merge.rc:5260
+#: Merge.rc:5259
 #, c-format
 msgid "[%1 files selected]"
 msgstr "[%1 ملفات تم تحديدها]"
 
 #. IDS_DIFF_NORMAL
-#: Merge.rc:5261
+#: Merge.rc:5260
 msgid "Normal"
 msgstr "عادي"
 
 #. IDS_DIFF_CONTEXT
-#: Merge.rc:5262
+#: Merge.rc:5261
 msgid "Context"
 msgstr "حسب السياق"
 
 #. IDS_DIFF_UNIFIED
-#: Merge.rc:5263
+#: Merge.rc:5262
 msgid "Unified"
 msgstr "موحد"
 
 #. IDS_FILEWRITE_ERROR
-#: Merge.rc:5265
+#: Merge.rc:5264
 #, c-format
 msgid "Could not write to file %1."
 msgstr "لا يمكن الكتابة في الملف %1."
 
 #. IDS_PATH_NOT_ABSOLUTE
-#: Merge.rc:5266
+#: Merge.rc:5265
 #, c-format
 msgid "Output path is not absolute: %1"
 msgstr "المسار المحدد للإخراج ليس مسارا مطلقا: %1"
 
 #. IDS_MUST_SPECIFY_OUTPUT
-#: Merge.rc:5267
+#: Merge.rc:5266
 msgid "Specify an output file."
 msgstr "حدد مجلد للإخراج."
 
-#: Merge.rc:5269
+#: Merge.rc:5268
 msgid "Cannot create patch from binary files."
 msgstr "لا يمكن إنشاء ملف تصحيح من ملفات ثنائية."
 
 #. IDS_SAVEFILES_FORPATCH
-#: Merge.rc:5270
+#: Merge.rc:5269
 msgid ""
 "Save all files first.\n"
 "\n"
@@ -7436,22 +7431,22 @@ msgstr ""
 "إنشاء ملف تصحيح يتطلب عدم وجود أي تغييرات غير محفوظة في الملفات."
 
 #. IDS_FOLDER_NOTEXIST
-#: Merge.rc:5271
+#: Merge.rc:5270
 msgid "Folder does not exist."
 msgstr "المجلد غير موجود."
 
 #. IDS_ARCHIVE_SUCCEEDED
-#: Merge.rc:5277
+#: Merge.rc:5276
 msgid "Archive file written."
 msgstr ""
 
 #. IDS_ARCHIVE_SAVEFILES
-#: Merge.rc:5278
+#: Merge.rc:5277
 msgid "Save all files first.\n\nCreating an archive requires no unsaved changes."
 msgstr ""
 
 #. IDS_NO_ZIP_SUPPORT
-#: Merge.rc:5283
+#: Merge.rc:5282
 msgid "Archive support not enabled.\n7-Zip and/or Merge7z*.dll not found.\nSee manual for archive support."
 msgstr ""
 "دعم الملفات المؤرشفة غير مفعل.\n"
@@ -7461,37 +7456,37 @@ msgstr ""
 "تفعيلها."
 
 #. IDS_OPT_EXPORT_CAPTION
-#: Merge.rc:5284
+#: Merge.rc:5283
 msgid "Select file for export"
 msgstr "قم باختيار الملف للتصدير"
 
 #. IDS_OPT_IMPORT_CAPTION
-#: Merge.rc:5285
+#: Merge.rc:5284
 msgid "Select file for import"
 msgstr "قم باختيار الملف للإستيراد"
 
 #. IDS_OPT_IMPORT_DONE
-#: Merge.rc:5286
+#: Merge.rc:5285
 msgid "Options imported from file."
 msgstr "الخيارات مستوردة من الملف."
 
 #. IDS_OPT_EXPORT_DONE
-#: Merge.rc:5287
+#: Merge.rc:5286
 msgid "Options exported to file."
 msgstr "الخيارات مصدرة إلى الملف."
 
 #. IDS_OPT_IMPORT_ERR
-#: Merge.rc:5288
+#: Merge.rc:5287
 msgid "Failed to import options from file."
 msgstr "فشل في استيراد الخيارات من الملف."
 
 #. IDS_OPT_EXPORT_ERR
-#: Merge.rc:5289
+#: Merge.rc:5288
 msgid "Failed to write options to file."
 msgstr "فشل في الكتابة الخيارات إلى الملف."
 
 #. IDS_CLOSEALL_WINDOWS
-#: Merge.rc:5290
+#: Merge.rc:5289
 msgid ""
 "Close multiple compare windows?\n"
 "\n"
@@ -7502,34 +7497,34 @@ msgstr ""
 "هل ترغب في الاستمرار؟"
 
 #. IDS_EOL_BIN
-#: Merge.rc:5300
+#: Merge.rc:5299
 msgctxt "EOL Type"
 msgid "Binary"
 msgstr "ثنائي"
 
 #. IDS_MARKER_COLOR_FMT
-#: Merge.rc:5305
+#: Merge.rc:5304
 #, c-format
 msgid "Marker Color %d"
 msgstr ""
 
 #. IDS_MARKER_NEW_PATTERN
-#: Merge.rc:5306
+#: Merge.rc:5305
 msgid "New Pattern"
 msgstr ""
 
 #. IDS_PLUGINSLIST_TYPE
-#: Merge.rc:5312
+#: Merge.rc:5311
 msgid "Type"
 msgstr "النوع"
 
 #. IDS_PLUGINS_TYPE_EDITSCRIPT
-#: Merge.rc:5316
+#: Merge.rc:5315
 msgid "Editor script"
 msgstr "محرر اللغة النصية (سكريبت)"
 
 #. ID_SELECTLINEDIFF
-#: Merge.rc:5322
+#: Merge.rc:5321
 msgid ""
 "\n"
 "Difference in Current Line (F4)"
@@ -7538,7 +7533,7 @@ msgstr ""
 "الاختلاف في السطر الحالي (F4)"
 
 #. ID_OPTIONS
-#: Merge.rc:5323
+#: Merge.rc:5322
 msgid ""
 "\n"
 "Options"
@@ -7547,7 +7542,7 @@ msgstr ""
 "الخيارات"
 
 #. ID_REFRESH
-#: Merge.rc:5324
+#: Merge.rc:5323
 msgid ""
 "\n"
 "Refresh (F5)"
@@ -7556,7 +7551,7 @@ msgstr ""
 "تحديث (F5)"
 
 #. ID_PREVDIFF
-#: Merge.rc:5330
+#: Merge.rc:5329
 msgid ""
 "\n"
 "Previous Difference (Alt+Up)"
@@ -7565,7 +7560,7 @@ msgstr ""
 "الاختلاف السابق (Alt+Up)"
 
 #. ID_NEXTDIFF
-#: Merge.rc:5331
+#: Merge.rc:5330
 msgid ""
 "\n"
 "Next Difference (Alt+Down)"
@@ -7574,7 +7569,7 @@ msgstr ""
 "الاختلاف التالي (Alt+Down)"
 
 #. ID_PREVCONFLICT
-#: Merge.rc:5332
+#: Merge.rc:5331
 msgid ""
 "\n"
 "Previous Conflict (Alt+Shift+Up)"
@@ -7583,7 +7578,7 @@ msgstr ""
 "التضارب السابق (Alt+Shift+Up)"
 
 #. ID_NEXTCONFLICT
-#: Merge.rc:5333
+#: Merge.rc:5332
 msgid ""
 "\n"
 "Next Conflict (Alt+Shift+Down)"
@@ -7592,7 +7587,7 @@ msgstr ""
 "التضارب التالي (Alt+Shift+Down)"
 
 #. ID_FIRSTDIFF
-#: Merge.rc:5338
+#: Merge.rc:5337
 msgid ""
 "\n"
 "First Difference (Alt+Home)"
@@ -7601,7 +7596,7 @@ msgstr ""
 "الاختلاف الأول (Alt+Home)"
 
 #. ID_CURDIFF
-#: Merge.rc:5339
+#: Merge.rc:5338
 msgid ""
 "\n"
 "Current Difference (Alt+Enter)"
@@ -7610,7 +7605,7 @@ msgstr ""
 "الاختلاف الحالي (Alt+Enter)"
 
 #. ID_LASTDIFF
-#: Merge.rc:5340
+#: Merge.rc:5339
 msgid ""
 "\n"
 "Last Difference (Alt+End)"
@@ -7619,37 +7614,37 @@ msgstr ""
 "الاختلاف الأخير (Alt+End)"
 
 #. ID_L2R
-#: Merge.rc:5341
+#: Merge.rc:5340
 msgid "\nCopy to Right (Alt+Right)"
 msgstr "\nالنسخ لليمين (Alt+Right)"
 
 #. ID_R2L
-#: Merge.rc:5342
+#: Merge.rc:5341
 msgid "\nCopy to Left (Alt+Left)"
 msgstr "\nالنسخ لليسار (Alt+Left)"
 
 #. ID_L2RNEXT
-#: Merge.rc:5343
+#: Merge.rc:5342
 msgid "\nCopy to Right and Advance (Ctrl+Alt+Right)"
 msgstr "\nالنسخ لليمين والتقدم (Ctrl+Alt+Right)"
 
 #. ID_R2LNEXT
-#: Merge.rc:5344
+#: Merge.rc:5343
 msgid "\nCopy to Left and Advance (Ctrl+Alt+Left)"
 msgstr "\nالنسخ لليسار والتقدم (Ctrl+Alt+Left)"
 
 #. ID_ALL_RIGHT
-#: Merge.rc:5345
+#: Merge.rc:5344
 msgid "\nCopy All to Right"
 msgstr "\nنسخ الكل إلى الجزء الأيمن"
 
 #. ID_ALL_LEFT
-#: Merge.rc:5346
+#: Merge.rc:5345
 msgid "\nCopy All to Left"
 msgstr "\nنسخ الكل إلى الجزء الأيسر"
 
 #. ID_AUTO_MERGE
-#: Merge.rc:5347
+#: Merge.rc:5346
 msgid ""
 "\n"
 "Auto Merge (Ctrl+Alt+M)"
@@ -7658,162 +7653,162 @@ msgstr ""
 "الدمج التلقائي (Ctrl+Alt+M)"
 
 #. ID_FIRSTFILE
-#: Merge.rc:5348
+#: Merge.rc:5347
 msgid "\nFirst File"
 msgstr ""
 
 #. ID_NEXTFILE
-#: Merge.rc:5349
+#: Merge.rc:5348
 msgid "\nNext File (Ctrl+F8)"
 msgstr ""
 
 #. ID_LASTFILE
-#: Merge.rc:5350
+#: Merge.rc:5349
 msgid "\nLast File"
 msgstr ""
 
 #. ID_PREVFILE
-#: Merge.rc:5351
+#: Merge.rc:5350
 msgid "\nPrevious File (Ctrl+F7)"
 msgstr ""
 
 #. IDS_UNPACK_AUTO
-#: Merge.rc:5358
+#: Merge.rc:5357
 msgid "Adapted unpacker applied to both files (one needs extension)."
 msgstr ""
 "أداة فك الحزمة المختارة يتم تطبيقه لكلا الملفين (ملف واحد فقط يحتاج للإمتداد)."
 
 #. IDS_NO_PREDIFFER
-#: Merge.rc:5359
+#: Merge.rc:5358
 msgid "No Prediffer (Normal)"
 msgstr "لا اختلافات مسبقة (عادي)"
 
 #. IDS_SUGGESTED_PLUGINS
-#: Merge.rc:5360
+#: Merge.rc:5359
 msgid "Suggested Plugins"
 msgstr "الإضافات المقترحة"
 
 #. IDS_NOT_SUGGESTED_PLUGINS
-#: Merge.rc:5361
+#: Merge.rc:5360
 msgid "All Plugins"
 msgstr ""
 
 #. IDS_PRIVATEBUILD_FMT
-#: Merge.rc:5367
+#: Merge.rc:5366
 #, c-format
 msgid "Private Build: %1"
 msgstr "نسخة خاصة: %1"
 
 #. IDS_ALLRIGHTS_RESERVED
-#: Merge.rc:5368
+#: Merge.rc:5367
 msgid " - All rights reserved."
 msgstr ""
 
 #. IDS_TITLE_PLUGINS_SETTINGS
-#: Merge.rc:5374
+#: Merge.rc:5373
 msgid "Plugin Settings"
 msgstr "إعدادات الإضافات"
 
 #. IDS_NO_SCT_SCRIPTS
-#: Merge.rc:5376
+#: Merge.rc:5375
 msgid "WSH not found - .sct scripts disabled"
 msgstr "WSH غير موجود - .sct سكربت معطل"
 
 #. IDS_LOCBAR_GOTOLINE_FMT
-#: Merge.rc:5384
+#: Merge.rc:5383
 #, c-format
 msgid "G&o to Line %1"
 msgstr "إ&ذهب إلى السطر %1"
 
 #. IDS_GOTO_MOVED_LINE
-#: Merge.rc:5390
+#: Merge.rc:5389
 msgid "Go to Moved Line\tCtrl+Shift+G"
 msgstr ""
 
 #. IDS_AUTOCOMPLETE_DISABLED
-#: Merge.rc:5396
+#: Merge.rc:5395
 msgctxt "Options dialog|General|Open dialog Auto completion"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_AUTOCOMPLETE_FILE_SYS
-#: Merge.rc:5397
+#: Merge.rc:5396
 msgid "From file system"
 msgstr "من ملف النظام"
 
 #. IDS_AUTOCOMPLETE_MRU
-#: Merge.rc:5398
+#: Merge.rc:5397
 msgid "From Most Recently Used list"
 msgstr "من قائمة MRU"
 
 #. IDS_COLORSCHEME_PLAIN
-#: Merge.rc:5404
+#: Merge.rc:5403
 msgid "No Highlighting"
 msgstr "بدون تظليل"
 
 #. IDS_COLORSCHEME_PO
-#: Merge.rc:5439
+#: Merge.rc:5438
 msgid "Portable Object"
 msgstr "Portable Object"
 
 #. IDS_COLORSCHEME_RSRC
-#: Merge.rc:5444
+#: Merge.rc:5443
 msgid "Resources"
 msgstr "Resources"
 
 #. IDS_COLORSCHEME_SH
-#: Merge.rc:5448
+#: Merge.rc:5447
 msgid "Shell"
 msgstr "Shell"
 
 #. IDS_CLOSE_LEFT_TABS
-#: Merge.rc:5469
+#: Merge.rc:5468
 msgid "Close &Left Tabs"
 msgstr "إ&غلاق التبويبات في الجزء الأيسر"
 
 #. IDS_CLOSE_RIGHT_TABS
-#: Merge.rc:5470
+#: Merge.rc:5469
 msgid "Close R&ight Tabs"
 msgstr "إغ&لاق التبويبات في الجزء الأيمن"
 
 #. IDS_CLOSE_OTHER_TABS
-#: Merge.rc:5471
+#: Merge.rc:5470
 msgid "Close &Other Tabs"
 msgstr "إغلا&ق التبويبات الأخرى"
 
 #. IDS_TABBAR_AUTO_MAXWIDTH
-#: Merge.rc:5472
+#: Merge.rc:5471
 msgid "Enable &Auto Max Width"
 msgstr "&تفعيل النطاق الأقصى التلقائي"
 
 #. IDS_WEBPAGE_MENU
-#: Merge.rc:5482
+#: Merge.rc:5481
 msgid "We&bpage"
 msgstr ""
 
 #. IDS_VIEW_WRAP_TEXT
-#: Merge.rc:5487
+#: Merge.rc:5486
 msgid "W&rap Text"
 msgstr ""
 
 #. IDS_NOTINSTALLED
-#: Merge.rc:5492
+#: Merge.rc:5491
 msgid "%1 is not installed."
 msgstr "المحرر %1 غير مثبت."
 
 #. IDS_CREATE_FOLDER
-#: Merge.rc:5497
+#: Merge.rc:5496
 #, c-format
 msgid "%1 does not exist. Create it?"
 msgstr "%1 غير موجود. هل تريد إنشائه؟"
 
 #. IDS_CREATE_FOLDER_ERROR
-#: Merge.rc:5498
+#: Merge.rc:5497
 msgid "Failed to create folder."
 msgstr "فشل في إنشاء المجلد."
 
 #. IDC_EXT_EDITOR_PATH
-#: Merge.rc:5503
+#: Merge.rc:5502
 msgid ""
 "Parameters:\n"
 "$file: Current file path\n"
@@ -7824,908 +7819,908 @@ msgstr ""
 "$linenum: رقم السطر لموضع المؤشر الحالي"
 
 #. IDS_DIFF_ALGORITHM_DEFAULT
-#: Merge.rc:5508
+#: Merge.rc:5507
 msgid "default"
 msgstr ""
 
 #. IDS_DIFF_ALGORITHM_MINIMAL
-#: Merge.rc:5509
+#: Merge.rc:5508
 msgid "minimal"
 msgstr ""
 
 #. IDS_DIFF_ALGORITHM_PATIENCE
-#: Merge.rc:5510
+#: Merge.rc:5509
 msgid "patience"
 msgstr ""
 
 #. IDS_DIFF_ALGORITHM_HISTOGRAM
-#: Merge.rc:5511
+#: Merge.rc:5510
 msgid "histogram"
 msgstr ""
 
 #. IDS_DIFF_ALGORITHM_NONE
-#: Merge.rc:5512
+#: Merge.rc:5511
 msgid "none"
 msgstr ""
 
 #. IDS_RENDERING_MODE_GDI
-#: Merge.rc:5517
+#: Merge.rc:5516
 msgid "GDI"
 msgstr ""
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_DEFAULT
-#: Merge.rc:5518
+#: Merge.rc:5517
 msgid "DirectWrite Default"
 msgstr ""
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_ALIASED
-#: Merge.rc:5519
+#: Merge.rc:5518
 msgid "DirectWrite Aliased"
 msgstr ""
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_GDI_CLASSIC
-#: Merge.rc:5520
+#: Merge.rc:5519
 msgid "DirectWrite GDI Classic"
 msgstr ""
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_GDI_NATURAL
-#: Merge.rc:5521
+#: Merge.rc:5520
 msgid "DirectWrite GDI Natural"
 msgstr ""
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_NATURAL
-#: Merge.rc:5522
+#: Merge.rc:5521
 msgid "DirectWrite Natural"
 msgstr ""
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_NATURAL_SYMMETRIC
-#: Merge.rc:5523
+#: Merge.rc:5522
 msgid "DirectWrite Natural Symmetric"
 msgstr ""
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_DISABLED
-#: Merge.rc:5528
+#: Merge.rc:5527
 msgctxt "Options dialog|General|Close windows with Esc"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_1
-#: Merge.rc:5529
+#: Merge.rc:5528
 msgid "MDI child window or main window"
 msgstr ""
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_2
-#: Merge.rc:5530
+#: Merge.rc:5529
 msgid "MDI child window only"
 msgstr ""
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_3
-#: Merge.rc:5531
+#: Merge.rc:5530
 msgid "Close main window if only one MDI child window"
 msgstr ""
 
 #. IDS_DIFF_GROUP
-#: Merge.rc:5536
+#: Merge.rc:5535
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Diff"
 msgstr ""
 
 #. IDS_DIFF_HIGHLIGHT
-#: Merge.rc:5537
+#: Merge.rc:5536
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Highlight"
 msgstr ""
 
 #. IDS_DIFF_BLINK
-#: Merge.rc:5538
+#: Merge.rc:5537
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Blink"
 msgstr ""
 
 #. IDS_DIFF_BLOCKSIZE
-#: Merge.rc:5539
+#: Merge.rc:5538
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Block Size"
 msgstr ""
 
 #. IDS_DIFF_BLOCKALPHA
-#: Merge.rc:5540
+#: Merge.rc:5539
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Block Alpha"
 msgstr ""
 
 #. IDS_DIFF_CDTHRESHOLD
-#: Merge.rc:5541
+#: Merge.rc:5540
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "CD Threshold"
 msgstr ""
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION
-#: Merge.rc:5542
+#: Merge.rc:5541
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Ins/Del Detection"
 msgstr ""
 
 #. IDS_OVERLAY_MODE_NONE
-#: Merge.rc:5543 Merge.rc:5548
+#: Merge.rc:5542 Merge.rc:5547
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "None"
 msgstr ""
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION_VERTICAL
-#: Merge.rc:5544
+#: Merge.rc:5543
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Vertical"
 msgstr ""
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION_HORIZONTAL
-#: Merge.rc:5545
+#: Merge.rc:5544
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Horizontal"
 msgstr ""
 
 #. IDS_OVERLAY_GROUP
-#: Merge.rc:5546
+#: Merge.rc:5545
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Overlay"
 msgstr ""
 
 #. IDS_OVERLAY_ALPHA
-#: Merge.rc:5547
+#: Merge.rc:5546
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha"
 msgstr ""
 
 #. IDS_OVERLAY_MODE_XOR
-#: Merge.rc:5549
+#: Merge.rc:5548
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "XOR"
 msgstr ""
 
 #. IDS_OVERLAY_MODE_ALPHA
-#: Merge.rc:5550
+#: Merge.rc:5549
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha Blend"
 msgstr ""
 
 #. IDS_OVERLAY_MODE_ALPHA_ANIMATION
-#: Merge.rc:5551
+#: Merge.rc:5550
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha Animation"
 msgstr ""
 
 #. IDS_ZOOM
-#: Merge.rc:5552
+#: Merge.rc:5551
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Zoom"
 msgstr ""
 
 #. IDS_PAGE
-#: Merge.rc:5553
+#: Merge.rc:5552
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Page:"
 msgstr ""
 
 #. IDS_IMGCMP_STATUS_PT_RGBA_FMT
-#: Merge.rc:5554
+#: Merge.rc:5553
 #, c-format
 msgid "Pt: (%d, %d)  RGBA: (%d, %d, %d, %d)  "
 msgstr ""
 
 #. IDS_IMGCMP_STATUS_DIST1_FMT
-#: Merge.rc:5555
+#: Merge.rc:5554
 #, c-format
 msgid "Dist: %g  "
 msgstr ""
 
 #. IDS_IMGCMP_STATUS_DIST2_FMT
-#: Merge.rc:5556
+#: Merge.rc:5555
 #, c-format
 msgid "Dist: %g, %g  "
 msgstr ""
 
 #. IDS_IMGCMP_STATUS_PAGE_ZOOM_SIZE_BPP_FMT
-#: Merge.rc:5557
+#: Merge.rc:5556
 #, c-format
 msgid "Page: %d/%d  Zoom: %d%%  %dx%dpx  %dbpp  "
 msgstr ""
 
 #. IDS_IMGCMP_STATUS_RC_FMT
-#: Merge.rc:5558
+#: Merge.rc:5557
 #, c-format
 msgid "Rc: (%d, %d)  "
 msgstr ""
 
 #. IDS_IMGCMP_STATUS_FLIPPED_FMT
-#: Merge.rc:5559
+#: Merge.rc:5558
 #, c-format
 msgid "Flipped: %s  "
 msgstr ""
 
 #. IDS_IMGCMP_STATUS_ROTATED_FMT
-#: Merge.rc:5560
+#: Merge.rc:5559
 #, c-format
 msgid "Rotated: %d  "
 msgstr ""
 
 #. IDS_IMGCMP_REPORT_ALLPAGES
-#: Merge.rc:5561
+#: Merge.rc:5560
 msgid "All pages"
 msgstr ""
 
 #. IDS_IGNSUB_STR1
-#: Merge.rc:5566
+#: Merge.rc:5565
 msgid "<Edit here>"
 msgstr ""
 
 #. IDS_IGNSUB_STR2
-#: Merge.rc:5567
+#: Merge.rc:5566
 msgid "No differences found to select"
 msgstr ""
 
 #. IDS_IGNSUB_STR3
-#: Merge.rc:5568
+#: Merge.rc:5567
 msgid "No differences found to add as substitution filter"
 msgstr ""
 
 #. IDS_IGNSUB_STR4
-#: Merge.rc:5569
+#: Merge.rc:5568
 msgid "The pair is already in the Substitution Filters list"
 msgstr ""
 
 #. IDS_IGNSUB_STR5
-#: Merge.rc:5570
+#: Merge.rc:5569
 msgid "Add this change to Substitution Filters?"
 msgstr ""
 
 #. IDS_OCRRESULT_TEXTONLY
-#: Merge.rc:5575
+#: Merge.rc:5574
 msgid "Text only"
 msgstr ""
 
 #. IDS_OCRRESULT_POS_LINE
-#: Merge.rc:5576
+#: Merge.rc:5575
 msgid "Line-by-line position and text"
 msgstr ""
 
 #. IDS_OCRRESULT_POS_WORD
-#: Merge.rc:5577
+#: Merge.rc:5576
 msgid "Word-by-word position and text"
 msgstr ""
 
 #. IDS_USERDATAFOLDER_APPDATA
-#: Merge.rc:5582
+#: Merge.rc:5581
 msgid "AppData (Roaming) folder"
 msgstr ""
 
 #. IDS_USERDATAFOLDER_INSTALL
-#: Merge.rc:5583
+#: Merge.rc:5582
 msgid "Install folder"
 msgstr ""
 
 #. IDS_USERDATAFOLDER_DOCUMENTS
-#: Merge.rc:5584
+#: Merge.rc:5583
 msgid "Documents folder"
 msgstr ""
 
 #. IDS_SINGLEINSTANCE_DISABLED
-#: Merge.rc:5589
+#: Merge.rc:5588
 msgctxt "Options dialog|General|Single instance mode"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_SINGLEINSTANCE_STR1
-#: Merge.rc:5590
+#: Merge.rc:5589
 msgid "Allow only one instance to run"
 msgstr "السماح بتشغيل عنصر واحد فقط"
 
 #. IDS_CLIPBOARD_HISTORY
-#: Merge.rc:5591
+#: Merge.rc:5590
 msgid "Clipboard &History"
 msgstr ""
 
 #. IDS_SINGLEINSTANCE_STR2
-#: Merge.rc:5592
+#: Merge.rc:5591
 msgid "Allow only one instance; wait for termination"
 msgstr ""
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_DISABLED
-#: Merge.rc:5597
+#: Merge.rc:5596
 msgctxt "Options dialog|General|Auto-reload modified files"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_STR1
-#: Merge.rc:5598
+#: Merge.rc:5597
 msgid "Only on window activated"
 msgstr ""
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_STR2
-#: Merge.rc:5599
+#: Merge.rc:5598
 msgid "Immediately"
 msgstr ""
 
 #. IDS_PLUGIN_ALL
-#: Merge.rc:5604
+#: Merge.rc:5603
 msgid "Al&l"
 msgstr ""
 
 #. IDS_PLUGIN_OTHERS
-#: Merge.rc:5605
+#: Merge.rc:5604
 msgid "&Others"
 msgstr ""
 
-#: Merge.rc:5607
+#: Merge.rc:5606
 #, c-format
 msgid "Missing plugin name in pipeline: %1"
 msgstr ""
 
-#: Merge.rc:5609
+#: Merge.rc:5608
 #, c-format
 msgid "Missing quote in plugin pipeline: %1"
 msgstr ""
 
 #. IDS_PLUGIN_NAME_ALREADY_EXISTS
-#: Merge.rc:5610
+#: Merge.rc:5609
 #, c-format
 msgid "Plugin name '%1' already exists."
 msgstr ""
 
 #. IDS_PLUGIN_TITLE1
-#: Merge.rc:5611
+#: Merge.rc:5610
 msgid "Specify plugin arguments"
 msgstr ""
 
-#: Merge.rc:5613
+#: Merge.rc:5612
 #, c-format
 msgid "Plugin not found or invalid: %1"
 msgstr ""
 
 #. IDS_PLUGIN_NOT_UNPACK
-#: Merge.rc:5614
+#: Merge.rc:5613
 #, c-format
 msgid "'%1' is not an unpacker plugin"
 msgstr ""
 
 #. IDS_PLUGIN_NOT_PREDIFF
-#: Merge.rc:5615
+#: Merge.rc:5614
 #, c-format
 msgid "'%1' is not a prediffer plugin"
 msgstr ""
 
-#: Merge.rc:5617
+#: Merge.rc:5616
 #, c-format
 msgid "Error prediffing '%1' with '%2'. Prediffing disabled."
 msgstr ""
 
 #. IDS_PLUGIN_CIRCULAR_REFERENCE
-#: Merge.rc:5618
+#: Merge.rc:5617
 #, c-format
 msgid "Circular reference in plugin pipeline: %1"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE1
-#: Merge.rc:5619
+#: Merge.rc:5618
 msgid "URL Handler"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE2
-#: Merge.rc:5620
+#: Merge.rc:5619
 msgid "File Unpacker"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE3
-#: Merge.rc:5621
+#: Merge.rc:5620
 msgid "File or Folder Unpacker"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE5
-#: Merge.rc:5623
+#: Merge.rc:5622
 msgid "Alias for Unpacker"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE6
-#: Merge.rc:5624
+#: Merge.rc:5623
 msgid "Alias for Prediffer"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE7
-#: Merge.rc:5625
+#: Merge.rc:5624
 msgid "Alias for Editor script"
 msgstr ""
 
 #. IDS_PLUGIN_ALIAS_DESC
-#: Merge.rc:5626
+#: Merge.rc:5625
 #, c-format
 msgid "Alias for plugin pipeline '%1'"
 msgstr ""
 
 #. IDS_PLUGIN_NEW_DESC
-#: Merge.rc:5627
+#: Merge.rc:5626
 msgid "New plugin description"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_ALL
-#: Merge.rc:5628
+#: Merge.rc:5627
 msgid "All"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_1ST
-#: Merge.rc:5629
+#: Merge.rc:5628
 msgid "1st"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_2ND
-#: Merge.rc:5630
+#: Merge.rc:5629
 msgid "2nd"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_3RD
-#: Merge.rc:5631
+#: Merge.rc:5630
 msgid "3rd"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_1ST_2ND
-#: Merge.rc:5632
+#: Merge.rc:5631
 msgid "1st and 2nd"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_1ST_3RD
-#: Merge.rc:5633
+#: Merge.rc:5632
 msgid "1st and 3rd"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_2ND_3RD
-#: Merge.rc:5634
+#: Merge.rc:5633
 msgid "2nd and 3rd"
 msgstr ""
 
 #. IDS_PLUGIN_CTRL_CLICK
-#: Merge.rc:5635
+#: Merge.rc:5634
 msgid "(Ctrl+Click to add to pipeline)"
 msgstr ""
 
 #. IDS_FILTER_APPLIED
-#: Merge.rc:5640
+#: Merge.rc:5639
 msgid "Filter applied"
 msgstr ""
 
 #. IDS_FILTERMENU_COMPARE
-#: Merge.rc:5645
+#: Merge.rc:5644
 #, c-format
 msgid "Compare %1"
 msgstr ""
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN2
-#: Merge.rc:5647
+#: Merge.rc:5646
 msgid "&Filter by This Column..."
 msgstr ""
 
 #. IDS_CLIPBOARDHISTORY_TIME
-#: Merge.rc:5652
+#: Merge.rc:5651
 #, c-format
 msgid "Clipboard at %s"
 msgstr ""
 
 #. IDS_CLIPBOARDHISTORY_DISABLED
-#: Merge.rc:5653
+#: Merge.rc:5652
 msgid "Clipboard history disabled.\r\nEnable: Windows logo key + V, then Turn on."
 msgstr ""
 
-#: Merge.rc:5655
+#: Merge.rc:5654
 msgid "This system does not support clipboard history."
 msgstr ""
 
-#: Merge.rc:5657
+#: Merge.rc:5656
 msgid "32-bit WinMerge does not support Clipboard Compare"
 msgstr ""
 
 #. IDS_WEBVIEW2_RUNTIME_NOT_INSTALLED
-#: Merge.rc:5662
+#: Merge.rc:5661
 msgid "WebView2 runtime not installed. Download it?"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_TEXT_COMPARE
-#: Merge.rc:5667
+#: Merge.rc:5666
 msgid "New Text Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_TABLE_COMPARE
-#: Merge.rc:5668
+#: Merge.rc:5667
 msgid "New Table Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_BINARY_COMPARE
-#: Merge.rc:5669
+#: Merge.rc:5668
 msgid "New Binary Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_IMAGE_COMPARE
-#: Merge.rc:5670
+#: Merge.rc:5669
 msgid "New Image Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_WEBPAGE_COMPARE
-#: Merge.rc:5671
+#: Merge.rc:5670
 msgid "New Webpage Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_FOLDER_COMPARE
-#: Merge.rc:5672
+#: Merge.rc:5671
 msgid "New Folder Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_CLIPBOARD_COMPARE
-#: Merge.rc:5673
+#: Merge.rc:5672
 msgid "Clipboard Compare"
 msgstr ""
 
 #. IDS_PREVIEWBAR_PRINT
-#: Merge.rc:5678
+#: Merge.rc:5677
 msgid "&Print..."
 msgstr ""
 
 #. IDS_PREVIEWBAR_PREVPAGE
-#: Merge.rc:5680
+#: Merge.rc:5679
 msgid "Pre&v Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_TWOPAGE
-#: Merge.rc:5681
+#: Merge.rc:5680
 msgid "&Two Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_ONEPAGE
-#: Merge.rc:5682
+#: Merge.rc:5681
 msgid "&One Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_ZOOMIN
-#: Merge.rc:5683
+#: Merge.rc:5682
 msgid "Zoom &In"
 msgstr ""
 
 #. IDS_PREVIEWBAR_ZOOMOUT
-#: Merge.rc:5684
+#: Merge.rc:5683
 msgid "Zoom &Out"
 msgstr ""
 
 #. IDS_WEBPAGE_COMPARING
-#: Merge.rc:5690
+#: Merge.rc:5689
 msgid "Comparing..."
 msgstr ""
 
 #. IDS_WEBPAGE_ZOOM
-#: Merge.rc:5691
+#: Merge.rc:5690
 msgid "Zoom:"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_DIFFHUNK
-#: Merge.rc:5696
+#: Merge.rc:5695
 msgid "Diff hunk"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_INLINE
-#: Merge.rc:5697
+#: Merge.rc:5696
 msgid "Inline diff"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_LINE
-#: Merge.rc:5698
+#: Merge.rc:5697
 msgid "Line"
 msgstr ""
 
-#: Merge.rc:5699
+#: Merge.rc:5698
 msgid "Character"
 msgstr ""
 
 #. ID_MICE_PREVDIFF
-#: Merge.rc:5704
+#: Merge.rc:5703
 msgid "\nPrevious Difference (Alt+Up)\n(Right Button+Wheel Up)\n(Alt+Wheel Up)"
 msgstr ""
 
 #. ID_MICE_NEXTDIFF
-#: Merge.rc:5705
+#: Merge.rc:5704
 msgid "\nNext Difference (Alt+Down)\n(Right Button+Wheel Down)\n(Alt+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_L2R
-#: Merge.rc:5706
+#: Merge.rc:5705
 msgid "\nCopy to Right (Alt+Right)\n(Right Button+Wheel Right)\n(Alt+Wheel Right)\n(Alt+Shift+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_R2L
-#: Merge.rc:5707
+#: Merge.rc:5706
 msgid "\nCopy to Left (Alt+Left)\n(Right Button+Wheel Left)\n(Alt+Wheel Left)\n(Alt+Shift+Wheel Up)"
 msgstr ""
 
 #. ID_MICE_L2RNEXT
-#: Merge.rc:5708
+#: Merge.rc:5707
 msgid "\nCopy to Right and Advance (Ctrl+Alt+Right)\n(Ctrl+Alt+Wheel Right)\n(Ctrl+Alt+Shift+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_R2LNEXT
-#: Merge.rc:5709
+#: Merge.rc:5708
 msgid "\nCopy to Left and Advance (Ctrl+Alt+Left)\n(Ctrl+Alt+Wheel Left)\n(Ctrl+Alt+Shift+Wheel Up)"
 msgstr ""
 
 #. IDS_LOG_COMPARING_2
-#: Merge.rc:5719
+#: Merge.rc:5718
 #, c-format
 msgid "Comparing %1 with %2"
 msgstr ""
 
 #. IDS_LOG_COMPARING_3
-#: Merge.rc:5720
+#: Merge.rc:5719
 #, c-format
 msgid "Comparing %1 with %2 and %3"
 msgstr ""
 
 #. IDS_LOG_COMPARE_COMPLETED
-#: Merge.rc:5721
+#: Merge.rc:5720
 msgid "Comparison completed"
 msgstr ""
 
 #. IDS_LOG_COMPARE_ERROR_2
-#: Merge.rc:5722
+#: Merge.rc:5721
 #, c-format
 msgid "Failed to compare %1 with %2: "
 msgstr ""
 
 #. IDS_LOG_COMPARE_ERROR_3
-#: Merge.rc:5723
+#: Merge.rc:5722
 #, c-format
 msgid "Failed to compare %1 with %2 and %3: "
 msgstr ""
 
 #. IDS_LOG_FILE_SAVED
-#: Merge.rc:5724
+#: Merge.rc:5723
 msgid "File saved"
 msgstr ""
 
 #. IDS_LOG_COPYING_FILES
-#: Merge.rc:5725
+#: Merge.rc:5724
 msgid "Copying files..."
 msgstr ""
 
 #. IDS_LOG_MOVING_FILES
-#: Merge.rc:5726
+#: Merge.rc:5725
 msgid "Moving files..."
 msgstr ""
 
 #. IDS_LOG_DELETING_FILES
-#: Merge.rc:5727
+#: Merge.rc:5726
 msgid "Deleting files..."
 msgstr ""
 
 #. IDS_LOG_RECYCLEBIN
-#: Merge.rc:5728
+#: Merge.rc:5727
 msgid "Recycle Bin"
 msgstr ""
 
 #. IDS_LOG_PERMANENTLY_DELETED
-#: Merge.rc:5729
+#: Merge.rc:5728
 msgid "Permanently deleted"
 msgstr ""
 
 #. IDS_LOG_FILEOPERATION_COMPLETED
-#: Merge.rc:5730
+#: Merge.rc:5729
 msgid "File operation completed successfully"
 msgstr ""
 
 #. IDS_LOG_FILEOPERATION_CANCELED
-#: Merge.rc:5731
+#: Merge.rc:5730
 msgid "File operation canceled"
 msgstr ""
 
 #. IDS_FILTER_ERROR_NO_ERROR
-#: Merge.rc:5736
+#: Merge.rc:5735
 msgid "No error"
 msgstr ""
 
 #. IDS_FILTER_ERROR_EMPTY_EXPRESSION
-#: Merge.rc:5737
+#: Merge.rc:5736
 msgid "Filter expression is empty"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNKNOWN_CHAR
-#: Merge.rc:5738
+#: Merge.rc:5737
 msgid "Unknown character in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNTERMINATED_STRING
-#: Merge.rc:5739
+#: Merge.rc:5738
 msgid "Unterminated string literal"
 msgstr ""
 
 #. IDS_FILTER_ERROR_SYNTAX_ERROR
-#: Merge.rc:5740
+#: Merge.rc:5739
 msgid "Syntax error in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_PARSE_FAILURE
-#: Merge.rc:5741
+#: Merge.rc:5740
 msgid "Failed to parse filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_LITERAL
-#: Merge.rc:5742
+#: Merge.rc:5741
 msgid "Invalid literal value"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_REGULAR_EXPRESSION
-#: Merge.rc:5743
+#: Merge.rc:5742
 msgid "Invalid regular expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNDEFINED_IDENTIFIER
-#: Merge.rc:5744
+#: Merge.rc:5743
 msgid "Undefined identifier"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_ARGUMENT_COUNT
-#: Merge.rc:5745
+#: Merge.rc:5744
 msgid "Invalid number of arguments"
 msgstr ""
 
 #. IDS_FILTER_ERROR_FILTER_NAME_NOT_FOUND
-#: Merge.rc:5746
+#: Merge.rc:5745
 msgid "Filter name not found"
 msgstr ""
 
 #. IDS_FILTER_ERROR_DIVIDE_BY_ZERO
-#: Merge.rc:5747
+#: Merge.rc:5746
 msgid "Division by zero in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNKNOWN_ERROR
-#: Merge.rc:5748
+#: Merge.rc:5747
 msgid "Unknown error"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_PROPERTY_NAME
-#: Merge.rc:5749
+#: Merge.rc:5748
 msgid "Invalid property name"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_DIRECTIVE
-#: Merge.rc:5750
+#: Merge.rc:5749
 msgid "Invalid directive"
 msgstr ""
 
 #. IDS_FILTER_OP_EQUALS
-#: Merge.rc:5755
+#: Merge.rc:5754
 msgid "Equals"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_EQUALS
-#: Merge.rc:5756
+#: Merge.rc:5755
 msgid "Does not equal"
 msgstr ""
 
 #. IDS_FILTER_OP_LESS_THAN
-#: Merge.rc:5757
+#: Merge.rc:5756
 msgid "Less than"
 msgstr ""
 
 #. IDS_FILTER_OP_LESS_EQUAL
-#: Merge.rc:5758
+#: Merge.rc:5757
 msgid "Less than or equal to"
 msgstr ""
 
 #. IDS_FILTER_OP_GREATER_EQUAL
-#: Merge.rc:5759
+#: Merge.rc:5758
 msgid "Greater than or equal to"
 msgstr ""
 
 #. IDS_FILTER_OP_GREATER_THAN
-#: Merge.rc:5760
+#: Merge.rc:5759
 msgid "Greater than"
 msgstr ""
 
 #. IDS_FILTER_OP_BETWEEN
-#: Merge.rc:5761
+#: Merge.rc:5760
 msgid "Between"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_BETWEEN
-#: Merge.rc:5762
+#: Merge.rc:5761
 msgid "Not Between"
 msgstr ""
 
 #. IDS_FILTER_OP_CONTAINS
-#: Merge.rc:5763
+#: Merge.rc:5762
 msgid "Contains"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_CONTAINS
-#: Merge.rc:5764
+#: Merge.rc:5763
 msgid "Not Contains"
 msgstr ""
 
 #. IDS_FILTER_OP_RECONTAINS
-#: Merge.rc:5765
+#: Merge.rc:5764
 msgid "Contains (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_RECONTAINS
-#: Merge.rc:5766
+#: Merge.rc:5765
 msgid "Not Contains (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_LIKE
-#: Merge.rc:5767
+#: Merge.rc:5766
 msgid "Match (wildcard)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_LIKE
-#: Merge.rc:5768
+#: Merge.rc:5767
 msgid "Not match (wildcard)"
 msgstr ""
 
 #. IDS_FILTER_OP_MATCHES
-#: Merge.rc:5769
+#: Merge.rc:5768
 msgid "Match (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_MATCHES
-#: Merge.rc:5770
+#: Merge.rc:5769
 msgid "Not match (regex)"
 msgstr ""
 
 #. IDS_COLORMODE_LIGHT
-#: Merge.rc:5775
+#: Merge.rc:5774
 msgid "Light"
 msgstr ""
 
 #. IDS_COLORMODE_DARK
-#: Merge.rc:5776
+#: Merge.rc:5775
 msgid "Dark"
 msgstr ""
 
 #. IDS_COLORMODE_FOLLOWSYSTEM
-#: Merge.rc:5777
+#: Merge.rc:5776
 msgid "Follow system"
 msgstr ""
 
 #. IDS_EXAMPLE
-#: Merge.rc:5782
+#: Merge.rc:5781
 #, c-format
 msgid "e.g. %1"
 msgstr ""
 
 #. IDS_DETECTED_PREVIOUS_CRASH
-#: Merge.rc:5787
+#: Merge.rc:5786
 msgid "WinMerge detected a previous crash. Please report this if possible."
 msgstr ""
 
 #. IDS_REGEX_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5792
+#: Merge.rc:5791
 msgid "# Regex replacement list\r\n# Format: regex<TAB>replacement\r\n# Backreferences like $1, $2 are supported\r\n\r\n(\\d{4})-(\\d{2})-(\\d{2})\t$1_$2_$3\r\n"
 msgstr ""
 
 #. IDS_STRING_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5793
+#: Merge.rc:5792
 msgid "# Replacement list\r\n# Format: search<TAB>replacement\r\n# Lines starting with # are ignored\r\n\r\nfrom1\tto1\r\nfrom2\tto2\r\n"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_ONLY
-#: Merge.rc:5798
+#: Merge.rc:5797
 msgid "Built-in only"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_FIRST
-#: Merge.rc:5799
+#: Merge.rc:5798
 msgid "Built-in first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_FIRST
-#: Merge.rc:5800
+#: Merge.rc:5799
 msgid "Tree-sitter first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_ONLY
-#: Merge.rc:5801
+#: Merge.rc:5800
 msgid "Tree-sitter only"
 msgstr ""
 

--- a/Translations/WinMerge/Basque.po
+++ b/Translations/WinMerge/Basque.po
@@ -24,7 +24,7 @@ msgstr ""
 "X-Generator: Poedit 1.5.3\n"
 
 #. LANGUAGE, SUBLANGUAGE
-#: Merge.rc:26 Merge.rc:59 Merge.rc:5818
+#: Merge.rc:26 Merge.rc:59 Merge.rc:5817
 #, c-format
 msgid "LANG_ENGLISH, SUBLANG_ENGLISH_US"
 msgstr "LANG_BASQUE, SUBLANG_DEFAULT"
@@ -174,7 +174,7 @@ msgstr "E&skriptak"
 #. IDS_NO_EDIT_SCRIPTS
 #: Merge.rc:127 Merge.rc:352 Merge.rc:463 Merge.rc:673 Merge.rc:678
 #: Merge.rc:887 Merge.rc:899 Merge.rc:906 Merge.rc:963 Merge.rc:1210
-#: Merge.rc:5375
+#: Merge.rc:5374
 #, c-format
 msgid "< Empty >"
 msgstr "< Hutsik >"
@@ -241,7 +241,7 @@ msgid "Auto-Fit All Columns"
 msgstr ""
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN
-#: Merge.rc:153 Merge.rc:5646
+#: Merge.rc:153 Merge.rc:5645
 msgid "&Filter by This Column"
 msgstr ""
 
@@ -307,7 +307,7 @@ msgid "&Previous Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_NEXTPAGE
-#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5679
+#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5678
 #, c-format
 msgid "&Next Page"
 msgstr ""
@@ -575,7 +575,7 @@ msgstr "&Binarioa"
 #. IDS_IMAGE_MENU
 #: Merge.rc:329 Merge.rc:338 Merge.rc:432 Merge.rc:441 Merge.rc:609
 #: Merge.rc:618 Merge.rc:670 Merge.rc:960 Merge.rc:1187 Merge.rc:1200
-#: Merge.rc:5477
+#: Merge.rc:5476
 #, c-format
 msgid "&Image"
 msgstr ""
@@ -713,7 +713,7 @@ msgid "&Huge"
 msgstr ""
 
 #. IDS_VIEW_MENU_BAR
-#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5714
+#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5713
 msgid "Men&u Bar"
 msgstr ""
 
@@ -1476,7 +1476,7 @@ msgid "Lo&cation Pane"
 msgstr "Kokalek&u Panela"
 
 #. IDS_OUTPUTBAR_CAPTION
-#: Merge.rc:782 Merge.rc:5252
+#: Merge.rc:782 Merge.rc:5251
 msgid "Output Pane"
 msgstr ""
 
@@ -1772,55 +1772,55 @@ msgid "Co&mpare As"
 msgstr "Alderatu &Honela"
 
 #. IDS_COPY_LEFT_TO_MIDDLE2
-#: Merge.rc:968 Merge.rc:980 Merge.rc:4852
+#: Merge.rc:968 Merge.rc:980 Merge.rc:4851
 #, c-format
 msgid "Left to Middle (%1 of %2)"
 msgstr ""
 
 #. IDS_COPY_LEFT_TO_RIGHT2
-#: Merge.rc:969 Merge.rc:981 Merge.rc:4851
+#: Merge.rc:969 Merge.rc:981 Merge.rc:4850
 #, c-format
 msgid "Left to Right (%1 of %2)"
 msgstr "Ezkerra Eskuinera (%1 %2-tik)"
 
 #. IDS_MOVE_LEFT_TO2
-#: Merge.rc:970 Merge.rc:982 Merge.rc:1045 Merge.rc:4863 Merge.rc:4892
+#: Merge.rc:970 Merge.rc:982 Merge.rc:1045 Merge.rc:4862 Merge.rc:4891
 #, c-format
 msgid "Left to... (%1 of %2)"
 msgstr "Ezkerra hona... (%1 %2-tik)"
 
 #. IDS_COPY_MIDDLE_TO_LEFT2
-#: Merge.rc:971 Merge.rc:983 Merge.rc:4849
+#: Merge.rc:971 Merge.rc:983 Merge.rc:4848
 #, c-format
 msgid "Middle to Left (%1 of %2)"
 msgstr ""
 
 #. IDS_COPY_MIDDLE_TO_RIGHT2
-#: Merge.rc:972 Merge.rc:984 Merge.rc:4850
+#: Merge.rc:972 Merge.rc:984 Merge.rc:4849
 #, c-format
 msgid "Middle to Right (%1 of %2)"
 msgstr ""
 
 #. IDS_MOVE_MIDDLE_TO2
-#: Merge.rc:973 Merge.rc:985 Merge.rc:1046 Merge.rc:4864 Merge.rc:4893
+#: Merge.rc:973 Merge.rc:985 Merge.rc:1046 Merge.rc:4863 Merge.rc:4892
 #, c-format
 msgid "Middle to... (%1 of %2)"
 msgstr ""
 
 #. IDS_COPY_RIGHT_TO_MIDDLE2
-#: Merge.rc:974 Merge.rc:986 Merge.rc:4848
+#: Merge.rc:974 Merge.rc:986 Merge.rc:4847
 #, c-format
 msgid "Right to Middle (%1 of %2)"
 msgstr ""
 
 #. IDS_COPY_RIGHT_TO_LEFT2
-#: Merge.rc:975 Merge.rc:987 Merge.rc:4847
+#: Merge.rc:975 Merge.rc:987 Merge.rc:4846
 #, c-format
 msgid "Right to Left (%1 of %2)"
 msgstr "Eskuina Ezkerrera (%1 %2-tik)"
 
 #. IDS_MOVE_RIGHT_TO2
-#: Merge.rc:976 Merge.rc:988 Merge.rc:1047 Merge.rc:4865 Merge.rc:4894
+#: Merge.rc:976 Merge.rc:988 Merge.rc:1047 Merge.rc:4864 Merge.rc:4893
 #, c-format
 msgid "Right to... (%1 of %2)"
 msgstr "Eskuina hona... (%1 %2-tik)"
@@ -1886,31 +1886,31 @@ msgid "Cop&y Paths"
 msgstr "Kopiatu &Helburu-izenak"
 
 #. IDS_DEL_LEFT_FMT2
-#: Merge.rc:1026 Merge.rc:1035 Merge.rc:4880
+#: Merge.rc:1026 Merge.rc:1035 Merge.rc:4879
 #, c-format
 msgid "Left (%1 of %2)"
 msgstr "Ezkerra (%1 %2-tik)"
 
 #. IDS_DEL_MIDDLE_FMT2
-#: Merge.rc:1027 Merge.rc:1036 Merge.rc:4881
+#: Merge.rc:1027 Merge.rc:1036 Merge.rc:4880
 #, c-format
 msgid "Middle (%1 of %2)"
 msgstr ""
 
 #. IDS_DEL_RIGHT_FMT2
-#: Merge.rc:1028 Merge.rc:1037 Merge.rc:4882
+#: Merge.rc:1028 Merge.rc:1037 Merge.rc:4881
 #, c-format
 msgid "Right (%1 of %2)"
 msgstr "Eskuina (%1 %2-tik)"
 
 #. IDS_DEL_BOTH_FMT2
-#: Merge.rc:1029 Merge.rc:1038 Merge.rc:4883
+#: Merge.rc:1029 Merge.rc:1038 Merge.rc:4882
 #, c-format
 msgid "Both (%1 of %2)"
 msgstr "Biak (%1 %2-tik)"
 
 #. IDS_DEL_ALL_FMT2
-#: Merge.rc:1030 Merge.rc:1039 Merge.rc:4888
+#: Merge.rc:1030 Merge.rc:1039 Merge.rc:4887
 #, c-format
 msgid "All (%1 of %2)"
 msgstr ""
@@ -1939,19 +1939,19 @@ msgid "&Zip"
 msgstr "&Zipa"
 
 #. IDS_COPY_BOTH_TO2
-#: Merge.rc:1048 Merge.rc:4866
+#: Merge.rc:1048 Merge.rc:4865
 #, c-format
 msgid "Both to... (%1 of %2)"
 msgstr ""
 
 #. IDS_COPY_ALL_TO2
-#: Merge.rc:1049 Merge.rc:4867
+#: Merge.rc:1049 Merge.rc:4866
 #, c-format
 msgid "All to... (%1 of %2)"
 msgstr ""
 
 #. IDS_COPY_DIFFERENCES_TO2
-#: Merge.rc:1050 Merge.rc:4868
+#: Merge.rc:1050 Merge.rc:4867
 #, c-format
 msgid "Differences to... (%1 of %2)"
 msgstr ""
@@ -2024,13 +2024,13 @@ msgstr ""
 
 #. IDS_USERCHOICE_NONE
 #: Merge.rc:1088 Merge.rc:1094 Merge.rc:1836 Merge.rc:1840 Merge.rc:2031
-#: Merge.rc:2035 Merge.rc:5377
+#: Merge.rc:2035 Merge.rc:5376
 #, c-format
 msgid "<None>"
 msgstr "<Ezer ez>"
 
 #. IDS_USERCHOICE_AUTOMATIC
-#: Merge.rc:1089 Merge.rc:1095 Merge.rc:5378
+#: Merge.rc:1089 Merge.rc:1095 Merge.rc:5377
 #, c-format
 msgid "<Automatic>"
 msgstr "<Berezgaitasunez>"
@@ -2982,13 +2982,13 @@ msgid "Text files only"
 msgstr ""
 
 #. IDS_EOL_NONE
-#: Merge.rc:1667 Merge.rc:1918 Merge.rc:5304
+#: Merge.rc:1667 Merge.rc:1918 Merge.rc:5303
 #, c-format
 msgid "None"
 msgstr "Bat ere ez"
 
 #. IDS_EOL_MIXED
-#: Merge.rc:1668 Merge.rc:5299
+#: Merge.rc:1668 Merge.rc:5298
 #, c-format
 msgid "Mixed"
 msgstr "Mixed"
@@ -3262,14 +3262,14 @@ msgstr ""
 
 #. IDS_DIFFERENT
 #: Merge.rc:1904 Merge.rc:1988 Merge.rc:2866 Merge.rc:3036 Merge.rc:3077
-#: Merge.rc:5058
+#: Merge.rc:5057
 #, c-format
 msgid "Different"
 msgstr "Ezberdin"
 
 #. IDS_IDENTICAL
 #: Merge.rc:1905 Merge.rc:1989 Merge.rc:2865 Merge.rc:3055 Merge.rc:3116
-#: Merge.rc:5048
+#: Merge.rc:5047
 #, c-format
 msgid "Identical"
 msgstr "Berdin"
@@ -3290,7 +3290,7 @@ msgid "Missing"
 msgstr ""
 
 #. IDS_MOVED
-#: Merge.rc:1910 Merge.rc:5076
+#: Merge.rc:1910 Merge.rc:5075
 msgid "Moved"
 msgstr ""
 
@@ -4118,7 +4118,7 @@ msgid "&Use custom system colors"
 msgstr ""
 
 #. IDS_PRPCAT_SYSTEM
-#: Merge.rc:2565 Merge.rc:4559 Merge.rc:4560 Merge.rc:5007
+#: Merge.rc:2565 Merge.rc:4559 Merge.rc:4560 Merge.rc:5006
 #, c-format
 msgid "System"
 msgstr "Sistema"
@@ -4568,7 +4568,7 @@ msgid "Items compared:"
 msgstr "Alderatutako gaiak:"
 
 #. IDS_PREVIEWBAR_CLOSE
-#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5685
+#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5684
 #, c-format
 msgid "&Close"
 msgstr "&Itxi"
@@ -5255,7 +5255,7 @@ msgid "A&ppend timestamp"
 msgstr "Erantsi &denbora"
 
 #. IDS_CONFIRM_COPY_CAPTION
-#: Merge.rc:3214 Merge.rc:4915
+#: Merge.rc:3214 Merge.rc:4914
 #, c-format
 msgid "Confirm Copy"
 msgstr "Berretsi Kopiatzea"
@@ -5516,7 +5516,7 @@ msgid "&Character Set..."
 msgstr ""
 
 #. IDS_PRPCAT_IMAGE
-#: Merge.rc:3351 Merge.rc:4574 Merge.rc:5015
+#: Merge.rc:3351 Merge.rc:4574 Merge.rc:5014
 msgid "Image"
 msgstr ""
 
@@ -5920,7 +5920,7 @@ msgid "Project"
 msgstr ""
 
 #. IDS_COLHDR_NSDIFFS
-#: Merge.rc:4566 Merge.rc:4990
+#: Merge.rc:4566 Merge.rc:4989
 #, c-format
 msgid "Differences"
 msgstr "Ezberdintasunak"
@@ -6080,13 +6080,13 @@ msgid "File Type"
 msgstr ""
 
 #. IDS_COLHDR_EXTENSION
-#: Merge.rc:4653 Merge.rc:4947
+#: Merge.rc:4653 Merge.rc:4946
 #, c-format
 msgid "Extension"
 msgstr "Luzapena"
 
 #. IDS_PRPCAT_MESSAGE
-#: Merge.rc:4659 Merge.rc:5019
+#: Merge.rc:4659 Merge.rc:5018
 msgid "Message"
 msgstr ""
 
@@ -6126,7 +6126,7 @@ msgid "Hidden Items"
 msgstr ""
 
 #. IDS_PLUGINSLIST_NAME
-#: Merge.rc:4680 Merge.rc:5311
+#: Merge.rc:4680 Merge.rc:5310
 #, c-format
 msgid "Name"
 msgstr "Izena"
@@ -6150,7 +6150,7 @@ msgid "[F] "
 msgstr "[F] "
 
 #. IDS_PLUGINSLIST_DESC
-#: Merge.rc:4684 Merge.rc:5313
+#: Merge.rc:4684 Merge.rc:5312
 #, c-format
 msgid "Description"
 msgstr "Azalpena"
@@ -6322,171 +6322,165 @@ msgstr ""
 msgid "  Sel: %d | %d"
 msgstr ""
 
-#. IDS_MERGEMODE_MERGING
-#: Merge.rc:4734
-#, c-format
-msgid "Merge"
-msgstr "Batu"
-
 #. IDS_DIFF_NUMBER_STATUS_FMT
-#: Merge.rc:4735
+#: Merge.rc:4734
 #, c-format
 msgid "Difference %1 of %2"
 msgstr "Ezberdintasuna %1 %2-tik"
 
 #. IDS_NO_DIFF_SEL_FMT
-#: Merge.rc:4736
+#: Merge.rc:4735
 #, c-format
 msgid "%1 Differences Found"
 msgstr "%1 Ezberdintasun Aurkiturik"
 
 #. IDS_1_DIFF_FOUND
-#: Merge.rc:4737
+#: Merge.rc:4736
 #, c-format
 msgid "1 Difference Found"
 msgstr "1 Ezberdintasun Aurkituta"
 
 #. IDS_NO_ERR_SEL_FMT
-#: Merge.rc:4738
+#: Merge.rc:4737
 #, c-format
 msgid "%1 Errors Found"
 msgstr ""
 
 #. IDS_1_ERR_FOUND
-#: Merge.rc:4739
+#: Merge.rc:4738
 msgid "1 Error Found"
 msgstr ""
 
 #. IDS_STATUSBAR_READONLY, Abbreviation from "Read Only"
-#: Merge.rc:4740
+#: Merge.rc:4739
 #, c-format
 msgid "RO"
 msgstr "RO"
 
 #. IDS_DIRVIEW_STATUS_FMT_FOCUS
-#: Merge.rc:4746
+#: Merge.rc:4745
 #, c-format
 msgid "Item %1 of %2"
 msgstr "Gaiak %1 %2-tik"
 
 #. IDS_DIRVIEW_STATUS_FMT_NOFOCUS
-#: Merge.rc:4747
+#: Merge.rc:4746
 #, c-format
 msgid "Items: %1"
 msgstr "Gaiak:%1"
 
 #. IDS_DIRVIEW_STATUS_COMPARING
-#: Merge.rc:4748
+#: Merge.rc:4747
 #, c-format
 msgid "Comparing items..."
 msgstr "Gaiak alderatzen..."
 
 #. IDS_ITEMS_PER_SEC
-#: Merge.rc:4749
+#: Merge.rc:4748
 #, c-format
 msgid "%.1f[items/sec]"
 msgstr ""
 
 #. IDS_ERROR_INCOMPARABLE
-#: Merge.rc:4755
+#: Merge.rc:4754
 msgid "Select two existing folders/files to compare."
 msgstr "Hautatu badauden bi agiritegi edo agiri alderatzeko."
 
 #. IDS_DIRSEL_TAG
-#: Merge.rc:4756
+#: Merge.rc:4755
 #, c-format
 msgid "Folder Selection"
 msgstr "Agirtegi Hautapena"
 
 #. IDS_OPEN_FILESDIRS
-#: Merge.rc:4757
+#: Merge.rc:4756
 #, c-format
 msgid "Select two (or three) folders/files to compare."
 msgstr ""
 
 #. IDS_OPEN_LEFTINVALID
-#: Merge.rc:4758
+#: Merge.rc:4757
 #, c-format
 msgid "Left (1st) path is invalid!"
 msgstr ""
 
 #. IDS_OPEN_MIDDLEINVALID
-#: Merge.rc:4759
+#: Merge.rc:4758
 #, c-format
 msgid "Middle (2nd) path is invalid!"
 msgstr ""
 
 #. IDS_OPEN_RIGHTINVALID2
-#: Merge.rc:4760
+#: Merge.rc:4759
 #, c-format
 msgid "Right (2nd) path is invalid!"
 msgstr ""
 
 #. IDS_OPEN_RIGHTINVALID3
-#: Merge.rc:4761
+#: Merge.rc:4760
 #, c-format
 msgid "Right (3rd) path is invalid!"
 msgstr ""
 
 #. IDS_OPEN_BOTHINVALID
-#: Merge.rc:4762
+#: Merge.rc:4761
 #, c-format
 msgid "Both paths are invalid!"
 msgstr "Bi helburuak baliogabeak dira!"
 
-#: Merge.rc:4764
+#: Merge.rc:4763
 #, c-format
 msgid "Left (1st) and Middle (2nd) paths are invalid!"
 msgstr ""
 
 #. IDS_OPEN_LEFTRIGHTINVALID
-#: Merge.rc:4765
+#: Merge.rc:4764
 #, c-format
 msgid "Left (1st) and Right (3rd) paths are invalid!"
 msgstr ""
 
-#: Merge.rc:4767
+#: Merge.rc:4766
 #, c-format
 msgid "Middle (2nd) and Right (3rd) paths are invalid!"
 msgstr ""
 
 #. IDS_OPEN_ALLINVALID
-#: Merge.rc:4768
+#: Merge.rc:4767
 #, c-format
 msgid "All paths are invalid!"
 msgstr ""
 
 #. IDS_OPEN_UNPACKERDISABLED
-#: Merge.rc:4769
+#: Merge.rc:4768
 msgid "Only enabled for file comparisons"
 msgstr ""
 
 #. IDS_OPEN_MISMATCH
-#: Merge.rc:4770
+#: Merge.rc:4769
 #, c-format
 msgid "Cannot compare file and folder!"
 msgstr "Ezin dira agiria eta agiritegia alderatu!"
 
 #. IDS_ERROR_FILE_NOT_FOUND
-#: Merge.rc:4776
+#: Merge.rc:4775
 #, c-format
 msgid "File not found: %1"
 msgstr "Agiria ez da aurkitu: %1"
 
 #. IDS_ERROR_FOLDER_NOT_FOUND
-#: Merge.rc:4777
+#: Merge.rc:4776
 #, c-format
 msgid "Folder not found: %1"
 msgstr ""
 
 #. IDS_ERROR_FILE_NOT_UNPACKED
-#: Merge.rc:4778
+#: Merge.rc:4777
 #, c-format
 msgid "File not unpacked: %1"
 msgstr "Agiria ez da despaketatu: %1"
 
 #. IDS_ERROR_FILEOPEN
-#: Merge.rc:4779
+#: Merge.rc:4778
 #, c-format
 msgid ""
 "Cannot open file\n"
@@ -6500,13 +6494,13 @@ msgstr ""
 "%2"
 
 #. IDS_ERROR_CONF_RESOLVE
-#: Merge.rc:4780
+#: Merge.rc:4779
 #, c-format
 msgid "Failed to parse conflict file."
 msgstr "Hutsegitea gatazka agiria aztertzerakoan."
 
 #. IDS_NOT_CONFLICT_FILE
-#: Merge.rc:4781
+#: Merge.rc:4780
 #, c-format
 msgid "The file\n%1\nis not a conflict file."
 msgstr ""
@@ -6515,35 +6509,35 @@ msgstr ""
 "ez da agiri gatazkatsu bat."
 
 #. IDS_COMPARE_LARGE_FILES
-#: Merge.rc:4782
+#: Merge.rc:4781
 msgid "Comparing large files requires significant memory.\nShow only comparison results (not file contents)?"
 msgstr ""
 
 #. IDS_SAVE_AS_TITLE
-#: Merge.rc:4788
+#: Merge.rc:4787
 #, c-format
 msgid "Save As"
 msgstr "Gorde Honela"
 
 #. IDS_SAVE_FMT
-#: Merge.rc:4789
+#: Merge.rc:4788
 #, c-format
 msgid "Save changes to %1?"
 msgstr "Gorde aldaketak %1-ri?"
 
 #. IDS_SAVEREADONLY_FMT
-#: Merge.rc:4790
+#: Merge.rc:4789
 #, c-format
 msgid "%1 is read-only. Override? Or 'No' to save as new filename?"
 msgstr "%1 markatuta dago irrakurtzeko-bakarrik bezala. Nahi duzu ezabatzea irakurtzeko-bakarrik agiria? (Ez gordetzeko agirizen berri bezala.)"
 
 #. IDS_ERROR_BACKUP
-#: Merge.rc:4791
+#: Merge.rc:4790
 #, c-format
 msgid "Error backing up file"
 msgstr "Akatsa babeskopia agirian"
 
-#: Merge.rc:4793
+#: Merge.rc:4792
 #, c-format
 msgid ""
 "Unable to backup original file:\n"
@@ -6557,7 +6551,7 @@ msgstr ""
 "Jarraitu horrela ere?"
 
 #. IDS_FILESAVE_FAILED
-#: Merge.rc:4794
+#: Merge.rc:4793
 #, c-format
 msgid "Saving file failed.\n%1\n%2\n\t- Use different filename (OK)\n\t- Abort (Cancel)?"
 msgstr ""
@@ -6568,7 +6562,7 @@ msgstr ""
 "\t- agirizen ezberdin bat erabiltzea (Sakatu Ongi)\n"
 "\t- uneko eragiketa uztea (Sakatu Ezeztatu)?"
 
-#: Merge.rc:4796
+#: Merge.rc:4795
 #, c-format
 msgid "Plugin '%2' cannot pack changes to left file into '%1'.\n\nOriginal unchanged. Save unpacked version?"
 msgstr ""
@@ -6578,12 +6572,12 @@ msgstr ""
 "\n"
 "Nahi duzu despaketatutako bertsioa beste agiri batean gordetzea?"
 
-#: Merge.rc:4798
+#: Merge.rc:4797
 #, c-format
 msgid "Plugin '%2' cannot pack changes to middle file into '%1'.\n\nOriginal unchanged. Save unpacked version?"
 msgstr ""
 
-#: Merge.rc:4800
+#: Merge.rc:4799
 #, c-format
 msgid "Plugin '%2' cannot pack changes to right file into '%1'.\n\nOriginal unchanged. Save unpacked version?"
 msgstr ""
@@ -6594,7 +6588,7 @@ msgstr ""
 "Nahi duzu despaketatutako bertsioa beste agiri batean gordetzea?"
 
 #. IDS_FILECHANGED_ONDISK
-#: Merge.rc:4801
+#: Merge.rc:4800
 #, c-format
 msgid ""
 "Another application updated\n"
@@ -6610,7 +6604,7 @@ msgstr ""
 "Gainidatzi aldatutako agiria?"
 
 #. IDS_SAVEREADONLY_MULTI
-#: Merge.rc:4802
+#: Merge.rc:4801
 #, c-format
 msgid ""
 "%1\n"
@@ -6620,7 +6614,7 @@ msgstr ""
 "irakurtzeko-bakarrik markatuta dago. Irakurtzeko-bakarrik gaia ezeztatzea nahi duzu?"
 
 #. IDS_FILECHANGED_RESCAN
-#: Merge.rc:4803
+#: Merge.rc:4802
 #, c-format
 msgid "Another application updated\n%1\nsince last scan.\n\nReload?"
 msgstr ""
@@ -6631,25 +6625,25 @@ msgstr ""
 "Nahi duzu agiria birgertatzea?"
 
 #. IDS_SAVE_LEFT_AS
-#: Merge.rc:4804
+#: Merge.rc:4803
 #, c-format
 msgid "Save Left File As"
 msgstr "Gorde Ezker Agiria Honela"
 
 #. IDS_SAVE_MIDDLE_AS
-#: Merge.rc:4805
+#: Merge.rc:4804
 #, c-format
 msgid "Save Middle File As"
 msgstr ""
 
 #. IDS_SAVE_RIGHT_AS
-#: Merge.rc:4806
+#: Merge.rc:4805
 #, c-format
 msgid "Save Right File As"
 msgstr "Gorde Eskuineko Agiria Honela"
 
 #. IDS_FILE_DISAPPEARED
-#: Merge.rc:4811
+#: Merge.rc:4810
 #, c-format
 msgid ""
 "File\n"
@@ -6661,7 +6655,7 @@ msgstr ""
 "ezagertuta dago. Mesedez gorde agiriaren kopia bat jarraitzeko."
 
 #. IDS_VIEWS_OUTOFSYNC
-#: Merge.rc:4817
+#: Merge.rc:4816
 #, c-format
 msgid ""
 "Cannot merge unsynched documents.\n"
@@ -6673,189 +6667,189 @@ msgstr ""
 "Berritu agiriak jarraitu aurretik."
 
 #. IDS_BREAK_ON_WHITESPACE
-#: Merge.rc:4822
+#: Merge.rc:4821
 msgid "Break at whitespace"
 msgstr "Hautsi zurigunean"
 
 #. IDS_BREAK_ON_PUNCTUATION
-#: Merge.rc:4823
+#: Merge.rc:4822
 msgid "Break at whitespace or punctuation"
 msgstr "Hautsi zurigunean edo puntuaketan"
 
 #. IDS_L2M
-#: Merge.rc:4829
+#: Merge.rc:4828
 msgid "Copy to &Middle\tAlt+Right"
 msgstr ""
 
 #. IDS_R2M
-#: Merge.rc:4830
+#: Merge.rc:4829
 msgid "Copy to &Middle\tAlt+Left"
 msgstr ""
 
 #. IDS_COPY_FROM_MIDDLE_R
-#: Merge.rc:4831
+#: Merge.rc:4830
 msgid "Copy from Middle\tAlt+Shift+Right"
 msgstr ""
 
 #. IDS_COPY_FROM_MIDDLE_L
-#: Merge.rc:4832
+#: Merge.rc:4831
 msgid "Copy from Middle\tAlt+Shift+Left"
 msgstr ""
 
 #. IDS_L2MNEXT
-#: Merge.rc:4833
+#: Merge.rc:4832
 msgid "Copy to Middle and Advance\tCtrl+Alt+Right"
 msgstr ""
 
 #. IDS_R2MNEXT
-#: Merge.rc:4834
+#: Merge.rc:4833
 msgid "Copy to Middle and Advance\tCtrl+Alt+Left"
 msgstr ""
 
 #. IDS_ALL_MIDDLE
-#: Merge.rc:4835
+#: Merge.rc:4834
 msgid "Copy All to Middle"
 msgstr ""
 
 #. IDS_COPY_RIGHT_TO_LEFT
-#: Merge.rc:4841
+#: Merge.rc:4840
 #, c-format
 msgid "Right to Left (%1)"
 msgstr "Eskuina Ezkerrera (%1)"
 
 #. IDS_COPY_RIGHT_TO_MIDDLE
-#: Merge.rc:4842
+#: Merge.rc:4841
 #, c-format
 msgid "Right to Middle (%1)"
 msgstr ""
 
 #. IDS_COPY_MIDDLE_TO_LEFT
-#: Merge.rc:4843
+#: Merge.rc:4842
 #, c-format
 msgid "Middle to Left (%1)"
 msgstr ""
 
 #. IDS_COPY_MIDDLE_TO_RIGHT
-#: Merge.rc:4844
+#: Merge.rc:4843
 #, c-format
 msgid "Middle to Right (%1)"
 msgstr ""
 
 #. IDS_COPY_LEFT_TO_RIGHT
-#: Merge.rc:4845
+#: Merge.rc:4844
 #, c-format
 msgid "Left to Right (%1)"
 msgstr "Ezkerra Eskuinera (%1)"
 
 #. IDS_COPY_LEFT_TO_MIDDLE
-#: Merge.rc:4846
+#: Merge.rc:4845
 #, c-format
 msgid "Left to Middle (%1)"
 msgstr ""
 
 #. IDS_MOVE_LEFT_TO
-#: Merge.rc:4857 Merge.rc:4889
+#: Merge.rc:4856 Merge.rc:4888
 #, c-format
 msgid "Left to... (%1)"
 msgstr "Ezkerra hona... (%1)"
 
 #. IDS_MOVE_MIDDLE_TO
-#: Merge.rc:4858 Merge.rc:4890
+#: Merge.rc:4857 Merge.rc:4889
 #, c-format
 msgid "Middle to... (%1)"
 msgstr ""
 
 #. IDS_MOVE_RIGHT_TO
-#: Merge.rc:4859 Merge.rc:4891
+#: Merge.rc:4858 Merge.rc:4890
 #, c-format
 msgid "Right to... (%1)"
 msgstr "Eskuina hona... (%1)"
 
 #. IDS_COPY_BOTH_TO
-#: Merge.rc:4860
+#: Merge.rc:4859
 #, c-format
 msgid "Both to... (%1)"
 msgstr ""
 
 #. IDS_COPY_ALL_TO
-#: Merge.rc:4861
+#: Merge.rc:4860
 #, c-format
 msgid "All to... (%1)"
 msgstr ""
 
 #. IDS_COPY_DIFFERENCES_TO
-#: Merge.rc:4862
+#: Merge.rc:4861
 #, c-format
 msgid "Differences to... (%1)"
 msgstr ""
 
 #. IDS_ONLYDIFFITEMS_CONFIRM
-#: Merge.rc:4869
+#: Merge.rc:4868
 msgid "Some selected items are identical or skipped.\nProcess only items with differences?"
 msgstr ""
 
 #. IDS_DEL_LEFT_FMT
-#: Merge.rc:4875
+#: Merge.rc:4874
 #, c-format
 msgid "Left (%1)"
 msgstr "Ezkerra (%1)"
 
 #. IDS_DEL_MIDDLE_FMT
-#: Merge.rc:4876
+#: Merge.rc:4875
 #, c-format
 msgid "Middle (%1)"
 msgstr ""
 
 #. IDS_DEL_RIGHT_FMT
-#: Merge.rc:4877
+#: Merge.rc:4876
 #, c-format
 msgid "Right (%1)"
 msgstr "Eskuina (%1)"
 
 #. IDS_DEL_BOTH_FMT
-#: Merge.rc:4878
+#: Merge.rc:4877
 #, c-format
 msgid "Both (%1)"
 msgstr "Biak (%1)"
 
 #. IDS_DEL_ALL_FMT
-#: Merge.rc:4879
+#: Merge.rc:4878
 #, c-format
 msgid "All (%1)"
 msgstr ""
 
 #. IDS_SELECT_DEST_LEFT
-#: Merge.rc:4895
+#: Merge.rc:4894
 #, c-format
 msgid "Left Side - Select Destination Folder:"
 msgstr "Ezkerraldea - hautatu helmuga agiritegia:"
 
 #. IDS_SELECT_DEST_MIDDLE
-#: Merge.rc:4896
+#: Merge.rc:4895
 #, c-format
 msgid "Middle Side - Select Destination Folder:"
 msgstr ""
 
 #. IDS_SELECT_DEST_RIGHT
-#: Merge.rc:4897
+#: Merge.rc:4896
 #, c-format
 msgid "Right Side - Select Destination Folder:"
 msgstr "Eskuinaldea - hautatu helmuga agiritegia:"
 
 #. IDS_FILES_AFFECTED_FMT
-#: Merge.rc:4898
+#: Merge.rc:4897
 #, c-format
 msgid "(%1 Files Affected)"
 msgstr "(%1 Agiri Eraginda)"
 
 #. IDS_FILES_AFFECTED_FMT2
-#: Merge.rc:4899
+#: Merge.rc:4898
 #, c-format
 msgid "(%1 of %2 Files Affected)"
 msgstr "(%1 Agiri %2-tik Eraginda)"
 
 #. IDS_CONFIRM_DELETE_SINGLE
-#: Merge.rc:4905
+#: Merge.rc:4904
 #, c-format
 msgid ""
 "Are you sure you want to delete\n"
@@ -6867,18 +6861,18 @@ msgstr ""
 "%1?"
 
 #. IDS_CONFIRM_SINGLE_COPY
-#: Merge.rc:4906
+#: Merge.rc:4905
 msgid "Are you sure you want to copy?"
 msgstr "Zihur zaude hona kopiatzea nahi duzula?"
 
 #. IDS_CONFIRM_MULTIPLE_COPY
-#: Merge.rc:4907
+#: Merge.rc:4906
 #, c-format
 msgid "Are you sure you want to copy %d items?"
 msgstr "Zihur zaude %d gaiak kopiatzea nahi dituzula?"
 
 #. IDS_DIRCMP_NOTSYNC
-#: Merge.rc:4908
+#: Merge.rc:4907
 #, c-format
 msgid ""
 "Operation aborted!\n"
@@ -6898,873 +6892,873 @@ msgstr ""
 "Mesedez berritu alderaketa."
 
 #. IDS_CONFIRM_SINGLE_MOVE
-#: Merge.rc:4913
+#: Merge.rc:4912
 msgid "Are you sure you want to move?"
 msgstr "Zihur zaude mugitzea nahi duzula?"
 
 #. IDS_CONFIRM_MULTIPLE_MOVE
-#: Merge.rc:4914
+#: Merge.rc:4913
 #, c-format
 msgid "Are you sure you want to move %d items?"
 msgstr "Zihur zaude %d gaiak mugitzea nahi dituzula?"
 
 #. IDS_CONFIRM_MOVE_CAPTION
-#: Merge.rc:4916
+#: Merge.rc:4915
 #, c-format
 msgid "Confirm Move"
 msgstr "Berretsi Mugitzea"
 
-#: Merge.rc:4918
+#: Merge.rc:4917
 #, c-format
 msgid "Close the folder comparison window?"
 msgstr ""
 
-#: Merge.rc:4920
+#: Merge.rc:4919
 msgid "Close the folder comparison window, which took a long time?"
 msgstr ""
 
 #. IDS_ERROR_INVALID_DIR_FILE_NAME
-#: Merge.rc:4921
+#: Merge.rc:4920
 msgid "The file or folder name is invalid."
 msgstr ""
 
 #. IDS_ERROR_EXECUTE_FILE
-#: Merge.rc:4927
+#: Merge.rc:4926
 #, c-format
 msgid "Failed to execute external editor: %1"
 msgstr "Hutsegitea kanpoko editatzailea ekiterakoan: %1"
 
 #. IDS_UNKNOWN_ARCHIVE_FORMAT
-#: Merge.rc:4933
+#: Merge.rc:4932
 #, c-format
 msgid "Unknown archive format"
 msgstr "Agiri heuskarri ezezaguna"
 
-#: Merge.rc:4935
+#: Merge.rc:4934
 msgid "Failed to extract archive.\nCompare as text file?"
 msgstr ""
 
 #. IDS_COLHDR_FILENAME
-#: Merge.rc:4941
+#: Merge.rc:4940
 #, c-format
 msgid "Filename"
 msgstr "Agirizena"
 
 #. IDS_COLHDR_DIR
-#: Merge.rc:4942
+#: Merge.rc:4941
 msgctxt "DirView|ColumnHeader"
 msgid "Folder"
 msgstr "Agiritegia"
 
 #. IDS_COLHDR_RESULT
-#: Merge.rc:4943
+#: Merge.rc:4942
 #, c-format
 msgid "Comparison Result"
 msgstr "Alderaketa emaitza"
 
 #. IDS_COLHDR_LTIMEM
-#: Merge.rc:4944
+#: Merge.rc:4943
 #, c-format
 msgid "Left Date"
 msgstr "Ezker Eguna"
 
 #. IDS_COLHDR_RTIMEM
-#: Merge.rc:4945
+#: Merge.rc:4944
 #, c-format
 msgid "Right Date"
 msgstr "Eskuin Eguna"
 
 #. IDS_COLHDR_MTIMEM
-#: Merge.rc:4946
+#: Merge.rc:4945
 #, c-format
 msgid "Middle Date"
 msgstr ""
 
 #. IDS_COLHDR_LSIZE
-#: Merge.rc:4948
+#: Merge.rc:4947
 #, c-format
 msgid "Left Size"
 msgstr "Ezker Neurria"
 
 #. IDS_COLHDR_RSIZE
-#: Merge.rc:4949
+#: Merge.rc:4948
 #, c-format
 msgid "Right Size"
 msgstr "Eskuin Neurria"
 
 #. IDS_COLHDR_MSIZE
-#: Merge.rc:4954
+#: Merge.rc:4953
 #, c-format
 msgid "Middle Size"
 msgstr ""
 
 #. IDS_COLHDR_RSIZE_SHORT
-#: Merge.rc:4955
+#: Merge.rc:4954
 #, c-format
 msgid "Right Size (Short)"
 msgstr "Eskuin Neurria (Laburra)"
 
 #. IDS_COLHDR_LSIZE_SHORT
-#: Merge.rc:4956
+#: Merge.rc:4955
 #, c-format
 msgid "Left Size (Short)"
 msgstr "Ezker Neurria (Laburra)"
 
 #. IDS_COLHDR_MSIZE_SHORT
-#: Merge.rc:4957
+#: Merge.rc:4956
 #, c-format
 msgid "Middle Size (Short)"
 msgstr ""
 
 #. IDS_COLHDR_LTIMEC
-#: Merge.rc:4963
+#: Merge.rc:4962
 #, c-format
 msgid "Left Creation Time"
 msgstr "Ezkerreko Sortze Denbora"
 
 #. IDS_COLHDR_RTIMEC
-#: Merge.rc:4964
+#: Merge.rc:4963
 #, c-format
 msgid "Right Creation Time"
 msgstr "Eskuineko Sortze Denbora"
 
 #. IDS_COLHDR_MTIMEC
-#: Merge.rc:4965
+#: Merge.rc:4964
 #, c-format
 msgid "Middle Creation Time"
 msgstr ""
 
 #. IDS_COLHDR_NEWER
-#: Merge.rc:4966
+#: Merge.rc:4965
 #, c-format
 msgid "Newer File"
 msgstr "Agiri Berriena"
 
 #. IDS_COLHDR_LVERSION
-#: Merge.rc:4967
+#: Merge.rc:4966
 #, c-format
 msgid "Left File Version"
 msgstr "Ezkerreko Agiri Bertsioa"
 
 #. IDS_COLHDR_RVERSION
-#: Merge.rc:4968
+#: Merge.rc:4967
 #, c-format
 msgid "Right File Version"
 msgstr "Eskuineko Agiri Bertsioa"
 
 #. IDS_COLHDR_MVERSION
-#: Merge.rc:4969
+#: Merge.rc:4968
 #, c-format
 msgid "Middle File Version"
 msgstr ""
 
 #. IDS_COLHDR_RESULT_ABBR
-#: Merge.rc:4970
+#: Merge.rc:4969
 #, c-format
 msgid "Short Result"
 msgstr "Emaitz Laburra"
 
 #. IDS_COLHDR_LATTRIBUTES
-#: Merge.rc:4971
+#: Merge.rc:4970
 #, c-format
 msgid "Left Attributes"
 msgstr "Ezkerraren Ezaugarriak"
 
 #. IDS_COLHDR_RATTRIBUTES
-#: Merge.rc:4972
+#: Merge.rc:4971
 #, c-format
 msgid "Right Attributes"
 msgstr "Eskuinaren Ezaugarriak"
 
 #. IDS_COLHDR_MATTRIBUTES
-#: Merge.rc:4973
+#: Merge.rc:4972
 #, c-format
 msgid "Middle Attributes"
 msgstr ""
 
 #. IDS_COLHDR_LEOL_TYPE
-#: Merge.rc:4978
+#: Merge.rc:4977
 #, c-format
 msgid "Left EOL"
 msgstr "Ezker EOL"
 
 #. IDS_COLHDR_MEOL_TYPE
-#: Merge.rc:4979
+#: Merge.rc:4978
 #, c-format
 msgid "Middle EOL"
 msgstr ""
 
 #. IDS_COLHDR_REOL_TYPE
-#: Merge.rc:4980
+#: Merge.rc:4979
 #, c-format
 msgid "Right EOL"
 msgstr "Eskuin EOL"
 
 #. IDS_COLHDR_LENCODING
-#: Merge.rc:4986
+#: Merge.rc:4985
 #, c-format
 msgid "Left Encoding"
 msgstr "Ezker Kodeaketa"
 
 #. IDS_COLHDR_RENCODING
-#: Merge.rc:4987
+#: Merge.rc:4986
 #, c-format
 msgid "Right Encoding"
 msgstr "Eskuin Kodeaketa"
 
 #. IDS_COLHDR_MENCODING
-#: Merge.rc:4988
+#: Merge.rc:4987
 #, c-format
 msgid "Middle Encoding"
 msgstr ""
 
 #. IDS_COLHDR_NIDIFFS
-#: Merge.rc:4989
+#: Merge.rc:4988
 msgid "Ignored Diff"
 msgstr "Ezikusitako Ezberd"
 
 #. IDS_COLHDR_BINARY
-#: Merge.rc:4991
+#: Merge.rc:4990
 msgctxt "DirView|ColumnHeader"
 msgid "Binary"
 msgstr "Binarioa"
 
 #. IDS_PLUGINS_TYPE_UNPACKER
-#: Merge.rc:4992 Merge.rc:5314
+#: Merge.rc:4991 Merge.rc:5313
 #, c-format
 msgid "Unpacker"
 msgstr "Despaketatzailea"
 
 #. IDS_PLUGIN_TYPE4
-#: Merge.rc:4993 Merge.rc:5315 Merge.rc:5622
+#: Merge.rc:4992 Merge.rc:5314 Merge.rc:5621
 #, c-format
 msgid "Prediffer"
 msgstr "Aurrezberd"
 
 #. IDS_COLHDR_LEFT
-#: Merge.rc:4994
+#: Merge.rc:4993
 msgid "Left"
 msgstr ""
 
 #. IDS_COLHDR_MIDDLE
-#: Merge.rc:4995
+#: Merge.rc:4994
 msgid "Middle"
 msgstr ""
 
 #. IDS_COLHDR_RIGHT
-#: Merge.rc:4996
+#: Merge.rc:4995
 msgid "Right"
 msgstr ""
 
 #. IDS_COLHDR_DIFF
-#: Merge.rc:4997
+#: Merge.rc:4996
 msgid "Diff"
 msgstr ""
 
 #. IDS_COLHDR_LEFT_DUPLICATE
-#: Merge.rc:4998
+#: Merge.rc:4997
 msgid "Left Duplicate Count"
 msgstr ""
 
 #. IDS_COLHDR_RIGHT_DUPLICATE
-#: Merge.rc:4999
+#: Merge.rc:4998
 msgid "Right Duplicate Count"
 msgstr ""
 
 #. IDS_COLHDR_MIDDLE_DUPLICATE
-#: Merge.rc:5000
+#: Merge.rc:4999
 msgid "Middle Duplicate Count"
 msgstr ""
 
 #. IDS_COLHDR_MOVE
-#: Merge.rc:5001
+#: Merge.rc:5000
 msgid "Move"
 msgstr ""
 
 #. IDS_PRPCAT_AUDIO
-#: Merge.rc:5008
+#: Merge.rc:5007
 msgid "Audio"
 msgstr ""
 
 #. IDS_PRPCAT_CALENDAR
-#: Merge.rc:5009
+#: Merge.rc:5008
 msgid "Calendar"
 msgstr ""
 
 #. IDS_PRPCAT_COMMUNICATION
-#: Merge.rc:5010
+#: Merge.rc:5009
 msgid "Communication"
 msgstr ""
 
 #. IDS_PRPCAT_CONTACT
-#: Merge.rc:5011
+#: Merge.rc:5010
 msgid "Contact"
 msgstr ""
 
 #. IDS_PRPCAT_DEVICES
-#: Merge.rc:5012
+#: Merge.rc:5011
 msgid "Devices"
 msgstr ""
 
 #. IDS_PRPCAT_DOCUMENT
-#: Merge.rc:5013
+#: Merge.rc:5012
 msgid "Document"
 msgstr ""
 
 #. IDS_PRPCAT_HOME
-#: Merge.rc:5014
+#: Merge.rc:5013
 msgid "Home"
 msgstr ""
 
 #. IDS_PRPCAT_JOURNAL
-#: Merge.rc:5016
+#: Merge.rc:5015
 msgid "Journal"
 msgstr ""
 
 #. IDS_PRPCAT_LINK
-#: Merge.rc:5017
+#: Merge.rc:5016
 msgid "Link"
 msgstr ""
 
 #. IDS_PRPCAT_MEDIA
-#: Merge.rc:5018
+#: Merge.rc:5017
 msgid "Media"
 msgstr ""
 
 #. IDS_PRPCAT_MUSIC
-#: Merge.rc:5020
+#: Merge.rc:5019
 msgid "Music"
 msgstr ""
 
 #. IDS_PRPCAT_NOTE
-#: Merge.rc:5021
+#: Merge.rc:5020
 msgid "Note"
 msgstr ""
 
 #. IDS_PRPCAT_PHOTO
-#: Merge.rc:5022
+#: Merge.rc:5021
 msgid "Photo"
 msgstr ""
 
 #. IDS_PRPCAT_RECORDEDTV
-#: Merge.rc:5023
+#: Merge.rc:5022
 msgid "RecordedTV"
 msgstr ""
 
 #. IDS_PRPCAT_SEARCH
-#: Merge.rc:5024
+#: Merge.rc:5023
 msgid "Search"
 msgstr ""
 
 #. IDS_PRPCAT_SECURITY
-#: Merge.rc:5025
+#: Merge.rc:5024
 msgid "Security"
 msgstr ""
 
 #. IDS_PRPCAT_SOFTWARE
-#: Merge.rc:5026
+#: Merge.rc:5025
 msgid "Software"
 msgstr ""
 
 #. IDS_PRPCAT_TASK
-#: Merge.rc:5027
+#: Merge.rc:5026
 msgid "Task"
 msgstr ""
 
 #. IDS_PRPCAT_VIDEO
-#: Merge.rc:5028
+#: Merge.rc:5027
 msgid "Video"
 msgstr ""
 
 #. IDS_PRPCAT_HASH
-#: Merge.rc:5029
+#: Merge.rc:5028
 msgid "Hash"
 msgstr ""
 
 #. IDS_CANT_COMPARE_FILES
-#: Merge.rc:5035
+#: Merge.rc:5034
 #, c-format
 msgid "Unable to compare files"
 msgstr "Ezinezkoa agiriak alderatzea"
 
 #. IDS_ABORTED_ITEM
-#: Merge.rc:5036
+#: Merge.rc:5035
 #, c-format
 msgid "Item aborted"
 msgstr "Gaia utzita"
 
 #. IDS_FILE_SKIPPED
-#: Merge.rc:5037
+#: Merge.rc:5036
 #, c-format
 msgid "File skipped"
 msgstr "Agiria Jauzita"
 
 #. IDS_DIR_SKIPPED
-#: Merge.rc:5038
+#: Merge.rc:5037
 #, c-format
 msgid "Folder skipped"
 msgstr "Agiritegia jauzita"
 
 #. IDS_LEFT_ONLY_IN_FMT
-#: Merge.rc:5039
+#: Merge.rc:5038
 #, c-format
 msgid "Left only: %1"
 msgstr "Ezkerra bakarrik: %1"
 
 #. IDS_MIDDLE_ONLY_IN_FMT
-#: Merge.rc:5040
+#: Merge.rc:5039
 #, c-format
 msgid "Middle only: %1"
 msgstr ""
 
 #. IDS_RIGHT_ONLY_IN_FMT
-#: Merge.rc:5041
+#: Merge.rc:5040
 #, c-format
 msgid "Right only: %1"
 msgstr "Eskuina bakarrik: %1"
 
 #. IDS_DOES_NOT_EXIST_IN_FMT
-#: Merge.rc:5042
+#: Merge.rc:5041
 #, c-format
 msgid "Does not exist in %1"
 msgstr ""
 
 #. IDS_BIN_FILES_SAME
-#: Merge.rc:5043
+#: Merge.rc:5042
 #, c-format
 msgid "Binary files are identical"
 msgstr "Agiri binarioak berdinak dira"
 
 #. IDS_BIN_FILES_DIFF
-#: Merge.rc:5049
+#: Merge.rc:5048
 #, c-format
 msgid "Binary files are different"
 msgstr "Agiri binarioak ezberdinak dira"
 
 #. IDS_FILES_ARE_DIFFERENT
-#: Merge.rc:5050
+#: Merge.rc:5049
 #, c-format
 msgid "Files are different"
 msgstr "Agiriak ezberdinak dira"
 
 #. IDS_FOLDERS_ARE_DIFFERENT
-#: Merge.rc:5051
+#: Merge.rc:5050
 #, c-format
 msgid "Folders are different"
 msgstr "Agiritegiak ezberdinak dira"
 
 #. IDS_LEFTONLY
-#: Merge.rc:5052
+#: Merge.rc:5051
 #, c-format
 msgid "Left Only"
 msgstr "Ezkerra Bakarrik"
 
 #. IDS_RIGHTONLY
-#: Merge.rc:5053
+#: Merge.rc:5052
 #, c-format
 msgid "Right Only"
 msgstr "Eskuina Bakarrik"
 
 #. IDS_MIDDLEONLY
-#: Merge.rc:5054
+#: Merge.rc:5053
 #, c-format
 msgid "Middle Only"
 msgstr ""
 
 #. IDS_NOITEMLEFT
-#: Merge.rc:5055
+#: Merge.rc:5054
 #, c-format
 msgid "No item in left"
 msgstr ""
 
 #. IDS_NOITEMRIGHT
-#: Merge.rc:5056
+#: Merge.rc:5055
 #, c-format
 msgid "No item in right"
 msgstr ""
 
 #. IDS_NOITEMMIDDLE
-#: Merge.rc:5057
+#: Merge.rc:5056
 #, c-format
 msgid "No item in middle"
 msgstr ""
 
 #. IDS_CMPRES_ERROR
-#: Merge.rc:5059
+#: Merge.rc:5058
 #, c-format
 msgid "Error"
 msgstr "Akatsa"
 
 #. IDS_TEXT_FILES_SAME
-#: Merge.rc:5060
+#: Merge.rc:5059
 #, c-format
 msgid "Text files are identical"
 msgstr "Idazki agiriak berdinak dira"
 
 #. IDS_LEFTONLY_DIFF
-#: Merge.rc:5061
+#: Merge.rc:5060
 msgid " (Middle and right are identical)"
 msgstr ""
 
 #. IDS_MIDDLEONLY_DIFF
-#: Merge.rc:5062
+#: Merge.rc:5061
 msgid " (Left and right are identical)"
 msgstr ""
 
 #. IDS_RIGHTONLY_DIFF
-#: Merge.rc:5063
+#: Merge.rc:5062
 msgid " (Left and middle are identical)"
 msgstr ""
 
 #. IDS_PATH_MISMATCH
-#: Merge.rc:5064
+#: Merge.rc:5063
 msgid " (paths differ)"
 msgstr ""
 
 #. IDS_TEXT_FILES_DIFF
-#: Merge.rc:5065
+#: Merge.rc:5064
 #, c-format
 msgid "Text files are different"
 msgstr "Idazki agiriak ezberdinak dira"
 
 #. IDS_IMAGE_FILES_SAME
-#: Merge.rc:5066
+#: Merge.rc:5065
 msgid "Image files are identical"
 msgstr ""
 
 #. IDS_IMAGE_FILES_DIFF
-#: Merge.rc:5067
+#: Merge.rc:5066
 msgid "Image files are different"
 msgstr ""
 
 #. IDS_EXPR_DIFF
-#: Merge.rc:5068
+#: Merge.rc:5067
 #, c-format
 msgid "Files are different (expr: %1)"
 msgstr ""
 
 #. IDS_HASH_GROUP
-#: Merge.rc:5069
+#: Merge.rc:5068
 #, c-format
 msgid "Group%d"
 msgstr ""
 
 #. IDS_RENAME_MOVE_DETECTION_DISALBED
-#: Merge.rc:5070
+#: Merge.rc:5069
 msgctxt "Options dialog|Compare|Folder|Detect renames and moves"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_RENAME_MOVE_DETECTION_RENAME
-#: Merge.rc:5071
+#: Merge.rc:5070
 msgid "Detect renames"
 msgstr ""
 
 #. IDS_RENAME_MOVE_DETECTION_RENAME_MOVE
-#: Merge.rc:5072
+#: Merge.rc:5071
 msgid "Detect renames and moves"
 msgstr ""
 
 #. IDS_RENAME_MOVE_MERGE_MODE_RENAME
-#: Merge.rc:5073
+#: Merge.rc:5072
 msgid "Merge renames"
 msgstr ""
 
 #. IDS_RENAME_MOVE_MERGE_MODE_RENAME_MOVE
-#: Merge.rc:5074
+#: Merge.rc:5073
 msgid "Merge renames and moves"
 msgstr ""
 
 #. IDS_RENAMED
-#: Merge.rc:5075
+#: Merge.rc:5074
 msgid "Renamed"
 msgstr ""
 
 #. IDS_RENAMED_MOVED
-#: Merge.rc:5077
+#: Merge.rc:5076
 msgid "Renamed/Moved"
 msgstr ""
 
 #. IDS_RENAMED_MOVED_ITEMS
-#: Merge.rc:5078
+#: Merge.rc:5077
 #, c-format
 msgid "(%1 items)"
 msgstr ""
 
 #. IDS_RENAMED_MOVED_RESULT
-#: Merge.rc:5079
+#: Merge.rc:5078
 #, c-format
 msgid "%1 (set %2): "
 msgstr ""
 
 #. IDS_SWITCH_FLAT_MODE
-#: Merge.rc:5080
+#: Merge.rc:5079
 msgid "Some moved items have been merged.\nIn Tree Mode, these items may appear in positions that do not reflect the actual folder structure, which can be confusing.\nSwitch to Flat Mode?"
 msgstr ""
 
 #. IDS_ELAPSED_TIME
-#: Merge.rc:5086
+#: Merge.rc:5085
 #, c-format
 msgid "Elapsed time: %ld ms"
 msgstr "Igarotako denbora: %ld sm"
 
 #. IDS_STATUS_SELITEM1
-#: Merge.rc:5087
+#: Merge.rc:5086
 #, c-format
 msgid "1 item selected"
 msgstr "1 gai hautatuta"
 
 #. IDS_STATUS_SELITEMS
-#: Merge.rc:5088
+#: Merge.rc:5087
 #, c-format
 msgid "%1 items selected"
 msgstr "%1 gai hautatuta"
 
 #. IDS_COLDESC_FILENAME
-#: Merge.rc:5094
+#: Merge.rc:5093
 #, c-format
 msgid "Filename or folder name."
 msgstr "Agirizena edo agiritegi izena"
 
 #. IDS_COLDESC_DIR
-#: Merge.rc:5095
+#: Merge.rc:5094
 #, c-format
 msgid "Subfolder name when subfolders are included."
 msgstr "Azpiagiritegi izena azpiagiritegiak barne direnean."
 
 #. IDS_COLDESC_RESULT
-#: Merge.rc:5096
+#: Merge.rc:5095
 #, c-format
 msgid "Comparison result, long form."
 msgstr "Alderaketa emaitza, modu luzean."
 
 #. IDS_COLDESC_LTIMEM
-#: Merge.rc:5101
+#: Merge.rc:5100
 #, c-format
 msgid "Left side modification date."
 msgstr "Ezkerralde aldaketa eguna."
 
 #. IDS_COLDESC_RTIMEM
-#: Merge.rc:5102
+#: Merge.rc:5101
 #, c-format
 msgid "Right side modification date."
 msgstr "Eskuinalde aldaketa eguna."
 
 #. IDS_COLDESC_MTIMEM
-#: Merge.rc:5103
+#: Merge.rc:5102
 #, c-format
 msgid "Middle side modification date."
 msgstr ""
 
 #. IDS_COLDESC_EXTENSION
-#: Merge.rc:5104
+#: Merge.rc:5103
 #, c-format
 msgid "File's extension."
 msgstr "Agiriaren luzapena."
 
 #. IDS_COLDESC_LSIZE
-#: Merge.rc:5105
+#: Merge.rc:5104
 #, c-format
 msgid "Left file size in bytes."
 msgstr "Ezkerreko agiriaren neurria byte-tan"
 
 #. IDS_COLDESC_RSIZE
-#: Merge.rc:5106
+#: Merge.rc:5105
 #, c-format
 msgid "Right file size in bytes."
 msgstr "Eskuineko agiriaren neurria byte-tan"
 
 #. IDS_COLDESC_MSIZE
-#: Merge.rc:5107
+#: Merge.rc:5106
 #, c-format
 msgid "Middle file size in bytes."
 msgstr ""
 
 #. IDS_COLDESC_LSIZE_SHORT
-#: Merge.rc:5108
+#: Merge.rc:5107
 #, c-format
 msgid "Left file size abbreviated."
 msgstr "Ezkerreko agiri neurria laburtuta."
 
 #. IDS_COLDESC_RSIZE_SHORT
-#: Merge.rc:5109
+#: Merge.rc:5108
 #, c-format
 msgid "Right file size abbreviated."
 msgstr "Eskuineko agiri neurria laburtuta."
 
 #. IDS_COLDESC_MSIZE_SHORT
-#: Merge.rc:5110
+#: Merge.rc:5109
 #, c-format
 msgid "Middle file size abbreviated."
 msgstr ""
 
 #. IDS_COLDESC_LTIMEC
-#: Merge.rc:5116
+#: Merge.rc:5115
 #, c-format
 msgid "Left side creation time."
 msgstr "Ezkerraldearen sortze denbora."
 
 #. IDS_COLDESC_RTIMEC
-#: Merge.rc:5117
+#: Merge.rc:5116
 #, c-format
 msgid "Right side creation time."
 msgstr "Eskuinaldearen sortze denbora."
 
 #. IDS_COLDESC_MTIMEC
-#: Merge.rc:5118
+#: Merge.rc:5117
 #, c-format
 msgid "Middle side creation time."
 msgstr ""
 
 #. IDS_COLDESC_NEWER
-#: Merge.rc:5119
+#: Merge.rc:5118
 #, c-format
 msgid "Tells which side has newer modification date."
 msgstr "Esaten du zein aldek duen aldaketa egun berriagoa."
 
 #. IDS_COLDESC_LVERSION
-#: Merge.rc:5120
+#: Merge.rc:5119
 msgid "Left side file version, only for some file types."
 msgstr "Ezkerraldeko agiri bertsioa, agiri-mota batzuentzat bakarrik."
 
 #. IDS_COLDESC_RVERSION
-#: Merge.rc:5121
+#: Merge.rc:5120
 msgid "Right side file version, only for some file types."
 msgstr "Eskuinaldeko agiri bertsioa, agiri-mota batzuentzat bakarrik."
 
 #. IDS_COLDESC_MVERSION
-#: Merge.rc:5126
+#: Merge.rc:5125
 msgid "Middle side file version, only for some file types."
 msgstr ""
 
 #. IDS_COLDESC_RESULT_ABBR
-#: Merge.rc:5127
+#: Merge.rc:5126
 #, c-format
 msgid "Short comparison result."
 msgstr "Alderaketa laburraren emaitza."
 
 #. IDS_COLDESC_LATTRIBUTES
-#: Merge.rc:5128
+#: Merge.rc:5127
 #, c-format
 msgid "Left side attributes."
 msgstr "Ezkerraldearen ezaugarriak."
 
 #. IDS_COLDESC_RATTRIBUTES
-#: Merge.rc:5129
+#: Merge.rc:5128
 #, c-format
 msgid "Right side attributes."
 msgstr "Eskuinaldearen ezaugarriak."
 
 #. IDS_COLDESC_MATTRIBUTES
-#: Merge.rc:5130
+#: Merge.rc:5129
 #, c-format
 msgid "Middle side attributes."
 msgstr ""
 
 #. IDS_COLDESC_LEOL_TYPE
-#: Merge.rc:5131
+#: Merge.rc:5130
 msgid "Left side file EOL type."
 msgstr "Ezkerraldeko agiria EOL motakoa da."
 
 #. IDS_COLDESC_REOL_TYPE
-#: Merge.rc:5132
+#: Merge.rc:5131
 msgid "Right side file EOL type."
 msgstr "Eskuinaldeko agiria EOL motakoa da."
 
 #. IDS_COLDESC_MEOL_TYPE
-#: Merge.rc:5133
+#: Merge.rc:5132
 msgid "Middle side file EOL type."
 msgstr ""
 
 #. IDS_COLDESC_LENCODING
-#: Merge.rc:5139
+#: Merge.rc:5138
 #, c-format
 msgid "Left side encoding."
 msgstr "Eskuinalde kodeaketa."
 
 #. IDS_COLDESC_RENCODING
-#: Merge.rc:5140
+#: Merge.rc:5139
 #, c-format
 msgid "Right side encoding."
 msgstr "Ezkerralde kodeaketa."
 
 #. IDS_COLDESC_MENCODING
-#: Merge.rc:5141
+#: Merge.rc:5140
 #, c-format
 msgid "Middle side encoding."
 msgstr ""
 
 #. IDS_COLDESC_NIDIFFS
-#: Merge.rc:5142
+#: Merge.rc:5141
 #, c-format
 msgid "Number of ignored differences in file. Ignored and cannot be merged."
 msgstr "Agirian ezikusitako ezberdintasun zenbatekoa. Ezberdintasun hauek WinMergek ezikusi ditu eta ezin dira batu."
 
 #. IDS_COLDESC_NSDIFFS
-#: Merge.rc:5143
+#: Merge.rc:5142
 #, c-format
 msgid "Number of differences in file (excluding ignored)."
 msgstr "Agirian dauden ezberdintasun zenbatekoa. Zenbateko honek ez ditu barnebiltzen ezikusitako ezberdintasunak."
 
 #. IDS_COLDESC_BINARY
-#: Merge.rc:5144
+#: Merge.rc:5143
 #, c-format
 msgid "Shows an asterisk (*) if the file is binary."
 msgstr "Erakutsi asteriskoa (*) agiria binarioa bada."
 
 #. IDS_COLDESC_UNPACKER
-#: Merge.rc:5145
+#: Merge.rc:5144
 msgid "Unpacker plugin name or pipeline."
 msgstr ""
 
 #. IDS_COLDESC_PREDIFFER
-#: Merge.rc:5146
+#: Merge.rc:5145
 msgid "Prediffer plugin name or pipeline."
 msgstr ""
 
 #. IDS_DIRECTORY_REPORT_TITLE
-#: Merge.rc:5152
+#: Merge.rc:5151
 #, c-format
 msgid "Compare %1 with %2"
 msgstr "Alderatu %1 %2-rekin"
 
 #. IDS_DIRECTORY_REPORT_TITLE3
-#: Merge.rc:5153
+#: Merge.rc:5152
 #, c-format
 msgid "Compare %1 with %2 and %3"
 msgstr ""
 
 #. IDS_REPORT_COMMALIST
-#: Merge.rc:5154
+#: Merge.rc:5153
 #, c-format
 msgid "Comma-separated list"
 msgstr "Kakotxaz banandutako zerrenda"
 
 #. IDS_REPORT_TABLIST
-#: Merge.rc:5155
+#: Merge.rc:5154
 #, c-format
 msgid "Tab-separated list"
 msgstr "Fitxaz banandutako zerrenda"
 
 #. IDS_REPORT_SIMPLEHTML
-#: Merge.rc:5156
+#: Merge.rc:5155
 #, c-format
 msgid "Simple HTML"
 msgstr "HTML Arrunta"
 
 #. IDS_REPORT_SIMPLEXML
-#: Merge.rc:5157
+#: Merge.rc:5156
 #, c-format
 msgid "Simple XML"
 msgstr "XML Arrunta"
 
-#: Merge.rc:5159
+#: Merge.rc:5158
 #, c-format
 msgid "Report file already exists. Overwrite?"
 msgstr "Jakinarazpen agiria jadanik badago. Dagoen agiria gainidaztea nahi duzu?"
 
 #. IDS_REPORT_ERROR
-#: Merge.rc:5164
+#: Merge.rc:5163
 #, c-format
 msgid ""
 "Error creating the report:\n"
@@ -7774,62 +7768,62 @@ msgstr ""
 "%1"
 
 #. IDS_REPORT_SUCCESS
-#: Merge.rc:5165
+#: Merge.rc:5164
 #, c-format
 msgid "Report created successfully."
 msgstr "Jakinarazpena ongi sortu da."
 
 #. IDS_SYNCPOINT_LASTBLOCK
-#: Merge.rc:5171
+#: Merge.rc:5170
 msgid "Cannot add a synchronization point at this line."
 msgstr ""
 
 #. IDS_FILE_TO_ITSELF
-#: Merge.rc:5177
+#: Merge.rc:5176
 #, c-format
 msgid "Same file is opened in both panes."
 msgstr "Agiri berdina dago irekita bi paneletan."
 
 #. IDS_FILESSAME
-#: Merge.rc:5178
+#: Merge.rc:5177
 #, c-format
 msgid "Selected files are identical."
 msgstr "Hautatutako agiriak berdinak dira."
 
 #. IDS_FILESSAME_CURCFG
-#: Merge.rc:5179
+#: Merge.rc:5178
 msgid "Selected files are identical (with current settings).\r\nChecking binary identity..."
 msgstr ""
 
 #. IDS_FILESSAME_BINERROR
-#: Merge.rc:5180
+#: Merge.rc:5179
 msgid "Selected files are identical (with current settings).\r\nBut binary comparison failed."
 msgstr ""
 
 #. IDS_FILESSAME_BINSAME
-#: Merge.rc:5181
+#: Merge.rc:5180
 msgid "Selected files are identical (binary match)."
 msgstr ""
 
 #. IDS_FILESSAME_BINDIFF
-#: Merge.rc:5182
+#: Merge.rc:5181
 msgid "Selected files are identical (with current settings).\r\nBut differ at the binary level."
 msgstr ""
 
 #. IDS_FILEERROR
-#: Merge.rc:5183
+#: Merge.rc:5182
 #, c-format
 msgid "An error occurred while comparing files."
 msgstr "Akats bat gertatu da agiriak alderatzerakoan."
 
 #. IDS_TEMP_FILEERROR
-#: Merge.rc:5184
+#: Merge.rc:5183
 #, c-format
 msgid "Could not create temporary files. Check your temporary path settings."
 msgstr "Aldibaterako agiriak ezin izan dira sortu. Egiaztatu zure aldibaterako helburu ezarpenak."
 
 #. IDS_SUGGEST_IGNOREEOL
-#: Merge.rc:5185
+#: Merge.rc:5184
 msgid "Files use different EOL.\n\nTreat all EOL as equivalent?\n\nSet 'Ignore EOL differences (Windows/Unix/Mac)' in Compare section of Options."
 msgstr ""
 "Agiri hauek gurdi itzulera mota ezberdinak erabiltzen dituzte.\n"
@@ -7839,19 +7833,19 @@ msgstr ""
 "Oharra: Gurdi itzulera mota guztiak berdin bezala tratatzea nahi badituzu, ezarri 'Ezikusi gurdi itzulera ezberdintasunak (Windows/Unix/Mac)' aukera Alderaketa fitxan aukeren elkarrizketan (eskuragarri hemen: Editatu/Aukerak)."
 
 #. IDS_INVALID_DIRECTORY
-#: Merge.rc:5186
+#: Merge.rc:5185
 #, c-format
 msgid "Selected folder is invalid."
 msgstr "Hautatutako agiritegia ez da baliogarria"
 
 #. IDS_CANNOT_OPEN_BINARYFILE
-#: Merge.rc:5187
+#: Merge.rc:5186
 #, c-format
 msgid "Cannot open a binary file in Editor."
 msgstr "Ezinenezkoa agiri binarioa editatzailera irekitzea"
 
 #. IDS_CREATE_PAIR_FOLDER
-#: Merge.rc:5188
+#: Merge.rc:5187
 #, c-format
 msgid "Create matching folder:\n%1\non the other side and open?"
 msgstr ""
@@ -7862,45 +7856,45 @@ msgstr ""
 "beste aldean eta agiritegi hauek irekitzea?"
 
 #. IDS_CONFIRM_COPY_ALL_DIFFS
-#: Merge.rc:5189
+#: Merge.rc:5188
 msgid "Copy all differences to other file?"
 msgstr ""
 
 #. IDS_MOVE_TO_NEXTFILE
-#: Merge.rc:5194
+#: Merge.rc:5193
 #, c-format
 msgid "Move to next file?"
 msgstr ""
 
 #. IDS_MOVE_TO_PREVFILE
-#: Merge.rc:5195
+#: Merge.rc:5194
 #, c-format
 msgid "Move to previous file?"
 msgstr ""
 
 #. IDS_MOVE_TO_NEXTPAGE
-#: Merge.rc:5196
+#: Merge.rc:5195
 #, c-format
 msgid "Move to next page?"
 msgstr ""
 
 #. IDS_MOVE_TO_PREVPAGE
-#: Merge.rc:5197
+#: Merge.rc:5196
 #, c-format
 msgid "Move to previous page?"
 msgstr ""
 
 #. IDS_MOVE_TO_FIRSTFILE
-#: Merge.rc:5198
+#: Merge.rc:5197
 msgid "Move to first file?"
 msgstr ""
 
 #. IDS_MOVE_TO_LASTFILE
-#: Merge.rc:5199
+#: Merge.rc:5198
 msgid "Move to last file?"
 msgstr ""
 
-#: Merge.rc:5206
+#: Merge.rc:5205
 #, c-format
 msgid "Different codepages: left (cp%d), right (cp%d).\nDisplay in codepage (better display) or default Windows codepage (safer merging)?\n(Recommended: default Windows codepage)"
 msgstr ""
@@ -7908,153 +7902,153 @@ msgstr ""
 "Erakutsiz agiri bakoitza kode-orrialde horretan erakuspen hobeago bat emango du baina batzea/kopiatzea kaltegarria izango da.\n"
 "Nahi duzu agiri biak tratatzea windowsen kode-orrialde berezkoan (gomendatuta)?"
 
-#: Merge.rc:5208
+#: Merge.rc:5207
 #, c-format
 msgid "Information lost due to encoding errors: both files"
 msgstr "Informazioa galduta kodeaketa akatsengaitik: bi agirietan"
 
-#: Merge.rc:5210
+#: Merge.rc:5209
 #, c-format
 msgid "Information lost due to encoding errors: first file"
 msgstr ""
 
-#: Merge.rc:5212
+#: Merge.rc:5211
 #, c-format
 msgid "Information lost due to encoding errors: second file"
 msgstr ""
 
-#: Merge.rc:5214
+#: Merge.rc:5213
 #, c-format
 msgid "Information lost due to encoding errors: third file"
 msgstr ""
 
 #. IDS_LINEDIFF_NODIFF
-#: Merge.rc:5220
+#: Merge.rc:5219
 #, c-format
 msgid "No difference"
 msgstr "Ezberdintasunik ez"
 
 #. IDS_LINEDIFF_NODIFF_CAPTION
-#: Merge.rc:5221
+#: Merge.rc:5220
 #, c-format
 msgid "Line difference"
 msgstr "Lerro ezberdintasuna"
 
 #. IDS_NUM_REPLACED
-#: Merge.rc:5227
+#: Merge.rc:5226
 #, c-format
 msgid "Replaced %1 string(s)."
 msgstr "Ordeztuta %1 kate."
 
 #. IDS_EDIT_TEXT_NOT_FOUND
-#: Merge.rc:5228
+#: Merge.rc:5227
 #, c-format
 msgid "Cannot find string \"%s\"."
 msgstr "Ezin da kate hau aurkitu: \"%s\"."
 
 #. IDS_MERGE_MODE
-#: Merge.rc:5234
+#: Merge.rc:5233
 msgid "Entering Merge Mode. Press F9 to turn off."
 msgstr ""
 
 #. IDS_AUTO_MERGE
-#: Merge.rc:5240
+#: Merge.rc:5239
 #, c-format
 msgid "Automatic merges: %1\nUnresolved conflicts: %2"
 msgstr ""
 
 #. IDS_CODEPAGE_MERGED
-#: Merge.rc:5241
+#: Merge.rc:5240
 msgid "Codepage change merged."
 msgstr ""
 
 #. IDS_CODEPAGE_CONFLICT
-#: Merge.rc:5242
+#: Merge.rc:5241
 msgid "Codepage changes are conflicting."
 msgstr ""
 
 #. IDS_EOL_MERGED
-#: Merge.rc:5243
+#: Merge.rc:5242
 msgid "EOL change merged."
 msgstr ""
 
 #. IDS_EOL_CONFLICT
-#: Merge.rc:5244
+#: Merge.rc:5243
 msgid "EOL changes are conflicting."
 msgstr ""
 
 #. IDS_LOCBAR_CAPTION
-#: Merge.rc:5250
+#: Merge.rc:5249
 #, c-format
 msgid "Location Pane"
 msgstr "Kokaleku Panela"
 
 #. IDS_DIFFBAR_CAPTION
-#: Merge.rc:5251
+#: Merge.rc:5250
 #, c-format
 msgid "Diff Pane"
 msgstr "Ezberdint. Panela"
 
 #. IDS_DIFF_SUCCEEDED
-#: Merge.rc:5258
+#: Merge.rc:5257
 #, c-format
 msgid "Patch file written."
 msgstr "Eranskina agiria ongi idatzi da."
 
 #. IDS_DIFF_FILEOVERWRITE
-#: Merge.rc:5259
+#: Merge.rc:5258
 #, c-format
 msgid "Patch file already exists. Overwrite?"
 msgstr "Eranskin agiria jadanik badago. Gainidaztea nahi duzu?"
 
 #. IDS_DIFF_SELECTEDFILES
-#: Merge.rc:5260
+#: Merge.rc:5259
 #, c-format
 msgid "[%1 files selected]"
 msgstr "[%1 agiri hautatuta]"
 
 #. IDS_DIFF_NORMAL
-#: Merge.rc:5261
+#: Merge.rc:5260
 #, c-format
 msgid "Normal"
 msgstr "Normala"
 
 #. IDS_DIFF_CONTEXT
-#: Merge.rc:5262
+#: Merge.rc:5261
 #, c-format
 msgid "Context"
 msgstr "Hitzingurua"
 
 #. IDS_DIFF_UNIFIED
-#: Merge.rc:5263
+#: Merge.rc:5262
 #, c-format
 msgid "Unified"
 msgstr "Bateratuta"
 
 #. IDS_FILEWRITE_ERROR
-#: Merge.rc:5265
+#: Merge.rc:5264
 #, c-format
 msgid "Could not write to file %1."
 msgstr "Ezin da %1 agirira idatzi."
 
 #. IDS_PATH_NOT_ABSOLUTE
-#: Merge.rc:5266
+#: Merge.rc:5265
 #, c-format
 msgid "Output path is not absolute: %1"
 msgstr "Adierazitako irteera helburua ez helburu osoa: %1"
 
 #. IDS_MUST_SPECIFY_OUTPUT
-#: Merge.rc:5267
+#: Merge.rc:5266
 msgid "Specify an output file."
 msgstr "Adierazi irteera agiri bat."
 
-#: Merge.rc:5269
+#: Merge.rc:5268
 #, c-format
 msgid "Cannot create patch from binary files."
 msgstr "Ezin da eranski agiria sortu agiri binarioetatik."
 
 #. IDS_SAVEFILES_FORPATCH
-#: Merge.rc:5270
+#: Merge.rc:5269
 #, c-format
 msgid ""
 "Save all files first.\n"
@@ -8066,23 +8060,23 @@ msgstr ""
 "Eranskina sortzeak agirietan gordegabeko aldaketarik ez egotea eskatzen du."
 
 #. IDS_FOLDER_NOTEXIST
-#: Merge.rc:5271
+#: Merge.rc:5270
 #, c-format
 msgid "Folder does not exist."
 msgstr "Agiritegia ez dago."
 
 #. IDS_ARCHIVE_SUCCEEDED
-#: Merge.rc:5277
+#: Merge.rc:5276
 msgid "Archive file written."
 msgstr ""
 
 #. IDS_ARCHIVE_SAVEFILES
-#: Merge.rc:5278
+#: Merge.rc:5277
 msgid "Save all files first.\n\nCreating an archive requires no unsaved changes."
 msgstr ""
 
 #. IDS_NO_ZIP_SUPPORT
-#: Merge.rc:5283
+#: Merge.rc:5282
 msgid "Archive support not enabled.\n7-Zip and/or Merge7z*.dll not found.\nSee manual for archive support."
 msgstr ""
 "Agiri sostengua ez dago gaituta\n"
@@ -8090,43 +8084,43 @@ msgstr ""
 "Ikusi eskuliburua argibide gehigorako agiri sostenguari buruz eta nola gaitzeaz."
 
 #. IDS_OPT_EXPORT_CAPTION
-#: Merge.rc:5284
+#: Merge.rc:5283
 #, c-format
 msgid "Select file for export"
 msgstr "Hautatu esportatzeko agiria"
 
 #. IDS_OPT_IMPORT_CAPTION
-#: Merge.rc:5285
+#: Merge.rc:5284
 #, c-format
 msgid "Select file for import"
 msgstr "Hautatu inportatzeko agiria"
 
 #. IDS_OPT_IMPORT_DONE
-#: Merge.rc:5286
+#: Merge.rc:5285
 #, c-format
 msgid "Options imported from file."
 msgstr "Agiritik inportatutako aukerak"
 
 #. IDS_OPT_EXPORT_DONE
-#: Merge.rc:5287
+#: Merge.rc:5286
 #, c-format
 msgid "Options exported to file."
 msgstr "Agiritik esportatutako aukerak"
 
 #. IDS_OPT_IMPORT_ERR
-#: Merge.rc:5288
+#: Merge.rc:5287
 #, c-format
 msgid "Failed to import options from file."
 msgstr "Hutsegitea agiritik aukerak inportatzerakoan."
 
 #. IDS_OPT_EXPORT_ERR
-#: Merge.rc:5289
+#: Merge.rc:5288
 #, c-format
 msgid "Failed to write options to file."
 msgstr "Hutsegitea aukerak agirian idazterakoan."
 
 #. IDS_CLOSEALL_WINDOWS
-#: Merge.rc:5290
+#: Merge.rc:5289
 #, c-format
 msgid ""
 "Close multiple compare windows?\n"
@@ -8138,1208 +8132,1208 @@ msgstr ""
 "Jarraitzea nahi duzu?"
 
 #. IDS_EOL_BIN
-#: Merge.rc:5300
+#: Merge.rc:5299
 msgctxt "EOL Type"
 msgid "Binary"
 msgstr "Binarioa"
 
 #. IDS_MARKER_COLOR_FMT
-#: Merge.rc:5305
+#: Merge.rc:5304
 #, c-format
 msgid "Marker Color %d"
 msgstr ""
 
 #. IDS_MARKER_NEW_PATTERN
-#: Merge.rc:5306
+#: Merge.rc:5305
 msgid "New Pattern"
 msgstr ""
 
 #. IDS_PLUGINSLIST_TYPE
-#: Merge.rc:5312
+#: Merge.rc:5311
 #, c-format
 msgid "Type"
 msgstr "Mota"
 
 #. IDS_PLUGINS_TYPE_EDITSCRIPT
-#: Merge.rc:5316
+#: Merge.rc:5315
 #, c-format
 msgid "Editor script"
 msgstr "Editatzaile eskripta"
 
 #. ID_SELECTLINEDIFF
-#: Merge.rc:5322
+#: Merge.rc:5321
 #, c-format
 msgid "\nDifference in Current Line (F4)"
 msgstr ""
 
 #. ID_OPTIONS
-#: Merge.rc:5323
+#: Merge.rc:5322
 #, c-format
 msgid "\nOptions"
 msgstr ""
 
 #. ID_REFRESH
-#: Merge.rc:5324
+#: Merge.rc:5323
 #, c-format
 msgid "\nRefresh (F5)"
 msgstr ""
 
 #. ID_PREVDIFF
-#: Merge.rc:5330
+#: Merge.rc:5329
 #, c-format
 msgid "\nPrevious Difference (Alt+Up)"
 msgstr ""
 
 #. ID_NEXTDIFF
-#: Merge.rc:5331
+#: Merge.rc:5330
 #, c-format
 msgid "\nNext Difference (Alt+Down)"
 msgstr ""
 
 #. ID_PREVCONFLICT
-#: Merge.rc:5332
+#: Merge.rc:5331
 #, c-format
 msgid "\nPrevious Conflict (Alt+Shift+Up)"
 msgstr ""
 
 #. ID_NEXTCONFLICT
-#: Merge.rc:5333
+#: Merge.rc:5332
 #, c-format
 msgid "\nNext Conflict (Alt+Shift+Down)"
 msgstr ""
 
 #. ID_FIRSTDIFF
-#: Merge.rc:5338
+#: Merge.rc:5337
 #, c-format
 msgid "\nFirst Difference (Alt+Home)"
 msgstr ""
 
 #. ID_CURDIFF
-#: Merge.rc:5339
+#: Merge.rc:5338
 #, c-format
 msgid "\nCurrent Difference (Alt+Enter)"
 msgstr ""
 
 #. ID_LASTDIFF
-#: Merge.rc:5340
+#: Merge.rc:5339
 #, c-format
 msgid "\nLast Difference (Alt+End)"
 msgstr ""
 
 #. ID_L2R
-#: Merge.rc:5341
+#: Merge.rc:5340
 msgid "\nCopy to Right (Alt+Right)"
 msgstr ""
 
 #. ID_R2L
-#: Merge.rc:5342
+#: Merge.rc:5341
 msgid "\nCopy to Left (Alt+Left)"
 msgstr ""
 
 #. ID_L2RNEXT
-#: Merge.rc:5343
+#: Merge.rc:5342
 msgid "\nCopy to Right and Advance (Ctrl+Alt+Right)"
 msgstr ""
 
 #. ID_R2LNEXT
-#: Merge.rc:5344
+#: Merge.rc:5343
 msgid "\nCopy to Left and Advance (Ctrl+Alt+Left)"
 msgstr ""
 
 #. ID_ALL_RIGHT
-#: Merge.rc:5345
+#: Merge.rc:5344
 msgid "\nCopy All to Right"
 msgstr "\nKopiatu Dena Eskuinera"
 
 #. ID_ALL_LEFT
-#: Merge.rc:5346
+#: Merge.rc:5345
 msgid "\nCopy All to Left"
 msgstr "\nKopiatu Dena Ezkerrera"
 
 #. ID_AUTO_MERGE
-#: Merge.rc:5347
+#: Merge.rc:5346
 #, c-format
 msgid "\nAuto Merge (Ctrl+Alt+M)"
 msgstr ""
 
 #. ID_FIRSTFILE
-#: Merge.rc:5348
+#: Merge.rc:5347
 msgid "\nFirst File"
 msgstr ""
 
 #. ID_NEXTFILE
-#: Merge.rc:5349
+#: Merge.rc:5348
 msgid "\nNext File (Ctrl+F8)"
 msgstr ""
 
 #. ID_LASTFILE
-#: Merge.rc:5350
+#: Merge.rc:5349
 msgid "\nLast File"
 msgstr ""
 
 #. ID_PREVFILE
-#: Merge.rc:5351
+#: Merge.rc:5350
 msgid "\nPrevious File (Ctrl+F7)"
 msgstr ""
 
 #. IDS_UNPACK_AUTO
-#: Merge.rc:5358
+#: Merge.rc:5357
 msgid "Adapted unpacker applied to both files (one needs extension)."
 msgstr "Egokitutako despaketatzailea bi agiriei ezartzen zaie (agiri batek bakarrik behar du luzapena)."
 
 #. IDS_NO_PREDIFFER
-#: Merge.rc:5359
+#: Merge.rc:5358
 #, c-format
 msgid "No Prediffer (Normal)"
 msgstr "Ez aurrezberd (normala)"
 
 #. IDS_SUGGESTED_PLUGINS
-#: Merge.rc:5360
+#: Merge.rc:5359
 #, c-format
 msgid "Suggested Plugins"
 msgstr "Iradokitutako pluginak"
 
 #. IDS_NOT_SUGGESTED_PLUGINS
-#: Merge.rc:5361
+#: Merge.rc:5360
 msgid "All Plugins"
 msgstr ""
 
 #. IDS_PRIVATEBUILD_FMT
-#: Merge.rc:5367
+#: Merge.rc:5366
 #, c-format
 msgid "Private Build: %1"
 msgstr "Bilduma Pribatua: %1"
 
 #. IDS_ALLRIGHTS_RESERVED
-#: Merge.rc:5368
+#: Merge.rc:5367
 msgid " - All rights reserved."
 msgstr ""
 
 #. IDS_TITLE_PLUGINS_SETTINGS
-#: Merge.rc:5374
+#: Merge.rc:5373
 #, c-format
 msgid "Plugin Settings"
 msgstr "Plugin Ezarpenak"
 
 #. IDS_NO_SCT_SCRIPTS
-#: Merge.rc:5376
+#: Merge.rc:5375
 #, c-format
 msgid "WSH not found - .sct scripts disabled"
 msgstr "WSH ez da aurkitu - .sct eskriptak ezgaituta"
 
 #. IDS_LOCBAR_GOTOLINE_FMT
-#: Merge.rc:5384
+#: Merge.rc:5383
 #, c-format
 msgid "G&o to Line %1"
 msgstr "&Joan lerro honetara: %1"
 
 #. IDS_GOTO_MOVED_LINE
-#: Merge.rc:5390
+#: Merge.rc:5389
 msgid "Go to Moved Line\tCtrl+Shift+G"
 msgstr ""
 
 #. IDS_AUTOCOMPLETE_DISABLED
-#: Merge.rc:5396
+#: Merge.rc:5395
 msgctxt "Options dialog|General|Open dialog Auto completion"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_AUTOCOMPLETE_FILE_SYS
-#: Merge.rc:5397
+#: Merge.rc:5396
 #, c-format
 msgid "From file system"
 msgstr "Agiri sistematik"
 
 #. IDS_AUTOCOMPLETE_MRU
-#: Merge.rc:5398
+#: Merge.rc:5397
 msgid "From Most Recently Used list"
 msgstr "MRU zerrendatik"
 
 #. IDS_COLORSCHEME_PLAIN
-#: Merge.rc:5404
+#: Merge.rc:5403
 #, c-format
 msgid "No Highlighting"
 msgstr "Ez Nabarmenduta"
 
 #. IDS_COLORSCHEME_PO
-#: Merge.rc:5439
+#: Merge.rc:5438
 #, c-format
 msgid "Portable Object"
 msgstr "Portable Object"
 
 #. IDS_COLORSCHEME_RSRC
-#: Merge.rc:5444
+#: Merge.rc:5443
 #, c-format
 msgid "Resources"
 msgstr "Resources"
 
 #. IDS_COLORSCHEME_SH
-#: Merge.rc:5448
+#: Merge.rc:5447
 #, c-format
 msgid "Shell"
 msgstr "Shell"
 
 #. IDS_CLOSE_LEFT_TABS
-#: Merge.rc:5469
+#: Merge.rc:5468
 #, c-format
 msgid "Close &Left Tabs"
 msgstr ""
 
 #. IDS_CLOSE_RIGHT_TABS
-#: Merge.rc:5470
+#: Merge.rc:5469
 #, c-format
 msgid "Close R&ight Tabs"
 msgstr ""
 
 #. IDS_CLOSE_OTHER_TABS
-#: Merge.rc:5471
+#: Merge.rc:5470
 #, c-format
 msgid "Close &Other Tabs"
 msgstr ""
 
 #. IDS_TABBAR_AUTO_MAXWIDTH
-#: Merge.rc:5472
+#: Merge.rc:5471
 #, c-format
 msgid "Enable &Auto Max Width"
 msgstr ""
 
 #. IDS_WEBPAGE_MENU
-#: Merge.rc:5482
+#: Merge.rc:5481
 msgid "We&bpage"
 msgstr ""
 
 #. IDS_VIEW_WRAP_TEXT
-#: Merge.rc:5487
+#: Merge.rc:5486
 msgid "W&rap Text"
 msgstr ""
 
 #. IDS_NOTINSTALLED
-#: Merge.rc:5492
+#: Merge.rc:5491
 msgid "%1 is not installed."
 msgstr ""
 
 #. IDS_CREATE_FOLDER
-#: Merge.rc:5497
+#: Merge.rc:5496
 #, c-format
 msgid "%1 does not exist. Create it?"
 msgstr ""
 
 #. IDS_CREATE_FOLDER_ERROR
-#: Merge.rc:5498
+#: Merge.rc:5497
 #, c-format
 msgid "Failed to create folder."
 msgstr ""
 
 #. IDC_EXT_EDITOR_PATH
-#: Merge.rc:5503
+#: Merge.rc:5502
 #, c-format
 msgid "Parameters:\n$file: Current file path\n$linenum: Current cursor line number"
 msgstr ""
 
 #. IDS_DIFF_ALGORITHM_DEFAULT
-#: Merge.rc:5508
+#: Merge.rc:5507
 msgid "default"
 msgstr ""
 
 #. IDS_DIFF_ALGORITHM_MINIMAL
-#: Merge.rc:5509
+#: Merge.rc:5508
 msgid "minimal"
 msgstr ""
 
 #. IDS_DIFF_ALGORITHM_PATIENCE
-#: Merge.rc:5510
+#: Merge.rc:5509
 msgid "patience"
 msgstr ""
 
 #. IDS_DIFF_ALGORITHM_HISTOGRAM
-#: Merge.rc:5511
+#: Merge.rc:5510
 msgid "histogram"
 msgstr ""
 
 #. IDS_DIFF_ALGORITHM_NONE
-#: Merge.rc:5512
+#: Merge.rc:5511
 msgid "none"
 msgstr ""
 
 #. IDS_RENDERING_MODE_GDI
-#: Merge.rc:5517
+#: Merge.rc:5516
 msgid "GDI"
 msgstr ""
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_DEFAULT
-#: Merge.rc:5518
+#: Merge.rc:5517
 msgid "DirectWrite Default"
 msgstr ""
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_ALIASED
-#: Merge.rc:5519
+#: Merge.rc:5518
 msgid "DirectWrite Aliased"
 msgstr ""
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_GDI_CLASSIC
-#: Merge.rc:5520
+#: Merge.rc:5519
 msgid "DirectWrite GDI Classic"
 msgstr ""
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_GDI_NATURAL
-#: Merge.rc:5521
+#: Merge.rc:5520
 msgid "DirectWrite GDI Natural"
 msgstr ""
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_NATURAL
-#: Merge.rc:5522
+#: Merge.rc:5521
 msgid "DirectWrite Natural"
 msgstr ""
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_NATURAL_SYMMETRIC
-#: Merge.rc:5523
+#: Merge.rc:5522
 msgid "DirectWrite Natural Symmetric"
 msgstr ""
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_DISABLED
-#: Merge.rc:5528
+#: Merge.rc:5527
 msgctxt "Options dialog|General|Close windows with Esc"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_1
-#: Merge.rc:5529
+#: Merge.rc:5528
 msgid "MDI child window or main window"
 msgstr ""
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_2
-#: Merge.rc:5530
+#: Merge.rc:5529
 msgid "MDI child window only"
 msgstr ""
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_3
-#: Merge.rc:5531
+#: Merge.rc:5530
 msgid "Close main window if only one MDI child window"
 msgstr ""
 
 #. IDS_DIFF_GROUP
-#: Merge.rc:5536
+#: Merge.rc:5535
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Diff"
 msgstr ""
 
 #. IDS_DIFF_HIGHLIGHT
-#: Merge.rc:5537
+#: Merge.rc:5536
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Highlight"
 msgstr ""
 
 #. IDS_DIFF_BLINK
-#: Merge.rc:5538
+#: Merge.rc:5537
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Blink"
 msgstr ""
 
 #. IDS_DIFF_BLOCKSIZE
-#: Merge.rc:5539
+#: Merge.rc:5538
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Block Size"
 msgstr ""
 
 #. IDS_DIFF_BLOCKALPHA
-#: Merge.rc:5540
+#: Merge.rc:5539
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Block Alpha"
 msgstr ""
 
 #. IDS_DIFF_CDTHRESHOLD
-#: Merge.rc:5541
+#: Merge.rc:5540
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "CD Threshold"
 msgstr ""
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION
-#: Merge.rc:5542
+#: Merge.rc:5541
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Ins/Del Detection"
 msgstr ""
 
 #. IDS_OVERLAY_MODE_NONE
-#: Merge.rc:5543 Merge.rc:5548
+#: Merge.rc:5542 Merge.rc:5547
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "None"
 msgstr ""
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION_VERTICAL
-#: Merge.rc:5544
+#: Merge.rc:5543
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Vertical"
 msgstr ""
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION_HORIZONTAL
-#: Merge.rc:5545
+#: Merge.rc:5544
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Horizontal"
 msgstr ""
 
 #. IDS_OVERLAY_GROUP
-#: Merge.rc:5546
+#: Merge.rc:5545
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Overlay"
 msgstr ""
 
 #. IDS_OVERLAY_ALPHA
-#: Merge.rc:5547
+#: Merge.rc:5546
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha"
 msgstr ""
 
 #. IDS_OVERLAY_MODE_XOR
-#: Merge.rc:5549
+#: Merge.rc:5548
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "XOR"
 msgstr ""
 
 #. IDS_OVERLAY_MODE_ALPHA
-#: Merge.rc:5550
+#: Merge.rc:5549
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha Blend"
 msgstr ""
 
 #. IDS_OVERLAY_MODE_ALPHA_ANIMATION
-#: Merge.rc:5551
+#: Merge.rc:5550
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha Animation"
 msgstr ""
 
 #. IDS_ZOOM
-#: Merge.rc:5552
+#: Merge.rc:5551
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Zoom"
 msgstr ""
 
 #. IDS_PAGE
-#: Merge.rc:5553
+#: Merge.rc:5552
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Page:"
 msgstr ""
 
 #. IDS_IMGCMP_STATUS_PT_RGBA_FMT
-#: Merge.rc:5554
+#: Merge.rc:5553
 #, c-format
 msgid "Pt: (%d, %d)  RGBA: (%d, %d, %d, %d)  "
 msgstr ""
 
 #. IDS_IMGCMP_STATUS_DIST1_FMT
-#: Merge.rc:5555
+#: Merge.rc:5554
 #, c-format
 msgid "Dist: %g  "
 msgstr ""
 
 #. IDS_IMGCMP_STATUS_DIST2_FMT
-#: Merge.rc:5556
+#: Merge.rc:5555
 #, c-format
 msgid "Dist: %g, %g  "
 msgstr ""
 
 #. IDS_IMGCMP_STATUS_PAGE_ZOOM_SIZE_BPP_FMT
-#: Merge.rc:5557
+#: Merge.rc:5556
 #, c-format
 msgid "Page: %d/%d  Zoom: %d%%  %dx%dpx  %dbpp  "
 msgstr ""
 
 #. IDS_IMGCMP_STATUS_RC_FMT
-#: Merge.rc:5558
+#: Merge.rc:5557
 #, c-format
 msgid "Rc: (%d, %d)  "
 msgstr ""
 
 #. IDS_IMGCMP_STATUS_FLIPPED_FMT
-#: Merge.rc:5559
+#: Merge.rc:5558
 #, c-format
 msgid "Flipped: %s  "
 msgstr ""
 
 #. IDS_IMGCMP_STATUS_ROTATED_FMT
-#: Merge.rc:5560
+#: Merge.rc:5559
 #, c-format
 msgid "Rotated: %d  "
 msgstr ""
 
 #. IDS_IMGCMP_REPORT_ALLPAGES
-#: Merge.rc:5561
+#: Merge.rc:5560
 msgid "All pages"
 msgstr ""
 
 #. IDS_IGNSUB_STR1
-#: Merge.rc:5566
+#: Merge.rc:5565
 msgid "<Edit here>"
 msgstr ""
 
 #. IDS_IGNSUB_STR2
-#: Merge.rc:5567
+#: Merge.rc:5566
 msgid "No differences found to select"
 msgstr ""
 
 #. IDS_IGNSUB_STR3
-#: Merge.rc:5568
+#: Merge.rc:5567
 msgid "No differences found to add as substitution filter"
 msgstr ""
 
 #. IDS_IGNSUB_STR4
-#: Merge.rc:5569
+#: Merge.rc:5568
 msgid "The pair is already in the Substitution Filters list"
 msgstr ""
 
 #. IDS_IGNSUB_STR5
-#: Merge.rc:5570
+#: Merge.rc:5569
 msgid "Add this change to Substitution Filters?"
 msgstr ""
 
 #. IDS_OCRRESULT_TEXTONLY
-#: Merge.rc:5575
+#: Merge.rc:5574
 msgid "Text only"
 msgstr ""
 
 #. IDS_OCRRESULT_POS_LINE
-#: Merge.rc:5576
+#: Merge.rc:5575
 msgid "Line-by-line position and text"
 msgstr ""
 
 #. IDS_OCRRESULT_POS_WORD
-#: Merge.rc:5577
+#: Merge.rc:5576
 msgid "Word-by-word position and text"
 msgstr ""
 
 #. IDS_USERDATAFOLDER_APPDATA
-#: Merge.rc:5582
+#: Merge.rc:5581
 msgid "AppData (Roaming) folder"
 msgstr ""
 
 #. IDS_USERDATAFOLDER_INSTALL
-#: Merge.rc:5583
+#: Merge.rc:5582
 msgid "Install folder"
 msgstr ""
 
 #. IDS_USERDATAFOLDER_DOCUMENTS
-#: Merge.rc:5584
+#: Merge.rc:5583
 msgid "Documents folder"
 msgstr ""
 
 #. IDS_SINGLEINSTANCE_DISABLED
-#: Merge.rc:5589
+#: Merge.rc:5588
 msgctxt "Options dialog|General|Single instance mode"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_SINGLEINSTANCE_STR1
-#: Merge.rc:5590
+#: Merge.rc:5589
 #, c-format
 msgid "Allow only one instance to run"
 msgstr "Ahalbidetu ekinbide bat bakarrik "
 
 #. IDS_CLIPBOARD_HISTORY
-#: Merge.rc:5591
+#: Merge.rc:5590
 msgid "Clipboard &History"
 msgstr ""
 
 #. IDS_SINGLEINSTANCE_STR2
-#: Merge.rc:5592
+#: Merge.rc:5591
 msgid "Allow only one instance; wait for termination"
 msgstr ""
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_DISABLED
-#: Merge.rc:5597
+#: Merge.rc:5596
 msgctxt "Options dialog|General|Auto-reload modified files"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_STR1
-#: Merge.rc:5598
+#: Merge.rc:5597
 msgid "Only on window activated"
 msgstr ""
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_STR2
-#: Merge.rc:5599
+#: Merge.rc:5598
 msgid "Immediately"
 msgstr ""
 
 #. IDS_PLUGIN_ALL
-#: Merge.rc:5604
+#: Merge.rc:5603
 msgid "Al&l"
 msgstr ""
 
 #. IDS_PLUGIN_OTHERS
-#: Merge.rc:5605
+#: Merge.rc:5604
 msgid "&Others"
 msgstr ""
 
-#: Merge.rc:5607
+#: Merge.rc:5606
 #, c-format
 msgid "Missing plugin name in pipeline: %1"
 msgstr ""
 
-#: Merge.rc:5609
+#: Merge.rc:5608
 #, c-format
 msgid "Missing quote in plugin pipeline: %1"
 msgstr ""
 
 #. IDS_PLUGIN_NAME_ALREADY_EXISTS
-#: Merge.rc:5610
+#: Merge.rc:5609
 #, c-format
 msgid "Plugin name '%1' already exists."
 msgstr ""
 
 #. IDS_PLUGIN_TITLE1
-#: Merge.rc:5611
+#: Merge.rc:5610
 msgid "Specify plugin arguments"
 msgstr ""
 
-#: Merge.rc:5613
+#: Merge.rc:5612
 #, c-format
 msgid "Plugin not found or invalid: %1"
 msgstr ""
 
 #. IDS_PLUGIN_NOT_UNPACK
-#: Merge.rc:5614
+#: Merge.rc:5613
 #, c-format
 msgid "'%1' is not an unpacker plugin"
 msgstr ""
 
 #. IDS_PLUGIN_NOT_PREDIFF
-#: Merge.rc:5615
+#: Merge.rc:5614
 #, c-format
 msgid "'%1' is not a prediffer plugin"
 msgstr ""
 
-#: Merge.rc:5617
+#: Merge.rc:5616
 #, c-format
 msgid "Error prediffing '%1' with '%2'. Prediffing disabled."
 msgstr ""
 
 #. IDS_PLUGIN_CIRCULAR_REFERENCE
-#: Merge.rc:5618
+#: Merge.rc:5617
 #, c-format
 msgid "Circular reference in plugin pipeline: %1"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE1
-#: Merge.rc:5619
+#: Merge.rc:5618
 msgid "URL Handler"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE2
-#: Merge.rc:5620
+#: Merge.rc:5619
 msgid "File Unpacker"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE3
-#: Merge.rc:5621
+#: Merge.rc:5620
 msgid "File or Folder Unpacker"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE5
-#: Merge.rc:5623
+#: Merge.rc:5622
 msgid "Alias for Unpacker"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE6
-#: Merge.rc:5624
+#: Merge.rc:5623
 msgid "Alias for Prediffer"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE7
-#: Merge.rc:5625
+#: Merge.rc:5624
 msgid "Alias for Editor script"
 msgstr ""
 
 #. IDS_PLUGIN_ALIAS_DESC
-#: Merge.rc:5626
+#: Merge.rc:5625
 #, c-format
 msgid "Alias for plugin pipeline '%1'"
 msgstr ""
 
 #. IDS_PLUGIN_NEW_DESC
-#: Merge.rc:5627
+#: Merge.rc:5626
 msgid "New plugin description"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_ALL
-#: Merge.rc:5628
+#: Merge.rc:5627
 msgid "All"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_1ST
-#: Merge.rc:5629
+#: Merge.rc:5628
 msgid "1st"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_2ND
-#: Merge.rc:5630
+#: Merge.rc:5629
 msgid "2nd"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_3RD
-#: Merge.rc:5631
+#: Merge.rc:5630
 msgid "3rd"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_1ST_2ND
-#: Merge.rc:5632
+#: Merge.rc:5631
 msgid "1st and 2nd"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_1ST_3RD
-#: Merge.rc:5633
+#: Merge.rc:5632
 msgid "1st and 3rd"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_2ND_3RD
-#: Merge.rc:5634
+#: Merge.rc:5633
 msgid "2nd and 3rd"
 msgstr ""
 
 #. IDS_PLUGIN_CTRL_CLICK
-#: Merge.rc:5635
+#: Merge.rc:5634
 msgid "(Ctrl+Click to add to pipeline)"
 msgstr ""
 
 #. IDS_FILTER_APPLIED
-#: Merge.rc:5640
+#: Merge.rc:5639
 msgid "Filter applied"
 msgstr ""
 
 #. IDS_FILTERMENU_COMPARE
-#: Merge.rc:5645
+#: Merge.rc:5644
 #, c-format
 msgid "Compare %1"
 msgstr ""
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN2
-#: Merge.rc:5647
+#: Merge.rc:5646
 msgid "&Filter by This Column..."
 msgstr ""
 
 #. IDS_CLIPBOARDHISTORY_TIME
-#: Merge.rc:5652
+#: Merge.rc:5651
 #, c-format
 msgid "Clipboard at %s"
 msgstr ""
 
 #. IDS_CLIPBOARDHISTORY_DISABLED
-#: Merge.rc:5653
+#: Merge.rc:5652
 msgid "Clipboard history disabled.\r\nEnable: Windows logo key + V, then Turn on."
 msgstr ""
 
-#: Merge.rc:5655
+#: Merge.rc:5654
 msgid "This system does not support clipboard history."
 msgstr ""
 
-#: Merge.rc:5657
+#: Merge.rc:5656
 msgid "32-bit WinMerge does not support Clipboard Compare"
 msgstr ""
 
 #. IDS_WEBVIEW2_RUNTIME_NOT_INSTALLED
-#: Merge.rc:5662
+#: Merge.rc:5661
 msgid "WebView2 runtime not installed. Download it?"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_TEXT_COMPARE
-#: Merge.rc:5667
+#: Merge.rc:5666
 msgid "New Text Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_TABLE_COMPARE
-#: Merge.rc:5668
+#: Merge.rc:5667
 msgid "New Table Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_BINARY_COMPARE
-#: Merge.rc:5669
+#: Merge.rc:5668
 msgid "New Binary Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_IMAGE_COMPARE
-#: Merge.rc:5670
+#: Merge.rc:5669
 msgid "New Image Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_WEBPAGE_COMPARE
-#: Merge.rc:5671
+#: Merge.rc:5670
 msgid "New Webpage Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_FOLDER_COMPARE
-#: Merge.rc:5672
+#: Merge.rc:5671
 msgid "New Folder Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_CLIPBOARD_COMPARE
-#: Merge.rc:5673
+#: Merge.rc:5672
 msgid "Clipboard Compare"
 msgstr ""
 
 #. IDS_PREVIEWBAR_PRINT
-#: Merge.rc:5678
+#: Merge.rc:5677
 msgid "&Print..."
 msgstr ""
 
 #. IDS_PREVIEWBAR_PREVPAGE
-#: Merge.rc:5680
+#: Merge.rc:5679
 msgid "Pre&v Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_TWOPAGE
-#: Merge.rc:5681
+#: Merge.rc:5680
 msgid "&Two Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_ONEPAGE
-#: Merge.rc:5682
+#: Merge.rc:5681
 msgid "&One Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_ZOOMIN
-#: Merge.rc:5683
+#: Merge.rc:5682
 msgid "Zoom &In"
 msgstr ""
 
 #. IDS_PREVIEWBAR_ZOOMOUT
-#: Merge.rc:5684
+#: Merge.rc:5683
 msgid "Zoom &Out"
 msgstr ""
 
 #. IDS_WEBPAGE_COMPARING
-#: Merge.rc:5690
+#: Merge.rc:5689
 msgid "Comparing..."
 msgstr ""
 
 #. IDS_WEBPAGE_ZOOM
-#: Merge.rc:5691
+#: Merge.rc:5690
 msgid "Zoom:"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_DIFFHUNK
-#: Merge.rc:5696
+#: Merge.rc:5695
 msgid "Diff hunk"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_INLINE
-#: Merge.rc:5697
+#: Merge.rc:5696
 msgid "Inline diff"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_LINE
-#: Merge.rc:5698
+#: Merge.rc:5697
 msgid "Line"
 msgstr ""
 
-#: Merge.rc:5699
+#: Merge.rc:5698
 msgid "Character"
 msgstr ""
 
 #. ID_MICE_PREVDIFF
-#: Merge.rc:5704
+#: Merge.rc:5703
 msgid "\nPrevious Difference (Alt+Up)\n(Right Button+Wheel Up)\n(Alt+Wheel Up)"
 msgstr ""
 
 #. ID_MICE_NEXTDIFF
-#: Merge.rc:5705
+#: Merge.rc:5704
 msgid "\nNext Difference (Alt+Down)\n(Right Button+Wheel Down)\n(Alt+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_L2R
-#: Merge.rc:5706
+#: Merge.rc:5705
 msgid "\nCopy to Right (Alt+Right)\n(Right Button+Wheel Right)\n(Alt+Wheel Right)\n(Alt+Shift+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_R2L
-#: Merge.rc:5707
+#: Merge.rc:5706
 msgid "\nCopy to Left (Alt+Left)\n(Right Button+Wheel Left)\n(Alt+Wheel Left)\n(Alt+Shift+Wheel Up)"
 msgstr ""
 
 #. ID_MICE_L2RNEXT
-#: Merge.rc:5708
+#: Merge.rc:5707
 msgid "\nCopy to Right and Advance (Ctrl+Alt+Right)\n(Ctrl+Alt+Wheel Right)\n(Ctrl+Alt+Shift+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_R2LNEXT
-#: Merge.rc:5709
+#: Merge.rc:5708
 msgid "\nCopy to Left and Advance (Ctrl+Alt+Left)\n(Ctrl+Alt+Wheel Left)\n(Ctrl+Alt+Shift+Wheel Up)"
 msgstr ""
 
 #. IDS_LOG_COMPARING_2
-#: Merge.rc:5719
+#: Merge.rc:5718
 #, c-format
 msgid "Comparing %1 with %2"
 msgstr ""
 
 #. IDS_LOG_COMPARING_3
-#: Merge.rc:5720
+#: Merge.rc:5719
 #, c-format
 msgid "Comparing %1 with %2 and %3"
 msgstr ""
 
 #. IDS_LOG_COMPARE_COMPLETED
-#: Merge.rc:5721
+#: Merge.rc:5720
 msgid "Comparison completed"
 msgstr ""
 
 #. IDS_LOG_COMPARE_ERROR_2
-#: Merge.rc:5722
+#: Merge.rc:5721
 #, c-format
 msgid "Failed to compare %1 with %2: "
 msgstr ""
 
 #. IDS_LOG_COMPARE_ERROR_3
-#: Merge.rc:5723
+#: Merge.rc:5722
 #, c-format
 msgid "Failed to compare %1 with %2 and %3: "
 msgstr ""
 
 #. IDS_LOG_FILE_SAVED
-#: Merge.rc:5724
+#: Merge.rc:5723
 msgid "File saved"
 msgstr ""
 
 #. IDS_LOG_COPYING_FILES
-#: Merge.rc:5725
+#: Merge.rc:5724
 msgid "Copying files..."
 msgstr ""
 
 #. IDS_LOG_MOVING_FILES
-#: Merge.rc:5726
+#: Merge.rc:5725
 msgid "Moving files..."
 msgstr ""
 
 #. IDS_LOG_DELETING_FILES
-#: Merge.rc:5727
+#: Merge.rc:5726
 msgid "Deleting files..."
 msgstr ""
 
 #. IDS_LOG_RECYCLEBIN
-#: Merge.rc:5728
+#: Merge.rc:5727
 msgid "Recycle Bin"
 msgstr ""
 
 #. IDS_LOG_PERMANENTLY_DELETED
-#: Merge.rc:5729
+#: Merge.rc:5728
 msgid "Permanently deleted"
 msgstr ""
 
 #. IDS_LOG_FILEOPERATION_COMPLETED
-#: Merge.rc:5730
+#: Merge.rc:5729
 msgid "File operation completed successfully"
 msgstr ""
 
 #. IDS_LOG_FILEOPERATION_CANCELED
-#: Merge.rc:5731
+#: Merge.rc:5730
 msgid "File operation canceled"
 msgstr ""
 
 #. IDS_FILTER_ERROR_NO_ERROR
-#: Merge.rc:5736
+#: Merge.rc:5735
 msgid "No error"
 msgstr ""
 
 #. IDS_FILTER_ERROR_EMPTY_EXPRESSION
-#: Merge.rc:5737
+#: Merge.rc:5736
 msgid "Filter expression is empty"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNKNOWN_CHAR
-#: Merge.rc:5738
+#: Merge.rc:5737
 msgid "Unknown character in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNTERMINATED_STRING
-#: Merge.rc:5739
+#: Merge.rc:5738
 msgid "Unterminated string literal"
 msgstr ""
 
 #. IDS_FILTER_ERROR_SYNTAX_ERROR
-#: Merge.rc:5740
+#: Merge.rc:5739
 msgid "Syntax error in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_PARSE_FAILURE
-#: Merge.rc:5741
+#: Merge.rc:5740
 msgid "Failed to parse filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_LITERAL
-#: Merge.rc:5742
+#: Merge.rc:5741
 msgid "Invalid literal value"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_REGULAR_EXPRESSION
-#: Merge.rc:5743
+#: Merge.rc:5742
 msgid "Invalid regular expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNDEFINED_IDENTIFIER
-#: Merge.rc:5744
+#: Merge.rc:5743
 msgid "Undefined identifier"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_ARGUMENT_COUNT
-#: Merge.rc:5745
+#: Merge.rc:5744
 msgid "Invalid number of arguments"
 msgstr ""
 
 #. IDS_FILTER_ERROR_FILTER_NAME_NOT_FOUND
-#: Merge.rc:5746
+#: Merge.rc:5745
 msgid "Filter name not found"
 msgstr ""
 
 #. IDS_FILTER_ERROR_DIVIDE_BY_ZERO
-#: Merge.rc:5747
+#: Merge.rc:5746
 msgid "Division by zero in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNKNOWN_ERROR
-#: Merge.rc:5748
+#: Merge.rc:5747
 msgid "Unknown error"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_PROPERTY_NAME
-#: Merge.rc:5749
+#: Merge.rc:5748
 msgid "Invalid property name"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_DIRECTIVE
-#: Merge.rc:5750
+#: Merge.rc:5749
 msgid "Invalid directive"
 msgstr ""
 
 #. IDS_FILTER_OP_EQUALS
-#: Merge.rc:5755
+#: Merge.rc:5754
 msgid "Equals"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_EQUALS
-#: Merge.rc:5756
+#: Merge.rc:5755
 msgid "Does not equal"
 msgstr ""
 
 #. IDS_FILTER_OP_LESS_THAN
-#: Merge.rc:5757
+#: Merge.rc:5756
 msgid "Less than"
 msgstr ""
 
 #. IDS_FILTER_OP_LESS_EQUAL
-#: Merge.rc:5758
+#: Merge.rc:5757
 msgid "Less than or equal to"
 msgstr ""
 
 #. IDS_FILTER_OP_GREATER_EQUAL
-#: Merge.rc:5759
+#: Merge.rc:5758
 msgid "Greater than or equal to"
 msgstr ""
 
 #. IDS_FILTER_OP_GREATER_THAN
-#: Merge.rc:5760
+#: Merge.rc:5759
 msgid "Greater than"
 msgstr ""
 
 #. IDS_FILTER_OP_BETWEEN
-#: Merge.rc:5761
+#: Merge.rc:5760
 msgid "Between"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_BETWEEN
-#: Merge.rc:5762
+#: Merge.rc:5761
 msgid "Not Between"
 msgstr ""
 
 #. IDS_FILTER_OP_CONTAINS
-#: Merge.rc:5763
+#: Merge.rc:5762
 msgid "Contains"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_CONTAINS
-#: Merge.rc:5764
+#: Merge.rc:5763
 msgid "Not Contains"
 msgstr ""
 
 #. IDS_FILTER_OP_RECONTAINS
-#: Merge.rc:5765
+#: Merge.rc:5764
 msgid "Contains (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_RECONTAINS
-#: Merge.rc:5766
+#: Merge.rc:5765
 msgid "Not Contains (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_LIKE
-#: Merge.rc:5767
+#: Merge.rc:5766
 msgid "Match (wildcard)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_LIKE
-#: Merge.rc:5768
+#: Merge.rc:5767
 msgid "Not match (wildcard)"
 msgstr ""
 
 #. IDS_FILTER_OP_MATCHES
-#: Merge.rc:5769
+#: Merge.rc:5768
 msgid "Match (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_MATCHES
-#: Merge.rc:5770
+#: Merge.rc:5769
 msgid "Not match (regex)"
 msgstr ""
 
 #. IDS_COLORMODE_LIGHT
-#: Merge.rc:5775
+#: Merge.rc:5774
 msgid "Light"
 msgstr ""
 
 #. IDS_COLORMODE_DARK
-#: Merge.rc:5776
+#: Merge.rc:5775
 msgid "Dark"
 msgstr ""
 
 #. IDS_COLORMODE_FOLLOWSYSTEM
-#: Merge.rc:5777
+#: Merge.rc:5776
 msgid "Follow system"
 msgstr ""
 
 #. IDS_EXAMPLE
-#: Merge.rc:5782
+#: Merge.rc:5781
 #, c-format
 msgid "e.g. %1"
 msgstr ""
 
 #. IDS_DETECTED_PREVIOUS_CRASH
-#: Merge.rc:5787
+#: Merge.rc:5786
 msgid "WinMerge detected a previous crash. Please report this if possible."
 msgstr ""
 
 #. IDS_REGEX_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5792
+#: Merge.rc:5791
 msgid "# Regex replacement list\r\n# Format: regex<TAB>replacement\r\n# Backreferences like $1, $2 are supported\r\n\r\n(\\d{4})-(\\d{2})-(\\d{2})\t$1_$2_$3\r\n"
 msgstr ""
 
 #. IDS_STRING_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5793
+#: Merge.rc:5792
 msgid "# Replacement list\r\n# Format: search<TAB>replacement\r\n# Lines starting with # are ignored\r\n\r\nfrom1\tto1\r\nfrom2\tto2\r\n"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_ONLY
-#: Merge.rc:5798
+#: Merge.rc:5797
 msgid "Built-in only"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_FIRST
-#: Merge.rc:5799
+#: Merge.rc:5798
 msgid "Built-in first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_FIRST
-#: Merge.rc:5800
+#: Merge.rc:5799
 msgid "Tree-sitter first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_ONLY
-#: Merge.rc:5801
+#: Merge.rc:5800
 msgid "Tree-sitter only"
 msgstr ""
 

--- a/Translations/WinMerge/Brazilian.po
+++ b/Translations/WinMerge/Brazilian.po
@@ -25,7 +25,7 @@ msgstr ""
 "X-Generator: Poedit 3.9\n"
 
 #. LANGUAGE, SUBLANGUAGE
-#: Merge.rc:26 Merge.rc:59 Merge.rc:5818
+#: Merge.rc:26 Merge.rc:59 Merge.rc:5817
 msgid "LANG_ENGLISH, SUBLANG_ENGLISH_US"
 msgstr "LANG_PORTUGUESE, SUBLANG_PORTUGUESE_BRAZILIAN"
 
@@ -167,7 +167,7 @@ msgstr "&Scripts"
 #. IDS_NO_EDIT_SCRIPTS
 #: Merge.rc:127 Merge.rc:352 Merge.rc:463 Merge.rc:673 Merge.rc:678
 #: Merge.rc:887 Merge.rc:899 Merge.rc:906 Merge.rc:963 Merge.rc:1210
-#: Merge.rc:5375
+#: Merge.rc:5374
 msgid "< Empty >"
 msgstr "< Vazio >"
 
@@ -232,7 +232,7 @@ msgid "Auto-Fit All Columns"
 msgstr "Ajustar Automaticamente Todas as Colunas"
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN
-#: Merge.rc:153 Merge.rc:5646
+#: Merge.rc:153 Merge.rc:5645
 msgid "&Filter by This Column"
 msgstr "&Filtrar por Esta Coluna"
 
@@ -293,7 +293,7 @@ msgid "&Previous Page"
 msgstr "&Página Anterior"
 
 #. IDS_PREVIEWBAR_NEXTPAGE
-#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5679
+#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5678
 msgid "&Next Page"
 msgstr "Pá&gina Seguinte"
 
@@ -544,7 +544,7 @@ msgstr "&Binário"
 #. IDS_IMAGE_MENU
 #: Merge.rc:329 Merge.rc:338 Merge.rc:432 Merge.rc:441 Merge.rc:609
 #: Merge.rc:618 Merge.rc:670 Merge.rc:960 Merge.rc:1187 Merge.rc:1200
-#: Merge.rc:5477
+#: Merge.rc:5476
 msgid "&Image"
 msgstr "&Imagem"
 
@@ -666,7 +666,7 @@ msgid "&Huge"
 msgstr "&Enorme"
 
 #. IDS_VIEW_MENU_BAR
-#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5714
+#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5713
 msgid "Men&u Bar"
 msgstr "Barra de Men&us"
 
@@ -1321,7 +1321,7 @@ msgid "Lo&cation Pane"
 msgstr "Pa&inel de Localização"
 
 #. IDS_OUTPUTBAR_CAPTION
-#: Merge.rc:782 Merge.rc:5252
+#: Merge.rc:782 Merge.rc:5251
 msgid "Output Pane"
 msgstr "Painel de Saída"
 
@@ -1584,55 +1584,55 @@ msgid "Co&mpare As"
 msgstr "Co&mparar Como"
 
 #. IDS_COPY_LEFT_TO_MIDDLE2
-#: Merge.rc:968 Merge.rc:980 Merge.rc:4852
+#: Merge.rc:968 Merge.rc:980 Merge.rc:4851
 #, c-format
 msgid "Left to Middle (%1 of %2)"
 msgstr "Da Esquerda para o Meio (%1 de %2)"
 
 #. IDS_COPY_LEFT_TO_RIGHT2
-#: Merge.rc:969 Merge.rc:981 Merge.rc:4851
+#: Merge.rc:969 Merge.rc:981 Merge.rc:4850
 #, c-format
 msgid "Left to Right (%1 of %2)"
 msgstr "Da Esquerda para a Direita (%1 de %2)"
 
 #. IDS_MOVE_LEFT_TO2
-#: Merge.rc:970 Merge.rc:982 Merge.rc:1045 Merge.rc:4863 Merge.rc:4892
+#: Merge.rc:970 Merge.rc:982 Merge.rc:1045 Merge.rc:4862 Merge.rc:4891
 #, c-format
 msgid "Left to... (%1 of %2)"
 msgstr "Da Esquerda para... (%1 de %2)"
 
 #. IDS_COPY_MIDDLE_TO_LEFT2
-#: Merge.rc:971 Merge.rc:983 Merge.rc:4849
+#: Merge.rc:971 Merge.rc:983 Merge.rc:4848
 #, c-format
 msgid "Middle to Left (%1 of %2)"
 msgstr "Do Meio para a Esquerda (%1 de %2)"
 
 #. IDS_COPY_MIDDLE_TO_RIGHT2
-#: Merge.rc:972 Merge.rc:984 Merge.rc:4850
+#: Merge.rc:972 Merge.rc:984 Merge.rc:4849
 #, c-format
 msgid "Middle to Right (%1 of %2)"
 msgstr "Do Meio para a Direita (%1 de %2)"
 
 #. IDS_MOVE_MIDDLE_TO2
-#: Merge.rc:973 Merge.rc:985 Merge.rc:1046 Merge.rc:4864 Merge.rc:4893
+#: Merge.rc:973 Merge.rc:985 Merge.rc:1046 Merge.rc:4863 Merge.rc:4892
 #, c-format
 msgid "Middle to... (%1 of %2)"
 msgstr "Do Meio para... (%1 de %2)"
 
 #. IDS_COPY_RIGHT_TO_MIDDLE2
-#: Merge.rc:974 Merge.rc:986 Merge.rc:4848
+#: Merge.rc:974 Merge.rc:986 Merge.rc:4847
 #, c-format
 msgid "Right to Middle (%1 of %2)"
 msgstr "Da Direita para o Meio (%1 de %2)"
 
 #. IDS_COPY_RIGHT_TO_LEFT2
-#: Merge.rc:975 Merge.rc:987 Merge.rc:4847
+#: Merge.rc:975 Merge.rc:987 Merge.rc:4846
 #, c-format
 msgid "Right to Left (%1 of %2)"
 msgstr "Da Direita para a Esquerda (%1 de %2)"
 
 #. IDS_MOVE_RIGHT_TO2
-#: Merge.rc:976 Merge.rc:988 Merge.rc:1047 Merge.rc:4865 Merge.rc:4894
+#: Merge.rc:976 Merge.rc:988 Merge.rc:1047 Merge.rc:4864 Merge.rc:4893
 #, c-format
 msgid "Right to... (%1 of %2)"
 msgstr "Da Direita para... (%1 de %2)"
@@ -1688,31 +1688,31 @@ msgid "Cop&y Paths"
 msgstr "Cop&iar Caminhos"
 
 #. IDS_DEL_LEFT_FMT2
-#: Merge.rc:1026 Merge.rc:1035 Merge.rc:4880
+#: Merge.rc:1026 Merge.rc:1035 Merge.rc:4879
 #, c-format
 msgid "Left (%1 of %2)"
 msgstr "Da Esquerda (%1 de %2)"
 
 #. IDS_DEL_MIDDLE_FMT2
-#: Merge.rc:1027 Merge.rc:1036 Merge.rc:4881
+#: Merge.rc:1027 Merge.rc:1036 Merge.rc:4880
 #, c-format
 msgid "Middle (%1 of %2)"
 msgstr "Do Meio (%1 de %2)"
 
 #. IDS_DEL_RIGHT_FMT2
-#: Merge.rc:1028 Merge.rc:1037 Merge.rc:4882
+#: Merge.rc:1028 Merge.rc:1037 Merge.rc:4881
 #, c-format
 msgid "Right (%1 of %2)"
 msgstr "Da Direita (%1 de %2)"
 
 #. IDS_DEL_BOTH_FMT2
-#: Merge.rc:1029 Merge.rc:1038 Merge.rc:4883
+#: Merge.rc:1029 Merge.rc:1038 Merge.rc:4882
 #, c-format
 msgid "Both (%1 of %2)"
 msgstr "De Ambos(as) (%1 de %2)"
 
 #. IDS_DEL_ALL_FMT2
-#: Merge.rc:1030 Merge.rc:1039 Merge.rc:4888
+#: Merge.rc:1030 Merge.rc:1039 Merge.rc:4887
 #, c-format
 msgid "All (%1 of %2)"
 msgstr "De Tudo (%1 de %2)"
@@ -1738,19 +1738,19 @@ msgid "&Zip"
 msgstr "&Compactar"
 
 #. IDS_COPY_BOTH_TO2
-#: Merge.rc:1048 Merge.rc:4866
+#: Merge.rc:1048 Merge.rc:4865
 #, c-format
 msgid "Both to... (%1 of %2)"
 msgstr "Ambos para... (%1 de %2)"
 
 #. IDS_COPY_ALL_TO2
-#: Merge.rc:1049 Merge.rc:4867
+#: Merge.rc:1049 Merge.rc:4866
 #, c-format
 msgid "All to... (%1 of %2)"
 msgstr "Todos para... (%1 de %2)"
 
 #. IDS_COPY_DIFFERENCES_TO2
-#: Merge.rc:1050 Merge.rc:4868
+#: Merge.rc:1050 Merge.rc:4867
 #, c-format
 msgid "Differences to... (%1 of %2)"
 msgstr "Diferenças para... (%1 de %2)"
@@ -1817,12 +1817,12 @@ msgstr "Configurações do Descompactador"
 
 #. IDS_USERCHOICE_NONE
 #: Merge.rc:1088 Merge.rc:1094 Merge.rc:1836 Merge.rc:1840 Merge.rc:2031
-#: Merge.rc:2035 Merge.rc:5377
+#: Merge.rc:2035 Merge.rc:5376
 msgid "<None>"
 msgstr "<Nenhum>"
 
 #. IDS_USERCHOICE_AUTOMATIC
-#: Merge.rc:1089 Merge.rc:1095 Merge.rc:5378
+#: Merge.rc:1089 Merge.rc:1095 Merge.rc:5377
 msgid "<Automatic>"
 msgstr "<Automático>"
 
@@ -2752,12 +2752,12 @@ msgid "Text files only"
 msgstr "Apenas arquivos de texto"
 
 #. IDS_EOL_NONE
-#: Merge.rc:1667 Merge.rc:1918 Merge.rc:5304
+#: Merge.rc:1667 Merge.rc:1918 Merge.rc:5303
 msgid "None"
 msgstr "Nenhum"
 
 #. IDS_EOL_MIXED
-#: Merge.rc:1668 Merge.rc:5299
+#: Merge.rc:1668 Merge.rc:5298
 msgid "Mixed"
 msgstr "Misturado"
 
@@ -3029,13 +3029,13 @@ msgstr "&Status da Linha"
 
 #. IDS_DIFFERENT
 #: Merge.rc:1904 Merge.rc:1988 Merge.rc:2866 Merge.rc:3036 Merge.rc:3077
-#: Merge.rc:5058
+#: Merge.rc:5057
 msgid "Different"
 msgstr "Diferentes"
 
 #. IDS_IDENTICAL
 #: Merge.rc:1905 Merge.rc:1989 Merge.rc:2865 Merge.rc:3055 Merge.rc:3116
-#: Merge.rc:5048
+#: Merge.rc:5047
 msgid "Identical"
 msgstr "Idênticos(as)"
 
@@ -3055,7 +3055,7 @@ msgid "Missing"
 msgstr "Ausentes"
 
 #. IDS_MOVED
-#: Merge.rc:1910 Merge.rc:5076
+#: Merge.rc:1910 Merge.rc:5075
 msgid "Moved"
 msgstr "Movidos(as)"
 
@@ -3791,7 +3791,7 @@ msgid "&Use custom system colors"
 msgstr "&Usar cores personalizadas do sistema"
 
 #. IDS_PRPCAT_SYSTEM
-#: Merge.rc:2565 Merge.rc:4559 Merge.rc:4560 Merge.rc:5007
+#: Merge.rc:2565 Merge.rc:4559 Merge.rc:4560 Merge.rc:5006
 msgid "System"
 msgstr "Sistema"
 
@@ -4191,7 +4191,7 @@ msgid "Items compared:"
 msgstr "Itens comparados:"
 
 #. IDS_PREVIEWBAR_CLOSE
-#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5685
+#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5684
 msgid "&Close"
 msgstr "&Fechar"
 
@@ -4806,7 +4806,7 @@ msgid "A&ppend timestamp"
 msgstr "A&nexar carimbo de data/hora"
 
 #. IDS_CONFIRM_COPY_CAPTION
-#: Merge.rc:3214 Merge.rc:4915
+#: Merge.rc:3214 Merge.rc:4914
 msgid "Confirm Copy"
 msgstr "Confirmar a Cópia"
 
@@ -5043,7 +5043,7 @@ msgid "&Character Set..."
 msgstr "C&onjunto de Caracteres..."
 
 #. IDS_PRPCAT_IMAGE
-#: Merge.rc:3351 Merge.rc:4574 Merge.rc:5015
+#: Merge.rc:3351 Merge.rc:4574 Merge.rc:5014
 msgid "Image"
 msgstr "Imagem"
 
@@ -5388,7 +5388,7 @@ msgid "Project"
 msgstr "Projeto"
 
 #. IDS_COLHDR_NSDIFFS
-#: Merge.rc:4566 Merge.rc:4990
+#: Merge.rc:4566 Merge.rc:4989
 msgid "Differences"
 msgstr "Diferenças"
 
@@ -5530,12 +5530,12 @@ msgid "File Type"
 msgstr "Tipo de Arquivo"
 
 #. IDS_COLHDR_EXTENSION
-#: Merge.rc:4653 Merge.rc:4947
+#: Merge.rc:4653 Merge.rc:4946
 msgid "Extension"
 msgstr "Extensão"
 
 #. IDS_PRPCAT_MESSAGE
-#: Merge.rc:4659 Merge.rc:5019
+#: Merge.rc:4659 Merge.rc:5018
 msgid "Message"
 msgstr "Mensagem"
 
@@ -5575,7 +5575,7 @@ msgid "Hidden Items"
 msgstr "Itens Ocultados"
 
 #. IDS_PLUGINSLIST_NAME
-#: Merge.rc:4680 Merge.rc:5311
+#: Merge.rc:4680 Merge.rc:5310
 msgid "Name"
 msgstr "Nome"
 
@@ -5595,7 +5595,7 @@ msgid "[F] "
 msgstr "[F] "
 
 #. IDS_PLUGINSLIST_DESC
-#: Merge.rc:4684 Merge.rc:5313
+#: Merge.rc:4684 Merge.rc:5312
 msgid "Description"
 msgstr "Descrição"
 
@@ -5721,2735 +5721,2730 @@ msgstr "Lin: %s  Col: %d/%d  Car: %d/%d"
 msgid "  Sel: %d | %d"
 msgstr "  Sel: %d | %d"
 
-#. IDS_MERGEMODE_MERGING
-#: Merge.rc:4734
-msgid "Merge"
-msgstr "Unir"
-
 #. IDS_DIFF_NUMBER_STATUS_FMT
-#: Merge.rc:4735
+#: Merge.rc:4734
 #, c-format
 msgid "Difference %1 of %2"
 msgstr "Diferença %1 de %2"
 
 #. IDS_NO_DIFF_SEL_FMT
-#: Merge.rc:4736
+#: Merge.rc:4735
 #, c-format
 msgid "%1 Differences Found"
 msgstr "%1 Diferenças Encontradas"
 
 #. IDS_1_DIFF_FOUND
-#: Merge.rc:4737
+#: Merge.rc:4736
 msgid "1 Difference Found"
 msgstr "1 Diferença Encontrada"
 
 #. IDS_NO_ERR_SEL_FMT
-#: Merge.rc:4738
+#: Merge.rc:4737
 #, c-format
 msgid "%1 Errors Found"
 msgstr "%1 Erros Encontrados"
 
 #. IDS_1_ERR_FOUND
-#: Merge.rc:4739
+#: Merge.rc:4738
 msgid "1 Error Found"
 msgstr "1 Erro Encontrado"
 
 #. IDS_STATUSBAR_READONLY, Abbreviation from "Read Only"
-#: Merge.rc:4740
+#: Merge.rc:4739
 msgid "RO"
 msgstr "SL"
 
 #. IDS_DIRVIEW_STATUS_FMT_FOCUS
-#: Merge.rc:4746
+#: Merge.rc:4745
 #, c-format
 msgid "Item %1 of %2"
 msgstr "Item %1 de %2"
 
 #. IDS_DIRVIEW_STATUS_FMT_NOFOCUS
-#: Merge.rc:4747
+#: Merge.rc:4746
 #, c-format
 msgid "Items: %1"
 msgstr "Itens: %1"
 
 #. IDS_DIRVIEW_STATUS_COMPARING
-#: Merge.rc:4748
+#: Merge.rc:4747
 msgid "Comparing items..."
 msgstr "Comparando os itens..."
 
 #. IDS_ITEMS_PER_SEC
-#: Merge.rc:4749
+#: Merge.rc:4748
 #, c-format
 msgid "%.1f[items/sec]"
 msgstr "%.1f[itens/seg]"
 
 #. IDS_ERROR_INCOMPARABLE
-#: Merge.rc:4755
+#: Merge.rc:4754
 msgid "Select two existing folders/files to compare."
 msgstr "Selecione duas/dois pastas/arquivos existentes para comparar."
 
 #. IDS_DIRSEL_TAG
-#: Merge.rc:4756
+#: Merge.rc:4755
 msgid "Folder Selection"
 msgstr "Seleção de Pastas"
 
 #. IDS_OPEN_FILESDIRS
-#: Merge.rc:4757
+#: Merge.rc:4756
 msgid "Select two (or three) folders/files to compare."
 msgstr "Selecione duas/dois (ou três) pastas/arquivos para comparar."
 
 #. IDS_OPEN_LEFTINVALID
-#: Merge.rc:4758
+#: Merge.rc:4757
 msgid "Left (1st) path is invalid!"
 msgstr "O caminho da esquerda (1º) é inválido!"
 
 #. IDS_OPEN_MIDDLEINVALID
-#: Merge.rc:4759
+#: Merge.rc:4758
 msgid "Middle (2nd) path is invalid!"
 msgstr "O caminho do meio (2º) é inválido!"
 
 #. IDS_OPEN_RIGHTINVALID2
-#: Merge.rc:4760
+#: Merge.rc:4759
 msgid "Right (2nd) path is invalid!"
 msgstr "O caminho da direita (2º) é inválido!"
 
 #. IDS_OPEN_RIGHTINVALID3
-#: Merge.rc:4761
+#: Merge.rc:4760
 msgid "Right (3rd) path is invalid!"
 msgstr "O caminho da direita (3º) é inválido!"
 
 #. IDS_OPEN_BOTHINVALID
-#: Merge.rc:4762
+#: Merge.rc:4761
 msgid "Both paths are invalid!"
 msgstr "Ambos os caminhos são inválidos!"
 
-#: Merge.rc:4764
+#: Merge.rc:4763
 msgid "Left (1st) and Middle (2nd) paths are invalid!"
 msgstr "Os caminhos da esquerda (1º) e do meio (2º) são inválidos!"
 
 #. IDS_OPEN_LEFTRIGHTINVALID
-#: Merge.rc:4765
+#: Merge.rc:4764
 msgid "Left (1st) and Right (3rd) paths are invalid!"
 msgstr "Os caminhos da esquerda (1º) e da direita (3º) são inválidos!"
 
-#: Merge.rc:4767
+#: Merge.rc:4766
 msgid "Middle (2nd) and Right (3rd) paths are invalid!"
 msgstr "Os caminhos do meio (2º) e da direita (3º) são inválidos!"
 
 #. IDS_OPEN_ALLINVALID
-#: Merge.rc:4768
+#: Merge.rc:4767
 msgid "All paths are invalid!"
 msgstr "Todos os caminhos são inválidos!"
 
 #. IDS_OPEN_UNPACKERDISABLED
-#: Merge.rc:4769
+#: Merge.rc:4768
 msgid "Only enabled for file comparisons"
 msgstr "Só habilitado para comparações de arquivos"
 
 #. IDS_OPEN_MISMATCH
-#: Merge.rc:4770
+#: Merge.rc:4769
 msgid "Cannot compare file and folder!"
 msgstr "Não foi possível comparar o arquivo e a pasta!"
 
 #. IDS_ERROR_FILE_NOT_FOUND
-#: Merge.rc:4776
+#: Merge.rc:4775
 #, c-format
 msgid "File not found: %1"
 msgstr "Arquivo não encontrado: %1"
 
 #. IDS_ERROR_FOLDER_NOT_FOUND
-#: Merge.rc:4777
+#: Merge.rc:4776
 #, c-format
 msgid "Folder not found: %1"
 msgstr "Pasta não encontrada: %1"
 
 #. IDS_ERROR_FILE_NOT_UNPACKED
-#: Merge.rc:4778
+#: Merge.rc:4777
 #, c-format
 msgid "File not unpacked: %1"
 msgstr "Arquivo não descompactado: %1"
 
 #. IDS_ERROR_FILEOPEN
-#: Merge.rc:4779
+#: Merge.rc:4778
 #, c-format
 msgid "Cannot open file\n%1\n\n%2"
 msgstr "Não foi possível abrir o arquivo\n%1\n\n%2"
 
 #. IDS_ERROR_CONF_RESOLVE
-#: Merge.rc:4780
+#: Merge.rc:4779
 msgid "Failed to parse conflict file."
 msgstr "Falha ao analisar o arquivo de conflito."
 
 #. IDS_NOT_CONFLICT_FILE
-#: Merge.rc:4781
+#: Merge.rc:4780
 #, c-format
 msgid "The file\n%1\nis not a conflict file."
 msgstr "O arquivo\n%1\nnão é um arquivo de conflito."
 
 #. IDS_COMPARE_LARGE_FILES
-#: Merge.rc:4782
+#: Merge.rc:4781
 msgid "Comparing large files requires significant memory.\nShow only comparison results (not file contents)?"
 msgstr "A comparação de arquivos grandes requer uma memória significativa.\nMostrar apenas os resultados da comparação (não o conteúdo dos arquivos)?"
 
 #. IDS_SAVE_AS_TITLE
-#: Merge.rc:4788
+#: Merge.rc:4787
 msgid "Save As"
 msgstr "Salvar Como"
 
 #. IDS_SAVE_FMT
-#: Merge.rc:4789
+#: Merge.rc:4788
 #, c-format
 msgid "Save changes to %1?"
 msgstr "Salvar as alterações em %1?"
 
 #. IDS_SAVEREADONLY_FMT
-#: Merge.rc:4790
+#: Merge.rc:4789
 #, c-format
 msgid "%1 is read-only. Override? Or 'No' to save as new filename?"
 msgstr "%1 é somente leitura. Substituir? Ou 'Não' para salvar como novo nome de arquivo?"
 
 #. IDS_ERROR_BACKUP
-#: Merge.rc:4791
+#: Merge.rc:4790
 msgid "Error backing up file"
 msgstr "Erro ao fazer o backup do arquivo"
 
-#: Merge.rc:4793
+#: Merge.rc:4792
 #, c-format
 msgid "Unable to backup original file:\n%1\n\nContinue anyway?"
 msgstr "Incapaz de fazer o backup do arquivo original:\n%1\n\nContinuar de qualquer maneira?"
 
 #. IDS_FILESAVE_FAILED
-#: Merge.rc:4794
+#: Merge.rc:4793
 #, c-format
 msgid "Saving file failed.\n%1\n%2\n\t- Use different filename (OK)\n\t- Abort (Cancel)?"
 msgstr "Falha ao salvar o arquivo.\n%1\n%2\n\t- Usar um nome de arquivo diferente (OK)\n\t- Abortar (Cancelar)?"
 
-#: Merge.rc:4796
+#: Merge.rc:4795
 #, c-format
 msgid "Plugin '%2' cannot pack changes to left file into '%1'.\n\nOriginal unchanged. Save unpacked version?"
 msgstr "O plug-in ‘%2’ não consegue compactar as alterações do arquivo da esquerda em ‘%1’.\n\nOriginal inalterado. Salvar a versão descompactada?"
 
-#: Merge.rc:4798
+#: Merge.rc:4797
 #, c-format
 msgid "Plugin '%2' cannot pack changes to middle file into '%1'.\n\nOriginal unchanged. Save unpacked version?"
 msgstr "O plug-in ‘%2’ não consegue compactar as alterações no arquivo do meio em ‘%1’.\n\nOriginal inalterado. Salvar a versão descompactada?"
 
-#: Merge.rc:4800
+#: Merge.rc:4799
 #, c-format
 msgid "Plugin '%2' cannot pack changes to right file into '%1'.\n\nOriginal unchanged. Save unpacked version?"
 msgstr "O plug-in ‘%2’ não consegue compactar as alterações no arquivo da direita em ‘%1’.\n\nOriginal inalterado. Salvar a versão descompactada?"
 
 #. IDS_FILECHANGED_ONDISK
-#: Merge.rc:4801
+#: Merge.rc:4800
 #, c-format
 msgid "Another application updated\n%1\nsince WinMerge loaded it.\n\nOverwrite?"
 msgstr "Outro aplicativo atualizou\n%1\ndesde que o WinMerge o carregou.\n\nSobrescrever?"
 
 #. IDS_SAVEREADONLY_MULTI
-#: Merge.rc:4802
+#: Merge.rc:4801
 #, c-format
 msgid "%1\nis read-only. Override?"
 msgstr "%1\né somente leitura. Substituir?"
 
 #. IDS_FILECHANGED_RESCAN
-#: Merge.rc:4803
+#: Merge.rc:4802
 #, c-format
 msgid "Another application updated\n%1\nsince last scan.\n\nReload?"
 msgstr "Outro aplicativo atualizou\n%1\ndesde o último escaneamento.\n\nRecarregar?"
 
 #. IDS_SAVE_LEFT_AS
-#: Merge.rc:4804
+#: Merge.rc:4803
 msgid "Save Left File As"
 msgstr "Salvar o Arquivo da Esquerda Como"
 
 #. IDS_SAVE_MIDDLE_AS
-#: Merge.rc:4805
+#: Merge.rc:4804
 msgid "Save Middle File As"
 msgstr "Salvar o Arquivo do Meio Como"
 
 #. IDS_SAVE_RIGHT_AS
-#: Merge.rc:4806
+#: Merge.rc:4805
 msgid "Save Right File As"
 msgstr "Salvar o Arquivo da Direita Como"
 
 #. IDS_FILE_DISAPPEARED
-#: Merge.rc:4811
+#: Merge.rc:4810
 #, c-format
 msgid "File\n%1\nnot found. Save a copy to continue."
 msgstr "Arquivo\n%1\nnão encontrado. Salve uma cópia para continuar."
 
 #. IDS_VIEWS_OUTOFSYNC
-#: Merge.rc:4817
+#: Merge.rc:4816
 msgid "Cannot merge unsynched documents.\n\nRefresh before continuing."
 msgstr "Não é possível unir documentos não sincronizados.\n\nAtualize antes de continuar."
 
 #. IDS_BREAK_ON_WHITESPACE
-#: Merge.rc:4822
+#: Merge.rc:4821
 msgid "Break at whitespace"
 msgstr "Quebrar no espaço em branco"
 
 #. IDS_BREAK_ON_PUNCTUATION
-#: Merge.rc:4823
+#: Merge.rc:4822
 msgid "Break at whitespace or punctuation"
 msgstr "Quebrar no espaço em branco ou pontuação"
 
 #. IDS_L2M
-#: Merge.rc:4829
+#: Merge.rc:4828
 msgid "Copy to &Middle\tAlt+Right"
 msgstr "Copiar para o &Meio\tAlt+Right"
 
 #. IDS_R2M
-#: Merge.rc:4830
+#: Merge.rc:4829
 msgid "Copy to &Middle\tAlt+Left"
 msgstr "Copiar para o &Meio\tAlt+Left"
 
 #. IDS_COPY_FROM_MIDDLE_R
-#: Merge.rc:4831
+#: Merge.rc:4830
 msgid "Copy from Middle\tAlt+Shift+Right"
 msgstr "Copiar do Meio\tAlt+Shift+Right"
 
 #. IDS_COPY_FROM_MIDDLE_L
-#: Merge.rc:4832
+#: Merge.rc:4831
 msgid "Copy from Middle\tAlt+Shift+Left"
 msgstr "Copiar do Meio\tAlt+Shift+Left"
 
 #. IDS_L2MNEXT
-#: Merge.rc:4833
+#: Merge.rc:4832
 msgid "Copy to Middle and Advance\tCtrl+Alt+Right"
 msgstr "Copiar para o &Meio e Avançar\tCtrl+Alt+Right"
 
 #. IDS_R2MNEXT
-#: Merge.rc:4834
+#: Merge.rc:4833
 msgid "Copy to Middle and Advance\tCtrl+Alt+Left"
 msgstr "Copiar para o Meio e Avançar\tCtrl+Alt+Left"
 
 #. IDS_ALL_MIDDLE
-#: Merge.rc:4835
+#: Merge.rc:4834
 msgid "Copy All to Middle"
 msgstr "Copiar Tudo para o Meio"
 
 #. IDS_COPY_RIGHT_TO_LEFT
-#: Merge.rc:4841
+#: Merge.rc:4840
 #, c-format
 msgid "Right to Left (%1)"
 msgstr "Da Direita para a Esquerda (%1)"
 
 #. IDS_COPY_RIGHT_TO_MIDDLE
-#: Merge.rc:4842
+#: Merge.rc:4841
 #, c-format
 msgid "Right to Middle (%1)"
 msgstr "Da Direita para o Meio (%1)"
 
 #. IDS_COPY_MIDDLE_TO_LEFT
-#: Merge.rc:4843
+#: Merge.rc:4842
 #, c-format
 msgid "Middle to Left (%1)"
 msgstr "Do Meio para a Esquerda (%1)"
 
 #. IDS_COPY_MIDDLE_TO_RIGHT
-#: Merge.rc:4844
+#: Merge.rc:4843
 #, c-format
 msgid "Middle to Right (%1)"
 msgstr "Do Meio para a Direita (%1)"
 
 #. IDS_COPY_LEFT_TO_RIGHT
-#: Merge.rc:4845
+#: Merge.rc:4844
 #, c-format
 msgid "Left to Right (%1)"
 msgstr "Da Esquerda para a Direita (%1)"
 
 #. IDS_COPY_LEFT_TO_MIDDLE
-#: Merge.rc:4846
+#: Merge.rc:4845
 #, c-format
 msgid "Left to Middle (%1)"
 msgstr "Da Esquerda para o Meio (%1)"
 
 #. IDS_MOVE_LEFT_TO
-#: Merge.rc:4857 Merge.rc:4889
+#: Merge.rc:4856 Merge.rc:4888
 #, c-format
 msgid "Left to... (%1)"
 msgstr "Da Esquerda para... (%1)"
 
 #. IDS_MOVE_MIDDLE_TO
-#: Merge.rc:4858 Merge.rc:4890
+#: Merge.rc:4857 Merge.rc:4889
 #, c-format
 msgid "Middle to... (%1)"
 msgstr "Do Meio para... (%1)"
 
 #. IDS_MOVE_RIGHT_TO
-#: Merge.rc:4859 Merge.rc:4891
+#: Merge.rc:4858 Merge.rc:4890
 #, c-format
 msgid "Right to... (%1)"
 msgstr "Da Direita para... (%1)"
 
 #. IDS_COPY_BOTH_TO
-#: Merge.rc:4860
+#: Merge.rc:4859
 #, c-format
 msgid "Both to... (%1)"
 msgstr "De Ambos para... (%1)"
 
 #. IDS_COPY_ALL_TO
-#: Merge.rc:4861
+#: Merge.rc:4860
 #, c-format
 msgid "All to... (%1)"
 msgstr "De Todos para... (%1)"
 
 #. IDS_COPY_DIFFERENCES_TO
-#: Merge.rc:4862
+#: Merge.rc:4861
 #, c-format
 msgid "Differences to... (%1)"
 msgstr "Diferenças para... (%1)"
 
 #. IDS_ONLYDIFFITEMS_CONFIRM
-#: Merge.rc:4869
+#: Merge.rc:4868
 msgid "Some selected items are identical or skipped.\nProcess only items with differences?"
 msgstr "Alguns itens selecionados são idênticos ou pulados.\nProcessar apenas os itens com diferenças?"
 
 #. IDS_DEL_LEFT_FMT
-#: Merge.rc:4875
+#: Merge.rc:4874
 #, c-format
 msgid "Left (%1)"
 msgstr "Esquerda (%1)"
 
 #. IDS_DEL_MIDDLE_FMT
-#: Merge.rc:4876
+#: Merge.rc:4875
 #, c-format
 msgid "Middle (%1)"
 msgstr "Meio (%1)"
 
 #. IDS_DEL_RIGHT_FMT
-#: Merge.rc:4877
+#: Merge.rc:4876
 #, c-format
 msgid "Right (%1)"
 msgstr "Direita (%1)"
 
 #. IDS_DEL_BOTH_FMT
-#: Merge.rc:4878
+#: Merge.rc:4877
 #, c-format
 msgid "Both (%1)"
 msgstr "Ambos(as) (%1)"
 
 #. IDS_DEL_ALL_FMT
-#: Merge.rc:4879
+#: Merge.rc:4878
 #, c-format
 msgid "All (%1)"
 msgstr "Tudo (%1)"
 
 #. IDS_SELECT_DEST_LEFT
-#: Merge.rc:4895
+#: Merge.rc:4894
 msgid "Left Side - Select Destination Folder:"
 msgstr "Lado Esquerdo - Selecionar Pasta de Destino:"
 
 #. IDS_SELECT_DEST_MIDDLE
-#: Merge.rc:4896
+#: Merge.rc:4895
 msgid "Middle Side - Select Destination Folder:"
 msgstr "Lado do Meio - Selecionar Pasta de Destino:"
 
 #. IDS_SELECT_DEST_RIGHT
-#: Merge.rc:4897
+#: Merge.rc:4896
 msgid "Right Side - Select Destination Folder:"
 msgstr "Lado Direito - Selecionar Pasta de Destino:"
 
 #. IDS_FILES_AFFECTED_FMT
-#: Merge.rc:4898
+#: Merge.rc:4897
 #, c-format
 msgid "(%1 Files Affected)"
 msgstr "(%1 Arquivos Afetados)"
 
 #. IDS_FILES_AFFECTED_FMT2
-#: Merge.rc:4899
+#: Merge.rc:4898
 #, c-format
 msgid "(%1 of %2 Files Affected)"
 msgstr "(%1 de %2 Arquivos Afetados)"
 
 #. IDS_CONFIRM_DELETE_SINGLE
-#: Merge.rc:4905
+#: Merge.rc:4904
 #, c-format
 msgid "Are you sure you want to delete\n\n%1 ?"
 msgstr "Tem certeza de que quer excluir \n\n%1 ?"
 
 #. IDS_CONFIRM_SINGLE_COPY
-#: Merge.rc:4906
+#: Merge.rc:4905
 msgid "Are you sure you want to copy?"
 msgstr "Tem certeza de que quer copiar?"
 
 #. IDS_CONFIRM_MULTIPLE_COPY
-#: Merge.rc:4907
+#: Merge.rc:4906
 #, c-format
 msgid "Are you sure you want to copy %d items?"
 msgstr "Tem certeza de que quer copiar %d itens?"
 
 #. IDS_DIRCMP_NOTSYNC
-#: Merge.rc:4908
+#: Merge.rc:4907
 #, c-format
 msgid "Operation aborted!\n\nFolder contents changed, path\n%1\nnot found.\n\nRefresh the compare."
 msgstr "Operação abortada!\n\nConteúdo da pasta alterado, caminho\n%1\nnão encontrado.\n\nAtualize a comparação."
 
 #. IDS_CONFIRM_SINGLE_MOVE
-#: Merge.rc:4913
+#: Merge.rc:4912
 msgid "Are you sure you want to move?"
 msgstr "Tem certeza de que quer mover?"
 
 #. IDS_CONFIRM_MULTIPLE_MOVE
-#: Merge.rc:4914
+#: Merge.rc:4913
 #, c-format
 msgid "Are you sure you want to move %d items?"
 msgstr "Tem certeza de que quer mover %d itens?"
 
 #. IDS_CONFIRM_MOVE_CAPTION
-#: Merge.rc:4916
+#: Merge.rc:4915
 msgid "Confirm Move"
 msgstr "Confirmar o Movimento"
 
-#: Merge.rc:4918
+#: Merge.rc:4917
 msgid "Close the folder comparison window?"
 msgstr "Fechar a janela de comparação de pastas?"
 
-#: Merge.rc:4920
+#: Merge.rc:4919
 msgid "Close the folder comparison window, which took a long time?"
 msgstr "Fechar a janela de comparação de pastas, que demandou um longo tempo?"
 
 #. IDS_ERROR_INVALID_DIR_FILE_NAME
-#: Merge.rc:4921
+#: Merge.rc:4920
 msgid "The file or folder name is invalid."
 msgstr "O nome do arquivo ou da pasta é inválido."
 
 #. IDS_ERROR_EXECUTE_FILE
-#: Merge.rc:4927
+#: Merge.rc:4926
 #, c-format
 msgid "Failed to execute external editor: %1"
 msgstr "Falha ao executar o editor externo: %1"
 
 #. IDS_UNKNOWN_ARCHIVE_FORMAT
-#: Merge.rc:4933
+#: Merge.rc:4932
 msgid "Unknown archive format"
 msgstr "Formato de arquivo compactado desconhecido"
 
-#: Merge.rc:4935
+#: Merge.rc:4934
 msgid "Failed to extract archive.\nCompare as text file?"
 msgstr "Falha ao extrair arquivo compactado.\nComparar como arquivo de texto?"
 
 #. IDS_COLHDR_FILENAME
-#: Merge.rc:4941
+#: Merge.rc:4940
 msgid "Filename"
 msgstr "Nome de arquivo"
 
 #. IDS_COLHDR_DIR
-#: Merge.rc:4942
+#: Merge.rc:4941
 msgctxt "DirView|ColumnHeader"
 msgid "Folder"
 msgstr "Pasta"
 
 #. IDS_COLHDR_RESULT
-#: Merge.rc:4943
+#: Merge.rc:4942
 msgid "Comparison Result"
 msgstr "Resultado da Comparação"
 
 #. IDS_COLHDR_LTIMEM
-#: Merge.rc:4944
+#: Merge.rc:4943
 msgid "Left Date"
 msgstr "Data da Esquerda"
 
 #. IDS_COLHDR_RTIMEM
-#: Merge.rc:4945
+#: Merge.rc:4944
 msgid "Right Date"
 msgstr "Data da Direita"
 
 #. IDS_COLHDR_MTIMEM
-#: Merge.rc:4946
+#: Merge.rc:4945
 msgid "Middle Date"
 msgstr "Data do Meio"
 
 #. IDS_COLHDR_LSIZE
-#: Merge.rc:4948
+#: Merge.rc:4947
 msgid "Left Size"
 msgstr "Tamanho da Esquerda"
 
 #. IDS_COLHDR_RSIZE
-#: Merge.rc:4949
+#: Merge.rc:4948
 msgid "Right Size"
 msgstr "Tamanho da Direita"
 
 #. IDS_COLHDR_MSIZE
-#: Merge.rc:4954
+#: Merge.rc:4953
 msgid "Middle Size"
 msgstr "Tamanho do Meio"
 
 #. IDS_COLHDR_RSIZE_SHORT
-#: Merge.rc:4955
+#: Merge.rc:4954
 msgid "Right Size (Short)"
 msgstr "Tamanho da Direita (Curto)"
 
 #. IDS_COLHDR_LSIZE_SHORT
-#: Merge.rc:4956
+#: Merge.rc:4955
 msgid "Left Size (Short)"
 msgstr "Tamanho da Esquerda (Curto)"
 
 #. IDS_COLHDR_MSIZE_SHORT
-#: Merge.rc:4957
+#: Merge.rc:4956
 msgid "Middle Size (Short)"
 msgstr "Tamanho do Meio (Curto)"
 
 #. IDS_COLHDR_LTIMEC
-#: Merge.rc:4963
+#: Merge.rc:4962
 msgid "Left Creation Time"
 msgstr "Hora de Criação da Esquerda"
 
 #. IDS_COLHDR_RTIMEC
-#: Merge.rc:4964
+#: Merge.rc:4963
 msgid "Right Creation Time"
 msgstr "Hora de Criação da Direita"
 
 #. IDS_COLHDR_MTIMEC
-#: Merge.rc:4965
+#: Merge.rc:4964
 msgid "Middle Creation Time"
 msgstr "Hora de Criação do Meio"
 
 #. IDS_COLHDR_NEWER
-#: Merge.rc:4966
+#: Merge.rc:4965
 msgid "Newer File"
 msgstr "Arquivo Mais Novo"
 
 #. IDS_COLHDR_LVERSION
-#: Merge.rc:4967
+#: Merge.rc:4966
 msgid "Left File Version"
 msgstr "Versão do Arquivo da Esquerda"
 
 #. IDS_COLHDR_RVERSION
-#: Merge.rc:4968
+#: Merge.rc:4967
 msgid "Right File Version"
 msgstr "Versão do Arquivo da Direita"
 
 #. IDS_COLHDR_MVERSION
-#: Merge.rc:4969
+#: Merge.rc:4968
 msgid "Middle File Version"
 msgstr "Versão do Arquivo do Meio"
 
 #. IDS_COLHDR_RESULT_ABBR
-#: Merge.rc:4970
+#: Merge.rc:4969
 msgid "Short Result"
 msgstr "Resultado Curto"
 
 #. IDS_COLHDR_LATTRIBUTES
-#: Merge.rc:4971
+#: Merge.rc:4970
 msgid "Left Attributes"
 msgstr "Atributos da Esquerda"
 
 #. IDS_COLHDR_RATTRIBUTES
-#: Merge.rc:4972
+#: Merge.rc:4971
 msgid "Right Attributes"
 msgstr "Atributos da Direita"
 
 #. IDS_COLHDR_MATTRIBUTES
-#: Merge.rc:4973
+#: Merge.rc:4972
 msgid "Middle Attributes"
 msgstr "Atributos do Meio"
 
 #. IDS_COLHDR_LEOL_TYPE
-#: Merge.rc:4978
+#: Merge.rc:4977
 msgid "Left EOL"
 msgstr "EOL da Esquerda"
 
 #. IDS_COLHDR_MEOL_TYPE
-#: Merge.rc:4979
+#: Merge.rc:4978
 msgid "Middle EOL"
 msgstr "EOL do Meio"
 
 #. IDS_COLHDR_REOL_TYPE
-#: Merge.rc:4980
+#: Merge.rc:4979
 msgid "Right EOL"
 msgstr "EOL da Direita"
 
 #. IDS_COLHDR_LENCODING
-#: Merge.rc:4986
+#: Merge.rc:4985
 msgid "Left Encoding"
 msgstr "Codificação da Esquerda"
 
 #. IDS_COLHDR_RENCODING
-#: Merge.rc:4987
+#: Merge.rc:4986
 msgid "Right Encoding"
 msgstr "Codificação da Direita"
 
 #. IDS_COLHDR_MENCODING
-#: Merge.rc:4988
+#: Merge.rc:4987
 msgid "Middle Encoding"
 msgstr "Codificação do Meio"
 
 #. IDS_COLHDR_NIDIFFS
-#: Merge.rc:4989
+#: Merge.rc:4988
 msgid "Ignored Diff"
 msgstr "Diferença Ignorada"
 
 #. IDS_COLHDR_BINARY
-#: Merge.rc:4991
+#: Merge.rc:4990
 msgctxt "DirView|ColumnHeader"
 msgid "Binary"
 msgstr "Binário"
 
 #. IDS_PLUGINS_TYPE_UNPACKER
-#: Merge.rc:4992 Merge.rc:5314
+#: Merge.rc:4991 Merge.rc:5313
 msgid "Unpacker"
 msgstr "Descompactador"
 
 #. IDS_PLUGIN_TYPE4
-#: Merge.rc:4993 Merge.rc:5315 Merge.rc:5622
+#: Merge.rc:4992 Merge.rc:5314 Merge.rc:5621
 msgid "Prediffer"
 msgstr "Pré-Diferenciação"
 
 #. IDS_COLHDR_LEFT
-#: Merge.rc:4994
+#: Merge.rc:4993
 msgid "Left"
 msgstr "Esquerda"
 
 #. IDS_COLHDR_MIDDLE
-#: Merge.rc:4995
+#: Merge.rc:4994
 msgid "Middle"
 msgstr "Meio"
 
 #. IDS_COLHDR_RIGHT
-#: Merge.rc:4996
+#: Merge.rc:4995
 msgid "Right"
 msgstr "Direita"
 
 #. IDS_COLHDR_DIFF
-#: Merge.rc:4997
+#: Merge.rc:4996
 msgid "Diff"
 msgstr "Diferenciação"
 
 #. IDS_COLHDR_LEFT_DUPLICATE
-#: Merge.rc:4998
+#: Merge.rc:4997
 msgid "Left Duplicate Count"
 msgstr "Contagem de Duplicados à Esquerda"
 
 #. IDS_COLHDR_RIGHT_DUPLICATE
-#: Merge.rc:4999
+#: Merge.rc:4998
 msgid "Right Duplicate Count"
 msgstr "Contagem de Duplicados à Direita"
 
 #. IDS_COLHDR_MIDDLE_DUPLICATE
-#: Merge.rc:5000
+#: Merge.rc:4999
 msgid "Middle Duplicate Count"
 msgstr "Contagem de Duplicados no Meio"
 
 #. IDS_COLHDR_MOVE
-#: Merge.rc:5001
+#: Merge.rc:5000
 msgid "Move"
 msgstr "Movimento"
 
 #. IDS_PRPCAT_AUDIO
-#: Merge.rc:5008
+#: Merge.rc:5007
 msgid "Audio"
 msgstr "Áudio"
 
 #. IDS_PRPCAT_CALENDAR
-#: Merge.rc:5009
+#: Merge.rc:5008
 msgid "Calendar"
 msgstr "Calendário"
 
 #. IDS_PRPCAT_COMMUNICATION
-#: Merge.rc:5010
+#: Merge.rc:5009
 msgid "Communication"
 msgstr "Comunicação"
 
 #. IDS_PRPCAT_CONTACT
-#: Merge.rc:5011
+#: Merge.rc:5010
 msgid "Contact"
 msgstr "Contato"
 
 #. IDS_PRPCAT_DEVICES
-#: Merge.rc:5012
+#: Merge.rc:5011
 msgid "Devices"
 msgstr "Dispositivos"
 
 #. IDS_PRPCAT_DOCUMENT
-#: Merge.rc:5013
+#: Merge.rc:5012
 msgid "Document"
 msgstr "Documento"
 
 #. IDS_PRPCAT_HOME
-#: Merge.rc:5014
+#: Merge.rc:5013
 msgid "Home"
 msgstr "Página inicial"
 
 #. IDS_PRPCAT_JOURNAL
-#: Merge.rc:5016
+#: Merge.rc:5015
 msgid "Journal"
 msgstr "Diário"
 
 #. IDS_PRPCAT_LINK
-#: Merge.rc:5017
+#: Merge.rc:5016
 msgid "Link"
 msgstr "Link"
 
 #. IDS_PRPCAT_MEDIA
-#: Merge.rc:5018
+#: Merge.rc:5017
 msgid "Media"
 msgstr "Mídia"
 
 #. IDS_PRPCAT_MUSIC
-#: Merge.rc:5020
+#: Merge.rc:5019
 msgid "Music"
 msgstr "Música"
 
 #. IDS_PRPCAT_NOTE
-#: Merge.rc:5021
+#: Merge.rc:5020
 msgid "Note"
 msgstr "Nota"
 
 #. IDS_PRPCAT_PHOTO
-#: Merge.rc:5022
+#: Merge.rc:5021
 msgid "Photo"
 msgstr "Foto"
 
 #. IDS_PRPCAT_RECORDEDTV
-#: Merge.rc:5023
+#: Merge.rc:5022
 msgid "RecordedTV"
 msgstr "TV Gravada"
 
 #. IDS_PRPCAT_SEARCH
-#: Merge.rc:5024
+#: Merge.rc:5023
 msgid "Search"
 msgstr "Busca"
 
 #. IDS_PRPCAT_SECURITY
-#: Merge.rc:5025
+#: Merge.rc:5024
 msgid "Security"
 msgstr "Segurança"
 
 #. IDS_PRPCAT_SOFTWARE
-#: Merge.rc:5026
+#: Merge.rc:5025
 msgid "Software"
 msgstr "Software"
 
 #. IDS_PRPCAT_TASK
-#: Merge.rc:5027
+#: Merge.rc:5026
 msgid "Task"
 msgstr "Tarefa"
 
 #. IDS_PRPCAT_VIDEO
-#: Merge.rc:5028
+#: Merge.rc:5027
 msgid "Video"
 msgstr "Vídeo"
 
 #. IDS_PRPCAT_HASH
-#: Merge.rc:5029
+#: Merge.rc:5028
 msgid "Hash"
 msgstr "Hash"
 
 #. IDS_CANT_COMPARE_FILES
-#: Merge.rc:5035
+#: Merge.rc:5034
 msgid "Unable to compare files"
 msgstr "Incapaz de comparar os arquivos"
 
 #. IDS_ABORTED_ITEM
-#: Merge.rc:5036
+#: Merge.rc:5035
 msgid "Item aborted"
 msgstr "Item abortado"
 
 #. IDS_FILE_SKIPPED
-#: Merge.rc:5037
+#: Merge.rc:5036
 msgid "File skipped"
 msgstr "Arquivo pulado"
 
 #. IDS_DIR_SKIPPED
-#: Merge.rc:5038
+#: Merge.rc:5037
 msgid "Folder skipped"
 msgstr "Pasta pulada"
 
 #. IDS_LEFT_ONLY_IN_FMT
-#: Merge.rc:5039
+#: Merge.rc:5038
 #, c-format
 msgid "Left only: %1"
 msgstr "Só à esquerda: %1"
 
 #. IDS_MIDDLE_ONLY_IN_FMT
-#: Merge.rc:5040
+#: Merge.rc:5039
 #, c-format
 msgid "Middle only: %1"
 msgstr "Só no meio: %1"
 
 #. IDS_RIGHT_ONLY_IN_FMT
-#: Merge.rc:5041
+#: Merge.rc:5040
 #, c-format
 msgid "Right only: %1"
 msgstr "Só à direita: %1"
 
 #. IDS_DOES_NOT_EXIST_IN_FMT
-#: Merge.rc:5042
+#: Merge.rc:5041
 #, c-format
 msgid "Does not exist in %1"
 msgstr "Não existe em %1"
 
 #. IDS_BIN_FILES_SAME
-#: Merge.rc:5043
+#: Merge.rc:5042
 msgid "Binary files are identical"
 msgstr "Os arquivos binários são idênticos"
 
 #. IDS_BIN_FILES_DIFF
-#: Merge.rc:5049
+#: Merge.rc:5048
 msgid "Binary files are different"
 msgstr "Os arquivos binários são diferentes"
 
 #. IDS_FILES_ARE_DIFFERENT
-#: Merge.rc:5050
+#: Merge.rc:5049
 msgid "Files are different"
 msgstr "Os arquivos são diferentes"
 
 #. IDS_FOLDERS_ARE_DIFFERENT
-#: Merge.rc:5051
+#: Merge.rc:5050
 msgid "Folders are different"
 msgstr "As pastas são diferentes"
 
 #. IDS_LEFTONLY
-#: Merge.rc:5052
+#: Merge.rc:5051
 msgid "Left Only"
 msgstr "Somente à Esquerda"
 
 #. IDS_RIGHTONLY
-#: Merge.rc:5053
+#: Merge.rc:5052
 msgid "Right Only"
 msgstr "Somente à Direita"
 
 #. IDS_MIDDLEONLY
-#: Merge.rc:5054
+#: Merge.rc:5053
 msgid "Middle Only"
 msgstr "Somente no Meio"
 
 #. IDS_NOITEMLEFT
-#: Merge.rc:5055
+#: Merge.rc:5054
 msgid "No item in left"
 msgstr "Nenhum item na esquerda"
 
 #. IDS_NOITEMRIGHT
-#: Merge.rc:5056
+#: Merge.rc:5055
 msgid "No item in right"
 msgstr "Nenhum item na direita"
 
 #. IDS_NOITEMMIDDLE
-#: Merge.rc:5057
+#: Merge.rc:5056
 msgid "No item in middle"
 msgstr "Nenhum item no meio"
 
 #. IDS_CMPRES_ERROR
-#: Merge.rc:5059
+#: Merge.rc:5058
 msgid "Error"
 msgstr "Erro"
 
 #. IDS_TEXT_FILES_SAME
-#: Merge.rc:5060
+#: Merge.rc:5059
 msgid "Text files are identical"
 msgstr "Os arquivos de texto são idênticos"
 
 #. IDS_LEFTONLY_DIFF
-#: Merge.rc:5061
+#: Merge.rc:5060
 msgid " (Middle and right are identical)"
 msgstr " (O do meio e o da direita são idênticos)"
 
 #. IDS_MIDDLEONLY_DIFF
-#: Merge.rc:5062
+#: Merge.rc:5061
 msgid " (Left and right are identical)"
 msgstr " (O da esquerda e o da direita são idênticos)"
 
 #. IDS_RIGHTONLY_DIFF
-#: Merge.rc:5063
+#: Merge.rc:5062
 msgid " (Left and middle are identical)"
 msgstr " (O da esquerda e o do meio são idênticos)"
 
 #. IDS_PATH_MISMATCH
-#: Merge.rc:5064
+#: Merge.rc:5063
 msgid " (paths differ)"
 msgstr " (os caminhos diferem)"
 
 #. IDS_TEXT_FILES_DIFF
-#: Merge.rc:5065
+#: Merge.rc:5064
 msgid "Text files are different"
 msgstr "Os arquivos de texto são diferentes"
 
 #. IDS_IMAGE_FILES_SAME
-#: Merge.rc:5066
+#: Merge.rc:5065
 msgid "Image files are identical"
 msgstr "Os arquivos de imagem são idênticos"
 
 #. IDS_IMAGE_FILES_DIFF
-#: Merge.rc:5067
+#: Merge.rc:5066
 msgid "Image files are different"
 msgstr "Os arquivos de imagem são diferentes"
 
 #. IDS_EXPR_DIFF
-#: Merge.rc:5068
+#: Merge.rc:5067
 #, c-format
 msgid "Files are different (expr: %1)"
 msgstr "Os arquivos são diferentes (expr: %1)"
 
 #. IDS_HASH_GROUP
-#: Merge.rc:5069
+#: Merge.rc:5068
 #, c-format
 msgid "Group%d"
 msgstr "Grupo%d"
 
 #. IDS_RENAME_MOVE_DETECTION_DISALBED
-#: Merge.rc:5070
+#: Merge.rc:5069
 msgctxt "Options dialog|Compare|Folder|Detect renames and moves"
 msgid "Disabled"
 msgstr "Desabilitada"
 
 #. IDS_RENAME_MOVE_DETECTION_RENAME
-#: Merge.rc:5071
+#: Merge.rc:5070
 msgid "Detect renames"
 msgstr "Detectar renomeações"
 
 #. IDS_RENAME_MOVE_DETECTION_RENAME_MOVE
-#: Merge.rc:5072
+#: Merge.rc:5071
 msgid "Detect renames and moves"
 msgstr "Detectar renomeações e movimentações"
 
 #. IDS_RENAME_MOVE_MERGE_MODE_RENAME
-#: Merge.rc:5073
+#: Merge.rc:5072
 msgid "Merge renames"
 msgstr "Unir renomeações"
 
 #. IDS_RENAME_MOVE_MERGE_MODE_RENAME_MOVE
-#: Merge.rc:5074
+#: Merge.rc:5073
 msgid "Merge renames and moves"
 msgstr "Unir renomeações e movimentações"
 
 #. IDS_RENAMED
-#: Merge.rc:5075
+#: Merge.rc:5074
 msgid "Renamed"
 msgstr "Renomeados"
 
 #. IDS_RENAMED_MOVED
-#: Merge.rc:5077
+#: Merge.rc:5076
 msgid "Renamed/Moved"
 msgstr "Renomeados/Movidos"
 
 #. IDS_RENAMED_MOVED_ITEMS
-#: Merge.rc:5078
+#: Merge.rc:5077
 #, c-format
 msgid "(%1 items)"
 msgstr "(%1 itens)"
 
 #. IDS_RENAMED_MOVED_RESULT
-#: Merge.rc:5079
+#: Merge.rc:5078
 #, c-format
 msgid "%1 (set %2): "
 msgstr "%1 (conjunto %2): "
 
 #. IDS_SWITCH_FLAT_MODE
-#: Merge.rc:5080
+#: Merge.rc:5079
 msgid "Some moved items have been merged.\nIn Tree Mode, these items may appear in positions that do not reflect the actual folder structure, which can be confusing.\nSwitch to Flat Mode?"
 msgstr "Alguns itens movidos foram unidos.\nNo Modo Árvore, esses itens podem aparecer em posições que não refletem a estrutura real da pasta, o que pode causar confusão.\nAlternar para o Modo Nivelado?"
 
 #. IDS_ELAPSED_TIME
-#: Merge.rc:5086
+#: Merge.rc:5085
 #, c-format
 msgid "Elapsed time: %ld ms"
 msgstr "Tempo decorrido: %ld ms"
 
 #. IDS_STATUS_SELITEM1
-#: Merge.rc:5087
+#: Merge.rc:5086
 msgid "1 item selected"
 msgstr "1 item selecionado"
 
 #. IDS_STATUS_SELITEMS
-#: Merge.rc:5088
+#: Merge.rc:5087
 #, c-format
 msgid "%1 items selected"
 msgstr "%1 itens selecionados"
 
 #. IDS_COLDESC_FILENAME
-#: Merge.rc:5094
+#: Merge.rc:5093
 msgid "Filename or folder name."
 msgstr "Nome do arquivo ou nome da pasta."
 
 #. IDS_COLDESC_DIR
-#: Merge.rc:5095
+#: Merge.rc:5094
 msgid "Subfolder name when subfolders are included."
 msgstr "Nome da subpasta quando as subpastas são incluídas."
 
 #. IDS_COLDESC_RESULT
-#: Merge.rc:5096
+#: Merge.rc:5095
 msgid "Comparison result, long form."
 msgstr "Resultado da comparação, formulário longo."
 
 #. IDS_COLDESC_LTIMEM
-#: Merge.rc:5101
+#: Merge.rc:5100
 msgid "Left side modification date."
 msgstr "Data de modificação do lado esquerdo."
 
 #. IDS_COLDESC_RTIMEM
-#: Merge.rc:5102
+#: Merge.rc:5101
 msgid "Right side modification date."
 msgstr "Data de modificação do lado direito."
 
 #. IDS_COLDESC_MTIMEM
-#: Merge.rc:5103
+#: Merge.rc:5102
 msgid "Middle side modification date."
 msgstr "Data de modificação do lado do meio."
 
 #. IDS_COLDESC_EXTENSION
-#: Merge.rc:5104
+#: Merge.rc:5103
 msgid "File's extension."
 msgstr "Extensão do arquivo."
 
 #. IDS_COLDESC_LSIZE
-#: Merge.rc:5105
+#: Merge.rc:5104
 msgid "Left file size in bytes."
 msgstr "Tamanho do arquivo à esquerda em bytes."
 
 #. IDS_COLDESC_RSIZE
-#: Merge.rc:5106
+#: Merge.rc:5105
 msgid "Right file size in bytes."
 msgstr "Tamanho do arquivo à direita em bytes."
 
 #. IDS_COLDESC_MSIZE
-#: Merge.rc:5107
+#: Merge.rc:5106
 msgid "Middle file size in bytes."
 msgstr "Tamanho do arquivo do meio em bytes."
 
 #. IDS_COLDESC_LSIZE_SHORT
-#: Merge.rc:5108
+#: Merge.rc:5107
 msgid "Left file size abbreviated."
 msgstr "Tamanho do arquivo à esquerda abreviado."
 
 #. IDS_COLDESC_RSIZE_SHORT
-#: Merge.rc:5109
+#: Merge.rc:5108
 msgid "Right file size abbreviated."
 msgstr "Tamanho do arquivo à direita abreviado."
 
 #. IDS_COLDESC_MSIZE_SHORT
-#: Merge.rc:5110
+#: Merge.rc:5109
 msgid "Middle file size abbreviated."
 msgstr "Tamanho do arquivo do meio abreviado."
 
 #. IDS_COLDESC_LTIMEC
-#: Merge.rc:5116
+#: Merge.rc:5115
 msgid "Left side creation time."
 msgstr "Hora de criação do lado esquerdo."
 
 #. IDS_COLDESC_RTIMEC
-#: Merge.rc:5117
+#: Merge.rc:5116
 msgid "Right side creation time."
 msgstr "Hora de criação do lado direito."
 
 #. IDS_COLDESC_MTIMEC
-#: Merge.rc:5118
+#: Merge.rc:5117
 msgid "Middle side creation time."
 msgstr "Hora de criação do lado do meio."
 
 #. IDS_COLDESC_NEWER
-#: Merge.rc:5119
+#: Merge.rc:5118
 msgid "Tells which side has newer modification date."
 msgstr "Diz qual lado tem a data de modificação mais nova."
 
 #. IDS_COLDESC_LVERSION
-#: Merge.rc:5120
+#: Merge.rc:5119
 msgid "Left side file version, only for some file types."
 msgstr "Versão do arquivo do lado esquerdo, só para alguns tipos de arquivo."
 
 #. IDS_COLDESC_RVERSION
-#: Merge.rc:5121
+#: Merge.rc:5120
 msgid "Right side file version, only for some file types."
 msgstr "Versão do arquivo do lado direito, só para alguns tipos de arquivo."
 
 #. IDS_COLDESC_MVERSION
-#: Merge.rc:5126
+#: Merge.rc:5125
 msgid "Middle side file version, only for some file types."
 msgstr "Versão do arquivo do lado do meio, só para alguns tipos de arquivo."
 
 #. IDS_COLDESC_RESULT_ABBR
-#: Merge.rc:5127
+#: Merge.rc:5126
 msgid "Short comparison result."
 msgstr "Resultado curto da comparação."
 
 #. IDS_COLDESC_LATTRIBUTES
-#: Merge.rc:5128
+#: Merge.rc:5127
 msgid "Left side attributes."
 msgstr "Atributos do lado esquerdo."
 
 #. IDS_COLDESC_RATTRIBUTES
-#: Merge.rc:5129
+#: Merge.rc:5128
 msgid "Right side attributes."
 msgstr "Atributos do lado direito."
 
 #. IDS_COLDESC_MATTRIBUTES
-#: Merge.rc:5130
+#: Merge.rc:5129
 msgid "Middle side attributes."
 msgstr "Atributos do lado do meio."
 
 #. IDS_COLDESC_LEOL_TYPE
-#: Merge.rc:5131
+#: Merge.rc:5130
 msgid "Left side file EOL type."
 msgstr "Tipo de EOL do arquivo do lado esquerdo."
 
 #. IDS_COLDESC_REOL_TYPE
-#: Merge.rc:5132
+#: Merge.rc:5131
 msgid "Right side file EOL type."
 msgstr "Tipo de EOL do arquivo do lado direito."
 
 #. IDS_COLDESC_MEOL_TYPE
-#: Merge.rc:5133
+#: Merge.rc:5132
 msgid "Middle side file EOL type."
 msgstr "Tipo de EOL do arquivo do lado do meio."
 
 #. IDS_COLDESC_LENCODING
-#: Merge.rc:5139
+#: Merge.rc:5138
 msgid "Left side encoding."
 msgstr "Codificação do lado esquerdo."
 
 #. IDS_COLDESC_RENCODING
-#: Merge.rc:5140
+#: Merge.rc:5139
 msgid "Right side encoding."
 msgstr "Codificação do lado direito."
 
 #. IDS_COLDESC_MENCODING
-#: Merge.rc:5141
+#: Merge.rc:5140
 msgid "Middle side encoding."
 msgstr "Codificação do lado do meio."
 
 #. IDS_COLDESC_NIDIFFS
-#: Merge.rc:5142
+#: Merge.rc:5141
 msgid "Number of ignored differences in file. Ignored and cannot be merged."
 msgstr "Número de diferenças ignoradas no arquivo. Ignoradas e não podem ser unidas."
 
 #. IDS_COLDESC_NSDIFFS
-#: Merge.rc:5143
+#: Merge.rc:5142
 msgid "Number of differences in file (excluding ignored)."
 msgstr "Número de diferenças no arquivo (excluindo as ignoradas)."
 
 #. IDS_COLDESC_BINARY
-#: Merge.rc:5144
+#: Merge.rc:5143
 msgid "Shows an asterisk (*) if the file is binary."
 msgstr "Mostrar um asterisco (*) se o arquivo é binário."
 
 #. IDS_COLDESC_UNPACKER
-#: Merge.rc:5145
+#: Merge.rc:5144
 msgid "Unpacker plugin name or pipeline."
 msgstr "Nome ou pipeline do plugin de descompactador."
 
 #. IDS_COLDESC_PREDIFFER
-#: Merge.rc:5146
+#: Merge.rc:5145
 msgid "Prediffer plugin name or pipeline."
 msgstr "Nome ou pipeline do plugin de pré-diferenciação."
 
 #. IDS_DIRECTORY_REPORT_TITLE
-#: Merge.rc:5152
+#: Merge.rc:5151
 #, c-format
 msgid "Compare %1 with %2"
 msgstr "Comparar %1 com %2"
 
 #. IDS_DIRECTORY_REPORT_TITLE3
-#: Merge.rc:5153
+#: Merge.rc:5152
 #, c-format
 msgid "Compare %1 with %2 and %3"
 msgstr "Comparar %1 com %2 e %3"
 
 #. IDS_REPORT_COMMALIST
-#: Merge.rc:5154
+#: Merge.rc:5153
 msgid "Comma-separated list"
 msgstr "Lista separada por vírgulas"
 
 #. IDS_REPORT_TABLIST
-#: Merge.rc:5155
+#: Merge.rc:5154
 msgid "Tab-separated list"
 msgstr "Lista separada por tabulações"
 
 #. IDS_REPORT_SIMPLEHTML
-#: Merge.rc:5156
+#: Merge.rc:5155
 msgid "Simple HTML"
 msgstr "HTML Simples"
 
 #. IDS_REPORT_SIMPLEXML
-#: Merge.rc:5157
+#: Merge.rc:5156
 msgid "Simple XML"
 msgstr "XML Simples"
 
-#: Merge.rc:5159
+#: Merge.rc:5158
 msgid "Report file already exists. Overwrite?"
 msgstr "O arquivo de relatório já existe. Sobrescrever?"
 
 #. IDS_REPORT_ERROR
-#: Merge.rc:5164
+#: Merge.rc:5163
 #, c-format
 msgid "Error creating the report:\n%1"
 msgstr "Erro ao criar o relatório:\n%1"
 
 #. IDS_REPORT_SUCCESS
-#: Merge.rc:5165
+#: Merge.rc:5164
 msgid "Report created successfully."
 msgstr "Relatório criado com sucesso."
 
 #. IDS_SYNCPOINT_LASTBLOCK
-#: Merge.rc:5171
+#: Merge.rc:5170
 msgid "Cannot add a synchronization point at this line."
 msgstr "Não é possível adicionar um ponto de sincronização nesta linha."
 
 #. IDS_FILE_TO_ITSELF
-#: Merge.rc:5177
+#: Merge.rc:5176
 msgid "Same file is opened in both panes."
 msgstr "O mesmo arquivo está aberto em ambos os painéis."
 
 #. IDS_FILESSAME
-#: Merge.rc:5178
+#: Merge.rc:5177
 msgid "Selected files are identical."
 msgstr "Os arquivos selecionados são idênticos."
 
 #. IDS_FILESSAME_CURCFG
-#: Merge.rc:5179
+#: Merge.rc:5178
 msgid "Selected files are identical (with current settings).\r\nChecking binary identity..."
 msgstr "Os arquivos selecionados são idênticos (com as configurações atuais).\r\nChecando identidade binária..."
 
 #. IDS_FILESSAME_BINERROR
-#: Merge.rc:5180
+#: Merge.rc:5179
 msgid "Selected files are identical (with current settings).\r\nBut binary comparison failed."
 msgstr "Os arquivos selecionados são idênticos (com as configurações atuais).\r\nMas a comparação binária falhou."
 
 #. IDS_FILESSAME_BINSAME
-#: Merge.rc:5181
+#: Merge.rc:5180
 msgid "Selected files are identical (binary match)."
 msgstr "Os arquivos selecionados são idênticos (correspondência binária)."
 
 #. IDS_FILESSAME_BINDIFF
-#: Merge.rc:5182
+#: Merge.rc:5181
 msgid "Selected files are identical (with current settings).\r\nBut differ at the binary level."
 msgstr "Os arquivos selecionados são idênticos (com as configurações atuais).\r\nMas diferem no nível binário."
 
 #. IDS_FILEERROR
-#: Merge.rc:5183
+#: Merge.rc:5182
 msgid "An error occurred while comparing files."
 msgstr "Ocorreu um erro ao comparar os arquivos."
 
 #. IDS_TEMP_FILEERROR
-#: Merge.rc:5184
+#: Merge.rc:5183
 msgid "Could not create temporary files. Check your temporary path settings."
 msgstr "Não foi possível criar arquivos temporários. Verifique suas configurações do caminho de temporários."
 
 #. IDS_SUGGEST_IGNOREEOL
-#: Merge.rc:5185
+#: Merge.rc:5184
 msgid "Files use different EOL.\n\nTreat all EOL as equivalent?\n\nSet 'Ignore EOL differences (Windows/Unix/Mac)' in Compare section of Options."
 msgstr "Os arquivos usam caracteres EOL diferentes.\n\nTratar todos os caracteres EOL como equivalentes?\n\nDefina 'Ignorar diferenças de caractere EOL (Windows/Unix/Mac)' na seção Comparar das Opções."
 
 #. IDS_INVALID_DIRECTORY
-#: Merge.rc:5186
+#: Merge.rc:5185
 msgid "Selected folder is invalid."
 msgstr "A pasta selecionada é inválida."
 
 #. IDS_CANNOT_OPEN_BINARYFILE
-#: Merge.rc:5187
+#: Merge.rc:5186
 msgid "Cannot open a binary file in Editor."
 msgstr "Não é possível abrir um arquivo binário no Editor."
 
 #. IDS_CREATE_PAIR_FOLDER
-#: Merge.rc:5188
+#: Merge.rc:5187
 #, c-format
 msgid "Create matching folder:\n%1\non the other side and open?"
 msgstr "Criar pasta correspondente:\n%1\nno outro lado e abrir?"
 
 #. IDS_CONFIRM_COPY_ALL_DIFFS
-#: Merge.rc:5189
+#: Merge.rc:5188
 msgid "Copy all differences to other file?"
 msgstr "Copiar todas as diferenças para o outro arquivo?"
 
 #. IDS_MOVE_TO_NEXTFILE
-#: Merge.rc:5194
+#: Merge.rc:5193
 msgid "Move to next file?"
 msgstr "Mover para o próximo arquivo?"
 
 #. IDS_MOVE_TO_PREVFILE
-#: Merge.rc:5195
+#: Merge.rc:5194
 msgid "Move to previous file?"
 msgstr "Mover para o arquivo anterior?"
 
 #. IDS_MOVE_TO_NEXTPAGE
-#: Merge.rc:5196
+#: Merge.rc:5195
 msgid "Move to next page?"
 msgstr "Mover para a próxima página?"
 
 #. IDS_MOVE_TO_PREVPAGE
-#: Merge.rc:5197
+#: Merge.rc:5196
 msgid "Move to previous page?"
 msgstr "Mover para a página anterior?"
 
 #. IDS_MOVE_TO_FIRSTFILE
-#: Merge.rc:5198
+#: Merge.rc:5197
 msgid "Move to first file?"
 msgstr "Mover para o primeiro arquivo?"
 
 #. IDS_MOVE_TO_LASTFILE
-#: Merge.rc:5199
+#: Merge.rc:5198
 msgid "Move to last file?"
 msgstr "Mover para o último arquivo?"
 
-#: Merge.rc:5206
+#: Merge.rc:5205
 #, c-format
 msgid "Different codepages: left (cp%d), right (cp%d).\nDisplay in codepage (better display) or default Windows codepage (safer merging)?\n(Recommended: default Windows codepage)"
 msgstr "Páginas de código diferentes: esquerda (cp%d), direita (cp%d).\nExibir na página de código (melhor exibição) ou na página de código padrão do Windows (unificação mais segura)?\n(Recomendado: página de código padrão do Windows)"
 
-#: Merge.rc:5208
+#: Merge.rc:5207
 msgid "Information lost due to encoding errors: both files"
 msgstr "Informação perdida devido a erros de codificação: ambos os arquivos"
 
-#: Merge.rc:5210
+#: Merge.rc:5209
 msgid "Information lost due to encoding errors: first file"
 msgstr "Informação perdida devido a erros de codificação: primeiro arquivo"
 
-#: Merge.rc:5212
+#: Merge.rc:5211
 msgid "Information lost due to encoding errors: second file"
 msgstr "Informação perdida devido a erros de codificação: segundo arquivo"
 
-#: Merge.rc:5214
+#: Merge.rc:5213
 msgid "Information lost due to encoding errors: third file"
 msgstr "Informação perdida devido a erros de codificação: terceiro arquivo"
 
 #. IDS_LINEDIFF_NODIFF
-#: Merge.rc:5220
+#: Merge.rc:5219
 msgid "No difference"
 msgstr "Sem diferença"
 
 #. IDS_LINEDIFF_NODIFF_CAPTION
-#: Merge.rc:5221
+#: Merge.rc:5220
 msgid "Line difference"
 msgstr "Diferença da linha"
 
 #. IDS_NUM_REPLACED
-#: Merge.rc:5227
+#: Merge.rc:5226
 #, c-format
 msgid "Replaced %1 string(s)."
 msgstr "Substituiu %1 string(s)."
 
 #. IDS_EDIT_TEXT_NOT_FOUND
-#: Merge.rc:5228
+#: Merge.rc:5227
 #, c-format
 msgid "Cannot find string \"%s\"."
 msgstr "Não é possível encontrar a string “%s”."
 
 #. IDS_MERGE_MODE
-#: Merge.rc:5234
+#: Merge.rc:5233
 msgid "Entering Merge Mode. Press F9 to turn off."
 msgstr "Entrando no Modo de União. Pressione F9 para desativar."
 
 #. IDS_AUTO_MERGE
-#: Merge.rc:5240
+#: Merge.rc:5239
 #, c-format
 msgid "Automatic merges: %1\nUnresolved conflicts: %2"
 msgstr "Uniões automáticas: %1\nConflitos não resolvidos: %2"
 
 #. IDS_CODEPAGE_MERGED
-#: Merge.rc:5241
+#: Merge.rc:5240
 msgid "Codepage change merged."
 msgstr "Alteração de página de código unida."
 
 #. IDS_CODEPAGE_CONFLICT
-#: Merge.rc:5242
+#: Merge.rc:5241
 msgid "Codepage changes are conflicting."
 msgstr "As alterações de página de código estão em conflito."
 
 #. IDS_EOL_MERGED
-#: Merge.rc:5243
+#: Merge.rc:5242
 msgid "EOL change merged."
 msgstr "Alteração de caractere EOL unida."
 
 #. IDS_EOL_CONFLICT
-#: Merge.rc:5244
+#: Merge.rc:5243
 msgid "EOL changes are conflicting."
 msgstr "As alterações de caractere EOL estão em conflito."
 
 #. IDS_LOCBAR_CAPTION
-#: Merge.rc:5250
+#: Merge.rc:5249
 msgid "Location Pane"
 msgstr "Painel de Localização"
 
 #. IDS_DIFFBAR_CAPTION
-#: Merge.rc:5251
+#: Merge.rc:5250
 msgid "Diff Pane"
 msgstr "Painel de Diferenciação"
 
 #. IDS_DIFF_SUCCEEDED
-#: Merge.rc:5258
+#: Merge.rc:5257
 msgid "Patch file written."
 msgstr "Arquivo de patch gravado."
 
 #. IDS_DIFF_FILEOVERWRITE
-#: Merge.rc:5259
+#: Merge.rc:5258
 msgid "Patch file already exists. Overwrite?"
 msgstr "O arquivo de patch já existe. Sobrescrever?"
 
 #. IDS_DIFF_SELECTEDFILES
-#: Merge.rc:5260
+#: Merge.rc:5259
 #, c-format
 msgid "[%1 files selected]"
 msgstr "[%1 arquivos selecionados]"
 
 #. IDS_DIFF_NORMAL
-#: Merge.rc:5261
+#: Merge.rc:5260
 msgid "Normal"
 msgstr "Normal"
 
 #. IDS_DIFF_CONTEXT
-#: Merge.rc:5262
+#: Merge.rc:5261
 msgid "Context"
 msgstr "Contexto"
 
 #. IDS_DIFF_UNIFIED
-#: Merge.rc:5263
+#: Merge.rc:5262
 msgid "Unified"
 msgstr "Unificado"
 
 #. IDS_FILEWRITE_ERROR
-#: Merge.rc:5265
+#: Merge.rc:5264
 #, c-format
 msgid "Could not write to file %1."
 msgstr "Não foi possível gravar no arquivo %1."
 
 #. IDS_PATH_NOT_ABSOLUTE
-#: Merge.rc:5266
+#: Merge.rc:5265
 #, c-format
 msgid "Output path is not absolute: %1"
 msgstr "O caminho de saída não é absoluto: %1"
 
 #. IDS_MUST_SPECIFY_OUTPUT
-#: Merge.rc:5267
+#: Merge.rc:5266
 msgid "Specify an output file."
 msgstr "Especifique um arquivo de saída."
 
-#: Merge.rc:5269
+#: Merge.rc:5268
 msgid "Cannot create patch from binary files."
 msgstr "Não é possível criar patch a partir de arquivos binários."
 
 #. IDS_SAVEFILES_FORPATCH
-#: Merge.rc:5270
+#: Merge.rc:5269
 msgid "Save all files first.\n\nCreating a patch requires no unsaved changes."
 msgstr "Salve todos os arquivos primeiro.\n\nA criação de um patch requer que não haja alterações não salvas."
 
 #. IDS_FOLDER_NOTEXIST
-#: Merge.rc:5271
+#: Merge.rc:5270
 msgid "Folder does not exist."
 msgstr "A pasta não existe."
 
 #. IDS_ARCHIVE_SUCCEEDED
-#: Merge.rc:5277
+#: Merge.rc:5276
 msgid "Archive file written."
 msgstr "Arquivo compactado gravado."
 
 #. IDS_ARCHIVE_SAVEFILES
-#: Merge.rc:5278
+#: Merge.rc:5277
 msgid "Save all files first.\n\nCreating an archive requires no unsaved changes."
 msgstr "Salvar todos os arquivos primeiro.\n\nA criação de um arquivo compactado exige que não haja alterações não salvas."
 
 #. IDS_NO_ZIP_SUPPORT
-#: Merge.rc:5283
+#: Merge.rc:5282
 msgid "Archive support not enabled.\n7-Zip and/or Merge7z*.dll not found.\nSee manual for archive support."
 msgstr "Suporte a arquivos compactados não habilitado.\n7-Zip e/ou Merge7z*.dll não encontrados.\nVeja o manual para suporte a arquivos compactados."
 
 #. IDS_OPT_EXPORT_CAPTION
-#: Merge.rc:5284
+#: Merge.rc:5283
 msgid "Select file for export"
 msgstr "Selecione o arquivo para exportar"
 
 #. IDS_OPT_IMPORT_CAPTION
-#: Merge.rc:5285
+#: Merge.rc:5284
 msgid "Select file for import"
 msgstr "Selecione o arquivo para importar"
 
 #. IDS_OPT_IMPORT_DONE
-#: Merge.rc:5286
+#: Merge.rc:5285
 msgid "Options imported from file."
 msgstr "Opções importadas do arquivo."
 
 #. IDS_OPT_EXPORT_DONE
-#: Merge.rc:5287
+#: Merge.rc:5286
 msgid "Options exported to file."
 msgstr "Opções exportadas para o arquivo."
 
 #. IDS_OPT_IMPORT_ERR
-#: Merge.rc:5288
+#: Merge.rc:5287
 msgid "Failed to import options from file."
 msgstr "Falha na importação de opções do arquivo."
 
 #. IDS_OPT_EXPORT_ERR
-#: Merge.rc:5289
+#: Merge.rc:5288
 msgid "Failed to write options to file."
 msgstr "Falha na gravação de opções em arquivo."
 
 #. IDS_CLOSEALL_WINDOWS
-#: Merge.rc:5290
+#: Merge.rc:5289
 msgid "Close multiple compare windows?\n\nContinue?"
 msgstr "Fechar várias janelas de comparação?\n\nContinuar?"
 
 #. IDS_EOL_BIN
-#: Merge.rc:5300
+#: Merge.rc:5299
 msgctxt "EOL Type"
 msgid "Binary"
 msgstr "Binário"
 
 #. IDS_MARKER_COLOR_FMT
-#: Merge.rc:5305
+#: Merge.rc:5304
 #, c-format
 msgid "Marker Color %d"
 msgstr "Cor do Marcador %d"
 
 #. IDS_MARKER_NEW_PATTERN
-#: Merge.rc:5306
+#: Merge.rc:5305
 msgid "New Pattern"
 msgstr "Novo Padrão"
 
 #. IDS_PLUGINSLIST_TYPE
-#: Merge.rc:5312
+#: Merge.rc:5311
 msgid "Type"
 msgstr "Tipo"
 
 #. IDS_PLUGINS_TYPE_EDITSCRIPT
-#: Merge.rc:5316
+#: Merge.rc:5315
 msgid "Editor script"
 msgstr "Script do editor"
 
 #. ID_SELECTLINEDIFF
-#: Merge.rc:5322
+#: Merge.rc:5321
 msgid "\nDifference in Current Line (F4)"
 msgstr "\nDiferença na Linha Atual (F4)"
 
 #. ID_OPTIONS
-#: Merge.rc:5323
+#: Merge.rc:5322
 msgid "\nOptions"
 msgstr "\nOpções"
 
 #. ID_REFRESH
-#: Merge.rc:5324
+#: Merge.rc:5323
 msgid "\nRefresh (F5)"
 msgstr "\nAtualizar (F5)"
 
 #. ID_PREVDIFF
-#: Merge.rc:5330
+#: Merge.rc:5329
 msgid "\nPrevious Difference (Alt+Up)"
 msgstr "\nDiferença Anterior (Alt+Pra Cima)"
 
 #. ID_NEXTDIFF
-#: Merge.rc:5331
+#: Merge.rc:5330
 msgid "\nNext Difference (Alt+Down)"
 msgstr "\nDiferença Seguinte (Alt+Pra Baixo)"
 
 #. ID_PREVCONFLICT
-#: Merge.rc:5332
+#: Merge.rc:5331
 msgid "\nPrevious Conflict (Alt+Shift+Up)"
 msgstr "\nConflito Anterior (Alt+Shift+Pra Cima)"
 
 #. ID_NEXTCONFLICT
-#: Merge.rc:5333
+#: Merge.rc:5332
 msgid "\nNext Conflict (Alt+Shift+Down)"
 msgstr "\nConflito Seguinte (Alt+Shift+Pra Baixo)"
 
 #. ID_FIRSTDIFF
-#: Merge.rc:5338
+#: Merge.rc:5337
 msgid "\nFirst Difference (Alt+Home)"
 msgstr "\nPrimeira Diferença (Alt+Home)"
 
 #. ID_CURDIFF
-#: Merge.rc:5339
+#: Merge.rc:5338
 msgid "\nCurrent Difference (Alt+Enter)"
 msgstr "\nDiferença Atual (Alt+Enter)"
 
 #. ID_LASTDIFF
-#: Merge.rc:5340
+#: Merge.rc:5339
 msgid "\nLast Difference (Alt+End)"
 msgstr "\nÚltima Diferença (Alt+End)"
 
 #. ID_L2R
-#: Merge.rc:5341
+#: Merge.rc:5340
 msgid "\nCopy to Right (Alt+Right)"
 msgstr "\nCopiar para a Direita (Alt+Direita)"
 
 #. ID_R2L
-#: Merge.rc:5342
+#: Merge.rc:5341
 msgid "\nCopy to Left (Alt+Left)"
 msgstr "\nCopiar para a Esquerda (Alt+Esquerda)"
 
 #. ID_L2RNEXT
-#: Merge.rc:5343
+#: Merge.rc:5342
 msgid "\nCopy to Right and Advance (Ctrl+Alt+Right)"
 msgstr "\nCopiar para a Direita e Avançar (Ctrl+Alt+Direita)"
 
 #. ID_R2LNEXT
-#: Merge.rc:5344
+#: Merge.rc:5343
 msgid "\nCopy to Left and Advance (Ctrl+Alt+Left)"
 msgstr "\nCopiar para a Esquerda e Avançar (Ctrl+Alt+Esquerda)"
 
 #. ID_ALL_RIGHT
-#: Merge.rc:5345
+#: Merge.rc:5344
 msgid "\nCopy All to Right"
 msgstr "\nCopiar Tudo para a Direita"
 
 #. ID_ALL_LEFT
-#: Merge.rc:5346
+#: Merge.rc:5345
 msgid "\nCopy All to Left"
 msgstr "\nCopiar Tudo para a Esquerda"
 
 #. ID_AUTO_MERGE
-#: Merge.rc:5347
+#: Merge.rc:5346
 msgid "\nAuto Merge (Ctrl+Alt+M)"
 msgstr "\nUnião Automática (Ctrl+Alt+M)"
 
 #. ID_FIRSTFILE
-#: Merge.rc:5348
+#: Merge.rc:5347
 msgid "\nFirst File"
 msgstr "\nPrimeiro Arquivo"
 
 #. ID_NEXTFILE
-#: Merge.rc:5349
+#: Merge.rc:5348
 msgid "\nNext File (Ctrl+F8)"
 msgstr "\nPróximo Arquivo (Ctrl+F8)"
 
 #. ID_LASTFILE
-#: Merge.rc:5350
+#: Merge.rc:5349
 msgid "\nLast File"
 msgstr "\nÚltimo Arquivo"
 
 #. ID_PREVFILE
-#: Merge.rc:5351
+#: Merge.rc:5350
 msgid "\nPrevious File (Ctrl+F7)"
 msgstr "\nArquivo Anterior (Ctrl+F7)"
 
 #. IDS_UNPACK_AUTO
-#: Merge.rc:5358
+#: Merge.rc:5357
 msgid "Adapted unpacker applied to both files (one needs extension)."
 msgstr "Descompactador adaptado aplicado a ambos os arquivos (um deles precisa de extensão)."
 
 #. IDS_NO_PREDIFFER
-#: Merge.rc:5359
+#: Merge.rc:5358
 msgid "No Prediffer (Normal)"
 msgstr "Sem Pré-Diferenciação (Normal)"
 
 #. IDS_SUGGESTED_PLUGINS
-#: Merge.rc:5360
+#: Merge.rc:5359
 msgid "Suggested Plugins"
 msgstr "Plugins Sugeridos"
 
 #. IDS_NOT_SUGGESTED_PLUGINS
-#: Merge.rc:5361
+#: Merge.rc:5360
 msgid "All Plugins"
 msgstr "Todos os Plugins"
 
 #. IDS_PRIVATEBUILD_FMT
-#: Merge.rc:5367
+#: Merge.rc:5366
 #, c-format
 msgid "Private Build: %1"
 msgstr "Compilação Privada: %1"
 
 #. IDS_ALLRIGHTS_RESERVED
-#: Merge.rc:5368
+#: Merge.rc:5367
 msgid " - All rights reserved."
 msgstr " - Todos os direitos reservados."
 
 #. IDS_TITLE_PLUGINS_SETTINGS
-#: Merge.rc:5374
+#: Merge.rc:5373
 msgid "Plugin Settings"
 msgstr "Configurações do Plugin"
 
 #. IDS_NO_SCT_SCRIPTS
-#: Merge.rc:5376
+#: Merge.rc:5375
 msgid "WSH not found - .sct scripts disabled"
 msgstr "WSH não encontrado - scripts .sct desabilitados"
 
 #. IDS_LOCBAR_GOTOLINE_FMT
-#: Merge.rc:5384
+#: Merge.rc:5383
 #, c-format
 msgid "G&o to Line %1"
 msgstr "I&r para a Linha %1"
 
 #. IDS_GOTO_MOVED_LINE
-#: Merge.rc:5390
+#: Merge.rc:5389
 msgid "Go to Moved Line\tCtrl+Shift+G"
 msgstr "Ir para a Linha Movida\tCtrl+Shift+G"
 
 #. IDS_AUTOCOMPLETE_DISABLED
-#: Merge.rc:5396
+#: Merge.rc:5395
 msgctxt "Options dialog|General|Open dialog Auto completion"
 msgid "Disabled"
 msgstr "Desabilitado"
 
 #. IDS_AUTOCOMPLETE_FILE_SYS
-#: Merge.rc:5397
+#: Merge.rc:5396
 msgid "From file system"
 msgstr "Do sistema de arquivos"
 
 #. IDS_AUTOCOMPLETE_MRU
-#: Merge.rc:5398
+#: Merge.rc:5397
 msgid "From Most Recently Used list"
 msgstr "Da lista Mais Recentemente Usados"
 
 #. IDS_COLORSCHEME_PLAIN
-#: Merge.rc:5404
+#: Merge.rc:5403
 msgid "No Highlighting"
 msgstr "Sem Destaque"
 
 #. IDS_COLORSCHEME_PO
-#: Merge.rc:5439
+#: Merge.rc:5438
 msgid "Portable Object"
 msgstr "Objeto Portátil"
 
 #. IDS_COLORSCHEME_RSRC
-#: Merge.rc:5444
+#: Merge.rc:5443
 msgid "Resources"
 msgstr "Recursos"
 
 #. IDS_COLORSCHEME_SH
-#: Merge.rc:5448
+#: Merge.rc:5447
 msgid "Shell"
 msgstr "Shell"
 
 #. IDS_CLOSE_LEFT_TABS
-#: Merge.rc:5469
+#: Merge.rc:5468
 msgid "Close &Left Tabs"
 msgstr "Fechar as &Abas da Esquerda"
 
 #. IDS_CLOSE_RIGHT_TABS
-#: Merge.rc:5470
+#: Merge.rc:5469
 msgid "Close R&ight Tabs"
 msgstr "Fechar as A&bas da Direita"
 
 #. IDS_CLOSE_OTHER_TABS
-#: Merge.rc:5471
+#: Merge.rc:5470
 msgid "Close &Other Tabs"
 msgstr "Fechar as &Outras Abas"
 
 #. IDS_TABBAR_AUTO_MAXWIDTH
-#: Merge.rc:5472
+#: Merge.rc:5471
 msgid "Enable &Auto Max Width"
 msgstr "Habilitar Largura &Máxima Automática"
 
 #. IDS_WEBPAGE_MENU
-#: Merge.rc:5482
+#: Merge.rc:5481
 msgid "We&bpage"
 msgstr "Página da W&eb"
 
 #. IDS_VIEW_WRAP_TEXT
-#: Merge.rc:5487
+#: Merge.rc:5486
 msgid "W&rap Text"
 msgstr "Queb&rar Texto"
 
 #. IDS_NOTINSTALLED
-#: Merge.rc:5492
+#: Merge.rc:5491
 #, c-format
 msgid "%1 is not installed."
 msgstr "%1 não está instalado."
 
 #. IDS_CREATE_FOLDER
-#: Merge.rc:5497
+#: Merge.rc:5496
 #, c-format
 msgid "%1 does not exist. Create it?"
 msgstr "%1 não existe. Criá-la?"
 
 #. IDS_CREATE_FOLDER_ERROR
-#: Merge.rc:5498
+#: Merge.rc:5497
 msgid "Failed to create folder."
 msgstr "Falha ao criar a pasta."
 
 #. IDC_EXT_EDITOR_PATH
-#: Merge.rc:5503
+#: Merge.rc:5502
 msgid "Parameters:\n$file: Current file path\n$linenum: Current cursor line number"
 msgstr "Parâmetros:\n$file: Caminho do arquivo atual\n$linenum: Número da linha atual do cursor"
 
 #. IDS_DIFF_ALGORITHM_DEFAULT
-#: Merge.rc:5508
+#: Merge.rc:5507
 msgid "default"
 msgstr "padrão"
 
 #. IDS_DIFF_ALGORITHM_MINIMAL
-#: Merge.rc:5509
+#: Merge.rc:5508
 msgid "minimal"
 msgstr "mínimo"
 
 #. IDS_DIFF_ALGORITHM_PATIENCE
-#: Merge.rc:5510
+#: Merge.rc:5509
 msgid "patience"
 msgstr "paciência"
 
 #. IDS_DIFF_ALGORITHM_HISTOGRAM
-#: Merge.rc:5511
+#: Merge.rc:5510
 msgid "histogram"
 msgstr "histograma"
 
 #. IDS_DIFF_ALGORITHM_NONE
-#: Merge.rc:5512
+#: Merge.rc:5511
 msgid "none"
 msgstr "nenhum"
 
 #. IDS_RENDERING_MODE_GDI
-#: Merge.rc:5517
+#: Merge.rc:5516
 msgid "GDI"
 msgstr "GDI"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_DEFAULT
-#: Merge.rc:5518
+#: Merge.rc:5517
 msgid "DirectWrite Default"
 msgstr "DirectWrite Padrão"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_ALIASED
-#: Merge.rc:5519
+#: Merge.rc:5518
 msgid "DirectWrite Aliased"
 msgstr "DirectWrite com Efeito de Alias"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_GDI_CLASSIC
-#: Merge.rc:5520
+#: Merge.rc:5519
 msgid "DirectWrite GDI Classic"
 msgstr "DirectWrite GDI Clássico"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_GDI_NATURAL
-#: Merge.rc:5521
+#: Merge.rc:5520
 msgid "DirectWrite GDI Natural"
 msgstr "DirectWrite GDI Natural"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_NATURAL
-#: Merge.rc:5522
+#: Merge.rc:5521
 msgid "DirectWrite Natural"
 msgstr "DirectWrite Natural"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_NATURAL_SYMMETRIC
-#: Merge.rc:5523
+#: Merge.rc:5522
 msgid "DirectWrite Natural Symmetric"
 msgstr "DirectWrite Natural Simétrico"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_DISABLED
-#: Merge.rc:5528
+#: Merge.rc:5527
 msgctxt "Options dialog|General|Close windows with Esc"
 msgid "Disabled"
 msgstr "Desabilitado"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_1
-#: Merge.rc:5529
+#: Merge.rc:5528
 msgid "MDI child window or main window"
 msgstr "Janela filha ou janela principal da MDI"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_2
-#: Merge.rc:5530
+#: Merge.rc:5529
 msgid "MDI child window only"
 msgstr "Só janela filha da MDI"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_3
-#: Merge.rc:5531
+#: Merge.rc:5530
 msgid "Close main window if only one MDI child window"
 msgstr "Fechar a janela principal se só houver uma janela filha da MDI"
 
 #. IDS_DIFF_GROUP
-#: Merge.rc:5536
+#: Merge.rc:5535
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Diff"
 msgstr "Diferenciação"
 
 #. IDS_DIFF_HIGHLIGHT
-#: Merge.rc:5537
+#: Merge.rc:5536
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Highlight"
 msgstr "Destacar"
 
 #. IDS_DIFF_BLINK
-#: Merge.rc:5538
+#: Merge.rc:5537
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Blink"
 msgstr "Piscar"
 
 #. IDS_DIFF_BLOCKSIZE
-#: Merge.rc:5539
+#: Merge.rc:5538
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Block Size"
 msgstr "Tamanho do Bloco"
 
 #. IDS_DIFF_BLOCKALPHA
-#: Merge.rc:5540
+#: Merge.rc:5539
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Block Alpha"
 msgstr "Alfa do Bloco"
 
 #. IDS_DIFF_CDTHRESHOLD
-#: Merge.rc:5541
+#: Merge.rc:5540
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "CD Threshold"
 msgstr "Limiar da DC"
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION
-#: Merge.rc:5542
+#: Merge.rc:5541
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Ins/Del Detection"
 msgstr "Detecção de Ins/Del"
 
 #. IDS_OVERLAY_MODE_NONE
-#: Merge.rc:5543 Merge.rc:5548
+#: Merge.rc:5542 Merge.rc:5547
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "None"
 msgstr "Nenhuma"
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION_VERTICAL
-#: Merge.rc:5544
+#: Merge.rc:5543
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Vertical"
 msgstr "Vertical"
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION_HORIZONTAL
-#: Merge.rc:5545
+#: Merge.rc:5544
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Horizontal"
 msgstr "Horizontal"
 
 #. IDS_OVERLAY_GROUP
-#: Merge.rc:5546
+#: Merge.rc:5545
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Overlay"
 msgstr "Sobreposição"
 
 #. IDS_OVERLAY_ALPHA
-#: Merge.rc:5547
+#: Merge.rc:5546
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha"
 msgstr "Alfa"
 
 #. IDS_OVERLAY_MODE_XOR
-#: Merge.rc:5549
+#: Merge.rc:5548
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "XOR"
 msgstr "XOR"
 
 #. IDS_OVERLAY_MODE_ALPHA
-#: Merge.rc:5550
+#: Merge.rc:5549
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha Blend"
 msgstr "Mistura do Alfa"
 
 #. IDS_OVERLAY_MODE_ALPHA_ANIMATION
-#: Merge.rc:5551
+#: Merge.rc:5550
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha Animation"
 msgstr "Animação do Alfa"
 
 #. IDS_ZOOM
-#: Merge.rc:5552
+#: Merge.rc:5551
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Zoom"
 msgstr "Zoom"
 
 #. IDS_PAGE
-#: Merge.rc:5553
+#: Merge.rc:5552
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Page:"
 msgstr "Página:"
 
 #. IDS_IMGCMP_STATUS_PT_RGBA_FMT
-#: Merge.rc:5554
+#: Merge.rc:5553
 #, c-format
 msgid "Pt: (%d, %d)  RGBA: (%d, %d, %d, %d)  "
 msgstr "Pt: (%d, %d)  RGBA: (%d, %d, %d, %d)  "
 
 #. IDS_IMGCMP_STATUS_DIST1_FMT
-#: Merge.rc:5555
+#: Merge.rc:5554
 #, c-format
 msgid "Dist: %g  "
 msgstr "Dist: %g  "
 
 #. IDS_IMGCMP_STATUS_DIST2_FMT
-#: Merge.rc:5556
+#: Merge.rc:5555
 #, c-format
 msgid "Dist: %g, %g  "
 msgstr "Dist: %g, %g  "
 
 #. IDS_IMGCMP_STATUS_PAGE_ZOOM_SIZE_BPP_FMT
-#: Merge.rc:5557
+#: Merge.rc:5556
 #, c-format
 msgid "Page: %d/%d  Zoom: %d%%  %dx%dpx  %dbpp  "
 msgstr "Página: %d/%d  Zoom: %d%%  %dx%dpx  %dbpp "
 
 #. IDS_IMGCMP_STATUS_RC_FMT
-#: Merge.rc:5558
+#: Merge.rc:5557
 #, c-format
 msgid "Rc: (%d, %d)  "
 msgstr "Rc: (%d, %d)  "
 
 #. IDS_IMGCMP_STATUS_FLIPPED_FMT
-#: Merge.rc:5559
+#: Merge.rc:5558
 #, c-format
 msgid "Flipped: %s  "
 msgstr "Virada: %s "
 
 #. IDS_IMGCMP_STATUS_ROTATED_FMT
-#: Merge.rc:5560
+#: Merge.rc:5559
 #, c-format
 msgid "Rotated: %d  "
 msgstr "Rotacionada: %d "
 
 #. IDS_IMGCMP_REPORT_ALLPAGES
-#: Merge.rc:5561
+#: Merge.rc:5560
 msgid "All pages"
 msgstr "Todas as páginas"
 
 #. IDS_IGNSUB_STR1
-#: Merge.rc:5566
+#: Merge.rc:5565
 msgid "<Edit here>"
 msgstr "<Editar aqui>"
 
 #. IDS_IGNSUB_STR2
-#: Merge.rc:5567
+#: Merge.rc:5566
 msgid "No differences found to select"
 msgstr "Nenhuma diferença encontrada para selecionar"
 
 #. IDS_IGNSUB_STR3
-#: Merge.rc:5568
+#: Merge.rc:5567
 msgid "No differences found to add as substitution filter"
 msgstr "Nenhuma diferença encontrada para adicionar como filtro de substituição"
 
 #. IDS_IGNSUB_STR4
-#: Merge.rc:5569
+#: Merge.rc:5568
 msgid "The pair is already in the Substitution Filters list"
 msgstr "O par já está na lista de Filtros de Substituição"
 
 #. IDS_IGNSUB_STR5
-#: Merge.rc:5570
+#: Merge.rc:5569
 msgid "Add this change to Substitution Filters?"
 msgstr "Adicionar esta alteração aos Filtros de Substituição?"
 
 #. IDS_OCRRESULT_TEXTONLY
-#: Merge.rc:5575
+#: Merge.rc:5574
 msgid "Text only"
 msgstr "Só texto"
 
 #. IDS_OCRRESULT_POS_LINE
-#: Merge.rc:5576
+#: Merge.rc:5575
 msgid "Line-by-line position and text"
 msgstr "Posição e texto linha por linha"
 
 #. IDS_OCRRESULT_POS_WORD
-#: Merge.rc:5577
+#: Merge.rc:5576
 msgid "Word-by-word position and text"
 msgstr "Posição e texto palavra por palavra"
 
 #. IDS_USERDATAFOLDER_APPDATA
-#: Merge.rc:5582
+#: Merge.rc:5581
 msgid "AppData (Roaming) folder"
 msgstr "Pasta AppData (Roaming)"
 
 #. IDS_USERDATAFOLDER_INSTALL
-#: Merge.rc:5583
+#: Merge.rc:5582
 msgid "Install folder"
 msgstr "Pasta de instalação"
 
 #. IDS_USERDATAFOLDER_DOCUMENTS
-#: Merge.rc:5584
+#: Merge.rc:5583
 msgid "Documents folder"
 msgstr "Pasta Documentos"
 
 #. IDS_SINGLEINSTANCE_DISABLED
-#: Merge.rc:5589
+#: Merge.rc:5588
 msgctxt "Options dialog|General|Single instance mode"
 msgid "Disabled"
 msgstr "Desabilitado"
 
 #. IDS_SINGLEINSTANCE_STR1
-#: Merge.rc:5590
+#: Merge.rc:5589
 msgid "Allow only one instance to run"
 msgstr "Permitir que apenas uma instância seja executada"
 
 #. IDS_CLIPBOARD_HISTORY
-#: Merge.rc:5591
+#: Merge.rc:5590
 msgid "Clipboard &History"
 msgstr "&Histórico da Área de Transferência"
 
 #. IDS_SINGLEINSTANCE_STR2
-#: Merge.rc:5592
+#: Merge.rc:5591
 msgid "Allow only one instance; wait for termination"
 msgstr "Permitir apenas uma instância; aguardar encerramento"
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_DISABLED
-#: Merge.rc:5597
+#: Merge.rc:5596
 msgctxt "Options dialog|General|Auto-reload modified files"
 msgid "Disabled"
 msgstr "Desabilitado"
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_STR1
-#: Merge.rc:5598
+#: Merge.rc:5597
 msgid "Only on window activated"
 msgstr "Apenas na janela ativada"
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_STR2
-#: Merge.rc:5599
+#: Merge.rc:5598
 msgid "Immediately"
 msgstr "Imediatamente"
 
 #. IDS_PLUGIN_ALL
-#: Merge.rc:5604
+#: Merge.rc:5603
 msgid "Al&l"
 msgstr "Tu&do"
 
 #. IDS_PLUGIN_OTHERS
-#: Merge.rc:5605
+#: Merge.rc:5604
 msgid "&Others"
 msgstr "&Outros"
 
-#: Merge.rc:5607
+#: Merge.rc:5606
 #, c-format
 msgid "Missing plugin name in pipeline: %1"
 msgstr "Nome do plugin ausente no pipeline: %1"
 
-#: Merge.rc:5609
+#: Merge.rc:5608
 #, c-format
 msgid "Missing quote in plugin pipeline: %1"
 msgstr "Aspas ausentes no pipeline do plugin: %1"
 
 #. IDS_PLUGIN_NAME_ALREADY_EXISTS
-#: Merge.rc:5610
+#: Merge.rc:5609
 #, c-format
 msgid "Plugin name '%1' already exists."
 msgstr "O nome de plugin '%1' já existe."
 
 #. IDS_PLUGIN_TITLE1
-#: Merge.rc:5611
+#: Merge.rc:5610
 msgid "Specify plugin arguments"
 msgstr "Especifique os argumentos do plugin"
 
-#: Merge.rc:5613
+#: Merge.rc:5612
 #, c-format
 msgid "Plugin not found or invalid: %1"
 msgstr "Plugin não encontrado ou inválido: %1"
 
 #. IDS_PLUGIN_NOT_UNPACK
-#: Merge.rc:5614
+#: Merge.rc:5613
 #, c-format
 msgid "'%1' is not an unpacker plugin"
 msgstr "'%1' não é um plugin de descompactador"
 
 #. IDS_PLUGIN_NOT_PREDIFF
-#: Merge.rc:5615
+#: Merge.rc:5614
 #, c-format
 msgid "'%1' is not a prediffer plugin"
 msgstr "'%1' não é um plugin de pré-diferenciação"
 
-#: Merge.rc:5617
+#: Merge.rc:5616
 #, c-format
 msgid "Error prediffing '%1' with '%2'. Prediffing disabled."
 msgstr "Erro ao pré-diferenciar ‘%1’ com ‘%2’. Pré-diferenciação desabilitada."
 
 #. IDS_PLUGIN_CIRCULAR_REFERENCE
-#: Merge.rc:5618
+#: Merge.rc:5617
 #, c-format
 msgid "Circular reference in plugin pipeline: %1"
 msgstr "Referência circular no pipeline do plugin: %1"
 
 #. IDS_PLUGIN_TYPE1
-#: Merge.rc:5619
+#: Merge.rc:5618
 msgid "URL Handler"
 msgstr "Manipulador de URL"
 
 #. IDS_PLUGIN_TYPE2
-#: Merge.rc:5620
+#: Merge.rc:5619
 msgid "File Unpacker"
 msgstr "Descompactador de Arquivo"
 
 #. IDS_PLUGIN_TYPE3
-#: Merge.rc:5621
+#: Merge.rc:5620
 msgid "File or Folder Unpacker"
 msgstr "Descompactador de Arquivo ou Pasta"
 
 #. IDS_PLUGIN_TYPE5
-#: Merge.rc:5623
+#: Merge.rc:5622
 msgid "Alias for Unpacker"
 msgstr "Alias para o Descompactador"
 
 #. IDS_PLUGIN_TYPE6
-#: Merge.rc:5624
+#: Merge.rc:5623
 msgid "Alias for Prediffer"
 msgstr "Alias para o Pré-Diferenciador"
 
 #. IDS_PLUGIN_TYPE7
-#: Merge.rc:5625
+#: Merge.rc:5624
 msgid "Alias for Editor script"
 msgstr "Alias para o script do Editor"
 
 #. IDS_PLUGIN_ALIAS_DESC
-#: Merge.rc:5626
+#: Merge.rc:5625
 #, c-format
 msgid "Alias for plugin pipeline '%1'"
 msgstr "Alias para o pipeline de plugin '%1'"
 
 #. IDS_PLUGIN_NEW_DESC
-#: Merge.rc:5627
+#: Merge.rc:5626
 msgid "New plugin description"
 msgstr "Descrição do novo plugin"
 
 #. IDS_PLUGIN_TARGETS_ALL
-#: Merge.rc:5628
+#: Merge.rc:5627
 msgid "All"
 msgstr "Todos"
 
 #. IDS_PLUGIN_TARGETS_1ST
-#: Merge.rc:5629
+#: Merge.rc:5628
 msgid "1st"
 msgstr "1º"
 
 #. IDS_PLUGIN_TARGETS_2ND
-#: Merge.rc:5630
+#: Merge.rc:5629
 msgid "2nd"
 msgstr "2º"
 
 #. IDS_PLUGIN_TARGETS_3RD
-#: Merge.rc:5631
+#: Merge.rc:5630
 msgid "3rd"
 msgstr "3º"
 
 #. IDS_PLUGIN_TARGETS_1ST_2ND
-#: Merge.rc:5632
+#: Merge.rc:5631
 msgid "1st and 2nd"
 msgstr "1º e 2º"
 
 #. IDS_PLUGIN_TARGETS_1ST_3RD
-#: Merge.rc:5633
+#: Merge.rc:5632
 msgid "1st and 3rd"
 msgstr "1º e 3º"
 
 #. IDS_PLUGIN_TARGETS_2ND_3RD
-#: Merge.rc:5634
+#: Merge.rc:5633
 msgid "2nd and 3rd"
 msgstr "2º e 3º"
 
 #. IDS_PLUGIN_CTRL_CLICK
-#: Merge.rc:5635
+#: Merge.rc:5634
 msgid "(Ctrl+Click to add to pipeline)"
 msgstr "(Ctrl+Click para adicionar à pipeline)"
 
 #. IDS_FILTER_APPLIED
-#: Merge.rc:5640
+#: Merge.rc:5639
 msgid "Filter applied"
 msgstr "Filtro aplicado"
 
 #. IDS_FILTERMENU_COMPARE
-#: Merge.rc:5645
+#: Merge.rc:5644
 #, c-format
 msgid "Compare %1"
 msgstr "Comparar %1"
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN2
-#: Merge.rc:5647
+#: Merge.rc:5646
 msgid "&Filter by This Column..."
 msgstr "&Filtrar por Esta Coluna..."
 
 #. IDS_CLIPBOARDHISTORY_TIME
-#: Merge.rc:5652
+#: Merge.rc:5651
 #, c-format
 msgid "Clipboard at %s"
 msgstr "Área de transferência em %s"
 
 #. IDS_CLIPBOARDHISTORY_DISABLED
-#: Merge.rc:5653
+#: Merge.rc:5652
 msgid "Clipboard history disabled.\r\nEnable: Windows logo key + V, then Turn on."
 msgstr "Histórico da área de transferência desabilitado.\r\nHabilitar: tecla do logotipo do Windows + V e, em seguida, Ativar."
 
-#: Merge.rc:5655
+#: Merge.rc:5654
 msgid "This system does not support clipboard history."
 msgstr "Este sistema não suporta histórico da área de transferência."
 
-#: Merge.rc:5657
+#: Merge.rc:5656
 msgid "32-bit WinMerge does not support Clipboard Compare"
 msgstr "O WinMerge de 32 bits não suporta a Comparação da Área de Transferência"
 
 #. IDS_WEBVIEW2_RUNTIME_NOT_INSTALLED
-#: Merge.rc:5662
+#: Merge.rc:5661
 msgid "WebView2 runtime not installed. Download it?"
 msgstr "O WebView2 runtime não está instalado. Baixá-lo?"
 
 #. IDS_JUMPLIST_NEW_TEXT_COMPARE
-#: Merge.rc:5667
+#: Merge.rc:5666
 msgid "New Text Compare"
 msgstr "Nova Comparação de Textos"
 
 #. IDS_JUMPLIST_NEW_TABLE_COMPARE
-#: Merge.rc:5668
+#: Merge.rc:5667
 msgid "New Table Compare"
 msgstr "Nova Comparação de Tabelas"
 
 #. IDS_JUMPLIST_NEW_BINARY_COMPARE
-#: Merge.rc:5669
+#: Merge.rc:5668
 msgid "New Binary Compare"
 msgstr "Nova Comparação de Binários"
 
 #. IDS_JUMPLIST_NEW_IMAGE_COMPARE
-#: Merge.rc:5670
+#: Merge.rc:5669
 msgid "New Image Compare"
 msgstr "Nova Comparação de Imagens"
 
 #. IDS_JUMPLIST_NEW_WEBPAGE_COMPARE
-#: Merge.rc:5671
+#: Merge.rc:5670
 msgid "New Webpage Compare"
 msgstr "Nova Comparação de Páginas da Web"
 
 #. IDS_JUMPLIST_NEW_FOLDER_COMPARE
-#: Merge.rc:5672
+#: Merge.rc:5671
 msgid "New Folder Compare"
 msgstr "Nova Comparação de Pastas"
 
 #. IDS_JUMPLIST_CLIPBOARD_COMPARE
-#: Merge.rc:5673
+#: Merge.rc:5672
 msgid "Clipboard Compare"
 msgstr "Comparação da Área de Transferência"
 
 #. IDS_PREVIEWBAR_PRINT
-#: Merge.rc:5678
+#: Merge.rc:5677
 msgid "&Print..."
 msgstr "&Imprimir..."
 
 #. IDS_PREVIEWBAR_PREVPAGE
-#: Merge.rc:5680
+#: Merge.rc:5679
 msgid "Pre&v Page"
 msgstr "&Página Anterior"
 
 #. IDS_PREVIEWBAR_TWOPAGE
-#: Merge.rc:5681
+#: Merge.rc:5680
 msgid "&Two Page"
 msgstr "&Duas Páginas"
 
 #. IDS_PREVIEWBAR_ONEPAGE
-#: Merge.rc:5682
+#: Merge.rc:5681
 msgid "&One Page"
 msgstr "&Uma Página"
 
 #. IDS_PREVIEWBAR_ZOOMIN
-#: Merge.rc:5683
+#: Merge.rc:5682
 msgid "Zoom &In"
 msgstr "&Ampliar"
 
 #. IDS_PREVIEWBAR_ZOOMOUT
-#: Merge.rc:5684
+#: Merge.rc:5683
 msgid "Zoom &Out"
 msgstr "&Reduzir"
 
 #. IDS_WEBPAGE_COMPARING
-#: Merge.rc:5690
+#: Merge.rc:5689
 msgid "Comparing..."
 msgstr "Comparando..."
 
 #. IDS_WEBPAGE_ZOOM
-#: Merge.rc:5691
+#: Merge.rc:5690
 msgid "Zoom:"
 msgstr "Zoom:"
 
 #. IDS_COPY_GRANULARITY_DIFFHUNK
-#: Merge.rc:5696
+#: Merge.rc:5695
 msgid "Diff hunk"
 msgstr "Bloco da diferenciação"
 
 #. IDS_COPY_GRANULARITY_INLINE
-#: Merge.rc:5697
+#: Merge.rc:5696
 msgid "Inline diff"
 msgstr "Diferenciação em linha"
 
 #. IDS_COPY_GRANULARITY_LINE
-#: Merge.rc:5698
+#: Merge.rc:5697
 msgid "Line"
 msgstr "Linha"
 
-#: Merge.rc:5699
+#: Merge.rc:5698
 msgid "Character"
 msgstr "Caracter"
 
 #. ID_MICE_PREVDIFF
-#: Merge.rc:5704
+#: Merge.rc:5703
 msgid "\nPrevious Difference (Alt+Up)\n(Right Button+Wheel Up)\n(Alt+Wheel Up)"
 msgstr "\nDiferença Anterior (Alt+para Cima)\n(Botão Direito+Rolagem para Cima)\n(Alt+Rolagem para Cima)"
 
 #. ID_MICE_NEXTDIFF
-#: Merge.rc:5705
+#: Merge.rc:5704
 msgid "\nNext Difference (Alt+Down)\n(Right Button+Wheel Down)\n(Alt+Wheel Down)"
 msgstr "\nDiferença Seguinte (Alt+para Baixo)\n(Botão Direito+Rolagem para Baixo)\n(Alt+Rolagem para Baixo)"
 
 #. ID_MICE_L2R
-#: Merge.rc:5706
+#: Merge.rc:5705
 msgid "\nCopy to Right (Alt+Right)\n(Right Button+Wheel Right)\n(Alt+Wheel Right)\n(Alt+Shift+Wheel Down)"
 msgstr "\nCopiar para a Direita (Alt+Direita)\n(Botão Direito+Rolagem para a Direita)\n(Alt+Rolagem para a Direita)\n(Alt+Shift+Rolagem para Baixo)"
 
 #. ID_MICE_R2L
-#: Merge.rc:5707
+#: Merge.rc:5706
 msgid "\nCopy to Left (Alt+Left)\n(Right Button+Wheel Left)\n(Alt+Wheel Left)\n(Alt+Shift+Wheel Up)"
 msgstr "\nCopiar para a Esquerda (Alt+Esquerda)\n(Botão Direito+Rolagem para a Esquerda)\n(Alt+Rolagem para a Esquerda)\n(Alt+Shift+Rolagem para Cima)"
 
 #. ID_MICE_L2RNEXT
-#: Merge.rc:5708
+#: Merge.rc:5707
 msgid "\nCopy to Right and Advance (Ctrl+Alt+Right)\n(Ctrl+Alt+Wheel Right)\n(Ctrl+Alt+Shift+Wheel Down)"
 msgstr "\nCopiar para a Direita e Avançar (Ctrl+Alt+Direita)\n(Ctrl+Alt+Rolagem para a Direita)\n(Ctrl+Alt+Shift+Rolagem para Baixo)"
 
 #. ID_MICE_R2LNEXT
-#: Merge.rc:5709
+#: Merge.rc:5708
 msgid "\nCopy to Left and Advance (Ctrl+Alt+Left)\n(Ctrl+Alt+Wheel Left)\n(Ctrl+Alt+Shift+Wheel Up)"
 msgstr "\nCopiar para a Esquerda e Avançar (Ctrl+Alt+Esquerda)\n(Ctrl+Alt+Rolagem para a Esquerda)\n(Ctrl+Alt+Shift+Rolagem para Cima)"
 
 #. IDS_LOG_COMPARING_2
-#: Merge.rc:5719
+#: Merge.rc:5718
 #, c-format
 msgid "Comparing %1 with %2"
 msgstr "Comparando %1 com %2"
 
 #. IDS_LOG_COMPARING_3
-#: Merge.rc:5720
+#: Merge.rc:5719
 #, c-format
 msgid "Comparing %1 with %2 and %3"
 msgstr "Comparando %1 com %2 e %3"
 
 #. IDS_LOG_COMPARE_COMPLETED
-#: Merge.rc:5721
+#: Merge.rc:5720
 msgid "Comparison completed"
 msgstr "Comparação completada"
 
 #. IDS_LOG_COMPARE_ERROR_2
-#: Merge.rc:5722
+#: Merge.rc:5721
 #, c-format
 msgid "Failed to compare %1 with %2: "
 msgstr "Falha ao comparar %1 com %2: "
 
 #. IDS_LOG_COMPARE_ERROR_3
-#: Merge.rc:5723
+#: Merge.rc:5722
 #, c-format
 msgid "Failed to compare %1 with %2 and %3: "
 msgstr "Falha ao comparar %1 com %2 e %3: "
 
 #. IDS_LOG_FILE_SAVED
-#: Merge.rc:5724
+#: Merge.rc:5723
 msgid "File saved"
 msgstr "Arquivo salvo"
 
 #. IDS_LOG_COPYING_FILES
-#: Merge.rc:5725
+#: Merge.rc:5724
 msgid "Copying files..."
 msgstr "Copiando arquivos..."
 
 #. IDS_LOG_MOVING_FILES
-#: Merge.rc:5726
+#: Merge.rc:5725
 msgid "Moving files..."
 msgstr "Movendo arquivos..."
 
 #. IDS_LOG_DELETING_FILES
-#: Merge.rc:5727
+#: Merge.rc:5726
 msgid "Deleting files..."
 msgstr "Excluindo arquivos..."
 
 #. IDS_LOG_RECYCLEBIN
-#: Merge.rc:5728
+#: Merge.rc:5727
 msgid "Recycle Bin"
 msgstr "Lixeira"
 
 #. IDS_LOG_PERMANENTLY_DELETED
-#: Merge.rc:5729
+#: Merge.rc:5728
 msgid "Permanently deleted"
 msgstr "Excluído(s) permanentemente"
 
 #. IDS_LOG_FILEOPERATION_COMPLETED
-#: Merge.rc:5730
+#: Merge.rc:5729
 msgid "File operation completed successfully"
 msgstr "Operação de arquivos completada com sucesso"
 
 #. IDS_LOG_FILEOPERATION_CANCELED
-#: Merge.rc:5731
+#: Merge.rc:5730
 msgid "File operation canceled"
 msgstr "Operação de arquivos cancelada"
 
 #. IDS_FILTER_ERROR_NO_ERROR
-#: Merge.rc:5736
+#: Merge.rc:5735
 msgid "No error"
 msgstr "Sem erro"
 
 #. IDS_FILTER_ERROR_EMPTY_EXPRESSION
-#: Merge.rc:5737
+#: Merge.rc:5736
 msgid "Filter expression is empty"
 msgstr "A expressão de filtro está vazia"
 
 #. IDS_FILTER_ERROR_UNKNOWN_CHAR
-#: Merge.rc:5738
+#: Merge.rc:5737
 msgid "Unknown character in filter expression"
 msgstr "Caracter desconhecido na expressão de filtro"
 
 #. IDS_FILTER_ERROR_UNTERMINATED_STRING
-#: Merge.rc:5739
+#: Merge.rc:5738
 msgid "Unterminated string literal"
 msgstr "Literal de string não terminado"
 
 #. IDS_FILTER_ERROR_SYNTAX_ERROR
-#: Merge.rc:5740
+#: Merge.rc:5739
 msgid "Syntax error in filter expression"
 msgstr "Erro de sintaxe na expressão de filtro"
 
 #. IDS_FILTER_ERROR_PARSE_FAILURE
-#: Merge.rc:5741
+#: Merge.rc:5740
 msgid "Failed to parse filter expression"
 msgstr "Falha ao analisar a expressão de filtro"
 
 #. IDS_FILTER_ERROR_INVALID_LITERAL
-#: Merge.rc:5742
+#: Merge.rc:5741
 msgid "Invalid literal value"
 msgstr "Valor de literal inválido"
 
 #. IDS_FILTER_ERROR_INVALID_REGULAR_EXPRESSION
-#: Merge.rc:5743
+#: Merge.rc:5742
 msgid "Invalid regular expression"
 msgstr "Expressão regular inválida"
 
 #. IDS_FILTER_ERROR_UNDEFINED_IDENTIFIER
-#: Merge.rc:5744
+#: Merge.rc:5743
 msgid "Undefined identifier"
 msgstr "Identificador indefinido"
 
 #. IDS_FILTER_ERROR_INVALID_ARGUMENT_COUNT
-#: Merge.rc:5745
+#: Merge.rc:5744
 msgid "Invalid number of arguments"
 msgstr "Número de argumentos inválido"
 
 #. IDS_FILTER_ERROR_FILTER_NAME_NOT_FOUND
-#: Merge.rc:5746
+#: Merge.rc:5745
 msgid "Filter name not found"
 msgstr "Nome de filtro não encontrado"
 
 #. IDS_FILTER_ERROR_DIVIDE_BY_ZERO
-#: Merge.rc:5747
+#: Merge.rc:5746
 msgid "Division by zero in filter expression"
 msgstr "Divisão por zero na expressão de filtro"
 
 #. IDS_FILTER_ERROR_UNKNOWN_ERROR
-#: Merge.rc:5748
+#: Merge.rc:5747
 msgid "Unknown error"
 msgstr "Erro desconhecido"
 
 #. IDS_FILTER_ERROR_INVALID_PROPERTY_NAME
-#: Merge.rc:5749
+#: Merge.rc:5748
 msgid "Invalid property name"
 msgstr "Nome de propriedade inválido"
 
 #. IDS_FILTER_ERROR_INVALID_DIRECTIVE
-#: Merge.rc:5750
+#: Merge.rc:5749
 msgid "Invalid directive"
 msgstr "Diretiva inválida"
 
 #. IDS_FILTER_OP_EQUALS
-#: Merge.rc:5755
+#: Merge.rc:5754
 msgid "Equals"
 msgstr "Igual a"
 
 #. IDS_FILTER_OP_NOT_EQUALS
-#: Merge.rc:5756
+#: Merge.rc:5755
 msgid "Does not equal"
 msgstr "Não é igual a"
 
 #. IDS_FILTER_OP_LESS_THAN
-#: Merge.rc:5757
+#: Merge.rc:5756
 msgid "Less than"
 msgstr "Menor que"
 
 #. IDS_FILTER_OP_LESS_EQUAL
-#: Merge.rc:5758
+#: Merge.rc:5757
 msgid "Less than or equal to"
 msgstr "Menor que ou igual a"
 
 #. IDS_FILTER_OP_GREATER_EQUAL
-#: Merge.rc:5759
+#: Merge.rc:5758
 msgid "Greater than or equal to"
 msgstr "Maior que ou igual a"
 
 #. IDS_FILTER_OP_GREATER_THAN
-#: Merge.rc:5760
+#: Merge.rc:5759
 msgid "Greater than"
 msgstr "Maior que"
 
 #. IDS_FILTER_OP_BETWEEN
-#: Merge.rc:5761
+#: Merge.rc:5760
 msgid "Between"
 msgstr "Entre"
 
 #. IDS_FILTER_OP_NOT_BETWEEN
-#: Merge.rc:5762
+#: Merge.rc:5761
 msgid "Not Between"
 msgstr "Não Entre"
 
 #. IDS_FILTER_OP_CONTAINS
-#: Merge.rc:5763
+#: Merge.rc:5762
 msgid "Contains"
 msgstr "Contém"
 
 #. IDS_FILTER_OP_NOT_CONTAINS
-#: Merge.rc:5764
+#: Merge.rc:5763
 msgid "Not Contains"
 msgstr "Não Contém"
 
 #. IDS_FILTER_OP_RECONTAINS
-#: Merge.rc:5765
+#: Merge.rc:5764
 msgid "Contains (regex)"
 msgstr "Contém (regex)"
 
 #. IDS_FILTER_OP_NOT_RECONTAINS
-#: Merge.rc:5766
+#: Merge.rc:5765
 msgid "Not Contains (regex)"
 msgstr "Não Contém (regex)"
 
 #. IDS_FILTER_OP_LIKE
-#: Merge.rc:5767
+#: Merge.rc:5766
 msgid "Match (wildcard)"
 msgstr "Correspondência (curinga)"
 
 #. IDS_FILTER_OP_NOT_LIKE
-#: Merge.rc:5768
+#: Merge.rc:5767
 msgid "Not match (wildcard)"
 msgstr "Sem correspondência (curinga)"
 
 #. IDS_FILTER_OP_MATCHES
-#: Merge.rc:5769
+#: Merge.rc:5768
 msgid "Match (regex)"
 msgstr "Correspondência (regex)"
 
 #. IDS_FILTER_OP_NOT_MATCHES
-#: Merge.rc:5770
+#: Merge.rc:5769
 msgid "Not match (regex)"
 msgstr "Sem correspondência (regex)"
 
 #. IDS_COLORMODE_LIGHT
-#: Merge.rc:5775
+#: Merge.rc:5774
 msgid "Light"
 msgstr "Claro"
 
 #. IDS_COLORMODE_DARK
-#: Merge.rc:5776
+#: Merge.rc:5775
 msgid "Dark"
 msgstr "Escuro"
 
 #. IDS_COLORMODE_FOLLOWSYSTEM
-#: Merge.rc:5777
+#: Merge.rc:5776
 msgid "Follow system"
 msgstr "Seguir o sistema"
 
 #. IDS_EXAMPLE
-#: Merge.rc:5782
+#: Merge.rc:5781
 #, c-format
 msgid "e.g. %1"
 msgstr "p.ex. %1"
 
 #. IDS_DETECTED_PREVIOUS_CRASH
-#: Merge.rc:5787
+#: Merge.rc:5786
 msgid "WinMerge detected a previous crash. Please report this if possible."
 msgstr "O WinMerge detectou uma falha anterior. Por favor, relate isso se possível."
 
 #. IDS_REGEX_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5792
+#: Merge.rc:5791
 msgid "# Regex replacement list\r\n# Format: regex<TAB>replacement\r\n# Backreferences like $1, $2 are supported\r\n\r\n(\\d{4})-(\\d{2})-(\\d{2})\t$1_$2_$3\r\n"
 msgstr "# Lista de substituição de regex\r\n# Formato: regex<TAB>substituição\r\n# Referências anteriores como $1, $2 são suportadas\r\n\r\n(\\d{4})-(\\d{2})-(\\d{2})\t$1_$2_$3\r\n"
 
 #. IDS_STRING_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5793
+#: Merge.rc:5792
 msgid "# Replacement list\r\n# Format: search<TAB>replacement\r\n# Lines starting with # are ignored\r\n\r\nfrom1\tto1\r\nfrom2\tto2\r\n"
 msgstr "# Lista de substituição\r\n# Formato: busca<TAB>substituição\r\n# Linhas começando com # são ignoradas\r\n\r\nde1\tpara1\r\nde2\tpara2\r\n"
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_ONLY
-#: Merge.rc:5798
+#: Merge.rc:5797
 msgid "Built-in only"
 msgstr "Integrado apenas"
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_FIRST
-#: Merge.rc:5799
+#: Merge.rc:5798
 msgid "Built-in first"
 msgstr "Integrado primeiro"
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_FIRST
-#: Merge.rc:5800
+#: Merge.rc:5799
 msgid "Tree-sitter first"
 msgstr "Tree-sitter primeiro"
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_ONLY
-#: Merge.rc:5801
+#: Merge.rc:5800
 msgid "Tree-sitter only"
 msgstr "Tree-sitter apenas"
 

--- a/Translations/WinMerge/Bulgarian.po
+++ b/Translations/WinMerge/Bulgarian.po
@@ -20,7 +20,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 #. LANGUAGE, SUBLANGUAGE
-#: Merge.rc:26 Merge.rc:59 Merge.rc:5818
+#: Merge.rc:26 Merge.rc:59 Merge.rc:5817
 msgid "LANG_ENGLISH, SUBLANG_ENGLISH_US"
 msgstr "LANG_BULGARIAN, SUBLANG_DEFAULT"
 
@@ -162,7 +162,7 @@ msgstr "&Скриптове"
 #. IDS_NO_EDIT_SCRIPTS
 #: Merge.rc:127 Merge.rc:352 Merge.rc:463 Merge.rc:673 Merge.rc:678
 #: Merge.rc:887 Merge.rc:899 Merge.rc:906 Merge.rc:963 Merge.rc:1210
-#: Merge.rc:5375
+#: Merge.rc:5374
 msgid "< Empty >"
 msgstr "<празно>"
 
@@ -227,7 +227,7 @@ msgid "Auto-Fit All Columns"
 msgstr "Автоматично побиране на колоните"
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN
-#: Merge.rc:153 Merge.rc:5646
+#: Merge.rc:153 Merge.rc:5645
 msgid "&Filter by This Column"
 msgstr ""
 
@@ -288,7 +288,7 @@ msgid "&Previous Page"
 msgstr "&Предишна страница"
 
 #. IDS_PREVIEWBAR_NEXTPAGE
-#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5679
+#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5678
 msgid "&Next Page"
 msgstr "&Следваща страница"
 
@@ -539,7 +539,7 @@ msgstr "&Двоични файлове"
 #. IDS_IMAGE_MENU
 #: Merge.rc:329 Merge.rc:338 Merge.rc:432 Merge.rc:441 Merge.rc:609
 #: Merge.rc:618 Merge.rc:670 Merge.rc:960 Merge.rc:1187 Merge.rc:1200
-#: Merge.rc:5477
+#: Merge.rc:5476
 msgid "&Image"
 msgstr "&Изображения"
 
@@ -661,7 +661,7 @@ msgid "&Huge"
 msgstr "&Огромен"
 
 #. IDS_VIEW_MENU_BAR
-#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5714
+#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5713
 msgid "Men&u Bar"
 msgstr "&Лента с менюто"
 
@@ -1316,7 +1316,7 @@ msgid "Lo&cation Pane"
 msgstr "Миниатюрна &карта"
 
 #. IDS_OUTPUTBAR_CAPTION
-#: Merge.rc:782 Merge.rc:5252
+#: Merge.rc:782 Merge.rc:5251
 msgid "Output Pane"
 msgstr "Панел за извеждане на съдържание"
 
@@ -1579,55 +1579,55 @@ msgid "Co&mpare As"
 msgstr "С&равняване като"
 
 #. IDS_COPY_LEFT_TO_MIDDLE2
-#: Merge.rc:968 Merge.rc:980 Merge.rc:4852
+#: Merge.rc:968 Merge.rc:980 Merge.rc:4851
 #, c-format
 msgid "Left to Middle (%1 of %2)"
 msgstr "Ляв със среден (%1 от %2)"
 
 #. IDS_COPY_LEFT_TO_RIGHT2
-#: Merge.rc:969 Merge.rc:981 Merge.rc:4851
+#: Merge.rc:969 Merge.rc:981 Merge.rc:4850
 #, c-format
 msgid "Left to Right (%1 of %2)"
 msgstr "Ляв с десен (%1 от %2)"
 
 #. IDS_MOVE_LEFT_TO2
-#: Merge.rc:970 Merge.rc:982 Merge.rc:1045 Merge.rc:4863 Merge.rc:4892
+#: Merge.rc:970 Merge.rc:982 Merge.rc:1045 Merge.rc:4862 Merge.rc:4891
 #, c-format
 msgid "Left to... (%1 of %2)"
 msgstr "Ляв с… (%1 от %2)"
 
 #. IDS_COPY_MIDDLE_TO_LEFT2
-#: Merge.rc:971 Merge.rc:983 Merge.rc:4849
+#: Merge.rc:971 Merge.rc:983 Merge.rc:4848
 #, c-format
 msgid "Middle to Left (%1 of %2)"
 msgstr "Среден с ляв (%1 от %2)"
 
 #. IDS_COPY_MIDDLE_TO_RIGHT2
-#: Merge.rc:972 Merge.rc:984 Merge.rc:4850
+#: Merge.rc:972 Merge.rc:984 Merge.rc:4849
 #, c-format
 msgid "Middle to Right (%1 of %2)"
 msgstr "Среден с десен (%1 от %2)"
 
 #. IDS_MOVE_MIDDLE_TO2
-#: Merge.rc:973 Merge.rc:985 Merge.rc:1046 Merge.rc:4864 Merge.rc:4893
+#: Merge.rc:973 Merge.rc:985 Merge.rc:1046 Merge.rc:4863 Merge.rc:4892
 #, c-format
 msgid "Middle to... (%1 of %2)"
 msgstr "Среден с… (%1 от %2)"
 
 #. IDS_COPY_RIGHT_TO_MIDDLE2
-#: Merge.rc:974 Merge.rc:986 Merge.rc:4848
+#: Merge.rc:974 Merge.rc:986 Merge.rc:4847
 #, c-format
 msgid "Right to Middle (%1 of %2)"
 msgstr "Десен със среден (%1 от %2)"
 
 #. IDS_COPY_RIGHT_TO_LEFT2
-#: Merge.rc:975 Merge.rc:987 Merge.rc:4847
+#: Merge.rc:975 Merge.rc:987 Merge.rc:4846
 #, c-format
 msgid "Right to Left (%1 of %2)"
 msgstr "Десен с ляв (%1 от %2)"
 
 #. IDS_MOVE_RIGHT_TO2
-#: Merge.rc:976 Merge.rc:988 Merge.rc:1047 Merge.rc:4865 Merge.rc:4894
+#: Merge.rc:976 Merge.rc:988 Merge.rc:1047 Merge.rc:4864 Merge.rc:4893
 #, c-format
 msgid "Right to... (%1 of %2)"
 msgstr "Десен с… (%1 от %2)"
@@ -1683,31 +1683,31 @@ msgid "Cop&y Paths"
 msgstr "Копиране на &пътищата"
 
 #. IDS_DEL_LEFT_FMT2
-#: Merge.rc:1026 Merge.rc:1035 Merge.rc:4880
+#: Merge.rc:1026 Merge.rc:1035 Merge.rc:4879
 #, c-format
 msgid "Left (%1 of %2)"
 msgstr "Ляв (%1 от %2)"
 
 #. IDS_DEL_MIDDLE_FMT2
-#: Merge.rc:1027 Merge.rc:1036 Merge.rc:4881
+#: Merge.rc:1027 Merge.rc:1036 Merge.rc:4880
 #, c-format
 msgid "Middle (%1 of %2)"
 msgstr "Среден (%1 от %2)"
 
 #. IDS_DEL_RIGHT_FMT2
-#: Merge.rc:1028 Merge.rc:1037 Merge.rc:4882
+#: Merge.rc:1028 Merge.rc:1037 Merge.rc:4881
 #, c-format
 msgid "Right (%1 of %2)"
 msgstr "Десен (%1 от %2)"
 
 #. IDS_DEL_BOTH_FMT2
-#: Merge.rc:1029 Merge.rc:1038 Merge.rc:4883
+#: Merge.rc:1029 Merge.rc:1038 Merge.rc:4882
 #, c-format
 msgid "Both (%1 of %2)"
 msgstr "Двата (%1 от %2)"
 
 #. IDS_DEL_ALL_FMT2
-#: Merge.rc:1030 Merge.rc:1039 Merge.rc:4888
+#: Merge.rc:1030 Merge.rc:1039 Merge.rc:4887
 #, c-format
 msgid "All (%1 of %2)"
 msgstr "Всички (%1 от %2)"
@@ -1733,19 +1733,19 @@ msgid "&Zip"
 msgstr "&Zip"
 
 #. IDS_COPY_BOTH_TO2
-#: Merge.rc:1048 Merge.rc:4866
+#: Merge.rc:1048 Merge.rc:4865
 #, c-format
 msgid "Both to... (%1 of %2)"
 msgstr "И двата… (%1 от %2)"
 
 #. IDS_COPY_ALL_TO2
-#: Merge.rc:1049 Merge.rc:4867
+#: Merge.rc:1049 Merge.rc:4866
 #, c-format
 msgid "All to... (%1 of %2)"
 msgstr "Всички към… (%1 от %2)"
 
 #. IDS_COPY_DIFFERENCES_TO2
-#: Merge.rc:1050 Merge.rc:4868
+#: Merge.rc:1050 Merge.rc:4867
 #, c-format
 msgid "Differences to... (%1 of %2)"
 msgstr "Различията към… (%1 от %2)"
@@ -1812,12 +1812,12 @@ msgstr "Настройки на разопаковчик"
 
 #. IDS_USERCHOICE_NONE
 #: Merge.rc:1088 Merge.rc:1094 Merge.rc:1836 Merge.rc:1840 Merge.rc:2031
-#: Merge.rc:2035 Merge.rc:5377
+#: Merge.rc:2035 Merge.rc:5376
 msgid "<None>"
 msgstr "<Няма>"
 
 #. IDS_USERCHOICE_AUTOMATIC
-#: Merge.rc:1089 Merge.rc:1095 Merge.rc:5378
+#: Merge.rc:1089 Merge.rc:1095 Merge.rc:5377
 msgid "<Automatic>"
 msgstr "<Автоматично>"
 
@@ -2747,12 +2747,12 @@ msgid "Text files only"
 msgstr ""
 
 #. IDS_EOL_NONE
-#: Merge.rc:1667 Merge.rc:1918 Merge.rc:5304
+#: Merge.rc:1667 Merge.rc:1918 Merge.rc:5303
 msgid "None"
 msgstr "Няма"
 
 #. IDS_EOL_MIXED
-#: Merge.rc:1668 Merge.rc:5299
+#: Merge.rc:1668 Merge.rc:5298
 msgid "Mixed"
 msgstr "Смесен"
 
@@ -3024,13 +3024,13 @@ msgstr ""
 
 #. IDS_DIFFERENT
 #: Merge.rc:1904 Merge.rc:1988 Merge.rc:2866 Merge.rc:3036 Merge.rc:3077
-#: Merge.rc:5058
+#: Merge.rc:5057
 msgid "Different"
 msgstr "Различни"
 
 #. IDS_IDENTICAL
 #: Merge.rc:1905 Merge.rc:1989 Merge.rc:2865 Merge.rc:3055 Merge.rc:3116
-#: Merge.rc:5048
+#: Merge.rc:5047
 msgid "Identical"
 msgstr "Еднакви"
 
@@ -3050,7 +3050,7 @@ msgid "Missing"
 msgstr ""
 
 #. IDS_MOVED
-#: Merge.rc:1910 Merge.rc:5076
+#: Merge.rc:1910 Merge.rc:5075
 msgid "Moved"
 msgstr ""
 
@@ -3786,7 +3786,7 @@ msgid "&Use custom system colors"
 msgstr ""
 
 #. IDS_PRPCAT_SYSTEM
-#: Merge.rc:2565 Merge.rc:4559 Merge.rc:4560 Merge.rc:5007
+#: Merge.rc:2565 Merge.rc:4559 Merge.rc:4560 Merge.rc:5006
 msgid "System"
 msgstr "Системни"
 
@@ -4186,7 +4186,7 @@ msgid "Items compared:"
 msgstr "Сравнени:"
 
 #. IDS_PREVIEWBAR_CLOSE
-#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5685
+#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5684
 msgid "&Close"
 msgstr "&Затваряне"
 
@@ -4809,7 +4809,7 @@ msgid "A&ppend timestamp"
 msgstr "Добавяне на времеви &маркер"
 
 #. IDS_CONFIRM_COPY_CAPTION
-#: Merge.rc:3214 Merge.rc:4915
+#: Merge.rc:3214 Merge.rc:4914
 msgid "Confirm Copy"
 msgstr "Потвърждаване на копиране"
 
@@ -5046,7 +5046,7 @@ msgid "&Character Set..."
 msgstr "Набор от &символи…"
 
 #. IDS_PRPCAT_IMAGE
-#: Merge.rc:3351 Merge.rc:4574 Merge.rc:5015
+#: Merge.rc:3351 Merge.rc:4574 Merge.rc:5014
 msgid "Image"
 msgstr "Изображения"
 
@@ -5439,7 +5439,7 @@ msgid "Project"
 msgstr "Проекти"
 
 #. IDS_COLHDR_NSDIFFS
-#: Merge.rc:4566 Merge.rc:4990
+#: Merge.rc:4566 Merge.rc:4989
 msgid "Differences"
 msgstr "Различия"
 
@@ -5581,12 +5581,12 @@ msgid "File Type"
 msgstr "Вид на файла"
 
 #. IDS_COLHDR_EXTENSION
-#: Merge.rc:4653 Merge.rc:4947
+#: Merge.rc:4653 Merge.rc:4946
 msgid "Extension"
 msgstr "Разширение"
 
 #. IDS_PRPCAT_MESSAGE
-#: Merge.rc:4659 Merge.rc:5019
+#: Merge.rc:4659 Merge.rc:5018
 msgid "Message"
 msgstr "Съобщение"
 
@@ -5626,7 +5626,7 @@ msgid "Hidden Items"
 msgstr "Скрити елементи"
 
 #. IDS_PLUGINSLIST_NAME
-#: Merge.rc:4680 Merge.rc:5311
+#: Merge.rc:4680 Merge.rc:5310
 msgid "Name"
 msgstr "Име"
 
@@ -5646,7 +5646,7 @@ msgid "[F] "
 msgstr "[Ф] "
 
 #. IDS_PLUGINSLIST_DESC
-#: Merge.rc:4684 Merge.rc:5313
+#: Merge.rc:4684 Merge.rc:5312
 msgid "Description"
 msgstr "Описание"
 
@@ -5814,155 +5814,150 @@ msgstr "Ред: %s  колона: %d/%d  знак: %d/%d"
 msgid "  Sel: %d | %d"
 msgstr "  Избр: %d | %d"
 
-#. IDS_MERGEMODE_MERGING
-#: Merge.rc:4734
-msgid "Merge"
-msgstr "Сливане"
-
 #. IDS_DIFF_NUMBER_STATUS_FMT
-#: Merge.rc:4735
+#: Merge.rc:4734
 #, c-format
 msgid "Difference %1 of %2"
 msgstr "Различие %1 от %2"
 
 #. IDS_NO_DIFF_SEL_FMT
-#: Merge.rc:4736
+#: Merge.rc:4735
 #, c-format
 msgid "%1 Differences Found"
 msgstr "%1 различия"
 
 #. IDS_1_DIFF_FOUND
-#: Merge.rc:4737
+#: Merge.rc:4736
 msgid "1 Difference Found"
 msgstr "1 различие"
 
 #. IDS_NO_ERR_SEL_FMT
-#: Merge.rc:4738
+#: Merge.rc:4737
 #, c-format
 msgid "%1 Errors Found"
 msgstr "%1 грешки"
 
 #. IDS_1_ERR_FOUND
-#: Merge.rc:4739
+#: Merge.rc:4738
 msgid "1 Error Found"
 msgstr "1 грешка"
 
 #. IDS_STATUSBAR_READONLY, Abbreviation from "Read Only"
-#: Merge.rc:4740
+#: Merge.rc:4739
 msgid "RO"
 msgstr "СЧ"
 
 #. IDS_DIRVIEW_STATUS_FMT_FOCUS
-#: Merge.rc:4746
+#: Merge.rc:4745
 #, c-format
 msgid "Item %1 of %2"
 msgstr "Елемент %1 от %2"
 
 #. IDS_DIRVIEW_STATUS_FMT_NOFOCUS
-#: Merge.rc:4747
+#: Merge.rc:4746
 #, c-format
 msgid "Items: %1"
 msgstr "Общо: %1"
 
 #. IDS_DIRVIEW_STATUS_COMPARING
-#: Merge.rc:4748
+#: Merge.rc:4747
 msgid "Comparing items..."
 msgstr "Сравняване на…"
 
 #. IDS_ITEMS_PER_SEC
-#: Merge.rc:4749
+#: Merge.rc:4748
 #, c-format
 msgid "%.1f[items/sec]"
 msgstr "%.1f[елемента/сек]"
 
 #. IDS_ERROR_INCOMPARABLE
-#: Merge.rc:4755
+#: Merge.rc:4754
 msgid "Select two existing folders/files to compare."
 msgstr "Изберете два съществуващи файла/папки, които да бъдат сравнени."
 
 #. IDS_DIRSEL_TAG
-#: Merge.rc:4756
+#: Merge.rc:4755
 msgid "Folder Selection"
 msgstr "Избор на папка"
 
 #. IDS_OPEN_FILESDIRS
-#: Merge.rc:4757
+#: Merge.rc:4756
 msgid "Select two (or three) folders/files to compare."
 msgstr "Изберете два (или три) съществуващи файла/папки, които да бъдат сравнени."
 
 #. IDS_OPEN_LEFTINVALID
-#: Merge.rc:4758
+#: Merge.rc:4757
 msgid "Left (1st) path is invalid!"
 msgstr "Левият (№1) път е недействителен!"
 
 #. IDS_OPEN_MIDDLEINVALID
-#: Merge.rc:4759
+#: Merge.rc:4758
 msgid "Middle (2nd) path is invalid!"
 msgstr "Средният (№2) път е недействителен!"
 
 #. IDS_OPEN_RIGHTINVALID2
-#: Merge.rc:4760
+#: Merge.rc:4759
 msgid "Right (2nd) path is invalid!"
 msgstr "Десният (№2) път е недействителен!"
 
 #. IDS_OPEN_RIGHTINVALID3
-#: Merge.rc:4761
+#: Merge.rc:4760
 msgid "Right (3rd) path is invalid!"
 msgstr "Десният (№3) път е недействителен!"
 
 #. IDS_OPEN_BOTHINVALID
-#: Merge.rc:4762
+#: Merge.rc:4761
 msgid "Both paths are invalid!"
 msgstr "Двата пътя са невалидни!"
 
-#: Merge.rc:4764
+#: Merge.rc:4763
 msgid "Left (1st) and Middle (2nd) paths are invalid!"
 msgstr "Левият (№1) и средният (№2) път са недействителни!"
 
 #. IDS_OPEN_LEFTRIGHTINVALID
-#: Merge.rc:4765
+#: Merge.rc:4764
 msgid "Left (1st) and Right (3rd) paths are invalid!"
 msgstr "Левият (№3) и десният (№3) път са недействителни!"
 
-#: Merge.rc:4767
+#: Merge.rc:4766
 msgid "Middle (2nd) and Right (3rd) paths are invalid!"
 msgstr "Средният (№2) и десният (№3) път са недействителни!"
 
 #. IDS_OPEN_ALLINVALID
-#: Merge.rc:4768
+#: Merge.rc:4767
 msgid "All paths are invalid!"
 msgstr "Всички пътища са недействителни!"
 
 #. IDS_OPEN_UNPACKERDISABLED
-#: Merge.rc:4769
+#: Merge.rc:4768
 msgid "Only enabled for file comparisons"
 msgstr "Разрешено само при сравняване на файлове"
 
 #. IDS_OPEN_MISMATCH
-#: Merge.rc:4770
+#: Merge.rc:4769
 msgid "Cannot compare file and folder!"
 msgstr "Не могат да бъдат сравнявани файлове с папки!"
 
 #. IDS_ERROR_FILE_NOT_FOUND
-#: Merge.rc:4776
+#: Merge.rc:4775
 #, c-format
 msgid "File not found: %1"
 msgstr "Не е намерен файла: %1"
 
 #. IDS_ERROR_FOLDER_NOT_FOUND
-#: Merge.rc:4777
+#: Merge.rc:4776
 #, c-format
 msgid "Folder not found: %1"
 msgstr ""
 
 #. IDS_ERROR_FILE_NOT_UNPACKED
-#: Merge.rc:4778
+#: Merge.rc:4777
 #, c-format
 msgid "File not unpacked: %1"
 msgstr "Не е разархивиран файла: %1"
 
 #. IDS_ERROR_FILEOPEN
-#: Merge.rc:4779
+#: Merge.rc:4778
 #, c-format
 msgid ""
 "Cannot open file\n"
@@ -5976,12 +5971,12 @@ msgstr ""
 "%2"
 
 #. IDS_ERROR_CONF_RESOLVE
-#: Merge.rc:4780
+#: Merge.rc:4779
 msgid "Failed to parse conflict file."
 msgstr "Грешка при разбора на файла с конфликти."
 
 #. IDS_NOT_CONFLICT_FILE
-#: Merge.rc:4781
+#: Merge.rc:4780
 #, c-format
 msgid ""
 "The file\n"
@@ -5993,7 +5988,7 @@ msgstr ""
 "не съдържа конфликти."
 
 #. IDS_COMPARE_LARGE_FILES
-#: Merge.rc:4782
+#: Merge.rc:4781
 msgid ""
 "Comparing large files requires significant memory.\n"
 "Show only comparison results (not file contents)?"
@@ -6002,28 +5997,28 @@ msgstr ""
 "Показване само на резултата от сравнението (без съдържанието)?"
 
 #. IDS_SAVE_AS_TITLE
-#: Merge.rc:4788
+#: Merge.rc:4787
 msgid "Save As"
 msgstr "Запазване като"
 
 #. IDS_SAVE_FMT
-#: Merge.rc:4789
+#: Merge.rc:4788
 #, c-format
 msgid "Save changes to %1?"
 msgstr "Запазване на промените на %1?"
 
 #. IDS_SAVEREADONLY_FMT
-#: Merge.rc:4790
+#: Merge.rc:4789
 #, c-format
 msgid "%1 is read-only. Override? Or 'No' to save as new filename?"
 msgstr "Файлът %1 е само за четене. Презаписване? При „Не“, ще бъде запазен под ново име."
 
 #. IDS_ERROR_BACKUP
-#: Merge.rc:4791
+#: Merge.rc:4790
 msgid "Error backing up file"
 msgstr "Грешка при създаване на резервно копие"
 
-#: Merge.rc:4793
+#: Merge.rc:4792
 #, c-format
 msgid ""
 "Unable to backup original file:\n"
@@ -6037,7 +6032,7 @@ msgstr ""
 "Продължаване?"
 
 #. IDS_FILESAVE_FAILED
-#: Merge.rc:4794
+#: Merge.rc:4793
 #, c-format
 msgid ""
 "Saving file failed.\n"
@@ -6052,7 +6047,7 @@ msgstr ""
 "\t- използване на различно име (изберете Добре)\n"
 "\t- отменяне текущото действие (изберете Отказ)?"
 
-#: Merge.rc:4796
+#: Merge.rc:4795
 #, c-format
 msgid ""
 "Plugin '%2' cannot pack changes to left file into '%1'.\n"
@@ -6063,7 +6058,7 @@ msgstr ""
 "\n"
 "Изходният файл няма да бъде променян. Запазване на непакетираната версия?"
 
-#: Merge.rc:4798
+#: Merge.rc:4797
 #, c-format
 msgid ""
 "Plugin '%2' cannot pack changes to middle file into '%1'.\n"
@@ -6074,7 +6069,7 @@ msgstr ""
 "\n"
 "Изходният файл няма да бъде променян. Запазване на непакетираната версия?"
 
-#: Merge.rc:4800
+#: Merge.rc:4799
 #, c-format
 msgid ""
 "Plugin '%2' cannot pack changes to right file into '%1'.\n"
@@ -6086,7 +6081,7 @@ msgstr ""
 "Изходният файл няма да бъде променян. Запазване на непакетираната версия?"
 
 #. IDS_FILECHANGED_ONDISK
-#: Merge.rc:4801
+#: Merge.rc:4800
 #, c-format
 msgid ""
 "Another application updated\n"
@@ -6102,7 +6097,7 @@ msgstr ""
 "Желаете ли файлът да бъде презаписан?"
 
 #. IDS_SAVEREADONLY_MULTI
-#: Merge.rc:4802
+#: Merge.rc:4801
 #, c-format
 msgid ""
 "%1\n"
@@ -6112,7 +6107,7 @@ msgstr ""
 "е само за четене. Презаписване?"
 
 #. IDS_FILECHANGED_RESCAN
-#: Merge.rc:4803
+#: Merge.rc:4802
 #, c-format
 msgid ""
 "Another application updated\n"
@@ -6128,22 +6123,22 @@ msgstr ""
 "Презареждане?"
 
 #. IDS_SAVE_LEFT_AS
-#: Merge.rc:4804
+#: Merge.rc:4803
 msgid "Save Left File As"
 msgstr "Запазване на левия файл като"
 
 #. IDS_SAVE_MIDDLE_AS
-#: Merge.rc:4805
+#: Merge.rc:4804
 msgid "Save Middle File As"
 msgstr "Запазване на средния файл като"
 
 #. IDS_SAVE_RIGHT_AS
-#: Merge.rc:4806
+#: Merge.rc:4805
 msgid "Save Right File As"
 msgstr "Запазване на десния файл като"
 
 #. IDS_FILE_DISAPPEARED
-#: Merge.rc:4811
+#: Merge.rc:4810
 #, c-format
 msgid ""
 "File\n"
@@ -6155,7 +6150,7 @@ msgstr ""
 "не е намерен. Запазете негово копие и продължете."
 
 #. IDS_VIEWS_OUTOFSYNC
-#: Merge.rc:4817
+#: Merge.rc:4816
 msgid ""
 "Cannot merge unsynched documents.\n"
 "\n"
@@ -6166,186 +6161,186 @@ msgstr ""
 "Презаредете документите преди да продължите."
 
 #. IDS_BREAK_ON_WHITESPACE
-#: Merge.rc:4822
+#: Merge.rc:4821
 msgid "Break at whitespace"
 msgstr "Пренасяне при интервали"
 
 #. IDS_BREAK_ON_PUNCTUATION
-#: Merge.rc:4823
+#: Merge.rc:4822
 msgid "Break at whitespace or punctuation"
 msgstr "Пренасяне при интервали или пунктуация"
 
 #. IDS_L2M
-#: Merge.rc:4829
+#: Merge.rc:4828
 msgid "Copy to &Middle\tAlt+Right"
 msgstr "Копиране в средата\tAlt+Right"
 
 #. IDS_R2M
-#: Merge.rc:4830
+#: Merge.rc:4829
 msgid "Copy to &Middle\tAlt+Left"
 msgstr "Копиране в средата\tAlt+Left"
 
 #. IDS_COPY_FROM_MIDDLE_R
-#: Merge.rc:4831
+#: Merge.rc:4830
 msgid "Copy from Middle\tAlt+Shift+Right"
 msgstr "Копиране oт средата\tAlt+Shift+Right"
 
 #. IDS_COPY_FROM_MIDDLE_L
-#: Merge.rc:4832
+#: Merge.rc:4831
 msgid "Copy from Middle\tAlt+Shift+Left"
 msgstr "Копиране oт средата\tAlt+Shift+Left"
 
 #. IDS_L2MNEXT
-#: Merge.rc:4833
+#: Merge.rc:4832
 msgid "Copy to Middle and Advance\tCtrl+Alt+Right"
 msgstr "Копиране в средата и продължаване\tCtrl+Alt+Right"
 
 #. IDS_R2MNEXT
-#: Merge.rc:4834
+#: Merge.rc:4833
 msgid "Copy to Middle and Advance\tCtrl+Alt+Left"
 msgstr "Копиране в средата и продължаване\tCtrl+Alt+Left"
 
 #. IDS_ALL_MIDDLE
-#: Merge.rc:4835
+#: Merge.rc:4834
 msgid "Copy All to Middle"
 msgstr "Копиране на всички в средата"
 
 #. IDS_COPY_RIGHT_TO_LEFT
-#: Merge.rc:4841
+#: Merge.rc:4840
 #, c-format
 msgid "Right to Left (%1)"
 msgstr "От дясно към ляво (%1)"
 
 #. IDS_COPY_RIGHT_TO_MIDDLE
-#: Merge.rc:4842
+#: Merge.rc:4841
 #, c-format
 msgid "Right to Middle (%1)"
 msgstr "От дясно към средно (%1)"
 
 #. IDS_COPY_MIDDLE_TO_LEFT
-#: Merge.rc:4843
+#: Merge.rc:4842
 #, c-format
 msgid "Middle to Left (%1)"
 msgstr "От средно към ляво (%1)"
 
 #. IDS_COPY_MIDDLE_TO_RIGHT
-#: Merge.rc:4844
+#: Merge.rc:4843
 #, c-format
 msgid "Middle to Right (%1)"
 msgstr "От средно към дясно (%1)"
 
 #. IDS_COPY_LEFT_TO_RIGHT
-#: Merge.rc:4845
+#: Merge.rc:4844
 #, c-format
 msgid "Left to Right (%1)"
 msgstr "От ляво към дясно (%1)"
 
 #. IDS_COPY_LEFT_TO_MIDDLE
-#: Merge.rc:4846
+#: Merge.rc:4845
 #, c-format
 msgid "Left to Middle (%1)"
 msgstr "От ляво към средно (%1)"
 
 #. IDS_MOVE_LEFT_TO
-#: Merge.rc:4857 Merge.rc:4889
+#: Merge.rc:4856 Merge.rc:4888
 #, c-format
 msgid "Left to... (%1)"
 msgstr "Ляво към… (%1)"
 
 #. IDS_MOVE_MIDDLE_TO
-#: Merge.rc:4858 Merge.rc:4890
+#: Merge.rc:4857 Merge.rc:4889
 #, c-format
 msgid "Middle to... (%1)"
 msgstr "Средно към… (%1)"
 
 #. IDS_MOVE_RIGHT_TO
-#: Merge.rc:4859 Merge.rc:4891
+#: Merge.rc:4858 Merge.rc:4890
 #, c-format
 msgid "Right to... (%1)"
 msgstr "Дясно към… (%1)"
 
 #. IDS_COPY_BOTH_TO
-#: Merge.rc:4860
+#: Merge.rc:4859
 #, c-format
 msgid "Both to... (%1)"
 msgstr "Двете към… (%1)"
 
 #. IDS_COPY_ALL_TO
-#: Merge.rc:4861
+#: Merge.rc:4860
 #, c-format
 msgid "All to... (%1)"
 msgstr "Всички към… (%1)"
 
 #. IDS_COPY_DIFFERENCES_TO
-#: Merge.rc:4862
+#: Merge.rc:4861
 #, c-format
 msgid "Differences to... (%1)"
 msgstr "Различия към… (%1)"
 
 #. IDS_ONLYDIFFITEMS_CONFIRM
-#: Merge.rc:4869
+#: Merge.rc:4868
 msgid "Some selected items are identical or skipped.\nProcess only items with differences?"
 msgstr ""
 
 #. IDS_DEL_LEFT_FMT
-#: Merge.rc:4875
+#: Merge.rc:4874
 #, c-format
 msgid "Left (%1)"
 msgstr "Ляво (%1)"
 
 #. IDS_DEL_MIDDLE_FMT
-#: Merge.rc:4876
+#: Merge.rc:4875
 #, c-format
 msgid "Middle (%1)"
 msgstr "Средно (%1)"
 
 #. IDS_DEL_RIGHT_FMT
-#: Merge.rc:4877
+#: Merge.rc:4876
 #, c-format
 msgid "Right (%1)"
 msgstr "Дясно (%1)"
 
 #. IDS_DEL_BOTH_FMT
-#: Merge.rc:4878
+#: Merge.rc:4877
 #, c-format
 msgid "Both (%1)"
 msgstr "Двете (%1)"
 
 #. IDS_DEL_ALL_FMT
-#: Merge.rc:4879
+#: Merge.rc:4878
 #, c-format
 msgid "All (%1)"
 msgstr "Всички (%1)"
 
 #. IDS_SELECT_DEST_LEFT
-#: Merge.rc:4895
+#: Merge.rc:4894
 msgid "Left Side - Select Destination Folder:"
 msgstr "Лява част - изберете целева папка:"
 
 #. IDS_SELECT_DEST_MIDDLE
-#: Merge.rc:4896
+#: Merge.rc:4895
 msgid "Middle Side - Select Destination Folder:"
 msgstr "Средна част - изберете целева папка:"
 
 #. IDS_SELECT_DEST_RIGHT
-#: Merge.rc:4897
+#: Merge.rc:4896
 msgid "Right Side - Select Destination Folder:"
 msgstr "Дясна част - изберете целева папка:"
 
 #. IDS_FILES_AFFECTED_FMT
-#: Merge.rc:4898
+#: Merge.rc:4897
 #, c-format
 msgid "(%1 Files Affected)"
 msgstr "(%1 Файла засегнати)"
 
 #. IDS_FILES_AFFECTED_FMT2
-#: Merge.rc:4899
+#: Merge.rc:4898
 #, c-format
 msgid "(%1 of %2 Files Affected)"
 msgstr "(%1 от %2 файла засегнати)"
 
 #. IDS_CONFIRM_DELETE_SINGLE
-#: Merge.rc:4905
+#: Merge.rc:4904
 #, c-format
 msgid ""
 "Are you sure you want to delete\n"
@@ -6357,18 +6352,18 @@ msgstr ""
 "%1 ?"
 
 #. IDS_CONFIRM_SINGLE_COPY
-#: Merge.rc:4906
+#: Merge.rc:4905
 msgid "Are you sure you want to copy?"
 msgstr "Искате ли да копирате?"
 
 #. IDS_CONFIRM_MULTIPLE_COPY
-#: Merge.rc:4907
+#: Merge.rc:4906
 #, c-format
 msgid "Are you sure you want to copy %d items?"
 msgstr "Искате ли да копирате %d елементи?"
 
 #. IDS_DIRCMP_NOTSYNC
-#: Merge.rc:4908
+#: Merge.rc:4907
 #, c-format
 msgid ""
 "Operation aborted!\n"
@@ -6388,792 +6383,792 @@ msgstr ""
 "Презаредете, за да бъде извършено сравняване."
 
 #. IDS_CONFIRM_SINGLE_MOVE
-#: Merge.rc:4913
+#: Merge.rc:4912
 msgid "Are you sure you want to move?"
 msgstr "Наистина ли искате да преместите?"
 
 #. IDS_CONFIRM_MULTIPLE_MOVE
-#: Merge.rc:4914
+#: Merge.rc:4913
 #, c-format
 msgid "Are you sure you want to move %d items?"
 msgstr "Наистина ли искате да преместите %d елемента?"
 
 #. IDS_CONFIRM_MOVE_CAPTION
-#: Merge.rc:4916
+#: Merge.rc:4915
 msgid "Confirm Move"
 msgstr "Потвърдете преместването"
 
-#: Merge.rc:4918
+#: Merge.rc:4917
 msgid "Close the folder comparison window?"
 msgstr "Затваряне на прозореца за сравняване на папки?"
 
-#: Merge.rc:4920
+#: Merge.rc:4919
 msgid "Close the folder comparison window, which took a long time?"
 msgstr "Затваряне на прозореца за сравняване на папки, което е отнело много време?"
 
 #. IDS_ERROR_INVALID_DIR_FILE_NAME
-#: Merge.rc:4921
+#: Merge.rc:4920
 msgid "The file or folder name is invalid."
 msgstr "Името на файла или папката е недействително."
 
 #. IDS_ERROR_EXECUTE_FILE
-#: Merge.rc:4927
+#: Merge.rc:4926
 #, c-format
 msgid "Failed to execute external editor: %1"
 msgstr "Външният редактор не може да стартира: %1"
 
 #. IDS_UNKNOWN_ARCHIVE_FORMAT
-#: Merge.rc:4933
+#: Merge.rc:4932
 msgid "Unknown archive format"
 msgstr "Непознат архив"
 
-#: Merge.rc:4935
+#: Merge.rc:4934
 msgid ""
 "Failed to extract archive.\n"
 "Compare as text file?"
 msgstr ""
 
 #. IDS_COLHDR_FILENAME
-#: Merge.rc:4941
+#: Merge.rc:4940
 msgid "Filename"
 msgstr "Име"
 
 #. IDS_COLHDR_DIR
-#: Merge.rc:4942
+#: Merge.rc:4941
 msgctxt "DirView|ColumnHeader"
 msgid "Folder"
 msgstr "Папка"
 
 #. IDS_COLHDR_RESULT
-#: Merge.rc:4943
+#: Merge.rc:4942
 msgid "Comparison Result"
 msgstr "Резултати при сравняване"
 
 #. IDS_COLHDR_LTIMEM
-#: Merge.rc:4944
+#: Merge.rc:4943
 msgid "Left Date"
 msgstr "Дата ляво"
 
 #. IDS_COLHDR_RTIMEM
-#: Merge.rc:4945
+#: Merge.rc:4944
 msgid "Right Date"
 msgstr "Дата дясно"
 
 #. IDS_COLHDR_MTIMEM
-#: Merge.rc:4946
+#: Merge.rc:4945
 msgid "Middle Date"
 msgstr "Дата средата"
 
 #. IDS_COLHDR_LSIZE
-#: Merge.rc:4948
+#: Merge.rc:4947
 msgid "Left Size"
 msgstr "Размер ляво"
 
 #. IDS_COLHDR_RSIZE
-#: Merge.rc:4949
+#: Merge.rc:4948
 msgid "Right Size"
 msgstr "Размер дясно"
 
 #. IDS_COLHDR_MSIZE
-#: Merge.rc:4954
+#: Merge.rc:4953
 msgid "Middle Size"
 msgstr "Размер средата"
 
 #. IDS_COLHDR_RSIZE_SHORT
-#: Merge.rc:4955
+#: Merge.rc:4954
 msgid "Right Size (Short)"
 msgstr "Размер дясно (кратък)"
 
 #. IDS_COLHDR_LSIZE_SHORT
-#: Merge.rc:4956
+#: Merge.rc:4955
 msgid "Left Size (Short)"
 msgstr "Размер ляво (кратък)"
 
 #. IDS_COLHDR_MSIZE_SHORT
-#: Merge.rc:4957
+#: Merge.rc:4956
 msgid "Middle Size (Short)"
 msgstr "Размер средата (кратък)"
 
 #. IDS_COLHDR_LTIMEC
-#: Merge.rc:4963
+#: Merge.rc:4962
 msgid "Left Creation Time"
 msgstr "Дата на създаване ляво"
 
 #. IDS_COLHDR_RTIMEC
-#: Merge.rc:4964
+#: Merge.rc:4963
 msgid "Right Creation Time"
 msgstr "Дата на създаване дясно"
 
 #. IDS_COLHDR_MTIMEC
-#: Merge.rc:4965
+#: Merge.rc:4964
 msgid "Middle Creation Time"
 msgstr "Дата на създаване средата"
 
 #. IDS_COLHDR_NEWER
-#: Merge.rc:4966
+#: Merge.rc:4965
 msgid "Newer File"
 msgstr "По-нов файл"
 
 #. IDS_COLHDR_LVERSION
-#: Merge.rc:4967
+#: Merge.rc:4966
 msgid "Left File Version"
 msgstr "Версия ляв файл"
 
 #. IDS_COLHDR_RVERSION
-#: Merge.rc:4968
+#: Merge.rc:4967
 msgid "Right File Version"
 msgstr "Версия десен файл"
 
 #. IDS_COLHDR_MVERSION
-#: Merge.rc:4969
+#: Merge.rc:4968
 msgid "Middle File Version"
 msgstr "Версия среден файл"
 
 #. IDS_COLHDR_RESULT_ABBR
-#: Merge.rc:4970
+#: Merge.rc:4969
 msgid "Short Result"
 msgstr "Бързи резултати"
 
 #. IDS_COLHDR_LATTRIBUTES
-#: Merge.rc:4971
+#: Merge.rc:4970
 msgid "Left Attributes"
 msgstr "Атрибути ляво"
 
 #. IDS_COLHDR_RATTRIBUTES
-#: Merge.rc:4972
+#: Merge.rc:4971
 msgid "Right Attributes"
 msgstr "Атрибути дясно"
 
 #. IDS_COLHDR_MATTRIBUTES
-#: Merge.rc:4973
+#: Merge.rc:4972
 msgid "Middle Attributes"
 msgstr "Атрибути средата"
 
 #. IDS_COLHDR_LEOL_TYPE
-#: Merge.rc:4978
+#: Merge.rc:4977
 msgid "Left EOL"
 msgstr "Знак за нов ред ляво"
 
 #. IDS_COLHDR_MEOL_TYPE
-#: Merge.rc:4979
+#: Merge.rc:4978
 msgid "Middle EOL"
 msgstr "Знак за нов ред средата"
 
 #. IDS_COLHDR_REOL_TYPE
-#: Merge.rc:4980
+#: Merge.rc:4979
 msgid "Right EOL"
 msgstr "Знак за нов ред дясно"
 
 #. IDS_COLHDR_LENCODING
-#: Merge.rc:4986
+#: Merge.rc:4985
 msgid "Left Encoding"
 msgstr "Кодиравка ляво"
 
 #. IDS_COLHDR_RENCODING
-#: Merge.rc:4987
+#: Merge.rc:4986
 msgid "Right Encoding"
 msgstr "Кодиравка дясно"
 
 #. IDS_COLHDR_MENCODING
-#: Merge.rc:4988
+#: Merge.rc:4987
 msgid "Middle Encoding"
 msgstr "Кодиравка средата"
 
 #. IDS_COLHDR_NIDIFFS
-#: Merge.rc:4989
+#: Merge.rc:4988
 msgid "Ignored Diff"
 msgstr "Пренебрегнати различия"
 
 #. IDS_COLHDR_BINARY
-#: Merge.rc:4991
+#: Merge.rc:4990
 msgctxt "DirView|ColumnHeader"
 msgid "Binary"
 msgstr "Двоичен"
 
 #. IDS_PLUGINS_TYPE_UNPACKER
-#: Merge.rc:4992 Merge.rc:5314
+#: Merge.rc:4991 Merge.rc:5313
 msgid "Unpacker"
 msgstr "Разопаковчик"
 
 #. IDS_PLUGIN_TYPE4
-#: Merge.rc:4993 Merge.rc:5315 Merge.rc:5622
+#: Merge.rc:4992 Merge.rc:5314 Merge.rc:5621
 msgid "Prediffer"
 msgstr ""
 
 #. IDS_COLHDR_LEFT
-#: Merge.rc:4994
+#: Merge.rc:4993
 msgid "Left"
 msgstr ""
 
 #. IDS_COLHDR_MIDDLE
-#: Merge.rc:4995
+#: Merge.rc:4994
 msgid "Middle"
 msgstr ""
 
 #. IDS_COLHDR_RIGHT
-#: Merge.rc:4996
+#: Merge.rc:4995
 msgid "Right"
 msgstr ""
 
 #. IDS_COLHDR_DIFF
-#: Merge.rc:4997
+#: Merge.rc:4996
 msgid "Diff"
 msgstr ""
 
 #. IDS_COLHDR_LEFT_DUPLICATE
-#: Merge.rc:4998
+#: Merge.rc:4997
 msgid "Left Duplicate Count"
 msgstr ""
 
 #. IDS_COLHDR_RIGHT_DUPLICATE
-#: Merge.rc:4999
+#: Merge.rc:4998
 msgid "Right Duplicate Count"
 msgstr ""
 
 #. IDS_COLHDR_MIDDLE_DUPLICATE
-#: Merge.rc:5000
+#: Merge.rc:4999
 msgid "Middle Duplicate Count"
 msgstr ""
 
 #. IDS_COLHDR_MOVE
-#: Merge.rc:5001
+#: Merge.rc:5000
 msgid "Move"
 msgstr "Преместване"
 
 #. IDS_PRPCAT_AUDIO
-#: Merge.rc:5008
+#: Merge.rc:5007
 msgid "Audio"
 msgstr "Аудио"
 
 #. IDS_PRPCAT_CALENDAR
-#: Merge.rc:5009
+#: Merge.rc:5008
 msgid "Calendar"
 msgstr "Календар"
 
 #. IDS_PRPCAT_COMMUNICATION
-#: Merge.rc:5010
+#: Merge.rc:5009
 msgid "Communication"
 msgstr "Разговори"
 
 #. IDS_PRPCAT_CONTACT
-#: Merge.rc:5011
+#: Merge.rc:5010
 msgid "Contact"
 msgstr "Контакт"
 
 #. IDS_PRPCAT_DEVICES
-#: Merge.rc:5012
+#: Merge.rc:5011
 msgid "Devices"
 msgstr "Устройства"
 
 #. IDS_PRPCAT_DOCUMENT
-#: Merge.rc:5013
+#: Merge.rc:5012
 msgid "Document"
 msgstr "Документ"
 
 #. IDS_PRPCAT_HOME
-#: Merge.rc:5014
+#: Merge.rc:5013
 msgid "Home"
 msgstr "Дом"
 
 #. IDS_PRPCAT_JOURNAL
-#: Merge.rc:5016
+#: Merge.rc:5015
 msgid "Journal"
 msgstr "Дневник"
 
 #. IDS_PRPCAT_LINK
-#: Merge.rc:5017
+#: Merge.rc:5016
 msgid "Link"
 msgstr "Препратка"
 
 #. IDS_PRPCAT_MEDIA
-#: Merge.rc:5018
+#: Merge.rc:5017
 msgid "Media"
 msgstr "Медия"
 
 #. IDS_PRPCAT_MUSIC
-#: Merge.rc:5020
+#: Merge.rc:5019
 msgid "Music"
 msgstr "Музика"
 
 #. IDS_PRPCAT_NOTE
-#: Merge.rc:5021
+#: Merge.rc:5020
 msgid "Note"
 msgstr "Бележка"
 
 #. IDS_PRPCAT_PHOTO
-#: Merge.rc:5022
+#: Merge.rc:5021
 msgid "Photo"
 msgstr "Снимка"
 
 #. IDS_PRPCAT_RECORDEDTV
-#: Merge.rc:5023
+#: Merge.rc:5022
 msgid "RecordedTV"
 msgstr "Запис"
 
 #. IDS_PRPCAT_SEARCH
-#: Merge.rc:5024
+#: Merge.rc:5023
 msgid "Search"
 msgstr "Търсене"
 
 #. IDS_PRPCAT_SECURITY
-#: Merge.rc:5025
+#: Merge.rc:5024
 msgid "Security"
 msgstr "Сигурност"
 
 #. IDS_PRPCAT_SOFTWARE
-#: Merge.rc:5026
+#: Merge.rc:5025
 msgid "Software"
 msgstr "Софтуер"
 
 #. IDS_PRPCAT_TASK
-#: Merge.rc:5027
+#: Merge.rc:5026
 msgid "Task"
 msgstr "Задача"
 
 #. IDS_PRPCAT_VIDEO
-#: Merge.rc:5028
+#: Merge.rc:5027
 msgid "Video"
 msgstr "Видео"
 
 #. IDS_PRPCAT_HASH
-#: Merge.rc:5029
+#: Merge.rc:5028
 msgid "Hash"
 msgstr "Цифров отпечатък"
 
 #. IDS_CANT_COMPARE_FILES
-#: Merge.rc:5035
+#: Merge.rc:5034
 msgid "Unable to compare files"
 msgstr "Файловете не могат да бъдат сравнени"
 
 #. IDS_ABORTED_ITEM
-#: Merge.rc:5036
+#: Merge.rc:5035
 msgid "Item aborted"
 msgstr "Елементът е прекъснат"
 
 #. IDS_FILE_SKIPPED
-#: Merge.rc:5037
+#: Merge.rc:5036
 msgid "File skipped"
 msgstr "Пропуснат файл"
 
 #. IDS_DIR_SKIPPED
-#: Merge.rc:5038
+#: Merge.rc:5037
 msgid "Folder skipped"
 msgstr "Пропусната папка"
 
 #. IDS_LEFT_ONLY_IN_FMT
-#: Merge.rc:5039
+#: Merge.rc:5038
 #, c-format
 msgid "Left only: %1"
 msgstr "От ляво само: %1"
 
 #. IDS_MIDDLE_ONLY_IN_FMT
-#: Merge.rc:5040
+#: Merge.rc:5039
 #, c-format
 msgid "Middle only: %1"
 msgstr "Само в средата: %1"
 
 #. IDS_RIGHT_ONLY_IN_FMT
-#: Merge.rc:5041
+#: Merge.rc:5040
 #, c-format
 msgid "Right only: %1"
 msgstr "От дясно само: %1"
 
 #. IDS_DOES_NOT_EXIST_IN_FMT
-#: Merge.rc:5042
+#: Merge.rc:5041
 #, c-format
 msgid "Does not exist in %1"
 msgstr "Не съществува в %1"
 
 #. IDS_BIN_FILES_SAME
-#: Merge.rc:5043
+#: Merge.rc:5042
 msgid "Binary files are identical"
 msgstr "Двоичните файлове са еднакви"
 
 #. IDS_BIN_FILES_DIFF
-#: Merge.rc:5049
+#: Merge.rc:5048
 msgid "Binary files are different"
 msgstr "Двоичните файлове са различни"
 
 #. IDS_FILES_ARE_DIFFERENT
-#: Merge.rc:5050
+#: Merge.rc:5049
 msgid "Files are different"
 msgstr "Файловете са различни"
 
 #. IDS_FOLDERS_ARE_DIFFERENT
-#: Merge.rc:5051
+#: Merge.rc:5050
 msgid "Folders are different"
 msgstr "Папките са различни"
 
 #. IDS_LEFTONLY
-#: Merge.rc:5052
+#: Merge.rc:5051
 msgid "Left Only"
 msgstr "Само левият"
 
 #. IDS_RIGHTONLY
-#: Merge.rc:5053
+#: Merge.rc:5052
 msgid "Right Only"
 msgstr "Само десният"
 
 #. IDS_MIDDLEONLY
-#: Merge.rc:5054
+#: Merge.rc:5053
 msgid "Middle Only"
 msgstr "Само средният"
 
 #. IDS_NOITEMLEFT
-#: Merge.rc:5055
+#: Merge.rc:5054
 msgid "No item in left"
 msgstr "Няма елемент вляво"
 
 #. IDS_NOITEMRIGHT
-#: Merge.rc:5056
+#: Merge.rc:5055
 msgid "No item in right"
 msgstr "Няма елемент вдясно"
 
 #. IDS_NOITEMMIDDLE
-#: Merge.rc:5057
+#: Merge.rc:5056
 msgid "No item in middle"
 msgstr "Няма елемент в средата"
 
 #. IDS_CMPRES_ERROR
-#: Merge.rc:5059
+#: Merge.rc:5058
 msgid "Error"
 msgstr "Грешка"
 
 #. IDS_TEXT_FILES_SAME
-#: Merge.rc:5060
+#: Merge.rc:5059
 msgid "Text files are identical"
 msgstr "Текстовите файлове са еднакви"
 
 #. IDS_LEFTONLY_DIFF
-#: Merge.rc:5061
+#: Merge.rc:5060
 msgid " (Middle and right are identical)"
 msgstr " (Среда и дясно са еднакви)"
 
 #. IDS_MIDDLEONLY_DIFF
-#: Merge.rc:5062
+#: Merge.rc:5061
 msgid " (Left and right are identical)"
 msgstr " (Ляво и дясно са еднакви)"
 
 #. IDS_RIGHTONLY_DIFF
-#: Merge.rc:5063
+#: Merge.rc:5062
 msgid " (Left and middle are identical)"
 msgstr " (Ляво и среда са еднакви)"
 
 #. IDS_PATH_MISMATCH
-#: Merge.rc:5064
+#: Merge.rc:5063
 msgid " (paths differ)"
 msgstr ""
 
 #. IDS_TEXT_FILES_DIFF
-#: Merge.rc:5065
+#: Merge.rc:5064
 msgid "Text files are different"
 msgstr "Текстовите файлове са различни"
 
 #. IDS_IMAGE_FILES_SAME
-#: Merge.rc:5066
+#: Merge.rc:5065
 msgid "Image files are identical"
 msgstr "Файловете с изображения са еднакви"
 
 #. IDS_IMAGE_FILES_DIFF
-#: Merge.rc:5067
+#: Merge.rc:5066
 msgid "Image files are different"
 msgstr "Файловете с изображения са различни"
 
 #. IDS_EXPR_DIFF
-#: Merge.rc:5068
+#: Merge.rc:5067
 #, c-format
 msgid "Files are different (expr: %1)"
 msgstr "Файловете са различни (израз: %1)"
 
 #. IDS_HASH_GROUP
-#: Merge.rc:5069
+#: Merge.rc:5068
 #, c-format
 msgid "Group%d"
 msgstr "Група%d"
 
 #. IDS_RENAME_MOVE_DETECTION_DISALBED
-#: Merge.rc:5070
+#: Merge.rc:5069
 msgctxt "Options dialog|Compare|Folder|Detect renames and moves"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_RENAME_MOVE_DETECTION_RENAME
-#: Merge.rc:5071
+#: Merge.rc:5070
 msgid "Detect renames"
 msgstr ""
 
 #. IDS_RENAME_MOVE_DETECTION_RENAME_MOVE
-#: Merge.rc:5072
+#: Merge.rc:5071
 msgid "Detect renames and moves"
 msgstr ""
 
 #. IDS_RENAME_MOVE_MERGE_MODE_RENAME
-#: Merge.rc:5073
+#: Merge.rc:5072
 msgid "Merge renames"
 msgstr ""
 
 #. IDS_RENAME_MOVE_MERGE_MODE_RENAME_MOVE
-#: Merge.rc:5074
+#: Merge.rc:5073
 msgid "Merge renames and moves"
 msgstr ""
 
 #. IDS_RENAMED
-#: Merge.rc:5075
+#: Merge.rc:5074
 msgid "Renamed"
 msgstr ""
 
 #. IDS_RENAMED_MOVED
-#: Merge.rc:5077
+#: Merge.rc:5076
 msgid "Renamed/Moved"
 msgstr ""
 
 #. IDS_RENAMED_MOVED_ITEMS
-#: Merge.rc:5078
+#: Merge.rc:5077
 #, c-format
 msgid "(%1 items)"
 msgstr ""
 
 #. IDS_RENAMED_MOVED_RESULT
-#: Merge.rc:5079
+#: Merge.rc:5078
 #, c-format
 msgid "%1 (set %2): "
 msgstr ""
 
 #. IDS_SWITCH_FLAT_MODE
-#: Merge.rc:5080
+#: Merge.rc:5079
 msgid "Some moved items have been merged.\nIn Tree Mode, these items may appear in positions that do not reflect the actual folder structure, which can be confusing.\nSwitch to Flat Mode?"
 msgstr ""
 
 #. IDS_ELAPSED_TIME
-#: Merge.rc:5086
+#: Merge.rc:5085
 #, c-format
 msgid "Elapsed time: %ld ms"
 msgstr "Изминало време: %ld мс"
 
 #. IDS_STATUS_SELITEM1
-#: Merge.rc:5087
+#: Merge.rc:5086
 msgid "1 item selected"
 msgstr "1 избран обект"
 
 #. IDS_STATUS_SELITEMS
-#: Merge.rc:5088
+#: Merge.rc:5087
 #, c-format
 msgid "%1 items selected"
 msgstr "%1 избрани обекта"
 
 #. IDS_COLDESC_FILENAME
-#: Merge.rc:5094
+#: Merge.rc:5093
 msgid "Filename or folder name."
 msgstr "Име на папка или файл."
 
 #. IDS_COLDESC_DIR
-#: Merge.rc:5095
+#: Merge.rc:5094
 msgid "Subfolder name when subfolders are included."
 msgstr "Име на подпапка, при включени подпапки."
 
 #. IDS_COLDESC_RESULT
-#: Merge.rc:5096
+#: Merge.rc:5095
 msgid "Comparison result, long form."
 msgstr "Резултат на сравнението, дълга форма."
 
 #. IDS_COLDESC_LTIMEM
-#: Merge.rc:5101
+#: Merge.rc:5100
 msgid "Left side modification date."
 msgstr "Дата на промяна на лявата секция."
 
 #. IDS_COLDESC_RTIMEM
-#: Merge.rc:5102
+#: Merge.rc:5101
 msgid "Right side modification date."
 msgstr "Дата на промяна на дясната секция."
 
 #. IDS_COLDESC_MTIMEM
-#: Merge.rc:5103
+#: Merge.rc:5102
 msgid "Middle side modification date."
 msgstr "Дата на промяна на средната секция."
 
 #. IDS_COLDESC_EXTENSION
-#: Merge.rc:5104
+#: Merge.rc:5103
 msgid "File's extension."
 msgstr "Разширение на файла."
 
 #. IDS_COLDESC_LSIZE
-#: Merge.rc:5105
+#: Merge.rc:5104
 msgid "Left file size in bytes."
 msgstr "Размер на файла отляво в байтове."
 
 #. IDS_COLDESC_RSIZE
-#: Merge.rc:5106
+#: Merge.rc:5105
 msgid "Right file size in bytes."
 msgstr "Размер на файла отдясно в байтове."
 
 #. IDS_COLDESC_MSIZE
-#: Merge.rc:5107
+#: Merge.rc:5106
 msgid "Middle file size in bytes."
 msgstr "Размер на файла всредата в байтове."
 
 #. IDS_COLDESC_LSIZE_SHORT
-#: Merge.rc:5108
+#: Merge.rc:5107
 msgid "Left file size abbreviated."
 msgstr "Съкратен размер на файла отляво."
 
 #. IDS_COLDESC_RSIZE_SHORT
-#: Merge.rc:5109
+#: Merge.rc:5108
 msgid "Right file size abbreviated."
 msgstr "Съкратен размер на файла отдясно."
 
 #. IDS_COLDESC_MSIZE_SHORT
-#: Merge.rc:5110
+#: Merge.rc:5109
 msgid "Middle file size abbreviated."
 msgstr "Съкратен размер на файла всредата."
 
 #. IDS_COLDESC_LTIMEC
-#: Merge.rc:5116
+#: Merge.rc:5115
 msgid "Left side creation time."
 msgstr "Дата на създаване на лявата секция."
 
 #. IDS_COLDESC_RTIMEC
-#: Merge.rc:5117
+#: Merge.rc:5116
 msgid "Right side creation time."
 msgstr "Дата на създаване на дясната секция."
 
 #. IDS_COLDESC_MTIMEC
-#: Merge.rc:5118
+#: Merge.rc:5117
 msgid "Middle side creation time."
 msgstr "Дата на създаване на средната секция."
 
 #. IDS_COLDESC_NEWER
-#: Merge.rc:5119
+#: Merge.rc:5118
 msgid "Tells which side has newer modification date."
 msgstr "Показва коя секция има късна дата на промяна."
 
 #. IDS_COLDESC_LVERSION
-#: Merge.rc:5120
+#: Merge.rc:5119
 msgid "Left side file version, only for some file types."
 msgstr "Версия на файла вляво, само за файлове от един вид."
 
 #. IDS_COLDESC_RVERSION
-#: Merge.rc:5121
+#: Merge.rc:5120
 msgid "Right side file version, only for some file types."
 msgstr "Версия на файла вдясно, само за файлове от един вид."
 
 #. IDS_COLDESC_MVERSION
-#: Merge.rc:5126
+#: Merge.rc:5125
 msgid "Middle side file version, only for some file types."
 msgstr "Версия на файла всредата, само за файлове от един вид."
 
 #. IDS_COLDESC_RESULT_ABBR
-#: Merge.rc:5127
+#: Merge.rc:5126
 msgid "Short comparison result."
 msgstr "Кратък резултат от сравнението."
 
 #. IDS_COLDESC_LATTRIBUTES
-#: Merge.rc:5128
+#: Merge.rc:5127
 msgid "Left side attributes."
 msgstr "Атрибути на лявата секция."
 
 #. IDS_COLDESC_RATTRIBUTES
-#: Merge.rc:5129
+#: Merge.rc:5128
 msgid "Right side attributes."
 msgstr "Атрибути на дясната секция."
 
 #. IDS_COLDESC_MATTRIBUTES
-#: Merge.rc:5130
+#: Merge.rc:5129
 msgid "Middle side attributes."
 msgstr "Атрибути на средната секция."
 
 #. IDS_COLDESC_LEOL_TYPE
-#: Merge.rc:5131
+#: Merge.rc:5130
 msgid "Left side file EOL type."
 msgstr "Знакът за нов ред на файла отляво."
 
 #. IDS_COLDESC_REOL_TYPE
-#: Merge.rc:5132
+#: Merge.rc:5131
 msgid "Right side file EOL type."
 msgstr "Знакът за нов ред на файла отдясно."
 
 #. IDS_COLDESC_MEOL_TYPE
-#: Merge.rc:5133
+#: Merge.rc:5132
 msgid "Middle side file EOL type."
 msgstr "Знакът за нов ред за файла всредата."
 
 #. IDS_COLDESC_LENCODING
-#: Merge.rc:5139
+#: Merge.rc:5138
 msgid "Left side encoding."
 msgstr "Кодировка на лявата секция."
 
 #. IDS_COLDESC_RENCODING
-#: Merge.rc:5140
+#: Merge.rc:5139
 msgid "Right side encoding."
 msgstr "Кодировка на дясната секция."
 
 #. IDS_COLDESC_MENCODING
-#: Merge.rc:5141
+#: Merge.rc:5140
 msgid "Middle side encoding."
 msgstr "Кодиравка на средната секция."
 
 #. IDS_COLDESC_NIDIFFS
-#: Merge.rc:5142
+#: Merge.rc:5141
 msgid "Number of ignored differences in file. Ignored and cannot be merged."
 msgstr "Брой пропуснати различия във файла. Те са пренебрегнати от WinMerge и не могат да бъдат сливани."
 
 #. IDS_COLDESC_NSDIFFS
-#: Merge.rc:5143
+#: Merge.rc:5142
 msgid "Number of differences in file (excluding ignored)."
 msgstr "Брой различия във файла. Не включва пренебрегнатите различия."
 
 #. IDS_COLDESC_BINARY
-#: Merge.rc:5144
+#: Merge.rc:5143
 msgid "Shows an asterisk (*) if the file is binary."
 msgstr "Показва звездичка (*), ако файлът е двоичен."
 
 #. IDS_COLDESC_UNPACKER
-#: Merge.rc:5145
+#: Merge.rc:5144
 msgid "Unpacker plugin name or pipeline."
 msgstr ""
 
 #. IDS_COLDESC_PREDIFFER
-#: Merge.rc:5146
+#: Merge.rc:5145
 msgid "Prediffer plugin name or pipeline."
 msgstr ""
 
 #. IDS_DIRECTORY_REPORT_TITLE
-#: Merge.rc:5152
+#: Merge.rc:5151
 #, c-format
 msgid "Compare %1 with %2"
 msgstr "Сравняване на %1 с %2"
 
 #. IDS_DIRECTORY_REPORT_TITLE3
-#: Merge.rc:5153
+#: Merge.rc:5152
 #, c-format
 msgid "Compare %1 with %2 and %3"
 msgstr "Сравняване на %1 с %2 и %3"
 
 #. IDS_REPORT_COMMALIST
-#: Merge.rc:5154
+#: Merge.rc:5153
 msgid "Comma-separated list"
 msgstr "Списък, разделен със запетая"
 
 #. IDS_REPORT_TABLIST
-#: Merge.rc:5155
+#: Merge.rc:5154
 msgid "Tab-separated list"
 msgstr "Списък, разделен с табулация"
 
 #. IDS_REPORT_SIMPLEHTML
-#: Merge.rc:5156
+#: Merge.rc:5155
 msgid "Simple HTML"
 msgstr "Чист HTML"
 
 #. IDS_REPORT_SIMPLEXML
-#: Merge.rc:5157
+#: Merge.rc:5156
 msgid "Simple XML"
 msgstr "Чист XML"
 
-#: Merge.rc:5159
+#: Merge.rc:5158
 msgid "Report file already exists. Overwrite?"
 msgstr "Файлът с отчета вече съществува. Искате ли да замените съществуващия файл?"
 
 #. IDS_REPORT_ERROR
-#: Merge.rc:5164
+#: Merge.rc:5163
 #, c-format
 msgid ""
 "Error creating the report:\n"
@@ -7183,57 +7178,57 @@ msgstr ""
 "%1"
 
 #. IDS_REPORT_SUCCESS
-#: Merge.rc:5165
+#: Merge.rc:5164
 msgid "Report created successfully."
 msgstr "Отчетът беше създаден успешно."
 
 #. IDS_SYNCPOINT_LASTBLOCK
-#: Merge.rc:5171
+#: Merge.rc:5170
 msgid "Cannot add a synchronization point at this line."
 msgstr "Точка за синхронизация не може да бъде добавена на този ред."
 
 #. IDS_FILE_TO_ITSELF
-#: Merge.rc:5177
+#: Merge.rc:5176
 msgid "Same file is opened in both panes."
 msgstr "Един и същи файл е отворен и в двата панела."
 
 #. IDS_FILESSAME
-#: Merge.rc:5178
+#: Merge.rc:5177
 msgid "Selected files are identical."
 msgstr "Избраните файлове са еднакви."
 
 #. IDS_FILESSAME_CURCFG
-#: Merge.rc:5179
+#: Merge.rc:5178
 msgid "Selected files are identical (with current settings).\r\nChecking binary identity..."
 msgstr ""
 
 #. IDS_FILESSAME_BINERROR
-#: Merge.rc:5180
+#: Merge.rc:5179
 msgid "Selected files are identical (with current settings).\r\nBut binary comparison failed."
 msgstr ""
 
 #. IDS_FILESSAME_BINSAME
-#: Merge.rc:5181
+#: Merge.rc:5180
 msgid "Selected files are identical (binary match)."
 msgstr ""
 
 #. IDS_FILESSAME_BINDIFF
-#: Merge.rc:5182
+#: Merge.rc:5181
 msgid "Selected files are identical (with current settings).\r\nBut differ at the binary level."
 msgstr ""
 
 #. IDS_FILEERROR
-#: Merge.rc:5183
+#: Merge.rc:5182
 msgid "An error occurred while comparing files."
 msgstr "Възникна грешка при сравнение на файловете."
 
 #. IDS_TEMP_FILEERROR
-#: Merge.rc:5184
+#: Merge.rc:5183
 msgid "Could not create temporary files. Check your temporary path settings."
 msgstr "Не могат да бъдат създададени временни файлове. Проверете настройките за временната папка."
 
 #. IDS_SUGGEST_IGNOREEOL
-#: Merge.rc:5185
+#: Merge.rc:5184
 msgid ""
 "Files use different EOL.\n"
 "\n"
@@ -7243,17 +7238,17 @@ msgid ""
 msgstr ""
 
 #. IDS_INVALID_DIRECTORY
-#: Merge.rc:5186
+#: Merge.rc:5185
 msgid "Selected folder is invalid."
 msgstr "Избраната папка е недействителна."
 
 #. IDS_CANNOT_OPEN_BINARYFILE
-#: Merge.rc:5187
+#: Merge.rc:5186
 msgid "Cannot open a binary file in Editor."
 msgstr "Не може да бъде отворен двоичен файл с редактор."
 
 #. IDS_CREATE_PAIR_FOLDER
-#: Merge.rc:5188
+#: Merge.rc:5187
 #, c-format
 msgid ""
 "Create matching folder:\n"
@@ -7265,41 +7260,41 @@ msgstr ""
 "да бъде създадена и да бъде отворена?"
 
 #. IDS_CONFIRM_COPY_ALL_DIFFS
-#: Merge.rc:5189
+#: Merge.rc:5188
 msgid "Copy all differences to other file?"
 msgstr "Желаете ли всички различия да бъдат копирани в отсрещния файл?"
 
 #. IDS_MOVE_TO_NEXTFILE
-#: Merge.rc:5194
+#: Merge.rc:5193
 msgid "Move to next file?"
 msgstr "Желаете ли да бъде отворен следващия файл?"
 
 #. IDS_MOVE_TO_PREVFILE
-#: Merge.rc:5195
+#: Merge.rc:5194
 msgid "Move to previous file?"
 msgstr "Желаете ли да бъде отворен предишния файл?"
 
 #. IDS_MOVE_TO_NEXTPAGE
-#: Merge.rc:5196
+#: Merge.rc:5195
 msgid "Move to next page?"
 msgstr "Желаете ли да бъде отворенa следващата страница?"
 
 #. IDS_MOVE_TO_PREVPAGE
-#: Merge.rc:5197
+#: Merge.rc:5196
 msgid "Move to previous page?"
 msgstr "Желаете ли да бъде отворенa предишната страница?"
 
 #. IDS_MOVE_TO_FIRSTFILE
-#: Merge.rc:5198
+#: Merge.rc:5197
 msgid "Move to first file?"
 msgstr "Желаете ли да бъде отворен първия файл?"
 
 #. IDS_MOVE_TO_LASTFILE
-#: Merge.rc:5199
+#: Merge.rc:5198
 msgid "Move to last file?"
 msgstr "Желаете ли да бъде отворен последния файл?"
 
-#: Merge.rc:5206
+#: Merge.rc:5205
 #, c-format
 msgid ""
 "Different codepages: left (cp%d), right (cp%d).\n"
@@ -7310,51 +7305,51 @@ msgstr ""
 "Показването на всеки файл с неговата кодова страница ще даде по-добра видимост, но сливането или копирането ще е рисковано.\n"
 "Желаете ли файловете да бъдат третирани със зададената кодова страница на Windows (препоръчително)?"
 
-#: Merge.rc:5208
+#: Merge.rc:5207
 msgid "Information lost due to encoding errors: both files"
 msgstr "Има загуба на информация, поради грешка в кодировката на: двата файла"
 
-#: Merge.rc:5210
+#: Merge.rc:5209
 msgid "Information lost due to encoding errors: first file"
 msgstr "Има загуба на информация, поради грешка в кодировката на: първи файл"
 
-#: Merge.rc:5212
+#: Merge.rc:5211
 msgid "Information lost due to encoding errors: second file"
 msgstr "Има загуба на информация, поради грешка в кодировката на: втори файл"
 
-#: Merge.rc:5214
+#: Merge.rc:5213
 msgid "Information lost due to encoding errors: third file"
 msgstr "Има загуба на информация, поради грешка в кодировката на: трети файл"
 
 #. IDS_LINEDIFF_NODIFF
-#: Merge.rc:5220
+#: Merge.rc:5219
 msgid "No difference"
 msgstr "Без различия"
 
 #. IDS_LINEDIFF_NODIFF_CAPTION
-#: Merge.rc:5221
+#: Merge.rc:5220
 msgid "Line difference"
 msgstr "Различия в редовете"
 
 #. IDS_NUM_REPLACED
-#: Merge.rc:5227
+#: Merge.rc:5226
 #, c-format
 msgid "Replaced %1 string(s)."
 msgstr "Заменени %1 низ(а)."
 
 #. IDS_EDIT_TEXT_NOT_FOUND
-#: Merge.rc:5228
+#: Merge.rc:5227
 #, c-format
 msgid "Cannot find string \"%s\"."
 msgstr "Низът „%s“ не може да бъде намерен."
 
 #. IDS_MERGE_MODE
-#: Merge.rc:5234
+#: Merge.rc:5233
 msgid "Entering Merge Mode. Press F9 to turn off."
 msgstr "Режим на сливане. Ако желаете да излезете от него, натиснете клавиша F9."
 
 #. IDS_AUTO_MERGE
-#: Merge.rc:5240
+#: Merge.rc:5239
 #, c-format
 msgid ""
 "Automatic merges: %1\n"
@@ -7364,89 +7359,89 @@ msgstr ""
 "Брой неразрешени конфликти: %2"
 
 #. IDS_CODEPAGE_MERGED
-#: Merge.rc:5241
+#: Merge.rc:5240
 msgid "Codepage change merged."
 msgstr "Промяната на кодовата страница е слята."
 
 #. IDS_CODEPAGE_CONFLICT
-#: Merge.rc:5242
+#: Merge.rc:5241
 msgid "Codepage changes are conflicting."
 msgstr "Промените в кодовата страница са противоречиви."
 
 #. IDS_EOL_MERGED
-#: Merge.rc:5243
+#: Merge.rc:5242
 msgid "EOL change merged."
 msgstr "Промяната на EOL е обединена."
 
 #. IDS_EOL_CONFLICT
-#: Merge.rc:5244
+#: Merge.rc:5243
 msgid "EOL changes are conflicting."
 msgstr "Промените в EOL са противоречиви."
 
 #. IDS_LOCBAR_CAPTION
-#: Merge.rc:5250
+#: Merge.rc:5249
 msgid "Location Pane"
 msgstr "Kарта"
 
 #. IDS_DIFFBAR_CAPTION
-#: Merge.rc:5251
+#: Merge.rc:5250
 msgid "Diff Pane"
 msgstr "Панел с различия"
 
 #. IDS_DIFF_SUCCEEDED
-#: Merge.rc:5258
+#: Merge.rc:5257
 msgid "Patch file written."
 msgstr "Кръпката е успешно запазена."
 
 #. IDS_DIFF_FILEOVERWRITE
-#: Merge.rc:5259
+#: Merge.rc:5258
 msgid "Patch file already exists. Overwrite?"
 msgstr "Кръпката вече съществува. Да бъдели презаписана?"
 
 #. IDS_DIFF_SELECTEDFILES
-#: Merge.rc:5260
+#: Merge.rc:5259
 #, c-format
 msgid "[%1 files selected]"
 msgstr "[%1 избрани файлове]"
 
 #. IDS_DIFF_NORMAL
-#: Merge.rc:5261
+#: Merge.rc:5260
 msgid "Normal"
 msgstr "Нормален"
 
 #. IDS_DIFF_CONTEXT
-#: Merge.rc:5262
+#: Merge.rc:5261
 msgid "Context"
 msgstr "Контекст"
 
 #. IDS_DIFF_UNIFIED
-#: Merge.rc:5263
+#: Merge.rc:5262
 msgid "Unified"
 msgstr "Унифициран"
 
 #. IDS_FILEWRITE_ERROR
-#: Merge.rc:5265
+#: Merge.rc:5264
 #, c-format
 msgid "Could not write to file %1."
 msgstr "Не може да се запише върху %1."
 
 #. IDS_PATH_NOT_ABSOLUTE
-#: Merge.rc:5266
+#: Merge.rc:5265
 #, c-format
 msgid "Output path is not absolute: %1"
 msgstr "Зададеният път не е пълен път: %1"
 
 #. IDS_MUST_SPECIFY_OUTPUT
-#: Merge.rc:5267
+#: Merge.rc:5266
 msgid "Specify an output file."
 msgstr "Задайте изходен файл."
 
-#: Merge.rc:5269
+#: Merge.rc:5268
 msgid "Cannot create patch from binary files."
 msgstr "Не може да се създаде пач от двоични файлове."
 
 #. IDS_SAVEFILES_FORPATCH
-#: Merge.rc:5270
+#: Merge.rc:5269
 msgid ""
 "Save all files first.\n"
 "\n"
@@ -7457,22 +7452,22 @@ msgstr ""
 "Създаването на пач изисква да няма незаписани промени във файловете."
 
 #. IDS_FOLDER_NOTEXIST
-#: Merge.rc:5271
+#: Merge.rc:5270
 msgid "Folder does not exist."
 msgstr "Папката не съществува."
 
 #. IDS_ARCHIVE_SUCCEEDED
-#: Merge.rc:5277
+#: Merge.rc:5276
 msgid "Archive file written."
 msgstr ""
 
 #. IDS_ARCHIVE_SAVEFILES
-#: Merge.rc:5278
+#: Merge.rc:5277
 msgid "Save all files first.\n\nCreating an archive requires no unsaved changes."
 msgstr ""
 
 #. IDS_NO_ZIP_SUPPORT
-#: Merge.rc:5283
+#: Merge.rc:5282
 msgid ""
 "Archive support not enabled.\n"
 "7-Zip and/or Merge7z*.dll not found.\n"
@@ -7483,37 +7478,37 @@ msgstr ""
 "Погледнете ръководството за повече информация относно поддръжката на архиви и как да я включите."
 
 #. IDS_OPT_EXPORT_CAPTION
-#: Merge.rc:5284
+#: Merge.rc:5283
 msgid "Select file for export"
 msgstr "Изберете файл за експорт"
 
 #. IDS_OPT_IMPORT_CAPTION
-#: Merge.rc:5285
+#: Merge.rc:5284
 msgid "Select file for import"
 msgstr "Изберете файл за импорт"
 
 #. IDS_OPT_IMPORT_DONE
-#: Merge.rc:5286
+#: Merge.rc:5285
 msgid "Options imported from file."
 msgstr "Настройките са внесени от файла."
 
 #. IDS_OPT_EXPORT_DONE
-#: Merge.rc:5287
+#: Merge.rc:5286
 msgid "Options exported to file."
 msgstr "Настройките са изнесени във файла."
 
 #. IDS_OPT_IMPORT_ERR
-#: Merge.rc:5288
+#: Merge.rc:5287
 msgid "Failed to import options from file."
 msgstr "Грешка при внасяне на насторйките от файл."
 
 #. IDS_OPT_EXPORT_ERR
-#: Merge.rc:5289
+#: Merge.rc:5288
 msgid "Failed to write options to file."
 msgstr "Грешка при изнасяне на насторйките във файл."
 
 #. IDS_CLOSEALL_WINDOWS
-#: Merge.rc:5290
+#: Merge.rc:5289
 msgid ""
 "Close multiple compare windows?\n"
 "\n"
@@ -7524,34 +7519,34 @@ msgstr ""
 "Желаете ли да продължите?"
 
 #. IDS_EOL_BIN
-#: Merge.rc:5300
+#: Merge.rc:5299
 msgctxt "EOL Type"
 msgid "Binary"
 msgstr "Двоичен"
 
 #. IDS_MARKER_COLOR_FMT
-#: Merge.rc:5305
+#: Merge.rc:5304
 #, c-format
 msgid "Marker Color %d"
 msgstr ""
 
 #. IDS_MARKER_NEW_PATTERN
-#: Merge.rc:5306
+#: Merge.rc:5305
 msgid "New Pattern"
 msgstr ""
 
 #. IDS_PLUGINSLIST_TYPE
-#: Merge.rc:5312
+#: Merge.rc:5311
 msgid "Type"
 msgstr "Вид"
 
 #. IDS_PLUGINS_TYPE_EDITSCRIPT
-#: Merge.rc:5316
+#: Merge.rc:5315
 msgid "Editor script"
 msgstr ""
 
 #. ID_SELECTLINEDIFF
-#: Merge.rc:5322
+#: Merge.rc:5321
 msgid ""
 "\n"
 "Difference in Current Line (F4)"
@@ -7560,7 +7555,7 @@ msgstr ""
 "Различия на текущия ред (F4)"
 
 #. ID_OPTIONS
-#: Merge.rc:5323
+#: Merge.rc:5322
 msgid ""
 "\n"
 "Options"
@@ -7569,7 +7564,7 @@ msgstr ""
 "Настройки"
 
 #. ID_REFRESH
-#: Merge.rc:5324
+#: Merge.rc:5323
 msgid ""
 "\n"
 "Refresh (F5)"
@@ -7578,7 +7573,7 @@ msgstr ""
 "Презареждане (F5)"
 
 #. ID_PREVDIFF
-#: Merge.rc:5330
+#: Merge.rc:5329
 msgid ""
 "\n"
 "Previous Difference (Alt+Up)"
@@ -7587,7 +7582,7 @@ msgstr ""
 "Предишно различие (Alt+Up)"
 
 #. ID_NEXTDIFF
-#: Merge.rc:5331
+#: Merge.rc:5330
 msgid ""
 "\n"
 "Next Difference (Alt+Down)"
@@ -7596,7 +7591,7 @@ msgstr ""
 "Следващо различие (Alt+Down)"
 
 #. ID_PREVCONFLICT
-#: Merge.rc:5332
+#: Merge.rc:5331
 msgid ""
 "\n"
 "Previous Conflict (Alt+Shift+Up)"
@@ -7605,7 +7600,7 @@ msgstr ""
 "Предишен конфликт (Alt+Shift+Up)"
 
 #. ID_NEXTCONFLICT
-#: Merge.rc:5333
+#: Merge.rc:5332
 msgid ""
 "\n"
 "Next Conflict (Alt+Shift+Down)"
@@ -7614,7 +7609,7 @@ msgstr ""
 "Следващ конфликт (Alt+Shift+Down)"
 
 #. ID_FIRSTDIFF
-#: Merge.rc:5338
+#: Merge.rc:5337
 msgid ""
 "\n"
 "First Difference (Alt+Home)"
@@ -7623,7 +7618,7 @@ msgstr ""
 "Първо различие (Alt+Home)"
 
 #. ID_CURDIFF
-#: Merge.rc:5339
+#: Merge.rc:5338
 msgid ""
 "\n"
 "Current Difference (Alt+Enter)"
@@ -7632,7 +7627,7 @@ msgstr ""
 "Текущо различие (Alt+Enter)"
 
 #. ID_LASTDIFF
-#: Merge.rc:5340
+#: Merge.rc:5339
 msgid ""
 "\n"
 "Last Difference (Alt+End)"
@@ -7641,7 +7636,7 @@ msgstr ""
 "Последно различие (Alt+End)"
 
 #. ID_L2R
-#: Merge.rc:5341
+#: Merge.rc:5340
 msgid ""
 "\n"
 "Copy to Right (Alt+Right)"
@@ -7650,7 +7645,7 @@ msgstr ""
 "Копира вдясно (Alt+Right)"
 
 #. ID_R2L
-#: Merge.rc:5342
+#: Merge.rc:5341
 msgid ""
 "\n"
 "Copy to Left (Alt+Left)"
@@ -7659,7 +7654,7 @@ msgstr ""
 "Копира вляво (Alt+Left)"
 
 #. ID_L2RNEXT
-#: Merge.rc:5343
+#: Merge.rc:5342
 msgid ""
 "\n"
 "Copy to Right and Advance (Ctrl+Alt+Right)"
@@ -7668,7 +7663,7 @@ msgstr ""
 "Копира вдясно и продължава (Ctrl+Alt+Right)"
 
 #. ID_R2LNEXT
-#: Merge.rc:5344
+#: Merge.rc:5343
 msgid ""
 "\n"
 "Copy to Left and Advance (Ctrl+Alt+Left)"
@@ -7677,7 +7672,7 @@ msgstr ""
 "Копира вляво и продължава (Ctrl+Alt+Left)"
 
 #. ID_ALL_RIGHT
-#: Merge.rc:5345
+#: Merge.rc:5344
 msgid ""
 "\n"
 "Copy All to Right"
@@ -7686,7 +7681,7 @@ msgstr ""
 "Копира всичко вдясно"
 
 #. ID_ALL_LEFT
-#: Merge.rc:5346
+#: Merge.rc:5345
 msgid ""
 "\n"
 "Copy All to Left"
@@ -7695,7 +7690,7 @@ msgstr ""
 "Копира всичко вляво"
 
 #. ID_AUTO_MERGE
-#: Merge.rc:5347
+#: Merge.rc:5346
 msgid ""
 "\n"
 "Auto Merge (Ctrl+Alt+M)"
@@ -7704,7 +7699,7 @@ msgstr ""
 "Автоматично сливане (Ctrl+Alt+M)"
 
 #. ID_FIRSTFILE
-#: Merge.rc:5348
+#: Merge.rc:5347
 msgid ""
 "\n"
 "First File"
@@ -7713,7 +7708,7 @@ msgstr ""
 "Първи файл"
 
 #. ID_NEXTFILE
-#: Merge.rc:5349
+#: Merge.rc:5348
 msgid ""
 "\n"
 "Next File (Ctrl+F8)"
@@ -7722,7 +7717,7 @@ msgstr ""
 "Следващ файл (Ctrl+F8)"
 
 #. ID_LASTFILE
-#: Merge.rc:5350
+#: Merge.rc:5349
 msgid ""
 "\n"
 "Last File"
@@ -7731,7 +7726,7 @@ msgstr ""
 "Последен файл"
 
 #. ID_PREVFILE
-#: Merge.rc:5351
+#: Merge.rc:5350
 msgid ""
 "\n"
 "Previous File (Ctrl+F7)"
@@ -7740,141 +7735,141 @@ msgstr ""
 "Предишен файл (Ctrl+F7)"
 
 #. IDS_UNPACK_AUTO
-#: Merge.rc:5358
+#: Merge.rc:5357
 msgid "Adapted unpacker applied to both files (one needs extension)."
 msgstr "Зададения разархиватор ще се приложи и за двата файла (необходимо е разширение само на единия файл)."
 
 #. IDS_NO_PREDIFFER
-#: Merge.rc:5359
+#: Merge.rc:5358
 msgid "No Prediffer (Normal)"
 msgstr ""
 
 #. IDS_SUGGESTED_PLUGINS
-#: Merge.rc:5360
+#: Merge.rc:5359
 msgid "Suggested Plugins"
 msgstr "Предложена добавка"
 
 #. IDS_NOT_SUGGESTED_PLUGINS
-#: Merge.rc:5361
+#: Merge.rc:5360
 msgid "All Plugins"
 msgstr "Всички добавки"
 
 #. IDS_PRIVATEBUILD_FMT
-#: Merge.rc:5367
+#: Merge.rc:5366
 #, c-format
 msgid "Private Build: %1"
 msgstr "Вътрешен билд: %1"
 
 #. IDS_ALLRIGHTS_RESERVED
-#: Merge.rc:5368
+#: Merge.rc:5367
 msgid " - All rights reserved."
 msgstr " - Всички права запазени."
 
 #. IDS_TITLE_PLUGINS_SETTINGS
-#: Merge.rc:5374
+#: Merge.rc:5373
 msgid "Plugin Settings"
 msgstr "Настройки на добавки"
 
 #. IDS_NO_SCT_SCRIPTS
-#: Merge.rc:5376
+#: Merge.rc:5375
 msgid "WSH not found - .sct scripts disabled"
 msgstr "WSH не е намерен - скриптовете на .sct са забранени"
 
 #. IDS_LOCBAR_GOTOLINE_FMT
-#: Merge.rc:5384
+#: Merge.rc:5383
 #, c-format
 msgid "G&o to Line %1"
 msgstr "От&иване на ред %1"
 
 #. IDS_GOTO_MOVED_LINE
-#: Merge.rc:5390
+#: Merge.rc:5389
 msgid "Go to Moved Line\tCtrl+Shift+G"
 msgstr ""
 
 #. IDS_AUTOCOMPLETE_DISABLED
-#: Merge.rc:5396
+#: Merge.rc:5395
 msgctxt "Options dialog|General|Open dialog Auto completion"
 msgid "Disabled"
 msgstr "Изключено"
 
 #. IDS_AUTOCOMPLETE_FILE_SYS
-#: Merge.rc:5397
+#: Merge.rc:5396
 msgid "From file system"
 msgstr "От файловата система"
 
 #. IDS_AUTOCOMPLETE_MRU
-#: Merge.rc:5398
+#: Merge.rc:5397
 msgid "From Most Recently Used list"
 msgstr "От последно отваряните"
 
 #. IDS_COLORSCHEME_PLAIN
-#: Merge.rc:5404
+#: Merge.rc:5403
 msgid "No Highlighting"
 msgstr "Без оцветяване"
 
 #. IDS_COLORSCHEME_PO
-#: Merge.rc:5439
+#: Merge.rc:5438
 msgid "Portable Object"
 msgstr "Portable Object"
 
 #. IDS_COLORSCHEME_RSRC
-#: Merge.rc:5444
+#: Merge.rc:5443
 msgid "Resources"
 msgstr "Ресурси"
 
 #. IDS_COLORSCHEME_SH
-#: Merge.rc:5448
+#: Merge.rc:5447
 msgid "Shell"
 msgstr "Shell"
 
 #. IDS_CLOSE_LEFT_TABS
-#: Merge.rc:5469
+#: Merge.rc:5468
 msgid "Close &Left Tabs"
 msgstr "Затваряне на &левия раздел"
 
 #. IDS_CLOSE_RIGHT_TABS
-#: Merge.rc:5470
+#: Merge.rc:5469
 msgid "Close R&ight Tabs"
 msgstr "Затваряне на &десния раздел"
 
 #. IDS_CLOSE_OTHER_TABS
-#: Merge.rc:5471
+#: Merge.rc:5470
 msgid "Close &Other Tabs"
 msgstr "Затваряне на д&ругите раздели"
 
 #. IDS_TABBAR_AUTO_MAXWIDTH
-#: Merge.rc:5472
+#: Merge.rc:5471
 msgid "Enable &Auto Max Width"
 msgstr "Автоматична &максимална ширина"
 
 #. IDS_WEBPAGE_MENU
-#: Merge.rc:5482
+#: Merge.rc:5481
 msgid "We&bpage"
 msgstr "Страница от &интернет"
 
 #. IDS_VIEW_WRAP_TEXT
-#: Merge.rc:5487
+#: Merge.rc:5486
 msgid "W&rap Text"
 msgstr "П&ренасяне на текста"
 
 #. IDS_NOTINSTALLED
-#: Merge.rc:5492
+#: Merge.rc:5491
 msgid "%1 is not installed."
 msgstr "%1 не е инсталиран."
 
 #. IDS_CREATE_FOLDER
-#: Merge.rc:5497
+#: Merge.rc:5496
 #, c-format
 msgid "%1 does not exist. Create it?"
 msgstr "%1 не съществува. Искате ли да я създадете?"
 
 #. IDS_CREATE_FOLDER_ERROR
-#: Merge.rc:5498
+#: Merge.rc:5497
 msgid "Failed to create folder."
 msgstr "Неуспешно създаване на папка."
 
 #. IDC_EXT_EDITOR_PATH
-#: Merge.rc:5503
+#: Merge.rc:5502
 msgid ""
 "Parameters:\n"
 "$file: Current file path\n"
@@ -7885,605 +7880,605 @@ msgstr ""
 "$linenum: Номер на ред на текуща позиция на каретката"
 
 #. IDS_DIFF_ALGORITHM_DEFAULT
-#: Merge.rc:5508
+#: Merge.rc:5507
 msgid "default"
 msgstr "по подразбиране"
 
 #. IDS_DIFF_ALGORITHM_MINIMAL
-#: Merge.rc:5509
+#: Merge.rc:5508
 msgid "minimal"
 msgstr "minimal"
 
 #. IDS_DIFF_ALGORITHM_PATIENCE
-#: Merge.rc:5510
+#: Merge.rc:5509
 msgid "patience"
 msgstr "patience"
 
 #. IDS_DIFF_ALGORITHM_HISTOGRAM
-#: Merge.rc:5511
+#: Merge.rc:5510
 msgid "histogram"
 msgstr "histogram"
 
 #. IDS_DIFF_ALGORITHM_NONE
-#: Merge.rc:5512
+#: Merge.rc:5511
 msgid "none"
 msgstr "няма"
 
 #. IDS_RENDERING_MODE_GDI
-#: Merge.rc:5517
+#: Merge.rc:5516
 msgid "GDI"
 msgstr "GDI"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_DEFAULT
-#: Merge.rc:5518
+#: Merge.rc:5517
 msgid "DirectWrite Default"
 msgstr "Стандартен DirectWrite"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_ALIASED
-#: Merge.rc:5519
+#: Merge.rc:5518
 msgid "DirectWrite Aliased"
 msgstr "Назъбен DirectWrite"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_GDI_CLASSIC
-#: Merge.rc:5520
+#: Merge.rc:5519
 msgid "DirectWrite GDI Classic"
 msgstr "Класически DirectWrite GDI"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_GDI_NATURAL
-#: Merge.rc:5521
+#: Merge.rc:5520
 msgid "DirectWrite GDI Natural"
 msgstr "Естествен DirectWrite GDI"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_NATURAL
-#: Merge.rc:5522
+#: Merge.rc:5521
 msgid "DirectWrite Natural"
 msgstr "Естествен DirectWrite"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_NATURAL_SYMMETRIC
-#: Merge.rc:5523
+#: Merge.rc:5522
 msgid "DirectWrite Natural Symmetric"
 msgstr "Естествен симтричен DirectWrite"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_DISABLED
-#: Merge.rc:5528
+#: Merge.rc:5527
 msgctxt "Options dialog|General|Close windows with Esc"
 msgid "Disabled"
 msgstr "Изключено"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_1
-#: Merge.rc:5529
+#: Merge.rc:5528
 msgid "MDI child window or main window"
 msgstr "Дъщерен или основен прозорец (MDI)"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_2
-#: Merge.rc:5530
+#: Merge.rc:5529
 msgid "MDI child window only"
 msgstr "Само дъщерен прозорец (MDI)"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_3
-#: Merge.rc:5531
+#: Merge.rc:5530
 msgid "Close main window if only one MDI child window"
 msgstr "Затваряне на основния прозорец ако има само един дъщерен (MDI)"
 
 #. IDS_DIFF_GROUP
-#: Merge.rc:5536
+#: Merge.rc:5535
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Diff"
 msgstr ""
 
 #. IDS_DIFF_HIGHLIGHT
-#: Merge.rc:5537
+#: Merge.rc:5536
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Highlight"
 msgstr ""
 
 #. IDS_DIFF_BLINK
-#: Merge.rc:5538
+#: Merge.rc:5537
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Blink"
 msgstr ""
 
 #. IDS_DIFF_BLOCKSIZE
-#: Merge.rc:5539
+#: Merge.rc:5538
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Block Size"
 msgstr ""
 
 #. IDS_DIFF_BLOCKALPHA
-#: Merge.rc:5540
+#: Merge.rc:5539
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Block Alpha"
 msgstr ""
 
 #. IDS_DIFF_CDTHRESHOLD
-#: Merge.rc:5541
+#: Merge.rc:5540
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "CD Threshold"
 msgstr ""
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION
-#: Merge.rc:5542
+#: Merge.rc:5541
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Ins/Del Detection"
 msgstr ""
 
 #. IDS_OVERLAY_MODE_NONE
-#: Merge.rc:5543 Merge.rc:5548
+#: Merge.rc:5542 Merge.rc:5547
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "None"
 msgstr ""
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION_VERTICAL
-#: Merge.rc:5544
+#: Merge.rc:5543
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Vertical"
 msgstr ""
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION_HORIZONTAL
-#: Merge.rc:5545
+#: Merge.rc:5544
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Horizontal"
 msgstr ""
 
 #. IDS_OVERLAY_GROUP
-#: Merge.rc:5546
+#: Merge.rc:5545
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Overlay"
 msgstr ""
 
 #. IDS_OVERLAY_ALPHA
-#: Merge.rc:5547
+#: Merge.rc:5546
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha"
 msgstr ""
 
 #. IDS_OVERLAY_MODE_XOR
-#: Merge.rc:5549
+#: Merge.rc:5548
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "XOR"
 msgstr "ИЛИ"
 
 #. IDS_OVERLAY_MODE_ALPHA
-#: Merge.rc:5550
+#: Merge.rc:5549
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha Blend"
 msgstr ""
 
 #. IDS_OVERLAY_MODE_ALPHA_ANIMATION
-#: Merge.rc:5551
+#: Merge.rc:5550
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha Animation"
 msgstr ""
 
 #. IDS_ZOOM
-#: Merge.rc:5552
+#: Merge.rc:5551
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Zoom"
 msgstr "Мащаб"
 
 #. IDS_PAGE
-#: Merge.rc:5553
+#: Merge.rc:5552
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Page:"
 msgstr "Страница:"
 
 #. IDS_IMGCMP_STATUS_PT_RGBA_FMT
-#: Merge.rc:5554
+#: Merge.rc:5553
 #, c-format
 msgid "Pt: (%d, %d)  RGBA: (%d, %d, %d, %d)  "
 msgstr ""
 
 #. IDS_IMGCMP_STATUS_DIST1_FMT
-#: Merge.rc:5555
+#: Merge.rc:5554
 #, c-format
 msgid "Dist: %g  "
 msgstr ""
 
 #. IDS_IMGCMP_STATUS_DIST2_FMT
-#: Merge.rc:5556
+#: Merge.rc:5555
 #, c-format
 msgid "Dist: %g, %g  "
 msgstr ""
 
 #. IDS_IMGCMP_STATUS_PAGE_ZOOM_SIZE_BPP_FMT
-#: Merge.rc:5557
+#: Merge.rc:5556
 #, c-format
 msgid "Page: %d/%d  Zoom: %d%%  %dx%dpx  %dbpp  "
 msgstr ""
 
 #. IDS_IMGCMP_STATUS_RC_FMT
-#: Merge.rc:5558
+#: Merge.rc:5557
 #, c-format
 msgid "Rc: (%d, %d)  "
 msgstr ""
 
 #. IDS_IMGCMP_STATUS_FLIPPED_FMT
-#: Merge.rc:5559
+#: Merge.rc:5558
 #, c-format
 msgid "Flipped: %s  "
 msgstr ""
 
 #. IDS_IMGCMP_STATUS_ROTATED_FMT
-#: Merge.rc:5560
+#: Merge.rc:5559
 #, c-format
 msgid "Rotated: %d  "
 msgstr ""
 
 #. IDS_IMGCMP_REPORT_ALLPAGES
-#: Merge.rc:5561
+#: Merge.rc:5560
 msgid "All pages"
 msgstr "Всички страници"
 
 #. IDS_IGNSUB_STR1
-#: Merge.rc:5566
+#: Merge.rc:5565
 msgid "<Edit here>"
 msgstr "<въведете>"
 
 #. IDS_IGNSUB_STR2
-#: Merge.rc:5567
+#: Merge.rc:5566
 msgid "No differences found to select"
 msgstr "Липсват различия, които да бъдат избрани"
 
 #. IDS_IGNSUB_STR3
-#: Merge.rc:5568
+#: Merge.rc:5567
 msgid "No differences found to add as substitution filter"
 msgstr "Липсват различия, които да бъдат добавени като заместващ филтър"
 
 #. IDS_IGNSUB_STR4
-#: Merge.rc:5569
+#: Merge.rc:5568
 msgid "The pair is already in the Substitution Filters list"
 msgstr "Двойката вече съществува в заместващите филтри"
 
 #. IDS_IGNSUB_STR5
-#: Merge.rc:5570
+#: Merge.rc:5569
 msgid "Add this change to Substitution Filters?"
 msgstr "Нов заместващ филтър от тази промяна?"
 
 #. IDS_OCRRESULT_TEXTONLY
-#: Merge.rc:5575
+#: Merge.rc:5574
 msgid "Text only"
 msgstr "Само текст"
 
 #. IDS_OCRRESULT_POS_LINE
-#: Merge.rc:5576
+#: Merge.rc:5575
 msgid "Line-by-line position and text"
 msgstr "Позиция на редове и текст"
 
 #. IDS_OCRRESULT_POS_WORD
-#: Merge.rc:5577
+#: Merge.rc:5576
 msgid "Word-by-word position and text"
 msgstr "Позиция на думи и текст"
 
 #. IDS_USERDATAFOLDER_APPDATA
-#: Merge.rc:5582
+#: Merge.rc:5581
 msgid "AppData (Roaming) folder"
 msgstr ""
 
 #. IDS_USERDATAFOLDER_INSTALL
-#: Merge.rc:5583
+#: Merge.rc:5582
 msgid "Install folder"
 msgstr ""
 
 #. IDS_USERDATAFOLDER_DOCUMENTS
-#: Merge.rc:5584
+#: Merge.rc:5583
 msgid "Documents folder"
 msgstr ""
 
 #. IDS_SINGLEINSTANCE_DISABLED
-#: Merge.rc:5589
+#: Merge.rc:5588
 msgctxt "Options dialog|General|Single instance mode"
 msgid "Disabled"
 msgstr "Изключено"
 
 #. IDS_SINGLEINSTANCE_STR1
-#: Merge.rc:5590
+#: Merge.rc:5589
 msgid "Allow only one instance to run"
 msgstr "Позволи само едно стартирано копие"
 
 #. IDS_CLIPBOARD_HISTORY
-#: Merge.rc:5591
+#: Merge.rc:5590
 msgid "Clipboard &History"
 msgstr ""
 
 #. IDS_SINGLEINSTANCE_STR2
-#: Merge.rc:5592
+#: Merge.rc:5591
 msgid "Allow only one instance; wait for termination"
 msgstr ""
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_DISABLED
-#: Merge.rc:5597
+#: Merge.rc:5596
 msgctxt "Options dialog|General|Auto-reload modified files"
 msgid "Disabled"
 msgstr "Изключено"
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_STR1
-#: Merge.rc:5598
+#: Merge.rc:5597
 msgid "Only on window activated"
 msgstr "Само при фокусиране на прозореца"
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_STR2
-#: Merge.rc:5599
+#: Merge.rc:5598
 msgid "Immediately"
 msgstr "Незабавно"
 
 #. IDS_PLUGIN_ALL
-#: Merge.rc:5604
+#: Merge.rc:5603
 msgid "Al&l"
 msgstr "В&сички"
 
 #. IDS_PLUGIN_OTHERS
-#: Merge.rc:5605
+#: Merge.rc:5604
 msgid "&Others"
 msgstr "&Други"
 
-#: Merge.rc:5607
+#: Merge.rc:5606
 #, c-format
 msgid "Missing plugin name in pipeline: %1"
 msgstr ""
 
-#: Merge.rc:5609
+#: Merge.rc:5608
 #, c-format
 msgid "Missing quote in plugin pipeline: %1"
 msgstr ""
 
 #. IDS_PLUGIN_NAME_ALREADY_EXISTS
-#: Merge.rc:5610
+#: Merge.rc:5609
 #, c-format
 msgid "Plugin name '%1' already exists."
 msgstr ""
 
 #. IDS_PLUGIN_TITLE1
-#: Merge.rc:5611
+#: Merge.rc:5610
 msgid "Specify plugin arguments"
 msgstr ""
 
-#: Merge.rc:5613
+#: Merge.rc:5612
 #, c-format
 msgid "Plugin not found or invalid: %1"
 msgstr ""
 
 #. IDS_PLUGIN_NOT_UNPACK
-#: Merge.rc:5614
+#: Merge.rc:5613
 #, c-format
 msgid "'%1' is not an unpacker plugin"
 msgstr ""
 
 #. IDS_PLUGIN_NOT_PREDIFF
-#: Merge.rc:5615
+#: Merge.rc:5614
 #, c-format
 msgid "'%1' is not a prediffer plugin"
 msgstr ""
 
-#: Merge.rc:5617
+#: Merge.rc:5616
 #, c-format
 msgid "Error prediffing '%1' with '%2'. Prediffing disabled."
 msgstr ""
 
 #. IDS_PLUGIN_CIRCULAR_REFERENCE
-#: Merge.rc:5618
+#: Merge.rc:5617
 #, c-format
 msgid "Circular reference in plugin pipeline: %1"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE1
-#: Merge.rc:5619
+#: Merge.rc:5618
 msgid "URL Handler"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE2
-#: Merge.rc:5620
+#: Merge.rc:5619
 msgid "File Unpacker"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE3
-#: Merge.rc:5621
+#: Merge.rc:5620
 msgid "File or Folder Unpacker"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE5
-#: Merge.rc:5623
+#: Merge.rc:5622
 msgid "Alias for Unpacker"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE6
-#: Merge.rc:5624
+#: Merge.rc:5623
 msgid "Alias for Prediffer"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE7
-#: Merge.rc:5625
+#: Merge.rc:5624
 msgid "Alias for Editor script"
 msgstr ""
 
 #. IDS_PLUGIN_ALIAS_DESC
-#: Merge.rc:5626
+#: Merge.rc:5625
 #, c-format
 msgid "Alias for plugin pipeline '%1'"
 msgstr ""
 
 #. IDS_PLUGIN_NEW_DESC
-#: Merge.rc:5627
+#: Merge.rc:5626
 msgid "New plugin description"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_ALL
-#: Merge.rc:5628
+#: Merge.rc:5627
 msgid "All"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_1ST
-#: Merge.rc:5629
+#: Merge.rc:5628
 msgid "1st"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_2ND
-#: Merge.rc:5630
+#: Merge.rc:5629
 msgid "2nd"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_3RD
-#: Merge.rc:5631
+#: Merge.rc:5630
 msgid "3rd"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_1ST_2ND
-#: Merge.rc:5632
+#: Merge.rc:5631
 msgid "1st and 2nd"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_1ST_3RD
-#: Merge.rc:5633
+#: Merge.rc:5632
 msgid "1st and 3rd"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_2ND_3RD
-#: Merge.rc:5634
+#: Merge.rc:5633
 msgid "2nd and 3rd"
 msgstr ""
 
 #. IDS_PLUGIN_CTRL_CLICK
-#: Merge.rc:5635
+#: Merge.rc:5634
 msgid "(Ctrl+Click to add to pipeline)"
 msgstr ""
 
 #. IDS_FILTER_APPLIED
-#: Merge.rc:5640
+#: Merge.rc:5639
 msgid "Filter applied"
 msgstr ""
 
 #. IDS_FILTERMENU_COMPARE
-#: Merge.rc:5645
+#: Merge.rc:5644
 #, c-format
 msgid "Compare %1"
 msgstr "Сравняване на %1"
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN2
-#: Merge.rc:5647
+#: Merge.rc:5646
 msgid "&Filter by This Column..."
 msgstr ""
 
 #. IDS_CLIPBOARDHISTORY_TIME
-#: Merge.rc:5652
+#: Merge.rc:5651
 #, c-format
 msgid "Clipboard at %s"
 msgstr ""
 
 #. IDS_CLIPBOARDHISTORY_DISABLED
-#: Merge.rc:5653
+#: Merge.rc:5652
 msgid ""
 "Clipboard history disabled.\r\n"
 "Enable: Windows logo key + V, then Turn on."
 msgstr ""
 
-#: Merge.rc:5655
+#: Merge.rc:5654
 msgid "This system does not support clipboard history."
 msgstr ""
 
-#: Merge.rc:5657
+#: Merge.rc:5656
 msgid "32-bit WinMerge does not support Clipboard Compare"
 msgstr ""
 
 #. IDS_WEBVIEW2_RUNTIME_NOT_INSTALLED
-#: Merge.rc:5662
+#: Merge.rc:5661
 msgid "WebView2 runtime not installed. Download it?"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_TEXT_COMPARE
-#: Merge.rc:5667
+#: Merge.rc:5666
 msgid "New Text Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_TABLE_COMPARE
-#: Merge.rc:5668
+#: Merge.rc:5667
 msgid "New Table Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_BINARY_COMPARE
-#: Merge.rc:5669
+#: Merge.rc:5668
 msgid "New Binary Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_IMAGE_COMPARE
-#: Merge.rc:5670
+#: Merge.rc:5669
 msgid "New Image Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_WEBPAGE_COMPARE
-#: Merge.rc:5671
+#: Merge.rc:5670
 msgid "New Webpage Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_FOLDER_COMPARE
-#: Merge.rc:5672
+#: Merge.rc:5671
 msgid "New Folder Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_CLIPBOARD_COMPARE
-#: Merge.rc:5673
+#: Merge.rc:5672
 msgid "Clipboard Compare"
 msgstr ""
 
 #. IDS_PREVIEWBAR_PRINT
-#: Merge.rc:5678
+#: Merge.rc:5677
 msgid "&Print..."
 msgstr ""
 
 #. IDS_PREVIEWBAR_PREVPAGE
-#: Merge.rc:5680
+#: Merge.rc:5679
 msgid "Pre&v Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_TWOPAGE
-#: Merge.rc:5681
+#: Merge.rc:5680
 msgid "&Two Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_ONEPAGE
-#: Merge.rc:5682
+#: Merge.rc:5681
 msgid "&One Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_ZOOMIN
-#: Merge.rc:5683
+#: Merge.rc:5682
 msgid "Zoom &In"
 msgstr ""
 
 #. IDS_PREVIEWBAR_ZOOMOUT
-#: Merge.rc:5684
+#: Merge.rc:5683
 msgid "Zoom &Out"
 msgstr ""
 
 #. IDS_WEBPAGE_COMPARING
-#: Merge.rc:5690
+#: Merge.rc:5689
 msgid "Comparing..."
 msgstr "Сравняване…"
 
 #. IDS_WEBPAGE_ZOOM
-#: Merge.rc:5691
+#: Merge.rc:5690
 msgid "Zoom:"
 msgstr "Мащаб:"
 
 #. IDS_COPY_GRANULARITY_DIFFHUNK
-#: Merge.rc:5696
+#: Merge.rc:5695
 msgid "Diff hunk"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_INLINE
-#: Merge.rc:5697
+#: Merge.rc:5696
 msgid "Inline diff"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_LINE
-#: Merge.rc:5698
+#: Merge.rc:5697
 msgid "Line"
 msgstr "Ред"
 
-#: Merge.rc:5699
+#: Merge.rc:5698
 msgid "Character"
 msgstr "Знак"
 
 #. ID_MICE_PREVDIFF
-#: Merge.rc:5704
+#: Merge.rc:5703
 msgid ""
 "\n"
 "Previous Difference (Alt+Up)\n"
@@ -8492,7 +8487,7 @@ msgid ""
 msgstr ""
 
 #. ID_MICE_NEXTDIFF
-#: Merge.rc:5705
+#: Merge.rc:5704
 msgid ""
 "\n"
 "Next Difference (Alt+Down)\n"
@@ -8501,7 +8496,7 @@ msgid ""
 msgstr ""
 
 #. ID_MICE_L2R
-#: Merge.rc:5706
+#: Merge.rc:5705
 msgid ""
 "\n"
 "Copy to Right (Alt+Right)\n"
@@ -8511,7 +8506,7 @@ msgid ""
 msgstr ""
 
 #. ID_MICE_R2L
-#: Merge.rc:5707
+#: Merge.rc:5706
 msgid ""
 "\n"
 "Copy to Left (Alt+Left)\n"
@@ -8521,7 +8516,7 @@ msgid ""
 msgstr ""
 
 #. ID_MICE_L2RNEXT
-#: Merge.rc:5708
+#: Merge.rc:5707
 msgid ""
 "\n"
 "Copy to Right and Advance (Ctrl+Alt+Right)\n"
@@ -8530,7 +8525,7 @@ msgid ""
 msgstr ""
 
 #. ID_MICE_R2LNEXT
-#: Merge.rc:5709
+#: Merge.rc:5708
 msgid ""
 "\n"
 "Copy to Left and Advance (Ctrl+Alt+Left)\n"
@@ -8539,282 +8534,282 @@ msgid ""
 msgstr ""
 
 #. IDS_LOG_COMPARING_2
-#: Merge.rc:5719
+#: Merge.rc:5718
 #, c-format
 msgid "Comparing %1 with %2"
 msgstr ""
 
 #. IDS_LOG_COMPARING_3
-#: Merge.rc:5720
+#: Merge.rc:5719
 #, c-format
 msgid "Comparing %1 with %2 and %3"
 msgstr ""
 
 #. IDS_LOG_COMPARE_COMPLETED
-#: Merge.rc:5721
+#: Merge.rc:5720
 msgid "Comparison completed"
 msgstr ""
 
 #. IDS_LOG_COMPARE_ERROR_2
-#: Merge.rc:5722
+#: Merge.rc:5721
 #, c-format
 msgid "Failed to compare %1 with %2: "
 msgstr ""
 
 #. IDS_LOG_COMPARE_ERROR_3
-#: Merge.rc:5723
+#: Merge.rc:5722
 #, c-format
 msgid "Failed to compare %1 with %2 and %3: "
 msgstr ""
 
 #. IDS_LOG_FILE_SAVED
-#: Merge.rc:5724
+#: Merge.rc:5723
 msgid "File saved"
 msgstr ""
 
 #. IDS_LOG_COPYING_FILES
-#: Merge.rc:5725
+#: Merge.rc:5724
 msgid "Copying files..."
 msgstr ""
 
 #. IDS_LOG_MOVING_FILES
-#: Merge.rc:5726
+#: Merge.rc:5725
 msgid "Moving files..."
 msgstr ""
 
 #. IDS_LOG_DELETING_FILES
-#: Merge.rc:5727
+#: Merge.rc:5726
 msgid "Deleting files..."
 msgstr ""
 
 #. IDS_LOG_RECYCLEBIN
-#: Merge.rc:5728
+#: Merge.rc:5727
 msgid "Recycle Bin"
 msgstr ""
 
 #. IDS_LOG_PERMANENTLY_DELETED
-#: Merge.rc:5729
+#: Merge.rc:5728
 msgid "Permanently deleted"
 msgstr ""
 
 #. IDS_LOG_FILEOPERATION_COMPLETED
-#: Merge.rc:5730
+#: Merge.rc:5729
 msgid "File operation completed successfully"
 msgstr ""
 
 #. IDS_LOG_FILEOPERATION_CANCELED
-#: Merge.rc:5731
+#: Merge.rc:5730
 msgid "File operation canceled"
 msgstr ""
 
 #. IDS_FILTER_ERROR_NO_ERROR
-#: Merge.rc:5736
+#: Merge.rc:5735
 msgid "No error"
 msgstr ""
 
 #. IDS_FILTER_ERROR_EMPTY_EXPRESSION
-#: Merge.rc:5737
+#: Merge.rc:5736
 msgid "Filter expression is empty"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNKNOWN_CHAR
-#: Merge.rc:5738
+#: Merge.rc:5737
 msgid "Unknown character in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNTERMINATED_STRING
-#: Merge.rc:5739
+#: Merge.rc:5738
 msgid "Unterminated string literal"
 msgstr ""
 
 #. IDS_FILTER_ERROR_SYNTAX_ERROR
-#: Merge.rc:5740
+#: Merge.rc:5739
 msgid "Syntax error in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_PARSE_FAILURE
-#: Merge.rc:5741
+#: Merge.rc:5740
 msgid "Failed to parse filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_LITERAL
-#: Merge.rc:5742
+#: Merge.rc:5741
 msgid "Invalid literal value"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_REGULAR_EXPRESSION
-#: Merge.rc:5743
+#: Merge.rc:5742
 msgid "Invalid regular expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNDEFINED_IDENTIFIER
-#: Merge.rc:5744
+#: Merge.rc:5743
 msgid "Undefined identifier"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_ARGUMENT_COUNT
-#: Merge.rc:5745
+#: Merge.rc:5744
 msgid "Invalid number of arguments"
 msgstr ""
 
 #. IDS_FILTER_ERROR_FILTER_NAME_NOT_FOUND
-#: Merge.rc:5746
+#: Merge.rc:5745
 msgid "Filter name not found"
 msgstr ""
 
 #. IDS_FILTER_ERROR_DIVIDE_BY_ZERO
-#: Merge.rc:5747
+#: Merge.rc:5746
 msgid "Division by zero in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNKNOWN_ERROR
-#: Merge.rc:5748
+#: Merge.rc:5747
 msgid "Unknown error"
 msgstr "Неочаквана грешка"
 
 #. IDS_FILTER_ERROR_INVALID_PROPERTY_NAME
-#: Merge.rc:5749
+#: Merge.rc:5748
 msgid "Invalid property name"
 msgstr "Неприемливо име на свойство"
 
 #. IDS_FILTER_ERROR_INVALID_DIRECTIVE
-#: Merge.rc:5750
+#: Merge.rc:5749
 msgid "Invalid directive"
 msgstr ""
 
 #. IDS_FILTER_OP_EQUALS
-#: Merge.rc:5755
+#: Merge.rc:5754
 msgid "Equals"
 msgstr "Е равно на"
 
 #. IDS_FILTER_OP_NOT_EQUALS
-#: Merge.rc:5756
+#: Merge.rc:5755
 msgid "Does not equal"
 msgstr "Не е равно на"
 
 #. IDS_FILTER_OP_LESS_THAN
-#: Merge.rc:5757
+#: Merge.rc:5756
 msgid "Less than"
 msgstr "По-малко от"
 
 #. IDS_FILTER_OP_LESS_EQUAL
-#: Merge.rc:5758
+#: Merge.rc:5757
 msgid "Less than or equal to"
 msgstr "По-малко или равно на"
 
 #. IDS_FILTER_OP_GREATER_EQUAL
-#: Merge.rc:5759
+#: Merge.rc:5758
 msgid "Greater than or equal to"
 msgstr "По-голямо или равно на"
 
 #. IDS_FILTER_OP_GREATER_THAN
-#: Merge.rc:5760
+#: Merge.rc:5759
 msgid "Greater than"
 msgstr "По-голямо на"
 
 #. IDS_FILTER_OP_BETWEEN
-#: Merge.rc:5761
+#: Merge.rc:5760
 msgid "Between"
 msgstr "Между"
 
 #. IDS_FILTER_OP_NOT_BETWEEN
-#: Merge.rc:5762
+#: Merge.rc:5761
 msgid "Not Between"
 msgstr "Не меЖду"
 
 #. IDS_FILTER_OP_CONTAINS
-#: Merge.rc:5763
+#: Merge.rc:5762
 msgid "Contains"
 msgstr "Съдържа"
 
 #. IDS_FILTER_OP_NOT_CONTAINS
-#: Merge.rc:5764
+#: Merge.rc:5763
 msgid "Not Contains"
 msgstr "Не съдържа"
 
 #. IDS_FILTER_OP_RECONTAINS
-#: Merge.rc:5765
+#: Merge.rc:5764
 msgid "Contains (regex)"
 msgstr "Съдържа (регулярен израз)"
 
 #. IDS_FILTER_OP_NOT_RECONTAINS
-#: Merge.rc:5766
+#: Merge.rc:5765
 msgid "Not Contains (regex)"
 msgstr "Не съдържа (регулярен израз)"
 
 #. IDS_FILTER_OP_LIKE
-#: Merge.rc:5767
+#: Merge.rc:5766
 msgid "Match (wildcard)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_LIKE
-#: Merge.rc:5768
+#: Merge.rc:5767
 msgid "Not match (wildcard)"
 msgstr ""
 
 #. IDS_FILTER_OP_MATCHES
-#: Merge.rc:5769
+#: Merge.rc:5768
 msgid "Match (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_MATCHES
-#: Merge.rc:5770
+#: Merge.rc:5769
 msgid "Not match (regex)"
 msgstr ""
 
 #. IDS_COLORMODE_LIGHT
-#: Merge.rc:5775
+#: Merge.rc:5774
 msgid "Light"
 msgstr "Светла"
 
 #. IDS_COLORMODE_DARK
-#: Merge.rc:5776
+#: Merge.rc:5775
 msgid "Dark"
 msgstr "Тъмна"
 
 #. IDS_COLORMODE_FOLLOWSYSTEM
-#: Merge.rc:5777
+#: Merge.rc:5776
 msgid "Follow system"
 msgstr "Според системата"
 
 #. IDS_EXAMPLE
-#: Merge.rc:5782
+#: Merge.rc:5781
 #, c-format
 msgid "e.g. %1"
 msgstr ""
 
 #. IDS_DETECTED_PREVIOUS_CRASH
-#: Merge.rc:5787
+#: Merge.rc:5786
 msgid "WinMerge detected a previous crash. Please report this if possible."
 msgstr ""
 
 #. IDS_REGEX_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5792
+#: Merge.rc:5791
 msgid "# Regex replacement list\r\n# Format: regex<TAB>replacement\r\n# Backreferences like $1, $2 are supported\r\n\r\n(\\d{4})-(\\d{2})-(\\d{2})\t$1_$2_$3\r\n"
 msgstr ""
 
 #. IDS_STRING_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5793
+#: Merge.rc:5792
 msgid "# Replacement list\r\n# Format: search<TAB>replacement\r\n# Lines starting with # are ignored\r\n\r\nfrom1\tto1\r\nfrom2\tto2\r\n"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_ONLY
-#: Merge.rc:5798
+#: Merge.rc:5797
 msgid "Built-in only"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_FIRST
-#: Merge.rc:5799
+#: Merge.rc:5798
 msgid "Built-in first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_FIRST
-#: Merge.rc:5800
+#: Merge.rc:5799
 msgid "Tree-sitter first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_ONLY
-#: Merge.rc:5801
+#: Merge.rc:5800
 msgid "Tree-sitter only"
 msgstr ""
 

--- a/Translations/WinMerge/Catalan.po
+++ b/Translations/WinMerge/Catalan.po
@@ -22,7 +22,7 @@ msgstr ""
 "X-Generator: Poedit 3.4.2\n"
 
 #. LANGUAGE, SUBLANGUAGE
-#: Merge.rc:26 Merge.rc:59 Merge.rc:5818
+#: Merge.rc:26 Merge.rc:59 Merge.rc:5817
 #, c-format
 msgid "LANG_ENGLISH, SUBLANG_ENGLISH_US"
 msgstr "LANG_CATALAN, SUBLANG_DEFAULT"
@@ -172,7 +172,7 @@ msgstr "&Seqüències d'ordres"
 #. IDS_NO_EDIT_SCRIPTS
 #: Merge.rc:127 Merge.rc:352 Merge.rc:463 Merge.rc:673 Merge.rc:678
 #: Merge.rc:887 Merge.rc:899 Merge.rc:906 Merge.rc:963 Merge.rc:1210
-#: Merge.rc:5375
+#: Merge.rc:5374
 #, c-format
 msgid "< Empty >"
 msgstr "< Buit >"
@@ -239,7 +239,7 @@ msgid "Auto-Fit All Columns"
 msgstr "Ajusta automàticament totes les columnes"
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN
-#: Merge.rc:153 Merge.rc:5646
+#: Merge.rc:153 Merge.rc:5645
 msgid "&Filter by This Column"
 msgstr ""
 
@@ -305,7 +305,7 @@ msgid "&Previous Page"
 msgstr "&Pàgina anterior"
 
 #. IDS_PREVIEWBAR_NEXTPAGE
-#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5679
+#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5678
 #, c-format
 msgid "&Next Page"
 msgstr "Pàgina següe&nt"
@@ -573,7 +573,7 @@ msgstr "&Binari"
 #. IDS_IMAGE_MENU
 #: Merge.rc:329 Merge.rc:338 Merge.rc:432 Merge.rc:441 Merge.rc:609
 #: Merge.rc:618 Merge.rc:670 Merge.rc:960 Merge.rc:1187 Merge.rc:1200
-#: Merge.rc:5477
+#: Merge.rc:5476
 #, c-format
 msgid "&Image"
 msgstr "&Imatge"
@@ -711,7 +711,7 @@ msgid "&Huge"
 msgstr "&Immensa"
 
 #. IDS_VIEW_MENU_BAR
-#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5714
+#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5713
 msgid "Men&u Bar"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgid "Lo&cation Pane"
 msgstr "Subfinestra d'&ubicació"
 
 #. IDS_OUTPUTBAR_CAPTION
-#: Merge.rc:782 Merge.rc:5252
+#: Merge.rc:782 Merge.rc:5251
 msgid "Output Pane"
 msgstr ""
 
@@ -1770,55 +1770,55 @@ msgid "Co&mpare As"
 msgstr "Compara com"
 
 #. IDS_COPY_LEFT_TO_MIDDLE2
-#: Merge.rc:968 Merge.rc:980 Merge.rc:4852
+#: Merge.rc:968 Merge.rc:980 Merge.rc:4851
 #, c-format
 msgid "Left to Middle (%1 of %2)"
 msgstr "Esquerra al mig (%1 de %2)"
 
 #. IDS_COPY_LEFT_TO_RIGHT2
-#: Merge.rc:969 Merge.rc:981 Merge.rc:4851
+#: Merge.rc:969 Merge.rc:981 Merge.rc:4850
 #, c-format
 msgid "Left to Right (%1 of %2)"
 msgstr "Esquerra a dreta (%1 de %2)"
 
 #. IDS_MOVE_LEFT_TO2
-#: Merge.rc:970 Merge.rc:982 Merge.rc:1045 Merge.rc:4863 Merge.rc:4892
+#: Merge.rc:970 Merge.rc:982 Merge.rc:1045 Merge.rc:4862 Merge.rc:4891
 #, c-format
 msgid "Left to... (%1 of %2)"
 msgstr "Esquerra a... (%1 de %2)"
 
 #. IDS_COPY_MIDDLE_TO_LEFT2
-#: Merge.rc:971 Merge.rc:983 Merge.rc:4849
+#: Merge.rc:971 Merge.rc:983 Merge.rc:4848
 #, c-format
 msgid "Middle to Left (%1 of %2)"
 msgstr "Del mig a esquerra (%1 de %2)"
 
 #. IDS_COPY_MIDDLE_TO_RIGHT2
-#: Merge.rc:972 Merge.rc:984 Merge.rc:4850
+#: Merge.rc:972 Merge.rc:984 Merge.rc:4849
 #, c-format
 msgid "Middle to Right (%1 of %2)"
 msgstr "Del mig a dreta (%1 de %2)"
 
 #. IDS_MOVE_MIDDLE_TO2
-#: Merge.rc:973 Merge.rc:985 Merge.rc:1046 Merge.rc:4864 Merge.rc:4893
+#: Merge.rc:973 Merge.rc:985 Merge.rc:1046 Merge.rc:4863 Merge.rc:4892
 #, c-format
 msgid "Middle to... (%1 of %2)"
 msgstr "Del mig a... (%1 de %2)"
 
 #. IDS_COPY_RIGHT_TO_MIDDLE2
-#: Merge.rc:974 Merge.rc:986 Merge.rc:4848
+#: Merge.rc:974 Merge.rc:986 Merge.rc:4847
 #, c-format
 msgid "Right to Middle (%1 of %2)"
 msgstr "Dreta al mig (%1 de %2)"
 
 #. IDS_COPY_RIGHT_TO_LEFT2
-#: Merge.rc:975 Merge.rc:987 Merge.rc:4847
+#: Merge.rc:975 Merge.rc:987 Merge.rc:4846
 #, c-format
 msgid "Right to Left (%1 of %2)"
 msgstr "Dreta a esquerra (%1 de %2)"
 
 #. IDS_MOVE_RIGHT_TO2
-#: Merge.rc:976 Merge.rc:988 Merge.rc:1047 Merge.rc:4865 Merge.rc:4894
+#: Merge.rc:976 Merge.rc:988 Merge.rc:1047 Merge.rc:4864 Merge.rc:4893
 #, c-format
 msgid "Right to... (%1 of %2)"
 msgstr "Dreta a... (%1 de %2)"
@@ -1884,31 +1884,31 @@ msgid "Cop&y Paths"
 msgstr "C&opia els camins"
 
 #. IDS_DEL_LEFT_FMT2
-#: Merge.rc:1026 Merge.rc:1035 Merge.rc:4880
+#: Merge.rc:1026 Merge.rc:1035 Merge.rc:4879
 #, c-format
 msgid "Left (%1 of %2)"
 msgstr "Esquerra (%1 de %2)"
 
 #. IDS_DEL_MIDDLE_FMT2
-#: Merge.rc:1027 Merge.rc:1036 Merge.rc:4881
+#: Merge.rc:1027 Merge.rc:1036 Merge.rc:4880
 #, c-format
 msgid "Middle (%1 of %2)"
 msgstr "Mig (%1 de %2)"
 
 #. IDS_DEL_RIGHT_FMT2
-#: Merge.rc:1028 Merge.rc:1037 Merge.rc:4882
+#: Merge.rc:1028 Merge.rc:1037 Merge.rc:4881
 #, c-format
 msgid "Right (%1 of %2)"
 msgstr "Dreta (%1 de %2)"
 
 #. IDS_DEL_BOTH_FMT2
-#: Merge.rc:1029 Merge.rc:1038 Merge.rc:4883
+#: Merge.rc:1029 Merge.rc:1038 Merge.rc:4882
 #, c-format
 msgid "Both (%1 of %2)"
 msgstr "Ambdós (%1 de %2)"
 
 #. IDS_DEL_ALL_FMT2
-#: Merge.rc:1030 Merge.rc:1039 Merge.rc:4888
+#: Merge.rc:1030 Merge.rc:1039 Merge.rc:4887
 #, c-format
 msgid "All (%1 of %2)"
 msgstr "Tots (%1 de %2)"
@@ -1937,19 +1937,19 @@ msgid "&Zip"
 msgstr "Co&mprimeix"
 
 #. IDS_COPY_BOTH_TO2
-#: Merge.rc:1048 Merge.rc:4866
+#: Merge.rc:1048 Merge.rc:4865
 #, c-format
 msgid "Both to... (%1 of %2)"
 msgstr "Ambdós a... (%1 de %2)"
 
 #. IDS_COPY_ALL_TO2
-#: Merge.rc:1049 Merge.rc:4867
+#: Merge.rc:1049 Merge.rc:4866
 #, c-format
 msgid "All to... (%1 of %2)"
 msgstr "Tots a... (%1 de %2)"
 
 #. IDS_COPY_DIFFERENCES_TO2
-#: Merge.rc:1050 Merge.rc:4868
+#: Merge.rc:1050 Merge.rc:4867
 #, c-format
 msgid "Differences to... (%1 of %2)"
 msgstr "Diferències a... (%1 de %2)"
@@ -2022,13 +2022,13 @@ msgstr "Opcions del desempaquetador"
 
 #. IDS_USERCHOICE_NONE
 #: Merge.rc:1088 Merge.rc:1094 Merge.rc:1836 Merge.rc:1840 Merge.rc:2031
-#: Merge.rc:2035 Merge.rc:5377
+#: Merge.rc:2035 Merge.rc:5376
 #, c-format
 msgid "<None>"
 msgstr "<Cap>"
 
 #. IDS_USERCHOICE_AUTOMATIC
-#: Merge.rc:1089 Merge.rc:1095 Merge.rc:5378
+#: Merge.rc:1089 Merge.rc:1095 Merge.rc:5377
 #, c-format
 msgid "<Automatic>"
 msgstr "<Automàtic>"
@@ -2980,13 +2980,13 @@ msgid "Text files only"
 msgstr ""
 
 #. IDS_EOL_NONE
-#: Merge.rc:1667 Merge.rc:1918 Merge.rc:5304
+#: Merge.rc:1667 Merge.rc:1918 Merge.rc:5303
 #, c-format
 msgid "None"
 msgstr "Cap"
 
 #. IDS_EOL_MIXED
-#: Merge.rc:1668 Merge.rc:5299
+#: Merge.rc:1668 Merge.rc:5298
 #, c-format
 msgid "Mixed"
 msgstr "Barrejat"
@@ -3260,14 +3260,14 @@ msgstr ""
 
 #. IDS_DIFFERENT
 #: Merge.rc:1904 Merge.rc:1988 Merge.rc:2866 Merge.rc:3036 Merge.rc:3077
-#: Merge.rc:5058
+#: Merge.rc:5057
 #, c-format
 msgid "Different"
 msgstr "Diferents"
 
 #. IDS_IDENTICAL
 #: Merge.rc:1905 Merge.rc:1989 Merge.rc:2865 Merge.rc:3055 Merge.rc:3116
-#: Merge.rc:5048
+#: Merge.rc:5047
 #, c-format
 msgid "Identical"
 msgstr "Idèntics"
@@ -3288,7 +3288,7 @@ msgid "Missing"
 msgstr ""
 
 #. IDS_MOVED
-#: Merge.rc:1910 Merge.rc:5076
+#: Merge.rc:1910 Merge.rc:5075
 msgid "Moved"
 msgstr ""
 
@@ -4116,7 +4116,7 @@ msgid "&Use custom system colors"
 msgstr ""
 
 #. IDS_PRPCAT_SYSTEM
-#: Merge.rc:2565 Merge.rc:4559 Merge.rc:4560 Merge.rc:5007
+#: Merge.rc:2565 Merge.rc:4559 Merge.rc:4560 Merge.rc:5006
 #, c-format
 msgid "System"
 msgstr "Sistema"
@@ -4567,7 +4567,7 @@ msgid "Items compared:"
 msgstr "Elements comparats:"
 
 #. IDS_PREVIEWBAR_CLOSE
-#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5685
+#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5684
 #, c-format
 msgid "&Close"
 msgstr "&Tanca"
@@ -5260,7 +5260,7 @@ msgid "A&ppend timestamp"
 msgstr "A&fegeix una marca horària"
 
 #. IDS_CONFIRM_COPY_CAPTION
-#: Merge.rc:3214 Merge.rc:4915
+#: Merge.rc:3214 Merge.rc:4914
 #, c-format
 msgid "Confirm Copy"
 msgstr "Confirmació de còpia"
@@ -5521,7 +5521,7 @@ msgid "&Character Set..."
 msgstr "Taula de codificació de caràcters..."
 
 #. IDS_PRPCAT_IMAGE
-#: Merge.rc:3351 Merge.rc:4574 Merge.rc:5015
+#: Merge.rc:3351 Merge.rc:4574 Merge.rc:5014
 msgid "Image"
 msgstr "Imatge"
 
@@ -5945,7 +5945,7 @@ msgid "Project"
 msgstr "Projecte"
 
 #. IDS_COLHDR_NSDIFFS
-#: Merge.rc:4566 Merge.rc:4990
+#: Merge.rc:4566 Merge.rc:4989
 #, c-format
 msgid "Differences"
 msgstr "Diferències"
@@ -6105,13 +6105,13 @@ msgid "File Type"
 msgstr "Tipus de fitxer"
 
 #. IDS_COLHDR_EXTENSION
-#: Merge.rc:4653 Merge.rc:4947
+#: Merge.rc:4653 Merge.rc:4946
 #, c-format
 msgid "Extension"
 msgstr "Extensió"
 
 #. IDS_PRPCAT_MESSAGE
-#: Merge.rc:4659 Merge.rc:5019
+#: Merge.rc:4659 Merge.rc:5018
 msgid "Message"
 msgstr "Missatge"
 
@@ -6151,7 +6151,7 @@ msgid "Hidden Items"
 msgstr "Elements ocults"
 
 #. IDS_PLUGINSLIST_NAME
-#: Merge.rc:4680 Merge.rc:5311
+#: Merge.rc:4680 Merge.rc:5310
 #, c-format
 msgid "Name"
 msgstr "Nom"
@@ -6175,7 +6175,7 @@ msgid "[F] "
 msgstr "[F] "
 
 #. IDS_PLUGINSLIST_DESC
-#: Merge.rc:4684 Merge.rc:5313
+#: Merge.rc:4684 Merge.rc:5312
 #, c-format
 msgid "Description"
 msgstr "Descripció"
@@ -6358,171 +6358,165 @@ msgstr "Lin: %s  Col: %d/%d  Car: %d/%d"
 msgid "  Sel: %d | %d"
 msgstr "  Sel: %d | %d"
 
-#. IDS_MERGEMODE_MERGING
-#: Merge.rc:4734
-#, c-format
-msgid "Merge"
-msgstr "Combina"
-
 #. IDS_DIFF_NUMBER_STATUS_FMT
-#: Merge.rc:4735
+#: Merge.rc:4734
 #, c-format
 msgid "Difference %1 of %2"
 msgstr "Diferència %1 de %2"
 
 #. IDS_NO_DIFF_SEL_FMT
-#: Merge.rc:4736
+#: Merge.rc:4735
 #, c-format
 msgid "%1 Differences Found"
 msgstr "S'han trobat %1 diferències"
 
 #. IDS_1_DIFF_FOUND
-#: Merge.rc:4737
+#: Merge.rc:4736
 #, c-format
 msgid "1 Difference Found"
 msgstr "S'ha trobat una diferència"
 
 #. IDS_NO_ERR_SEL_FMT
-#: Merge.rc:4738
+#: Merge.rc:4737
 #, c-format
 msgid "%1 Errors Found"
 msgstr ""
 
 #. IDS_1_ERR_FOUND
-#: Merge.rc:4739
+#: Merge.rc:4738
 msgid "1 Error Found"
 msgstr ""
 
 #. IDS_STATUSBAR_READONLY, Abbreviation from "Read Only"
-#: Merge.rc:4740
+#: Merge.rc:4739
 #, c-format
 msgid "RO"
 msgstr "LE"
 
 #. IDS_DIRVIEW_STATUS_FMT_FOCUS
-#: Merge.rc:4746
+#: Merge.rc:4745
 #, c-format
 msgid "Item %1 of %2"
 msgstr "Element %1 de %2"
 
 #. IDS_DIRVIEW_STATUS_FMT_NOFOCUS
-#: Merge.rc:4747
+#: Merge.rc:4746
 #, c-format
 msgid "Items: %1"
 msgstr "Elements: %1"
 
 #. IDS_DIRVIEW_STATUS_COMPARING
-#: Merge.rc:4748
+#: Merge.rc:4747
 #, c-format
 msgid "Comparing items..."
 msgstr "Comparant elements..."
 
 #. IDS_ITEMS_PER_SEC
-#: Merge.rc:4749
+#: Merge.rc:4748
 #, c-format
 msgid "%.1f[items/sec]"
 msgstr "%.1f[elements/seg.]"
 
 #. IDS_ERROR_INCOMPARABLE
-#: Merge.rc:4755
+#: Merge.rc:4754
 msgid "Select two existing folders/files to compare."
 msgstr "Selecciona dos directoris o fitxers existents per a comparar."
 
 #. IDS_DIRSEL_TAG
-#: Merge.rc:4756
+#: Merge.rc:4755
 #, c-format
 msgid "Folder Selection"
 msgstr "Selecció de directori"
 
 #. IDS_OPEN_FILESDIRS
-#: Merge.rc:4757
+#: Merge.rc:4756
 #, c-format
 msgid "Select two (or three) folders/files to compare."
 msgstr "Selecciona dos (o tres) directoris o dos (o tres) fitxers per a comparar."
 
 #. IDS_OPEN_LEFTINVALID
-#: Merge.rc:4758
+#: Merge.rc:4757
 #, c-format
 msgid "Left (1st) path is invalid!"
 msgstr "El camí de l'esquerra (1er) no és vàlid."
 
 #. IDS_OPEN_MIDDLEINVALID
-#: Merge.rc:4759
+#: Merge.rc:4758
 #, c-format
 msgid "Middle (2nd) path is invalid!"
 msgstr "El camí del mig (2n) no és vàlid."
 
 #. IDS_OPEN_RIGHTINVALID2
-#: Merge.rc:4760
+#: Merge.rc:4759
 #, c-format
 msgid "Right (2nd) path is invalid!"
 msgstr "El camí de la dreta (2n) no és vàlid."
 
 #. IDS_OPEN_RIGHTINVALID3
-#: Merge.rc:4761
+#: Merge.rc:4760
 #, c-format
 msgid "Right (3rd) path is invalid!"
 msgstr "El camí de la dreta (3er) no és vàlid."
 
 #. IDS_OPEN_BOTHINVALID
-#: Merge.rc:4762
+#: Merge.rc:4761
 #, c-format
 msgid "Both paths are invalid!"
 msgstr "Els dos camins no són vàlids."
 
-#: Merge.rc:4764
+#: Merge.rc:4763
 #, c-format
 msgid "Left (1st) and Middle (2nd) paths are invalid!"
 msgstr "Els camins de l'esquerra (1er) i del mig (2n) no són vàlids."
 
 #. IDS_OPEN_LEFTRIGHTINVALID
-#: Merge.rc:4765
+#: Merge.rc:4764
 #, c-format
 msgid "Left (1st) and Right (3rd) paths are invalid!"
 msgstr "Els camins de l'esquerra (1er) i de la dreta (3er) no són vàlids."
 
-#: Merge.rc:4767
+#: Merge.rc:4766
 #, c-format
 msgid "Middle (2nd) and Right (3rd) paths are invalid!"
 msgstr "Els camins del mig (2on) i de l'esquerra (3er) no són vàlids."
 
 #. IDS_OPEN_ALLINVALID
-#: Merge.rc:4768
+#: Merge.rc:4767
 #, c-format
 msgid "All paths are invalid!"
 msgstr "No hi ha cap camí que sigui vàlid."
 
 #. IDS_OPEN_UNPACKERDISABLED
-#: Merge.rc:4769
+#: Merge.rc:4768
 msgid "Only enabled for file comparisons"
 msgstr "Només activat per a comparació de fitxers"
 
 #. IDS_OPEN_MISMATCH
-#: Merge.rc:4770
+#: Merge.rc:4769
 #, c-format
 msgid "Cannot compare file and folder!"
 msgstr "No es pot comparar un fitxer i un directori."
 
 #. IDS_ERROR_FILE_NOT_FOUND
-#: Merge.rc:4776
+#: Merge.rc:4775
 #, c-format
 msgid "File not found: %1"
 msgstr "No s'ha trobat el fitxer: %1"
 
 #. IDS_ERROR_FOLDER_NOT_FOUND
-#: Merge.rc:4777
+#: Merge.rc:4776
 #, c-format
 msgid "Folder not found: %1"
 msgstr ""
 
 #. IDS_ERROR_FILE_NOT_UNPACKED
-#: Merge.rc:4778
+#: Merge.rc:4777
 #, c-format
 msgid "File not unpacked: %1"
 msgstr "El fitxer no s'ha desempaquetat: %1"
 
 #. IDS_ERROR_FILEOPEN
-#: Merge.rc:4779
+#: Merge.rc:4778
 #, c-format
 msgid ""
 "Cannot open file\n"
@@ -6536,13 +6530,13 @@ msgstr ""
 "%2"
 
 #. IDS_ERROR_CONF_RESOLVE
-#: Merge.rc:4780
+#: Merge.rc:4779
 #, c-format
 msgid "Failed to parse conflict file."
 msgstr "No s'ha pogut interpretar el fitxer amb conflictes."
 
 #. IDS_NOT_CONFLICT_FILE
-#: Merge.rc:4781
+#: Merge.rc:4780
 #, c-format
 msgid "The file\n%1\nis not a conflict file."
 msgstr ""
@@ -6551,7 +6545,7 @@ msgstr ""
 "no és un fitxer amb conflictes."
 
 #. IDS_COMPARE_LARGE_FILES
-#: Merge.rc:4782
+#: Merge.rc:4781
 msgid "Comparing large files requires significant memory.\nShow only comparison results (not file contents)?"
 msgstr ""
 "Esteu a punt de comparar fitxers molt grans.\n"
@@ -6560,30 +6554,30 @@ msgstr ""
 "\n"
 
 #. IDS_SAVE_AS_TITLE
-#: Merge.rc:4788
+#: Merge.rc:4787
 #, c-format
 msgid "Save As"
 msgstr "Anomena i desa"
 
 #. IDS_SAVE_FMT
-#: Merge.rc:4789
+#: Merge.rc:4788
 #, c-format
 msgid "Save changes to %1?"
 msgstr "Voleu desar els canvis a %1?"
 
 #. IDS_SAVEREADONLY_FMT
-#: Merge.rc:4790
+#: Merge.rc:4789
 #, c-format
 msgid "%1 is read-only. Override? Or 'No' to save as new filename?"
 msgstr "El fitxer %1 és només de lectura. Voleu substituir el fitxer només de lectura? (Premeu no per desar amb un nom nou.)"
 
 #. IDS_ERROR_BACKUP
-#: Merge.rc:4791
+#: Merge.rc:4790
 #, c-format
 msgid "Error backing up file"
 msgstr "Hi ha hagut un error en crear una còpia de seguretat del fitxer"
 
-#: Merge.rc:4793
+#: Merge.rc:4792
 #, c-format
 msgid ""
 "Unable to backup original file:\n"
@@ -6597,7 +6591,7 @@ msgstr ""
 "Voleu continuar de totes maneres?"
 
 #. IDS_FILESAVE_FAILED
-#: Merge.rc:4794
+#: Merge.rc:4793
 #, c-format
 msgid "Saving file failed.\n%1\n%2\n\t- Use different filename (OK)\n\t- Abort (Cancel)?"
 msgstr ""
@@ -6608,7 +6602,7 @@ msgstr ""
 "\t- desar-lo amb un nom diferent (premeu D'acord)\n"
 "\t- avortar l'operació actual (Premeu Cancel·lar)?"
 
-#: Merge.rc:4796
+#: Merge.rc:4795
 #, c-format
 msgid "Plugin '%2' cannot pack changes to left file into '%1'.\n\nOriginal unchanged. Save unpacked version?"
 msgstr ""
@@ -6618,7 +6612,7 @@ msgstr ""
 "\n"
 "Voleu desar la versió desempaquetada en un altre fitxer?"
 
-#: Merge.rc:4798
+#: Merge.rc:4797
 #, c-format
 msgid "Plugin '%2' cannot pack changes to middle file into '%1'.\n\nOriginal unchanged. Save unpacked version?"
 msgstr ""
@@ -6628,7 +6622,7 @@ msgstr ""
 "\n"
 "Voleu desar la versió desempaquetada en un altre fitxer?"
 
-#: Merge.rc:4800
+#: Merge.rc:4799
 #, c-format
 msgid "Plugin '%2' cannot pack changes to right file into '%1'.\n\nOriginal unchanged. Save unpacked version?"
 msgstr ""
@@ -6639,7 +6633,7 @@ msgstr ""
 "Voleu desar la versió desempaquetada en un altre fitxer?"
 
 #. IDS_FILECHANGED_ONDISK
-#: Merge.rc:4801
+#: Merge.rc:4800
 #, c-format
 msgid ""
 "Another application updated\n"
@@ -6655,7 +6649,7 @@ msgstr ""
 "Voleu sobreescriure el fitxer?"
 
 #. IDS_SAVEREADONLY_MULTI
-#: Merge.rc:4802
+#: Merge.rc:4801
 #, c-format
 msgid ""
 "%1\n"
@@ -6665,7 +6659,7 @@ msgstr ""
 "està marcat com a només de lectura. Voleu substituir l'element només de lectura?"
 
 #. IDS_FILECHANGED_RESCAN
-#: Merge.rc:4803
+#: Merge.rc:4802
 #, c-format
 msgid "Another application updated\n%1\nsince last scan.\n\nReload?"
 msgstr ""
@@ -6676,25 +6670,25 @@ msgstr ""
 "Voleu recarregar el fitxer?"
 
 #. IDS_SAVE_LEFT_AS
-#: Merge.rc:4804
+#: Merge.rc:4803
 #, c-format
 msgid "Save Left File As"
 msgstr "Anomena i desa el fitxer de l'esquerra"
 
 #. IDS_SAVE_MIDDLE_AS
-#: Merge.rc:4805
+#: Merge.rc:4804
 #, c-format
 msgid "Save Middle File As"
 msgstr "Anomena i desa el fitxer del mig"
 
 #. IDS_SAVE_RIGHT_AS
-#: Merge.rc:4806
+#: Merge.rc:4805
 #, c-format
 msgid "Save Right File As"
 msgstr "Anomena i desa el fitxer de la dreta"
 
 #. IDS_FILE_DISAPPEARED
-#: Merge.rc:4811
+#: Merge.rc:4810
 #, c-format
 msgid ""
 "File\n"
@@ -6706,7 +6700,7 @@ msgstr ""
 "ha desapareguit. Si us plau, deseu una còpia del fitxer abans de continuar."
 
 #. IDS_VIEWS_OUTOFSYNC
-#: Merge.rc:4817
+#: Merge.rc:4816
 #, c-format
 msgid ""
 "Cannot merge unsynched documents.\n"
@@ -6718,189 +6712,189 @@ msgstr ""
 "Cal que refresqueu els documents abans de continuar."
 
 #. IDS_BREAK_ON_WHITESPACE
-#: Merge.rc:4822
+#: Merge.rc:4821
 msgid "Break at whitespace"
 msgstr "Separa a l'espai"
 
 #. IDS_BREAK_ON_PUNCTUATION
-#: Merge.rc:4823
+#: Merge.rc:4822
 msgid "Break at whitespace or punctuation"
 msgstr "Separa a l'espai o puntuació"
 
 #. IDS_L2M
-#: Merge.rc:4829
+#: Merge.rc:4828
 msgid "Copy to &Middle\tAlt+Right"
 msgstr "Copia al mig\tAlt+Dreta"
 
 #. IDS_R2M
-#: Merge.rc:4830
+#: Merge.rc:4829
 msgid "Copy to &Middle\tAlt+Left"
 msgstr "Copia al mig\tAlt+Esquerra"
 
 #. IDS_COPY_FROM_MIDDLE_R
-#: Merge.rc:4831
+#: Merge.rc:4830
 msgid "Copy from Middle\tAlt+Shift+Right"
 msgstr "Copia des del mig\tAlt+Maj+Dreta"
 
 #. IDS_COPY_FROM_MIDDLE_L
-#: Merge.rc:4832
+#: Merge.rc:4831
 msgid "Copy from Middle\tAlt+Shift+Left"
 msgstr "Copia des del mig\tAlt+Maj+Esquerra"
 
 #. IDS_L2MNEXT
-#: Merge.rc:4833
+#: Merge.rc:4832
 msgid "Copy to Middle and Advance\tCtrl+Alt+Right"
 msgstr "Copia al mig i avança\tControl+Alt+Dreta"
 
 #. IDS_R2MNEXT
-#: Merge.rc:4834
+#: Merge.rc:4833
 msgid "Copy to Middle and Advance\tCtrl+Alt+Left"
 msgstr "Copia al mig i avança\tControl+Alt+Esquerra"
 
 #. IDS_ALL_MIDDLE
-#: Merge.rc:4835
+#: Merge.rc:4834
 msgid "Copy All to Middle"
 msgstr "Copia-ho tot cap al mig"
 
 #. IDS_COPY_RIGHT_TO_LEFT
-#: Merge.rc:4841
+#: Merge.rc:4840
 #, c-format
 msgid "Right to Left (%1)"
 msgstr "Dreta a esquerra (%1)"
 
 #. IDS_COPY_RIGHT_TO_MIDDLE
-#: Merge.rc:4842
+#: Merge.rc:4841
 #, c-format
 msgid "Right to Middle (%1)"
 msgstr "Esquerra cap al mig (%1)"
 
 #. IDS_COPY_MIDDLE_TO_LEFT
-#: Merge.rc:4843
+#: Merge.rc:4842
 #, c-format
 msgid "Middle to Left (%1)"
 msgstr "Mig cap a l'esquerra (%1)"
 
 #. IDS_COPY_MIDDLE_TO_RIGHT
-#: Merge.rc:4844
+#: Merge.rc:4843
 #, c-format
 msgid "Middle to Right (%1)"
 msgstr "Mig cap a la dreta (%1)"
 
 #. IDS_COPY_LEFT_TO_RIGHT
-#: Merge.rc:4845
+#: Merge.rc:4844
 #, c-format
 msgid "Left to Right (%1)"
 msgstr "Esquerra a dreta (%1)"
 
 #. IDS_COPY_LEFT_TO_MIDDLE
-#: Merge.rc:4846
+#: Merge.rc:4845
 #, c-format
 msgid "Left to Middle (%1)"
 msgstr "Dreta cap al Mig (%1)"
 
 #. IDS_MOVE_LEFT_TO
-#: Merge.rc:4857 Merge.rc:4889
+#: Merge.rc:4856 Merge.rc:4888
 #, c-format
 msgid "Left to... (%1)"
 msgstr "Esquerra a... (%1)"
 
 #. IDS_MOVE_MIDDLE_TO
-#: Merge.rc:4858 Merge.rc:4890
+#: Merge.rc:4857 Merge.rc:4889
 #, c-format
 msgid "Middle to... (%1)"
 msgstr "Mig cap a... (%1)"
 
 #. IDS_MOVE_RIGHT_TO
-#: Merge.rc:4859 Merge.rc:4891
+#: Merge.rc:4858 Merge.rc:4890
 #, c-format
 msgid "Right to... (%1)"
 msgstr "Dreta a... (%1)"
 
 #. IDS_COPY_BOTH_TO
-#: Merge.rc:4860
+#: Merge.rc:4859
 #, c-format
 msgid "Both to... (%1)"
 msgstr "Ambdós a... (%1)"
 
 #. IDS_COPY_ALL_TO
-#: Merge.rc:4861
+#: Merge.rc:4860
 #, c-format
 msgid "All to... (%1)"
 msgstr "Tots a... (%1)"
 
 #. IDS_COPY_DIFFERENCES_TO
-#: Merge.rc:4862
+#: Merge.rc:4861
 #, c-format
 msgid "Differences to... (%1)"
 msgstr "Diferències a... (%1)"
 
 #. IDS_ONLYDIFFITEMS_CONFIRM
-#: Merge.rc:4869
+#: Merge.rc:4868
 msgid "Some selected items are identical or skipped.\nProcess only items with differences?"
 msgstr ""
 
 #. IDS_DEL_LEFT_FMT
-#: Merge.rc:4875
+#: Merge.rc:4874
 #, c-format
 msgid "Left (%1)"
 msgstr "Esquerra (%1)"
 
 #. IDS_DEL_MIDDLE_FMT
-#: Merge.rc:4876
+#: Merge.rc:4875
 #, c-format
 msgid "Middle (%1)"
 msgstr "Mig (%1)"
 
 #. IDS_DEL_RIGHT_FMT
-#: Merge.rc:4877
+#: Merge.rc:4876
 #, c-format
 msgid "Right (%1)"
 msgstr "Dreta (%1)"
 
 #. IDS_DEL_BOTH_FMT
-#: Merge.rc:4878
+#: Merge.rc:4877
 #, c-format
 msgid "Both (%1)"
 msgstr "Ambdós (%1)"
 
 #. IDS_DEL_ALL_FMT
-#: Merge.rc:4879
+#: Merge.rc:4878
 #, c-format
 msgid "All (%1)"
 msgstr "Tots (%1)"
 
 #. IDS_SELECT_DEST_LEFT
-#: Merge.rc:4895
+#: Merge.rc:4894
 #, c-format
 msgid "Left Side - Select Destination Folder:"
 msgstr "Costat esquerre - seleccioneu la carpeta de destinació:"
 
 #. IDS_SELECT_DEST_MIDDLE
-#: Merge.rc:4896
+#: Merge.rc:4895
 #, c-format
 msgid "Middle Side - Select Destination Folder:"
 msgstr "Costat del mig - seleccioneu la carpeta de destinació:"
 
 #. IDS_SELECT_DEST_RIGHT
-#: Merge.rc:4897
+#: Merge.rc:4896
 #, c-format
 msgid "Right Side - Select Destination Folder:"
 msgstr "Costat dret - seleccioneu la carpeta de destinació:"
 
 #. IDS_FILES_AFFECTED_FMT
-#: Merge.rc:4898
+#: Merge.rc:4897
 #, c-format
 msgid "(%1 Files Affected)"
 msgstr "(%1 fitxers afectats)"
 
 #. IDS_FILES_AFFECTED_FMT2
-#: Merge.rc:4899
+#: Merge.rc:4898
 #, c-format
 msgid "(%1 of %2 Files Affected)"
 msgstr "(%1 de %2 fitxers afectats)"
 
 #. IDS_CONFIRM_DELETE_SINGLE
-#: Merge.rc:4905
+#: Merge.rc:4904
 #, c-format
 msgid ""
 "Are you sure you want to delete\n"
@@ -6912,18 +6906,18 @@ msgstr ""
 "%1 ?"
 
 #. IDS_CONFIRM_SINGLE_COPY
-#: Merge.rc:4906
+#: Merge.rc:4905
 msgid "Are you sure you want to copy?"
 msgstr "Esteu segur que voleu copiar?"
 
 #. IDS_CONFIRM_MULTIPLE_COPY
-#: Merge.rc:4907
+#: Merge.rc:4906
 #, c-format
 msgid "Are you sure you want to copy %d items?"
 msgstr "Esteu segur que voleu copiar %d elements?"
 
 #. IDS_DIRCMP_NOTSYNC
-#: Merge.rc:4908
+#: Merge.rc:4907
 #, c-format
 msgid ""
 "Operation aborted!\n"
@@ -6943,49 +6937,49 @@ msgstr ""
 "Actualitzeu la comparació."
 
 #. IDS_CONFIRM_SINGLE_MOVE
-#: Merge.rc:4913
+#: Merge.rc:4912
 msgid "Are you sure you want to move?"
 msgstr "Esteu segur que voleu moure?"
 
 #. IDS_CONFIRM_MULTIPLE_MOVE
-#: Merge.rc:4914
+#: Merge.rc:4913
 #, c-format
 msgid "Are you sure you want to move %d items?"
 msgstr "Esteu segur que voleu moure %d elements?"
 
 #. IDS_CONFIRM_MOVE_CAPTION
-#: Merge.rc:4916
+#: Merge.rc:4915
 #, c-format
 msgid "Confirm Move"
 msgstr "Confirmeu l'acció de moure"
 
-#: Merge.rc:4918
+#: Merge.rc:4917
 #, c-format
 msgid "Close the folder comparison window?"
 msgstr "Esteu a punt de tancar la finestra que compara els directoris. Esteu segurs de tancar la finestra?"
 
-#: Merge.rc:4920
+#: Merge.rc:4919
 msgid "Close the folder comparison window, which took a long time?"
 msgstr "Esteu a punt de tancar la finestra de comparació de carpetes que ha trigat molt de temps. Esteu segur que voleu tancar la finestra?"
 
 #. IDS_ERROR_INVALID_DIR_FILE_NAME
-#: Merge.rc:4921
+#: Merge.rc:4920
 msgid "The file or folder name is invalid."
 msgstr "El nom del fitxer o de la carpeta no és vàlid."
 
 #. IDS_ERROR_EXECUTE_FILE
-#: Merge.rc:4927
+#: Merge.rc:4926
 #, c-format
 msgid "Failed to execute external editor: %1"
 msgstr "No s'ha pogut executar l'editor extern: %1"
 
 #. IDS_UNKNOWN_ARCHIVE_FORMAT
-#: Merge.rc:4933
+#: Merge.rc:4932
 #, c-format
 msgid "Unknown archive format"
 msgstr "El format de l'arxiu és desconegut"
 
-#: Merge.rc:4935
+#: Merge.rc:4934
 msgid ""
 "Failed to extract archive.\n"
 "Compare as text file?"
@@ -6994,826 +6988,826 @@ msgstr ""
 "Voleu comparar els fitxers de l'arxiu com a fitxers de text?"
 
 #. IDS_COLHDR_FILENAME
-#: Merge.rc:4941
+#: Merge.rc:4940
 #, c-format
 msgid "Filename"
 msgstr "Nom de fitxer"
 
 #. IDS_COLHDR_DIR
-#: Merge.rc:4942
+#: Merge.rc:4941
 msgctxt "DirView|ColumnHeader"
 msgid "Folder"
 msgstr "Directori"
 
 #. IDS_COLHDR_RESULT
-#: Merge.rc:4943
+#: Merge.rc:4942
 #, c-format
 msgid "Comparison Result"
 msgstr "Resultat de la comparació"
 
 #. IDS_COLHDR_LTIMEM
-#: Merge.rc:4944
+#: Merge.rc:4943
 #, c-format
 msgid "Left Date"
 msgstr "Data esquerra"
 
 #. IDS_COLHDR_RTIMEM
-#: Merge.rc:4945
+#: Merge.rc:4944
 #, c-format
 msgid "Right Date"
 msgstr "Data dreta"
 
 #. IDS_COLHDR_MTIMEM
-#: Merge.rc:4946
+#: Merge.rc:4945
 #, c-format
 msgid "Middle Date"
 msgstr "Data del Mig"
 
 #. IDS_COLHDR_LSIZE
-#: Merge.rc:4948
+#: Merge.rc:4947
 #, c-format
 msgid "Left Size"
 msgstr "Mida esquerra"
 
 #. IDS_COLHDR_RSIZE
-#: Merge.rc:4949
+#: Merge.rc:4948
 #, c-format
 msgid "Right Size"
 msgstr "Mida dreta"
 
 #. IDS_COLHDR_MSIZE
-#: Merge.rc:4954
+#: Merge.rc:4953
 #, c-format
 msgid "Middle Size"
 msgstr "Mida del Mig"
 
 #. IDS_COLHDR_RSIZE_SHORT
-#: Merge.rc:4955
+#: Merge.rc:4954
 #, c-format
 msgid "Right Size (Short)"
 msgstr "Mida dreta (breu)"
 
 #. IDS_COLHDR_LSIZE_SHORT
-#: Merge.rc:4956
+#: Merge.rc:4955
 #, c-format
 msgid "Left Size (Short)"
 msgstr "Mida esquerra (breu)"
 
 #. IDS_COLHDR_MSIZE_SHORT
-#: Merge.rc:4957
+#: Merge.rc:4956
 #, c-format
 msgid "Middle Size (Short)"
 msgstr "Mida del Mig (Curta)"
 
 #. IDS_COLHDR_LTIMEC
-#: Merge.rc:4963
+#: Merge.rc:4962
 #, c-format
 msgid "Left Creation Time"
 msgstr "Data de creació esquerra"
 
 #. IDS_COLHDR_RTIMEC
-#: Merge.rc:4964
+#: Merge.rc:4963
 #, c-format
 msgid "Right Creation Time"
 msgstr "Data de creació dreta"
 
 #. IDS_COLHDR_MTIMEC
-#: Merge.rc:4965
+#: Merge.rc:4964
 #, c-format
 msgid "Middle Creation Time"
 msgstr "Data de creació del Mig"
 
 #. IDS_COLHDR_NEWER
-#: Merge.rc:4966
+#: Merge.rc:4965
 #, c-format
 msgid "Newer File"
 msgstr "Fitxer més nou"
 
 #. IDS_COLHDR_LVERSION
-#: Merge.rc:4967
+#: Merge.rc:4966
 #, c-format
 msgid "Left File Version"
 msgstr "Versió del fitxer esquerra"
 
 #. IDS_COLHDR_RVERSION
-#: Merge.rc:4968
+#: Merge.rc:4967
 #, c-format
 msgid "Right File Version"
 msgstr "Versió del fitxer dreta"
 
 #. IDS_COLHDR_MVERSION
-#: Merge.rc:4969
+#: Merge.rc:4968
 #, c-format
 msgid "Middle File Version"
 msgstr "Versió del Mig"
 
 #. IDS_COLHDR_RESULT_ABBR
-#: Merge.rc:4970
+#: Merge.rc:4969
 #, c-format
 msgid "Short Result"
 msgstr "Resultat breu"
 
 #. IDS_COLHDR_LATTRIBUTES
-#: Merge.rc:4971
+#: Merge.rc:4970
 #, c-format
 msgid "Left Attributes"
 msgstr "Atributs esquerra"
 
 #. IDS_COLHDR_RATTRIBUTES
-#: Merge.rc:4972
+#: Merge.rc:4971
 #, c-format
 msgid "Right Attributes"
 msgstr "Atributs dreta"
 
 #. IDS_COLHDR_MATTRIBUTES
-#: Merge.rc:4973
+#: Merge.rc:4972
 #, c-format
 msgid "Middle Attributes"
 msgstr "Atributs del Mig"
 
 #. IDS_COLHDR_LEOL_TYPE
-#: Merge.rc:4978
+#: Merge.rc:4977
 #, c-format
 msgid "Left EOL"
 msgstr "Salt de línia esquerra"
 
 #. IDS_COLHDR_MEOL_TYPE
-#: Merge.rc:4979
+#: Merge.rc:4978
 #, c-format
 msgid "Middle EOL"
 msgstr "Salt de línia del Mig"
 
 #. IDS_COLHDR_REOL_TYPE
-#: Merge.rc:4980
+#: Merge.rc:4979
 #, c-format
 msgid "Right EOL"
 msgstr "Salt de línia dreta"
 
 #. IDS_COLHDR_LENCODING
-#: Merge.rc:4986
+#: Merge.rc:4985
 #, c-format
 msgid "Left Encoding"
 msgstr "Codificació esquerra"
 
 #. IDS_COLHDR_RENCODING
-#: Merge.rc:4987
+#: Merge.rc:4986
 #, c-format
 msgid "Right Encoding"
 msgstr "Codificació dreta"
 
 #. IDS_COLHDR_MENCODING
-#: Merge.rc:4988
+#: Merge.rc:4987
 #, c-format
 msgid "Middle Encoding"
 msgstr "Codificació del Mig"
 
 #. IDS_COLHDR_NIDIFFS
-#: Merge.rc:4989
+#: Merge.rc:4988
 msgid "Ignored Diff"
 msgstr "Diferències ignorades"
 
 #. IDS_COLHDR_BINARY
-#: Merge.rc:4991
+#: Merge.rc:4990
 msgctxt "DirView|ColumnHeader"
 msgid "Binary"
 msgstr "Binari"
 
 #. IDS_PLUGINS_TYPE_UNPACKER
-#: Merge.rc:4992 Merge.rc:5314
+#: Merge.rc:4991 Merge.rc:5313
 #, c-format
 msgid "Unpacker"
 msgstr "Desempaquetador"
 
 #. IDS_PLUGIN_TYPE4
-#: Merge.rc:4993 Merge.rc:5315 Merge.rc:5622
+#: Merge.rc:4992 Merge.rc:5314 Merge.rc:5621
 #, c-format
 msgid "Prediffer"
 msgstr "Prediferenciador"
 
 #. IDS_COLHDR_LEFT
-#: Merge.rc:4994
+#: Merge.rc:4993
 msgid "Left"
 msgstr "Esquerra"
 
 #. IDS_COLHDR_MIDDLE
-#: Merge.rc:4995
+#: Merge.rc:4994
 msgid "Middle"
 msgstr "Mig"
 
 #. IDS_COLHDR_RIGHT
-#: Merge.rc:4996
+#: Merge.rc:4995
 msgid "Right"
 msgstr "Dreta"
 
 #. IDS_COLHDR_DIFF
-#: Merge.rc:4997
+#: Merge.rc:4996
 msgid "Diff"
 msgstr "Diferència"
 
 #. IDS_COLHDR_LEFT_DUPLICATE
-#: Merge.rc:4998
+#: Merge.rc:4997
 msgid "Left Duplicate Count"
 msgstr "Duplicats de l'esquerra"
 
 #. IDS_COLHDR_RIGHT_DUPLICATE
-#: Merge.rc:4999
+#: Merge.rc:4998
 msgid "Right Duplicate Count"
 msgstr "Duplicats de la dreta"
 
 #. IDS_COLHDR_MIDDLE_DUPLICATE
-#: Merge.rc:5000
+#: Merge.rc:4999
 msgid "Middle Duplicate Count"
 msgstr "Duplicats del Mig"
 
 #. IDS_COLHDR_MOVE
-#: Merge.rc:5001
+#: Merge.rc:5000
 msgid "Move"
 msgstr "Mou"
 
 #. IDS_PRPCAT_AUDIO
-#: Merge.rc:5008
+#: Merge.rc:5007
 msgid "Audio"
 msgstr "Àudio"
 
 #. IDS_PRPCAT_CALENDAR
-#: Merge.rc:5009
+#: Merge.rc:5008
 msgid "Calendar"
 msgstr "Calendari"
 
 #. IDS_PRPCAT_COMMUNICATION
-#: Merge.rc:5010
+#: Merge.rc:5009
 msgid "Communication"
 msgstr "Comunicació"
 
 #. IDS_PRPCAT_CONTACT
-#: Merge.rc:5011
+#: Merge.rc:5010
 msgid "Contact"
 msgstr "Contacte"
 
 #. IDS_PRPCAT_DEVICES
-#: Merge.rc:5012
+#: Merge.rc:5011
 msgid "Devices"
 msgstr "Dispositius"
 
 #. IDS_PRPCAT_DOCUMENT
-#: Merge.rc:5013
+#: Merge.rc:5012
 msgid "Document"
 msgstr "Document"
 
 #. IDS_PRPCAT_HOME
-#: Merge.rc:5014
+#: Merge.rc:5013
 msgid "Home"
 msgstr "Inici"
 
 #. IDS_PRPCAT_JOURNAL
-#: Merge.rc:5016
+#: Merge.rc:5015
 msgid "Journal"
 msgstr "Diari"
 
 #. IDS_PRPCAT_LINK
-#: Merge.rc:5017
+#: Merge.rc:5016
 msgid "Link"
 msgstr "Enllaç"
 
 #. IDS_PRPCAT_MEDIA
-#: Merge.rc:5018
+#: Merge.rc:5017
 msgid "Media"
 msgstr "Mitjans"
 
 #. IDS_PRPCAT_MUSIC
-#: Merge.rc:5020
+#: Merge.rc:5019
 msgid "Music"
 msgstr "Música"
 
 #. IDS_PRPCAT_NOTE
-#: Merge.rc:5021
+#: Merge.rc:5020
 msgid "Note"
 msgstr "Nota"
 
 #. IDS_PRPCAT_PHOTO
-#: Merge.rc:5022
+#: Merge.rc:5021
 msgid "Photo"
 msgstr "Foto"
 
 #. IDS_PRPCAT_RECORDEDTV
-#: Merge.rc:5023
+#: Merge.rc:5022
 msgid "RecordedTV"
 msgstr "RecordedTV"
 
 #. IDS_PRPCAT_SEARCH
-#: Merge.rc:5024
+#: Merge.rc:5023
 msgid "Search"
 msgstr "Cerca"
 
 #. IDS_PRPCAT_SECURITY
-#: Merge.rc:5025
+#: Merge.rc:5024
 msgid "Security"
 msgstr "Seguretat"
 
 #. IDS_PRPCAT_SOFTWARE
-#: Merge.rc:5026
+#: Merge.rc:5025
 msgid "Software"
 msgstr "Aplicacions"
 
 #. IDS_PRPCAT_TASK
-#: Merge.rc:5027
+#: Merge.rc:5026
 msgid "Task"
 msgstr "Tasques"
 
 #. IDS_PRPCAT_VIDEO
-#: Merge.rc:5028
+#: Merge.rc:5027
 msgid "Video"
 msgstr "Vídeo"
 
 #. IDS_PRPCAT_HASH
-#: Merge.rc:5029
+#: Merge.rc:5028
 msgid "Hash"
 msgstr "Resum"
 
 #. IDS_CANT_COMPARE_FILES
-#: Merge.rc:5035
+#: Merge.rc:5034
 #, c-format
 msgid "Unable to compare files"
 msgstr "No es pot comparar els fitxers"
 
 #. IDS_ABORTED_ITEM
-#: Merge.rc:5036
+#: Merge.rc:5035
 #, c-format
 msgid "Item aborted"
 msgstr "Element avortat"
 
 #. IDS_FILE_SKIPPED
-#: Merge.rc:5037
+#: Merge.rc:5036
 #, c-format
 msgid "File skipped"
 msgstr "Fitxer omès"
 
 #. IDS_DIR_SKIPPED
-#: Merge.rc:5038
+#: Merge.rc:5037
 #, c-format
 msgid "Folder skipped"
 msgstr "Directori omès"
 
 #. IDS_LEFT_ONLY_IN_FMT
-#: Merge.rc:5039
+#: Merge.rc:5038
 #, c-format
 msgid "Left only: %1"
 msgstr "Només esquerra: %1"
 
 #. IDS_MIDDLE_ONLY_IN_FMT
-#: Merge.rc:5040
+#: Merge.rc:5039
 #, c-format
 msgid "Middle only: %1"
 msgstr "Només mig: %1"
 
 #. IDS_RIGHT_ONLY_IN_FMT
-#: Merge.rc:5041
+#: Merge.rc:5040
 #, c-format
 msgid "Right only: %1"
 msgstr "Només dreta: %1"
 
 #. IDS_DOES_NOT_EXIST_IN_FMT
-#: Merge.rc:5042
+#: Merge.rc:5041
 #, c-format
 msgid "Does not exist in %1"
 msgstr "No existeix en %1"
 
 #. IDS_BIN_FILES_SAME
-#: Merge.rc:5043
+#: Merge.rc:5042
 #, c-format
 msgid "Binary files are identical"
 msgstr "Els fitxers binaris són idèntics"
 
 #. IDS_BIN_FILES_DIFF
-#: Merge.rc:5049
+#: Merge.rc:5048
 #, c-format
 msgid "Binary files are different"
 msgstr "Els fitxers binaris són diferents"
 
 #. IDS_FILES_ARE_DIFFERENT
-#: Merge.rc:5050
+#: Merge.rc:5049
 #, c-format
 msgid "Files are different"
 msgstr "Els fitxers són diferents"
 
 #. IDS_FOLDERS_ARE_DIFFERENT
-#: Merge.rc:5051
+#: Merge.rc:5050
 #, c-format
 msgid "Folders are different"
 msgstr "Els directoris són diferents"
 
 #. IDS_LEFTONLY
-#: Merge.rc:5052
+#: Merge.rc:5051
 #, c-format
 msgid "Left Only"
 msgstr "Només l'esquerre"
 
 #. IDS_RIGHTONLY
-#: Merge.rc:5053
+#: Merge.rc:5052
 #, c-format
 msgid "Right Only"
 msgstr "Només el dret"
 
 #. IDS_MIDDLEONLY
-#: Merge.rc:5054
+#: Merge.rc:5053
 #, c-format
 msgid "Middle Only"
 msgstr "Només el del mig"
 
 #. IDS_NOITEMLEFT
-#: Merge.rc:5055
+#: Merge.rc:5054
 #, c-format
 msgid "No item in left"
 msgstr "Sense element a l'esquerra"
 
 #. IDS_NOITEMRIGHT
-#: Merge.rc:5056
+#: Merge.rc:5055
 #, c-format
 msgid "No item in right"
 msgstr "Sense element al mig"
 
 #. IDS_NOITEMMIDDLE
-#: Merge.rc:5057
+#: Merge.rc:5056
 #, c-format
 msgid "No item in middle"
 msgstr "Sense element al mig"
 
 #. IDS_CMPRES_ERROR
-#: Merge.rc:5059
+#: Merge.rc:5058
 #, c-format
 msgid "Error"
 msgstr "Error"
 
 #. IDS_TEXT_FILES_SAME
-#: Merge.rc:5060
+#: Merge.rc:5059
 #, c-format
 msgid "Text files are identical"
 msgstr "Els fitxers de text són idèntics"
 
 #. IDS_LEFTONLY_DIFF
-#: Merge.rc:5061
+#: Merge.rc:5060
 msgid " (Middle and right are identical)"
 msgstr " (Mig i dreta són idèntics)"
 
 #. IDS_MIDDLEONLY_DIFF
-#: Merge.rc:5062
+#: Merge.rc:5061
 msgid " (Left and right are identical)"
 msgstr " (Esquerra i dreta són idèntics)"
 
 #. IDS_RIGHTONLY_DIFF
-#: Merge.rc:5063
+#: Merge.rc:5062
 msgid " (Left and middle are identical)"
 msgstr " (Esquerra i mig són idèntics)"
 
 #. IDS_PATH_MISMATCH
-#: Merge.rc:5064
+#: Merge.rc:5063
 msgid " (paths differ)"
 msgstr ""
 
 #. IDS_TEXT_FILES_DIFF
-#: Merge.rc:5065
+#: Merge.rc:5064
 #, c-format
 msgid "Text files are different"
 msgstr "Els fitxers de text són diferents"
 
 #. IDS_IMAGE_FILES_SAME
-#: Merge.rc:5066
+#: Merge.rc:5065
 msgid "Image files are identical"
 msgstr "Les imatges són idèntiques"
 
 #. IDS_IMAGE_FILES_DIFF
-#: Merge.rc:5067
+#: Merge.rc:5066
 msgid "Image files are different"
 msgstr "Les imatges són diferents"
 
 #. IDS_EXPR_DIFF
-#: Merge.rc:5068
+#: Merge.rc:5067
 #, c-format
 msgid "Files are different (expr: %1)"
 msgstr ""
 
 #. IDS_HASH_GROUP
-#: Merge.rc:5069
+#: Merge.rc:5068
 #, c-format
 msgid "Group%d"
 msgstr "Grup%d"
 
 #. IDS_RENAME_MOVE_DETECTION_DISALBED
-#: Merge.rc:5070
+#: Merge.rc:5069
 msgctxt "Options dialog|Compare|Folder|Detect renames and moves"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_RENAME_MOVE_DETECTION_RENAME
-#: Merge.rc:5071
+#: Merge.rc:5070
 msgid "Detect renames"
 msgstr ""
 
 #. IDS_RENAME_MOVE_DETECTION_RENAME_MOVE
-#: Merge.rc:5072
+#: Merge.rc:5071
 msgid "Detect renames and moves"
 msgstr ""
 
 #. IDS_RENAME_MOVE_MERGE_MODE_RENAME
-#: Merge.rc:5073
+#: Merge.rc:5072
 msgid "Merge renames"
 msgstr ""
 
 #. IDS_RENAME_MOVE_MERGE_MODE_RENAME_MOVE
-#: Merge.rc:5074
+#: Merge.rc:5073
 msgid "Merge renames and moves"
 msgstr ""
 
 #. IDS_RENAMED
-#: Merge.rc:5075
+#: Merge.rc:5074
 msgid "Renamed"
 msgstr ""
 
 #. IDS_RENAMED_MOVED
-#: Merge.rc:5077
+#: Merge.rc:5076
 msgid "Renamed/Moved"
 msgstr ""
 
 #. IDS_RENAMED_MOVED_ITEMS
-#: Merge.rc:5078
+#: Merge.rc:5077
 #, c-format
 msgid "(%1 items)"
 msgstr ""
 
 #. IDS_RENAMED_MOVED_RESULT
-#: Merge.rc:5079
+#: Merge.rc:5078
 #, c-format
 msgid "%1 (set %2): "
 msgstr ""
 
 #. IDS_SWITCH_FLAT_MODE
-#: Merge.rc:5080
+#: Merge.rc:5079
 msgid "Some moved items have been merged.\nIn Tree Mode, these items may appear in positions that do not reflect the actual folder structure, which can be confusing.\nSwitch to Flat Mode?"
 msgstr ""
 
 #. IDS_ELAPSED_TIME
-#: Merge.rc:5086
+#: Merge.rc:5085
 #, c-format
 msgid "Elapsed time: %ld ms"
 msgstr "Temps transcorregut: %ld ms"
 
 #. IDS_STATUS_SELITEM1
-#: Merge.rc:5087
+#: Merge.rc:5086
 #, c-format
 msgid "1 item selected"
 msgstr "1 element seleccionat"
 
 #. IDS_STATUS_SELITEMS
-#: Merge.rc:5088
+#: Merge.rc:5087
 #, c-format
 msgid "%1 items selected"
 msgstr "%1 elements seleccionats"
 
 #. IDS_COLDESC_FILENAME
-#: Merge.rc:5094
+#: Merge.rc:5093
 #, c-format
 msgid "Filename or folder name."
 msgstr "Nom del fitxer o directori."
 
 #. IDS_COLDESC_DIR
-#: Merge.rc:5095
+#: Merge.rc:5094
 #, c-format
 msgid "Subfolder name when subfolders are included."
 msgstr "Nom del subdirectori quan s'incloguin els subdirectoris."
 
 #. IDS_COLDESC_RESULT
-#: Merge.rc:5096
+#: Merge.rc:5095
 #, c-format
 msgid "Comparison result, long form."
 msgstr "Resultat de la comparació, en forma llarga."
 
 #. IDS_COLDESC_LTIMEM
-#: Merge.rc:5101
+#: Merge.rc:5100
 #, c-format
 msgid "Left side modification date."
 msgstr "Data de modificació del costat esquerre."
 
 #. IDS_COLDESC_RTIMEM
-#: Merge.rc:5102
+#: Merge.rc:5101
 #, c-format
 msgid "Right side modification date."
 msgstr "Data de modificació del costat dret."
 
 #. IDS_COLDESC_MTIMEM
-#: Merge.rc:5103
+#: Merge.rc:5102
 #, c-format
 msgid "Middle side modification date."
 msgstr "Data de modificació del mig."
 
 #. IDS_COLDESC_EXTENSION
-#: Merge.rc:5104
+#: Merge.rc:5103
 #, c-format
 msgid "File's extension."
 msgstr "Extensió del fitxer."
 
 #. IDS_COLDESC_LSIZE
-#: Merge.rc:5105
+#: Merge.rc:5104
 #, c-format
 msgid "Left file size in bytes."
 msgstr "Mida en bytes del fitxer esquerre."
 
 #. IDS_COLDESC_RSIZE
-#: Merge.rc:5106
+#: Merge.rc:5105
 #, c-format
 msgid "Right file size in bytes."
 msgstr "Mida en bytes del fitxer dret."
 
 #. IDS_COLDESC_MSIZE
-#: Merge.rc:5107
+#: Merge.rc:5106
 #, c-format
 msgid "Middle file size in bytes."
 msgstr "Mida en bytes del fitxer del mig."
 
 #. IDS_COLDESC_LSIZE_SHORT
-#: Merge.rc:5108
+#: Merge.rc:5107
 #, c-format
 msgid "Left file size abbreviated."
 msgstr "Mida del fitxer esquerre en format abreujat."
 
 #. IDS_COLDESC_RSIZE_SHORT
-#: Merge.rc:5109
+#: Merge.rc:5108
 #, c-format
 msgid "Right file size abbreviated."
 msgstr "Mida del fitxer dret en format abreujat."
 
 #. IDS_COLDESC_MSIZE_SHORT
-#: Merge.rc:5110
+#: Merge.rc:5109
 #, c-format
 msgid "Middle file size abbreviated."
 msgstr "Mida del fitxer del mig en format abreujat."
 
 #. IDS_COLDESC_LTIMEC
-#: Merge.rc:5116
+#: Merge.rc:5115
 #, c-format
 msgid "Left side creation time."
 msgstr "Data de creació del fitxer esquerre."
 
 #. IDS_COLDESC_RTIMEC
-#: Merge.rc:5117
+#: Merge.rc:5116
 #, c-format
 msgid "Right side creation time."
 msgstr "Data de creació del fitxer dret."
 
 #. IDS_COLDESC_MTIMEC
-#: Merge.rc:5118
+#: Merge.rc:5117
 #, c-format
 msgid "Middle side creation time."
 msgstr "Data de creació del fitxer del mig."
 
 #. IDS_COLDESC_NEWER
-#: Merge.rc:5119
+#: Merge.rc:5118
 #, c-format
 msgid "Tells which side has newer modification date."
 msgstr "Indica quin costat té una data de modificació més recent."
 
 #. IDS_COLDESC_LVERSION
-#: Merge.rc:5120
+#: Merge.rc:5119
 msgid "Left side file version, only for some file types."
 msgstr "Versió del fitxer del costat esquerre, només per a alguns tipus de fitxer."
 
 #. IDS_COLDESC_RVERSION
-#: Merge.rc:5121
+#: Merge.rc:5120
 msgid "Right side file version, only for some file types."
 msgstr "Versió del fitxer del costat dret, només per a alguns tipus de fitxer."
 
 #. IDS_COLDESC_MVERSION
-#: Merge.rc:5126
+#: Merge.rc:5125
 msgid "Middle side file version, only for some file types."
 msgstr "Versió del fitxer del mig, només per a alguns tipus de fitxer."
 
 #. IDS_COLDESC_RESULT_ABBR
-#: Merge.rc:5127
+#: Merge.rc:5126
 #, c-format
 msgid "Short comparison result."
 msgstr "Resultat breu de la comparació."
 
 #. IDS_COLDESC_LATTRIBUTES
-#: Merge.rc:5128
+#: Merge.rc:5127
 #, c-format
 msgid "Left side attributes."
 msgstr "Atributs del costat esquerre."
 
 #. IDS_COLDESC_RATTRIBUTES
-#: Merge.rc:5129
+#: Merge.rc:5128
 #, c-format
 msgid "Right side attributes."
 msgstr "Atributs del costat dret."
 
 #. IDS_COLDESC_MATTRIBUTES
-#: Merge.rc:5130
+#: Merge.rc:5129
 #, c-format
 msgid "Middle side attributes."
 msgstr "Atributs del mig."
 
 #. IDS_COLDESC_LEOL_TYPE
-#: Merge.rc:5131
+#: Merge.rc:5130
 msgid "Left side file EOL type."
 msgstr "Tipus de salt de línia del fitxer del costat esquerre."
 
 #. IDS_COLDESC_REOL_TYPE
-#: Merge.rc:5132
+#: Merge.rc:5131
 msgid "Right side file EOL type."
 msgstr "Tipus de salt de línia del fitxer del costat dret."
 
 #. IDS_COLDESC_MEOL_TYPE
-#: Merge.rc:5133
+#: Merge.rc:5132
 msgid "Middle side file EOL type."
 msgstr "Tipus de salt de línia del fitxer del mig."
 
 #. IDS_COLDESC_LENCODING
-#: Merge.rc:5139
+#: Merge.rc:5138
 #, c-format
 msgid "Left side encoding."
 msgstr "Codificació del costat esquerre."
 
 #. IDS_COLDESC_RENCODING
-#: Merge.rc:5140
+#: Merge.rc:5139
 #, c-format
 msgid "Right side encoding."
 msgstr "Codificació del costat dret."
 
 #. IDS_COLDESC_MENCODING
-#: Merge.rc:5141
+#: Merge.rc:5140
 #, c-format
 msgid "Middle side encoding."
 msgstr "Codificació del mig."
 
 #. IDS_COLDESC_NIDIFFS
-#: Merge.rc:5142
+#: Merge.rc:5141
 #, c-format
 msgid "Number of ignored differences in file. Ignored and cannot be merged."
 msgstr "Nombre de diferències ignorades al fitxer. Aquestes diferències són ignorades pel WinMerge i no es poden combinar."
 
 #. IDS_COLDESC_NSDIFFS
-#: Merge.rc:5143
+#: Merge.rc:5142
 #, c-format
 msgid "Number of differences in file (excluding ignored)."
 msgstr "Nombre de diferències al fitxer. Aquest nombre no inclou les diferències ignorades."
 
 #. IDS_COLDESC_BINARY
-#: Merge.rc:5144
+#: Merge.rc:5143
 #, c-format
 msgid "Shows an asterisk (*) if the file is binary."
 msgstr "Mostra un asterisc (*) si el fitxer és binari."
 
 #. IDS_COLDESC_UNPACKER
-#: Merge.rc:5145
+#: Merge.rc:5144
 msgid "Unpacker plugin name or pipeline."
 msgstr "Nom del connector desempaquetador o seqüència."
 
 #. IDS_COLDESC_PREDIFFER
-#: Merge.rc:5146
+#: Merge.rc:5145
 msgid "Prediffer plugin name or pipeline."
 msgstr "Nom del connector de prediferenciació o seqüència."
 
 #. IDS_DIRECTORY_REPORT_TITLE
-#: Merge.rc:5152
+#: Merge.rc:5151
 #, c-format
 msgid "Compare %1 with %2"
 msgstr "Compara %1 amb %2"
 
 #. IDS_DIRECTORY_REPORT_TITLE3
-#: Merge.rc:5153
+#: Merge.rc:5152
 #, c-format
 msgid "Compare %1 with %2 and %3"
 msgstr "Compara %1 amb %2 i %3"
 
 #. IDS_REPORT_COMMALIST
-#: Merge.rc:5154
+#: Merge.rc:5153
 #, c-format
 msgid "Comma-separated list"
 msgstr "Llista delimitada per comes"
 
 #. IDS_REPORT_TABLIST
-#: Merge.rc:5155
+#: Merge.rc:5154
 #, c-format
 msgid "Tab-separated list"
 msgstr "Llista delimitada per tabulacions"
 
 #. IDS_REPORT_SIMPLEHTML
-#: Merge.rc:5156
+#: Merge.rc:5155
 #, c-format
 msgid "Simple HTML"
 msgstr "HTML simple"
 
 #. IDS_REPORT_SIMPLEXML
-#: Merge.rc:5157
+#: Merge.rc:5156
 #, c-format
 msgid "Simple XML"
 msgstr "XML simple"
 
-#: Merge.rc:5159
+#: Merge.rc:5158
 #, c-format
 msgid "Report file already exists. Overwrite?"
 msgstr "El fitxer d'informe ja existeix. Voleu sobreescriure'l?"
 
 #. IDS_REPORT_ERROR
-#: Merge.rc:5164
+#: Merge.rc:5163
 #, c-format
 msgid ""
 "Error creating the report:\n"
@@ -7823,62 +7817,62 @@ msgstr ""
 "%1"
 
 #. IDS_REPORT_SUCCESS
-#: Merge.rc:5165
+#: Merge.rc:5164
 #, c-format
 msgid "Report created successfully."
 msgstr "L'informe s'ha creat satisfactòriament."
 
 #. IDS_SYNCPOINT_LASTBLOCK
-#: Merge.rc:5171
+#: Merge.rc:5170
 msgid "Cannot add a synchronization point at this line."
 msgstr "No es pot afegir un punt de sincronització en aquesta línia."
 
 #. IDS_FILE_TO_ITSELF
-#: Merge.rc:5177
+#: Merge.rc:5176
 #, c-format
 msgid "Same file is opened in both panes."
 msgstr "El mateix fitxer és obert a ambdues subfinestres."
 
 #. IDS_FILESSAME
-#: Merge.rc:5178
+#: Merge.rc:5177
 #, c-format
 msgid "Selected files are identical."
 msgstr "Els fitxers seleccionats són idèntics."
 
 #. IDS_FILESSAME_CURCFG
-#: Merge.rc:5179
+#: Merge.rc:5178
 msgid "Selected files are identical (with current settings).\r\nChecking binary identity..."
 msgstr ""
 
 #. IDS_FILESSAME_BINERROR
-#: Merge.rc:5180
+#: Merge.rc:5179
 msgid "Selected files are identical (with current settings).\r\nBut binary comparison failed."
 msgstr ""
 
 #. IDS_FILESSAME_BINSAME
-#: Merge.rc:5181
+#: Merge.rc:5180
 msgid "Selected files are identical (binary match)."
 msgstr ""
 
 #. IDS_FILESSAME_BINDIFF
-#: Merge.rc:5182
+#: Merge.rc:5181
 msgid "Selected files are identical (with current settings).\r\nBut differ at the binary level."
 msgstr ""
 
 #. IDS_FILEERROR
-#: Merge.rc:5183
+#: Merge.rc:5182
 #, c-format
 msgid "An error occurred while comparing files."
 msgstr "S'ha produït un error en comparar els fitxers."
 
 #. IDS_TEMP_FILEERROR
-#: Merge.rc:5184
+#: Merge.rc:5183
 #, c-format
 msgid "Could not create temporary files. Check your temporary path settings."
 msgstr "No s'han pogut obrir els fitxers temporals. Comproveu la configuració del directori temporal."
 
 #. IDS_SUGGEST_IGNOREEOL
-#: Merge.rc:5185
+#: Merge.rc:5184
 msgid "Files use different EOL.\n\nTreat all EOL as equivalent?\n\nSet 'Ignore EOL differences (Windows/Unix/Mac)' in Compare section of Options."
 msgstr ""
 "Els fitxers tenen tipus de salt de línia de diferents.\n"
@@ -7888,19 +7882,19 @@ msgstr ""
 "Nota: Si voleu tractar els salts de línia sempre com a equivalents, especifiqueu l'opció 'Ignora les diferències de salt de línia (Windows/Unix/Mac)' a la secció Comparació de la finestra d'opcions (disponible des del menú Edita/Opcions)."
 
 #. IDS_INVALID_DIRECTORY
-#: Merge.rc:5186
+#: Merge.rc:5185
 #, c-format
 msgid "Selected folder is invalid."
 msgstr "La carpeta seleccionada no és vàlida."
 
 #. IDS_CANNOT_OPEN_BINARYFILE
-#: Merge.rc:5187
+#: Merge.rc:5186
 #, c-format
 msgid "Cannot open a binary file in Editor."
 msgstr "No es poden obrir fitxers binaris a l'editor."
 
 #. IDS_CREATE_PAIR_FOLDER
-#: Merge.rc:5188
+#: Merge.rc:5187
 #, c-format
 msgid "Create matching folder:\n%1\non the other side and open?"
 msgstr ""
@@ -7911,45 +7905,45 @@ msgstr ""
 "i obrir ambdós directoris?"
 
 #. IDS_CONFIRM_COPY_ALL_DIFFS
-#: Merge.rc:5189
+#: Merge.rc:5188
 msgid "Copy all differences to other file?"
 msgstr "Esteu segur que voleu copiar totes les diferències a l'altre fitxer?"
 
 #. IDS_MOVE_TO_NEXTFILE
-#: Merge.rc:5194
+#: Merge.rc:5193
 #, c-format
 msgid "Move to next file?"
 msgstr "Voleu anar al següent fitxer?"
 
 #. IDS_MOVE_TO_PREVFILE
-#: Merge.rc:5195
+#: Merge.rc:5194
 #, c-format
 msgid "Move to previous file?"
 msgstr "Voleu anar al fitxer anterior?"
 
 #. IDS_MOVE_TO_NEXTPAGE
-#: Merge.rc:5196
+#: Merge.rc:5195
 #, c-format
 msgid "Move to next page?"
 msgstr "Voleu anar a la següent pàgina?"
 
 #. IDS_MOVE_TO_PREVPAGE
-#: Merge.rc:5197
+#: Merge.rc:5196
 #, c-format
 msgid "Move to previous page?"
 msgstr "Voleu anar a la pàgina anterior?"
 
 #. IDS_MOVE_TO_FIRSTFILE
-#: Merge.rc:5198
+#: Merge.rc:5197
 msgid "Move to first file?"
 msgstr "Voleu anar al primer fitxer?"
 
 #. IDS_MOVE_TO_LASTFILE
-#: Merge.rc:5199
+#: Merge.rc:5198
 msgid "Move to last file?"
 msgstr "Voleu anar a l'últim fitxer?"
 
-#: Merge.rc:5206
+#: Merge.rc:5205
 #, c-format
 msgid "Different codepages: left (cp%d), right (cp%d).\nDisplay in codepage (better display) or default Windows codepage (safer merging)?\n(Recommended: default Windows codepage)"
 msgstr ""
@@ -7957,57 +7951,57 @@ msgstr ""
 "Si es mostra cada fitxer en la seva codificació potser es visualitzaran millor, però la fusió/còpia serà perillosa.\n"
 "Voleu tractar ambdós fitxers com si tinguessin la codificació predeterminada del Windows (recomanat)?"
 
-#: Merge.rc:5208
+#: Merge.rc:5207
 #, c-format
 msgid "Information lost due to encoding errors: both files"
 msgstr "S'ha perdut informació degut a errors de codificació: ambdós fitxers"
 
-#: Merge.rc:5210
+#: Merge.rc:5209
 #, c-format
 msgid "Information lost due to encoding errors: first file"
 msgstr "S'ha perdut informació degut a errors de codificació: primer fitxer"
 
-#: Merge.rc:5212
+#: Merge.rc:5211
 #, c-format
 msgid "Information lost due to encoding errors: second file"
 msgstr "S'ha perdut informació degut a errors de codificació: segon fitxer"
 
-#: Merge.rc:5214
+#: Merge.rc:5213
 #, c-format
 msgid "Information lost due to encoding errors: third file"
 msgstr "S'ha perdut informació degut a errors de codificació: tercer fitxer"
 
 #. IDS_LINEDIFF_NODIFF
-#: Merge.rc:5220
+#: Merge.rc:5219
 #, c-format
 msgid "No difference"
 msgstr "Sense diferències"
 
 #. IDS_LINEDIFF_NODIFF_CAPTION
-#: Merge.rc:5221
+#: Merge.rc:5220
 #, c-format
 msgid "Line difference"
 msgstr "Diferència de línia"
 
 #. IDS_NUM_REPLACED
-#: Merge.rc:5227
+#: Merge.rc:5226
 #, c-format
 msgid "Replaced %1 string(s)."
 msgstr "S'ha(n) substituït %1 cadena(es)."
 
 #. IDS_EDIT_TEXT_NOT_FOUND
-#: Merge.rc:5228
+#: Merge.rc:5227
 #, c-format
 msgid "Cannot find string \"%s\"."
 msgstr "No s'ha trobat la cadena \"%s\"."
 
 #. IDS_MERGE_MODE
-#: Merge.rc:5234
+#: Merge.rc:5233
 msgid "Entering Merge Mode. Press F9 to turn off."
 msgstr "Esteu entrant al mode de fusió. Si voleu desactivar el mode de fusió, premeu la tecla F9."
 
 #. IDS_AUTO_MERGE
-#: Merge.rc:5240
+#: Merge.rc:5239
 #, c-format
 msgid ""
 "Automatic merges: %1\n"
@@ -8017,97 +8011,97 @@ msgstr ""
 "El nombre de conflictes no resolts: %2"
 
 #. IDS_CODEPAGE_MERGED
-#: Merge.rc:5241
+#: Merge.rc:5240
 msgid "Codepage change merged."
 msgstr "El canvi de codificació de caràcters s'ha fusionat."
 
 #. IDS_CODEPAGE_CONFLICT
-#: Merge.rc:5242
+#: Merge.rc:5241
 msgid "Codepage changes are conflicting."
 msgstr "Els canvis de codificació de caràcters estan en conflicte."
 
 #. IDS_EOL_MERGED
-#: Merge.rc:5243
+#: Merge.rc:5242
 msgid "EOL change merged."
 msgstr "El canvi en els salts de línia s'han fusionat."
 
 #. IDS_EOL_CONFLICT
-#: Merge.rc:5244
+#: Merge.rc:5243
 msgid "EOL changes are conflicting."
 msgstr "Els canvis en els salts de línia estan en conflicte."
 
 #. IDS_LOCBAR_CAPTION
-#: Merge.rc:5250
+#: Merge.rc:5249
 #, c-format
 msgid "Location Pane"
 msgstr "Subfinestra d'ubicació"
 
 #. IDS_DIFFBAR_CAPTION
-#: Merge.rc:5251
+#: Merge.rc:5250
 #, c-format
 msgid "Diff Pane"
 msgstr "Subfinestra de diferències"
 
 #. IDS_DIFF_SUCCEEDED
-#: Merge.rc:5258
+#: Merge.rc:5257
 #, c-format
 msgid "Patch file written."
 msgstr "El pedaç s'ha generat satisfactòriament."
 
 #. IDS_DIFF_FILEOVERWRITE
-#: Merge.rc:5259
+#: Merge.rc:5258
 #, c-format
 msgid "Patch file already exists. Overwrite?"
 msgstr "El fitxer de pedaç ja existeix. El voleu sobreescriure?"
 
 #. IDS_DIFF_SELECTEDFILES
-#: Merge.rc:5260
+#: Merge.rc:5259
 #, c-format
 msgid "[%1 files selected]"
 msgstr "[%1 fitxers seleccionats]"
 
 #. IDS_DIFF_NORMAL
-#: Merge.rc:5261
+#: Merge.rc:5260
 #, c-format
 msgid "Normal"
 msgstr "Normal"
 
 #. IDS_DIFF_CONTEXT
-#: Merge.rc:5262
+#: Merge.rc:5261
 #, c-format
 msgid "Context"
 msgstr "Context"
 
 #. IDS_DIFF_UNIFIED
-#: Merge.rc:5263
+#: Merge.rc:5262
 #, c-format
 msgid "Unified"
 msgstr "Unificat"
 
 #. IDS_FILEWRITE_ERROR
-#: Merge.rc:5265
+#: Merge.rc:5264
 #, c-format
 msgid "Could not write to file %1."
 msgstr "No s'ha pogut escriure al fitxer  %1."
 
 #. IDS_PATH_NOT_ABSOLUTE
-#: Merge.rc:5266
+#: Merge.rc:5265
 #, c-format
 msgid "Output path is not absolute: %1"
 msgstr "El camí de sortida especificat no és un camí absolut: %1"
 
 #. IDS_MUST_SPECIFY_OUTPUT
-#: Merge.rc:5267
+#: Merge.rc:5266
 msgid "Specify an output file."
 msgstr "Especifiqueu un fitxer de sortida."
 
-#: Merge.rc:5269
+#: Merge.rc:5268
 #, c-format
 msgid "Cannot create patch from binary files."
 msgstr "No es pot crear un pedaç de fitxers binaris."
 
 #. IDS_SAVEFILES_FORPATCH
-#: Merge.rc:5270
+#: Merge.rc:5269
 #, c-format
 msgid ""
 "Save all files first.\n"
@@ -8119,23 +8113,23 @@ msgstr ""
 "Cal que no hi hagi cap fitxer pendent de desar per tal de crear un pedaç."
 
 #. IDS_FOLDER_NOTEXIST
-#: Merge.rc:5271
+#: Merge.rc:5270
 #, c-format
 msgid "Folder does not exist."
 msgstr "El directori no existeix."
 
 #. IDS_ARCHIVE_SUCCEEDED
-#: Merge.rc:5277
+#: Merge.rc:5276
 msgid "Archive file written."
 msgstr ""
 
 #. IDS_ARCHIVE_SAVEFILES
-#: Merge.rc:5278
+#: Merge.rc:5277
 msgid "Save all files first.\n\nCreating an archive requires no unsaved changes."
 msgstr ""
 
 #. IDS_NO_ZIP_SUPPORT
-#: Merge.rc:5283
+#: Merge.rc:5282
 msgid ""
 "Archive support not enabled.\n"
 "7-Zip and/or Merge7z*.dll not found.\n"
@@ -8146,43 +8140,43 @@ msgstr ""
 "Vegeu el manual per a més informació sobre al suport per a arxivament i com habilitar-lo."
 
 #. IDS_OPT_EXPORT_CAPTION
-#: Merge.rc:5284
+#: Merge.rc:5283
 #, c-format
 msgid "Select file for export"
 msgstr "Trieu el fitxer a exportar"
 
 #. IDS_OPT_IMPORT_CAPTION
-#: Merge.rc:5285
+#: Merge.rc:5284
 #, c-format
 msgid "Select file for import"
 msgstr "Trieu el fitxer a importar"
 
 #. IDS_OPT_IMPORT_DONE
-#: Merge.rc:5286
+#: Merge.rc:5285
 #, c-format
 msgid "Options imported from file."
 msgstr "S'ha importat les opcions des del fitxer."
 
 #. IDS_OPT_EXPORT_DONE
-#: Merge.rc:5287
+#: Merge.rc:5286
 #, c-format
 msgid "Options exported to file."
 msgstr "S'ha exportat les opcions al fitxer."
 
 #. IDS_OPT_IMPORT_ERR
-#: Merge.rc:5288
+#: Merge.rc:5287
 #, c-format
 msgid "Failed to import options from file."
 msgstr "No s'ha pogut importar les opcions del fitxer."
 
 #. IDS_OPT_EXPORT_ERR
-#: Merge.rc:5289
+#: Merge.rc:5288
 #, c-format
 msgid "Failed to write options to file."
 msgstr "No s'ha pogut escriure les opcions al fitxer."
 
 #. IDS_CLOSEALL_WINDOWS
-#: Merge.rc:5290
+#: Merge.rc:5289
 #, c-format
 msgid ""
 "Close multiple compare windows?\n"
@@ -8194,36 +8188,36 @@ msgstr ""
 "Voleu continuar?"
 
 #. IDS_EOL_BIN
-#: Merge.rc:5300
+#: Merge.rc:5299
 msgctxt "EOL Type"
 msgid "Binary"
 msgstr "Binari"
 
 #. IDS_MARKER_COLOR_FMT
-#: Merge.rc:5305
+#: Merge.rc:5304
 #, c-format
 msgid "Marker Color %d"
 msgstr "Color de marca %d"
 
 #. IDS_MARKER_NEW_PATTERN
-#: Merge.rc:5306
+#: Merge.rc:5305
 msgid "New Pattern"
 msgstr "Patró nou"
 
 #. IDS_PLUGINSLIST_TYPE
-#: Merge.rc:5312
+#: Merge.rc:5311
 #, c-format
 msgid "Type"
 msgstr "Tipus"
 
 #. IDS_PLUGINS_TYPE_EDITSCRIPT
-#: Merge.rc:5316
+#: Merge.rc:5315
 #, c-format
 msgid "Editor script"
 msgstr "Editor de scripts"
 
 #. ID_SELECTLINEDIFF
-#: Merge.rc:5322
+#: Merge.rc:5321
 #, c-format
 msgid ""
 "\n"
@@ -8233,7 +8227,7 @@ msgstr ""
 "Diferència en la línia actual (F4)"
 
 #. ID_OPTIONS
-#: Merge.rc:5323
+#: Merge.rc:5322
 #, c-format
 msgid ""
 "\n"
@@ -8243,7 +8237,7 @@ msgstr ""
 "Opcions"
 
 #. ID_REFRESH
-#: Merge.rc:5324
+#: Merge.rc:5323
 #, c-format
 msgid ""
 "\n"
@@ -8253,7 +8247,7 @@ msgstr ""
 "Actualitza (F5)"
 
 #. ID_PREVDIFF
-#: Merge.rc:5330
+#: Merge.rc:5329
 #, c-format
 msgid ""
 "\n"
@@ -8263,7 +8257,7 @@ msgstr ""
 "Diferència anterior (Alt+Amunt)"
 
 #. ID_NEXTDIFF
-#: Merge.rc:5331
+#: Merge.rc:5330
 #, c-format
 msgid ""
 "\n"
@@ -8273,7 +8267,7 @@ msgstr ""
 "Diferència següent (Alt+Avall)"
 
 #. ID_PREVCONFLICT
-#: Merge.rc:5332
+#: Merge.rc:5331
 #, c-format
 msgid ""
 "\n"
@@ -8283,7 +8277,7 @@ msgstr ""
 "Conflicte anterior (Alt+Maj+Amunt)"
 
 #. ID_NEXTCONFLICT
-#: Merge.rc:5333
+#: Merge.rc:5332
 #, c-format
 msgid ""
 "\n"
@@ -8293,7 +8287,7 @@ msgstr ""
 "Conflicte següent (Alt+Maj+Avall)"
 
 #. ID_FIRSTDIFF
-#: Merge.rc:5338
+#: Merge.rc:5337
 #, c-format
 msgid ""
 "\n"
@@ -8303,7 +8297,7 @@ msgstr ""
 "Primera diferència (Alt+Inici)"
 
 #. ID_CURDIFF
-#: Merge.rc:5339
+#: Merge.rc:5338
 #, c-format
 msgid ""
 "\n"
@@ -8313,7 +8307,7 @@ msgstr ""
 "Diferència actual (Alt+Retorn)"
 
 #. ID_LASTDIFF
-#: Merge.rc:5340
+#: Merge.rc:5339
 #, c-format
 msgid ""
 "\n"
@@ -8323,7 +8317,7 @@ msgstr ""
 "Darrera diferència (Alt+Fi)"
 
 #. ID_L2R
-#: Merge.rc:5341
+#: Merge.rc:5340
 msgid ""
 "\n"
 "Copy to Right (Alt+Right)"
@@ -8332,7 +8326,7 @@ msgstr ""
 "Copia a la dreta (Alt+Dreta)"
 
 #. ID_R2L
-#: Merge.rc:5342
+#: Merge.rc:5341
 msgid ""
 "\n"
 "Copy to Left (Alt+Left)"
@@ -8341,7 +8335,7 @@ msgstr ""
 "Copia a l'esquerra (Alt+Esquerra)"
 
 #. ID_L2RNEXT
-#: Merge.rc:5343
+#: Merge.rc:5342
 msgid ""
 "\n"
 "Copy to Right and Advance (Ctrl+Alt+Right)"
@@ -8350,7 +8344,7 @@ msgstr ""
 "Copia a la dreta i avança (Alt+Control+Dreta)"
 
 #. ID_R2LNEXT
-#: Merge.rc:5344
+#: Merge.rc:5343
 msgid ""
 "\n"
 "Copy to Left and Advance (Ctrl+Alt+Left)"
@@ -8359,7 +8353,7 @@ msgstr ""
 "Copia a l'esquerra i avança (Alt+Control+Esquerra)"
 
 #. ID_ALL_RIGHT
-#: Merge.rc:5345
+#: Merge.rc:5344
 msgid ""
 "\n"
 "Copy All to Right"
@@ -8368,7 +8362,7 @@ msgstr ""
 "Copia-ho tot a la dreta"
 
 #. ID_ALL_LEFT
-#: Merge.rc:5346
+#: Merge.rc:5345
 msgid ""
 "\n"
 "Copy All to Left"
@@ -8377,7 +8371,7 @@ msgstr ""
 "Copia-ho tot a l'esquerra"
 
 #. ID_AUTO_MERGE
-#: Merge.rc:5347
+#: Merge.rc:5346
 #, c-format
 msgid ""
 "\n"
@@ -8387,7 +8381,7 @@ msgstr ""
 "Fusiona automàticament (Control+Alt+M)"
 
 #. ID_FIRSTFILE
-#: Merge.rc:5348
+#: Merge.rc:5347
 msgid ""
 "\n"
 "First File"
@@ -8396,7 +8390,7 @@ msgstr ""
 "Primer fitxer"
 
 #. ID_NEXTFILE
-#: Merge.rc:5349
+#: Merge.rc:5348
 msgid ""
 "\n"
 "Next File (Ctrl+F8)"
@@ -8405,7 +8399,7 @@ msgstr ""
 "Següent fitxer (Control+F8)"
 
 #. ID_LASTFILE
-#: Merge.rc:5350
+#: Merge.rc:5349
 msgid ""
 "\n"
 "Last File"
@@ -8414,7 +8408,7 @@ msgstr ""
 "Darrer fitxer"
 
 #. ID_PREVFILE
-#: Merge.rc:5351
+#: Merge.rc:5350
 msgid ""
 "\n"
 "Previous File (Ctrl+F7)"
@@ -8423,156 +8417,156 @@ msgstr ""
 "Fitxer anterior (Control+F7)"
 
 #. IDS_UNPACK_AUTO
-#: Merge.rc:5358
+#: Merge.rc:5357
 msgid "Adapted unpacker applied to both files (one needs extension)."
 msgstr "El desempaquetador adaptat s'aplica a ambdós fitxers (només hi cal l'extensió en un fitxer)."
 
 #. IDS_NO_PREDIFFER
-#: Merge.rc:5359
+#: Merge.rc:5358
 #, c-format
 msgid "No Prediffer (Normal)"
 msgstr "Sense prediferència (normal)"
 
 #. IDS_SUGGESTED_PLUGINS
-#: Merge.rc:5360
+#: Merge.rc:5359
 #, c-format
 msgid "Suggested Plugins"
 msgstr "Connectors suggerits"
 
 #. IDS_NOT_SUGGESTED_PLUGINS
-#: Merge.rc:5361
+#: Merge.rc:5360
 msgid "All Plugins"
 msgstr "Tots els connectors"
 
 #. IDS_PRIVATEBUILD_FMT
-#: Merge.rc:5367
+#: Merge.rc:5366
 #, c-format
 msgid "Private Build: %1"
 msgstr "Muntatge privat: %1"
 
 #. IDS_ALLRIGHTS_RESERVED
-#: Merge.rc:5368
+#: Merge.rc:5367
 msgid " - All rights reserved."
 msgstr ""
 
 #. IDS_TITLE_PLUGINS_SETTINGS
-#: Merge.rc:5374
+#: Merge.rc:5373
 #, c-format
 msgid "Plugin Settings"
 msgstr "Paràmetres del connector"
 
 #. IDS_NO_SCT_SCRIPTS
-#: Merge.rc:5376
+#: Merge.rc:5375
 #, c-format
 msgid "WSH not found - .sct scripts disabled"
 msgstr "No s'ha trobat el WSH - s'inhabiliten les seqüències d'ordres .sct"
 
 #. IDS_LOCBAR_GOTOLINE_FMT
-#: Merge.rc:5384
+#: Merge.rc:5383
 #, c-format
 msgid "G&o to Line %1"
 msgstr "Ves a la línia %1"
 
 #. IDS_GOTO_MOVED_LINE
-#: Merge.rc:5390
+#: Merge.rc:5389
 msgid "Go to Moved Line\tCtrl+Shift+G"
 msgstr "Ves a la línia desplaçada\tControl+Maj+G"
 
 #. IDS_AUTOCOMPLETE_DISABLED
-#: Merge.rc:5396
+#: Merge.rc:5395
 msgctxt "Options dialog|General|Open dialog Auto completion"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_AUTOCOMPLETE_FILE_SYS
-#: Merge.rc:5397
+#: Merge.rc:5396
 #, c-format
 msgid "From file system"
 msgstr "Des del sistema de fitxers"
 
 #. IDS_AUTOCOMPLETE_MRU
-#: Merge.rc:5398
+#: Merge.rc:5397
 #, c-format
 msgid "From Most Recently Used list"
 msgstr "Des de la llista de recents"
 
 #. IDS_COLORSCHEME_PLAIN
-#: Merge.rc:5404
+#: Merge.rc:5403
 #, c-format
 msgid "No Highlighting"
 msgstr "Sense ressaltat"
 
 #. IDS_COLORSCHEME_PO
-#: Merge.rc:5439
+#: Merge.rc:5438
 #, c-format
 msgid "Portable Object"
 msgstr "Objecte portable"
 
 #. IDS_COLORSCHEME_RSRC
-#: Merge.rc:5444
+#: Merge.rc:5443
 #, c-format
 msgid "Resources"
 msgstr "Recursos"
 
 #. IDS_COLORSCHEME_SH
-#: Merge.rc:5448
+#: Merge.rc:5447
 #, c-format
 msgid "Shell"
 msgstr "Finestra d'ordres"
 
 #. IDS_CLOSE_LEFT_TABS
-#: Merge.rc:5469
+#: Merge.rc:5468
 #, c-format
 msgid "Close &Left Tabs"
 msgstr "Tanca les pestanyes de l'esquerra"
 
 #. IDS_CLOSE_RIGHT_TABS
-#: Merge.rc:5470
+#: Merge.rc:5469
 #, c-format
 msgid "Close R&ight Tabs"
 msgstr "Tanca les pestanyes de la dreta"
 
 #. IDS_CLOSE_OTHER_TABS
-#: Merge.rc:5471
+#: Merge.rc:5470
 #, c-format
 msgid "Close &Other Tabs"
 msgstr "Tanca les altres pestanyes"
 
 #. IDS_TABBAR_AUTO_MAXWIDTH
-#: Merge.rc:5472
+#: Merge.rc:5471
 #, c-format
 msgid "Enable &Auto Max Width"
 msgstr "Activa l'amplada màxima automàtica"
 
 #. IDS_WEBPAGE_MENU
-#: Merge.rc:5482
+#: Merge.rc:5481
 msgid "We&bpage"
 msgstr "Pàgina &web"
 
 #. IDS_VIEW_WRAP_TEXT
-#: Merge.rc:5487
+#: Merge.rc:5486
 msgid "W&rap Text"
 msgstr "&Ajusta el text"
 
 #. IDS_NOTINSTALLED
-#: Merge.rc:5492
+#: Merge.rc:5491
 msgid "%1 is not installed."
 msgstr "L'aplicació %1 no està instal·lada."
 
 #. IDS_CREATE_FOLDER
-#: Merge.rc:5497
+#: Merge.rc:5496
 #, c-format
 msgid "%1 does not exist. Create it?"
 msgstr "No existeix %1. Voleu crear-lo?"
 
 #. IDS_CREATE_FOLDER_ERROR
-#: Merge.rc:5498
+#: Merge.rc:5497
 #, c-format
 msgid "Failed to create folder."
 msgstr "No s'ha pogut crear el directori."
 
 #. IDC_EXT_EDITOR_PATH
-#: Merge.rc:5503
+#: Merge.rc:5502
 #, c-format
 msgid ""
 "Parameters:\n"
@@ -8584,492 +8578,492 @@ msgstr ""
 "$linenum: Línia de la posició actual del cursor"
 
 #. IDS_DIFF_ALGORITHM_DEFAULT
-#: Merge.rc:5508
+#: Merge.rc:5507
 msgid "default"
 msgstr "per defecte"
 
 #. IDS_DIFF_ALGORITHM_MINIMAL
-#: Merge.rc:5509
+#: Merge.rc:5508
 msgid "minimal"
 msgstr "mínim"
 
 #. IDS_DIFF_ALGORITHM_PATIENCE
-#: Merge.rc:5510
+#: Merge.rc:5509
 msgid "patience"
 msgstr "paciència"
 
 #. IDS_DIFF_ALGORITHM_HISTOGRAM
-#: Merge.rc:5511
+#: Merge.rc:5510
 msgid "histogram"
 msgstr "histograma"
 
 #. IDS_DIFF_ALGORITHM_NONE
-#: Merge.rc:5512
+#: Merge.rc:5511
 msgid "none"
 msgstr "cap"
 
 #. IDS_RENDERING_MODE_GDI
-#: Merge.rc:5517
+#: Merge.rc:5516
 msgid "GDI"
 msgstr "GDI"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_DEFAULT
-#: Merge.rc:5518
+#: Merge.rc:5517
 msgid "DirectWrite Default"
 msgstr "DirectWrite per defecte"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_ALIASED
-#: Merge.rc:5519
+#: Merge.rc:5518
 msgid "DirectWrite Aliased"
 msgstr "DirectWrite amb aliasing"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_GDI_CLASSIC
-#: Merge.rc:5520
+#: Merge.rc:5519
 msgid "DirectWrite GDI Classic"
 msgstr "DirectWrite GDI clàssic"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_GDI_NATURAL
-#: Merge.rc:5521
+#: Merge.rc:5520
 msgid "DirectWrite GDI Natural"
 msgstr "DirectWrite GDI natural"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_NATURAL
-#: Merge.rc:5522
+#: Merge.rc:5521
 msgid "DirectWrite Natural"
 msgstr "DirectWrite Natural"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_NATURAL_SYMMETRIC
-#: Merge.rc:5523
+#: Merge.rc:5522
 msgid "DirectWrite Natural Symmetric"
 msgstr "DirectWrite natural simètric"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_DISABLED
-#: Merge.rc:5528
+#: Merge.rc:5527
 msgctxt "Options dialog|General|Close windows with Esc"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_1
-#: Merge.rc:5529
+#: Merge.rc:5528
 msgid "MDI child window or main window"
 msgstr "Subfinestra filla MDI o finestra principal"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_2
-#: Merge.rc:5530
+#: Merge.rc:5529
 msgid "MDI child window only"
 msgstr "Només subfinestra filla MDI"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_3
-#: Merge.rc:5531
+#: Merge.rc:5530
 msgid "Close main window if only one MDI child window"
 msgstr "Tanca la finestra principal si només hi ha una única subfinestra filla MDI"
 
 #. IDS_DIFF_GROUP
-#: Merge.rc:5536
+#: Merge.rc:5535
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Diff"
 msgstr "Diferències"
 
 #. IDS_DIFF_HIGHLIGHT
-#: Merge.rc:5537
+#: Merge.rc:5536
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Highlight"
 msgstr "Ressalta"
 
 #. IDS_DIFF_BLINK
-#: Merge.rc:5538
+#: Merge.rc:5537
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Blink"
 msgstr "Parpelleja"
 
 #. IDS_DIFF_BLOCKSIZE
-#: Merge.rc:5539
+#: Merge.rc:5538
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Block Size"
 msgstr "Mida del bloc"
 
 #. IDS_DIFF_BLOCKALPHA
-#: Merge.rc:5540
+#: Merge.rc:5539
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Block Alpha"
 msgstr "Trans. del bloc"
 
 #. IDS_DIFF_CDTHRESHOLD
-#: Merge.rc:5541
+#: Merge.rc:5540
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "CD Threshold"
 msgstr "Llindar Dif. Col."
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION
-#: Merge.rc:5542
+#: Merge.rc:5541
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Ins/Del Detection"
 msgstr "Detecció Ins/Elim"
 
 #. IDS_OVERLAY_MODE_NONE
-#: Merge.rc:5543 Merge.rc:5548
+#: Merge.rc:5542 Merge.rc:5547
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "None"
 msgstr "Cap"
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION_VERTICAL
-#: Merge.rc:5544
+#: Merge.rc:5543
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Vertical"
 msgstr "Vertical"
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION_HORIZONTAL
-#: Merge.rc:5545
+#: Merge.rc:5544
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Horizontal"
 msgstr "Horitzontal"
 
 #. IDS_OVERLAY_GROUP
-#: Merge.rc:5546
+#: Merge.rc:5545
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Overlay"
 msgstr "Superposició"
 
 #. IDS_OVERLAY_ALPHA
-#: Merge.rc:5547
+#: Merge.rc:5546
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha"
 msgstr "Grau transp."
 
 #. IDS_OVERLAY_MODE_XOR
-#: Merge.rc:5549
+#: Merge.rc:5548
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "XOR"
 msgstr "XOR"
 
 #. IDS_OVERLAY_MODE_ALPHA
-#: Merge.rc:5550
+#: Merge.rc:5549
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha Blend"
 msgstr "Superp. transp."
 
 #. IDS_OVERLAY_MODE_ALPHA_ANIMATION
-#: Merge.rc:5551
+#: Merge.rc:5550
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha Animation"
 msgstr "Superp. animada"
 
 #. IDS_ZOOM
-#: Merge.rc:5552
+#: Merge.rc:5551
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Zoom"
 msgstr "Zoom"
 
 #. IDS_PAGE
-#: Merge.rc:5553
+#: Merge.rc:5552
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Page:"
 msgstr "Pàgina:"
 
 #. IDS_IMGCMP_STATUS_PT_RGBA_FMT
-#: Merge.rc:5554
+#: Merge.rc:5553
 #, c-format
 msgid "Pt: (%d, %d)  RGBA: (%d, %d, %d, %d)  "
 msgstr "Pt: (%d, %d) RGBA: (%d, %d, %d, %d) "
 
 #. IDS_IMGCMP_STATUS_DIST1_FMT
-#: Merge.rc:5555
+#: Merge.rc:5554
 #, c-format
 msgid "Dist: %g  "
 msgstr "Dist: %g "
 
 #. IDS_IMGCMP_STATUS_DIST2_FMT
-#: Merge.rc:5556
+#: Merge.rc:5555
 #, c-format
 msgid "Dist: %g, %g  "
 msgstr "Dist: %g, %g "
 
 #. IDS_IMGCMP_STATUS_PAGE_ZOOM_SIZE_BPP_FMT
-#: Merge.rc:5557
+#: Merge.rc:5556
 #, c-format
 msgid "Page: %d/%d  Zoom: %d%%  %dx%dpx  %dbpp  "
 msgstr "Pàgina: %d/%d  Zoom: %d%%  %dx%dpx  %dbpp  "
 
 #. IDS_IMGCMP_STATUS_RC_FMT
-#: Merge.rc:5558
+#: Merge.rc:5557
 #, c-format
 msgid "Rc: (%d, %d)  "
 msgstr "Rc: (%d, %d) "
 
 #. IDS_IMGCMP_STATUS_FLIPPED_FMT
-#: Merge.rc:5559
+#: Merge.rc:5558
 #, c-format
 msgid "Flipped: %s  "
 msgstr "Voltejat: %s "
 
 #. IDS_IMGCMP_STATUS_ROTATED_FMT
-#: Merge.rc:5560
+#: Merge.rc:5559
 #, c-format
 msgid "Rotated: %d  "
 msgstr "Girat: %d "
 
 #. IDS_IMGCMP_REPORT_ALLPAGES
-#: Merge.rc:5561
+#: Merge.rc:5560
 msgid "All pages"
 msgstr "Totes les pàgines"
 
 #. IDS_IGNSUB_STR1
-#: Merge.rc:5566
+#: Merge.rc:5565
 msgid "<Edit here>"
 msgstr "<Edita aquí>"
 
 #. IDS_IGNSUB_STR2
-#: Merge.rc:5567
+#: Merge.rc:5566
 msgid "No differences found to select"
 msgstr "No s'han trobat diferències per seleccionar"
 
 #. IDS_IGNSUB_STR3
-#: Merge.rc:5568
+#: Merge.rc:5567
 msgid "No differences found to add as substitution filter"
 msgstr "No s'han trobat diferències per afegir com a filtre de substitució"
 
 #. IDS_IGNSUB_STR4
-#: Merge.rc:5569
+#: Merge.rc:5568
 msgid "The pair is already in the Substitution Filters list"
 msgstr "La parella ja està present a la llista de filtres de substitució"
 
 #. IDS_IGNSUB_STR5
-#: Merge.rc:5570
+#: Merge.rc:5569
 msgid "Add this change to Substitution Filters?"
 msgstr "Voleu afegir aquest canvi als filtres de substitució?"
 
 #. IDS_OCRRESULT_TEXTONLY
-#: Merge.rc:5575
+#: Merge.rc:5574
 msgid "Text only"
 msgstr "Només text"
 
 #. IDS_OCRRESULT_POS_LINE
-#: Merge.rc:5576
+#: Merge.rc:5575
 msgid "Line-by-line position and text"
 msgstr "Posició Línia a línia i text"
 
 #. IDS_OCRRESULT_POS_WORD
-#: Merge.rc:5577
+#: Merge.rc:5576
 msgid "Word-by-word position and text"
 msgstr "Posició paraula a paraula i text"
 
 #. IDS_USERDATAFOLDER_APPDATA
-#: Merge.rc:5582
+#: Merge.rc:5581
 msgid "AppData (Roaming) folder"
 msgstr ""
 
 #. IDS_USERDATAFOLDER_INSTALL
-#: Merge.rc:5583
+#: Merge.rc:5582
 msgid "Install folder"
 msgstr "Carpeta d'instal·lació"
 
 #. IDS_USERDATAFOLDER_DOCUMENTS
-#: Merge.rc:5584
+#: Merge.rc:5583
 msgid "Documents folder"
 msgstr ""
 
 #. IDS_SINGLEINSTANCE_DISABLED
-#: Merge.rc:5589
+#: Merge.rc:5588
 msgctxt "Options dialog|General|Single instance mode"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_SINGLEINSTANCE_STR1
-#: Merge.rc:5590
+#: Merge.rc:5589
 #, c-format
 msgid "Allow only one instance to run"
 msgstr "Permet d'executar només una instància"
 
 #. IDS_CLIPBOARD_HISTORY
-#: Merge.rc:5591
+#: Merge.rc:5590
 msgid "Clipboard &History"
 msgstr ""
 
 #. IDS_SINGLEINSTANCE_STR2
-#: Merge.rc:5592
+#: Merge.rc:5591
 msgid "Allow only one instance; wait for termination"
 msgstr "Permet d'executar només una instància i espera que la instància acabi"
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_DISABLED
-#: Merge.rc:5597
+#: Merge.rc:5596
 msgctxt "Options dialog|General|Auto-reload modified files"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_STR1
-#: Merge.rc:5598
+#: Merge.rc:5597
 msgid "Only on window activated"
 msgstr "Només a la finestra activada"
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_STR2
-#: Merge.rc:5599
+#: Merge.rc:5598
 msgid "Immediately"
 msgstr "Immediatament"
 
 #. IDS_PLUGIN_ALL
-#: Merge.rc:5604
+#: Merge.rc:5603
 msgid "Al&l"
 msgstr "Tot"
 
 #. IDS_PLUGIN_OTHERS
-#: Merge.rc:5605
+#: Merge.rc:5604
 msgid "&Others"
 msgstr "Altres"
 
-#: Merge.rc:5607
+#: Merge.rc:5606
 #, c-format
 msgid "Missing plugin name in pipeline: %1"
 msgstr "Manca el nom del connector a la seqüència: %1"
 
-#: Merge.rc:5609
+#: Merge.rc:5608
 #, c-format
 msgid "Missing quote in plugin pipeline: %1"
 msgstr "Manca les cometes a la seqüència: %1"
 
 #. IDS_PLUGIN_NAME_ALREADY_EXISTS
-#: Merge.rc:5610
+#: Merge.rc:5609
 #, c-format
 msgid "Plugin name '%1' already exists."
 msgstr ""
 
 #. IDS_PLUGIN_TITLE1
-#: Merge.rc:5611
+#: Merge.rc:5610
 msgid "Specify plugin arguments"
 msgstr "Especifiqueu els paràmetres del connector"
 
-#: Merge.rc:5613
+#: Merge.rc:5612
 #, c-format
 msgid "Plugin not found or invalid: %1"
 msgstr "El connector no s'ha trobat o no és vàlid: %1"
 
 #. IDS_PLUGIN_NOT_UNPACK
-#: Merge.rc:5614
+#: Merge.rc:5613
 #, c-format
 msgid "'%1' is not an unpacker plugin"
 msgstr "«%1» no és un connector desempaquetador"
 
 #. IDS_PLUGIN_NOT_PREDIFF
-#: Merge.rc:5615
+#: Merge.rc:5614
 #, c-format
 msgid "'%1' is not a prediffer plugin"
 msgstr "«%1» no és un connector de prediferència"
 
-#: Merge.rc:5617
+#: Merge.rc:5616
 #, c-format
 msgid "Error prediffing '%1' with '%2'. Prediffing disabled."
 msgstr "S'ha produït un error en veure les prediferències del fitxer «%1» amb el connector «%2». La prediferència ja no s'aplica."
 
 #. IDS_PLUGIN_CIRCULAR_REFERENCE
-#: Merge.rc:5618
+#: Merge.rc:5617
 #, c-format
 msgid "Circular reference in plugin pipeline: %1"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE1
-#: Merge.rc:5619
+#: Merge.rc:5618
 msgid "URL Handler"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE2
-#: Merge.rc:5620
+#: Merge.rc:5619
 msgid "File Unpacker"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE3
-#: Merge.rc:5621
+#: Merge.rc:5620
 msgid "File or Folder Unpacker"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE5
-#: Merge.rc:5623
+#: Merge.rc:5622
 msgid "Alias for Unpacker"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE6
-#: Merge.rc:5624
+#: Merge.rc:5623
 msgid "Alias for Prediffer"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE7
-#: Merge.rc:5625
+#: Merge.rc:5624
 msgid "Alias for Editor script"
 msgstr ""
 
 #. IDS_PLUGIN_ALIAS_DESC
-#: Merge.rc:5626
+#: Merge.rc:5625
 #, c-format
 msgid "Alias for plugin pipeline '%1'"
 msgstr ""
 
 #. IDS_PLUGIN_NEW_DESC
-#: Merge.rc:5627
+#: Merge.rc:5626
 msgid "New plugin description"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_ALL
-#: Merge.rc:5628
+#: Merge.rc:5627
 msgid "All"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_1ST
-#: Merge.rc:5629
+#: Merge.rc:5628
 msgid "1st"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_2ND
-#: Merge.rc:5630
+#: Merge.rc:5629
 msgid "2nd"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_3RD
-#: Merge.rc:5631
+#: Merge.rc:5630
 msgid "3rd"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_1ST_2ND
-#: Merge.rc:5632
+#: Merge.rc:5631
 msgid "1st and 2nd"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_1ST_3RD
-#: Merge.rc:5633
+#: Merge.rc:5632
 msgid "1st and 3rd"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_2ND_3RD
-#: Merge.rc:5634
+#: Merge.rc:5633
 msgid "2nd and 3rd"
 msgstr ""
 
 #. IDS_PLUGIN_CTRL_CLICK
-#: Merge.rc:5635
+#: Merge.rc:5634
 msgid "(Ctrl+Click to add to pipeline)"
 msgstr ""
 
 #. IDS_FILTER_APPLIED
-#: Merge.rc:5640
+#: Merge.rc:5639
 msgid "Filter applied"
 msgstr "Filtre aplicat"
 
 #. IDS_FILTERMENU_COMPARE
-#: Merge.rc:5645
+#: Merge.rc:5644
 #, c-format
 msgid "Compare %1"
 msgstr ""
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN2
-#: Merge.rc:5647
+#: Merge.rc:5646
 msgid "&Filter by This Column..."
 msgstr ""
 
 #. IDS_CLIPBOARDHISTORY_TIME
-#: Merge.rc:5652
+#: Merge.rc:5651
 #, c-format
 msgid "Clipboard at %s"
 msgstr "Porta-retalls a %s"
 
 #. IDS_CLIPBOARDHISTORY_DISABLED
-#: Merge.rc:5653
+#: Merge.rc:5652
 msgid ""
 "Clipboard history disabled.\r\n"
 "Enable: Windows logo key + V, then Turn on."
@@ -9077,420 +9071,420 @@ msgstr ""
 "L'historial del porta-retalls està desactivat.\r\n"
 "Per activar l'historial del porta-retalls, premeu la tecla del logotip de Windows + V i aleshores feu clic al botó Activa."
 
-#: Merge.rc:5655
+#: Merge.rc:5654
 msgid "This system does not support clipboard history."
 msgstr "Aquest sistema no té suport per a l'historial del porta-retalls."
 
-#: Merge.rc:5657
+#: Merge.rc:5656
 msgid "32-bit WinMerge does not support Clipboard Compare"
 msgstr "La versió de 32 bits del WinMerge no suporta comparar via porta-retalls"
 
 #. IDS_WEBVIEW2_RUNTIME_NOT_INSTALLED
-#: Merge.rc:5662
+#: Merge.rc:5661
 msgid "WebView2 runtime not installed. Download it?"
 msgstr "L'entorn d'execució WebView2 no està instal·lat. El voleu descarregar?"
 
 #. IDS_JUMPLIST_NEW_TEXT_COMPARE
-#: Merge.rc:5667
+#: Merge.rc:5666
 msgid "New Text Compare"
 msgstr "Nova comparació de text"
 
 #. IDS_JUMPLIST_NEW_TABLE_COMPARE
-#: Merge.rc:5668
+#: Merge.rc:5667
 msgid "New Table Compare"
 msgstr "Nova comparació de taules"
 
 #. IDS_JUMPLIST_NEW_BINARY_COMPARE
-#: Merge.rc:5669
+#: Merge.rc:5668
 msgid "New Binary Compare"
 msgstr "Nova comparació binària"
 
 #. IDS_JUMPLIST_NEW_IMAGE_COMPARE
-#: Merge.rc:5670
+#: Merge.rc:5669
 msgid "New Image Compare"
 msgstr "Nova comparació d'imatges"
 
 #. IDS_JUMPLIST_NEW_WEBPAGE_COMPARE
-#: Merge.rc:5671
+#: Merge.rc:5670
 msgid "New Webpage Compare"
 msgstr "Nova comparació de pàgines web"
 
 #. IDS_JUMPLIST_NEW_FOLDER_COMPARE
-#: Merge.rc:5672
+#: Merge.rc:5671
 msgid "New Folder Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_CLIPBOARD_COMPARE
-#: Merge.rc:5673
+#: Merge.rc:5672
 msgid "Clipboard Compare"
 msgstr "Comparació del porta-retalls"
 
 #. IDS_PREVIEWBAR_PRINT
-#: Merge.rc:5678
+#: Merge.rc:5677
 msgid "&Print..."
 msgstr "&Imprimeix..."
 
 #. IDS_PREVIEWBAR_PREVPAGE
-#: Merge.rc:5680
+#: Merge.rc:5679
 msgid "Pre&v Page"
 msgstr "Pàgina &anterior"
 
 #. IDS_PREVIEWBAR_TWOPAGE
-#: Merge.rc:5681
+#: Merge.rc:5680
 msgid "&Two Page"
 msgstr "&Dues pàgines"
 
 #. IDS_PREVIEWBAR_ONEPAGE
-#: Merge.rc:5682
+#: Merge.rc:5681
 msgid "&One Page"
 msgstr "&Una pàgina"
 
 #. IDS_PREVIEWBAR_ZOOMIN
-#: Merge.rc:5683
+#: Merge.rc:5682
 msgid "Zoom &In"
 msgstr "A&propa"
 
 #. IDS_PREVIEWBAR_ZOOMOUT
-#: Merge.rc:5684
+#: Merge.rc:5683
 msgid "Zoom &Out"
 msgstr "All&unya"
 
 #. IDS_WEBPAGE_COMPARING
-#: Merge.rc:5690
+#: Merge.rc:5689
 msgid "Comparing..."
 msgstr "Comparant..."
 
 #. IDS_WEBPAGE_ZOOM
-#: Merge.rc:5691
+#: Merge.rc:5690
 msgid "Zoom:"
 msgstr "Zoom:"
 
 #. IDS_COPY_GRANULARITY_DIFFHUNK
-#: Merge.rc:5696
+#: Merge.rc:5695
 msgid "Diff hunk"
 msgstr "Tros de diferència"
 
 #. IDS_COPY_GRANULARITY_INLINE
-#: Merge.rc:5697
+#: Merge.rc:5696
 msgid "Inline diff"
 msgstr "Diferència en línia"
 
 #. IDS_COPY_GRANULARITY_LINE
-#: Merge.rc:5698
+#: Merge.rc:5697
 msgid "Line"
 msgstr "Línia"
 
-#: Merge.rc:5699
+#: Merge.rc:5698
 msgid "Character"
 msgstr "Caràcter"
 
 #. ID_MICE_PREVDIFF
-#: Merge.rc:5704
+#: Merge.rc:5703
 msgid "\nPrevious Difference (Alt+Up)\n(Right Button+Wheel Up)\n(Alt+Wheel Up)"
 msgstr ""
 
 #. ID_MICE_NEXTDIFF
-#: Merge.rc:5705
+#: Merge.rc:5704
 msgid "\nNext Difference (Alt+Down)\n(Right Button+Wheel Down)\n(Alt+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_L2R
-#: Merge.rc:5706
+#: Merge.rc:5705
 msgid "\nCopy to Right (Alt+Right)\n(Right Button+Wheel Right)\n(Alt+Wheel Right)\n(Alt+Shift+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_R2L
-#: Merge.rc:5707
+#: Merge.rc:5706
 msgid "\nCopy to Left (Alt+Left)\n(Right Button+Wheel Left)\n(Alt+Wheel Left)\n(Alt+Shift+Wheel Up)"
 msgstr ""
 
 #. ID_MICE_L2RNEXT
-#: Merge.rc:5708
+#: Merge.rc:5707
 msgid "\nCopy to Right and Advance (Ctrl+Alt+Right)\n(Ctrl+Alt+Wheel Right)\n(Ctrl+Alt+Shift+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_R2LNEXT
-#: Merge.rc:5709
+#: Merge.rc:5708
 msgid "\nCopy to Left and Advance (Ctrl+Alt+Left)\n(Ctrl+Alt+Wheel Left)\n(Ctrl+Alt+Shift+Wheel Up)"
 msgstr ""
 
 #. IDS_LOG_COMPARING_2
-#: Merge.rc:5719
+#: Merge.rc:5718
 #, c-format
 msgid "Comparing %1 with %2"
 msgstr ""
 
 #. IDS_LOG_COMPARING_3
-#: Merge.rc:5720
+#: Merge.rc:5719
 #, c-format
 msgid "Comparing %1 with %2 and %3"
 msgstr ""
 
 #. IDS_LOG_COMPARE_COMPLETED
-#: Merge.rc:5721
+#: Merge.rc:5720
 msgid "Comparison completed"
 msgstr ""
 
 #. IDS_LOG_COMPARE_ERROR_2
-#: Merge.rc:5722
+#: Merge.rc:5721
 #, c-format
 msgid "Failed to compare %1 with %2: "
 msgstr ""
 
 #. IDS_LOG_COMPARE_ERROR_3
-#: Merge.rc:5723
+#: Merge.rc:5722
 #, c-format
 msgid "Failed to compare %1 with %2 and %3: "
 msgstr ""
 
 #. IDS_LOG_FILE_SAVED
-#: Merge.rc:5724
+#: Merge.rc:5723
 msgid "File saved"
 msgstr ""
 
 #. IDS_LOG_COPYING_FILES
-#: Merge.rc:5725
+#: Merge.rc:5724
 msgid "Copying files..."
 msgstr ""
 
 #. IDS_LOG_MOVING_FILES
-#: Merge.rc:5726
+#: Merge.rc:5725
 msgid "Moving files..."
 msgstr ""
 
 #. IDS_LOG_DELETING_FILES
-#: Merge.rc:5727
+#: Merge.rc:5726
 msgid "Deleting files..."
 msgstr ""
 
 #. IDS_LOG_RECYCLEBIN
-#: Merge.rc:5728
+#: Merge.rc:5727
 msgid "Recycle Bin"
 msgstr ""
 
 #. IDS_LOG_PERMANENTLY_DELETED
-#: Merge.rc:5729
+#: Merge.rc:5728
 msgid "Permanently deleted"
 msgstr ""
 
 #. IDS_LOG_FILEOPERATION_COMPLETED
-#: Merge.rc:5730
+#: Merge.rc:5729
 msgid "File operation completed successfully"
 msgstr ""
 
 #. IDS_LOG_FILEOPERATION_CANCELED
-#: Merge.rc:5731
+#: Merge.rc:5730
 msgid "File operation canceled"
 msgstr ""
 
 #. IDS_FILTER_ERROR_NO_ERROR
-#: Merge.rc:5736
+#: Merge.rc:5735
 msgid "No error"
 msgstr ""
 
 #. IDS_FILTER_ERROR_EMPTY_EXPRESSION
-#: Merge.rc:5737
+#: Merge.rc:5736
 msgid "Filter expression is empty"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNKNOWN_CHAR
-#: Merge.rc:5738
+#: Merge.rc:5737
 msgid "Unknown character in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNTERMINATED_STRING
-#: Merge.rc:5739
+#: Merge.rc:5738
 msgid "Unterminated string literal"
 msgstr ""
 
 #. IDS_FILTER_ERROR_SYNTAX_ERROR
-#: Merge.rc:5740
+#: Merge.rc:5739
 msgid "Syntax error in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_PARSE_FAILURE
-#: Merge.rc:5741
+#: Merge.rc:5740
 msgid "Failed to parse filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_LITERAL
-#: Merge.rc:5742
+#: Merge.rc:5741
 msgid "Invalid literal value"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_REGULAR_EXPRESSION
-#: Merge.rc:5743
+#: Merge.rc:5742
 msgid "Invalid regular expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNDEFINED_IDENTIFIER
-#: Merge.rc:5744
+#: Merge.rc:5743
 msgid "Undefined identifier"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_ARGUMENT_COUNT
-#: Merge.rc:5745
+#: Merge.rc:5744
 msgid "Invalid number of arguments"
 msgstr ""
 
 #. IDS_FILTER_ERROR_FILTER_NAME_NOT_FOUND
-#: Merge.rc:5746
+#: Merge.rc:5745
 msgid "Filter name not found"
 msgstr ""
 
 #. IDS_FILTER_ERROR_DIVIDE_BY_ZERO
-#: Merge.rc:5747
+#: Merge.rc:5746
 msgid "Division by zero in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNKNOWN_ERROR
-#: Merge.rc:5748
+#: Merge.rc:5747
 msgid "Unknown error"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_PROPERTY_NAME
-#: Merge.rc:5749
+#: Merge.rc:5748
 msgid "Invalid property name"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_DIRECTIVE
-#: Merge.rc:5750
+#: Merge.rc:5749
 msgid "Invalid directive"
 msgstr ""
 
 #. IDS_FILTER_OP_EQUALS
-#: Merge.rc:5755
+#: Merge.rc:5754
 msgid "Equals"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_EQUALS
-#: Merge.rc:5756
+#: Merge.rc:5755
 msgid "Does not equal"
 msgstr ""
 
 #. IDS_FILTER_OP_LESS_THAN
-#: Merge.rc:5757
+#: Merge.rc:5756
 msgid "Less than"
 msgstr ""
 
 #. IDS_FILTER_OP_LESS_EQUAL
-#: Merge.rc:5758
+#: Merge.rc:5757
 msgid "Less than or equal to"
 msgstr ""
 
 #. IDS_FILTER_OP_GREATER_EQUAL
-#: Merge.rc:5759
+#: Merge.rc:5758
 msgid "Greater than or equal to"
 msgstr ""
 
 #. IDS_FILTER_OP_GREATER_THAN
-#: Merge.rc:5760
+#: Merge.rc:5759
 msgid "Greater than"
 msgstr ""
 
 #. IDS_FILTER_OP_BETWEEN
-#: Merge.rc:5761
+#: Merge.rc:5760
 msgid "Between"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_BETWEEN
-#: Merge.rc:5762
+#: Merge.rc:5761
 msgid "Not Between"
 msgstr ""
 
 #. IDS_FILTER_OP_CONTAINS
-#: Merge.rc:5763
+#: Merge.rc:5762
 msgid "Contains"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_CONTAINS
-#: Merge.rc:5764
+#: Merge.rc:5763
 msgid "Not Contains"
 msgstr ""
 
 #. IDS_FILTER_OP_RECONTAINS
-#: Merge.rc:5765
+#: Merge.rc:5764
 msgid "Contains (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_RECONTAINS
-#: Merge.rc:5766
+#: Merge.rc:5765
 msgid "Not Contains (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_LIKE
-#: Merge.rc:5767
+#: Merge.rc:5766
 msgid "Match (wildcard)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_LIKE
-#: Merge.rc:5768
+#: Merge.rc:5767
 msgid "Not match (wildcard)"
 msgstr ""
 
 #. IDS_FILTER_OP_MATCHES
-#: Merge.rc:5769
+#: Merge.rc:5768
 msgid "Match (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_MATCHES
-#: Merge.rc:5770
+#: Merge.rc:5769
 msgid "Not match (regex)"
 msgstr ""
 
 #. IDS_COLORMODE_LIGHT
-#: Merge.rc:5775
+#: Merge.rc:5774
 msgid "Light"
 msgstr ""
 
 #. IDS_COLORMODE_DARK
-#: Merge.rc:5776
+#: Merge.rc:5775
 msgid "Dark"
 msgstr ""
 
 #. IDS_COLORMODE_FOLLOWSYSTEM
-#: Merge.rc:5777
+#: Merge.rc:5776
 msgid "Follow system"
 msgstr ""
 
 #. IDS_EXAMPLE
-#: Merge.rc:5782
+#: Merge.rc:5781
 #, c-format
 msgid "e.g. %1"
 msgstr ""
 
 #. IDS_DETECTED_PREVIOUS_CRASH
-#: Merge.rc:5787
+#: Merge.rc:5786
 msgid "WinMerge detected a previous crash. Please report this if possible."
 msgstr ""
 
 #. IDS_REGEX_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5792
+#: Merge.rc:5791
 msgid "# Regex replacement list\r\n# Format: regex<TAB>replacement\r\n# Backreferences like $1, $2 are supported\r\n\r\n(\\d{4})-(\\d{2})-(\\d{2})\t$1_$2_$3\r\n"
 msgstr ""
 
 #. IDS_STRING_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5793
+#: Merge.rc:5792
 msgid "# Replacement list\r\n# Format: search<TAB>replacement\r\n# Lines starting with # are ignored\r\n\r\nfrom1\tto1\r\nfrom2\tto2\r\n"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_ONLY
-#: Merge.rc:5798
+#: Merge.rc:5797
 msgid "Built-in only"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_FIRST
-#: Merge.rc:5799
+#: Merge.rc:5798
 msgid "Built-in first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_FIRST
-#: Merge.rc:5800
+#: Merge.rc:5799
 msgid "Tree-sitter first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_ONLY
-#: Merge.rc:5801
+#: Merge.rc:5800
 msgid "Tree-sitter only"
 msgstr ""
 

--- a/Translations/WinMerge/ChineseSimplified.po
+++ b/Translations/WinMerge/ChineseSimplified.po
@@ -27,7 +27,7 @@ msgstr ""
 "X-Poedit-SearchPath-0: .\n"
 
 #. LANGUAGE, SUBLANGUAGE
-#: Merge.rc:26 Merge.rc:59 Merge.rc:5818
+#: Merge.rc:26 Merge.rc:59 Merge.rc:5817
 msgid "LANG_ENGLISH, SUBLANG_ENGLISH_US"
 msgstr "LANG_CHINESE, SUBLANG_CHINESE_SIMPLIFIED"
 
@@ -169,7 +169,7 @@ msgstr "脚本(&S)"
 #. IDS_NO_EDIT_SCRIPTS
 #: Merge.rc:127 Merge.rc:352 Merge.rc:463 Merge.rc:673 Merge.rc:678
 #: Merge.rc:887 Merge.rc:899 Merge.rc:906 Merge.rc:963 Merge.rc:1210
-#: Merge.rc:5375
+#: Merge.rc:5374
 msgid "< Empty >"
 msgstr "< 空 >"
 
@@ -234,7 +234,7 @@ msgid "Auto-Fit All Columns"
 msgstr "自动适应所有列"
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN
-#: Merge.rc:153 Merge.rc:5646
+#: Merge.rc:153 Merge.rc:5645
 msgid "&Filter by This Column"
 msgstr "按该列过滤(&F)"
 
@@ -295,7 +295,7 @@ msgid "&Previous Page"
 msgstr "上一页(&P)"
 
 #. IDS_PREVIEWBAR_NEXTPAGE
-#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5679
+#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5678
 msgid "&Next Page"
 msgstr "下一页(&N)"
 
@@ -546,7 +546,7 @@ msgstr "二进制(&B)"
 #. IDS_IMAGE_MENU
 #: Merge.rc:329 Merge.rc:338 Merge.rc:432 Merge.rc:441 Merge.rc:609
 #: Merge.rc:618 Merge.rc:670 Merge.rc:960 Merge.rc:1187 Merge.rc:1200
-#: Merge.rc:5477
+#: Merge.rc:5476
 msgid "&Image"
 msgstr "图像(&I)"
 
@@ -668,7 +668,7 @@ msgid "&Huge"
 msgstr "特大(&H)"
 
 #. IDS_VIEW_MENU_BAR
-#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5714
+#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5713
 msgid "Men&u Bar"
 msgstr "菜单栏(&U)"
 
@@ -1323,7 +1323,7 @@ msgid "Lo&cation Pane"
 msgstr "定位窗格(&C)"
 
 #. IDS_OUTPUTBAR_CAPTION
-#: Merge.rc:782 Merge.rc:5252
+#: Merge.rc:782 Merge.rc:5251
 msgid "Output Pane"
 msgstr "输出窗格"
 
@@ -1586,55 +1586,55 @@ msgid "Co&mpare As"
 msgstr "重新比较(&M)"
 
 #. IDS_COPY_LEFT_TO_MIDDLE2
-#: Merge.rc:968 Merge.rc:980 Merge.rc:4852
+#: Merge.rc:968 Merge.rc:980 Merge.rc:4851
 #, c-format
 msgid "Left to Middle (%1 of %2)"
 msgstr "左侧到中间 (%1 / %2)"
 
 #. IDS_COPY_LEFT_TO_RIGHT2
-#: Merge.rc:969 Merge.rc:981 Merge.rc:4851
+#: Merge.rc:969 Merge.rc:981 Merge.rc:4850
 #, c-format
 msgid "Left to Right (%1 of %2)"
 msgstr "左侧到右侧 (%1 / %2)"
 
 #. IDS_MOVE_LEFT_TO2
-#: Merge.rc:970 Merge.rc:982 Merge.rc:1045 Merge.rc:4863 Merge.rc:4892
+#: Merge.rc:970 Merge.rc:982 Merge.rc:1045 Merge.rc:4862 Merge.rc:4891
 #, c-format
 msgid "Left to... (%1 of %2)"
 msgstr "左侧到... (%1 / %2)"
 
 #. IDS_COPY_MIDDLE_TO_LEFT2
-#: Merge.rc:971 Merge.rc:983 Merge.rc:4849
+#: Merge.rc:971 Merge.rc:983 Merge.rc:4848
 #, c-format
 msgid "Middle to Left (%1 of %2)"
 msgstr "中间到左侧 (%1 / %2)"
 
 #. IDS_COPY_MIDDLE_TO_RIGHT2
-#: Merge.rc:972 Merge.rc:984 Merge.rc:4850
+#: Merge.rc:972 Merge.rc:984 Merge.rc:4849
 #, c-format
 msgid "Middle to Right (%1 of %2)"
 msgstr "中间到右侧 (%1 / %2)"
 
 #. IDS_MOVE_MIDDLE_TO2
-#: Merge.rc:973 Merge.rc:985 Merge.rc:1046 Merge.rc:4864 Merge.rc:4893
+#: Merge.rc:973 Merge.rc:985 Merge.rc:1046 Merge.rc:4863 Merge.rc:4892
 #, c-format
 msgid "Middle to... (%1 of %2)"
 msgstr "中间到... (%1 / %2)"
 
 #. IDS_COPY_RIGHT_TO_MIDDLE2
-#: Merge.rc:974 Merge.rc:986 Merge.rc:4848
+#: Merge.rc:974 Merge.rc:986 Merge.rc:4847
 #, c-format
 msgid "Right to Middle (%1 of %2)"
 msgstr "右侧到中间 (%1 / %2)"
 
 #. IDS_COPY_RIGHT_TO_LEFT2
-#: Merge.rc:975 Merge.rc:987 Merge.rc:4847
+#: Merge.rc:975 Merge.rc:987 Merge.rc:4846
 #, c-format
 msgid "Right to Left (%1 of %2)"
 msgstr "右侧到左侧 (%1 / %2)"
 
 #. IDS_MOVE_RIGHT_TO2
-#: Merge.rc:976 Merge.rc:988 Merge.rc:1047 Merge.rc:4865 Merge.rc:4894
+#: Merge.rc:976 Merge.rc:988 Merge.rc:1047 Merge.rc:4864 Merge.rc:4893
 #, c-format
 msgid "Right to... (%1 of %2)"
 msgstr "右侧到... (%1 / %2)"
@@ -1690,31 +1690,31 @@ msgid "Cop&y Paths"
 msgstr "复制完整路径(&Y)"
 
 #. IDS_DEL_LEFT_FMT2
-#: Merge.rc:1026 Merge.rc:1035 Merge.rc:4880
+#: Merge.rc:1026 Merge.rc:1035 Merge.rc:4879
 #, c-format
 msgid "Left (%1 of %2)"
 msgstr "左侧 (%1 / %2)"
 
 #. IDS_DEL_MIDDLE_FMT2
-#: Merge.rc:1027 Merge.rc:1036 Merge.rc:4881
+#: Merge.rc:1027 Merge.rc:1036 Merge.rc:4880
 #, c-format
 msgid "Middle (%1 of %2)"
 msgstr "中间 (%1 / %2)"
 
 #. IDS_DEL_RIGHT_FMT2
-#: Merge.rc:1028 Merge.rc:1037 Merge.rc:4882
+#: Merge.rc:1028 Merge.rc:1037 Merge.rc:4881
 #, c-format
 msgid "Right (%1 of %2)"
 msgstr "右侧 (%1 / %2)"
 
 #. IDS_DEL_BOTH_FMT2
-#: Merge.rc:1029 Merge.rc:1038 Merge.rc:4883
+#: Merge.rc:1029 Merge.rc:1038 Merge.rc:4882
 #, c-format
 msgid "Both (%1 of %2)"
 msgstr "两侧 (%1 / %2)"
 
 #. IDS_DEL_ALL_FMT2
-#: Merge.rc:1030 Merge.rc:1039 Merge.rc:4888
+#: Merge.rc:1030 Merge.rc:1039 Merge.rc:4887
 #, c-format
 msgid "All (%1 of %2)"
 msgstr "全部 (%1 / %2)"
@@ -1740,19 +1740,19 @@ msgid "&Zip"
 msgstr "Zip (&Z)"
 
 #. IDS_COPY_BOTH_TO2
-#: Merge.rc:1048 Merge.rc:4866
+#: Merge.rc:1048 Merge.rc:4865
 #, c-format
 msgid "Both to... (%1 of %2)"
 msgstr "两者到... (%1 / %2)"
 
 #. IDS_COPY_ALL_TO2
-#: Merge.rc:1049 Merge.rc:4867
+#: Merge.rc:1049 Merge.rc:4866
 #, c-format
 msgid "All to... (%1 of %2)"
 msgstr "全部到... (%1 / %2)"
 
 #. IDS_COPY_DIFFERENCES_TO2
-#: Merge.rc:1050 Merge.rc:4868
+#: Merge.rc:1050 Merge.rc:4867
 #, c-format
 msgid "Differences to... (%1 of %2)"
 msgstr "差异到... (%1 / %2)"
@@ -1819,12 +1819,12 @@ msgstr "解包插件设置"
 
 #. IDS_USERCHOICE_NONE
 #: Merge.rc:1088 Merge.rc:1094 Merge.rc:1836 Merge.rc:1840 Merge.rc:2031
-#: Merge.rc:2035 Merge.rc:5377
+#: Merge.rc:2035 Merge.rc:5376
 msgid "<None>"
 msgstr "<无>"
 
 #. IDS_USERCHOICE_AUTOMATIC
-#: Merge.rc:1089 Merge.rc:1095 Merge.rc:5378
+#: Merge.rc:1089 Merge.rc:1095 Merge.rc:5377
 msgid "<Automatic>"
 msgstr "<自动>"
 
@@ -2754,12 +2754,12 @@ msgid "Text files only"
 msgstr "仅文本文件"
 
 #. IDS_EOL_NONE
-#: Merge.rc:1667 Merge.rc:1918 Merge.rc:5304
+#: Merge.rc:1667 Merge.rc:1918 Merge.rc:5303
 msgid "None"
 msgstr "无"
 
 #. IDS_EOL_MIXED
-#: Merge.rc:1668 Merge.rc:5299
+#: Merge.rc:1668 Merge.rc:5298
 msgid "Mixed"
 msgstr "混合"
 
@@ -3031,13 +3031,13 @@ msgstr "行状态(&S)"
 
 #. IDS_DIFFERENT
 #: Merge.rc:1904 Merge.rc:1988 Merge.rc:2866 Merge.rc:3036 Merge.rc:3077
-#: Merge.rc:5058
+#: Merge.rc:5057
 msgid "Different"
 msgstr "不同"
 
 #. IDS_IDENTICAL
 #: Merge.rc:1905 Merge.rc:1989 Merge.rc:2865 Merge.rc:3055 Merge.rc:3116
-#: Merge.rc:5048
+#: Merge.rc:5047
 msgid "Identical"
 msgstr "完全相同"
 
@@ -3057,7 +3057,7 @@ msgid "Missing"
 msgstr "缺失的"
 
 #. IDS_MOVED
-#: Merge.rc:1910 Merge.rc:5076
+#: Merge.rc:1910 Merge.rc:5075
 msgid "Moved"
 msgstr "移动的"
 
@@ -3793,7 +3793,7 @@ msgid "&Use custom system colors"
 msgstr "使用自定义系统颜色（某些用户界面元素可能不适用）(&U)"
 
 #. IDS_PRPCAT_SYSTEM
-#: Merge.rc:2565 Merge.rc:4559 Merge.rc:4560 Merge.rc:5007
+#: Merge.rc:2565 Merge.rc:4559 Merge.rc:4560 Merge.rc:5006
 msgid "System"
 msgstr "系统"
 
@@ -4193,7 +4193,7 @@ msgid "Items compared:"
 msgstr "已比较条目："
 
 #. IDS_PREVIEWBAR_CLOSE
-#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5685
+#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5684
 msgid "&Close"
 msgstr "关闭(&C)"
 
@@ -4816,7 +4816,7 @@ msgid "A&ppend timestamp"
 msgstr "追加时间戳(&P)"
 
 #. IDS_CONFIRM_COPY_CAPTION
-#: Merge.rc:3214 Merge.rc:4915
+#: Merge.rc:3214 Merge.rc:4914
 msgid "Confirm Copy"
 msgstr "确认复制"
 
@@ -5053,7 +5053,7 @@ msgid "&Character Set..."
 msgstr "字符集(&C)..."
 
 #. IDS_PRPCAT_IMAGE
-#: Merge.rc:3351 Merge.rc:4574 Merge.rc:5015
+#: Merge.rc:3351 Merge.rc:4574 Merge.rc:5014
 msgid "Image"
 msgstr "图像"
 
@@ -5458,7 +5458,7 @@ msgid "Project"
 msgstr "项目"
 
 #. IDS_COLHDR_NSDIFFS
-#: Merge.rc:4566 Merge.rc:4990
+#: Merge.rc:4566 Merge.rc:4989
 msgid "Differences"
 msgstr "差异"
 
@@ -5603,12 +5603,12 @@ msgid "File Type"
 msgstr "文件类型"
 
 #. IDS_COLHDR_EXTENSION
-#: Merge.rc:4653 Merge.rc:4947
+#: Merge.rc:4653 Merge.rc:4946
 msgid "Extension"
 msgstr "扩展名"
 
 #. IDS_PRPCAT_MESSAGE
-#: Merge.rc:4659 Merge.rc:5019
+#: Merge.rc:4659 Merge.rc:5018
 msgid "Message"
 msgstr "消息"
 
@@ -5648,7 +5648,7 @@ msgid "Hidden Items"
 msgstr "隐藏条目"
 
 #. IDS_PLUGINSLIST_NAME
-#: Merge.rc:4680 Merge.rc:5311
+#: Merge.rc:4680 Merge.rc:5310
 msgid "Name"
 msgstr "名称"
 
@@ -5668,7 +5668,7 @@ msgid "[F] "
 msgstr "[F] "
 
 #. IDS_PLUGINSLIST_DESC
-#: Merge.rc:4684 Merge.rc:5313
+#: Merge.rc:4684 Merge.rc:5312
 msgid "Description"
 msgstr "描述"
 
@@ -5835,155 +5835,150 @@ msgstr "行：%s  列：%d/%d  字符：%d/%d"
 msgid "  Sel: %d | %d"
 msgstr "  选中：%d | %d"
 
-#. IDS_MERGEMODE_MERGING
-#: Merge.rc:4734
-msgid "Merge"
-msgstr "合并"
-
 #. IDS_DIFF_NUMBER_STATUS_FMT
-#: Merge.rc:4735
+#: Merge.rc:4734
 #, c-format
 msgid "Difference %1 of %2"
 msgstr "第 %1 处差异(共 %2 处)"
 
 #. IDS_NO_DIFF_SEL_FMT
-#: Merge.rc:4736
+#: Merge.rc:4735
 #, c-format
 msgid "%1 Differences Found"
 msgstr "共找到 %1 处差异"
 
 #. IDS_1_DIFF_FOUND
-#: Merge.rc:4737
+#: Merge.rc:4736
 msgid "1 Difference Found"
 msgstr "找到 1 处差异"
 
 #. IDS_NO_ERR_SEL_FMT
-#: Merge.rc:4738
+#: Merge.rc:4737
 #, c-format
 msgid "%1 Errors Found"
 msgstr "找到 %1 个错误"
 
 #. IDS_1_ERR_FOUND
-#: Merge.rc:4739
+#: Merge.rc:4738
 msgid "1 Error Found"
 msgstr "找到 1 个错误"
 
 #. IDS_STATUSBAR_READONLY, Abbreviation from "Read Only"
-#: Merge.rc:4740
+#: Merge.rc:4739
 msgid "RO"
 msgstr "只读"
 
 #. IDS_DIRVIEW_STATUS_FMT_FOCUS
-#: Merge.rc:4746
+#: Merge.rc:4745
 #, c-format
 msgid "Item %1 of %2"
 msgstr "第 %1 项，共 %2 项"
 
 #. IDS_DIRVIEW_STATUS_FMT_NOFOCUS
-#: Merge.rc:4747
+#: Merge.rc:4746
 #, c-format
 msgid "Items: %1"
 msgstr "条目：%1"
 
 #. IDS_DIRVIEW_STATUS_COMPARING
-#: Merge.rc:4748
+#: Merge.rc:4747
 msgid "Comparing items..."
 msgstr "正在比较条目..."
 
 #. IDS_ITEMS_PER_SEC
-#: Merge.rc:4749
+#: Merge.rc:4748
 #, c-format
 msgid "%.1f[items/sec]"
 msgstr "%.1f [条目/秒]"
 
 #. IDS_ERROR_INCOMPARABLE
-#: Merge.rc:4755
+#: Merge.rc:4754
 msgid "Select two existing folders/files to compare."
 msgstr "选择两个现有的文件或文件夹来进行比较。"
 
 #. IDS_DIRSEL_TAG
-#: Merge.rc:4756
+#: Merge.rc:4755
 msgid "Folder Selection"
 msgstr "选择文件夹"
 
 #. IDS_OPEN_FILESDIRS
-#: Merge.rc:4757
+#: Merge.rc:4756
 msgid "Select two (or three) folders/files to compare."
 msgstr "选择两个或三个文件或文件夹来进行比较。"
 
 #. IDS_OPEN_LEFTINVALID
-#: Merge.rc:4758
+#: Merge.rc:4757
 msgid "Left (1st) path is invalid!"
 msgstr "左侧（组1）路径无效！"
 
 #. IDS_OPEN_MIDDLEINVALID
-#: Merge.rc:4759
+#: Merge.rc:4758
 msgid "Middle (2nd) path is invalid!"
 msgstr "中间（组2）路径无效！"
 
 #. IDS_OPEN_RIGHTINVALID2
-#: Merge.rc:4760
+#: Merge.rc:4759
 msgid "Right (2nd) path is invalid!"
 msgstr "右侧（组3）路径无效！"
 
 #. IDS_OPEN_RIGHTINVALID3
-#: Merge.rc:4761
+#: Merge.rc:4760
 msgid "Right (3rd) path is invalid!"
 msgstr "右侧（组3）路径无效！"
 
 #. IDS_OPEN_BOTHINVALID
-#: Merge.rc:4762
+#: Merge.rc:4761
 msgid "Both paths are invalid!"
 msgstr "两个路径均无效!"
 
-#: Merge.rc:4764
+#: Merge.rc:4763
 msgid "Left (1st) and Middle (2nd) paths are invalid!"
 msgstr "左侧（组1）和中间（组2）路径无效！"
 
 #. IDS_OPEN_LEFTRIGHTINVALID
-#: Merge.rc:4765
+#: Merge.rc:4764
 msgid "Left (1st) and Right (3rd) paths are invalid!"
 msgstr "左侧（组1）和右侧（组3）路径无效！"
 
-#: Merge.rc:4767
+#: Merge.rc:4766
 msgid "Middle (2nd) and Right (3rd) paths are invalid!"
 msgstr "中间（组2）和右侧（组3）路径无效！"
 
 #. IDS_OPEN_ALLINVALID
-#: Merge.rc:4768
+#: Merge.rc:4767
 msgid "All paths are invalid!"
 msgstr "所有路径均无效！"
 
 #. IDS_OPEN_UNPACKERDISABLED
-#: Merge.rc:4769
+#: Merge.rc:4768
 msgid "Only enabled for file comparisons"
 msgstr "仅启用文件比较"
 
 #. IDS_OPEN_MISMATCH
-#: Merge.rc:4770
+#: Merge.rc:4769
 msgid "Cannot compare file and folder!"
 msgstr "不能比较一个文件与一个文件夹！"
 
 #. IDS_ERROR_FILE_NOT_FOUND
-#: Merge.rc:4776
+#: Merge.rc:4775
 #, c-format
 msgid "File not found: %1"
 msgstr "找不到文件：%1"
 
 #. IDS_ERROR_FOLDER_NOT_FOUND
-#: Merge.rc:4777
+#: Merge.rc:4776
 #, c-format
 msgid "Folder not found: %1"
 msgstr "找不到文件夹：%1"
 
 #. IDS_ERROR_FILE_NOT_UNPACKED
-#: Merge.rc:4778
+#: Merge.rc:4777
 #, c-format
 msgid "File not unpacked: %1"
 msgstr "文件未解包：%1"
 
 #. IDS_ERROR_FILEOPEN
-#: Merge.rc:4779
+#: Merge.rc:4778
 #, c-format
 msgid ""
 "Cannot open file\n"
@@ -5997,12 +5992,12 @@ msgstr ""
 "%2"
 
 #. IDS_ERROR_CONF_RESOLVE
-#: Merge.rc:4780
+#: Merge.rc:4779
 msgid "Failed to parse conflict file."
 msgstr "解析冲突文件失败。"
 
 #. IDS_NOT_CONFLICT_FILE
-#: Merge.rc:4781
+#: Merge.rc:4780
 #, c-format
 msgid ""
 "The file\n"
@@ -6014,7 +6009,7 @@ msgstr ""
 "不是一个冲突文件。"
 
 #. IDS_COMPARE_LARGE_FILES
-#: Merge.rc:4782
+#: Merge.rc:4781
 msgid ""
 "Comparing large files requires significant memory.\n"
 "Show only comparison results (not file contents)?"
@@ -6023,28 +6018,28 @@ msgstr ""
 "是否只显示比较结果而不显示文件内容？"
 
 #. IDS_SAVE_AS_TITLE
-#: Merge.rc:4788
+#: Merge.rc:4787
 msgid "Save As"
 msgstr "另存为"
 
 #. IDS_SAVE_FMT
-#: Merge.rc:4789
+#: Merge.rc:4788
 #, c-format
 msgid "Save changes to %1?"
 msgstr "保存更改到 %1？"
 
 #. IDS_SAVEREADONLY_FMT
-#: Merge.rc:4790
+#: Merge.rc:4789
 #, c-format
 msgid "%1 is read-only. Override? Or 'No' to save as new filename?"
 msgstr "%1 标记为只读。您希望覆盖只读文件吗？（选“否”使用新文件名保存）"
 
 #. IDS_ERROR_BACKUP
-#: Merge.rc:4791
+#: Merge.rc:4790
 msgid "Error backing up file"
 msgstr "备份文件时出错"
 
-#: Merge.rc:4793
+#: Merge.rc:4792
 #, c-format
 msgid ""
 "Unable to backup original file:\n"
@@ -6058,7 +6053,7 @@ msgstr ""
 "仍要继续吗？"
 
 #. IDS_FILESAVE_FAILED
-#: Merge.rc:4794
+#: Merge.rc:4793
 #, c-format
 msgid ""
 "Saving file failed.\n"
@@ -6074,7 +6069,7 @@ msgstr ""
 "\t- 使用其他文件名保存（点击“确定”）\n"
 "\t- 中止当前操作 (点击“取消”）？"
 
-#: Merge.rc:4796
+#: Merge.rc:4795
 #, c-format
 msgid ""
 "Plugin '%2' cannot pack changes to left file into '%1'.\n"
@@ -6087,7 +6082,7 @@ msgstr ""
 "\n"
 "是否将解包版本保存为另一文件？"
 
-#: Merge.rc:4798
+#: Merge.rc:4797
 #, c-format
 msgid ""
 "Plugin '%2' cannot pack changes to middle file into '%1'.\n"
@@ -6100,7 +6095,7 @@ msgstr ""
 "\n"
 "是否将解包版本保存为另一文件？"
 
-#: Merge.rc:4800
+#: Merge.rc:4799
 #, c-format
 msgid ""
 "Plugin '%2' cannot pack changes to right file into '%1'.\n"
@@ -6114,7 +6109,7 @@ msgstr ""
 "是否将解包版本保存为另一文件？"
 
 #. IDS_FILECHANGED_ONDISK
-#: Merge.rc:4801
+#: Merge.rc:4800
 #, c-format
 msgid ""
 "Another application updated\n"
@@ -6130,7 +6125,7 @@ msgstr ""
 "要覆盖已被修改的文件吗？"
 
 #. IDS_SAVEREADONLY_MULTI
-#: Merge.rc:4802
+#: Merge.rc:4801
 #, c-format
 msgid ""
 "%1\n"
@@ -6140,7 +6135,7 @@ msgstr ""
 "文件标记为只读。您要覆盖只读的文件吗？"
 
 #. IDS_FILECHANGED_RESCAN
-#: Merge.rc:4803
+#: Merge.rc:4802
 #, c-format
 msgid ""
 "Another application updated\n"
@@ -6155,22 +6150,22 @@ msgstr ""
 "是否重新加载该文件？"
 
 #. IDS_SAVE_LEFT_AS
-#: Merge.rc:4804
+#: Merge.rc:4803
 msgid "Save Left File As"
 msgstr "左侧文件另存为"
 
 #. IDS_SAVE_MIDDLE_AS
-#: Merge.rc:4805
+#: Merge.rc:4804
 msgid "Save Middle File As"
 msgstr "中间文件另存为"
 
 #. IDS_SAVE_RIGHT_AS
-#: Merge.rc:4806
+#: Merge.rc:4805
 msgid "Save Right File As"
 msgstr "右侧文件另存为"
 
 #. IDS_FILE_DISAPPEARED
-#: Merge.rc:4811
+#: Merge.rc:4810
 #, c-format
 msgid ""
 "File\n"
@@ -6182,7 +6177,7 @@ msgstr ""
 "已不存在。请保存文件的副本再继续。"
 
 #. IDS_VIEWS_OUTOFSYNC
-#: Merge.rc:4817
+#: Merge.rc:4816
 msgid ""
 "Cannot merge unsynched documents.\n"
 "\n"
@@ -6193,124 +6188,124 @@ msgstr ""
 "请刷新文档后再继续。"
 
 #. IDS_BREAK_ON_WHITESPACE
-#: Merge.rc:4822
+#: Merge.rc:4821
 msgid "Break at whitespace"
 msgstr "以空白分隔"
 
 #. IDS_BREAK_ON_PUNCTUATION
-#: Merge.rc:4823
+#: Merge.rc:4822
 msgid "Break at whitespace or punctuation"
 msgstr "以空白或标点分隔"
 
 #. IDS_L2M
-#: Merge.rc:4829
+#: Merge.rc:4828
 msgid "Copy to &Middle\tAlt+Right"
 msgstr "复制到中间(&M)\tAlt+Right"
 
 #. IDS_R2M
-#: Merge.rc:4830
+#: Merge.rc:4829
 msgid "Copy to &Middle\tAlt+Left"
 msgstr "复制到中间(&M)\tAlt+Left"
 
 #. IDS_COPY_FROM_MIDDLE_R
-#: Merge.rc:4831
+#: Merge.rc:4830
 msgid "Copy from Middle\tAlt+Shift+Right"
 msgstr "从中间复制\tAlt+Shift+Right"
 
 #. IDS_COPY_FROM_MIDDLE_L
-#: Merge.rc:4832
+#: Merge.rc:4831
 msgid "Copy from Middle\tAlt+Shift+Left"
 msgstr "从中间复制\tAlt+Shift+Left"
 
 #. IDS_L2MNEXT
-#: Merge.rc:4833
+#: Merge.rc:4832
 msgid "Copy to Middle and Advance\tCtrl+Alt+Right"
 msgstr "复制到中间并前进\tCtrl+Alt+Right"
 
 #. IDS_R2MNEXT
-#: Merge.rc:4834
+#: Merge.rc:4833
 msgid "Copy to Middle and Advance\tCtrl+Alt+Left"
 msgstr "复制到中间并前进\tCtrl+Alt+Left"
 
 #. IDS_ALL_MIDDLE
-#: Merge.rc:4835
+#: Merge.rc:4834
 msgid "Copy All to Middle"
 msgstr "全部复制到中间"
 
 #. IDS_COPY_RIGHT_TO_LEFT
-#: Merge.rc:4841
+#: Merge.rc:4840
 #, c-format
 msgid "Right to Left (%1)"
 msgstr "右侧到左侧 (%1)"
 
 #. IDS_COPY_RIGHT_TO_MIDDLE
-#: Merge.rc:4842
+#: Merge.rc:4841
 #, c-format
 msgid "Right to Middle (%1)"
 msgstr "右侧到中间 (%1)"
 
 #. IDS_COPY_MIDDLE_TO_LEFT
-#: Merge.rc:4843
+#: Merge.rc:4842
 #, c-format
 msgid "Middle to Left (%1)"
 msgstr "中间到左侧 (%1)"
 
 #. IDS_COPY_MIDDLE_TO_RIGHT
-#: Merge.rc:4844
+#: Merge.rc:4843
 #, c-format
 msgid "Middle to Right (%1)"
 msgstr "中间到右侧 (%1)"
 
 #. IDS_COPY_LEFT_TO_RIGHT
-#: Merge.rc:4845
+#: Merge.rc:4844
 #, c-format
 msgid "Left to Right (%1)"
 msgstr "左侧到右侧 (%1)"
 
 #. IDS_COPY_LEFT_TO_MIDDLE
-#: Merge.rc:4846
+#: Merge.rc:4845
 #, c-format
 msgid "Left to Middle (%1)"
 msgstr "左侧到中间 (%1)"
 
 #. IDS_MOVE_LEFT_TO
-#: Merge.rc:4857 Merge.rc:4889
+#: Merge.rc:4856 Merge.rc:4888
 #, c-format
 msgid "Left to... (%1)"
 msgstr "左侧到... (%1)"
 
 #. IDS_MOVE_MIDDLE_TO
-#: Merge.rc:4858 Merge.rc:4890
+#: Merge.rc:4857 Merge.rc:4889
 #, c-format
 msgid "Middle to... (%1)"
 msgstr "中间到... (%1)"
 
 #. IDS_MOVE_RIGHT_TO
-#: Merge.rc:4859 Merge.rc:4891
+#: Merge.rc:4858 Merge.rc:4890
 #, c-format
 msgid "Right to... (%1)"
 msgstr "右侧到... (%1)"
 
 #. IDS_COPY_BOTH_TO
-#: Merge.rc:4860
+#: Merge.rc:4859
 #, c-format
 msgid "Both to... (%1)"
 msgstr "两者到... (%1)"
 
 #. IDS_COPY_ALL_TO
-#: Merge.rc:4861
+#: Merge.rc:4860
 #, c-format
 msgid "All to... (%1)"
 msgstr "全部到... (%1)"
 
 #. IDS_COPY_DIFFERENCES_TO
-#: Merge.rc:4862
+#: Merge.rc:4861
 #, c-format
 msgid "Differences to... (%1)"
 msgstr "差异到... (%1)"
 
 #. IDS_ONLYDIFFITEMS_CONFIRM
-#: Merge.rc:4869
+#: Merge.rc:4868
 msgid ""
 "Some selected items are identical or skipped.\n"
 "Process only items with differences?"
@@ -6319,64 +6314,64 @@ msgstr ""
 "是否仅处理存在差异的项目？"
 
 #. IDS_DEL_LEFT_FMT
-#: Merge.rc:4875
+#: Merge.rc:4874
 #, c-format
 msgid "Left (%1)"
 msgstr "左侧 (%1)"
 
 #. IDS_DEL_MIDDLE_FMT
-#: Merge.rc:4876
+#: Merge.rc:4875
 #, c-format
 msgid "Middle (%1)"
 msgstr "中间 (%1)"
 
 #. IDS_DEL_RIGHT_FMT
-#: Merge.rc:4877
+#: Merge.rc:4876
 #, c-format
 msgid "Right (%1)"
 msgstr "右侧 (%1)"
 
 #. IDS_DEL_BOTH_FMT
-#: Merge.rc:4878
+#: Merge.rc:4877
 #, c-format
 msgid "Both (%1)"
 msgstr "两侧 (%1)"
 
 #. IDS_DEL_ALL_FMT
-#: Merge.rc:4879
+#: Merge.rc:4878
 #, c-format
 msgid "All (%1)"
 msgstr "全部 (%1)"
 
 #. IDS_SELECT_DEST_LEFT
-#: Merge.rc:4895
+#: Merge.rc:4894
 msgid "Left Side - Select Destination Folder:"
 msgstr "左侧 - 请选择目标文件夹："
 
 #. IDS_SELECT_DEST_MIDDLE
-#: Merge.rc:4896
+#: Merge.rc:4895
 msgid "Middle Side - Select Destination Folder:"
 msgstr "中间 - 请选择目标文件夹："
 
 #. IDS_SELECT_DEST_RIGHT
-#: Merge.rc:4897
+#: Merge.rc:4896
 msgid "Right Side - Select Destination Folder:"
 msgstr "右侧 - 请选择目标文件夹："
 
 #. IDS_FILES_AFFECTED_FMT
-#: Merge.rc:4898
+#: Merge.rc:4897
 #, c-format
 msgid "(%1 Files Affected)"
 msgstr "(影响 %1 个文件)"
 
 #. IDS_FILES_AFFECTED_FMT2
-#: Merge.rc:4899
+#: Merge.rc:4898
 #, c-format
 msgid "(%1 of %2 Files Affected)"
 msgstr "(影响 %2 文件中的 %1 个)"
 
 #. IDS_CONFIRM_DELETE_SINGLE
-#: Merge.rc:4905
+#: Merge.rc:4904
 #, c-format
 msgid ""
 "Are you sure you want to delete\n"
@@ -6389,18 +6384,18 @@ msgstr ""
 "吗？"
 
 #. IDS_CONFIRM_SINGLE_COPY
-#: Merge.rc:4906
+#: Merge.rc:4905
 msgid "Are you sure you want to copy?"
 msgstr "您确定要复制？"
 
 #. IDS_CONFIRM_MULTIPLE_COPY
-#: Merge.rc:4907
+#: Merge.rc:4906
 #, c-format
 msgid "Are you sure you want to copy %d items?"
 msgstr "您确定要复制 %d 个条目？"
 
 #. IDS_DIRCMP_NOTSYNC
-#: Merge.rc:4908
+#: Merge.rc:4907
 #, c-format
 msgid ""
 "Operation aborted!\n"
@@ -6420,46 +6415,46 @@ msgstr ""
 "请刷新比较窗口。"
 
 #. IDS_CONFIRM_SINGLE_MOVE
-#: Merge.rc:4913
+#: Merge.rc:4912
 msgid "Are you sure you want to move?"
 msgstr "您确定要移动？"
 
 #. IDS_CONFIRM_MULTIPLE_MOVE
-#: Merge.rc:4914
+#: Merge.rc:4913
 #, c-format
 msgid "Are you sure you want to move %d items?"
 msgstr "您确定要移动 %d 个条目？"
 
 #. IDS_CONFIRM_MOVE_CAPTION
-#: Merge.rc:4916
+#: Merge.rc:4915
 msgid "Confirm Move"
 msgstr "确认移动"
 
-#: Merge.rc:4918
+#: Merge.rc:4917
 msgid "Close the folder comparison window?"
 msgstr "您即将关闭文件夹比较窗口。确定要关闭该窗口吗？"
 
-#: Merge.rc:4920
+#: Merge.rc:4919
 msgid "Close the folder comparison window, which took a long time?"
 msgstr "关闭文件夹比较窗口，这需要很长时间？"
 
 #. IDS_ERROR_INVALID_DIR_FILE_NAME
-#: Merge.rc:4921
+#: Merge.rc:4920
 msgid "The file or folder name is invalid."
 msgstr "文件或文件夹的名称无效。"
 
 #. IDS_ERROR_EXECUTE_FILE
-#: Merge.rc:4927
+#: Merge.rc:4926
 #, c-format
 msgid "Failed to execute external editor: %1"
 msgstr "外部编辑器运行失败：%1"
 
 #. IDS_UNKNOWN_ARCHIVE_FORMAT
-#: Merge.rc:4933
+#: Merge.rc:4932
 msgid "Unknown archive format"
 msgstr "未知的压缩包格式"
 
-#: Merge.rc:4935
+#: Merge.rc:4934
 msgid ""
 "Failed to extract archive.\n"
 "Compare as text file?"
@@ -6468,513 +6463,513 @@ msgstr ""
 "是否按文本文件格式进行比较？"
 
 #. IDS_COLHDR_FILENAME
-#: Merge.rc:4941
+#: Merge.rc:4940
 msgid "Filename"
 msgstr "文件名称"
 
 #. IDS_COLHDR_DIR
-#: Merge.rc:4942
+#: Merge.rc:4941
 msgctxt "DirView|ColumnHeader"
 msgid "Folder"
 msgstr "文件夹"
 
 #. IDS_COLHDR_RESULT
-#: Merge.rc:4943
+#: Merge.rc:4942
 msgid "Comparison Result"
 msgstr "比较结果"
 
 #. IDS_COLHDR_LTIMEM
-#: Merge.rc:4944
+#: Merge.rc:4943
 msgid "Left Date"
 msgstr "左侧日期"
 
 #. IDS_COLHDR_RTIMEM
-#: Merge.rc:4945
+#: Merge.rc:4944
 msgid "Right Date"
 msgstr "右侧日期"
 
 #. IDS_COLHDR_MTIMEM
-#: Merge.rc:4946
+#: Merge.rc:4945
 msgid "Middle Date"
 msgstr "中间日期"
 
 #. IDS_COLHDR_LSIZE
-#: Merge.rc:4948
+#: Merge.rc:4947
 msgid "Left Size"
 msgstr "左侧大小"
 
 #. IDS_COLHDR_RSIZE
-#: Merge.rc:4949
+#: Merge.rc:4948
 msgid "Right Size"
 msgstr "右侧大小"
 
 #. IDS_COLHDR_MSIZE
-#: Merge.rc:4954
+#: Merge.rc:4953
 msgid "Middle Size"
 msgstr "中间大小"
 
 #. IDS_COLHDR_RSIZE_SHORT
-#: Merge.rc:4955
+#: Merge.rc:4954
 msgid "Right Size (Short)"
 msgstr "右侧大小 (短)"
 
 #. IDS_COLHDR_LSIZE_SHORT
-#: Merge.rc:4956
+#: Merge.rc:4955
 msgid "Left Size (Short)"
 msgstr "左侧大小 (短)"
 
 #. IDS_COLHDR_MSIZE_SHORT
-#: Merge.rc:4957
+#: Merge.rc:4956
 msgid "Middle Size (Short)"
 msgstr "中间大小 (短)"
 
 #. IDS_COLHDR_LTIMEC
-#: Merge.rc:4963
+#: Merge.rc:4962
 msgid "Left Creation Time"
 msgstr "左侧创建时间"
 
 #. IDS_COLHDR_RTIMEC
-#: Merge.rc:4964
+#: Merge.rc:4963
 msgid "Right Creation Time"
 msgstr "右侧创建时间"
 
 #. IDS_COLHDR_MTIMEC
-#: Merge.rc:4965
+#: Merge.rc:4964
 msgid "Middle Creation Time"
 msgstr "中间创建时间"
 
 #. IDS_COLHDR_NEWER
-#: Merge.rc:4966
+#: Merge.rc:4965
 msgid "Newer File"
 msgstr "较新的文件"
 
 #. IDS_COLHDR_LVERSION
-#: Merge.rc:4967
+#: Merge.rc:4966
 msgid "Left File Version"
 msgstr "左侧文件版本"
 
 #. IDS_COLHDR_RVERSION
-#: Merge.rc:4968
+#: Merge.rc:4967
 msgid "Right File Version"
 msgstr "右侧文件版本"
 
 #. IDS_COLHDR_MVERSION
-#: Merge.rc:4969
+#: Merge.rc:4968
 msgid "Middle File Version"
 msgstr "中间文件版本"
 
 #. IDS_COLHDR_RESULT_ABBR
-#: Merge.rc:4970
+#: Merge.rc:4969
 msgid "Short Result"
 msgstr "简短结果"
 
 #. IDS_COLHDR_LATTRIBUTES
-#: Merge.rc:4971
+#: Merge.rc:4970
 msgid "Left Attributes"
 msgstr "左侧属性"
 
 #. IDS_COLHDR_RATTRIBUTES
-#: Merge.rc:4972
+#: Merge.rc:4971
 msgid "Right Attributes"
 msgstr "右侧属性"
 
 #. IDS_COLHDR_MATTRIBUTES
-#: Merge.rc:4973
+#: Merge.rc:4972
 msgid "Middle Attributes"
 msgstr "中间属性"
 
 #. IDS_COLHDR_LEOL_TYPE
-#: Merge.rc:4978
+#: Merge.rc:4977
 msgid "Left EOL"
 msgstr "左侧换行符"
 
 #. IDS_COLHDR_MEOL_TYPE
-#: Merge.rc:4979
+#: Merge.rc:4978
 msgid "Middle EOL"
 msgstr "中间换行符"
 
 #. IDS_COLHDR_REOL_TYPE
-#: Merge.rc:4980
+#: Merge.rc:4979
 msgid "Right EOL"
 msgstr "右侧换行符"
 
 #. IDS_COLHDR_LENCODING
-#: Merge.rc:4986
+#: Merge.rc:4985
 msgid "Left Encoding"
 msgstr "左侧文件编码"
 
 #. IDS_COLHDR_RENCODING
-#: Merge.rc:4987
+#: Merge.rc:4986
 msgid "Right Encoding"
 msgstr "右侧文件编码"
 
 #. IDS_COLHDR_MENCODING
-#: Merge.rc:4988
+#: Merge.rc:4987
 msgid "Middle Encoding"
 msgstr "中间文件编码"
 
 #. IDS_COLHDR_NIDIFFS
-#: Merge.rc:4989
+#: Merge.rc:4988
 msgid "Ignored Diff"
 msgstr "忽略的差异"
 
 #. IDS_COLHDR_BINARY
-#: Merge.rc:4991
+#: Merge.rc:4990
 msgctxt "DirView|ColumnHeader"
 msgid "Binary"
 msgstr "二进制"
 
 #. IDS_PLUGINS_TYPE_UNPACKER
-#: Merge.rc:4992 Merge.rc:5314
+#: Merge.rc:4991 Merge.rc:5313
 msgid "Unpacker"
 msgstr "解包插件"
 
 #. IDS_PLUGIN_TYPE4
-#: Merge.rc:4993 Merge.rc:5315 Merge.rc:5622
+#: Merge.rc:4992 Merge.rc:5314 Merge.rc:5621
 msgid "Prediffer"
 msgstr "预比较插件"
 
 #. IDS_COLHDR_LEFT
-#: Merge.rc:4994
+#: Merge.rc:4993
 msgid "Left"
 msgstr "左侧"
 
 #. IDS_COLHDR_MIDDLE
-#: Merge.rc:4995
+#: Merge.rc:4994
 msgid "Middle"
 msgstr "中间"
 
 #. IDS_COLHDR_RIGHT
-#: Merge.rc:4996
+#: Merge.rc:4995
 msgid "Right"
 msgstr "右侧"
 
 #. IDS_COLHDR_DIFF
-#: Merge.rc:4997
+#: Merge.rc:4996
 msgid "Diff"
 msgstr "差异"
 
 #. IDS_COLHDR_LEFT_DUPLICATE
-#: Merge.rc:4998
+#: Merge.rc:4997
 msgid "Left Duplicate Count"
 msgstr "左侧重复计数"
 
 #. IDS_COLHDR_RIGHT_DUPLICATE
-#: Merge.rc:4999
+#: Merge.rc:4998
 msgid "Right Duplicate Count"
 msgstr "右侧重复计数"
 
 #. IDS_COLHDR_MIDDLE_DUPLICATE
-#: Merge.rc:5000
+#: Merge.rc:4999
 msgid "Middle Duplicate Count"
 msgstr "中间重复计数"
 
 #. IDS_COLHDR_MOVE
-#: Merge.rc:5001
+#: Merge.rc:5000
 msgid "Move"
 msgstr "移动"
 
 #. IDS_PRPCAT_AUDIO
-#: Merge.rc:5008
+#: Merge.rc:5007
 msgid "Audio"
 msgstr "音频"
 
 #. IDS_PRPCAT_CALENDAR
-#: Merge.rc:5009
+#: Merge.rc:5008
 msgid "Calendar"
 msgstr "日历"
 
 #. IDS_PRPCAT_COMMUNICATION
-#: Merge.rc:5010
+#: Merge.rc:5009
 msgid "Communication"
 msgstr "通讯"
 
 #. IDS_PRPCAT_CONTACT
-#: Merge.rc:5011
+#: Merge.rc:5010
 msgid "Contact"
 msgstr "联系人"
 
 #. IDS_PRPCAT_DEVICES
-#: Merge.rc:5012
+#: Merge.rc:5011
 msgid "Devices"
 msgstr "设备"
 
 #. IDS_PRPCAT_DOCUMENT
-#: Merge.rc:5013
+#: Merge.rc:5012
 msgid "Document"
 msgstr "文档"
 
 #. IDS_PRPCAT_HOME
-#: Merge.rc:5014
+#: Merge.rc:5013
 msgid "Home"
 msgstr "家"
 
 #. IDS_PRPCAT_JOURNAL
-#: Merge.rc:5016
+#: Merge.rc:5015
 msgid "Journal"
 msgstr "日志"
 
 #. IDS_PRPCAT_LINK
-#: Merge.rc:5017
+#: Merge.rc:5016
 msgid "Link"
 msgstr "链接"
 
 #. IDS_PRPCAT_MEDIA
-#: Merge.rc:5018
+#: Merge.rc:5017
 msgid "Media"
 msgstr "媒体"
 
 #. IDS_PRPCAT_MUSIC
-#: Merge.rc:5020
+#: Merge.rc:5019
 msgid "Music"
 msgstr "音乐"
 
 #. IDS_PRPCAT_NOTE
-#: Merge.rc:5021
+#: Merge.rc:5020
 msgid "Note"
 msgstr "记事"
 
 #. IDS_PRPCAT_PHOTO
-#: Merge.rc:5022
+#: Merge.rc:5021
 msgid "Photo"
 msgstr "照片"
 
 #. IDS_PRPCAT_RECORDEDTV
-#: Merge.rc:5023
+#: Merge.rc:5022
 msgid "RecordedTV"
 msgstr "电视节目"
 
 #. IDS_PRPCAT_SEARCH
-#: Merge.rc:5024
+#: Merge.rc:5023
 msgid "Search"
 msgstr "搜索"
 
 #. IDS_PRPCAT_SECURITY
-#: Merge.rc:5025
+#: Merge.rc:5024
 msgid "Security"
 msgstr "安全"
 
 #. IDS_PRPCAT_SOFTWARE
-#: Merge.rc:5026
+#: Merge.rc:5025
 msgid "Software"
 msgstr "软件"
 
 #. IDS_PRPCAT_TASK
-#: Merge.rc:5027
+#: Merge.rc:5026
 msgid "Task"
 msgstr "任务"
 
 #. IDS_PRPCAT_VIDEO
-#: Merge.rc:5028
+#: Merge.rc:5027
 msgid "Video"
 msgstr "视频"
 
 #. IDS_PRPCAT_HASH
-#: Merge.rc:5029
+#: Merge.rc:5028
 msgid "Hash"
 msgstr "哈希值"
 
 #. IDS_CANT_COMPARE_FILES
-#: Merge.rc:5035
+#: Merge.rc:5034
 msgid "Unable to compare files"
 msgstr "无法比较文件"
 
 #. IDS_ABORTED_ITEM
-#: Merge.rc:5036
+#: Merge.rc:5035
 msgid "Item aborted"
 msgstr "条目已取消"
 
 #. IDS_FILE_SKIPPED
-#: Merge.rc:5037
+#: Merge.rc:5036
 msgid "File skipped"
 msgstr "文件已跳过"
 
 #. IDS_DIR_SKIPPED
-#: Merge.rc:5038
+#: Merge.rc:5037
 msgid "Folder skipped"
 msgstr "文件夹已跳过"
 
 #. IDS_LEFT_ONLY_IN_FMT
-#: Merge.rc:5039
+#: Merge.rc:5038
 #, c-format
 msgid "Left only: %1"
 msgstr "仅在左侧：%1"
 
 #. IDS_MIDDLE_ONLY_IN_FMT
-#: Merge.rc:5040
+#: Merge.rc:5039
 #, c-format
 msgid "Middle only: %1"
 msgstr "仅在中间：%1"
 
 #. IDS_RIGHT_ONLY_IN_FMT
-#: Merge.rc:5041
+#: Merge.rc:5040
 #, c-format
 msgid "Right only: %1"
 msgstr "仅在右侧：%1"
 
 #. IDS_DOES_NOT_EXIST_IN_FMT
-#: Merge.rc:5042
+#: Merge.rc:5041
 #, c-format
 msgid "Does not exist in %1"
 msgstr "%1 中不存在"
 
 #. IDS_BIN_FILES_SAME
-#: Merge.rc:5043
+#: Merge.rc:5042
 msgid "Binary files are identical"
 msgstr "二进制文件完全相同"
 
 #. IDS_BIN_FILES_DIFF
-#: Merge.rc:5049
+#: Merge.rc:5048
 msgid "Binary files are different"
 msgstr "二进制文件不同"
 
 #. IDS_FILES_ARE_DIFFERENT
-#: Merge.rc:5050
+#: Merge.rc:5049
 msgid "Files are different"
 msgstr "文件不同"
 
 #. IDS_FOLDERS_ARE_DIFFERENT
-#: Merge.rc:5051
+#: Merge.rc:5050
 msgid "Folders are different"
 msgstr "文件夹不同"
 
 #. IDS_LEFTONLY
-#: Merge.rc:5052
+#: Merge.rc:5051
 msgid "Left Only"
 msgstr "只存在左侧"
 
 #. IDS_RIGHTONLY
-#: Merge.rc:5053
+#: Merge.rc:5052
 msgid "Right Only"
 msgstr "只存在右侧"
 
 #. IDS_MIDDLEONLY
-#: Merge.rc:5054
+#: Merge.rc:5053
 msgid "Middle Only"
 msgstr "只存在中间"
 
 #. IDS_NOITEMLEFT
-#: Merge.rc:5055
+#: Merge.rc:5054
 msgid "No item in left"
 msgstr "左侧无条目"
 
 #. IDS_NOITEMRIGHT
-#: Merge.rc:5056
+#: Merge.rc:5055
 msgid "No item in right"
 msgstr "右侧无条目"
 
 #. IDS_NOITEMMIDDLE
-#: Merge.rc:5057
+#: Merge.rc:5056
 msgid "No item in middle"
 msgstr "中间无条目"
 
 #. IDS_CMPRES_ERROR
-#: Merge.rc:5059
+#: Merge.rc:5058
 msgid "Error"
 msgstr "错误"
 
 #. IDS_TEXT_FILES_SAME
-#: Merge.rc:5060
+#: Merge.rc:5059
 msgid "Text files are identical"
 msgstr "文本文件完全相同"
 
 #. IDS_LEFTONLY_DIFF
-#: Merge.rc:5061
+#: Merge.rc:5060
 msgid " (Middle and right are identical)"
 msgstr " (中间和右侧完全相同)"
 
 #. IDS_MIDDLEONLY_DIFF
-#: Merge.rc:5062
+#: Merge.rc:5061
 msgid " (Left and right are identical)"
 msgstr " (左侧和右侧完全相同)"
 
 #. IDS_RIGHTONLY_DIFF
-#: Merge.rc:5063
+#: Merge.rc:5062
 msgid " (Left and middle are identical)"
 msgstr " (左侧和中间完全相同)"
 
 #. IDS_PATH_MISMATCH
-#: Merge.rc:5064
+#: Merge.rc:5063
 msgid " (paths differ)"
 msgstr " （路径不同）"
 
 #. IDS_TEXT_FILES_DIFF
-#: Merge.rc:5065
+#: Merge.rc:5064
 msgid "Text files are different"
 msgstr "文本文件不同"
 
 #. IDS_IMAGE_FILES_SAME
-#: Merge.rc:5066
+#: Merge.rc:5065
 msgid "Image files are identical"
 msgstr "图像文件相同"
 
 #. IDS_IMAGE_FILES_DIFF
-#: Merge.rc:5067
+#: Merge.rc:5066
 msgid "Image files are different"
 msgstr "图像文件有差异"
 
 #. IDS_EXPR_DIFF
-#: Merge.rc:5068
+#: Merge.rc:5067
 #, c-format
 msgid "Files are different (expr: %1)"
 msgstr "文件不同（表达式：%1）"
 
 #. IDS_HASH_GROUP
-#: Merge.rc:5069
+#: Merge.rc:5068
 #, c-format
 msgid "Group%d"
 msgstr "分组 %d"
 
 #. IDS_RENAME_MOVE_DETECTION_DISALBED
-#: Merge.rc:5070
+#: Merge.rc:5069
 msgctxt "Options dialog|Compare|Folder|Detect renames and moves"
 msgid "Disabled"
 msgstr "已禁用"
 
 #. IDS_RENAME_MOVE_DETECTION_RENAME
-#: Merge.rc:5071
+#: Merge.rc:5070
 msgid "Detect renames"
 msgstr "检测重命名"
 
 #. IDS_RENAME_MOVE_DETECTION_RENAME_MOVE
-#: Merge.rc:5072
+#: Merge.rc:5071
 msgid "Detect renames and moves"
 msgstr "检测重命名和移动"
 
 #. IDS_RENAME_MOVE_MERGE_MODE_RENAME
-#: Merge.rc:5073
+#: Merge.rc:5072
 msgid "Merge renames"
 msgstr "合并重命名的文件"
 
 #. IDS_RENAME_MOVE_MERGE_MODE_RENAME_MOVE
-#: Merge.rc:5074
+#: Merge.rc:5073
 msgid "Merge renames and moves"
 msgstr "合并重命名和被移动的文件"
 
 #. IDS_RENAMED
-#: Merge.rc:5075
+#: Merge.rc:5074
 msgid "Renamed"
 msgstr "重命名的"
 
 #. IDS_RENAMED_MOVED
-#: Merge.rc:5077
+#: Merge.rc:5076
 msgid "Renamed/Moved"
 msgstr "重命名的/移动的"
 
 #. IDS_RENAMED_MOVED_ITEMS
-#: Merge.rc:5078
+#: Merge.rc:5077
 #, c-format
 msgid "(%1 items)"
 msgstr "(%1 条目)"
 
 #. IDS_RENAMED_MOVED_RESULT
-#: Merge.rc:5079
+#: Merge.rc:5078
 #, c-format
 msgid "%1 (set %2): "
 msgstr "%1 (集合 %2)："
 
 #. IDS_SWITCH_FLAT_MODE
-#: Merge.rc:5080
+#: Merge.rc:5079
 msgid ""
 "Some moved items have been merged.\n"
 "In Tree Mode, these items may appear in positions that do not reflect the actual folder structure, which can be confusing.\n"
@@ -6985,235 +6980,235 @@ msgstr ""
 "是否要切换到扁平模式？"
 
 #. IDS_ELAPSED_TIME
-#: Merge.rc:5086
+#: Merge.rc:5085
 #, c-format
 msgid "Elapsed time: %ld ms"
 msgstr "执行时间：%ld 毫秒"
 
 #. IDS_STATUS_SELITEM1
-#: Merge.rc:5087
+#: Merge.rc:5086
 msgid "1 item selected"
 msgstr "选中了 1 个条目"
 
 #. IDS_STATUS_SELITEMS
-#: Merge.rc:5088
+#: Merge.rc:5087
 #, c-format
 msgid "%1 items selected"
 msgstr "选中了 %1 个条目"
 
 #. IDS_COLDESC_FILENAME
-#: Merge.rc:5094
+#: Merge.rc:5093
 msgid "Filename or folder name."
 msgstr "文件名或文件夹名。"
 
 #. IDS_COLDESC_DIR
-#: Merge.rc:5095
+#: Merge.rc:5094
 msgid "Subfolder name when subfolders are included."
 msgstr "所处子文件夹名称。"
 
 #. IDS_COLDESC_RESULT
-#: Merge.rc:5096
+#: Merge.rc:5095
 msgid "Comparison result, long form."
 msgstr "比较结果，长格式。"
 
 #. IDS_COLDESC_LTIMEM
-#: Merge.rc:5101
+#: Merge.rc:5100
 msgid "Left side modification date."
 msgstr "左侧的最后修改日期。"
 
 #. IDS_COLDESC_RTIMEM
-#: Merge.rc:5102
+#: Merge.rc:5101
 msgid "Right side modification date."
 msgstr "右侧的最后修改日期。"
 
 #. IDS_COLDESC_MTIMEM
-#: Merge.rc:5103
+#: Merge.rc:5102
 msgid "Middle side modification date."
 msgstr "中间的最后修改日期。"
 
 #. IDS_COLDESC_EXTENSION
-#: Merge.rc:5104
+#: Merge.rc:5103
 msgid "File's extension."
 msgstr "文件的扩展名。"
 
 #. IDS_COLDESC_LSIZE
-#: Merge.rc:5105
+#: Merge.rc:5104
 msgid "Left file size in bytes."
 msgstr "左侧的文件大小字节数。"
 
 #. IDS_COLDESC_RSIZE
-#: Merge.rc:5106
+#: Merge.rc:5105
 msgid "Right file size in bytes."
 msgstr "右侧的文件大小字节数。"
 
 #. IDS_COLDESC_MSIZE
-#: Merge.rc:5107
+#: Merge.rc:5106
 msgid "Middle file size in bytes."
 msgstr "中间的文件大小字节数。"
 
 #. IDS_COLDESC_LSIZE_SHORT
-#: Merge.rc:5108
+#: Merge.rc:5107
 msgid "Left file size abbreviated."
 msgstr "左侧的文件大小简短表示。"
 
 #. IDS_COLDESC_RSIZE_SHORT
-#: Merge.rc:5109
+#: Merge.rc:5108
 msgid "Right file size abbreviated."
 msgstr "右侧的文件大小简短表示。"
 
 #. IDS_COLDESC_MSIZE_SHORT
-#: Merge.rc:5110
+#: Merge.rc:5109
 msgid "Middle file size abbreviated."
 msgstr "中间的文件大小简短表示。"
 
 #. IDS_COLDESC_LTIMEC
-#: Merge.rc:5116
+#: Merge.rc:5115
 msgid "Left side creation time."
 msgstr "左侧的创建时间。"
 
 #. IDS_COLDESC_RTIMEC
-#: Merge.rc:5117
+#: Merge.rc:5116
 msgid "Right side creation time."
 msgstr "右侧的创建时间。"
 
 #. IDS_COLDESC_MTIMEC
-#: Merge.rc:5118
+#: Merge.rc:5117
 msgid "Middle side creation time."
 msgstr "中间的创建时间。"
 
 #. IDS_COLDESC_NEWER
-#: Merge.rc:5119
+#: Merge.rc:5118
 msgid "Tells which side has newer modification date."
 msgstr "显示哪边是较晚才被修改。"
 
 #. IDS_COLDESC_LVERSION
-#: Merge.rc:5120
+#: Merge.rc:5119
 msgid "Left side file version, only for some file types."
 msgstr "左侧的文件版本，只对部分文件类型有效。"
 
 #. IDS_COLDESC_RVERSION
-#: Merge.rc:5121
+#: Merge.rc:5120
 msgid "Right side file version, only for some file types."
 msgstr "右侧的文件版本，只对部分文件类型有效。"
 
 #. IDS_COLDESC_MVERSION
-#: Merge.rc:5126
+#: Merge.rc:5125
 msgid "Middle side file version, only for some file types."
 msgstr "中间的文件版本，只对部分文件类型有效。"
 
 #. IDS_COLDESC_RESULT_ABBR
-#: Merge.rc:5127
+#: Merge.rc:5126
 msgid "Short comparison result."
 msgstr "简短格式的比较结果。"
 
 #. IDS_COLDESC_LATTRIBUTES
-#: Merge.rc:5128
+#: Merge.rc:5127
 msgid "Left side attributes."
 msgstr "左侧的属性。"
 
 #. IDS_COLDESC_RATTRIBUTES
-#: Merge.rc:5129
+#: Merge.rc:5128
 msgid "Right side attributes."
 msgstr "右侧的属性。"
 
 #. IDS_COLDESC_MATTRIBUTES
-#: Merge.rc:5130
+#: Merge.rc:5129
 msgid "Middle side attributes."
 msgstr "中间的属性。"
 
 #. IDS_COLDESC_LEOL_TYPE
-#: Merge.rc:5131
+#: Merge.rc:5130
 msgid "Left side file EOL type."
 msgstr "左侧文件的换行符类型。"
 
 #. IDS_COLDESC_REOL_TYPE
-#: Merge.rc:5132
+#: Merge.rc:5131
 msgid "Right side file EOL type."
 msgstr "右侧文件的换行符类型。"
 
 #. IDS_COLDESC_MEOL_TYPE
-#: Merge.rc:5133
+#: Merge.rc:5132
 msgid "Middle side file EOL type."
 msgstr "中间文件的换行符类型。"
 
 #. IDS_COLDESC_LENCODING
-#: Merge.rc:5139
+#: Merge.rc:5138
 msgid "Left side encoding."
 msgstr "左侧文件的字符编码。"
 
 #. IDS_COLDESC_RENCODING
-#: Merge.rc:5140
+#: Merge.rc:5139
 msgid "Right side encoding."
 msgstr "右侧文件的字符编码。"
 
 #. IDS_COLDESC_MENCODING
-#: Merge.rc:5141
+#: Merge.rc:5140
 msgid "Middle side encoding."
 msgstr "中间文件的字符编码。"
 
 #. IDS_COLDESC_NIDIFFS
-#: Merge.rc:5142
+#: Merge.rc:5141
 msgid "Number of ignored differences in file. Ignored and cannot be merged."
 msgstr "文件中已忽略的差异数。这些差异已被 WinMerge 忽略，无法合并它们。"
 
 #. IDS_COLDESC_NSDIFFS
-#: Merge.rc:5143
+#: Merge.rc:5142
 msgid "Number of differences in file (excluding ignored)."
 msgstr "文件中的差异数。不包含忽略的差异。"
 
 #. IDS_COLDESC_BINARY
-#: Merge.rc:5144
+#: Merge.rc:5143
 msgid "Shows an asterisk (*) if the file is binary."
 msgstr "在二进制文件处显示星号(*)。"
 
 #. IDS_COLDESC_UNPACKER
-#: Merge.rc:5145
+#: Merge.rc:5144
 msgid "Unpacker plugin name or pipeline."
 msgstr "解包插件名称或流水线。"
 
 #. IDS_COLDESC_PREDIFFER
-#: Merge.rc:5146
+#: Merge.rc:5145
 msgid "Prediffer plugin name or pipeline."
 msgstr "预比较插件名称或流水线。"
 
 #. IDS_DIRECTORY_REPORT_TITLE
-#: Merge.rc:5152
+#: Merge.rc:5151
 #, c-format
 msgid "Compare %1 with %2"
 msgstr "比较 %1 和 %2"
 
 #. IDS_DIRECTORY_REPORT_TITLE3
-#: Merge.rc:5153
+#: Merge.rc:5152
 #, c-format
 msgid "Compare %1 with %2 and %3"
 msgstr "比较 %1、%2 和 %3"
 
 #. IDS_REPORT_COMMALIST
-#: Merge.rc:5154
+#: Merge.rc:5153
 msgid "Comma-separated list"
 msgstr "逗号分隔的列表"
 
 #. IDS_REPORT_TABLIST
-#: Merge.rc:5155
+#: Merge.rc:5154
 msgid "Tab-separated list"
 msgstr "制表符分隔的列表"
 
 #. IDS_REPORT_SIMPLEHTML
-#: Merge.rc:5156
+#: Merge.rc:5155
 msgid "Simple HTML"
 msgstr "简单 HTML"
 
 #. IDS_REPORT_SIMPLEXML
-#: Merge.rc:5157
+#: Merge.rc:5156
 msgid "Simple XML"
 msgstr "简单 XML"
 
-#: Merge.rc:5159
+#: Merge.rc:5158
 msgid "Report file already exists. Overwrite?"
 msgstr "报告文件已经存在，是否要覆盖已存在的文件？"
 
 #. IDS_REPORT_ERROR
-#: Merge.rc:5164
+#: Merge.rc:5163
 #, c-format
 msgid ""
 "Error creating the report:\n"
@@ -7223,27 +7218,27 @@ msgstr ""
 "%1"
 
 #. IDS_REPORT_SUCCESS
-#: Merge.rc:5165
+#: Merge.rc:5164
 msgid "Report created successfully."
 msgstr "报告创建成功."
 
 #. IDS_SYNCPOINT_LASTBLOCK
-#: Merge.rc:5171
+#: Merge.rc:5170
 msgid "Cannot add a synchronization point at this line."
 msgstr "无法在该行添加同步点。"
 
 #. IDS_FILE_TO_ITSELF
-#: Merge.rc:5177
+#: Merge.rc:5176
 msgid "Same file is opened in both panes."
 msgstr "两侧打开的是同一个文件。"
 
 #. IDS_FILESSAME
-#: Merge.rc:5178
+#: Merge.rc:5177
 msgid "Selected files are identical."
 msgstr "选中的文件完全相同。"
 
 #. IDS_FILESSAME_CURCFG
-#: Merge.rc:5179
+#: Merge.rc:5178
 msgid ""
 "Selected files are identical (with current settings).\r\n"
 "Checking binary identity..."
@@ -7252,7 +7247,7 @@ msgstr ""
 "正在检查二进制的等同性..."
 
 #. IDS_FILESSAME_BINERROR
-#: Merge.rc:5180
+#: Merge.rc:5179
 msgid ""
 "Selected files are identical (with current settings).\r\n"
 "But binary comparison failed."
@@ -7261,12 +7256,12 @@ msgstr ""
 "但二进制比较失败。"
 
 #. IDS_FILESSAME_BINSAME
-#: Merge.rc:5181
+#: Merge.rc:5180
 msgid "Selected files are identical (binary match)."
 msgstr "所选的文件完全相同（且二进制匹配）。"
 
 #. IDS_FILESSAME_BINDIFF
-#: Merge.rc:5182
+#: Merge.rc:5181
 msgid ""
 "Selected files are identical (with current settings).\r\n"
 "But differ at the binary level."
@@ -7275,17 +7270,17 @@ msgstr ""
 "但在二进制层面存在差异。"
 
 #. IDS_FILEERROR
-#: Merge.rc:5183
+#: Merge.rc:5182
 msgid "An error occurred while comparing files."
 msgstr "比较文件时发生错误。"
 
 #. IDS_TEMP_FILEERROR
-#: Merge.rc:5184
+#: Merge.rc:5183
 msgid "Could not create temporary files. Check your temporary path settings."
 msgstr "无法创建临时文件。请检查您的临时路径设置。"
 
 #. IDS_SUGGEST_IGNOREEOL
-#: Merge.rc:5185
+#: Merge.rc:5184
 msgid ""
 "Files use different EOL.\n"
 "\n"
@@ -7300,17 +7295,17 @@ msgstr ""
 "在 \"选项 \"的 \"比较 \"部分设置 \"忽略换行符差异（Windows/Unix/Mac）\"。"
 
 #. IDS_INVALID_DIRECTORY
-#: Merge.rc:5186
+#: Merge.rc:5185
 msgid "Selected folder is invalid."
 msgstr "所选的文件夹无效。"
 
 #. IDS_CANNOT_OPEN_BINARYFILE
-#: Merge.rc:5187
+#: Merge.rc:5186
 msgid "Cannot open a binary file in Editor."
 msgstr "无法用编辑器打开二进制文件。"
 
 #. IDS_CREATE_PAIR_FOLDER
-#: Merge.rc:5188
+#: Merge.rc:5187
 #, c-format
 msgid ""
 "Create matching folder:\n"
@@ -7324,41 +7319,41 @@ msgstr ""
 "并且打开这两个文件夹？"
 
 #. IDS_CONFIRM_COPY_ALL_DIFFS
-#: Merge.rc:5189
+#: Merge.rc:5188
 msgid "Copy all differences to other file?"
 msgstr "您确定要把所有的差异复制到另一个文件吗？"
 
 #. IDS_MOVE_TO_NEXTFILE
-#: Merge.rc:5194
+#: Merge.rc:5193
 msgid "Move to next file?"
 msgstr "您是否要跳转到下一个文件？"
 
 #. IDS_MOVE_TO_PREVFILE
-#: Merge.rc:5195
+#: Merge.rc:5194
 msgid "Move to previous file?"
 msgstr "您是否要跳转到上一个文件？"
 
 #. IDS_MOVE_TO_NEXTPAGE
-#: Merge.rc:5196
+#: Merge.rc:5195
 msgid "Move to next page?"
 msgstr "您是否要跳转到下一页？"
 
 #. IDS_MOVE_TO_PREVPAGE
-#: Merge.rc:5197
+#: Merge.rc:5196
 msgid "Move to previous page?"
 msgstr "您是否要跳转到上一页？"
 
 #. IDS_MOVE_TO_FIRSTFILE
-#: Merge.rc:5198
+#: Merge.rc:5197
 msgid "Move to first file?"
 msgstr "您是否要跳转到第一个文件？"
 
 #. IDS_MOVE_TO_LASTFILE
-#: Merge.rc:5199
+#: Merge.rc:5198
 msgid "Move to last file?"
 msgstr "您是否要跳转到最后一个文件？"
 
-#: Merge.rc:5206
+#: Merge.rc:5205
 #, c-format
 msgid ""
 "Different codepages: left (cp%d), right (cp%d).\n"
@@ -7369,51 +7364,51 @@ msgstr ""
 "分别以不同代码页显示将会有较好的效果，但是合并/复制会有风险。\n"
 "您要以 Windows 默认的代码页显示两个文件吗？（推荐）"
 
-#: Merge.rc:5208
+#: Merge.rc:5207
 msgid "Information lost due to encoding errors: both files"
 msgstr "由于文件的字符编码错误导致两个文件的信息丢失"
 
-#: Merge.rc:5210
+#: Merge.rc:5209
 msgid "Information lost due to encoding errors: first file"
 msgstr "由于文件的字符编码错误导致第一个文件的信息丢失"
 
-#: Merge.rc:5212
+#: Merge.rc:5211
 msgid "Information lost due to encoding errors: second file"
 msgstr "由于文件的字符编码错误导致第二个文件的信息丢失"
 
-#: Merge.rc:5214
+#: Merge.rc:5213
 msgid "Information lost due to encoding errors: third file"
 msgstr "由于文件的字符编码错误导致第三个文件的信息丢失"
 
 #. IDS_LINEDIFF_NODIFF
-#: Merge.rc:5220
+#: Merge.rc:5219
 msgid "No difference"
 msgstr "没有差异"
 
 #. IDS_LINEDIFF_NODIFF_CAPTION
-#: Merge.rc:5221
+#: Merge.rc:5220
 msgid "Line difference"
 msgstr "行内差异"
 
 #. IDS_NUM_REPLACED
-#: Merge.rc:5227
+#: Merge.rc:5226
 #, c-format
 msgid "Replaced %1 string(s)."
 msgstr "已替换 %1 个字符串。"
 
 #. IDS_EDIT_TEXT_NOT_FOUND
-#: Merge.rc:5228
+#: Merge.rc:5227
 #, c-format
 msgid "Cannot find string \"%s\"."
 msgstr "找不到字符串“%s”。"
 
 #. IDS_MERGE_MODE
-#: Merge.rc:5234
+#: Merge.rc:5233
 msgid "Entering Merge Mode. Press F9 to turn off."
 msgstr "您正在进入合并模式。如果您想关闭合并模式，请按 F9 键。"
 
 #. IDS_AUTO_MERGE
-#: Merge.rc:5240
+#: Merge.rc:5239
 #, c-format
 msgid ""
 "Automatic merges: %1\n"
@@ -7423,89 +7418,89 @@ msgstr ""
 "未解决的冲突数：%2"
 
 #. IDS_CODEPAGE_MERGED
-#: Merge.rc:5241
+#: Merge.rc:5240
 msgid "Codepage change merged."
 msgstr "代码页的变更已被合并。"
 
 #. IDS_CODEPAGE_CONFLICT
-#: Merge.rc:5242
+#: Merge.rc:5241
 msgid "Codepage changes are conflicting."
 msgstr "代码页的变更存在冲突。"
 
 #. IDS_EOL_MERGED
-#: Merge.rc:5243
+#: Merge.rc:5242
 msgid "EOL change merged."
 msgstr "换行符的变更已被合并。"
 
 #. IDS_EOL_CONFLICT
-#: Merge.rc:5244
+#: Merge.rc:5243
 msgid "EOL changes are conflicting."
 msgstr "换行符的变更存在冲突。"
 
 #. IDS_LOCBAR_CAPTION
-#: Merge.rc:5250
+#: Merge.rc:5249
 msgid "Location Pane"
 msgstr "定位窗格"
 
 #. IDS_DIFFBAR_CAPTION
-#: Merge.rc:5251
+#: Merge.rc:5250
 msgid "Diff Pane"
 msgstr "差异窗格"
 
 #. IDS_DIFF_SUCCEEDED
-#: Merge.rc:5258
+#: Merge.rc:5257
 msgid "Patch file written."
 msgstr "补丁文件写入成功。"
 
 #. IDS_DIFF_FILEOVERWRITE
-#: Merge.rc:5259
+#: Merge.rc:5258
 msgid "Patch file already exists. Overwrite?"
 msgstr "补丁文件已经存在。是否覆盖？"
 
 #. IDS_DIFF_SELECTEDFILES
-#: Merge.rc:5260
+#: Merge.rc:5259
 #, c-format
 msgid "[%1 files selected]"
 msgstr "[选中 %1 个文件]"
 
 #. IDS_DIFF_NORMAL
-#: Merge.rc:5261
+#: Merge.rc:5260
 msgid "Normal"
 msgstr "正常格式 (Normal)"
 
 #. IDS_DIFF_CONTEXT
-#: Merge.rc:5262
+#: Merge.rc:5261
 msgid "Context"
 msgstr "上下文格式 (Context)"
 
 #. IDS_DIFF_UNIFIED
-#: Merge.rc:5263
+#: Merge.rc:5262
 msgid "Unified"
 msgstr "合并格式 (Unified)"
 
 #. IDS_FILEWRITE_ERROR
-#: Merge.rc:5265
+#: Merge.rc:5264
 #, c-format
 msgid "Could not write to file %1."
 msgstr "未能写入文件 %1。"
 
 #. IDS_PATH_NOT_ABSOLUTE
-#: Merge.rc:5266
+#: Merge.rc:5265
 #, c-format
 msgid "Output path is not absolute: %1"
 msgstr "指定的路径不是绝对路径：%1"
 
 #. IDS_MUST_SPECIFY_OUTPUT
-#: Merge.rc:5267
+#: Merge.rc:5266
 msgid "Specify an output file."
 msgstr "请指定输出文件。"
 
-#: Merge.rc:5269
+#: Merge.rc:5268
 msgid "Cannot create patch from binary files."
 msgstr "无法为二进制文件创建补丁。"
 
 #. IDS_SAVEFILES_FORPATCH
-#: Merge.rc:5270
+#: Merge.rc:5269
 msgid ""
 "Save all files first.\n"
 "\n"
@@ -7516,17 +7511,17 @@ msgstr ""
 "创建补丁需要文件中没有未保存的变更。"
 
 #. IDS_FOLDER_NOTEXIST
-#: Merge.rc:5271
+#: Merge.rc:5270
 msgid "Folder does not exist."
 msgstr "文件夹不存在。"
 
 #. IDS_ARCHIVE_SUCCEEDED
-#: Merge.rc:5277
+#: Merge.rc:5276
 msgid "Archive file written."
 msgstr "已写入压缩文件包。"
 
 #. IDS_ARCHIVE_SAVEFILES
-#: Merge.rc:5278
+#: Merge.rc:5277
 msgid ""
 "Save all files first.\n"
 "\n"
@@ -7537,7 +7532,7 @@ msgstr ""
 "创建压缩包时，系统要求所有未保存的更改必须先保存。"
 
 #. IDS_NO_ZIP_SUPPORT
-#: Merge.rc:5283
+#: Merge.rc:5282
 msgid ""
 "Archive support not enabled.\n"
 "7-Zip and/or Merge7z*.dll not found.\n"
@@ -7548,37 +7543,37 @@ msgstr ""
 "请查看手册获取有关压缩包支持及如何启用的更多信息。"
 
 #. IDS_OPT_EXPORT_CAPTION
-#: Merge.rc:5284
+#: Merge.rc:5283
 msgid "Select file for export"
 msgstr "选择导出文件"
 
 #. IDS_OPT_IMPORT_CAPTION
-#: Merge.rc:5285
+#: Merge.rc:5284
 msgid "Select file for import"
 msgstr "选择导入文件"
 
 #. IDS_OPT_IMPORT_DONE
-#: Merge.rc:5286
+#: Merge.rc:5285
 msgid "Options imported from file."
 msgstr "已从该文件导入选项。"
 
 #. IDS_OPT_EXPORT_DONE
-#: Merge.rc:5287
+#: Merge.rc:5286
 msgid "Options exported to file."
 msgstr "选项已导出到该文件。"
 
 #. IDS_OPT_IMPORT_ERR
-#: Merge.rc:5288
+#: Merge.rc:5287
 msgid "Failed to import options from file."
 msgstr "选项导入失败。"
 
 #. IDS_OPT_EXPORT_ERR
-#: Merge.rc:5289
+#: Merge.rc:5288
 msgid "Failed to write options to file."
 msgstr "选项导出失败。"
 
 #. IDS_CLOSEALL_WINDOWS
-#: Merge.rc:5290
+#: Merge.rc:5289
 msgid ""
 "Close multiple compare windows?\n"
 "\n"
@@ -7588,34 +7583,34 @@ msgstr ""
 "是否继续？"
 
 #. IDS_EOL_BIN
-#: Merge.rc:5300
+#: Merge.rc:5299
 msgctxt "EOL Type"
 msgid "Binary"
 msgstr "二进制"
 
 #. IDS_MARKER_COLOR_FMT
-#: Merge.rc:5305
+#: Merge.rc:5304
 #, c-format
 msgid "Marker Color %d"
 msgstr "标记颜色 %d"
 
 #. IDS_MARKER_NEW_PATTERN
-#: Merge.rc:5306
+#: Merge.rc:5305
 msgid "New Pattern"
 msgstr "新模式"
 
 #. IDS_PLUGINSLIST_TYPE
-#: Merge.rc:5312
+#: Merge.rc:5311
 msgid "Type"
 msgstr "类型"
 
 #. IDS_PLUGINS_TYPE_EDITSCRIPT
-#: Merge.rc:5316
+#: Merge.rc:5315
 msgid "Editor script"
 msgstr "编辑器脚本"
 
 #. ID_SELECTLINEDIFF
-#: Merge.rc:5322
+#: Merge.rc:5321
 msgid ""
 "\n"
 "Difference in Current Line (F4)"
@@ -7624,7 +7619,7 @@ msgstr ""
 "当前行中差异 (F4)"
 
 #. ID_OPTIONS
-#: Merge.rc:5323
+#: Merge.rc:5322
 msgid ""
 "\n"
 "Options"
@@ -7633,7 +7628,7 @@ msgstr ""
 "选项"
 
 #. ID_REFRESH
-#: Merge.rc:5324
+#: Merge.rc:5323
 msgid ""
 "\n"
 "Refresh (F5)"
@@ -7642,7 +7637,7 @@ msgstr ""
 "刷新 (F5)"
 
 #. ID_PREVDIFF
-#: Merge.rc:5330
+#: Merge.rc:5329
 msgid ""
 "\n"
 "Previous Difference (Alt+Up)"
@@ -7651,7 +7646,7 @@ msgstr ""
 "上一处差异 (Alt+Up)"
 
 #. ID_NEXTDIFF
-#: Merge.rc:5331
+#: Merge.rc:5330
 msgid ""
 "\n"
 "Next Difference (Alt+Down)"
@@ -7660,7 +7655,7 @@ msgstr ""
 "下一处差异 (Alt+Down)"
 
 #. ID_PREVCONFLICT
-#: Merge.rc:5332
+#: Merge.rc:5331
 msgid ""
 "\n"
 "Previous Conflict (Alt+Shift+Up)"
@@ -7669,7 +7664,7 @@ msgstr ""
 "上一处冲突 (Alt+Shift+Up)"
 
 #. ID_NEXTCONFLICT
-#: Merge.rc:5333
+#: Merge.rc:5332
 msgid ""
 "\n"
 "Next Conflict (Alt+Shift+Down)"
@@ -7678,7 +7673,7 @@ msgstr ""
 "下一处冲突 (Alt+Shift+Down)"
 
 #. ID_FIRSTDIFF
-#: Merge.rc:5338
+#: Merge.rc:5337
 msgid ""
 "\n"
 "First Difference (Alt+Home)"
@@ -7687,7 +7682,7 @@ msgstr ""
 "首个差异 (Alt+Home)"
 
 #. ID_CURDIFF
-#: Merge.rc:5339
+#: Merge.rc:5338
 msgid ""
 "\n"
 "Current Difference (Alt+Enter)"
@@ -7696,7 +7691,7 @@ msgstr ""
 "当前差异 (Alt+Enter)"
 
 #. ID_LASTDIFF
-#: Merge.rc:5340
+#: Merge.rc:5339
 msgid ""
 "\n"
 "Last Difference (Alt+End)"
@@ -7705,7 +7700,7 @@ msgstr ""
 "末个差异 (Alt+End)"
 
 #. ID_L2R
-#: Merge.rc:5341
+#: Merge.rc:5340
 msgid ""
 "\n"
 "Copy to Right (Alt+Right)"
@@ -7714,7 +7709,7 @@ msgstr ""
 "复制到右侧 (Alt+Right)"
 
 #. ID_R2L
-#: Merge.rc:5342
+#: Merge.rc:5341
 msgid ""
 "\n"
 "Copy to Left (Alt+Left)"
@@ -7723,7 +7718,7 @@ msgstr ""
 "复制到左侧 (Alt+Left)"
 
 #. ID_L2RNEXT
-#: Merge.rc:5343
+#: Merge.rc:5342
 msgid ""
 "\n"
 "Copy to Right and Advance (Ctrl+Alt+Right)"
@@ -7732,7 +7727,7 @@ msgstr ""
 "复制到右侧并前进 (Ctrl+Alt+Right)"
 
 #. ID_R2LNEXT
-#: Merge.rc:5344
+#: Merge.rc:5343
 msgid ""
 "\n"
 "Copy to Left and Advance (Ctrl+Alt+Left)"
@@ -7741,7 +7736,7 @@ msgstr ""
 "复制到左侧并前进 (Ctrl+Alt+Left)"
 
 #. ID_ALL_RIGHT
-#: Merge.rc:5345
+#: Merge.rc:5344
 msgid ""
 "\n"
 "Copy All to Right"
@@ -7750,7 +7745,7 @@ msgstr ""
 "全部复制到右侧"
 
 #. ID_ALL_LEFT
-#: Merge.rc:5346
+#: Merge.rc:5345
 msgid ""
 "\n"
 "Copy All to Left"
@@ -7759,7 +7754,7 @@ msgstr ""
 "全部复制到左侧"
 
 #. ID_AUTO_MERGE
-#: Merge.rc:5347
+#: Merge.rc:5346
 msgid ""
 "\n"
 "Auto Merge (Ctrl+Alt+M)"
@@ -7768,7 +7763,7 @@ msgstr ""
 "自动合并 (Ctrl+Alt+M)"
 
 #. ID_FIRSTFILE
-#: Merge.rc:5348
+#: Merge.rc:5347
 msgid ""
 "\n"
 "First File"
@@ -7777,7 +7772,7 @@ msgstr ""
 "第一个文件"
 
 #. ID_NEXTFILE
-#: Merge.rc:5349
+#: Merge.rc:5348
 msgid ""
 "\n"
 "Next File (Ctrl+F8)"
@@ -7786,7 +7781,7 @@ msgstr ""
 "下一个文件 (Ctrl+F8)"
 
 #. ID_LASTFILE
-#: Merge.rc:5350
+#: Merge.rc:5349
 msgid ""
 "\n"
 "Last File"
@@ -7795,7 +7790,7 @@ msgstr ""
 "最后一个文件"
 
 #. ID_PREVFILE
-#: Merge.rc:5351
+#: Merge.rc:5350
 msgid ""
 "\n"
 "Previous File (Ctrl+F7)"
@@ -7804,141 +7799,141 @@ msgstr ""
 "上一个文件 (Ctrl+F7)"
 
 #. IDS_UNPACK_AUTO
-#: Merge.rc:5358
+#: Merge.rc:5357
 msgid "Adapted unpacker applied to both files (one needs extension)."
 msgstr "在两个文件上应用适当的解包程序 (文件只需要有适当的扩展名)。"
 
 #. IDS_NO_PREDIFFER
-#: Merge.rc:5359
+#: Merge.rc:5358
 msgid "No Prediffer (Normal)"
 msgstr "不使用预比较插件（常规）"
 
 #. IDS_SUGGESTED_PLUGINS
-#: Merge.rc:5360
+#: Merge.rc:5359
 msgid "Suggested Plugins"
 msgstr "推荐的插件"
 
 #. IDS_NOT_SUGGESTED_PLUGINS
-#: Merge.rc:5361
+#: Merge.rc:5360
 msgid "All Plugins"
 msgstr "全部插件"
 
 #. IDS_PRIVATEBUILD_FMT
-#: Merge.rc:5367
+#: Merge.rc:5366
 #, c-format
 msgid "Private Build: %1"
 msgstr "定制版本：%1"
 
 #. IDS_ALLRIGHTS_RESERVED
-#: Merge.rc:5368
+#: Merge.rc:5367
 msgid " - All rights reserved."
 msgstr " - 保留所有权利。"
 
 #. IDS_TITLE_PLUGINS_SETTINGS
-#: Merge.rc:5374
+#: Merge.rc:5373
 msgid "Plugin Settings"
 msgstr "插件设置"
 
 #. IDS_NO_SCT_SCRIPTS
-#: Merge.rc:5376
+#: Merge.rc:5375
 msgid "WSH not found - .sct scripts disabled"
 msgstr "WSH 未找到 - .sct 脚本已禁用"
 
 #. IDS_LOCBAR_GOTOLINE_FMT
-#: Merge.rc:5384
+#: Merge.rc:5383
 #, c-format
 msgid "G&o to Line %1"
 msgstr "转到第 %1 行(&O)"
 
 #. IDS_GOTO_MOVED_LINE
-#: Merge.rc:5390
+#: Merge.rc:5389
 msgid "Go to Moved Line\tCtrl+Shift+G"
 msgstr "转到被移动的行\tCtrl+Shift+G"
 
 #. IDS_AUTOCOMPLETE_DISABLED
-#: Merge.rc:5396
+#: Merge.rc:5395
 msgctxt "Options dialog|General|Open dialog Auto completion"
 msgid "Disabled"
 msgstr "已禁用"
 
 #. IDS_AUTOCOMPLETE_FILE_SYS
-#: Merge.rc:5397
+#: Merge.rc:5396
 msgid "From file system"
 msgstr "由文件系统提供"
 
 #. IDS_AUTOCOMPLETE_MRU
-#: Merge.rc:5398
+#: Merge.rc:5397
 msgid "From Most Recently Used list"
 msgstr "匹配最近使用记录"
 
 #. IDS_COLORSCHEME_PLAIN
-#: Merge.rc:5404
+#: Merge.rc:5403
 msgid "No Highlighting"
 msgstr "无高亮"
 
 #. IDS_COLORSCHEME_PO
-#: Merge.rc:5439
+#: Merge.rc:5438
 msgid "Portable Object"
 msgstr "PO (可移植对象)"
 
 #. IDS_COLORSCHEME_RSRC
-#: Merge.rc:5444
+#: Merge.rc:5443
 msgid "Resources"
 msgstr "资源文件"
 
 #. IDS_COLORSCHEME_SH
-#: Merge.rc:5448
+#: Merge.rc:5447
 msgid "Shell"
 msgstr "Shell 脚本"
 
 #. IDS_CLOSE_LEFT_TABS
-#: Merge.rc:5469
+#: Merge.rc:5468
 msgid "Close &Left Tabs"
 msgstr "关闭左侧标签页(&L)"
 
 #. IDS_CLOSE_RIGHT_TABS
-#: Merge.rc:5470
+#: Merge.rc:5469
 msgid "Close R&ight Tabs"
 msgstr "关闭右侧标签页(&R)"
 
 #. IDS_CLOSE_OTHER_TABS
-#: Merge.rc:5471
+#: Merge.rc:5470
 msgid "Close &Other Tabs"
 msgstr "关闭其他标签页(&O)"
 
 #. IDS_TABBAR_AUTO_MAXWIDTH
-#: Merge.rc:5472
+#: Merge.rc:5471
 msgid "Enable &Auto Max Width"
 msgstr "启用自动最大宽度(&A)"
 
 #. IDS_WEBPAGE_MENU
-#: Merge.rc:5482
+#: Merge.rc:5481
 msgid "We&bpage"
 msgstr "网页(&B)"
 
 #. IDS_VIEW_WRAP_TEXT
-#: Merge.rc:5487
+#: Merge.rc:5486
 msgid "W&rap Text"
 msgstr "自动换行(&R)"
 
 #. IDS_NOTINSTALLED
-#: Merge.rc:5492
+#: Merge.rc:5491
 msgid "%1 is not installed."
 msgstr "%1 未安装。"
 
 #. IDS_CREATE_FOLDER
-#: Merge.rc:5497
+#: Merge.rc:5496
 #, c-format
 msgid "%1 does not exist. Create it?"
 msgstr "%1 不存在。是否创建？"
 
 #. IDS_CREATE_FOLDER_ERROR
-#: Merge.rc:5498
+#: Merge.rc:5497
 msgid "Failed to create folder."
 msgstr "创建文件夹失败。"
 
 #. IDC_EXT_EDITOR_PATH
-#: Merge.rc:5503
+#: Merge.rc:5502
 msgid ""
 "Parameters:\n"
 "$file: Current file path\n"
@@ -7949,491 +7944,491 @@ msgstr ""
 "$linenum: 当前输入符位置的行号"
 
 #. IDS_DIFF_ALGORITHM_DEFAULT
-#: Merge.rc:5508
+#: Merge.rc:5507
 msgid "default"
 msgstr "默认"
 
 #. IDS_DIFF_ALGORITHM_MINIMAL
-#: Merge.rc:5509
+#: Merge.rc:5508
 msgid "minimal"
 msgstr "最少"
 
 #. IDS_DIFF_ALGORITHM_PATIENCE
-#: Merge.rc:5510
+#: Merge.rc:5509
 msgid "patience"
 msgstr "耐心"
 
 #. IDS_DIFF_ALGORITHM_HISTOGRAM
-#: Merge.rc:5511
+#: Merge.rc:5510
 msgid "histogram"
 msgstr "直方图"
 
 #. IDS_DIFF_ALGORITHM_NONE
-#: Merge.rc:5512
+#: Merge.rc:5511
 msgid "none"
 msgstr "无"
 
 #. IDS_RENDERING_MODE_GDI
-#: Merge.rc:5517
+#: Merge.rc:5516
 msgid "GDI"
 msgstr "GDI"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_DEFAULT
-#: Merge.rc:5518
+#: Merge.rc:5517
 msgid "DirectWrite Default"
 msgstr "DirectWrite 默认"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_ALIASED
-#: Merge.rc:5519
+#: Merge.rc:5518
 msgid "DirectWrite Aliased"
 msgstr "DirectWrite Aliased"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_GDI_CLASSIC
-#: Merge.rc:5520
+#: Merge.rc:5519
 msgid "DirectWrite GDI Classic"
 msgstr "DirectWrite GDI Classic"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_GDI_NATURAL
-#: Merge.rc:5521
+#: Merge.rc:5520
 msgid "DirectWrite GDI Natural"
 msgstr "DirectWrite GDI Natural"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_NATURAL
-#: Merge.rc:5522
+#: Merge.rc:5521
 msgid "DirectWrite Natural"
 msgstr "DirectWrite Natural"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_NATURAL_SYMMETRIC
-#: Merge.rc:5523
+#: Merge.rc:5522
 msgid "DirectWrite Natural Symmetric"
 msgstr "DirectWrite Natural Symmetric"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_DISABLED
-#: Merge.rc:5528
+#: Merge.rc:5527
 msgctxt "Options dialog|General|Close windows with Esc"
 msgid "Disabled"
 msgstr "已禁用"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_1
-#: Merge.rc:5529
+#: Merge.rc:5528
 msgid "MDI child window or main window"
 msgstr "MDI 子窗口或主窗口"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_2
-#: Merge.rc:5530
+#: Merge.rc:5529
 msgid "MDI child window only"
 msgstr "仅 MDI 子窗口"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_3
-#: Merge.rc:5531
+#: Merge.rc:5530
 msgid "Close main window if only one MDI child window"
 msgstr "如果只有一个MDI子窗口，关闭主窗口"
 
 #. IDS_DIFF_GROUP
-#: Merge.rc:5536
+#: Merge.rc:5535
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Diff"
 msgstr "差异比较"
 
 #. IDS_DIFF_HIGHLIGHT
-#: Merge.rc:5537
+#: Merge.rc:5536
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Highlight"
 msgstr "高亮"
 
 #. IDS_DIFF_BLINK
-#: Merge.rc:5538
+#: Merge.rc:5537
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Blink"
 msgstr "闪动"
 
 #. IDS_DIFF_BLOCKSIZE
-#: Merge.rc:5539
+#: Merge.rc:5538
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Block Size"
 msgstr "块大小"
 
 #. IDS_DIFF_BLOCKALPHA
-#: Merge.rc:5540
+#: Merge.rc:5539
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Block Alpha"
 msgstr "块不透明度"
 
 #. IDS_DIFF_CDTHRESHOLD
-#: Merge.rc:5541
+#: Merge.rc:5540
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "CD Threshold"
 msgstr "色距阈值"
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION
-#: Merge.rc:5542
+#: Merge.rc:5541
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Ins/Del Detection"
 msgstr "增删检测"
 
 #. IDS_OVERLAY_MODE_NONE
-#: Merge.rc:5543 Merge.rc:5548
+#: Merge.rc:5542 Merge.rc:5547
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "None"
 msgstr "无"
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION_VERTICAL
-#: Merge.rc:5544
+#: Merge.rc:5543
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Vertical"
 msgstr "垂直"
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION_HORIZONTAL
-#: Merge.rc:5545
+#: Merge.rc:5544
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Horizontal"
 msgstr "水平"
 
 #. IDS_OVERLAY_GROUP
-#: Merge.rc:5546
+#: Merge.rc:5545
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Overlay"
 msgstr "遮罩层"
 
 #. IDS_OVERLAY_ALPHA
-#: Merge.rc:5547
+#: Merge.rc:5546
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha"
 msgstr "透明度"
 
 #. IDS_OVERLAY_MODE_XOR
-#: Merge.rc:5549
+#: Merge.rc:5548
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "XOR"
 msgstr "异或计算 (XOR)"
 
 #. IDS_OVERLAY_MODE_ALPHA
-#: Merge.rc:5550
+#: Merge.rc:5549
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha Blend"
 msgstr "半透明混合"
 
 #. IDS_OVERLAY_MODE_ALPHA_ANIMATION
-#: Merge.rc:5551
+#: Merge.rc:5550
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha Animation"
 msgstr "半透明闪动"
 
 #. IDS_ZOOM
-#: Merge.rc:5552
+#: Merge.rc:5551
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Zoom"
 msgstr "缩放"
 
 #. IDS_PAGE
-#: Merge.rc:5553
+#: Merge.rc:5552
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Page:"
 msgstr "页："
 
 #. IDS_IMGCMP_STATUS_PT_RGBA_FMT
-#: Merge.rc:5554
+#: Merge.rc:5553
 #, c-format
 msgid "Pt: (%d, %d)  RGBA: (%d, %d, %d, %d)  "
 msgstr "像素：(%d, %d)  RGBA：(%d, %d, %d, %d)  "
 
 #. IDS_IMGCMP_STATUS_DIST1_FMT
-#: Merge.rc:5555
+#: Merge.rc:5554
 #, c-format
 msgid "Dist: %g  "
 msgstr "色距：%g  "
 
 #. IDS_IMGCMP_STATUS_DIST2_FMT
-#: Merge.rc:5556
+#: Merge.rc:5555
 #, c-format
 msgid "Dist: %g, %g  "
 msgstr "色距：%g, %g  "
 
 #. IDS_IMGCMP_STATUS_PAGE_ZOOM_SIZE_BPP_FMT
-#: Merge.rc:5557
+#: Merge.rc:5556
 #, c-format
 msgid "Page: %d/%d  Zoom: %d%%  %dx%dpx  %dbpp  "
 msgstr "页：%d/%d  缩放：%d%%  %dx%d像素  %d比特/像素  "
 
 #. IDS_IMGCMP_STATUS_RC_FMT
-#: Merge.rc:5558
+#: Merge.rc:5557
 #, c-format
 msgid "Rc: (%d, %d)  "
 msgstr "选中：(%d, %d)  "
 
 #. IDS_IMGCMP_STATUS_FLIPPED_FMT
-#: Merge.rc:5559
+#: Merge.rc:5558
 #, c-format
 msgid "Flipped: %s  "
 msgstr "翻转：%s  "
 
 #. IDS_IMGCMP_STATUS_ROTATED_FMT
-#: Merge.rc:5560
+#: Merge.rc:5559
 #, c-format
 msgid "Rotated: %d  "
 msgstr "旋转：%d  "
 
 #. IDS_IMGCMP_REPORT_ALLPAGES
-#: Merge.rc:5561
+#: Merge.rc:5560
 msgid "All pages"
 msgstr "所有页"
 
 #. IDS_IGNSUB_STR1
-#: Merge.rc:5566
+#: Merge.rc:5565
 msgid "<Edit here>"
 msgstr "< 编辑这里 >"
 
 #. IDS_IGNSUB_STR2
-#: Merge.rc:5567
+#: Merge.rc:5566
 msgid "No differences found to select"
 msgstr "未找到要选择的差异"
 
 #. IDS_IGNSUB_STR3
-#: Merge.rc:5568
+#: Merge.rc:5567
 msgid "No differences found to add as substitution filter"
 msgstr "未找到要添加为置换过滤器的差异"
 
 #. IDS_IGNSUB_STR4
-#: Merge.rc:5569
+#: Merge.rc:5568
 msgid "The pair is already in the Substitution Filters list"
 msgstr "这一对已存在于置换过滤器列表中"
 
 #. IDS_IGNSUB_STR5
-#: Merge.rc:5570
+#: Merge.rc:5569
 msgid "Add this change to Substitution Filters?"
 msgstr "将此更改添加到置换过滤器？"
 
 #. IDS_OCRRESULT_TEXTONLY
-#: Merge.rc:5575
+#: Merge.rc:5574
 msgid "Text only"
 msgstr "纯文本"
 
 #. IDS_OCRRESULT_POS_LINE
-#: Merge.rc:5576
+#: Merge.rc:5575
 msgid "Line-by-line position and text"
 msgstr "逐行定位输入"
 
 #. IDS_OCRRESULT_POS_WORD
-#: Merge.rc:5577
+#: Merge.rc:5576
 msgid "Word-by-word position and text"
 msgstr "逐字定位输入"
 
 #. IDS_USERDATAFOLDER_APPDATA
-#: Merge.rc:5582
+#: Merge.rc:5581
 msgid "AppData (Roaming) folder"
 msgstr "AppData（Roaming）文件夹"
 
 #. IDS_USERDATAFOLDER_INSTALL
-#: Merge.rc:5583
+#: Merge.rc:5582
 msgid "Install folder"
 msgstr "安装文件夹"
 
 #. IDS_USERDATAFOLDER_DOCUMENTS
-#: Merge.rc:5584
+#: Merge.rc:5583
 msgid "Documents folder"
 msgstr "文档文件夹"
 
 #. IDS_SINGLEINSTANCE_DISABLED
-#: Merge.rc:5589
+#: Merge.rc:5588
 msgctxt "Options dialog|General|Single instance mode"
 msgid "Disabled"
 msgstr "已禁用"
 
 #. IDS_SINGLEINSTANCE_STR1
-#: Merge.rc:5590
+#: Merge.rc:5589
 msgid "Allow only one instance to run"
 msgstr "只允许运行一个实例"
 
 #. IDS_CLIPBOARD_HISTORY
-#: Merge.rc:5591
+#: Merge.rc:5590
 msgid "Clipboard &History"
 msgstr "剪贴板历史(&H)"
 
 #. IDS_SINGLEINSTANCE_STR2
-#: Merge.rc:5592
+#: Merge.rc:5591
 msgid "Allow only one instance; wait for termination"
 msgstr "只允许运行一个实例并等待该实例结束"
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_DISABLED
-#: Merge.rc:5597
+#: Merge.rc:5596
 msgctxt "Options dialog|General|Auto-reload modified files"
 msgid "Disabled"
 msgstr "已禁用"
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_STR1
-#: Merge.rc:5598
+#: Merge.rc:5597
 msgid "Only on window activated"
 msgstr "仅在窗口激活时"
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_STR2
-#: Merge.rc:5599
+#: Merge.rc:5598
 msgid "Immediately"
 msgstr "立即"
 
 #. IDS_PLUGIN_ALL
-#: Merge.rc:5604
+#: Merge.rc:5603
 msgid "Al&l"
 msgstr "全部(&L)"
 
 #. IDS_PLUGIN_OTHERS
-#: Merge.rc:5605
+#: Merge.rc:5604
 msgid "&Others"
 msgstr "其它(&O)"
 
-#: Merge.rc:5607
+#: Merge.rc:5606
 #, c-format
 msgid "Missing plugin name in pipeline: %1"
 msgstr "插件流水线中缺少插件名称：%1"
 
-#: Merge.rc:5609
+#: Merge.rc:5608
 #, c-format
 msgid "Missing quote in plugin pipeline: %1"
 msgstr "插件流水线中缺少引号：%1"
 
 #. IDS_PLUGIN_NAME_ALREADY_EXISTS
-#: Merge.rc:5610
+#: Merge.rc:5609
 #, c-format
 msgid "Plugin name '%1' already exists."
 msgstr "插件名称 '%1' 已存在。"
 
 #. IDS_PLUGIN_TITLE1
-#: Merge.rc:5611
+#: Merge.rc:5610
 msgid "Specify plugin arguments"
 msgstr "指定插件参数"
 
-#: Merge.rc:5613
+#: Merge.rc:5612
 #, c-format
 msgid "Plugin not found or invalid: %1"
 msgstr "插件不存在或无效：%1"
 
 #. IDS_PLUGIN_NOT_UNPACK
-#: Merge.rc:5614
+#: Merge.rc:5613
 #, c-format
 msgid "'%1' is not an unpacker plugin"
 msgstr "'%1' 不是解包插件"
 
 #. IDS_PLUGIN_NOT_PREDIFF
-#: Merge.rc:5615
+#: Merge.rc:5614
 #, c-format
 msgid "'%1' is not a prediffer plugin"
 msgstr "'%1' 不是预比较插件"
 
-#: Merge.rc:5617
+#: Merge.rc:5616
 #, c-format
 msgid "Error prediffing '%1' with '%2'. Prediffing disabled."
 msgstr "预比较 '%1' 和 '%2' 时出错，已禁用预比较。"
 
 #. IDS_PLUGIN_CIRCULAR_REFERENCE
-#: Merge.rc:5618
+#: Merge.rc:5617
 #, c-format
 msgid "Circular reference in plugin pipeline: %1"
 msgstr "插件流水线中的循环引用：%1"
 
 #. IDS_PLUGIN_TYPE1
-#: Merge.rc:5619
+#: Merge.rc:5618
 msgid "URL Handler"
 msgstr "网址处理器"
 
 #. IDS_PLUGIN_TYPE2
-#: Merge.rc:5620
+#: Merge.rc:5619
 msgid "File Unpacker"
 msgstr "文件解包插件"
 
 #. IDS_PLUGIN_TYPE3
-#: Merge.rc:5621
+#: Merge.rc:5620
 msgid "File or Folder Unpacker"
 msgstr "文件或文件夹解包插件"
 
 #. IDS_PLUGIN_TYPE5
-#: Merge.rc:5623
+#: Merge.rc:5622
 msgid "Alias for Unpacker"
 msgstr "解包插件别名"
 
 #. IDS_PLUGIN_TYPE6
-#: Merge.rc:5624
+#: Merge.rc:5623
 msgid "Alias for Prediffer"
 msgstr "预比较插件别名"
 
 #. IDS_PLUGIN_TYPE7
-#: Merge.rc:5625
+#: Merge.rc:5624
 msgid "Alias for Editor script"
 msgstr "编辑器脚本别名"
 
 #. IDS_PLUGIN_ALIAS_DESC
-#: Merge.rc:5626
+#: Merge.rc:5625
 #, c-format
 msgid "Alias for plugin pipeline '%1'"
 msgstr "插件流水线 '%1' 别名"
 
 #. IDS_PLUGIN_NEW_DESC
-#: Merge.rc:5627
+#: Merge.rc:5626
 msgid "New plugin description"
 msgstr "新的插件描述"
 
 #. IDS_PLUGIN_TARGETS_ALL
-#: Merge.rc:5628
+#: Merge.rc:5627
 msgid "All"
 msgstr "全部"
 
 #. IDS_PLUGIN_TARGETS_1ST
-#: Merge.rc:5629
+#: Merge.rc:5628
 msgid "1st"
 msgstr "第一个"
 
 #. IDS_PLUGIN_TARGETS_2ND
-#: Merge.rc:5630
+#: Merge.rc:5629
 msgid "2nd"
 msgstr "第二个"
 
 #. IDS_PLUGIN_TARGETS_3RD
-#: Merge.rc:5631
+#: Merge.rc:5630
 msgid "3rd"
 msgstr "第三个"
 
 #. IDS_PLUGIN_TARGETS_1ST_2ND
-#: Merge.rc:5632
+#: Merge.rc:5631
 msgid "1st and 2nd"
 msgstr "第一个和第二个"
 
 #. IDS_PLUGIN_TARGETS_1ST_3RD
-#: Merge.rc:5633
+#: Merge.rc:5632
 msgid "1st and 3rd"
 msgstr "第一个和第三个"
 
 #. IDS_PLUGIN_TARGETS_2ND_3RD
-#: Merge.rc:5634
+#: Merge.rc:5633
 msgid "2nd and 3rd"
 msgstr "第二个和第三个"
 
 #. IDS_PLUGIN_CTRL_CLICK
-#: Merge.rc:5635
+#: Merge.rc:5634
 msgid "(Ctrl+Click to add to pipeline)"
 msgstr ""
 
 #. IDS_FILTER_APPLIED
-#: Merge.rc:5640
+#: Merge.rc:5639
 msgid "Filter applied"
 msgstr "过滤器已应用"
 
 #. IDS_FILTERMENU_COMPARE
-#: Merge.rc:5645
+#: Merge.rc:5644
 #, c-format
 msgid "Compare %1"
 msgstr "比较 %1"
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN2
-#: Merge.rc:5647
+#: Merge.rc:5646
 msgid "&Filter by This Column..."
 msgstr "按该列过滤(&F)..."
 
 #. IDS_CLIPBOARDHISTORY_TIME
-#: Merge.rc:5652
+#: Merge.rc:5651
 #, c-format
 msgid "Clipboard at %s"
 msgstr "剪贴板位于 %s"
 
 #. IDS_CLIPBOARDHISTORY_DISABLED
-#: Merge.rc:5653
+#: Merge.rc:5652
 msgid ""
 "Clipboard history disabled.\r\n"
 "Enable: Windows logo key + V, then Turn on."
@@ -8441,115 +8436,115 @@ msgstr ""
 "剪贴板历史记录被禁用了。\r\n"
 "要启用剪贴板历史记录， 请按 Windows 徽标键 + V，然后单击“打开”按钮。"
 
-#: Merge.rc:5655
+#: Merge.rc:5654
 msgid "This system does not support clipboard history."
 msgstr "当前系统不支持剪贴板历史记录。"
 
-#: Merge.rc:5657
+#: Merge.rc:5656
 msgid "32-bit WinMerge does not support Clipboard Compare"
 msgstr "32 位的 WinMerge 不支持剪贴板比较"
 
 #. IDS_WEBVIEW2_RUNTIME_NOT_INSTALLED
-#: Merge.rc:5662
+#: Merge.rc:5661
 msgid "WebView2 runtime not installed. Download it?"
 msgstr "未安装 WebView2 运行库。您想下载吗？"
 
 #. IDS_JUMPLIST_NEW_TEXT_COMPARE
-#: Merge.rc:5667
+#: Merge.rc:5666
 msgid "New Text Compare"
 msgstr "新的文本比较"
 
 #. IDS_JUMPLIST_NEW_TABLE_COMPARE
-#: Merge.rc:5668
+#: Merge.rc:5667
 msgid "New Table Compare"
 msgstr "新的表格比较"
 
 #. IDS_JUMPLIST_NEW_BINARY_COMPARE
-#: Merge.rc:5669
+#: Merge.rc:5668
 msgid "New Binary Compare"
 msgstr "新的二进制比较"
 
 #. IDS_JUMPLIST_NEW_IMAGE_COMPARE
-#: Merge.rc:5670
+#: Merge.rc:5669
 msgid "New Image Compare"
 msgstr "新的图像比较"
 
 #. IDS_JUMPLIST_NEW_WEBPAGE_COMPARE
-#: Merge.rc:5671
+#: Merge.rc:5670
 msgid "New Webpage Compare"
 msgstr "新的网页比较"
 
 #. IDS_JUMPLIST_NEW_FOLDER_COMPARE
-#: Merge.rc:5672
+#: Merge.rc:5671
 msgid "New Folder Compare"
 msgstr "新建文件夹比较"
 
 #. IDS_JUMPLIST_CLIPBOARD_COMPARE
-#: Merge.rc:5673
+#: Merge.rc:5672
 msgid "Clipboard Compare"
 msgstr "剪贴板比较"
 
 #. IDS_PREVIEWBAR_PRINT
-#: Merge.rc:5678
+#: Merge.rc:5677
 msgid "&Print..."
 msgstr "打印(&P)..."
 
 #. IDS_PREVIEWBAR_PREVPAGE
-#: Merge.rc:5680
+#: Merge.rc:5679
 msgid "Pre&v Page"
 msgstr "上一页(&V)"
 
 #. IDS_PREVIEWBAR_TWOPAGE
-#: Merge.rc:5681
+#: Merge.rc:5680
 msgid "&Two Page"
 msgstr "双页(&T)"
 
 #. IDS_PREVIEWBAR_ONEPAGE
-#: Merge.rc:5682
+#: Merge.rc:5681
 msgid "&One Page"
 msgstr "单页(&O)"
 
 #. IDS_PREVIEWBAR_ZOOMIN
-#: Merge.rc:5683
+#: Merge.rc:5682
 msgid "Zoom &In"
 msgstr "放大(&I)"
 
 #. IDS_PREVIEWBAR_ZOOMOUT
-#: Merge.rc:5684
+#: Merge.rc:5683
 msgid "Zoom &Out"
 msgstr "缩小(&O)"
 
 #. IDS_WEBPAGE_COMPARING
-#: Merge.rc:5690
+#: Merge.rc:5689
 msgid "Comparing..."
 msgstr "比较中..."
 
 #. IDS_WEBPAGE_ZOOM
-#: Merge.rc:5691
+#: Merge.rc:5690
 msgid "Zoom:"
 msgstr "缩放："
 
 #. IDS_COPY_GRANULARITY_DIFFHUNK
-#: Merge.rc:5696
+#: Merge.rc:5695
 msgid "Diff hunk"
 msgstr "整个差异块"
 
 #. IDS_COPY_GRANULARITY_INLINE
-#: Merge.rc:5697
+#: Merge.rc:5696
 msgid "Inline diff"
 msgstr "行内差异"
 
 #. IDS_COPY_GRANULARITY_LINE
-#: Merge.rc:5698
+#: Merge.rc:5697
 msgid "Line"
 msgstr "整行"
 
-#: Merge.rc:5699
+#: Merge.rc:5698
 msgid "Character"
 msgstr "字符"
 
 #. ID_MICE_PREVDIFF
-#: Merge.rc:5704
+#: Merge.rc:5703
 msgid ""
 "\n"
 "Previous Difference (Alt+Up)\n"
@@ -8562,7 +8557,7 @@ msgstr ""
 "(Alt+滚轮上滚)"
 
 #. ID_MICE_NEXTDIFF
-#: Merge.rc:5705
+#: Merge.rc:5704
 msgid ""
 "\n"
 "Next Difference (Alt+Down)\n"
@@ -8575,7 +8570,7 @@ msgstr ""
 "(Alt+滚轮下滚)"
 
 #. ID_MICE_L2R
-#: Merge.rc:5706
+#: Merge.rc:5705
 msgid ""
 "\n"
 "Copy to Right (Alt+Right)\n"
@@ -8590,7 +8585,7 @@ msgstr ""
 "(Alt+Shift+滚轮下滚)"
 
 #. ID_MICE_R2L
-#: Merge.rc:5707
+#: Merge.rc:5706
 msgid ""
 "\n"
 "Copy to Left (Alt+Left)\n"
@@ -8605,7 +8600,7 @@ msgstr ""
 "(Alt+Shift+滚轮上滚)"
 
 #. ID_MICE_L2RNEXT
-#: Merge.rc:5708
+#: Merge.rc:5707
 msgid ""
 "\n"
 "Copy to Right and Advance (Ctrl+Alt+Right)\n"
@@ -8618,7 +8613,7 @@ msgstr ""
 "(Ctrl+Alt+Shift+滚轮下滚)"
 
 #. ID_MICE_R2LNEXT
-#: Merge.rc:5709
+#: Merge.rc:5708
 msgid ""
 "\n"
 "Copy to Left and Advance (Ctrl+Alt+Left)\n"
@@ -8631,257 +8626,257 @@ msgstr ""
 "(Ctrl+Alt+Shift+滚轮上滚)"
 
 #. IDS_LOG_COMPARING_2
-#: Merge.rc:5719
+#: Merge.rc:5718
 #, c-format
 msgid "Comparing %1 with %2"
 msgstr "比较 %1 和 %2"
 
 #. IDS_LOG_COMPARING_3
-#: Merge.rc:5720
+#: Merge.rc:5719
 #, c-format
 msgid "Comparing %1 with %2 and %3"
 msgstr "比较 %1、%2 和 %3"
 
 #. IDS_LOG_COMPARE_COMPLETED
-#: Merge.rc:5721
+#: Merge.rc:5720
 msgid "Comparison completed"
 msgstr "比较已完成"
 
 #. IDS_LOG_COMPARE_ERROR_2
-#: Merge.rc:5722
+#: Merge.rc:5721
 #, c-format
 msgid "Failed to compare %1 with %2: "
 msgstr "比较 %1 和 %2 失败："
 
 #. IDS_LOG_COMPARE_ERROR_3
-#: Merge.rc:5723
+#: Merge.rc:5722
 #, c-format
 msgid "Failed to compare %1 with %2 and %3: "
 msgstr "比较 %1 %2 和 %3 失败："
 
 #. IDS_LOG_FILE_SAVED
-#: Merge.rc:5724
+#: Merge.rc:5723
 msgid "File saved"
 msgstr "文件已保存"
 
 #. IDS_LOG_COPYING_FILES
-#: Merge.rc:5725
+#: Merge.rc:5724
 msgid "Copying files..."
 msgstr "复制文件..."
 
 #. IDS_LOG_MOVING_FILES
-#: Merge.rc:5726
+#: Merge.rc:5725
 msgid "Moving files..."
 msgstr "移动文件..."
 
 #. IDS_LOG_DELETING_FILES
-#: Merge.rc:5727
+#: Merge.rc:5726
 msgid "Deleting files..."
 msgstr "删除文件..."
 
 #. IDS_LOG_RECYCLEBIN
-#: Merge.rc:5728
+#: Merge.rc:5727
 msgid "Recycle Bin"
 msgstr "回收站"
 
 #. IDS_LOG_PERMANENTLY_DELETED
-#: Merge.rc:5729
+#: Merge.rc:5728
 msgid "Permanently deleted"
 msgstr "已永久删除"
 
 #. IDS_LOG_FILEOPERATION_COMPLETED
-#: Merge.rc:5730
+#: Merge.rc:5729
 msgid "File operation completed successfully"
 msgstr "文件操作已成功完成"
 
 #. IDS_LOG_FILEOPERATION_CANCELED
-#: Merge.rc:5731
+#: Merge.rc:5730
 msgid "File operation canceled"
 msgstr "文件操作已取消"
 
 #. IDS_FILTER_ERROR_NO_ERROR
-#: Merge.rc:5736
+#: Merge.rc:5735
 msgid "No error"
 msgstr "无错误"
 
 #. IDS_FILTER_ERROR_EMPTY_EXPRESSION
-#: Merge.rc:5737
+#: Merge.rc:5736
 msgid "Filter expression is empty"
 msgstr "过滤器表达式为空"
 
 #. IDS_FILTER_ERROR_UNKNOWN_CHAR
-#: Merge.rc:5738
+#: Merge.rc:5737
 msgid "Unknown character in filter expression"
 msgstr "过滤器表达式存在未知字符"
 
 #. IDS_FILTER_ERROR_UNTERMINATED_STRING
-#: Merge.rc:5739
+#: Merge.rc:5738
 msgid "Unterminated string literal"
 msgstr "未终止的字符串字面量"
 
 #. IDS_FILTER_ERROR_SYNTAX_ERROR
-#: Merge.rc:5740
+#: Merge.rc:5739
 msgid "Syntax error in filter expression"
 msgstr "过滤器表达式语法错误"
 
 #. IDS_FILTER_ERROR_PARSE_FAILURE
-#: Merge.rc:5741
+#: Merge.rc:5740
 msgid "Failed to parse filter expression"
 msgstr "无法解析过滤器表达式"
 
 #. IDS_FILTER_ERROR_INVALID_LITERAL
-#: Merge.rc:5742
+#: Merge.rc:5741
 msgid "Invalid literal value"
 msgstr "无效的字面量值"
 
 #. IDS_FILTER_ERROR_INVALID_REGULAR_EXPRESSION
-#: Merge.rc:5743
+#: Merge.rc:5742
 msgid "Invalid regular expression"
 msgstr "无效的正则表达式"
 
 #. IDS_FILTER_ERROR_UNDEFINED_IDENTIFIER
-#: Merge.rc:5744
+#: Merge.rc:5743
 msgid "Undefined identifier"
 msgstr "未定义的标识符"
 
 #. IDS_FILTER_ERROR_INVALID_ARGUMENT_COUNT
-#: Merge.rc:5745
+#: Merge.rc:5744
 msgid "Invalid number of arguments"
 msgstr "无效的参数数量"
 
 #. IDS_FILTER_ERROR_FILTER_NAME_NOT_FOUND
-#: Merge.rc:5746
+#: Merge.rc:5745
 msgid "Filter name not found"
 msgstr "过滤器名称不存在"
 
 #. IDS_FILTER_ERROR_DIVIDE_BY_ZERO
-#: Merge.rc:5747
+#: Merge.rc:5746
 msgid "Division by zero in filter expression"
 msgstr "过滤器表达式存在除零错误"
 
 #. IDS_FILTER_ERROR_UNKNOWN_ERROR
-#: Merge.rc:5748
+#: Merge.rc:5747
 msgid "Unknown error"
 msgstr "未知错误"
 
 #. IDS_FILTER_ERROR_INVALID_PROPERTY_NAME
-#: Merge.rc:5749
+#: Merge.rc:5748
 msgid "Invalid property name"
 msgstr "无效的属性名称"
 
 #. IDS_FILTER_ERROR_INVALID_DIRECTIVE
-#: Merge.rc:5750
+#: Merge.rc:5749
 msgid "Invalid directive"
 msgstr "无效的指示"
 
 #. IDS_FILTER_OP_EQUALS
-#: Merge.rc:5755
+#: Merge.rc:5754
 msgid "Equals"
 msgstr "等于"
 
 #. IDS_FILTER_OP_NOT_EQUALS
-#: Merge.rc:5756
+#: Merge.rc:5755
 msgid "Does not equal"
 msgstr "不等于"
 
 #. IDS_FILTER_OP_LESS_THAN
-#: Merge.rc:5757
+#: Merge.rc:5756
 msgid "Less than"
 msgstr "小于"
 
 #. IDS_FILTER_OP_LESS_EQUAL
-#: Merge.rc:5758
+#: Merge.rc:5757
 msgid "Less than or equal to"
 msgstr "小于等于"
 
 #. IDS_FILTER_OP_GREATER_EQUAL
-#: Merge.rc:5759
+#: Merge.rc:5758
 msgid "Greater than or equal to"
 msgstr "大于等于"
 
 #. IDS_FILTER_OP_GREATER_THAN
-#: Merge.rc:5760
+#: Merge.rc:5759
 msgid "Greater than"
 msgstr "大于"
 
 #. IDS_FILTER_OP_BETWEEN
-#: Merge.rc:5761
+#: Merge.rc:5760
 msgid "Between"
 msgstr "在"
 
 #. IDS_FILTER_OP_NOT_BETWEEN
-#: Merge.rc:5762
+#: Merge.rc:5761
 msgid "Not Between"
 msgstr "不在"
 
 #. IDS_FILTER_OP_CONTAINS
-#: Merge.rc:5763
+#: Merge.rc:5762
 msgid "Contains"
 msgstr "包含"
 
 #. IDS_FILTER_OP_NOT_CONTAINS
-#: Merge.rc:5764
+#: Merge.rc:5763
 msgid "Not Contains"
 msgstr "未包含"
 
 #. IDS_FILTER_OP_RECONTAINS
-#: Merge.rc:5765
+#: Merge.rc:5764
 msgid "Contains (regex)"
 msgstr "包含（正则表达式）"
 
 #. IDS_FILTER_OP_NOT_RECONTAINS
-#: Merge.rc:5766
+#: Merge.rc:5765
 msgid "Not Contains (regex)"
 msgstr "未包含（正则表达式）"
 
 #. IDS_FILTER_OP_LIKE
-#: Merge.rc:5767
+#: Merge.rc:5766
 msgid "Match (wildcard)"
 msgstr "匹配（通配符）"
 
 #. IDS_FILTER_OP_NOT_LIKE
-#: Merge.rc:5768
+#: Merge.rc:5767
 msgid "Not match (wildcard)"
 msgstr "未匹配（通配符）"
 
 #. IDS_FILTER_OP_MATCHES
-#: Merge.rc:5769
+#: Merge.rc:5768
 msgid "Match (regex)"
 msgstr "匹配（正则式）"
 
 #. IDS_FILTER_OP_NOT_MATCHES
-#: Merge.rc:5770
+#: Merge.rc:5769
 msgid "Not match (regex)"
 msgstr "未匹配（正则式）"
 
 #. IDS_COLORMODE_LIGHT
-#: Merge.rc:5775
+#: Merge.rc:5774
 msgid "Light"
 msgstr "浅色"
 
 #. IDS_COLORMODE_DARK
-#: Merge.rc:5776
+#: Merge.rc:5775
 msgid "Dark"
 msgstr "深色"
 
 #. IDS_COLORMODE_FOLLOWSYSTEM
-#: Merge.rc:5777
+#: Merge.rc:5776
 msgid "Follow system"
 msgstr "跟随系统"
 
 #. IDS_EXAMPLE
-#: Merge.rc:5782
+#: Merge.rc:5781
 #, c-format
 msgid "e.g. %1"
 msgstr "例：%1"
 
 #. IDS_DETECTED_PREVIOUS_CRASH
-#: Merge.rc:5787
+#: Merge.rc:5786
 msgid "WinMerge detected a previous crash. Please report this if possible."
 msgstr "WinMerge 检测到之前发生过崩溃。如有可能，请提交此问题报告。"
 
 #. IDS_REGEX_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5792
+#: Merge.rc:5791
 msgid ""
 "# Regex replacement list\r\n"
 "# Format: regex<TAB>replacement\r\n"
@@ -8896,7 +8891,7 @@ msgstr ""
 "(\\d{4})-(\\d{2})-(\\d{2})\t$1_$2_$3\n"
 
 #. IDS_STRING_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5793
+#: Merge.rc:5792
 msgid ""
 "# Replacement list\r\n"
 "# Format: search<TAB>replacement\r\n"
@@ -8913,22 +8908,22 @@ msgstr ""
 "from2\tto2\n"
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_ONLY
-#: Merge.rc:5798
+#: Merge.rc:5797
 msgid "Built-in only"
 msgstr "仅限内置"
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_FIRST
-#: Merge.rc:5799
+#: Merge.rc:5798
 msgid "Built-in first"
 msgstr "内置优先"
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_FIRST
-#: Merge.rc:5800
+#: Merge.rc:5799
 msgid "Tree-sitter first"
 msgstr "Tree-sitter 优先"
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_ONLY
-#: Merge.rc:5801
+#: Merge.rc:5800
 msgid "Tree-sitter only"
 msgstr "仅限 Tree-sitter"
 

--- a/Translations/WinMerge/ChineseTraditional.po
+++ b/Translations/WinMerge/ChineseTraditional.po
@@ -22,7 +22,7 @@ msgstr ""
 "X-Generator: Poedit 3.9\n"
 
 #. LANGUAGE, SUBLANGUAGE
-#: Merge.rc:26 Merge.rc:59 Merge.rc:5818
+#: Merge.rc:26 Merge.rc:59 Merge.rc:5817
 msgid "LANG_ENGLISH, SUBLANG_ENGLISH_US"
 msgstr "LANG_CHINESE, SUBLANG_CHINESE_TRADITIONAL"
 
@@ -164,7 +164,7 @@ msgstr "指令碼 (&S)"
 #. IDS_NO_EDIT_SCRIPTS
 #: Merge.rc:127 Merge.rc:352 Merge.rc:463 Merge.rc:673 Merge.rc:678
 #: Merge.rc:887 Merge.rc:899 Merge.rc:906 Merge.rc:963 Merge.rc:1210
-#: Merge.rc:5375
+#: Merge.rc:5374
 msgid "< Empty >"
 msgstr "< 空 >"
 
@@ -229,7 +229,7 @@ msgid "Auto-Fit All Columns"
 msgstr "自動調整所有欄位寬度"
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN
-#: Merge.rc:153 Merge.rc:5646
+#: Merge.rc:153 Merge.rc:5645
 msgid "&Filter by This Column"
 msgstr "依此欄篩選(&F)"
 
@@ -290,7 +290,7 @@ msgid "&Previous Page"
 msgstr "前一頁 (&P)"
 
 #. IDS_PREVIEWBAR_NEXTPAGE
-#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5679
+#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5678
 msgid "&Next Page"
 msgstr "後一頁 (&N)"
 
@@ -541,7 +541,7 @@ msgstr "二進位 (&B)"
 #. IDS_IMAGE_MENU
 #: Merge.rc:329 Merge.rc:338 Merge.rc:432 Merge.rc:441 Merge.rc:609
 #: Merge.rc:618 Merge.rc:670 Merge.rc:960 Merge.rc:1187 Merge.rc:1200
-#: Merge.rc:5477
+#: Merge.rc:5476
 msgid "&Image"
 msgstr "圖片 (&I)"
 
@@ -663,7 +663,7 @@ msgid "&Huge"
 msgstr "超大圖示 (&H)"
 
 #. IDS_VIEW_MENU_BAR
-#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5714
+#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5713
 msgid "Men&u Bar"
 msgstr "選單列 (&U)"
 
@@ -1322,7 +1322,7 @@ msgid "Lo&cation Pane"
 msgstr "位置窗格 (&P)"
 
 #. IDS_OUTPUTBAR_CAPTION
-#: Merge.rc:782 Merge.rc:5252
+#: Merge.rc:782 Merge.rc:5251
 msgid "Output Pane"
 msgstr "輸出窗格"
 
@@ -1585,55 +1585,55 @@ msgid "Co&mpare As"
 msgstr "比對為 (&M)"
 
 #. IDS_COPY_LEFT_TO_MIDDLE2
-#: Merge.rc:968 Merge.rc:980 Merge.rc:4852
+#: Merge.rc:968 Merge.rc:980 Merge.rc:4851
 #, c-format
 msgid "Left to Middle (%1 of %2)"
 msgstr "左側到中間 (%1／%2)"
 
 #. IDS_COPY_LEFT_TO_RIGHT2
-#: Merge.rc:969 Merge.rc:981 Merge.rc:4851
+#: Merge.rc:969 Merge.rc:981 Merge.rc:4850
 #, c-format
 msgid "Left to Right (%1 of %2)"
 msgstr "左側到右側 (%1／%2)"
 
 #. IDS_MOVE_LEFT_TO2
-#: Merge.rc:970 Merge.rc:982 Merge.rc:1045 Merge.rc:4863 Merge.rc:4892
+#: Merge.rc:970 Merge.rc:982 Merge.rc:1045 Merge.rc:4862 Merge.rc:4891
 #, c-format
 msgid "Left to... (%1 of %2)"
 msgstr "左側到... (%1／%2)"
 
 #. IDS_COPY_MIDDLE_TO_LEFT2
-#: Merge.rc:971 Merge.rc:983 Merge.rc:4849
+#: Merge.rc:971 Merge.rc:983 Merge.rc:4848
 #, c-format
 msgid "Middle to Left (%1 of %2)"
 msgstr "中間到左側 (%1／%2)"
 
 #. IDS_COPY_MIDDLE_TO_RIGHT2
-#: Merge.rc:972 Merge.rc:984 Merge.rc:4850
+#: Merge.rc:972 Merge.rc:984 Merge.rc:4849
 #, c-format
 msgid "Middle to Right (%1 of %2)"
 msgstr "中間到右側 (%1／%2)"
 
 #. IDS_MOVE_MIDDLE_TO2
-#: Merge.rc:973 Merge.rc:985 Merge.rc:1046 Merge.rc:4864 Merge.rc:4893
+#: Merge.rc:973 Merge.rc:985 Merge.rc:1046 Merge.rc:4863 Merge.rc:4892
 #, c-format
 msgid "Middle to... (%1 of %2)"
 msgstr "中間到... (%1／%2)"
 
 #. IDS_COPY_RIGHT_TO_MIDDLE2
-#: Merge.rc:974 Merge.rc:986 Merge.rc:4848
+#: Merge.rc:974 Merge.rc:986 Merge.rc:4847
 #, c-format
 msgid "Right to Middle (%1 of %2)"
 msgstr "右側到中間 (%1／%2)"
 
 #. IDS_COPY_RIGHT_TO_LEFT2
-#: Merge.rc:975 Merge.rc:987 Merge.rc:4847
+#: Merge.rc:975 Merge.rc:987 Merge.rc:4846
 #, c-format
 msgid "Right to Left (%1 of %2)"
 msgstr "右側到左側 (%1／%2)"
 
 #. IDS_MOVE_RIGHT_TO2
-#: Merge.rc:976 Merge.rc:988 Merge.rc:1047 Merge.rc:4865 Merge.rc:4894
+#: Merge.rc:976 Merge.rc:988 Merge.rc:1047 Merge.rc:4864 Merge.rc:4893
 #, c-format
 msgid "Right to... (%1 of %2)"
 msgstr "右側到... (%1／%2)"
@@ -1689,31 +1689,31 @@ msgid "Cop&y Paths"
 msgstr "複製路徑 (&Y)"
 
 #. IDS_DEL_LEFT_FMT2
-#: Merge.rc:1026 Merge.rc:1035 Merge.rc:4880
+#: Merge.rc:1026 Merge.rc:1035 Merge.rc:4879
 #, c-format
 msgid "Left (%1 of %2)"
 msgstr "左側 (%1／%2)"
 
 #. IDS_DEL_MIDDLE_FMT2
-#: Merge.rc:1027 Merge.rc:1036 Merge.rc:4881
+#: Merge.rc:1027 Merge.rc:1036 Merge.rc:4880
 #, c-format
 msgid "Middle (%1 of %2)"
 msgstr "中間 (%1／%2)"
 
 #. IDS_DEL_RIGHT_FMT2
-#: Merge.rc:1028 Merge.rc:1037 Merge.rc:4882
+#: Merge.rc:1028 Merge.rc:1037 Merge.rc:4881
 #, c-format
 msgid "Right (%1 of %2)"
 msgstr "右側 (%1／%2)"
 
 #. IDS_DEL_BOTH_FMT2
-#: Merge.rc:1029 Merge.rc:1038 Merge.rc:4883
+#: Merge.rc:1029 Merge.rc:1038 Merge.rc:4882
 #, c-format
 msgid "Both (%1 of %2)"
 msgstr "兩邊 (%1／%2)"
 
 #. IDS_DEL_ALL_FMT2
-#: Merge.rc:1030 Merge.rc:1039 Merge.rc:4888
+#: Merge.rc:1030 Merge.rc:1039 Merge.rc:4887
 #, c-format
 msgid "All (%1 of %2)"
 msgstr "全部 (%1／%2)"
@@ -1739,19 +1739,19 @@ msgid "&Zip"
 msgstr "Zip (&Z)"
 
 #. IDS_COPY_BOTH_TO2
-#: Merge.rc:1048 Merge.rc:4866
+#: Merge.rc:1048 Merge.rc:4865
 #, c-format
 msgid "Both to... (%1 of %2)"
 msgstr "兩邊到... (%1／%2)"
 
 #. IDS_COPY_ALL_TO2
-#: Merge.rc:1049 Merge.rc:4867
+#: Merge.rc:1049 Merge.rc:4866
 #, c-format
 msgid "All to... (%1 of %2)"
 msgstr "全部到... (%1／%2)"
 
 #. IDS_COPY_DIFFERENCES_TO2
-#: Merge.rc:1050 Merge.rc:4868
+#: Merge.rc:1050 Merge.rc:4867
 #, c-format
 msgid "Differences to... (%1 of %2)"
 msgstr "差異到... (%1／%2)"
@@ -1818,12 +1818,12 @@ msgstr "解包裝器設定"
 
 #. IDS_USERCHOICE_NONE
 #: Merge.rc:1088 Merge.rc:1094 Merge.rc:1836 Merge.rc:1840 Merge.rc:2031
-#: Merge.rc:2035 Merge.rc:5377
+#: Merge.rc:2035 Merge.rc:5376
 msgid "<None>"
 msgstr "<無>"
 
 #. IDS_USERCHOICE_AUTOMATIC
-#: Merge.rc:1089 Merge.rc:1095 Merge.rc:5378
+#: Merge.rc:1089 Merge.rc:1095 Merge.rc:5377
 msgid "<Automatic>"
 msgstr "<自動>"
 
@@ -2753,12 +2753,12 @@ msgid "Text files only"
 msgstr "僅文字檔案"
 
 #. IDS_EOL_NONE
-#: Merge.rc:1667 Merge.rc:1918 Merge.rc:5304
+#: Merge.rc:1667 Merge.rc:1918 Merge.rc:5303
 msgid "None"
 msgstr "無"
 
 #. IDS_EOL_MIXED
-#: Merge.rc:1668 Merge.rc:5299
+#: Merge.rc:1668 Merge.rc:5298
 msgid "Mixed"
 msgstr "混合"
 
@@ -3030,13 +3030,13 @@ msgstr "行狀態 (&S)"
 
 #. IDS_DIFFERENT
 #: Merge.rc:1904 Merge.rc:1988 Merge.rc:2866 Merge.rc:3036 Merge.rc:3077
-#: Merge.rc:5058
+#: Merge.rc:5057
 msgid "Different"
 msgstr "不同"
 
 #. IDS_IDENTICAL
 #: Merge.rc:1905 Merge.rc:1989 Merge.rc:2865 Merge.rc:3055 Merge.rc:3116
-#: Merge.rc:5048
+#: Merge.rc:5047
 msgid "Identical"
 msgstr "完全相同"
 
@@ -3056,7 +3056,7 @@ msgid "Missing"
 msgstr "遺失了"
 
 #. IDS_MOVED
-#: Merge.rc:1910 Merge.rc:5076
+#: Merge.rc:1910 Merge.rc:5075
 msgid "Moved"
 msgstr "已移動"
 
@@ -3795,7 +3795,7 @@ msgid "&Use custom system colors"
 msgstr "使用自訂系統顏色 (&U)"
 
 #. IDS_PRPCAT_SYSTEM
-#: Merge.rc:2565 Merge.rc:4559 Merge.rc:4560 Merge.rc:5007
+#: Merge.rc:2565 Merge.rc:4559 Merge.rc:4560 Merge.rc:5006
 msgid "System"
 msgstr "系統"
 
@@ -4199,7 +4199,7 @@ msgid "Items compared:"
 msgstr "比對過的項目："
 
 #. IDS_PREVIEWBAR_CLOSE
-#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5685
+#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5684
 msgid "&Close"
 msgstr "關閉 (&C)"
 
@@ -4822,7 +4822,7 @@ msgid "A&ppend timestamp"
 msgstr "附上時間戳記 (&P)"
 
 #. IDS_CONFIRM_COPY_CAPTION
-#: Merge.rc:3214 Merge.rc:4915
+#: Merge.rc:3214 Merge.rc:4914
 msgid "Confirm Copy"
 msgstr "確認複製"
 
@@ -5059,7 +5059,7 @@ msgid "&Character Set..."
 msgstr "字元設定... (&C)"
 
 #. IDS_PRPCAT_IMAGE
-#: Merge.rc:3351 Merge.rc:4574 Merge.rc:5015
+#: Merge.rc:3351 Merge.rc:4574 Merge.rc:5014
 msgid "Image"
 msgstr "圖片"
 
@@ -5472,7 +5472,7 @@ msgid "Project"
 msgstr "專案"
 
 #. IDS_COLHDR_NSDIFFS
-#: Merge.rc:4566 Merge.rc:4990
+#: Merge.rc:4566 Merge.rc:4989
 msgid "Differences"
 msgstr "差異"
 
@@ -5623,12 +5623,12 @@ msgid "File Type"
 msgstr "檔案類型"
 
 #. IDS_COLHDR_EXTENSION
-#: Merge.rc:4653 Merge.rc:4947
+#: Merge.rc:4653 Merge.rc:4946
 msgid "Extension"
 msgstr "副檔名"
 
 #. IDS_PRPCAT_MESSAGE
-#: Merge.rc:4659 Merge.rc:5019
+#: Merge.rc:4659 Merge.rc:5018
 msgid "Message"
 msgstr "訊息"
 
@@ -5668,7 +5668,7 @@ msgid "Hidden Items"
 msgstr "隱藏的項目"
 
 #. IDS_PLUGINSLIST_NAME
-#: Merge.rc:4680 Merge.rc:5311
+#: Merge.rc:4680 Merge.rc:5310
 msgid "Name"
 msgstr "名稱"
 
@@ -5688,7 +5688,7 @@ msgid "[F] "
 msgstr "[F] "
 
 #. IDS_PLUGINSLIST_DESC
-#: Merge.rc:4684 Merge.rc:5313
+#: Merge.rc:4684 Merge.rc:5312
 msgid "Description"
 msgstr "描述"
 
@@ -5857,155 +5857,150 @@ msgstr "行: %s  列: %d/%d  字元: %d/%d"
 msgid "  Sel: %d | %d"
 msgstr "  選取：%d 行| %d 字元"
 
-#. IDS_MERGEMODE_MERGING
-#: Merge.rc:4734
-msgid "Merge"
-msgstr "合併"
-
 #. IDS_DIFF_NUMBER_STATUS_FMT
-#: Merge.rc:4735
+#: Merge.rc:4734
 #, c-format
 msgid "Difference %1 of %2"
 msgstr "%2 個差異中 第 %1 個"
 
 #. IDS_NO_DIFF_SEL_FMT
-#: Merge.rc:4736
+#: Merge.rc:4735
 #, c-format
 msgid "%1 Differences Found"
 msgstr "找到 %1 個差異"
 
 #. IDS_1_DIFF_FOUND
-#: Merge.rc:4737
+#: Merge.rc:4736
 msgid "1 Difference Found"
 msgstr "找到 1 個差異"
 
 #. IDS_NO_ERR_SEL_FMT
-#: Merge.rc:4738
+#: Merge.rc:4737
 #, c-format
 msgid "%1 Errors Found"
 msgstr "發現 %1 個錯誤"
 
 #. IDS_1_ERR_FOUND
-#: Merge.rc:4739
+#: Merge.rc:4738
 msgid "1 Error Found"
 msgstr "發現 1 個錯誤"
 
 #. IDS_STATUSBAR_READONLY, Abbreviation from "Read Only"
-#: Merge.rc:4740
+#: Merge.rc:4739
 msgid "RO"
 msgstr "唯讀"
 
 #. IDS_DIRVIEW_STATUS_FMT_FOCUS
-#: Merge.rc:4746
+#: Merge.rc:4745
 #, c-format
 msgid "Item %1 of %2"
 msgstr "%2 個項目之 第 %1"
 
 #. IDS_DIRVIEW_STATUS_FMT_NOFOCUS
-#: Merge.rc:4747
+#: Merge.rc:4746
 #, c-format
 msgid "Items: %1"
 msgstr "項目：%1"
 
 #. IDS_DIRVIEW_STATUS_COMPARING
-#: Merge.rc:4748
+#: Merge.rc:4747
 msgid "Comparing items..."
 msgstr "比對項目中..."
 
 #. IDS_ITEMS_PER_SEC
-#: Merge.rc:4749
+#: Merge.rc:4748
 #, c-format
 msgid "%.1f[items/sec]"
 msgstr "%.1f[項目/秒]"
 
 #. IDS_ERROR_INCOMPARABLE
-#: Merge.rc:4755
+#: Merge.rc:4754
 msgid "Select two existing folders/files to compare."
 msgstr "選取兩個現存資料夾或檔案做比對。"
 
 #. IDS_DIRSEL_TAG
-#: Merge.rc:4756
+#: Merge.rc:4755
 msgid "Folder Selection"
 msgstr "資料夾選取"
 
 #. IDS_OPEN_FILESDIRS
-#: Merge.rc:4757
+#: Merge.rc:4756
 msgid "Select two (or three) folders/files to compare."
 msgstr "選取兩個 (或三個) 檔案或資料夾做比對。"
 
 #. IDS_OPEN_LEFTINVALID
-#: Merge.rc:4758
+#: Merge.rc:4757
 msgid "Left (1st) path is invalid!"
 msgstr "左側 (第一) 路徑無效！"
 
 #. IDS_OPEN_MIDDLEINVALID
-#: Merge.rc:4759
+#: Merge.rc:4758
 msgid "Middle (2nd) path is invalid!"
 msgstr "中間 (第二) 路徑無效！"
 
 #. IDS_OPEN_RIGHTINVALID2
-#: Merge.rc:4760
+#: Merge.rc:4759
 msgid "Right (2nd) path is invalid!"
 msgstr "右側 (第二) 路徑無效！"
 
 #. IDS_OPEN_RIGHTINVALID3
-#: Merge.rc:4761
+#: Merge.rc:4760
 msgid "Right (3rd) path is invalid!"
 msgstr "右側 (第三) 路徑無效！"
 
 #. IDS_OPEN_BOTHINVALID
-#: Merge.rc:4762
+#: Merge.rc:4761
 msgid "Both paths are invalid!"
 msgstr "兩邊路徑無效！"
 
-#: Merge.rc:4764
+#: Merge.rc:4763
 msgid "Left (1st) and Middle (2nd) paths are invalid!"
 msgstr "左側 (第一) 及中間 (第二) 路徑無效！"
 
 #. IDS_OPEN_LEFTRIGHTINVALID
-#: Merge.rc:4765
+#: Merge.rc:4764
 msgid "Left (1st) and Right (3rd) paths are invalid!"
 msgstr "左側 (第一) 及右側 (第三) 路徑無效！"
 
-#: Merge.rc:4767
+#: Merge.rc:4766
 msgid "Middle (2nd) and Right (3rd) paths are invalid!"
 msgstr "中間 (第二) 及右側 (第三) 路徑無效！"
 
 #. IDS_OPEN_ALLINVALID
-#: Merge.rc:4768
+#: Merge.rc:4767
 msgid "All paths are invalid!"
 msgstr "所有路徑無效！"
 
 #. IDS_OPEN_UNPACKERDISABLED
-#: Merge.rc:4769
+#: Merge.rc:4768
 msgid "Only enabled for file comparisons"
 msgstr "僅為檔案比對啟用"
 
 #. IDS_OPEN_MISMATCH
-#: Merge.rc:4770
+#: Merge.rc:4769
 msgid "Cannot compare file and folder!"
 msgstr "無法比對檔案和資料夾！"
 
 #. IDS_ERROR_FILE_NOT_FOUND
-#: Merge.rc:4776
+#: Merge.rc:4775
 #, c-format
 msgid "File not found: %1"
 msgstr "找不到檔案：%1"
 
 #. IDS_ERROR_FOLDER_NOT_FOUND
-#: Merge.rc:4777
+#: Merge.rc:4776
 #, c-format
 msgid "Folder not found: %1"
 msgstr "找不到資料夾：%1"
 
 #. IDS_ERROR_FILE_NOT_UNPACKED
-#: Merge.rc:4778
+#: Merge.rc:4777
 #, c-format
 msgid "File not unpacked: %1"
 msgstr "檔案未解包：%1"
 
 #. IDS_ERROR_FILEOPEN
-#: Merge.rc:4779
+#: Merge.rc:4778
 #, c-format
 msgid ""
 "Cannot open file\n"
@@ -6019,12 +6014,12 @@ msgstr ""
 "%2"
 
 #. IDS_ERROR_CONF_RESOLVE
-#: Merge.rc:4780
+#: Merge.rc:4779
 msgid "Failed to parse conflict file."
 msgstr "無法解析衝突檔。"
 
 #. IDS_NOT_CONFLICT_FILE
-#: Merge.rc:4781
+#: Merge.rc:4780
 #, c-format
 msgid ""
 "The file\n"
@@ -6036,7 +6031,7 @@ msgstr ""
 "不是衝突檔。"
 
 #. IDS_COMPARE_LARGE_FILES
-#: Merge.rc:4782
+#: Merge.rc:4781
 msgid ""
 "Comparing large files requires significant memory.\n"
 "Show only comparison results (not file contents)?"
@@ -6045,28 +6040,28 @@ msgstr ""
 "是否僅顯示比對結果（不顯示檔案內容）？"
 
 #. IDS_SAVE_AS_TITLE
-#: Merge.rc:4788
+#: Merge.rc:4787
 msgid "Save As"
 msgstr "另存新檔"
 
 #. IDS_SAVE_FMT
-#: Merge.rc:4789
+#: Merge.rc:4788
 #, c-format
 msgid "Save changes to %1?"
 msgstr "儲存更改到 %1？"
 
 #. IDS_SAVEREADONLY_FMT
-#: Merge.rc:4790
+#: Merge.rc:4789
 #, c-format
 msgid "%1 is read-only. Override? Or 'No' to save as new filename?"
 msgstr "%1 是唯讀檔。要強制覆蓋嗎？或選擇「否」另存新檔？"
 
 #. IDS_ERROR_BACKUP
-#: Merge.rc:4791
+#: Merge.rc:4790
 msgid "Error backing up file"
 msgstr "備份檔案時發生錯誤"
 
-#: Merge.rc:4793
+#: Merge.rc:4792
 #, c-format
 msgid ""
 "Unable to backup original file:\n"
@@ -6080,7 +6075,7 @@ msgstr ""
 "仍舊繼續嗎？"
 
 #. IDS_FILESAVE_FAILED
-#: Merge.rc:4794
+#: Merge.rc:4793
 #, c-format
 msgid ""
 "Saving file failed.\n"
@@ -6095,7 +6090,7 @@ msgstr ""
 "\t- 存為不同檔名 (確定)\n"
 "\t- 中斷 (取消)？"
 
-#: Merge.rc:4796
+#: Merge.rc:4795
 #, c-format
 msgid ""
 "Plugin '%2' cannot pack changes to left file into '%1'.\n"
@@ -6107,7 +6102,7 @@ msgstr ""
 "原始檔未變更。\n"
 "是否儲存解包後的版本？"
 
-#: Merge.rc:4798
+#: Merge.rc:4797
 #, c-format
 msgid ""
 "Plugin '%2' cannot pack changes to middle file into '%1'.\n"
@@ -6119,7 +6114,7 @@ msgstr ""
 "原始檔未變更。\n"
 "是否儲存解包後的版本？"
 
-#: Merge.rc:4800
+#: Merge.rc:4799
 #, c-format
 msgid ""
 "Plugin '%2' cannot pack changes to right file into '%1'.\n"
@@ -6132,7 +6127,7 @@ msgstr ""
 "是否儲存解包後的版本？"
 
 #. IDS_FILECHANGED_ONDISK
-#: Merge.rc:4801
+#: Merge.rc:4800
 #, c-format
 msgid ""
 "Another application updated\n"
@@ -6148,7 +6143,7 @@ msgstr ""
 "是否覆蓋為更新後檔案？"
 
 #. IDS_SAVEREADONLY_MULTI
-#: Merge.rc:4802
+#: Merge.rc:4801
 #, c-format
 msgid ""
 "%1\n"
@@ -6158,7 +6153,7 @@ msgstr ""
 "是唯讀檔。要強制覆蓋嗎？"
 
 #. IDS_FILECHANGED_RESCAN
-#: Merge.rc:4803
+#: Merge.rc:4802
 #, c-format
 msgid ""
 "Another application updated\n"
@@ -6174,22 +6169,22 @@ msgstr ""
 "要重新讀取嗎？"
 
 #. IDS_SAVE_LEFT_AS
-#: Merge.rc:4804
+#: Merge.rc:4803
 msgid "Save Left File As"
 msgstr "儲存左側檔案為"
 
 #. IDS_SAVE_MIDDLE_AS
-#: Merge.rc:4805
+#: Merge.rc:4804
 msgid "Save Middle File As"
 msgstr "儲存中間檔案為"
 
 #. IDS_SAVE_RIGHT_AS
-#: Merge.rc:4806
+#: Merge.rc:4805
 msgid "Save Right File As"
 msgstr "儲存右側檔案為"
 
 #. IDS_FILE_DISAPPEARED
-#: Merge.rc:4811
+#: Merge.rc:4810
 #, c-format
 msgid ""
 "File\n"
@@ -6201,7 +6196,7 @@ msgstr ""
 "消失。請儲存檔案副本再繼續。"
 
 #. IDS_VIEWS_OUTOFSYNC
-#: Merge.rc:4817
+#: Merge.rc:4816
 msgid ""
 "Cannot merge unsynched documents.\n"
 "\n"
@@ -6212,124 +6207,124 @@ msgstr ""
 "請在繼續之前先重新整理。"
 
 #. IDS_BREAK_ON_WHITESPACE
-#: Merge.rc:4822
+#: Merge.rc:4821
 msgid "Break at whitespace"
 msgstr "空白字元處斷行"
 
 #. IDS_BREAK_ON_PUNCTUATION
-#: Merge.rc:4823
+#: Merge.rc:4822
 msgid "Break at whitespace or punctuation"
 msgstr "在空白字元或標點符號處斷行"
 
 #. IDS_L2M
-#: Merge.rc:4829
+#: Merge.rc:4828
 msgid "Copy to &Middle\tAlt+Right"
 msgstr "複製到中間 (&M)\tAlt+Right"
 
 #. IDS_R2M
-#: Merge.rc:4830
+#: Merge.rc:4829
 msgid "Copy to &Middle\tAlt+Left"
 msgstr "複製到中間 (&M)\tAlt+Left"
 
 #. IDS_COPY_FROM_MIDDLE_R
-#: Merge.rc:4831
+#: Merge.rc:4830
 msgid "Copy from Middle\tAlt+Shift+Right"
 msgstr "從中間複製\tAlt+Shift+Right"
 
 #. IDS_COPY_FROM_MIDDLE_L
-#: Merge.rc:4832
+#: Merge.rc:4831
 msgid "Copy from Middle\tAlt+Shift+Left"
 msgstr "從中間複製\tAlt+Shift+Left"
 
 #. IDS_L2MNEXT
-#: Merge.rc:4833
+#: Merge.rc:4832
 msgid "Copy to Middle and Advance\tCtrl+Alt+Right"
 msgstr "複製至中間並前進\tCtrl+Alt+Right"
 
 #. IDS_R2MNEXT
-#: Merge.rc:4834
+#: Merge.rc:4833
 msgid "Copy to Middle and Advance\tCtrl+Alt+Left"
 msgstr "複製至中間並前進\tCtrl+Alt+Left"
 
 #. IDS_ALL_MIDDLE
-#: Merge.rc:4835
+#: Merge.rc:4834
 msgid "Copy All to Middle"
 msgstr "全部複製到中間"
 
 #. IDS_COPY_RIGHT_TO_LEFT
-#: Merge.rc:4841
+#: Merge.rc:4840
 #, c-format
 msgid "Right to Left (%1)"
 msgstr "右側到左側 (%1)"
 
 #. IDS_COPY_RIGHT_TO_MIDDLE
-#: Merge.rc:4842
+#: Merge.rc:4841
 #, c-format
 msgid "Right to Middle (%1)"
 msgstr "右側到中間 (%1)"
 
 #. IDS_COPY_MIDDLE_TO_LEFT
-#: Merge.rc:4843
+#: Merge.rc:4842
 #, c-format
 msgid "Middle to Left (%1)"
 msgstr "中間到左側 (%1)"
 
 #. IDS_COPY_MIDDLE_TO_RIGHT
-#: Merge.rc:4844
+#: Merge.rc:4843
 #, c-format
 msgid "Middle to Right (%1)"
 msgstr "中間到右側 (%1)"
 
 #. IDS_COPY_LEFT_TO_RIGHT
-#: Merge.rc:4845
+#: Merge.rc:4844
 #, c-format
 msgid "Left to Right (%1)"
 msgstr "左側到右側 (%1)"
 
 #. IDS_COPY_LEFT_TO_MIDDLE
-#: Merge.rc:4846
+#: Merge.rc:4845
 #, c-format
 msgid "Left to Middle (%1)"
 msgstr "左側到中間 (%1)"
 
 #. IDS_MOVE_LEFT_TO
-#: Merge.rc:4857 Merge.rc:4889
+#: Merge.rc:4856 Merge.rc:4888
 #, c-format
 msgid "Left to... (%1)"
 msgstr "左側到... (%1)"
 
 #. IDS_MOVE_MIDDLE_TO
-#: Merge.rc:4858 Merge.rc:4890
+#: Merge.rc:4857 Merge.rc:4889
 #, c-format
 msgid "Middle to... (%1)"
 msgstr "中間到... (%1)"
 
 #. IDS_MOVE_RIGHT_TO
-#: Merge.rc:4859 Merge.rc:4891
+#: Merge.rc:4858 Merge.rc:4890
 #, c-format
 msgid "Right to... (%1)"
 msgstr "右側到... (%1)"
 
 #. IDS_COPY_BOTH_TO
-#: Merge.rc:4860
+#: Merge.rc:4859
 #, c-format
 msgid "Both to... (%1)"
 msgstr "兩邊到... (%1)"
 
 #. IDS_COPY_ALL_TO
-#: Merge.rc:4861
+#: Merge.rc:4860
 #, c-format
 msgid "All to... (%1)"
 msgstr "全部到... (%1)"
 
 #. IDS_COPY_DIFFERENCES_TO
-#: Merge.rc:4862
+#: Merge.rc:4861
 #, c-format
 msgid "Differences to... (%1)"
 msgstr "差異到... (%1)"
 
 #. IDS_ONLYDIFFITEMS_CONFIRM
-#: Merge.rc:4869
+#: Merge.rc:4868
 msgid ""
 "Some selected items are identical or skipped.\n"
 "Process only items with differences?"
@@ -6338,64 +6333,64 @@ msgstr ""
 "僅處理有差異的項目？"
 
 #. IDS_DEL_LEFT_FMT
-#: Merge.rc:4875
+#: Merge.rc:4874
 #, c-format
 msgid "Left (%1)"
 msgstr "左側 (%1)"
 
 #. IDS_DEL_MIDDLE_FMT
-#: Merge.rc:4876
+#: Merge.rc:4875
 #, c-format
 msgid "Middle (%1)"
 msgstr "中間 (%1)"
 
 #. IDS_DEL_RIGHT_FMT
-#: Merge.rc:4877
+#: Merge.rc:4876
 #, c-format
 msgid "Right (%1)"
 msgstr "右側 (%1)"
 
 #. IDS_DEL_BOTH_FMT
-#: Merge.rc:4878
+#: Merge.rc:4877
 #, c-format
 msgid "Both (%1)"
 msgstr "兩邊 (%1)"
 
 #. IDS_DEL_ALL_FMT
-#: Merge.rc:4879
+#: Merge.rc:4878
 #, c-format
 msgid "All (%1)"
 msgstr "全部 (%1)"
 
 #. IDS_SELECT_DEST_LEFT
-#: Merge.rc:4895
+#: Merge.rc:4894
 msgid "Left Side - Select Destination Folder:"
 msgstr "左側 - 選取目標資料夾："
 
 #. IDS_SELECT_DEST_MIDDLE
-#: Merge.rc:4896
+#: Merge.rc:4895
 msgid "Middle Side - Select Destination Folder:"
 msgstr "中間 - 選取目標資料夾："
 
 #. IDS_SELECT_DEST_RIGHT
-#: Merge.rc:4897
+#: Merge.rc:4896
 msgid "Right Side - Select Destination Folder:"
 msgstr "右側 - 選取目標資料夾："
 
 #. IDS_FILES_AFFECTED_FMT
-#: Merge.rc:4898
+#: Merge.rc:4897
 #, c-format
 msgid "(%1 Files Affected)"
 msgstr "(%1 受影響檔案)"
 
 #. IDS_FILES_AFFECTED_FMT2
-#: Merge.rc:4899
+#: Merge.rc:4898
 #, c-format
 msgid "(%1 of %2 Files Affected)"
 msgstr "(%2 受影響檔案之 %1)"
 
 #. IDS_CONFIRM_DELETE_SINGLE
-#: Merge.rc:4905
+#: Merge.rc:4904
 #, c-format
 msgid ""
 "Are you sure you want to delete\n"
@@ -6407,18 +6402,18 @@ msgstr ""
 "%1？"
 
 #. IDS_CONFIRM_SINGLE_COPY
-#: Merge.rc:4906
+#: Merge.rc:4905
 msgid "Are you sure you want to copy?"
 msgstr "確定要複製？"
 
 #. IDS_CONFIRM_MULTIPLE_COPY
-#: Merge.rc:4907
+#: Merge.rc:4906
 #, c-format
 msgid "Are you sure you want to copy %d items?"
 msgstr "確定要複製 %d 項目？"
 
 #. IDS_DIRCMP_NOTSYNC
-#: Merge.rc:4908
+#: Merge.rc:4907
 #, c-format
 msgid ""
 "Operation aborted!\n"
@@ -6437,46 +6432,46 @@ msgstr ""
 "請重新整理再比對。"
 
 #. IDS_CONFIRM_SINGLE_MOVE
-#: Merge.rc:4913
+#: Merge.rc:4912
 msgid "Are you sure you want to move?"
 msgstr "確定要移除？"
 
 #. IDS_CONFIRM_MULTIPLE_MOVE
-#: Merge.rc:4914
+#: Merge.rc:4913
 #, c-format
 msgid "Are you sure you want to move %d items?"
 msgstr "確定要移除 %d 項目？"
 
 #. IDS_CONFIRM_MOVE_CAPTION
-#: Merge.rc:4916
+#: Merge.rc:4915
 msgid "Confirm Move"
 msgstr "確認移除"
 
-#: Merge.rc:4918
+#: Merge.rc:4917
 msgid "Close the folder comparison window?"
 msgstr "您要關閉一個正在比對資料夾的視窗，您確定要關閉視窗嗎？"
 
-#: Merge.rc:4920
+#: Merge.rc:4919
 msgid "Close the folder comparison window, which took a long time?"
 msgstr "關閉資料夾比對視窗嗎？，花了很長時間哦!?"
 
 #. IDS_ERROR_INVALID_DIR_FILE_NAME
-#: Merge.rc:4921
+#: Merge.rc:4920
 msgid "The file or folder name is invalid."
 msgstr "檔案或資料夾名稱無效。"
 
 #. IDS_ERROR_EXECUTE_FILE
-#: Merge.rc:4927
+#: Merge.rc:4926
 #, c-format
 msgid "Failed to execute external editor: %1"
 msgstr "無法執行外部編輯器 %1"
 
 #. IDS_UNKNOWN_ARCHIVE_FORMAT
-#: Merge.rc:4933
+#: Merge.rc:4932
 msgid "Unknown archive format"
 msgstr "未知封存檔格式"
 
-#: Merge.rc:4935
+#: Merge.rc:4934
 msgid ""
 "Failed to extract archive.\n"
 "Compare as text file?"
@@ -6485,513 +6480,513 @@ msgstr ""
 "要改以文字檔比對嗎？"
 
 #. IDS_COLHDR_FILENAME
-#: Merge.rc:4941
+#: Merge.rc:4940
 msgid "Filename"
 msgstr "檔案名稱"
 
 #. IDS_COLHDR_DIR
-#: Merge.rc:4942
+#: Merge.rc:4941
 msgctxt "DirView|ColumnHeader"
 msgid "Folder"
 msgstr "資料夾"
 
 #. IDS_COLHDR_RESULT
-#: Merge.rc:4943
+#: Merge.rc:4942
 msgid "Comparison Result"
 msgstr "比對結果"
 
 #. IDS_COLHDR_LTIMEM
-#: Merge.rc:4944
+#: Merge.rc:4943
 msgid "Left Date"
 msgstr "左側日期"
 
 #. IDS_COLHDR_RTIMEM
-#: Merge.rc:4945
+#: Merge.rc:4944
 msgid "Right Date"
 msgstr "右側日期"
 
 #. IDS_COLHDR_MTIMEM
-#: Merge.rc:4946
+#: Merge.rc:4945
 msgid "Middle Date"
 msgstr "中間日期"
 
 #. IDS_COLHDR_LSIZE
-#: Merge.rc:4948
+#: Merge.rc:4947
 msgid "Left Size"
 msgstr "左側大小"
 
 #. IDS_COLHDR_RSIZE
-#: Merge.rc:4949
+#: Merge.rc:4948
 msgid "Right Size"
 msgstr "右側大小"
 
 #. IDS_COLHDR_MSIZE
-#: Merge.rc:4954
+#: Merge.rc:4953
 msgid "Middle Size"
 msgstr "中間大小"
 
 #. IDS_COLHDR_RSIZE_SHORT
-#: Merge.rc:4955
+#: Merge.rc:4954
 msgid "Right Size (Short)"
 msgstr "右側大小 (簡式)"
 
 #. IDS_COLHDR_LSIZE_SHORT
-#: Merge.rc:4956
+#: Merge.rc:4955
 msgid "Left Size (Short)"
 msgstr "左側大小 (簡式)"
 
 #. IDS_COLHDR_MSIZE_SHORT
-#: Merge.rc:4957
+#: Merge.rc:4956
 msgid "Middle Size (Short)"
 msgstr "中間大小 (簡式)"
 
 #. IDS_COLHDR_LTIMEC
-#: Merge.rc:4963
+#: Merge.rc:4962
 msgid "Left Creation Time"
 msgstr "左側建立時間"
 
 #. IDS_COLHDR_RTIMEC
-#: Merge.rc:4964
+#: Merge.rc:4963
 msgid "Right Creation Time"
 msgstr "右側建立時間"
 
 #. IDS_COLHDR_MTIMEC
-#: Merge.rc:4965
+#: Merge.rc:4964
 msgid "Middle Creation Time"
 msgstr "中間建立時間"
 
 #. IDS_COLHDR_NEWER
-#: Merge.rc:4966
+#: Merge.rc:4965
 msgid "Newer File"
 msgstr "較新檔案"
 
 #. IDS_COLHDR_LVERSION
-#: Merge.rc:4967
+#: Merge.rc:4966
 msgid "Left File Version"
 msgstr "左側檔案版本"
 
 #. IDS_COLHDR_RVERSION
-#: Merge.rc:4968
+#: Merge.rc:4967
 msgid "Right File Version"
 msgstr "右側檔案版本"
 
 #. IDS_COLHDR_MVERSION
-#: Merge.rc:4969
+#: Merge.rc:4968
 msgid "Middle File Version"
 msgstr "中間檔案版本"
 
 #. IDS_COLHDR_RESULT_ABBR
-#: Merge.rc:4970
+#: Merge.rc:4969
 msgid "Short Result"
 msgstr "簡式結果"
 
 #. IDS_COLHDR_LATTRIBUTES
-#: Merge.rc:4971
+#: Merge.rc:4970
 msgid "Left Attributes"
 msgstr "左側屬性"
 
 #. IDS_COLHDR_RATTRIBUTES
-#: Merge.rc:4972
+#: Merge.rc:4971
 msgid "Right Attributes"
 msgstr "右側屬性"
 
 #. IDS_COLHDR_MATTRIBUTES
-#: Merge.rc:4973
+#: Merge.rc:4972
 msgid "Middle Attributes"
 msgstr "中間屬性"
 
 #. IDS_COLHDR_LEOL_TYPE
-#: Merge.rc:4978
+#: Merge.rc:4977
 msgid "Left EOL"
 msgstr "左側 EOL"
 
 #. IDS_COLHDR_MEOL_TYPE
-#: Merge.rc:4979
+#: Merge.rc:4978
 msgid "Middle EOL"
 msgstr "中間 EOL"
 
 #. IDS_COLHDR_REOL_TYPE
-#: Merge.rc:4980
+#: Merge.rc:4979
 msgid "Right EOL"
 msgstr "右側 EOL"
 
 #. IDS_COLHDR_LENCODING
-#: Merge.rc:4986
+#: Merge.rc:4985
 msgid "Left Encoding"
 msgstr "左側編碼"
 
 #. IDS_COLHDR_RENCODING
-#: Merge.rc:4987
+#: Merge.rc:4986
 msgid "Right Encoding"
 msgstr "右側編碼"
 
 #. IDS_COLHDR_MENCODING
-#: Merge.rc:4988
+#: Merge.rc:4987
 msgid "Middle Encoding"
 msgstr "中間編碼"
 
 #. IDS_COLHDR_NIDIFFS
-#: Merge.rc:4989
+#: Merge.rc:4988
 msgid "Ignored Diff"
 msgstr "忽略的差異"
 
 #. IDS_COLHDR_BINARY
-#: Merge.rc:4991
+#: Merge.rc:4990
 msgctxt "DirView|ColumnHeader"
 msgid "Binary"
 msgstr "二進位"
 
 #. IDS_PLUGINS_TYPE_UNPACKER
-#: Merge.rc:4992 Merge.rc:5314
+#: Merge.rc:4991 Merge.rc:5313
 msgid "Unpacker"
 msgstr "解包裝器"
 
 #. IDS_PLUGIN_TYPE4
-#: Merge.rc:4993 Merge.rc:5315 Merge.rc:5622
+#: Merge.rc:4992 Merge.rc:5314 Merge.rc:5621
 msgid "Prediffer"
 msgstr "預差異器"
 
 #. IDS_COLHDR_LEFT
-#: Merge.rc:4994
+#: Merge.rc:4993
 msgid "Left"
 msgstr "左側"
 
 #. IDS_COLHDR_MIDDLE
-#: Merge.rc:4995
+#: Merge.rc:4994
 msgid "Middle"
 msgstr "中間"
 
 #. IDS_COLHDR_RIGHT
-#: Merge.rc:4996
+#: Merge.rc:4995
 msgid "Right"
 msgstr "右側"
 
 #. IDS_COLHDR_DIFF
-#: Merge.rc:4997
+#: Merge.rc:4996
 msgid "Diff"
 msgstr "差異"
 
 #. IDS_COLHDR_LEFT_DUPLICATE
-#: Merge.rc:4998
+#: Merge.rc:4997
 msgid "Left Duplicate Count"
 msgstr "左側重複數"
 
 #. IDS_COLHDR_RIGHT_DUPLICATE
-#: Merge.rc:4999
+#: Merge.rc:4998
 msgid "Right Duplicate Count"
 msgstr "右側重複數"
 
 #. IDS_COLHDR_MIDDLE_DUPLICATE
-#: Merge.rc:5000
+#: Merge.rc:4999
 msgid "Middle Duplicate Count"
 msgstr "中間重複數"
 
 #. IDS_COLHDR_MOVE
-#: Merge.rc:5001
+#: Merge.rc:5000
 msgid "Move"
 msgstr "移動"
 
 #. IDS_PRPCAT_AUDIO
-#: Merge.rc:5008
+#: Merge.rc:5007
 msgid "Audio"
 msgstr "音訊"
 
 #. IDS_PRPCAT_CALENDAR
-#: Merge.rc:5009
+#: Merge.rc:5008
 msgid "Calendar"
 msgstr "日曆"
 
 #. IDS_PRPCAT_COMMUNICATION
-#: Merge.rc:5010
+#: Merge.rc:5009
 msgid "Communication"
 msgstr "通訊"
 
 #. IDS_PRPCAT_CONTACT
-#: Merge.rc:5011
+#: Merge.rc:5010
 msgid "Contact"
 msgstr "聯絡人"
 
 #. IDS_PRPCAT_DEVICES
-#: Merge.rc:5012
+#: Merge.rc:5011
 msgid "Devices"
 msgstr "裝置"
 
 #. IDS_PRPCAT_DOCUMENT
-#: Merge.rc:5013
+#: Merge.rc:5012
 msgid "Document"
 msgstr "文件"
 
 #. IDS_PRPCAT_HOME
-#: Merge.rc:5014
+#: Merge.rc:5013
 msgid "Home"
 msgstr "主頁"
 
 #. IDS_PRPCAT_JOURNAL
-#: Merge.rc:5016
+#: Merge.rc:5015
 msgid "Journal"
 msgstr "日誌"
 
 #. IDS_PRPCAT_LINK
-#: Merge.rc:5017
+#: Merge.rc:5016
 msgid "Link"
 msgstr "連結"
 
 #. IDS_PRPCAT_MEDIA
-#: Merge.rc:5018
+#: Merge.rc:5017
 msgid "Media"
 msgstr "媒體"
 
 #. IDS_PRPCAT_MUSIC
-#: Merge.rc:5020
+#: Merge.rc:5019
 msgid "Music"
 msgstr "音樂"
 
 #. IDS_PRPCAT_NOTE
-#: Merge.rc:5021
+#: Merge.rc:5020
 msgid "Note"
 msgstr "筆記"
 
 #. IDS_PRPCAT_PHOTO
-#: Merge.rc:5022
+#: Merge.rc:5021
 msgid "Photo"
 msgstr "照片"
 
 #. IDS_PRPCAT_RECORDEDTV
-#: Merge.rc:5023
+#: Merge.rc:5022
 msgid "RecordedTV"
 msgstr "RecordedTV"
 
 #. IDS_PRPCAT_SEARCH
-#: Merge.rc:5024
+#: Merge.rc:5023
 msgid "Search"
 msgstr "搜尋"
 
 #. IDS_PRPCAT_SECURITY
-#: Merge.rc:5025
+#: Merge.rc:5024
 msgid "Security"
 msgstr "安全性"
 
 #. IDS_PRPCAT_SOFTWARE
-#: Merge.rc:5026
+#: Merge.rc:5025
 msgid "Software"
 msgstr "軟體"
 
 #. IDS_PRPCAT_TASK
-#: Merge.rc:5027
+#: Merge.rc:5026
 msgid "Task"
 msgstr "工作"
 
 #. IDS_PRPCAT_VIDEO
-#: Merge.rc:5028
+#: Merge.rc:5027
 msgid "Video"
 msgstr "影片"
 
 #. IDS_PRPCAT_HASH
-#: Merge.rc:5029
+#: Merge.rc:5028
 msgid "Hash"
 msgstr "雜湊"
 
 #. IDS_CANT_COMPARE_FILES
-#: Merge.rc:5035
+#: Merge.rc:5034
 msgid "Unable to compare files"
 msgstr "無法比對檔案"
 
 #. IDS_ABORTED_ITEM
-#: Merge.rc:5036
+#: Merge.rc:5035
 msgid "Item aborted"
 msgstr "項目已中斷"
 
 #. IDS_FILE_SKIPPED
-#: Merge.rc:5037
+#: Merge.rc:5036
 msgid "File skipped"
 msgstr "略過的檔案"
 
 #. IDS_DIR_SKIPPED
-#: Merge.rc:5038
+#: Merge.rc:5037
 msgid "Folder skipped"
 msgstr "略過的資料夾"
 
 #. IDS_LEFT_ONLY_IN_FMT
-#: Merge.rc:5039
+#: Merge.rc:5038
 #, c-format
 msgid "Left only: %1"
 msgstr "僅左側：%1"
 
 #. IDS_MIDDLE_ONLY_IN_FMT
-#: Merge.rc:5040
+#: Merge.rc:5039
 #, c-format
 msgid "Middle only: %1"
 msgstr "僅中間：%1"
 
 #. IDS_RIGHT_ONLY_IN_FMT
-#: Merge.rc:5041
+#: Merge.rc:5040
 #, c-format
 msgid "Right only: %1"
 msgstr "僅右側：%1"
 
 #. IDS_DOES_NOT_EXIST_IN_FMT
-#: Merge.rc:5042
+#: Merge.rc:5041
 #, c-format
 msgid "Does not exist in %1"
 msgstr "在 %1 中不存在"
 
 #. IDS_BIN_FILES_SAME
-#: Merge.rc:5043
+#: Merge.rc:5042
 msgid "Binary files are identical"
 msgstr "二進位檔完全相同"
 
 #. IDS_BIN_FILES_DIFF
-#: Merge.rc:5049
+#: Merge.rc:5048
 msgid "Binary files are different"
 msgstr "二進位檔有差異"
 
 #. IDS_FILES_ARE_DIFFERENT
-#: Merge.rc:5050
+#: Merge.rc:5049
 msgid "Files are different"
 msgstr "檔案有差異"
 
 #. IDS_FOLDERS_ARE_DIFFERENT
-#: Merge.rc:5051
+#: Merge.rc:5050
 msgid "Folders are different"
 msgstr "資料夾有差異"
 
 #. IDS_LEFTONLY
-#: Merge.rc:5052
+#: Merge.rc:5051
 msgid "Left Only"
 msgstr "僅左側"
 
 #. IDS_RIGHTONLY
-#: Merge.rc:5053
+#: Merge.rc:5052
 msgid "Right Only"
 msgstr "僅右側"
 
 #. IDS_MIDDLEONLY
-#: Merge.rc:5054
+#: Merge.rc:5053
 msgid "Middle Only"
 msgstr "僅中間"
 
 #. IDS_NOITEMLEFT
-#: Merge.rc:5055
+#: Merge.rc:5054
 msgid "No item in left"
 msgstr "左側無項目"
 
 #. IDS_NOITEMRIGHT
-#: Merge.rc:5056
+#: Merge.rc:5055
 msgid "No item in right"
 msgstr "右側無項目"
 
 #. IDS_NOITEMMIDDLE
-#: Merge.rc:5057
+#: Merge.rc:5056
 msgid "No item in middle"
 msgstr "中間無項目"
 
 #. IDS_CMPRES_ERROR
-#: Merge.rc:5059
+#: Merge.rc:5058
 msgid "Error"
 msgstr "錯誤"
 
 #. IDS_TEXT_FILES_SAME
-#: Merge.rc:5060
+#: Merge.rc:5059
 msgid "Text files are identical"
 msgstr "文字檔內容完全相同"
 
 #. IDS_LEFTONLY_DIFF
-#: Merge.rc:5061
+#: Merge.rc:5060
 msgid " (Middle and right are identical)"
 msgstr " (中間和右側內容完全相同)"
 
 #. IDS_MIDDLEONLY_DIFF
-#: Merge.rc:5062
+#: Merge.rc:5061
 msgid " (Left and right are identical)"
 msgstr " (左側和右側內容完全相同)"
 
 #. IDS_RIGHTONLY_DIFF
-#: Merge.rc:5063
+#: Merge.rc:5062
 msgid " (Left and middle are identical)"
 msgstr " (左側和中間內容完全相同)"
 
 #. IDS_PATH_MISMATCH
-#: Merge.rc:5064
+#: Merge.rc:5063
 msgid " (paths differ)"
 msgstr "（路徑不同）"
 
 #. IDS_TEXT_FILES_DIFF
-#: Merge.rc:5065
+#: Merge.rc:5064
 msgid "Text files are different"
 msgstr "文字檔內容有差異"
 
 #. IDS_IMAGE_FILES_SAME
-#: Merge.rc:5066
+#: Merge.rc:5065
 msgid "Image files are identical"
 msgstr "圖片檔完全相同"
 
 #. IDS_IMAGE_FILES_DIFF
-#: Merge.rc:5067
+#: Merge.rc:5066
 msgid "Image files are different"
 msgstr "圖片檔有差異"
 
 #. IDS_EXPR_DIFF
-#: Merge.rc:5068
+#: Merge.rc:5067
 #, c-format
 msgid "Files are different (expr: %1)"
 msgstr "檔案有差異（表示式：%1）"
 
 #. IDS_HASH_GROUP
-#: Merge.rc:5069
+#: Merge.rc:5068
 #, c-format
 msgid "Group%d"
 msgstr "群組%d"
 
 #. IDS_RENAME_MOVE_DETECTION_DISALBED
-#: Merge.rc:5070
+#: Merge.rc:5069
 msgctxt "Options dialog|Compare|Folder|Detect renames and moves"
 msgid "Disabled"
 msgstr "已停用"
 
 #. IDS_RENAME_MOVE_DETECTION_RENAME
-#: Merge.rc:5071
+#: Merge.rc:5070
 msgid "Detect renames"
 msgstr "偵測重新命名"
 
 #. IDS_RENAME_MOVE_DETECTION_RENAME_MOVE
-#: Merge.rc:5072
+#: Merge.rc:5071
 msgid "Detect renames and moves"
 msgstr "偵測重新命名與移動"
 
 #. IDS_RENAME_MOVE_MERGE_MODE_RENAME
-#: Merge.rc:5073
+#: Merge.rc:5072
 msgid "Merge renames"
 msgstr "合併重新命名"
 
 #. IDS_RENAME_MOVE_MERGE_MODE_RENAME_MOVE
-#: Merge.rc:5074
+#: Merge.rc:5073
 msgid "Merge renames and moves"
 msgstr "合併重新命名與移動"
 
 #. IDS_RENAMED
-#: Merge.rc:5075
+#: Merge.rc:5074
 msgid "Renamed"
 msgstr "已重新命名"
 
 #. IDS_RENAMED_MOVED
-#: Merge.rc:5077
+#: Merge.rc:5076
 msgid "Renamed/Moved"
 msgstr "已重新命名/已移動"
 
 #. IDS_RENAMED_MOVED_ITEMS
-#: Merge.rc:5078
+#: Merge.rc:5077
 #, c-format
 msgid "(%1 items)"
 msgstr "(%1 個項目)"
 
 #. IDS_RENAMED_MOVED_RESULT
-#: Merge.rc:5079
+#: Merge.rc:5078
 #, c-format
 msgid "%1 (set %2): "
 msgstr "%1 (組合 %2):"
 
 #. IDS_SWITCH_FLAT_MODE
-#: Merge.rc:5080
+#: Merge.rc:5079
 msgid ""
 "Some moved items have been merged.\n"
 "In Tree Mode, these items may appear in positions that do not reflect the "
@@ -7004,235 +6999,235 @@ msgstr ""
 "是否切換至平坦模式？"
 
 #. IDS_ELAPSED_TIME
-#: Merge.rc:5086
+#: Merge.rc:5085
 #, c-format
 msgid "Elapsed time: %ld ms"
 msgstr "經過時間： %ld 毫秒"
 
 #. IDS_STATUS_SELITEM1
-#: Merge.rc:5087
+#: Merge.rc:5086
 msgid "1 item selected"
 msgstr "已選取 1 個項目"
 
 #. IDS_STATUS_SELITEMS
-#: Merge.rc:5088
+#: Merge.rc:5087
 #, c-format
 msgid "%1 items selected"
 msgstr "已選取 %1 個項目"
 
 #. IDS_COLDESC_FILENAME
-#: Merge.rc:5094
+#: Merge.rc:5093
 msgid "Filename or folder name."
 msgstr "檔案名稱或資料夾名稱。"
 
 #. IDS_COLDESC_DIR
-#: Merge.rc:5095
+#: Merge.rc:5094
 msgid "Subfolder name when subfolders are included."
 msgstr "包括子資料夾時的子資料夾名稱。"
 
 #. IDS_COLDESC_RESULT
-#: Merge.rc:5096
+#: Merge.rc:5095
 msgid "Comparison result, long form."
 msgstr "比對結果（詳細形式）。"
 
 #. IDS_COLDESC_LTIMEM
-#: Merge.rc:5101
+#: Merge.rc:5100
 msgid "Left side modification date."
 msgstr "左側修改日期。"
 
 #. IDS_COLDESC_RTIMEM
-#: Merge.rc:5102
+#: Merge.rc:5101
 msgid "Right side modification date."
 msgstr "左側修改日期。"
 
 #. IDS_COLDESC_MTIMEM
-#: Merge.rc:5103
+#: Merge.rc:5102
 msgid "Middle side modification date."
 msgstr "中間修改日期。"
 
 #. IDS_COLDESC_EXTENSION
-#: Merge.rc:5104
+#: Merge.rc:5103
 msgid "File's extension."
 msgstr "副檔名。"
 
 #. IDS_COLDESC_LSIZE
-#: Merge.rc:5105
+#: Merge.rc:5104
 msgid "Left file size in bytes."
 msgstr "左側檔案位元組大小。"
 
 #. IDS_COLDESC_RSIZE
-#: Merge.rc:5106
+#: Merge.rc:5105
 msgid "Right file size in bytes."
 msgstr "右側檔案位元組大小。"
 
 #. IDS_COLDESC_MSIZE
-#: Merge.rc:5107
+#: Merge.rc:5106
 msgid "Middle file size in bytes."
 msgstr "中間檔案位元組大小。"
 
 #. IDS_COLDESC_LSIZE_SHORT
-#: Merge.rc:5108
+#: Merge.rc:5107
 msgid "Left file size abbreviated."
 msgstr "左側檔案簡式大小。"
 
 #. IDS_COLDESC_RSIZE_SHORT
-#: Merge.rc:5109
+#: Merge.rc:5108
 msgid "Right file size abbreviated."
 msgstr "右側檔案簡式大小。"
 
 #. IDS_COLDESC_MSIZE_SHORT
-#: Merge.rc:5110
+#: Merge.rc:5109
 msgid "Middle file size abbreviated."
 msgstr "中間檔案簡式大小。"
 
 #. IDS_COLDESC_LTIMEC
-#: Merge.rc:5116
+#: Merge.rc:5115
 msgid "Left side creation time."
 msgstr "左側建立時間。"
 
 #. IDS_COLDESC_RTIMEC
-#: Merge.rc:5117
+#: Merge.rc:5116
 msgid "Right side creation time."
 msgstr "右側建立時間。"
 
 #. IDS_COLDESC_MTIMEC
-#: Merge.rc:5118
+#: Merge.rc:5117
 msgid "Middle side creation time."
 msgstr "中間建立時間。"
 
 #. IDS_COLDESC_NEWER
-#: Merge.rc:5119
+#: Merge.rc:5118
 msgid "Tells which side has newer modification date."
 msgstr "告知哪邊有較新的修改日期。"
 
 #. IDS_COLDESC_LVERSION
-#: Merge.rc:5120
+#: Merge.rc:5119
 msgid "Left side file version, only for some file types."
 msgstr "左側檔案版本，僅適用某些檔案類型。"
 
 #. IDS_COLDESC_RVERSION
-#: Merge.rc:5121
+#: Merge.rc:5120
 msgid "Right side file version, only for some file types."
 msgstr "右側檔案版本，僅適用某些檔案類型。"
 
 #. IDS_COLDESC_MVERSION
-#: Merge.rc:5126
+#: Merge.rc:5125
 msgid "Middle side file version, only for some file types."
 msgstr "中間檔案版本，僅適用某些檔案類型。"
 
 #. IDS_COLDESC_RESULT_ABBR
-#: Merge.rc:5127
+#: Merge.rc:5126
 msgid "Short comparison result."
 msgstr "短式比對結果。"
 
 #. IDS_COLDESC_LATTRIBUTES
-#: Merge.rc:5128
+#: Merge.rc:5127
 msgid "Left side attributes."
 msgstr "左側屬性。"
 
 #. IDS_COLDESC_RATTRIBUTES
-#: Merge.rc:5129
+#: Merge.rc:5128
 msgid "Right side attributes."
 msgstr "右側屬性。"
 
 #. IDS_COLDESC_MATTRIBUTES
-#: Merge.rc:5130
+#: Merge.rc:5129
 msgid "Middle side attributes."
 msgstr "中間屬性。"
 
 #. IDS_COLDESC_LEOL_TYPE
-#: Merge.rc:5131
+#: Merge.rc:5130
 msgid "Left side file EOL type."
 msgstr "左側檔案的換行符號類型。"
 
 #. IDS_COLDESC_REOL_TYPE
-#: Merge.rc:5132
+#: Merge.rc:5131
 msgid "Right side file EOL type."
 msgstr "右側檔案的換行符號類型。"
 
 #. IDS_COLDESC_MEOL_TYPE
-#: Merge.rc:5133
+#: Merge.rc:5132
 msgid "Middle side file EOL type."
 msgstr "中間檔案的換行符號類型。"
 
 #. IDS_COLDESC_LENCODING
-#: Merge.rc:5139
+#: Merge.rc:5138
 msgid "Left side encoding."
 msgstr "左側編碼。"
 
 #. IDS_COLDESC_RENCODING
-#: Merge.rc:5140
+#: Merge.rc:5139
 msgid "Right side encoding."
 msgstr "右側編碼。"
 
 #. IDS_COLDESC_MENCODING
-#: Merge.rc:5141
+#: Merge.rc:5140
 msgid "Middle side encoding."
 msgstr "中間編碼。"
 
 #. IDS_COLDESC_NIDIFFS
-#: Merge.rc:5142
+#: Merge.rc:5141
 msgid "Number of ignored differences in file. Ignored and cannot be merged."
 msgstr "檔案中已忽略的差異數量。已忽略且無法合併。"
 
 #. IDS_COLDESC_NSDIFFS
-#: Merge.rc:5143
+#: Merge.rc:5142
 msgid "Number of differences in file (excluding ignored)."
 msgstr "檔案中的差異數量 (不含已忽略)。"
 
 #. IDS_COLDESC_BINARY
-#: Merge.rc:5144
+#: Merge.rc:5143
 msgid "Shows an asterisk (*) if the file is binary."
 msgstr "是二進位檔，就顯示星號 (*)"
 
 #. IDS_COLDESC_UNPACKER
-#: Merge.rc:5145
+#: Merge.rc:5144
 msgid "Unpacker plugin name or pipeline."
 msgstr "解包裝器擴充功能名稱或處理序。"
 
 #. IDS_COLDESC_PREDIFFER
-#: Merge.rc:5146
+#: Merge.rc:5145
 msgid "Prediffer plugin name or pipeline."
 msgstr "預差異器擴充功能名稱或處理序。"
 
 #. IDS_DIRECTORY_REPORT_TITLE
-#: Merge.rc:5152
+#: Merge.rc:5151
 #, c-format
 msgid "Compare %1 with %2"
 msgstr "比對 %1 和 %2"
 
 #. IDS_DIRECTORY_REPORT_TITLE3
-#: Merge.rc:5153
+#: Merge.rc:5152
 #, c-format
 msgid "Compare %1 with %2 and %3"
 msgstr "比對 %1 和 %2 與 %3"
 
 #. IDS_REPORT_COMMALIST
-#: Merge.rc:5154
+#: Merge.rc:5153
 msgid "Comma-separated list"
 msgstr "逗號分隔列表"
 
 #. IDS_REPORT_TABLIST
-#: Merge.rc:5155
+#: Merge.rc:5154
 msgid "Tab-separated list"
 msgstr "定位字元（Tab）分隔列表"
 
 #. IDS_REPORT_SIMPLEHTML
-#: Merge.rc:5156
+#: Merge.rc:5155
 msgid "Simple HTML"
 msgstr "簡易 HTML"
 
 #. IDS_REPORT_SIMPLEXML
-#: Merge.rc:5157
+#: Merge.rc:5156
 msgid "Simple XML"
 msgstr "簡易 XML"
 
-#: Merge.rc:5159
+#: Merge.rc:5158
 msgid "Report file already exists. Overwrite?"
 msgstr "報告檔案已存在。要覆蓋嗎？"
 
 #. IDS_REPORT_ERROR
-#: Merge.rc:5164
+#: Merge.rc:5163
 #, c-format
 msgid ""
 "Error creating the report:\n"
@@ -7242,27 +7237,27 @@ msgstr ""
 "%1"
 
 #. IDS_REPORT_SUCCESS
-#: Merge.rc:5165
+#: Merge.rc:5164
 msgid "Report created successfully."
 msgstr "成功產生報告。"
 
 #. IDS_SYNCPOINT_LASTBLOCK
-#: Merge.rc:5171
+#: Merge.rc:5170
 msgid "Cannot add a synchronization point at this line."
 msgstr "無法在此行新增同步點。"
 
 #. IDS_FILE_TO_ITSELF
-#: Merge.rc:5177
+#: Merge.rc:5176
 msgid "Same file is opened in both panes."
 msgstr "相同檔案開啟到兩邊。"
 
 #. IDS_FILESSAME
-#: Merge.rc:5178
+#: Merge.rc:5177
 msgid "Selected files are identical."
 msgstr "所選檔案完全相同。"
 
 #. IDS_FILESSAME_CURCFG
-#: Merge.rc:5179
+#: Merge.rc:5178
 msgid ""
 "Selected files are identical (with current settings).\r\n"
 "Checking binary identity..."
@@ -7271,7 +7266,7 @@ msgstr ""
 "正在檢查二進位一致性..."
 
 #. IDS_FILESSAME_BINERROR
-#: Merge.rc:5180
+#: Merge.rc:5179
 msgid ""
 "Selected files are identical (with current settings).\r\n"
 "But binary comparison failed."
@@ -7280,12 +7275,12 @@ msgstr ""
 "但二進位比對失敗。"
 
 #. IDS_FILESSAME_BINSAME
-#: Merge.rc:5181
+#: Merge.rc:5180
 msgid "Selected files are identical (binary match)."
 msgstr "所選檔案完全相同（二進位符合）。"
 
 #. IDS_FILESSAME_BINDIFF
-#: Merge.rc:5182
+#: Merge.rc:5181
 msgid ""
 "Selected files are identical (with current settings).\r\n"
 "But differ at the binary level."
@@ -7294,17 +7289,17 @@ msgstr ""
 "但在二進位層級上有差異。"
 
 #. IDS_FILEERROR
-#: Merge.rc:5183
+#: Merge.rc:5182
 msgid "An error occurred while comparing files."
 msgstr "比對檔案時發生錯誤。"
 
 #. IDS_TEMP_FILEERROR
-#: Merge.rc:5184
+#: Merge.rc:5183
 msgid "Could not create temporary files. Check your temporary path settings."
 msgstr "無法建立暫存檔案。請檢查暫存路徑之設定。"
 
 #. IDS_SUGGEST_IGNOREEOL
-#: Merge.rc:5185
+#: Merge.rc:5184
 msgid ""
 "Files use different EOL.\n"
 "\n"
@@ -7319,17 +7314,17 @@ msgstr ""
 "您可以在「選項」的「比對」區塊中，設定「忽略 EOL 差異（Windows/Unix/Mac）」。"
 
 #. IDS_INVALID_DIRECTORY
-#: Merge.rc:5186
+#: Merge.rc:5185
 msgid "Selected folder is invalid."
 msgstr "所選的資料夾無效。"
 
 #. IDS_CANNOT_OPEN_BINARYFILE
-#: Merge.rc:5187
+#: Merge.rc:5186
 msgid "Cannot open a binary file in Editor."
 msgstr "編輯器不能開啟二進位檔。"
 
 #. IDS_CREATE_PAIR_FOLDER
-#: Merge.rc:5188
+#: Merge.rc:5187
 #, c-format
 msgid ""
 "Create matching folder:\n"
@@ -7341,41 +7336,41 @@ msgstr ""
 "並將其開啟？"
 
 #. IDS_CONFIRM_COPY_ALL_DIFFS
-#: Merge.rc:5189
+#: Merge.rc:5188
 msgid "Copy all differences to other file?"
 msgstr "您確定要將所有差異複製到另一個檔案嗎？"
 
 #. IDS_MOVE_TO_NEXTFILE
-#: Merge.rc:5194
+#: Merge.rc:5193
 msgid "Move to next file?"
 msgstr "您要移動到下一個檔案嗎？"
 
 #. IDS_MOVE_TO_PREVFILE
-#: Merge.rc:5195
+#: Merge.rc:5194
 msgid "Move to previous file?"
 msgstr "您要移動到上一個檔案嗎？"
 
 #. IDS_MOVE_TO_NEXTPAGE
-#: Merge.rc:5196
+#: Merge.rc:5195
 msgid "Move to next page?"
 msgstr "您要移動到下一頁嗎？"
 
 #. IDS_MOVE_TO_PREVPAGE
-#: Merge.rc:5197
+#: Merge.rc:5196
 msgid "Move to previous page?"
 msgstr "您要移動到上一頁嗎？"
 
 #. IDS_MOVE_TO_FIRSTFILE
-#: Merge.rc:5198
+#: Merge.rc:5197
 msgid "Move to first file?"
 msgstr "您要移動到首個檔案嗎？"
 
 #. IDS_MOVE_TO_LASTFILE
-#: Merge.rc:5199
+#: Merge.rc:5198
 msgid "Move to last file?"
 msgstr "您要移動到最後一個檔案嗎？"
 
-#: Merge.rc:5206
+#: Merge.rc:5205
 #, c-format
 msgid ""
 "Different codepages: left (cp%d), right (cp%d).\n"
@@ -7388,51 +7383,51 @@ msgstr ""
 "全)？\n"
 "要使用相同的預設 windows 字碼頁去看兩邊嗎？(建議)"
 
-#: Merge.rc:5208
+#: Merge.rc:5207
 msgid "Information lost due to encoding errors: both files"
 msgstr "因編碼問題導致內容無法正常呈現：兩個檔案皆如此"
 
-#: Merge.rc:5210
+#: Merge.rc:5209
 msgid "Information lost due to encoding errors: first file"
 msgstr "因編碼問題導致內容無法正常呈現：第一個檔案"
 
-#: Merge.rc:5212
+#: Merge.rc:5211
 msgid "Information lost due to encoding errors: second file"
 msgstr "因編碼問題導致內容無法正常呈現：第二個檔案"
 
-#: Merge.rc:5214
+#: Merge.rc:5213
 msgid "Information lost due to encoding errors: third file"
 msgstr "因編碼問題導致內容無法正常呈現：第三個檔案"
 
 #. IDS_LINEDIFF_NODIFF
-#: Merge.rc:5220
+#: Merge.rc:5219
 msgid "No difference"
 msgstr "無差異"
 
 #. IDS_LINEDIFF_NODIFF_CAPTION
-#: Merge.rc:5221
+#: Merge.rc:5220
 msgid "Line difference"
 msgstr "行內差異"
 
 #. IDS_NUM_REPLACED
-#: Merge.rc:5227
+#: Merge.rc:5226
 #, c-format
 msgid "Replaced %1 string(s)."
 msgstr "已取代 %1 個字串。"
 
 #. IDS_EDIT_TEXT_NOT_FOUND
-#: Merge.rc:5228
+#: Merge.rc:5227
 #, c-format
 msgid "Cannot find string \"%s\"."
 msgstr "找不到 \"%s\" 字串。"
 
 #. IDS_MERGE_MODE
-#: Merge.rc:5234
+#: Merge.rc:5233
 msgid "Entering Merge Mode. Press F9 to turn off."
 msgstr "您已經進入合併模式。如果您想要關閉合併模式，請按 F9。"
 
 #. IDS_AUTO_MERGE
-#: Merge.rc:5240
+#: Merge.rc:5239
 #, c-format
 msgid ""
 "Automatic merges: %1\n"
@@ -7442,92 +7437,92 @@ msgstr ""
 "未解決衝突數目： %2"
 
 #. IDS_CODEPAGE_MERGED
-#: Merge.rc:5241
+#: Merge.rc:5240
 msgid "Codepage change merged."
 msgstr "字碼頁變更已合併。"
 
 #. IDS_CODEPAGE_CONFLICT
-#: Merge.rc:5242
+#: Merge.rc:5241
 msgid "Codepage changes are conflicting."
 msgstr "字碼頁變更存在衝突。"
 
 #. IDS_EOL_MERGED
-#: Merge.rc:5243
+#: Merge.rc:5242
 msgid "EOL change merged."
 msgstr "換行符號變更已合併。"
 
 #. IDS_EOL_CONFLICT
-#: Merge.rc:5244
+#: Merge.rc:5243
 msgid "EOL changes are conflicting."
 msgstr "換行符號變更發生衝突。"
 
 # also refer to line 5584
 #. IDS_LOCBAR_CAPTION
-#: Merge.rc:5250
+#: Merge.rc:5249
 msgid "Location Pane"
 msgstr "位置窗格"
 
 # also refer to line 5578
 # 差異窗格
 #. IDS_DIFFBAR_CAPTION
-#: Merge.rc:5251
+#: Merge.rc:5250
 msgid "Diff Pane"
 msgstr "差異面板"
 
 #. IDS_DIFF_SUCCEEDED
-#: Merge.rc:5258
+#: Merge.rc:5257
 msgid "Patch file written."
 msgstr "已寫入修補檔案。"
 
 #. IDS_DIFF_FILEOVERWRITE
-#: Merge.rc:5259
+#: Merge.rc:5258
 msgid "Patch file already exists. Overwrite?"
 msgstr "修補檔案已存在。要覆蓋嗎？"
 
 #. IDS_DIFF_SELECTEDFILES
-#: Merge.rc:5260
+#: Merge.rc:5259
 #, c-format
 msgid "[%1 files selected]"
 msgstr "[%1 個檔案已選取]"
 
 #. IDS_DIFF_NORMAL
-#: Merge.rc:5261
+#: Merge.rc:5260
 msgid "Normal"
 msgstr "一般"
 
 #. IDS_DIFF_CONTEXT
-#: Merge.rc:5262
+#: Merge.rc:5261
 msgid "Context"
 msgstr "脈絡"
 
 #. IDS_DIFF_UNIFIED
-#: Merge.rc:5263
+#: Merge.rc:5262
 msgid "Unified"
 msgstr "同一化"
 
 #. IDS_FILEWRITE_ERROR
-#: Merge.rc:5265
+#: Merge.rc:5264
 #, c-format
 msgid "Could not write to file %1."
 msgstr "無法寫入到檔案 %1。"
 
 #. IDS_PATH_NOT_ABSOLUTE
-#: Merge.rc:5266
+#: Merge.rc:5265
 #, c-format
 msgid "Output path is not absolute: %1"
 msgstr "指定的輸出路徑不是絕對路徑：%1"
 
 #. IDS_MUST_SPECIFY_OUTPUT
-#: Merge.rc:5267
+#: Merge.rc:5266
 msgid "Specify an output file."
 msgstr "指定一個輸出檔。"
 
-#: Merge.rc:5269
+#: Merge.rc:5268
 msgid "Cannot create patch from binary files."
 msgstr "無法從二進位檔建立修補檔。"
 
 #. IDS_SAVEFILES_FORPATCH
-#: Merge.rc:5270
+#: Merge.rc:5269
 msgid ""
 "Save all files first.\n"
 "\n"
@@ -7538,17 +7533,17 @@ msgstr ""
 "建補綴檔前得先儲存檔內所有異動。"
 
 #. IDS_FOLDER_NOTEXIST
-#: Merge.rc:5271
+#: Merge.rc:5270
 msgid "Folder does not exist."
 msgstr "資料夾不存在。"
 
 #. IDS_ARCHIVE_SUCCEEDED
-#: Merge.rc:5277
+#: Merge.rc:5276
 msgid "Archive file written."
 msgstr "已寫入封存檔案。"
 
 #. IDS_ARCHIVE_SAVEFILES
-#: Merge.rc:5278
+#: Merge.rc:5277
 msgid ""
 "Save all files first.\n"
 "\n"
@@ -7559,7 +7554,7 @@ msgstr ""
 "建立封存檔前不能有未儲存的變更。"
 
 #. IDS_NO_ZIP_SUPPORT
-#: Merge.rc:5283
+#: Merge.rc:5282
 msgid ""
 "Archive support not enabled.\n"
 "7-Zip and/or Merge7z*.dll not found.\n"
@@ -7570,37 +7565,37 @@ msgstr ""
 "請參閱手冊以取得封存檔支援說明。"
 
 #. IDS_OPT_EXPORT_CAPTION
-#: Merge.rc:5284
+#: Merge.rc:5283
 msgid "Select file for export"
 msgstr "選取檔案以匯出"
 
 #. IDS_OPT_IMPORT_CAPTION
-#: Merge.rc:5285
+#: Merge.rc:5284
 msgid "Select file for import"
 msgstr "選取檔案以匯入"
 
 #. IDS_OPT_IMPORT_DONE
-#: Merge.rc:5286
+#: Merge.rc:5285
 msgid "Options imported from file."
 msgstr "從檔案匯入選項。"
 
 #. IDS_OPT_EXPORT_DONE
-#: Merge.rc:5287
+#: Merge.rc:5286
 msgid "Options exported to file."
 msgstr "匯出選項到檔案。"
 
 #. IDS_OPT_IMPORT_ERR
-#: Merge.rc:5288
+#: Merge.rc:5287
 msgid "Failed to import options from file."
 msgstr "無法從檔案匯入選項。"
 
 #. IDS_OPT_EXPORT_ERR
-#: Merge.rc:5289
+#: Merge.rc:5288
 msgid "Failed to write options to file."
 msgstr "無法匯出選項到檔案。"
 
 #. IDS_CLOSEALL_WINDOWS
-#: Merge.rc:5290
+#: Merge.rc:5289
 msgid ""
 "Close multiple compare windows?\n"
 "\n"
@@ -7611,35 +7606,35 @@ msgstr ""
 "要繼續嗎？"
 
 #. IDS_EOL_BIN
-#: Merge.rc:5300
+#: Merge.rc:5299
 msgctxt "EOL Type"
 msgid "Binary"
 msgstr "二進位"
 
 #. IDS_MARKER_COLOR_FMT
-#: Merge.rc:5305
+#: Merge.rc:5304
 #, c-format
 msgid "Marker Color %d"
 msgstr "標記顏色 %d"
 
 #. IDS_MARKER_NEW_PATTERN
-#: Merge.rc:5306
+#: Merge.rc:5305
 msgid "New Pattern"
 msgstr "新的樣式"
 
 #. IDS_PLUGINSLIST_TYPE
-#: Merge.rc:5312
+#: Merge.rc:5311
 msgid "Type"
 msgstr "類型"
 
 # What does "Editor script" mean? Perhaps "editing scripts" or "scripts to edit"?
 #. IDS_PLUGINS_TYPE_EDITSCRIPT
-#: Merge.rc:5316
+#: Merge.rc:5315
 msgid "Editor script"
 msgstr "編輯器指令碼"
 
 #. ID_SELECTLINEDIFF
-#: Merge.rc:5322
+#: Merge.rc:5321
 msgid ""
 "\n"
 "Difference in Current Line (F4)"
@@ -7648,7 +7643,7 @@ msgstr ""
 "選取行內差異 (F4)"
 
 #. ID_OPTIONS
-#: Merge.rc:5323
+#: Merge.rc:5322
 msgid ""
 "\n"
 "Options"
@@ -7657,7 +7652,7 @@ msgstr ""
 "選項"
 
 #. ID_REFRESH
-#: Merge.rc:5324
+#: Merge.rc:5323
 msgid ""
 "\n"
 "Refresh (F5)"
@@ -7666,7 +7661,7 @@ msgstr ""
 "重新整理 (F5)"
 
 #. ID_PREVDIFF
-#: Merge.rc:5330
+#: Merge.rc:5329
 msgid ""
 "\n"
 "Previous Difference (Alt+Up)"
@@ -7675,7 +7670,7 @@ msgstr ""
 "上一個差異 (Alt+Up)"
 
 #. ID_NEXTDIFF
-#: Merge.rc:5331
+#: Merge.rc:5330
 msgid ""
 "\n"
 "Next Difference (Alt+Down)"
@@ -7684,7 +7679,7 @@ msgstr ""
 "下一個差異 (Alt+Down)"
 
 #. ID_PREVCONFLICT
-#: Merge.rc:5332
+#: Merge.rc:5331
 msgid ""
 "\n"
 "Previous Conflict (Alt+Shift+Up)"
@@ -7693,7 +7688,7 @@ msgstr ""
 "上一個衝突 (Alt+Shift+Up)"
 
 #. ID_NEXTCONFLICT
-#: Merge.rc:5333
+#: Merge.rc:5332
 msgid ""
 "\n"
 "Next Conflict (Alt+Shift+Down)"
@@ -7702,7 +7697,7 @@ msgstr ""
 "下一個衝突 (Alt+Shift+Down)"
 
 #. ID_FIRSTDIFF
-#: Merge.rc:5338
+#: Merge.rc:5337
 msgid ""
 "\n"
 "First Difference (Alt+Home)"
@@ -7711,7 +7706,7 @@ msgstr ""
 "首個差異 (Alt+Home)"
 
 #. ID_CURDIFF
-#: Merge.rc:5339
+#: Merge.rc:5338
 msgid ""
 "\n"
 "Current Difference (Alt+Enter)"
@@ -7720,7 +7715,7 @@ msgstr ""
 "目前差異 (Alt+Enter)"
 
 #. ID_LASTDIFF
-#: Merge.rc:5340
+#: Merge.rc:5339
 msgid ""
 "\n"
 "Last Difference (Alt+End)"
@@ -7729,7 +7724,7 @@ msgstr ""
 "最後一個差異 (Alt+End)"
 
 #. ID_L2R
-#: Merge.rc:5341
+#: Merge.rc:5340
 msgid ""
 "\n"
 "Copy to Right (Alt+Right)"
@@ -7738,7 +7733,7 @@ msgstr ""
 "複製到右側 (Alt+Right)"
 
 #. ID_R2L
-#: Merge.rc:5342
+#: Merge.rc:5341
 msgid ""
 "\n"
 "Copy to Left (Alt+Left)"
@@ -7747,7 +7742,7 @@ msgstr ""
 "複製到左側 (Alt+Left)"
 
 #. ID_L2RNEXT
-#: Merge.rc:5343
+#: Merge.rc:5342
 msgid ""
 "\n"
 "Copy to Right and Advance (Ctrl+Alt+Right)"
@@ -7756,7 +7751,7 @@ msgstr ""
 "複製到右側後到下一個 (Ctrl+Alt+Right)"
 
 #. ID_R2LNEXT
-#: Merge.rc:5344
+#: Merge.rc:5343
 msgid ""
 "\n"
 "Copy to Left and Advance (Ctrl+Alt+Left)"
@@ -7765,7 +7760,7 @@ msgstr ""
 "複製到左側後到下一個 (Ctrl+Alt+Left)"
 
 #. ID_ALL_RIGHT
-#: Merge.rc:5345
+#: Merge.rc:5344
 msgid ""
 "\n"
 "Copy All to Right"
@@ -7774,7 +7769,7 @@ msgstr ""
 "全部複製到右側"
 
 #. ID_ALL_LEFT
-#: Merge.rc:5346
+#: Merge.rc:5345
 msgid ""
 "\n"
 "Copy All to Left"
@@ -7783,7 +7778,7 @@ msgstr ""
 "全部複製到左側"
 
 #. ID_AUTO_MERGE
-#: Merge.rc:5347
+#: Merge.rc:5346
 msgid ""
 "\n"
 "Auto Merge (Ctrl+Alt+M)"
@@ -7792,7 +7787,7 @@ msgstr ""
 "自動合併 (Ctrl+Alt+M)"
 
 #. ID_FIRSTFILE
-#: Merge.rc:5348
+#: Merge.rc:5347
 msgid ""
 "\n"
 "First File"
@@ -7801,7 +7796,7 @@ msgstr ""
 "首個檔案"
 
 #. ID_NEXTFILE
-#: Merge.rc:5349
+#: Merge.rc:5348
 msgid ""
 "\n"
 "Next File (Ctrl+F8)"
@@ -7810,7 +7805,7 @@ msgstr ""
 "下個檔案 (Ctrl+F8)"
 
 #. ID_LASTFILE
-#: Merge.rc:5350
+#: Merge.rc:5349
 msgid ""
 "\n"
 "Last File"
@@ -7819,7 +7814,7 @@ msgstr ""
 "最後一個檔案"
 
 #. ID_PREVFILE
-#: Merge.rc:5351
+#: Merge.rc:5350
 msgid ""
 "\n"
 "Previous File (Ctrl+F7)"
@@ -7828,142 +7823,142 @@ msgstr ""
 "上個檔案 (Ctrl+F7)"
 
 #. IDS_UNPACK_AUTO
-#: Merge.rc:5358
+#: Merge.rc:5357
 msgid "Adapted unpacker applied to both files (one needs extension)."
 msgstr "適用的解包裝器已應用至兩個檔案 (其中一個需要副檔名)。"
 
 #. IDS_NO_PREDIFFER
-#: Merge.rc:5359
+#: Merge.rc:5358
 msgid "No Prediffer (Normal)"
 msgstr "不要預差異器 (常態)"
 
 #. IDS_SUGGESTED_PLUGINS
-#: Merge.rc:5360
+#: Merge.rc:5359
 msgid "Suggested Plugins"
 msgstr "建議的擴充功能"
 
 #. IDS_NOT_SUGGESTED_PLUGINS
-#: Merge.rc:5361
+#: Merge.rc:5360
 msgid "All Plugins"
 msgstr "所有擴充功能"
 
 #. IDS_PRIVATEBUILD_FMT
-#: Merge.rc:5367
+#: Merge.rc:5366
 #, c-format
 msgid "Private Build: %1"
 msgstr "私人編譯：%1"
 
 #. IDS_ALLRIGHTS_RESERVED
-#: Merge.rc:5368
+#: Merge.rc:5367
 msgid " - All rights reserved."
 msgstr "- 版權所有。"
 
 #. IDS_TITLE_PLUGINS_SETTINGS
-#: Merge.rc:5374
+#: Merge.rc:5373
 msgid "Plugin Settings"
 msgstr "擴充功能設定"
 
 #. IDS_NO_SCT_SCRIPTS
-#: Merge.rc:5376
+#: Merge.rc:5375
 msgid "WSH not found - .sct scripts disabled"
 msgstr "找不到 WSH - 停用 .sct 指令碼"
 
 #. IDS_LOCBAR_GOTOLINE_FMT
-#: Merge.rc:5384
+#: Merge.rc:5383
 #, c-format
 msgid "G&o to Line %1"
 msgstr "跳至 第 %1 行 (&O)"
 
 #. IDS_GOTO_MOVED_LINE
-#: Merge.rc:5390
+#: Merge.rc:5389
 msgid "Go to Moved Line\tCtrl+Shift+G"
 msgstr "跳至已移位的行\tCtrl+Shift+G"
 
 #. IDS_AUTOCOMPLETE_DISABLED
-#: Merge.rc:5396
+#: Merge.rc:5395
 msgctxt "Options dialog|General|Open dialog Auto completion"
 msgid "Disabled"
 msgstr "已停用"
 
 #. IDS_AUTOCOMPLETE_FILE_SYS
-#: Merge.rc:5397
+#: Merge.rc:5396
 msgid "From file system"
 msgstr "從檔案系統"
 
 #. IDS_AUTOCOMPLETE_MRU
-#: Merge.rc:5398
+#: Merge.rc:5397
 msgid "From Most Recently Used list"
 msgstr "從最近使用清單"
 
 #. IDS_COLORSCHEME_PLAIN
-#: Merge.rc:5404
+#: Merge.rc:5403
 msgid "No Highlighting"
 msgstr "無高亮顯著提示"
 
 #. IDS_COLORSCHEME_PO
-#: Merge.rc:5439
+#: Merge.rc:5438
 msgid "Portable Object"
 msgstr "PO檔"
 
 #. IDS_COLORSCHEME_RSRC
-#: Merge.rc:5444
+#: Merge.rc:5443
 msgid "Resources"
 msgstr "資源檔"
 
 #. IDS_COLORSCHEME_SH
-#: Merge.rc:5448
+#: Merge.rc:5447
 msgid "Shell"
 msgstr "命令殼層(Shell)"
 
 #. IDS_CLOSE_LEFT_TABS
-#: Merge.rc:5469
+#: Merge.rc:5468
 msgid "Close &Left Tabs"
 msgstr "關閉左側分頁 (&L)"
 
 #. IDS_CLOSE_RIGHT_TABS
-#: Merge.rc:5470
+#: Merge.rc:5469
 msgid "Close R&ight Tabs"
 msgstr "關閉右側分頁 (&I)"
 
 #. IDS_CLOSE_OTHER_TABS
-#: Merge.rc:5471
+#: Merge.rc:5470
 msgid "Close &Other Tabs"
 msgstr "關閉其他分頁 (&O)"
 
 #. IDS_TABBAR_AUTO_MAXWIDTH
-#: Merge.rc:5472
+#: Merge.rc:5471
 msgid "Enable &Auto Max Width"
 msgstr "開啟自動最大寬度 (&A)"
 
 #. IDS_WEBPAGE_MENU
-#: Merge.rc:5482
+#: Merge.rc:5481
 msgid "We&bpage"
 msgstr "網頁 (&B)"
 
 #. IDS_VIEW_WRAP_TEXT
-#: Merge.rc:5487
+#: Merge.rc:5486
 msgid "W&rap Text"
 msgstr "自動換行 (&R)"
 
 #. IDS_NOTINSTALLED
-#: Merge.rc:5492
+#: Merge.rc:5491
 #, c-format
 msgid "%1 is not installed."
 msgstr "未安裝 %1。"
 
 #. IDS_CREATE_FOLDER
-#: Merge.rc:5497
+#: Merge.rc:5496
 #, c-format
 msgid "%1 does not exist. Create it?"
 msgstr "%1不存在，您想要建立它嗎？"
 
 #. IDS_CREATE_FOLDER_ERROR
-#: Merge.rc:5498
+#: Merge.rc:5497
 msgid "Failed to create folder."
 msgstr "建立資料夾失敗。"
 
 #. IDC_EXT_EDITOR_PATH
-#: Merge.rc:5503
+#: Merge.rc:5502
 msgid ""
 "Parameters:\n"
 "$file: Current file path\n"
@@ -7974,491 +7969,491 @@ msgstr ""
 "$linenum: 現在游標行號"
 
 #. IDS_DIFF_ALGORITHM_DEFAULT
-#: Merge.rc:5508
+#: Merge.rc:5507
 msgid "default"
 msgstr "預設"
 
 #. IDS_DIFF_ALGORITHM_MINIMAL
-#: Merge.rc:5509
+#: Merge.rc:5508
 msgid "minimal"
 msgstr "極簡"
 
 #. IDS_DIFF_ALGORITHM_PATIENCE
-#: Merge.rc:5510
+#: Merge.rc:5509
 msgid "patience"
 msgstr "耐心"
 
 #. IDS_DIFF_ALGORITHM_HISTOGRAM
-#: Merge.rc:5511
+#: Merge.rc:5510
 msgid "histogram"
 msgstr "長條圖"
 
 #. IDS_DIFF_ALGORITHM_NONE
-#: Merge.rc:5512
+#: Merge.rc:5511
 msgid "none"
 msgstr "無"
 
 #. IDS_RENDERING_MODE_GDI
-#: Merge.rc:5517
+#: Merge.rc:5516
 msgid "GDI"
 msgstr "GDI"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_DEFAULT
-#: Merge.rc:5518
+#: Merge.rc:5517
 msgid "DirectWrite Default"
 msgstr "DirectWrite 預設值"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_ALIASED
-#: Merge.rc:5519
+#: Merge.rc:5518
 msgid "DirectWrite Aliased"
 msgstr "DirectWrite 鋸齒"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_GDI_CLASSIC
-#: Merge.rc:5520
+#: Merge.rc:5519
 msgid "DirectWrite GDI Classic"
 msgstr "DirectWrite GDI 傳統"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_GDI_NATURAL
-#: Merge.rc:5521
+#: Merge.rc:5520
 msgid "DirectWrite GDI Natural"
 msgstr "DirectWrite GDI 自然"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_NATURAL
-#: Merge.rc:5522
+#: Merge.rc:5521
 msgid "DirectWrite Natural"
 msgstr "DirectWrite 自然"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_NATURAL_SYMMETRIC
-#: Merge.rc:5523
+#: Merge.rc:5522
 msgid "DirectWrite Natural Symmetric"
 msgstr "DirectWrite 自然對稱"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_DISABLED
-#: Merge.rc:5528
+#: Merge.rc:5527
 msgctxt "Options dialog|General|Close windows with Esc"
 msgid "Disabled"
 msgstr "已停用"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_1
-#: Merge.rc:5529
+#: Merge.rc:5528
 msgid "MDI child window or main window"
 msgstr "MDI 子視窗或主視窗"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_2
-#: Merge.rc:5530
+#: Merge.rc:5529
 msgid "MDI child window only"
 msgstr "僅 MDI 子視窗"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_3
-#: Merge.rc:5531
+#: Merge.rc:5530
 msgid "Close main window if only one MDI child window"
 msgstr "如果只剩下一個 MDI 子視窗，則關閉主視窗"
 
 #. IDS_DIFF_GROUP
-#: Merge.rc:5536
+#: Merge.rc:5535
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Diff"
 msgstr "差異"
 
 #. IDS_DIFF_HIGHLIGHT
-#: Merge.rc:5537
+#: Merge.rc:5536
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Highlight"
 msgstr "高亮顯著提示"
 
 #. IDS_DIFF_BLINK
-#: Merge.rc:5538
+#: Merge.rc:5537
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Blink"
 msgstr "閃爍"
 
 #. IDS_DIFF_BLOCKSIZE
-#: Merge.rc:5539
+#: Merge.rc:5538
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Block Size"
 msgstr "區塊大小"
 
 #. IDS_DIFF_BLOCKALPHA
-#: Merge.rc:5540
+#: Merge.rc:5539
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Block Alpha"
 msgstr "區塊透明度"
 
 #. IDS_DIFF_CDTHRESHOLD
-#: Merge.rc:5541
+#: Merge.rc:5540
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "CD Threshold"
 msgstr "顏色差異閾值"
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION
-#: Merge.rc:5542
+#: Merge.rc:5541
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Ins/Del Detection"
 msgstr "插入/刪除 偵測"
 
 #. IDS_OVERLAY_MODE_NONE
-#: Merge.rc:5543 Merge.rc:5548
+#: Merge.rc:5542 Merge.rc:5547
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "None"
 msgstr "無"
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION_VERTICAL
-#: Merge.rc:5544
+#: Merge.rc:5543
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Vertical"
 msgstr "垂直"
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION_HORIZONTAL
-#: Merge.rc:5545
+#: Merge.rc:5544
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Horizontal"
 msgstr "水平"
 
 #. IDS_OVERLAY_GROUP
-#: Merge.rc:5546
+#: Merge.rc:5545
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Overlay"
 msgstr "重疊"
 
 #. IDS_OVERLAY_ALPHA
-#: Merge.rc:5547
+#: Merge.rc:5546
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha"
 msgstr "透明度"
 
 #. IDS_OVERLAY_MODE_XOR
-#: Merge.rc:5549
+#: Merge.rc:5548
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "XOR"
 msgstr "XOR"
 
 #. IDS_OVERLAY_MODE_ALPHA
-#: Merge.rc:5550
+#: Merge.rc:5549
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha Blend"
 msgstr "透明合成"
 
 #. IDS_OVERLAY_MODE_ALPHA_ANIMATION
-#: Merge.rc:5551
+#: Merge.rc:5550
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha Animation"
 msgstr "透明動畫"
 
 #. IDS_ZOOM
-#: Merge.rc:5552
+#: Merge.rc:5551
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Zoom"
 msgstr "縮放"
 
 #. IDS_PAGE
-#: Merge.rc:5553
+#: Merge.rc:5552
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Page:"
 msgstr "頁面："
 
 #. IDS_IMGCMP_STATUS_PT_RGBA_FMT
-#: Merge.rc:5554
+#: Merge.rc:5553
 #, c-format
 msgid "Pt: (%d, %d)  RGBA: (%d, %d, %d, %d)  "
 msgstr "Pt：(%d, %d)  RGBA：(%d, %d, %d, %d)  "
 
 #. IDS_IMGCMP_STATUS_DIST1_FMT
-#: Merge.rc:5555
+#: Merge.rc:5554
 #, c-format
 msgid "Dist: %g  "
 msgstr "距離：%g  "
 
 #. IDS_IMGCMP_STATUS_DIST2_FMT
-#: Merge.rc:5556
+#: Merge.rc:5555
 #, c-format
 msgid "Dist: %g, %g  "
 msgstr "距離：%g, %g  "
 
 #. IDS_IMGCMP_STATUS_PAGE_ZOOM_SIZE_BPP_FMT
-#: Merge.rc:5557
+#: Merge.rc:5556
 #, c-format
 msgid "Page: %d/%d  Zoom: %d%%  %dx%dpx  %dbpp  "
 msgstr "頁面：%d/%d  縮放：%d%%  %dx%dpx  %dbpp  "
 
 #. IDS_IMGCMP_STATUS_RC_FMT
-#: Merge.rc:5558
+#: Merge.rc:5557
 #, c-format
 msgid "Rc: (%d, %d)  "
 msgstr "Rc：(%d, %d)  "
 
 #. IDS_IMGCMP_STATUS_FLIPPED_FMT
-#: Merge.rc:5559
+#: Merge.rc:5558
 #, c-format
 msgid "Flipped: %s  "
 msgstr "翻轉：%s"
 
 #. IDS_IMGCMP_STATUS_ROTATED_FMT
-#: Merge.rc:5560
+#: Merge.rc:5559
 #, c-format
 msgid "Rotated: %d  "
 msgstr "旋轉：%d"
 
 #. IDS_IMGCMP_REPORT_ALLPAGES
-#: Merge.rc:5561
+#: Merge.rc:5560
 msgid "All pages"
 msgstr "所有頁面"
 
 #. IDS_IGNSUB_STR1
-#: Merge.rc:5566
+#: Merge.rc:5565
 msgid "<Edit here>"
 msgstr "<在此編輯>"
 
 #. IDS_IGNSUB_STR2
-#: Merge.rc:5567
+#: Merge.rc:5566
 msgid "No differences found to select"
 msgstr "找不到要選擇的差異"
 
 #. IDS_IGNSUB_STR3
-#: Merge.rc:5568
+#: Merge.rc:5567
 msgid "No differences found to add as substitution filter"
 msgstr "找不到要新增為替代篩選器的差異"
 
 #. IDS_IGNSUB_STR4
-#: Merge.rc:5569
+#: Merge.rc:5568
 msgid "The pair is already in the Substitution Filters list"
 msgstr "該配對已存在於替代篩選器列表中"
 
 #. IDS_IGNSUB_STR5
-#: Merge.rc:5570
+#: Merge.rc:5569
 msgid "Add this change to Substitution Filters?"
 msgstr "要將將此變動加入替代篩選器嗎？"
 
 #. IDS_OCRRESULT_TEXTONLY
-#: Merge.rc:5575
+#: Merge.rc:5574
 msgid "Text only"
 msgstr "僅文字"
 
 #. IDS_OCRRESULT_POS_LINE
-#: Merge.rc:5576
+#: Merge.rc:5575
 msgid "Line-by-line position and text"
 msgstr "逐行位置和文字"
 
 #. IDS_OCRRESULT_POS_WORD
-#: Merge.rc:5577
+#: Merge.rc:5576
 msgid "Word-by-word position and text"
 msgstr "逐字位置和文字"
 
 #. IDS_USERDATAFOLDER_APPDATA
-#: Merge.rc:5582
+#: Merge.rc:5581
 msgid "AppData (Roaming) folder"
 msgstr "AppData (Roaming) 資料夾"
 
 #. IDS_USERDATAFOLDER_INSTALL
-#: Merge.rc:5583
+#: Merge.rc:5582
 msgid "Install folder"
 msgstr "安裝資料夾"
 
 #. IDS_USERDATAFOLDER_DOCUMENTS
-#: Merge.rc:5584
+#: Merge.rc:5583
 msgid "Documents folder"
 msgstr "文件資料夾"
 
 #. IDS_SINGLEINSTANCE_DISABLED
-#: Merge.rc:5589
+#: Merge.rc:5588
 msgctxt "Options dialog|General|Single instance mode"
 msgid "Disabled"
 msgstr "已停用"
 
 #. IDS_SINGLEINSTANCE_STR1
-#: Merge.rc:5590
+#: Merge.rc:5589
 msgid "Allow only one instance to run"
 msgstr "只允許執行唯一程式"
 
 #. IDS_CLIPBOARD_HISTORY
-#: Merge.rc:5591
+#: Merge.rc:5590
 msgid "Clipboard &History"
 msgstr "剪貼簿歷史紀錄 (&H)"
 
 #. IDS_SINGLEINSTANCE_STR2
-#: Merge.rc:5592
+#: Merge.rc:5591
 msgid "Allow only one instance; wait for termination"
 msgstr "只允許執行唯一程式；並等待終止"
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_DISABLED
-#: Merge.rc:5597
+#: Merge.rc:5596
 msgctxt "Options dialog|General|Auto-reload modified files"
 msgid "Disabled"
 msgstr "已停用"
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_STR1
-#: Merge.rc:5598
+#: Merge.rc:5597
 msgid "Only on window activated"
 msgstr "僅在視窗啟用時"
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_STR2
-#: Merge.rc:5599
+#: Merge.rc:5598
 msgid "Immediately"
 msgstr "立即"
 
 #. IDS_PLUGIN_ALL
-#: Merge.rc:5604
+#: Merge.rc:5603
 msgid "Al&l"
 msgstr "全部 (&L)"
 
 #. IDS_PLUGIN_OTHERS
-#: Merge.rc:5605
+#: Merge.rc:5604
 msgid "&Others"
 msgstr "其他 (&O)"
 
-#: Merge.rc:5607
+#: Merge.rc:5606
 #, c-format
 msgid "Missing plugin name in pipeline: %1"
 msgstr "處理序缺少擴充功能名稱：%1"
 
-#: Merge.rc:5609
+#: Merge.rc:5608
 #, c-format
 msgid "Missing quote in plugin pipeline: %1"
 msgstr "擴充功能處理序中缺少引號：%1"
 
 #. IDS_PLUGIN_NAME_ALREADY_EXISTS
-#: Merge.rc:5610
+#: Merge.rc:5609
 #, c-format
 msgid "Plugin name '%1' already exists."
 msgstr "擴充功能名稱「%1」已經存在。"
 
 #. IDS_PLUGIN_TITLE1
-#: Merge.rc:5611
+#: Merge.rc:5610
 msgid "Specify plugin arguments"
 msgstr "指定擴充功能引數"
 
-#: Merge.rc:5613
+#: Merge.rc:5612
 #, c-format
 msgid "Plugin not found or invalid: %1"
 msgstr "擴充功能未找到或無效：%1"
 
 #. IDS_PLUGIN_NOT_UNPACK
-#: Merge.rc:5614
+#: Merge.rc:5613
 #, c-format
 msgid "'%1' is not an unpacker plugin"
 msgstr "「%1」非解包裝器擴充功能"
 
 #. IDS_PLUGIN_NOT_PREDIFF
-#: Merge.rc:5615
+#: Merge.rc:5614
 #, c-format
 msgid "'%1' is not a prediffer plugin"
 msgstr "「%1」不是預差異器擴充功能"
 
-#: Merge.rc:5617
+#: Merge.rc:5616
 #, c-format
 msgid "Error prediffing '%1' with '%2'. Prediffing disabled."
 msgstr "使用擴充功能「%2」預先差異化檔案「%1」時發生錯誤。預先差異化將不再應用。"
 
 #. IDS_PLUGIN_CIRCULAR_REFERENCE
-#: Merge.rc:5618
+#: Merge.rc:5617
 #, c-format
 msgid "Circular reference in plugin pipeline: %1"
 msgstr "擴充功能處理序中出現循環參照：%1"
 
 #. IDS_PLUGIN_TYPE1
-#: Merge.rc:5619
+#: Merge.rc:5618
 msgid "URL Handler"
 msgstr "URL 處理程序"
 
 #. IDS_PLUGIN_TYPE2
-#: Merge.rc:5620
+#: Merge.rc:5619
 msgid "File Unpacker"
 msgstr "檔案解包裝器"
 
 #. IDS_PLUGIN_TYPE3
-#: Merge.rc:5621
+#: Merge.rc:5620
 msgid "File or Folder Unpacker"
 msgstr "檔案或資料夾解包裝器"
 
 #. IDS_PLUGIN_TYPE5
-#: Merge.rc:5623
+#: Merge.rc:5622
 msgid "Alias for Unpacker"
 msgstr "解包裝器的別名"
 
 #. IDS_PLUGIN_TYPE6
-#: Merge.rc:5624
+#: Merge.rc:5623
 msgid "Alias for Prediffer"
 msgstr "預差異器的別名"
 
 #. IDS_PLUGIN_TYPE7
-#: Merge.rc:5625
+#: Merge.rc:5624
 msgid "Alias for Editor script"
 msgstr "編輯器指令碼的別名"
 
 #. IDS_PLUGIN_ALIAS_DESC
-#: Merge.rc:5626
+#: Merge.rc:5625
 #, c-format
 msgid "Alias for plugin pipeline '%1'"
 msgstr "擴充功能處理序「%1」的別名"
 
 #. IDS_PLUGIN_NEW_DESC
-#: Merge.rc:5627
+#: Merge.rc:5626
 msgid "New plugin description"
 msgstr "新擴充功能描述"
 
 #. IDS_PLUGIN_TARGETS_ALL
-#: Merge.rc:5628
+#: Merge.rc:5627
 msgid "All"
 msgstr "全"
 
 #. IDS_PLUGIN_TARGETS_1ST
-#: Merge.rc:5629
+#: Merge.rc:5628
 msgid "1st"
 msgstr "第一"
 
 #. IDS_PLUGIN_TARGETS_2ND
-#: Merge.rc:5630
+#: Merge.rc:5629
 msgid "2nd"
 msgstr "第二"
 
 #. IDS_PLUGIN_TARGETS_3RD
-#: Merge.rc:5631
+#: Merge.rc:5630
 msgid "3rd"
 msgstr "第三"
 
 #. IDS_PLUGIN_TARGETS_1ST_2ND
-#: Merge.rc:5632
+#: Merge.rc:5631
 msgid "1st and 2nd"
 msgstr "第一和第二"
 
 #. IDS_PLUGIN_TARGETS_1ST_3RD
-#: Merge.rc:5633
+#: Merge.rc:5632
 msgid "1st and 3rd"
 msgstr "第一和第三"
 
 #. IDS_PLUGIN_TARGETS_2ND_3RD
-#: Merge.rc:5634
+#: Merge.rc:5633
 msgid "2nd and 3rd"
 msgstr "第二和第三"
 
 #. IDS_PLUGIN_CTRL_CLICK
-#: Merge.rc:5635
+#: Merge.rc:5634
 msgid "(Ctrl+Click to add to pipeline)"
 msgstr ""
 
 #. IDS_FILTER_APPLIED
-#: Merge.rc:5640
+#: Merge.rc:5639
 msgid "Filter applied"
 msgstr "已應用篩選器"
 
 #. IDS_FILTERMENU_COMPARE
-#: Merge.rc:5645
+#: Merge.rc:5644
 #, c-format
 msgid "Compare %1"
 msgstr "比對 %1"
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN2
-#: Merge.rc:5647
+#: Merge.rc:5646
 msgid "&Filter by This Column..."
 msgstr "依此欄篩選... (&F)"
 
 #. IDS_CLIPBOARDHISTORY_TIME
-#: Merge.rc:5652
+#: Merge.rc:5651
 #, c-format
 msgid "Clipboard at %s"
 msgstr "於 %s 的剪貼簿"
 
 #. IDS_CLIPBOARDHISTORY_DISABLED
-#: Merge.rc:5653
+#: Merge.rc:5652
 msgid ""
 "Clipboard history disabled.\r\n"
 "Enable: Windows logo key + V, then Turn on."
@@ -8466,115 +8461,115 @@ msgstr ""
 "剪貼簿歷史記錄已停用。\r\n"
 "要啟用剪貼簿歷史記錄，請按下 Windows 徽標鍵 + V，然後點選「開啟」按鈕。"
 
-#: Merge.rc:5655
+#: Merge.rc:5654
 msgid "This system does not support clipboard history."
 msgstr "此系統不支援剪貼簿歷史紀錄。"
 
-#: Merge.rc:5657
+#: Merge.rc:5656
 msgid "32-bit WinMerge does not support Clipboard Compare"
 msgstr "32 位元版本的 WinMerge 不支援剪貼簿比對"
 
 #. IDS_WEBVIEW2_RUNTIME_NOT_INSTALLED
-#: Merge.rc:5662
+#: Merge.rc:5661
 msgid "WebView2 runtime not installed. Download it?"
 msgstr "尚未安裝 WebView2 執行階段。是否要下載安裝？"
 
 #. IDS_JUMPLIST_NEW_TEXT_COMPARE
-#: Merge.rc:5667
+#: Merge.rc:5666
 msgid "New Text Compare"
 msgstr "新文字比對"
 
 #. IDS_JUMPLIST_NEW_TABLE_COMPARE
-#: Merge.rc:5668
+#: Merge.rc:5667
 msgid "New Table Compare"
 msgstr "新表格比對"
 
 #. IDS_JUMPLIST_NEW_BINARY_COMPARE
-#: Merge.rc:5669
+#: Merge.rc:5668
 msgid "New Binary Compare"
 msgstr "新二進位比對"
 
 #. IDS_JUMPLIST_NEW_IMAGE_COMPARE
-#: Merge.rc:5670
+#: Merge.rc:5669
 msgid "New Image Compare"
 msgstr "新圖片比對"
 
 #. IDS_JUMPLIST_NEW_WEBPAGE_COMPARE
-#: Merge.rc:5671
+#: Merge.rc:5670
 msgid "New Webpage Compare"
 msgstr "新網頁比對"
 
 #. IDS_JUMPLIST_NEW_FOLDER_COMPARE
-#: Merge.rc:5672
+#: Merge.rc:5671
 msgid "New Folder Compare"
 msgstr "新增資料夾比對"
 
 #. IDS_JUMPLIST_CLIPBOARD_COMPARE
-#: Merge.rc:5673
+#: Merge.rc:5672
 msgid "Clipboard Compare"
 msgstr "剪貼簿比對"
 
 #. IDS_PREVIEWBAR_PRINT
-#: Merge.rc:5678
+#: Merge.rc:5677
 msgid "&Print..."
 msgstr "列印... (&P)"
 
 #. IDS_PREVIEWBAR_PREVPAGE
-#: Merge.rc:5680
+#: Merge.rc:5679
 msgid "Pre&v Page"
 msgstr "上一頁 (&V)"
 
 #. IDS_PREVIEWBAR_TWOPAGE
-#: Merge.rc:5681
+#: Merge.rc:5680
 msgid "&Two Page"
 msgstr "雙頁 (&T)"
 
 #. IDS_PREVIEWBAR_ONEPAGE
-#: Merge.rc:5682
+#: Merge.rc:5681
 msgid "&One Page"
 msgstr "單頁 (&O)"
 
 #. IDS_PREVIEWBAR_ZOOMIN
-#: Merge.rc:5683
+#: Merge.rc:5682
 msgid "Zoom &In"
 msgstr "放大 (&I)"
 
 #. IDS_PREVIEWBAR_ZOOMOUT
-#: Merge.rc:5684
+#: Merge.rc:5683
 msgid "Zoom &Out"
 msgstr "縮小 (&O)"
 
 #. IDS_WEBPAGE_COMPARING
-#: Merge.rc:5690
+#: Merge.rc:5689
 msgid "Comparing..."
 msgstr "正在比對..."
 
 #. IDS_WEBPAGE_ZOOM
-#: Merge.rc:5691
+#: Merge.rc:5690
 msgid "Zoom:"
 msgstr "縮放："
 
 #. IDS_COPY_GRANULARITY_DIFFHUNK
-#: Merge.rc:5696
+#: Merge.rc:5695
 msgid "Diff hunk"
 msgstr "差異區塊"
 
 #. IDS_COPY_GRANULARITY_INLINE
-#: Merge.rc:5697
+#: Merge.rc:5696
 msgid "Inline diff"
 msgstr "行內差異"
 
 #. IDS_COPY_GRANULARITY_LINE
-#: Merge.rc:5698
+#: Merge.rc:5697
 msgid "Line"
 msgstr "行"
 
-#: Merge.rc:5699
+#: Merge.rc:5698
 msgid "Character"
 msgstr "字元"
 
 #. ID_MICE_PREVDIFF
-#: Merge.rc:5704
+#: Merge.rc:5703
 msgid ""
 "\n"
 "Previous Difference (Alt+Up)\n"
@@ -8587,7 +8582,7 @@ msgstr ""
 "(Alt+滾輪上滾)"
 
 #. ID_MICE_NEXTDIFF
-#: Merge.rc:5705
+#: Merge.rc:5704
 msgid ""
 "\n"
 "Next Difference (Alt+Down)\n"
@@ -8600,7 +8595,7 @@ msgstr ""
 "(Alt+滾輪下滾)"
 
 #. ID_MICE_L2R
-#: Merge.rc:5706
+#: Merge.rc:5705
 msgid ""
 "\n"
 "Copy to Right (Alt+Right)\n"
@@ -8615,7 +8610,7 @@ msgstr ""
 "(Alt+Shift+滾輪下滾)"
 
 #. ID_MICE_R2L
-#: Merge.rc:5707
+#: Merge.rc:5706
 msgid ""
 "\n"
 "Copy to Left (Alt+Left)\n"
@@ -8630,7 +8625,7 @@ msgstr ""
 "(Alt+Shift+滾輪上滾)"
 
 #. ID_MICE_L2RNEXT
-#: Merge.rc:5708
+#: Merge.rc:5707
 msgid ""
 "\n"
 "Copy to Right and Advance (Ctrl+Alt+Right)\n"
@@ -8643,7 +8638,7 @@ msgstr ""
 "(Ctrl+Alt+Shift+滾輪下滾)"
 
 #. ID_MICE_R2LNEXT
-#: Merge.rc:5709
+#: Merge.rc:5708
 msgid ""
 "\n"
 "Copy to Left and Advance (Ctrl+Alt+Left)\n"
@@ -8656,257 +8651,257 @@ msgstr ""
 "(Ctrl+Alt+Shift+滾輪上滾)"
 
 #. IDS_LOG_COMPARING_2
-#: Merge.rc:5719
+#: Merge.rc:5718
 #, c-format
 msgid "Comparing %1 with %2"
 msgstr "正在比對 %1 與 %2"
 
 #. IDS_LOG_COMPARING_3
-#: Merge.rc:5720
+#: Merge.rc:5719
 #, c-format
 msgid "Comparing %1 with %2 and %3"
 msgstr "正在比對 %1 與 %2 及 %3"
 
 #. IDS_LOG_COMPARE_COMPLETED
-#: Merge.rc:5721
+#: Merge.rc:5720
 msgid "Comparison completed"
 msgstr "比對完成"
 
 #. IDS_LOG_COMPARE_ERROR_2
-#: Merge.rc:5722
+#: Merge.rc:5721
 #, c-format
 msgid "Failed to compare %1 with %2: "
 msgstr "無法比對 %1 與 %2："
 
 #. IDS_LOG_COMPARE_ERROR_3
-#: Merge.rc:5723
+#: Merge.rc:5722
 #, c-format
 msgid "Failed to compare %1 with %2 and %3: "
 msgstr "無法比對 %1 與 %2 及 %3："
 
 #. IDS_LOG_FILE_SAVED
-#: Merge.rc:5724
+#: Merge.rc:5723
 msgid "File saved"
 msgstr "檔案已儲存"
 
 #. IDS_LOG_COPYING_FILES
-#: Merge.rc:5725
+#: Merge.rc:5724
 msgid "Copying files..."
 msgstr "正在複製檔案..."
 
 #. IDS_LOG_MOVING_FILES
-#: Merge.rc:5726
+#: Merge.rc:5725
 msgid "Moving files..."
 msgstr "正在移動檔案..."
 
 #. IDS_LOG_DELETING_FILES
-#: Merge.rc:5727
+#: Merge.rc:5726
 msgid "Deleting files..."
 msgstr "正在刪除檔案..."
 
 #. IDS_LOG_RECYCLEBIN
-#: Merge.rc:5728
+#: Merge.rc:5727
 msgid "Recycle Bin"
 msgstr "回收站"
 
 #. IDS_LOG_PERMANENTLY_DELETED
-#: Merge.rc:5729
+#: Merge.rc:5728
 msgid "Permanently deleted"
 msgstr "永久刪除"
 
 #. IDS_LOG_FILEOPERATION_COMPLETED
-#: Merge.rc:5730
+#: Merge.rc:5729
 msgid "File operation completed successfully"
 msgstr "檔案操作已成功完成"
 
 #. IDS_LOG_FILEOPERATION_CANCELED
-#: Merge.rc:5731
+#: Merge.rc:5730
 msgid "File operation canceled"
 msgstr "檔案操作已取消"
 
 #. IDS_FILTER_ERROR_NO_ERROR
-#: Merge.rc:5736
+#: Merge.rc:5735
 msgid "No error"
 msgstr "無錯誤"
 
 #. IDS_FILTER_ERROR_EMPTY_EXPRESSION
-#: Merge.rc:5737
+#: Merge.rc:5736
 msgid "Filter expression is empty"
 msgstr "篩選表示式為空"
 
 #. IDS_FILTER_ERROR_UNKNOWN_CHAR
-#: Merge.rc:5738
+#: Merge.rc:5737
 msgid "Unknown character in filter expression"
 msgstr "篩選表示式中存在未知字符"
 
 #. IDS_FILTER_ERROR_UNTERMINATED_STRING
-#: Merge.rc:5739
+#: Merge.rc:5738
 msgid "Unterminated string literal"
 msgstr "未終止的字串文字"
 
 #. IDS_FILTER_ERROR_SYNTAX_ERROR
-#: Merge.rc:5740
+#: Merge.rc:5739
 msgid "Syntax error in filter expression"
 msgstr "篩選表示式中的語法錯誤"
 
 #. IDS_FILTER_ERROR_PARSE_FAILURE
-#: Merge.rc:5741
+#: Merge.rc:5740
 msgid "Failed to parse filter expression"
 msgstr "解析篩選表示式失敗"
 
 #. IDS_FILTER_ERROR_INVALID_LITERAL
-#: Merge.rc:5742
+#: Merge.rc:5741
 msgid "Invalid literal value"
 msgstr "無效的文字值"
 
 #. IDS_FILTER_ERROR_INVALID_REGULAR_EXPRESSION
-#: Merge.rc:5743
+#: Merge.rc:5742
 msgid "Invalid regular expression"
 msgstr "無效的正規表示式"
 
 #. IDS_FILTER_ERROR_UNDEFINED_IDENTIFIER
-#: Merge.rc:5744
+#: Merge.rc:5743
 msgid "Undefined identifier"
 msgstr "未定義標識符"
 
 #. IDS_FILTER_ERROR_INVALID_ARGUMENT_COUNT
-#: Merge.rc:5745
+#: Merge.rc:5744
 msgid "Invalid number of arguments"
 msgstr "引數數量無效"
 
 #. IDS_FILTER_ERROR_FILTER_NAME_NOT_FOUND
-#: Merge.rc:5746
+#: Merge.rc:5745
 msgid "Filter name not found"
 msgstr "未找到篩選器名稱"
 
 #. IDS_FILTER_ERROR_DIVIDE_BY_ZERO
-#: Merge.rc:5747
+#: Merge.rc:5746
 msgid "Division by zero in filter expression"
 msgstr "篩選表示式中除以零"
 
 #. IDS_FILTER_ERROR_UNKNOWN_ERROR
-#: Merge.rc:5748
+#: Merge.rc:5747
 msgid "Unknown error"
 msgstr "未知錯誤"
 
 #. IDS_FILTER_ERROR_INVALID_PROPERTY_NAME
-#: Merge.rc:5749
+#: Merge.rc:5748
 msgid "Invalid property name"
 msgstr "無效的屬性名稱"
 
 #. IDS_FILTER_ERROR_INVALID_DIRECTIVE
-#: Merge.rc:5750
+#: Merge.rc:5749
 msgid "Invalid directive"
 msgstr "無效指令"
 
 #. IDS_FILTER_OP_EQUALS
-#: Merge.rc:5755
+#: Merge.rc:5754
 msgid "Equals"
 msgstr "等於"
 
 #. IDS_FILTER_OP_NOT_EQUALS
-#: Merge.rc:5756
+#: Merge.rc:5755
 msgid "Does not equal"
 msgstr "不等於"
 
 #. IDS_FILTER_OP_LESS_THAN
-#: Merge.rc:5757
+#: Merge.rc:5756
 msgid "Less than"
 msgstr "小於"
 
 #. IDS_FILTER_OP_LESS_EQUAL
-#: Merge.rc:5758
+#: Merge.rc:5757
 msgid "Less than or equal to"
 msgstr "小於或等於"
 
 #. IDS_FILTER_OP_GREATER_EQUAL
-#: Merge.rc:5759
+#: Merge.rc:5758
 msgid "Greater than or equal to"
 msgstr "大於或等於"
 
 #. IDS_FILTER_OP_GREATER_THAN
-#: Merge.rc:5760
+#: Merge.rc:5759
 msgid "Greater than"
 msgstr "大於"
 
 #. IDS_FILTER_OP_BETWEEN
-#: Merge.rc:5761
+#: Merge.rc:5760
 msgid "Between"
 msgstr "介於"
 
 #. IDS_FILTER_OP_NOT_BETWEEN
-#: Merge.rc:5762
+#: Merge.rc:5761
 msgid "Not Between"
 msgstr "不介於"
 
 #. IDS_FILTER_OP_CONTAINS
-#: Merge.rc:5763
+#: Merge.rc:5762
 msgid "Contains"
 msgstr "包括"
 
 #. IDS_FILTER_OP_NOT_CONTAINS
-#: Merge.rc:5764
+#: Merge.rc:5763
 msgid "Not Contains"
 msgstr "不包括"
 
 #. IDS_FILTER_OP_RECONTAINS
-#: Merge.rc:5765
+#: Merge.rc:5764
 msgid "Contains (regex)"
 msgstr "包括（正規表示式）"
 
 #. IDS_FILTER_OP_NOT_RECONTAINS
-#: Merge.rc:5766
+#: Merge.rc:5765
 msgid "Not Contains (regex)"
 msgstr "不包括（正規表示式）"
 
 #. IDS_FILTER_OP_LIKE
-#: Merge.rc:5767
+#: Merge.rc:5766
 msgid "Match (wildcard)"
 msgstr "符合 (萬用字元)"
 
 #. IDS_FILTER_OP_NOT_LIKE
-#: Merge.rc:5768
+#: Merge.rc:5767
 msgid "Not match (wildcard)"
 msgstr "不符合 (萬用字元)"
 
 #. IDS_FILTER_OP_MATCHES
-#: Merge.rc:5769
+#: Merge.rc:5768
 msgid "Match (regex)"
 msgstr "符合 (正規表示式)"
 
 #. IDS_FILTER_OP_NOT_MATCHES
-#: Merge.rc:5770
+#: Merge.rc:5769
 msgid "Not match (regex)"
 msgstr "不符合 (正規表示式)"
 
 #. IDS_COLORMODE_LIGHT
-#: Merge.rc:5775
+#: Merge.rc:5774
 msgid "Light"
 msgstr "亮色"
 
 #. IDS_COLORMODE_DARK
-#: Merge.rc:5776
+#: Merge.rc:5775
 msgid "Dark"
 msgstr "暗色"
 
 #. IDS_COLORMODE_FOLLOWSYSTEM
-#: Merge.rc:5777
+#: Merge.rc:5776
 msgid "Follow system"
 msgstr "遵循系統"
 
 #. IDS_EXAMPLE
-#: Merge.rc:5782
+#: Merge.rc:5781
 #, c-format
 msgid "e.g. %1"
 msgstr "例:%1"
 
 #. IDS_DETECTED_PREVIOUS_CRASH
-#: Merge.rc:5787
+#: Merge.rc:5786
 msgid "WinMerge detected a previous crash. Please report this if possible."
 msgstr "WinMerge 偵測到上一次執行時發生損毀。如果可以的話，請協助回報此問題。"
 
 #. IDS_REGEX_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5792
+#: Merge.rc:5791
 msgid ""
 "# Regex replacement list\r\n"
 "# Format: regex<TAB>replacement\r\n"
@@ -8921,7 +8916,7 @@ msgstr ""
 "(\\d{4})-(\\d{2})-(\\d{2})\t$1_$2_$3\r\n"
 
 #. IDS_STRING_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5793
+#: Merge.rc:5792
 msgid ""
 "# Replacement list\r\n"
 "# Format: search<TAB>replacement\r\n"
@@ -8938,22 +8933,22 @@ msgstr ""
 "from2\tto2\r\n"
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_ONLY
-#: Merge.rc:5798
+#: Merge.rc:5797
 msgid "Built-in only"
 msgstr "僅內建"
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_FIRST
-#: Merge.rc:5799
+#: Merge.rc:5798
 msgid "Built-in first"
 msgstr "內建優先"
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_FIRST
-#: Merge.rc:5800
+#: Merge.rc:5799
 msgid "Tree-sitter first"
 msgstr "Tree-sitter 優先"
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_ONLY
-#: Merge.rc:5801
+#: Merge.rc:5800
 msgid "Tree-sitter only"
 msgstr "僅 Tree-sitter"
 

--- a/Translations/WinMerge/Corsican.po
+++ b/Translations/WinMerge/Corsican.po
@@ -25,7 +25,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
 #. LANGUAGE, SUBLANGUAGE
-#: Merge.rc:26 Merge.rc:59 Merge.rc:5818
+#: Merge.rc:26 Merge.rc:59 Merge.rc:5817
 msgid "LANG_ENGLISH, SUBLANG_ENGLISH_US"
 msgstr "LANG_CORSICAN, SUBLANG_DEFAULT"
 
@@ -167,7 +167,7 @@ msgstr "S&cenarii"
 #. IDS_NO_EDIT_SCRIPTS
 #: Merge.rc:127 Merge.rc:352 Merge.rc:463 Merge.rc:673 Merge.rc:678
 #: Merge.rc:887 Merge.rc:899 Merge.rc:906 Merge.rc:963 Merge.rc:1210
-#: Merge.rc:5375
+#: Merge.rc:5374
 msgid "< Empty >"
 msgstr "<Viotu>"
 
@@ -232,7 +232,7 @@ msgid "Auto-Fit All Columns"
 msgstr "Adattà autumaticamente tutte e culonne"
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN
-#: Merge.rc:153 Merge.rc:5646
+#: Merge.rc:153 Merge.rc:5645
 msgid "&Filter by This Column"
 msgstr "&Filtru da sta culonna"
 
@@ -293,7 +293,7 @@ msgid "&Previous Page"
 msgstr "Pagina &precedente"
 
 #. IDS_PREVIEWBAR_NEXTPAGE
-#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5679
+#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5678
 msgid "&Next Page"
 msgstr "Pagina &seguente"
 
@@ -544,7 +544,7 @@ msgstr "&Binariu"
 #. IDS_IMAGE_MENU
 #: Merge.rc:329 Merge.rc:338 Merge.rc:432 Merge.rc:441 Merge.rc:609
 #: Merge.rc:618 Merge.rc:670 Merge.rc:960 Merge.rc:1187 Merge.rc:1200
-#: Merge.rc:5477
+#: Merge.rc:5476
 msgid "&Image"
 msgstr "&Fiura"
 
@@ -666,7 +666,7 @@ msgid "&Huge"
 msgstr "&Tamanta"
 
 #. IDS_VIEW_MENU_BAR
-#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5714
+#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5713
 msgid "Men&u Bar"
 msgstr "Barra di &listinu"
 
@@ -1321,7 +1321,7 @@ msgid "Lo&cation Pane"
 msgstr "Pannellu di pusizi&one"
 
 #. IDS_OUTPUTBAR_CAPTION
-#: Merge.rc:782 Merge.rc:5252
+#: Merge.rc:782 Merge.rc:5251
 msgid "Output Pane"
 msgstr "Pannellu d’esciuta"
 
@@ -1584,55 +1584,55 @@ msgid "Co&mpare As"
 msgstr "Paragunà cum’&è"
 
 #. IDS_COPY_LEFT_TO_MIDDLE2
-#: Merge.rc:968 Merge.rc:980 Merge.rc:4852
+#: Merge.rc:968 Merge.rc:980 Merge.rc:4851
 #, c-format
 msgid "Left to Middle (%1 of %2)"
 msgstr "Da manca à centru (%1 nant’à %2)"
 
 #. IDS_COPY_LEFT_TO_RIGHT2
-#: Merge.rc:969 Merge.rc:981 Merge.rc:4851
+#: Merge.rc:969 Merge.rc:981 Merge.rc:4850
 #, c-format
 msgid "Left to Right (%1 of %2)"
 msgstr "Da manca à diritta (%1 nant’à %2)"
 
 #. IDS_MOVE_LEFT_TO2
-#: Merge.rc:970 Merge.rc:982 Merge.rc:1045 Merge.rc:4863 Merge.rc:4892
+#: Merge.rc:970 Merge.rc:982 Merge.rc:1045 Merge.rc:4862 Merge.rc:4891
 #, c-format
 msgid "Left to... (%1 of %2)"
 msgstr "Da manca à… (%1 nant’à %2)"
 
 #. IDS_COPY_MIDDLE_TO_LEFT2
-#: Merge.rc:971 Merge.rc:983 Merge.rc:4849
+#: Merge.rc:971 Merge.rc:983 Merge.rc:4848
 #, c-format
 msgid "Middle to Left (%1 of %2)"
 msgstr "Da centru à manca (%1 nant’à %2)"
 
 #. IDS_COPY_MIDDLE_TO_RIGHT2
-#: Merge.rc:972 Merge.rc:984 Merge.rc:4850
+#: Merge.rc:972 Merge.rc:984 Merge.rc:4849
 #, c-format
 msgid "Middle to Right (%1 of %2)"
 msgstr "Da centru à diritta (%1 nant’à %2)"
 
 #. IDS_MOVE_MIDDLE_TO2
-#: Merge.rc:973 Merge.rc:985 Merge.rc:1046 Merge.rc:4864 Merge.rc:4893
+#: Merge.rc:973 Merge.rc:985 Merge.rc:1046 Merge.rc:4863 Merge.rc:4892
 #, c-format
 msgid "Middle to... (%1 of %2)"
 msgstr "Da centru à… (%1 nant’à %2)"
 
 #. IDS_COPY_RIGHT_TO_MIDDLE2
-#: Merge.rc:974 Merge.rc:986 Merge.rc:4848
+#: Merge.rc:974 Merge.rc:986 Merge.rc:4847
 #, c-format
 msgid "Right to Middle (%1 of %2)"
 msgstr "Da diritta à centru (%1 nant’à %2)"
 
 #. IDS_COPY_RIGHT_TO_LEFT2
-#: Merge.rc:975 Merge.rc:987 Merge.rc:4847
+#: Merge.rc:975 Merge.rc:987 Merge.rc:4846
 #, c-format
 msgid "Right to Left (%1 of %2)"
 msgstr "Da diritta à manca (%1 nant’à %2)"
 
 #. IDS_MOVE_RIGHT_TO2
-#: Merge.rc:976 Merge.rc:988 Merge.rc:1047 Merge.rc:4865 Merge.rc:4894
+#: Merge.rc:976 Merge.rc:988 Merge.rc:1047 Merge.rc:4864 Merge.rc:4893
 #, c-format
 msgid "Right to... (%1 of %2)"
 msgstr "Da diritta à… (%1 nant’à %2)"
@@ -1688,31 +1688,31 @@ msgid "Cop&y Paths"
 msgstr "Cupià i c&hjassi"
 
 #. IDS_DEL_LEFT_FMT2
-#: Merge.rc:1026 Merge.rc:1035 Merge.rc:4880
+#: Merge.rc:1026 Merge.rc:1035 Merge.rc:4879
 #, c-format
 msgid "Left (%1 of %2)"
 msgstr "Manca (%1 nant’à %2)"
 
 #. IDS_DEL_MIDDLE_FMT2
-#: Merge.rc:1027 Merge.rc:1036 Merge.rc:4881
+#: Merge.rc:1027 Merge.rc:1036 Merge.rc:4880
 #, c-format
 msgid "Middle (%1 of %2)"
 msgstr "Centru (%1 nant’à %2)"
 
 #. IDS_DEL_RIGHT_FMT2
-#: Merge.rc:1028 Merge.rc:1037 Merge.rc:4882
+#: Merge.rc:1028 Merge.rc:1037 Merge.rc:4881
 #, c-format
 msgid "Right (%1 of %2)"
 msgstr "Diritta (%1 nant’à %2)"
 
 #. IDS_DEL_BOTH_FMT2
-#: Merge.rc:1029 Merge.rc:1038 Merge.rc:4883
+#: Merge.rc:1029 Merge.rc:1038 Merge.rc:4882
 #, c-format
 msgid "Both (%1 of %2)"
 msgstr "Tramindui (%1 nant’à %2)"
 
 #. IDS_DEL_ALL_FMT2
-#: Merge.rc:1030 Merge.rc:1039 Merge.rc:4888
+#: Merge.rc:1030 Merge.rc:1039 Merge.rc:4887
 #, c-format
 msgid "All (%1 of %2)"
 msgstr "Tutti (%1 nant’à %2)"
@@ -1738,19 +1738,19 @@ msgid "&Zip"
 msgstr "C&umprime"
 
 #. IDS_COPY_BOTH_TO2
-#: Merge.rc:1048 Merge.rc:4866
+#: Merge.rc:1048 Merge.rc:4865
 #, c-format
 msgid "Both to... (%1 of %2)"
 msgstr "Tramindui versu… (%1 nant’à %2)"
 
 #. IDS_COPY_ALL_TO2
-#: Merge.rc:1049 Merge.rc:4867
+#: Merge.rc:1049 Merge.rc:4866
 #, c-format
 msgid "All to... (%1 of %2)"
 msgstr "Tutti versu… (%1 nant’à %2)"
 
 #. IDS_COPY_DIFFERENCES_TO2
-#: Merge.rc:1050 Merge.rc:4868
+#: Merge.rc:1050 Merge.rc:4867
 #, c-format
 msgid "Differences to... (%1 of %2)"
 msgstr "Sfarenze versu… (%1 nant’à %2)"
@@ -1817,12 +1817,12 @@ msgstr "Parametri di u spacchittadore"
 
 #. IDS_USERCHOICE_NONE
 #: Merge.rc:1088 Merge.rc:1094 Merge.rc:1836 Merge.rc:1840 Merge.rc:2031
-#: Merge.rc:2035 Merge.rc:5377
+#: Merge.rc:2035 Merge.rc:5376
 msgid "<None>"
 msgstr "<nisunu>"
 
 #. IDS_USERCHOICE_AUTOMATIC
-#: Merge.rc:1089 Merge.rc:1095 Merge.rc:5378
+#: Merge.rc:1089 Merge.rc:1095 Merge.rc:5377
 msgid "<Automatic>"
 msgstr "<autumaticu>"
 
@@ -2752,12 +2752,12 @@ msgid "Text files only"
 msgstr "Solu i schedarii di testu"
 
 #. IDS_EOL_NONE
-#: Merge.rc:1667 Merge.rc:1918 Merge.rc:5304
+#: Merge.rc:1667 Merge.rc:1918 Merge.rc:5303
 msgid "None"
 msgstr "Nisunu"
 
 #. IDS_EOL_MIXED
-#: Merge.rc:1668 Merge.rc:5299
+#: Merge.rc:1668 Merge.rc:5298
 msgid "Mixed"
 msgstr "Mistu"
 
@@ -3029,13 +3029,13 @@ msgstr "&Statu di linea"
 
 #. IDS_DIFFERENT
 #: Merge.rc:1904 Merge.rc:1988 Merge.rc:2866 Merge.rc:3036 Merge.rc:3077
-#: Merge.rc:5058
+#: Merge.rc:5057
 msgid "Different"
 msgstr "Sfarente"
 
 #. IDS_IDENTICAL
 #: Merge.rc:1905 Merge.rc:1989 Merge.rc:2865 Merge.rc:3055 Merge.rc:3116
-#: Merge.rc:5048
+#: Merge.rc:5047
 msgid "Identical"
 msgstr "Identichi"
 
@@ -3055,7 +3055,7 @@ msgid "Missing"
 msgstr "Assente"
 
 #. IDS_MOVED
-#: Merge.rc:1910 Merge.rc:5076
+#: Merge.rc:1910 Merge.rc:5075
 msgid "Moved"
 msgstr "Dispiazzatu"
 
@@ -3791,7 +3791,7 @@ msgid "&Use custom system colors"
 msgstr "&Impiegà i culori persunalizati di u sistema (certi elementi di l’interfaccia grafica puderianu ùn esse appiecati)"
 
 #. IDS_PRPCAT_SYSTEM
-#: Merge.rc:2565 Merge.rc:4559 Merge.rc:4560 Merge.rc:5007
+#: Merge.rc:2565 Merge.rc:4559 Merge.rc:4560 Merge.rc:5006
 msgid "System"
 msgstr "Sistema"
 
@@ -4191,7 +4191,7 @@ msgid "Items compared:"
 msgstr "Elementi paragunati :"
 
 #. IDS_PREVIEWBAR_CLOSE
-#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5685
+#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5684
 msgid "&Close"
 msgstr "&Chjode"
 
@@ -4814,7 +4814,7 @@ msgid "A&ppend timestamp"
 msgstr "Aghjunghje una stampiglia di &tempu"
 
 #. IDS_CONFIRM_COPY_CAPTION
-#: Merge.rc:3214 Merge.rc:4915
+#: Merge.rc:3214 Merge.rc:4914
 msgid "Confirm Copy"
 msgstr "Cunfirmazione di copia"
 
@@ -5051,7 +5051,7 @@ msgid "&Character Set..."
 msgstr "Inseme di &caratteri…"
 
 #. IDS_PRPCAT_IMAGE
-#: Merge.rc:3351 Merge.rc:4574 Merge.rc:5015
+#: Merge.rc:3351 Merge.rc:4574 Merge.rc:5014
 msgid "Image"
 msgstr "Fiura"
 
@@ -5458,7 +5458,7 @@ msgid "Project"
 msgstr "Prughjettu"
 
 #. IDS_COLHDR_NSDIFFS
-#: Merge.rc:4566 Merge.rc:4990
+#: Merge.rc:4566 Merge.rc:4989
 msgid "Differences"
 msgstr "Sfarenze"
 
@@ -5603,12 +5603,12 @@ msgid "File Type"
 msgstr "Tipu di schedariu"
 
 #. IDS_COLHDR_EXTENSION
-#: Merge.rc:4653 Merge.rc:4947
+#: Merge.rc:4653 Merge.rc:4946
 msgid "Extension"
 msgstr "Estensione"
 
 #. IDS_PRPCAT_MESSAGE
-#: Merge.rc:4659 Merge.rc:5019
+#: Merge.rc:4659 Merge.rc:5018
 msgid "Message"
 msgstr "Messaghju"
 
@@ -5648,7 +5648,7 @@ msgid "Hidden Items"
 msgstr "Elementi piattati"
 
 #. IDS_PLUGINSLIST_NAME
-#: Merge.rc:4680 Merge.rc:5311
+#: Merge.rc:4680 Merge.rc:5310
 msgid "Name"
 msgstr "Nome"
 
@@ -5668,7 +5668,7 @@ msgid "[F] "
 msgstr "[F] "
 
 #. IDS_PLUGINSLIST_DESC
-#: Merge.rc:4684 Merge.rc:5313
+#: Merge.rc:4684 Merge.rc:5312
 msgid "Description"
 msgstr "Discrizzione"
 
@@ -5836,155 +5836,150 @@ msgstr "Lin : %s  Col : %d/%d  Car : %d/%d"
 msgid "  Sel: %d | %d"
 msgstr "  Sel : %d | %d"
 
-#. IDS_MERGEMODE_MERGING
-#: Merge.rc:4734
-msgid "Merge"
-msgstr "Fusione"
-
 #. IDS_DIFF_NUMBER_STATUS_FMT
-#: Merge.rc:4735
+#: Merge.rc:4734
 #, c-format
 msgid "Difference %1 of %2"
 msgstr "Sfarenza %1 nant’à %2"
 
 #. IDS_NO_DIFF_SEL_FMT
-#: Merge.rc:4736
+#: Merge.rc:4735
 #, c-format
 msgid "%1 Differences Found"
 msgstr "%1 sfarenze trove"
 
 #. IDS_1_DIFF_FOUND
-#: Merge.rc:4737
+#: Merge.rc:4736
 msgid "1 Difference Found"
 msgstr "1 sfarenza trova"
 
 #. IDS_NO_ERR_SEL_FMT
-#: Merge.rc:4738
+#: Merge.rc:4737
 #, c-format
 msgid "%1 Errors Found"
 msgstr "%1 sbaglii trovi"
 
 #. IDS_1_ERR_FOUND
-#: Merge.rc:4739
+#: Merge.rc:4738
 msgid "1 Error Found"
 msgstr "1 sbagliu trovu"
 
 #. IDS_STATUSBAR_READONLY, Abbreviation from "Read Only"
-#: Merge.rc:4740
+#: Merge.rc:4739
 msgid "RO"
 msgstr "LS"
 
 #. IDS_DIRVIEW_STATUS_FMT_FOCUS
-#: Merge.rc:4746
+#: Merge.rc:4745
 #, c-format
 msgid "Item %1 of %2"
 msgstr "Elementu %1 nant’à %2"
 
 #. IDS_DIRVIEW_STATUS_FMT_NOFOCUS
-#: Merge.rc:4747
+#: Merge.rc:4746
 #, c-format
 msgid "Items: %1"
 msgstr "Elementi : %1"
 
 #. IDS_DIRVIEW_STATUS_COMPARING
-#: Merge.rc:4748
+#: Merge.rc:4747
 msgid "Comparing items..."
 msgstr "Paragone di l’elementi…"
 
 #. IDS_ITEMS_PER_SEC
-#: Merge.rc:4749
+#: Merge.rc:4748
 #, c-format
 msgid "%.1f[items/sec]"
 msgstr "%.1f[elementi/sec]"
 
 #. IDS_ERROR_INCOMPARABLE
-#: Merge.rc:4755
+#: Merge.rc:4754
 msgid "Select two existing folders/files to compare."
 msgstr "Selezziunà dui cartulari o schedarii esistente à paragunà."
 
 #. IDS_DIRSEL_TAG
-#: Merge.rc:4756
+#: Merge.rc:4755
 msgid "Folder Selection"
 msgstr "Selezzione di cartulare"
 
 #. IDS_OPEN_FILESDIRS
-#: Merge.rc:4757
+#: Merge.rc:4756
 msgid "Select two (or three) folders/files to compare."
 msgstr "Selezziunà dui (o trè) cartulari o schedarii à paragunà."
 
 #. IDS_OPEN_LEFTINVALID
-#: Merge.rc:4758
+#: Merge.rc:4757
 msgid "Left (1st) path is invalid!"
 msgstr "U chjassu à manca (1ᵘ) hè inaccettevule !"
 
 #. IDS_OPEN_MIDDLEINVALID
-#: Merge.rc:4759
+#: Merge.rc:4758
 msgid "Middle (2nd) path is invalid!"
 msgstr "U chjassu à u centru (2ᵘ) hè inaccettevule !"
 
 #. IDS_OPEN_RIGHTINVALID2
-#: Merge.rc:4760
+#: Merge.rc:4759
 msgid "Right (2nd) path is invalid!"
 msgstr "U chjassu à diritta (2ᵘ) hè inaccettevule !"
 
 #. IDS_OPEN_RIGHTINVALID3
-#: Merge.rc:4761
+#: Merge.rc:4760
 msgid "Right (3rd) path is invalid!"
 msgstr "U chjassu à diritta (3ᵘ) hè inaccettevule !"
 
 #. IDS_OPEN_BOTHINVALID
-#: Merge.rc:4762
+#: Merge.rc:4761
 msgid "Both paths are invalid!"
 msgstr "I dui chjassi sò inaccettevule !"
 
-#: Merge.rc:4764
+#: Merge.rc:4763
 msgid "Left (1st) and Middle (2nd) paths are invalid!"
 msgstr "I chjassi à manca (1ᵘ) è à u centru (2ᵘ) sò inaccettevule !"
 
 #. IDS_OPEN_LEFTRIGHTINVALID
-#: Merge.rc:4765
+#: Merge.rc:4764
 msgid "Left (1st) and Right (3rd) paths are invalid!"
 msgstr "I chjassi à manca (1ᵘ) è à diritta (3ᵘ) sò inaccettevule !"
 
-#: Merge.rc:4767
+#: Merge.rc:4766
 msgid "Middle (2nd) and Right (3rd) paths are invalid!"
 msgstr "I chjassi à u centru (2ᵘ) è à diritta (3ᵘ) sò inaccettevule !"
 
 #. IDS_OPEN_ALLINVALID
-#: Merge.rc:4768
+#: Merge.rc:4767
 msgid "All paths are invalid!"
 msgstr "Tutti i chjassi sò inaccettevule !"
 
 #. IDS_OPEN_UNPACKERDISABLED
-#: Merge.rc:4769
+#: Merge.rc:4768
 msgid "Only enabled for file comparisons"
 msgstr "Attivatu solu per i paragoni di schedariu"
 
 #. IDS_OPEN_MISMATCH
-#: Merge.rc:4770
+#: Merge.rc:4769
 msgid "Cannot compare file and folder!"
 msgstr "Ùn si pò micca paragunà schedariu è cartulare !"
 
 #. IDS_ERROR_FILE_NOT_FOUND
-#: Merge.rc:4776
+#: Merge.rc:4775
 #, c-format
 msgid "File not found: %1"
 msgstr "U schedariu hè intruvevule : %1"
 
 #. IDS_ERROR_FOLDER_NOT_FOUND
-#: Merge.rc:4777
+#: Merge.rc:4776
 #, c-format
 msgid "Folder not found: %1"
 msgstr "U cartulare hè intruvevule : %1"
 
 #. IDS_ERROR_FILE_NOT_UNPACKED
-#: Merge.rc:4778
+#: Merge.rc:4777
 #, c-format
 msgid "File not unpacked: %1"
 msgstr "Schedariu micca spacchittatu : %1"
 
 #. IDS_ERROR_FILEOPEN
-#: Merge.rc:4779
+#: Merge.rc:4778
 #, c-format
 msgid ""
 "Cannot open file\n"
@@ -5998,12 +5993,12 @@ msgstr ""
 "%2"
 
 #. IDS_ERROR_CONF_RESOLVE
-#: Merge.rc:4780
+#: Merge.rc:4779
 msgid "Failed to parse conflict file."
 msgstr "Fiascu per analizà u schedariu di u cunflittu."
 
 #. IDS_NOT_CONFLICT_FILE
-#: Merge.rc:4781
+#: Merge.rc:4780
 #, c-format
 msgid ""
 "The file\n"
@@ -6015,7 +6010,7 @@ msgstr ""
 "ùn hè micca un schedariu di cunflittu."
 
 #. IDS_COMPARE_LARGE_FILES
-#: Merge.rc:4782
+#: Merge.rc:4781
 msgid ""
 "Comparing large files requires significant memory.\n"
 "Show only comparison results (not file contents)?"
@@ -6024,28 +6019,28 @@ msgstr ""
 "Vulete affissà solu i risultati di u paragone (micca i cuntenuti di schedariu) ?"
 
 #. IDS_SAVE_AS_TITLE
-#: Merge.rc:4788
+#: Merge.rc:4787
 msgid "Save As"
 msgstr "Arregistrà cù u nome"
 
 #. IDS_SAVE_FMT
-#: Merge.rc:4789
+#: Merge.rc:4788
 #, c-format
 msgid "Save changes to %1?"
 msgstr "Arregistrà i cambiamenti in %1 ?"
 
 #. IDS_SAVEREADONLY_FMT
-#: Merge.rc:4790
+#: Merge.rc:4789
 #, c-format
 msgid "%1 is read-only. Override? Or 'No' to save as new filename?"
 msgstr "%1 hè in lettura sola. Vulete rimpiazzallu ? O « Nò » per arregistrallu cù un nome di schedariu novu ?"
 
 #. IDS_ERROR_BACKUP
-#: Merge.rc:4791
+#: Merge.rc:4790
 msgid "Error backing up file"
 msgstr "Sbagliu di salvaguardia di u schedariu"
 
-#: Merge.rc:4793
+#: Merge.rc:4792
 #, c-format
 msgid ""
 "Unable to backup original file:\n"
@@ -6059,7 +6054,7 @@ msgstr ""
 "Cuntinuà quantunque ?"
 
 #. IDS_FILESAVE_FAILED
-#: Merge.rc:4794
+#: Merge.rc:4793
 #, c-format
 msgid ""
 "Saving file failed.\n"
@@ -6074,7 +6069,7 @@ msgstr ""
 "\t- impiegà un altru nome di schedariu (Vai)\n"
 "\t- interrompe (Abbandunà)?"
 
-#: Merge.rc:4796
+#: Merge.rc:4795
 #, c-format
 msgid ""
 "Plugin '%2' cannot pack changes to left file into '%1'.\n"
@@ -6085,7 +6080,7 @@ msgstr ""
 "\n"
 "Schedariu d’origine micca cambiatu. Arregistrà a versione spacchittata ?"
 
-#: Merge.rc:4798
+#: Merge.rc:4797
 #, c-format
 msgid ""
 "Plugin '%2' cannot pack changes to middle file into '%1'.\n"
@@ -6096,7 +6091,7 @@ msgstr ""
 "\n"
 "Schedariu d’origine micca cambiatu. Arregistrà a versione spacchittata ?"
 
-#: Merge.rc:4800
+#: Merge.rc:4799
 #, c-format
 msgid ""
 "Plugin '%2' cannot pack changes to right file into '%1'.\n"
@@ -6108,7 +6103,7 @@ msgstr ""
 "Schedariu d’origine micca cambiatu. Arregistrà a versione spacchittata ?"
 
 #. IDS_FILECHANGED_ONDISK
-#: Merge.rc:4801
+#: Merge.rc:4800
 #, c-format
 msgid ""
 "Another application updated\n"
@@ -6124,7 +6119,7 @@ msgstr ""
 "Vulete rimpiazzallu ?"
 
 #. IDS_SAVEREADONLY_MULTI
-#: Merge.rc:4802
+#: Merge.rc:4801
 #, c-format
 msgid ""
 "%1\n"
@@ -6134,7 +6129,7 @@ msgstr ""
 "hè in lettura sola. Vulete rimpiazzallu ?"
 
 #. IDS_FILECHANGED_RESCAN
-#: Merge.rc:4803
+#: Merge.rc:4802
 #, c-format
 msgid ""
 "Another application updated\n"
@@ -6150,22 +6145,22 @@ msgstr ""
 "Vulete ricaricallu ?"
 
 #. IDS_SAVE_LEFT_AS
-#: Merge.rc:4804
+#: Merge.rc:4803
 msgid "Save Left File As"
 msgstr "Arregistrà u schedariu à manca cù u nome"
 
 #. IDS_SAVE_MIDDLE_AS
-#: Merge.rc:4805
+#: Merge.rc:4804
 msgid "Save Middle File As"
 msgstr "Arregistrà u schedariu à u centru cù u nome"
 
 #. IDS_SAVE_RIGHT_AS
-#: Merge.rc:4806
+#: Merge.rc:4805
 msgid "Save Right File As"
 msgstr "Arregistrà u schedariu à diritta cù u nome"
 
 #. IDS_FILE_DISAPPEARED
-#: Merge.rc:4811
+#: Merge.rc:4810
 #, c-format
 msgid ""
 "File\n"
@@ -6177,7 +6172,7 @@ msgstr ""
 "ùn si truva micca. Arregistrà una copia per cuntinuà."
 
 #. IDS_VIEWS_OUTOFSYNC
-#: Merge.rc:4817
+#: Merge.rc:4816
 msgid ""
 "Cannot merge unsynched documents.\n"
 "\n"
@@ -6188,186 +6183,186 @@ msgstr ""
 "Attualizà prima di cuntinuà."
 
 #. IDS_BREAK_ON_WHITESPACE
-#: Merge.rc:4822
+#: Merge.rc:4821
 msgid "Break at whitespace"
 msgstr "Interrompe à i spazii bianchi"
 
 #. IDS_BREAK_ON_PUNCTUATION
-#: Merge.rc:4823
+#: Merge.rc:4822
 msgid "Break at whitespace or punctuation"
 msgstr "Interrompe à i spazii bianchi o à a puntuazione"
 
 #. IDS_L2M
-#: Merge.rc:4829
+#: Merge.rc:4828
 msgid "Copy to &Middle\tAlt+Right"
 msgstr "Cupià versu u &centru\tAlt+Diritta"
 
 #. IDS_R2M
-#: Merge.rc:4830
+#: Merge.rc:4829
 msgid "Copy to &Middle\tAlt+Left"
 msgstr "Cupià versu u &centru\tAlt+Manca"
 
 #. IDS_COPY_FROM_MIDDLE_R
-#: Merge.rc:4831
+#: Merge.rc:4830
 msgid "Copy from Middle\tAlt+Shift+Right"
 msgstr "Cupià da u centru\tAlt+Maius+Diritta"
 
 #. IDS_COPY_FROM_MIDDLE_L
-#: Merge.rc:4832
+#: Merge.rc:4831
 msgid "Copy from Middle\tAlt+Shift+Left"
 msgstr "Cupià da u centru\tAlt+Maius+Manca"
 
 #. IDS_L2MNEXT
-#: Merge.rc:4833
+#: Merge.rc:4832
 msgid "Copy to Middle and Advance\tCtrl+Alt+Right"
 msgstr "Cupià versu u centru è avanzà\t(Ctrl+Alt+Diritta)"
 
 #. IDS_R2MNEXT
-#: Merge.rc:4834
+#: Merge.rc:4833
 msgid "Copy to Middle and Advance\tCtrl+Alt+Left"
 msgstr "Cupià versu u centru è avanzà\tCtrl+Alt+Manca"
 
 #. IDS_ALL_MIDDLE
-#: Merge.rc:4835
+#: Merge.rc:4834
 msgid "Copy All to Middle"
 msgstr "Tuttu cupià versu u centru"
 
 #. IDS_COPY_RIGHT_TO_LEFT
-#: Merge.rc:4841
+#: Merge.rc:4840
 #, c-format
 msgid "Right to Left (%1)"
 msgstr "Da diritta à manca (%1)"
 
 #. IDS_COPY_RIGHT_TO_MIDDLE
-#: Merge.rc:4842
+#: Merge.rc:4841
 #, c-format
 msgid "Right to Middle (%1)"
 msgstr "Da diritta à centru (%1)"
 
 #. IDS_COPY_MIDDLE_TO_LEFT
-#: Merge.rc:4843
+#: Merge.rc:4842
 #, c-format
 msgid "Middle to Left (%1)"
 msgstr "Da centru à manca (%1)"
 
 #. IDS_COPY_MIDDLE_TO_RIGHT
-#: Merge.rc:4844
+#: Merge.rc:4843
 #, c-format
 msgid "Middle to Right (%1)"
 msgstr "Da centru à diritta (%1)"
 
 #. IDS_COPY_LEFT_TO_RIGHT
-#: Merge.rc:4845
+#: Merge.rc:4844
 #, c-format
 msgid "Left to Right (%1)"
 msgstr "Da manca à diritta (%1)"
 
 #. IDS_COPY_LEFT_TO_MIDDLE
-#: Merge.rc:4846
+#: Merge.rc:4845
 #, c-format
 msgid "Left to Middle (%1)"
 msgstr "Da manca à centru (%1)"
 
 #. IDS_MOVE_LEFT_TO
-#: Merge.rc:4857 Merge.rc:4889
+#: Merge.rc:4856 Merge.rc:4888
 #, c-format
 msgid "Left to... (%1)"
 msgstr "Da manca à… (%1)"
 
 #. IDS_MOVE_MIDDLE_TO
-#: Merge.rc:4858 Merge.rc:4890
+#: Merge.rc:4857 Merge.rc:4889
 #, c-format
 msgid "Middle to... (%1)"
 msgstr "Da centru à… (%1)"
 
 #. IDS_MOVE_RIGHT_TO
-#: Merge.rc:4859 Merge.rc:4891
+#: Merge.rc:4858 Merge.rc:4890
 #, c-format
 msgid "Right to... (%1)"
 msgstr "Da diritta à… (%1)"
 
 #. IDS_COPY_BOTH_TO
-#: Merge.rc:4860
+#: Merge.rc:4859
 #, c-format
 msgid "Both to... (%1)"
 msgstr "Tramindui versu… (%1)"
 
 #. IDS_COPY_ALL_TO
-#: Merge.rc:4861
+#: Merge.rc:4860
 #, c-format
 msgid "All to... (%1)"
 msgstr "Tutti versu… (%1)"
 
 #. IDS_COPY_DIFFERENCES_TO
-#: Merge.rc:4862
+#: Merge.rc:4861
 #, c-format
 msgid "Differences to... (%1)"
 msgstr "Sfarenze versu… (%1)"
 
 #. IDS_ONLYDIFFITEMS_CONFIRM
-#: Merge.rc:4869
+#: Merge.rc:4868
 msgid "Some selected items are identical or skipped.\nProcess only items with differences?"
 msgstr ""
 
 #. IDS_DEL_LEFT_FMT
-#: Merge.rc:4875
+#: Merge.rc:4874
 #, c-format
 msgid "Left (%1)"
 msgstr "À manca (%1)"
 
 #. IDS_DEL_MIDDLE_FMT
-#: Merge.rc:4876
+#: Merge.rc:4875
 #, c-format
 msgid "Middle (%1)"
 msgstr "À u centru (%1)"
 
 #. IDS_DEL_RIGHT_FMT
-#: Merge.rc:4877
+#: Merge.rc:4876
 #, c-format
 msgid "Right (%1)"
 msgstr "À diritta (%1)"
 
 #. IDS_DEL_BOTH_FMT
-#: Merge.rc:4878
+#: Merge.rc:4877
 #, c-format
 msgid "Both (%1)"
 msgstr "Tramindui (%1)"
 
 #. IDS_DEL_ALL_FMT
-#: Merge.rc:4879
+#: Merge.rc:4878
 #, c-format
 msgid "All (%1)"
 msgstr "Tutti (%1)"
 
 #. IDS_SELECT_DEST_LEFT
-#: Merge.rc:4895
+#: Merge.rc:4894
 msgid "Left Side - Select Destination Folder:"
 msgstr "À manu manca - selezziunà u cartulare di destinazione :"
 
 #. IDS_SELECT_DEST_MIDDLE
-#: Merge.rc:4896
+#: Merge.rc:4895
 msgid "Middle Side - Select Destination Folder:"
 msgstr "À u centru - selezziunà u cartulare di destinazione :"
 
 #. IDS_SELECT_DEST_RIGHT
-#: Merge.rc:4897
+#: Merge.rc:4896
 msgid "Right Side - Select Destination Folder:"
 msgstr "À manu diritta - selezziunà u cartulare di destinazione :"
 
 #. IDS_FILES_AFFECTED_FMT
-#: Merge.rc:4898
+#: Merge.rc:4897
 #, c-format
 msgid "(%1 Files Affected)"
 msgstr "(%1 schedarii tocchi)"
 
 #. IDS_FILES_AFFECTED_FMT2
-#: Merge.rc:4899
+#: Merge.rc:4898
 #, c-format
 msgid "(%1 of %2 Files Affected)"
 msgstr "(%1 schedarii tocchi nant’à %2)"
 
 #. IDS_CONFIRM_DELETE_SINGLE
-#: Merge.rc:4905
+#: Merge.rc:4904
 #, c-format
 msgid ""
 "Are you sure you want to delete\n"
@@ -6379,18 +6374,18 @@ msgstr ""
 "%1 ?"
 
 #. IDS_CONFIRM_SINGLE_COPY
-#: Merge.rc:4906
+#: Merge.rc:4905
 msgid "Are you sure you want to copy?"
 msgstr "Da veru vulete cupià ?"
 
 #. IDS_CONFIRM_MULTIPLE_COPY
-#: Merge.rc:4907
+#: Merge.rc:4906
 #, c-format
 msgid "Are you sure you want to copy %d items?"
 msgstr "Da veru vulete cupià %d elementi ?"
 
 #. IDS_DIRCMP_NOTSYNC
-#: Merge.rc:4908
+#: Merge.rc:4907
 #, c-format
 msgid ""
 "Operation aborted!\n"
@@ -6410,46 +6405,46 @@ msgstr ""
 "Attualizà u paragone."
 
 #. IDS_CONFIRM_SINGLE_MOVE
-#: Merge.rc:4913
+#: Merge.rc:4912
 msgid "Are you sure you want to move?"
 msgstr "Da veru vulete dispiazzà ?"
 
 #. IDS_CONFIRM_MULTIPLE_MOVE
-#: Merge.rc:4914
+#: Merge.rc:4913
 #, c-format
 msgid "Are you sure you want to move %d items?"
 msgstr "Da veru vulete dispiazzà %d elementi ?"
 
 #. IDS_CONFIRM_MOVE_CAPTION
-#: Merge.rc:4916
+#: Merge.rc:4915
 msgid "Confirm Move"
 msgstr "Cunfirmà u dispiazzamentu"
 
-#: Merge.rc:4918
+#: Merge.rc:4917
 msgid "Close the folder comparison window?"
 msgstr "Chjode a finestra di paragone di i cartulari ?"
 
-#: Merge.rc:4920
+#: Merge.rc:4919
 msgid "Close the folder comparison window, which took a long time?"
 msgstr "Chjode a finestra di paragone di i cartulari, chì hà pigliatu un bellu pezzu ?"
 
 #. IDS_ERROR_INVALID_DIR_FILE_NAME
-#: Merge.rc:4921
+#: Merge.rc:4920
 msgid "The file or folder name is invalid."
 msgstr "U nome di u schedariu o di u cartulare hè inaccettevule."
 
 #. IDS_ERROR_EXECUTE_FILE
-#: Merge.rc:4927
+#: Merge.rc:4926
 #, c-format
 msgid "Failed to execute external editor: %1"
 msgstr "Impussibule di lancià l’editore esternu : %1"
 
 #. IDS_UNKNOWN_ARCHIVE_FORMAT
-#: Merge.rc:4933
+#: Merge.rc:4932
 msgid "Unknown archive format"
 msgstr "Furmatu scunnisciutu d’archiviu"
 
-#: Merge.rc:4935
+#: Merge.rc:4934
 msgid ""
 "Failed to extract archive.\n"
 "Compare as text file?"
@@ -6458,513 +6453,513 @@ msgstr ""
 "Vulete paragunà cum’è schedarii di testu ?"
 
 #. IDS_COLHDR_FILENAME
-#: Merge.rc:4941
+#: Merge.rc:4940
 msgid "Filename"
 msgstr "Nome di schedariu"
 
 #. IDS_COLHDR_DIR
-#: Merge.rc:4942
+#: Merge.rc:4941
 msgctxt "DirView|ColumnHeader"
 msgid "Folder"
 msgstr "Cartulare"
 
 #. IDS_COLHDR_RESULT
-#: Merge.rc:4943
+#: Merge.rc:4942
 msgid "Comparison Result"
 msgstr "Risultatu di u paragone"
 
 #. IDS_COLHDR_LTIMEM
-#: Merge.rc:4944
+#: Merge.rc:4943
 msgid "Left Date"
 msgstr "Data à manca"
 
 #. IDS_COLHDR_RTIMEM
-#: Merge.rc:4945
+#: Merge.rc:4944
 msgid "Right Date"
 msgstr "Data à diritta"
 
 #. IDS_COLHDR_MTIMEM
-#: Merge.rc:4946
+#: Merge.rc:4945
 msgid "Middle Date"
 msgstr "Data à u centru"
 
 #. IDS_COLHDR_LSIZE
-#: Merge.rc:4948
+#: Merge.rc:4947
 msgid "Left Size"
 msgstr "Dimensione à manca"
 
 #. IDS_COLHDR_RSIZE
-#: Merge.rc:4949
+#: Merge.rc:4948
 msgid "Right Size"
 msgstr "Dimensione à diritta"
 
 #. IDS_COLHDR_MSIZE
-#: Merge.rc:4954
+#: Merge.rc:4953
 msgid "Middle Size"
 msgstr "Dimensione à u centru"
 
 #. IDS_COLHDR_RSIZE_SHORT
-#: Merge.rc:4955
+#: Merge.rc:4954
 msgid "Right Size (Short)"
 msgstr "Dimensione à diritta (corta)"
 
 #. IDS_COLHDR_LSIZE_SHORT
-#: Merge.rc:4956
+#: Merge.rc:4955
 msgid "Left Size (Short)"
 msgstr "Dimensione à manca (corta)"
 
 #. IDS_COLHDR_MSIZE_SHORT
-#: Merge.rc:4957
+#: Merge.rc:4956
 msgid "Middle Size (Short)"
 msgstr "Dimensione à u centru (corta)"
 
 #. IDS_COLHDR_LTIMEC
-#: Merge.rc:4963
+#: Merge.rc:4962
 msgid "Left Creation Time"
 msgstr "Ora di creazione à manca"
 
 #. IDS_COLHDR_RTIMEC
-#: Merge.rc:4964
+#: Merge.rc:4963
 msgid "Right Creation Time"
 msgstr "Ora di creazione à diritta"
 
 #. IDS_COLHDR_MTIMEC
-#: Merge.rc:4965
+#: Merge.rc:4964
 msgid "Middle Creation Time"
 msgstr "Ora di creazione à u centru"
 
 #. IDS_COLHDR_NEWER
-#: Merge.rc:4966
+#: Merge.rc:4965
 msgid "Newer File"
 msgstr "Schedariu più recente"
 
 #. IDS_COLHDR_LVERSION
-#: Merge.rc:4967
+#: Merge.rc:4966
 msgid "Left File Version"
 msgstr "Versione di schedariu à manca"
 
 #. IDS_COLHDR_RVERSION
-#: Merge.rc:4968
+#: Merge.rc:4967
 msgid "Right File Version"
 msgstr "Versione di schedariu à diritta"
 
 #. IDS_COLHDR_MVERSION
-#: Merge.rc:4969
+#: Merge.rc:4968
 msgid "Middle File Version"
 msgstr "Versione di schedariu à u centru"
 
 #. IDS_COLHDR_RESULT_ABBR
-#: Merge.rc:4970
+#: Merge.rc:4969
 msgid "Short Result"
 msgstr "Risultatu cortu"
 
 #. IDS_COLHDR_LATTRIBUTES
-#: Merge.rc:4971
+#: Merge.rc:4970
 msgid "Left Attributes"
 msgstr "Attributi à manca"
 
 #. IDS_COLHDR_RATTRIBUTES
-#: Merge.rc:4972
+#: Merge.rc:4971
 msgid "Right Attributes"
 msgstr "Attributi à diritta"
 
 #. IDS_COLHDR_MATTRIBUTES
-#: Merge.rc:4973
+#: Merge.rc:4972
 msgid "Middle Attributes"
 msgstr "Attributi à u centru"
 
 #. IDS_COLHDR_LEOL_TYPE
-#: Merge.rc:4978
+#: Merge.rc:4977
 msgid "Left EOL"
 msgstr "Fine di linea à manca"
 
 #. IDS_COLHDR_MEOL_TYPE
-#: Merge.rc:4979
+#: Merge.rc:4978
 msgid "Middle EOL"
 msgstr "Fine di linea à u centru"
 
 #. IDS_COLHDR_REOL_TYPE
-#: Merge.rc:4980
+#: Merge.rc:4979
 msgid "Right EOL"
 msgstr "Fine di linea à diritta"
 
 #. IDS_COLHDR_LENCODING
-#: Merge.rc:4986
+#: Merge.rc:4985
 msgid "Left Encoding"
 msgstr "Cudificazione à manca"
 
 #. IDS_COLHDR_RENCODING
-#: Merge.rc:4987
+#: Merge.rc:4986
 msgid "Right Encoding"
 msgstr "Cudificazione à diritta"
 
 #. IDS_COLHDR_MENCODING
-#: Merge.rc:4988
+#: Merge.rc:4987
 msgid "Middle Encoding"
 msgstr "Cudificazione à u centru"
 
 #. IDS_COLHDR_NIDIFFS
-#: Merge.rc:4989
+#: Merge.rc:4988
 msgid "Ignored Diff"
 msgstr "Sfarenze ignurate"
 
 #. IDS_COLHDR_BINARY
-#: Merge.rc:4991
+#: Merge.rc:4990
 msgctxt "DirView|ColumnHeader"
 msgid "Binary"
 msgstr "Binariu"
 
 #. IDS_PLUGINS_TYPE_UNPACKER
-#: Merge.rc:4992 Merge.rc:5314
+#: Merge.rc:4991 Merge.rc:5313
 msgid "Unpacker"
 msgstr "Spacchittadore"
 
 #. IDS_PLUGIN_TYPE4
-#: Merge.rc:4993 Merge.rc:5315 Merge.rc:5622
+#: Merge.rc:4992 Merge.rc:5314 Merge.rc:5621
 msgid "Prediffer"
 msgstr "Preparagone"
 
 #. IDS_COLHDR_LEFT
-#: Merge.rc:4994
+#: Merge.rc:4993
 msgid "Left"
 msgstr "Manca"
 
 #. IDS_COLHDR_MIDDLE
-#: Merge.rc:4995
+#: Merge.rc:4994
 msgid "Middle"
 msgstr "Centru"
 
 #. IDS_COLHDR_RIGHT
-#: Merge.rc:4996
+#: Merge.rc:4995
 msgid "Right"
 msgstr "Diritta"
 
 #. IDS_COLHDR_DIFF
-#: Merge.rc:4997
+#: Merge.rc:4996
 msgid "Diff"
 msgstr "Sfarenze"
 
 #. IDS_COLHDR_LEFT_DUPLICATE
-#: Merge.rc:4998
+#: Merge.rc:4997
 msgid "Left Duplicate Count"
 msgstr "Numeru di doppiatura à manca"
 
 #. IDS_COLHDR_RIGHT_DUPLICATE
-#: Merge.rc:4999
+#: Merge.rc:4998
 msgid "Right Duplicate Count"
 msgstr "Numeru di doppiatura à diritta"
 
 #. IDS_COLHDR_MIDDLE_DUPLICATE
-#: Merge.rc:5000
+#: Merge.rc:4999
 msgid "Middle Duplicate Count"
 msgstr "Numeru di doppiatura à u centru"
 
 #. IDS_COLHDR_MOVE
-#: Merge.rc:5001
+#: Merge.rc:5000
 msgid "Move"
 msgstr "Dispiazzà"
 
 #. IDS_PRPCAT_AUDIO
-#: Merge.rc:5008
+#: Merge.rc:5007
 msgid "Audio"
 msgstr "Audio"
 
 #. IDS_PRPCAT_CALENDAR
-#: Merge.rc:5009
+#: Merge.rc:5008
 msgid "Calendar"
 msgstr "Calendariu"
 
 #. IDS_PRPCAT_COMMUNICATION
-#: Merge.rc:5010
+#: Merge.rc:5009
 msgid "Communication"
 msgstr "Cumunicazione"
 
 #. IDS_PRPCAT_CONTACT
-#: Merge.rc:5011
+#: Merge.rc:5010
 msgid "Contact"
 msgstr "Cuntattu"
 
 #. IDS_PRPCAT_DEVICES
-#: Merge.rc:5012
+#: Merge.rc:5011
 msgid "Devices"
 msgstr "Apparechji"
 
 #. IDS_PRPCAT_DOCUMENT
-#: Merge.rc:5013
+#: Merge.rc:5012
 msgid "Document"
 msgstr "Ducumentu"
 
 #. IDS_PRPCAT_HOME
-#: Merge.rc:5014
+#: Merge.rc:5013
 msgid "Home"
 msgstr "Accolta"
 
 #. IDS_PRPCAT_JOURNAL
-#: Merge.rc:5016
+#: Merge.rc:5015
 msgid "Journal"
 msgstr "Ghjurnale"
 
 #. IDS_PRPCAT_LINK
-#: Merge.rc:5017
+#: Merge.rc:5016
 msgid "Link"
 msgstr "Liame"
 
 #. IDS_PRPCAT_MEDIA
-#: Merge.rc:5018
+#: Merge.rc:5017
 msgid "Media"
 msgstr "Multimedià"
 
 #. IDS_PRPCAT_MUSIC
-#: Merge.rc:5020
+#: Merge.rc:5019
 msgid "Music"
 msgstr "Musica"
 
 #. IDS_PRPCAT_NOTE
-#: Merge.rc:5021
+#: Merge.rc:5020
 msgid "Note"
 msgstr "Nota"
 
 #. IDS_PRPCAT_PHOTO
-#: Merge.rc:5022
+#: Merge.rc:5021
 msgid "Photo"
 msgstr "Fotò"
 
 #. IDS_PRPCAT_RECORDEDTV
-#: Merge.rc:5023
+#: Merge.rc:5022
 msgid "RecordedTV"
 msgstr "TV arregistrata"
 
 #. IDS_PRPCAT_SEARCH
-#: Merge.rc:5024
+#: Merge.rc:5023
 msgid "Search"
 msgstr "Ricercà"
 
 #. IDS_PRPCAT_SECURITY
-#: Merge.rc:5025
+#: Merge.rc:5024
 msgid "Security"
 msgstr "Sicurità"
 
 #. IDS_PRPCAT_SOFTWARE
-#: Merge.rc:5026
+#: Merge.rc:5025
 msgid "Software"
 msgstr "Prugramma"
 
 #. IDS_PRPCAT_TASK
-#: Merge.rc:5027
+#: Merge.rc:5026
 msgid "Task"
 msgstr "Tacca"
 
 #. IDS_PRPCAT_VIDEO
-#: Merge.rc:5028
+#: Merge.rc:5027
 msgid "Video"
 msgstr "Video"
 
 #. IDS_PRPCAT_HASH
-#: Merge.rc:5029
+#: Merge.rc:5028
 msgid "Hash"
 msgstr "Tazzeghju"
 
 #. IDS_CANT_COMPARE_FILES
-#: Merge.rc:5035
+#: Merge.rc:5034
 msgid "Unable to compare files"
 msgstr "Impussibule di paragunà i schedarii"
 
 #. IDS_ABORTED_ITEM
-#: Merge.rc:5036
+#: Merge.rc:5035
 msgid "Item aborted"
 msgstr "Elementu interrottu"
 
 #. IDS_FILE_SKIPPED
-#: Merge.rc:5037
+#: Merge.rc:5036
 msgid "File skipped"
 msgstr "Schedariu tralasciatu"
 
 #. IDS_DIR_SKIPPED
-#: Merge.rc:5038
+#: Merge.rc:5037
 msgid "Folder skipped"
 msgstr "Cartulare tralasciatu"
 
 #. IDS_LEFT_ONLY_IN_FMT
-#: Merge.rc:5039
+#: Merge.rc:5038
 #, c-format
 msgid "Left only: %1"
 msgstr "Solu à manca : %1"
 
 #. IDS_MIDDLE_ONLY_IN_FMT
-#: Merge.rc:5040
+#: Merge.rc:5039
 #, c-format
 msgid "Middle only: %1"
 msgstr "Solu à u centru : %1"
 
 #. IDS_RIGHT_ONLY_IN_FMT
-#: Merge.rc:5041
+#: Merge.rc:5040
 #, c-format
 msgid "Right only: %1"
 msgstr "Solu à diritta : %1"
 
 #. IDS_DOES_NOT_EXIST_IN_FMT
-#: Merge.rc:5042
+#: Merge.rc:5041
 #, c-format
 msgid "Does not exist in %1"
 msgstr "Ùn esiste micca in %1"
 
 #. IDS_BIN_FILES_SAME
-#: Merge.rc:5043
+#: Merge.rc:5042
 msgid "Binary files are identical"
 msgstr "I schedarii binarii sò identichi"
 
 #. IDS_BIN_FILES_DIFF
-#: Merge.rc:5049
+#: Merge.rc:5048
 msgid "Binary files are different"
 msgstr "I schedarii binarii sò sfarenti"
 
 #. IDS_FILES_ARE_DIFFERENT
-#: Merge.rc:5050
+#: Merge.rc:5049
 msgid "Files are different"
 msgstr "I schedarii sò sfarenti"
 
 #. IDS_FOLDERS_ARE_DIFFERENT
-#: Merge.rc:5051
+#: Merge.rc:5050
 msgid "Folders are different"
 msgstr "I cartulari sò sfarenti"
 
 #. IDS_LEFTONLY
-#: Merge.rc:5052
+#: Merge.rc:5051
 msgid "Left Only"
 msgstr "Solu à manca"
 
 #. IDS_RIGHTONLY
-#: Merge.rc:5053
+#: Merge.rc:5052
 msgid "Right Only"
 msgstr "Solu à diritta"
 
 #. IDS_MIDDLEONLY
-#: Merge.rc:5054
+#: Merge.rc:5053
 msgid "Middle Only"
 msgstr "Solu à u centru"
 
 #. IDS_NOITEMLEFT
-#: Merge.rc:5055
+#: Merge.rc:5054
 msgid "No item in left"
 msgstr "Nisunu elementu à manca"
 
 #. IDS_NOITEMRIGHT
-#: Merge.rc:5056
+#: Merge.rc:5055
 msgid "No item in right"
 msgstr "Nisunu elementu à diritta"
 
 #. IDS_NOITEMMIDDLE
-#: Merge.rc:5057
+#: Merge.rc:5056
 msgid "No item in middle"
 msgstr "Nisunu elementu à u centru"
 
 #. IDS_CMPRES_ERROR
-#: Merge.rc:5059
+#: Merge.rc:5058
 msgid "Error"
 msgstr "Sbagliu"
 
 #. IDS_TEXT_FILES_SAME
-#: Merge.rc:5060
+#: Merge.rc:5059
 msgid "Text files are identical"
 msgstr "I schedarii di testu sò identichi"
 
 #. IDS_LEFTONLY_DIFF
-#: Merge.rc:5061
+#: Merge.rc:5060
 msgid " (Middle and right are identical)"
 msgstr " (centru è diritta sò identichi)"
 
 #. IDS_MIDDLEONLY_DIFF
-#: Merge.rc:5062
+#: Merge.rc:5061
 msgid " (Left and right are identical)"
 msgstr " (manca è diritta sò identichi)"
 
 #. IDS_RIGHTONLY_DIFF
-#: Merge.rc:5063
+#: Merge.rc:5062
 msgid " (Left and middle are identical)"
 msgstr " (manca è centru sò identichi)"
 
 #. IDS_PATH_MISMATCH
-#: Merge.rc:5064
+#: Merge.rc:5063
 msgid " (paths differ)"
 msgstr " (sfarenza di i chjassi)"
 
 #. IDS_TEXT_FILES_DIFF
-#: Merge.rc:5065
+#: Merge.rc:5064
 msgid "Text files are different"
 msgstr "I schedarii di testu sò sfarenti"
 
 #. IDS_IMAGE_FILES_SAME
-#: Merge.rc:5066
+#: Merge.rc:5065
 msgid "Image files are identical"
 msgstr "I schedarii di fiura sò identichi"
 
 #. IDS_IMAGE_FILES_DIFF
-#: Merge.rc:5067
+#: Merge.rc:5066
 msgid "Image files are different"
 msgstr "I schedarii di fiura sò sfarenti"
 
 #. IDS_EXPR_DIFF
-#: Merge.rc:5068
+#: Merge.rc:5067
 #, c-format
 msgid "Files are different (expr: %1)"
 msgstr "I schedarii sò sfarenti (espr : %1)"
 
 #. IDS_HASH_GROUP
-#: Merge.rc:5069
+#: Merge.rc:5068
 #, c-format
 msgid "Group%d"
 msgstr "Gruppu %d"
 
 #. IDS_RENAME_MOVE_DETECTION_DISALBED
-#: Merge.rc:5070
+#: Merge.rc:5069
 msgctxt "Options dialog|Compare|Folder|Detect renames and moves"
 msgid "Disabled"
 msgstr "Disattivata"
 
 #. IDS_RENAME_MOVE_DETECTION_RENAME
-#: Merge.rc:5071
+#: Merge.rc:5070
 msgid "Detect renames"
 msgstr "Scopre e rinuminazioni"
 
 #. IDS_RENAME_MOVE_DETECTION_RENAME_MOVE
-#: Merge.rc:5072
+#: Merge.rc:5071
 msgid "Detect renames and moves"
 msgstr "Scopre e rinuminazioni è i dispiazzamenti"
 
 #. IDS_RENAME_MOVE_MERGE_MODE_RENAME
-#: Merge.rc:5073
+#: Merge.rc:5072
 msgid "Merge renames"
 msgstr "Fusione di e rinuminazioni"
 
 #. IDS_RENAME_MOVE_MERGE_MODE_RENAME_MOVE
-#: Merge.rc:5074
+#: Merge.rc:5073
 msgid "Merge renames and moves"
 msgstr "Fusione di e rinuminazioni è i dispiazzamenti"
 
 #. IDS_RENAMED
-#: Merge.rc:5075
+#: Merge.rc:5074
 msgid "Renamed"
 msgstr "Rinuminatu"
 
 #. IDS_RENAMED_MOVED
-#: Merge.rc:5077
+#: Merge.rc:5076
 msgid "Renamed/Moved"
 msgstr "Rinuminatu è dispiazzatu"
 
 #. IDS_RENAMED_MOVED_ITEMS
-#: Merge.rc:5078
+#: Merge.rc:5077
 #, c-format
 msgid "(%1 items)"
 msgstr "(%1 elementi)"
 
 #. IDS_RENAMED_MOVED_RESULT
-#: Merge.rc:5079
+#: Merge.rc:5078
 #, c-format
 msgid "%1 (set %2): "
 msgstr "%1 (inseme %2) : "
 
 #. IDS_SWITCH_FLAT_MODE
-#: Merge.rc:5080
+#: Merge.rc:5079
 msgid ""
 "Some moved items have been merged.\n"
 "In Tree Mode, these items may appear in positions that do not reflect the actual folder structure, which can be confusing.\n"
@@ -6975,235 +6970,235 @@ msgstr ""
 "Passà à u modu pianu ?"
 
 #. IDS_ELAPSED_TIME
-#: Merge.rc:5086
+#: Merge.rc:5085
 #, c-format
 msgid "Elapsed time: %ld ms"
 msgstr "Tempu scorsu : %ld ms"
 
 #. IDS_STATUS_SELITEM1
-#: Merge.rc:5087
+#: Merge.rc:5086
 msgid "1 item selected"
 msgstr "1 elementu selezziunatu"
 
 #. IDS_STATUS_SELITEMS
-#: Merge.rc:5088
+#: Merge.rc:5087
 #, c-format
 msgid "%1 items selected"
 msgstr "%1 elementi selezziunati"
 
 #. IDS_COLDESC_FILENAME
-#: Merge.rc:5094
+#: Merge.rc:5093
 msgid "Filename or folder name."
 msgstr "Nome di schedariu o di cartulare."
 
 #. IDS_COLDESC_DIR
-#: Merge.rc:5095
+#: Merge.rc:5094
 msgid "Subfolder name when subfolders are included."
 msgstr "Nome di sottucartulare quandu i sottucartulari sò inclusi."
 
 #. IDS_COLDESC_RESULT
-#: Merge.rc:5096
+#: Merge.rc:5095
 msgid "Comparison result, long form."
 msgstr "Risultatu di u paragone, forma longa."
 
 #. IDS_COLDESC_LTIMEM
-#: Merge.rc:5101
+#: Merge.rc:5100
 msgid "Left side modification date."
 msgstr "Data di l’ultima mudificazione à manu manca."
 
 #. IDS_COLDESC_RTIMEM
-#: Merge.rc:5102
+#: Merge.rc:5101
 msgid "Right side modification date."
 msgstr "Data di l’ultima mudificazione à manu diritta."
 
 #. IDS_COLDESC_MTIMEM
-#: Merge.rc:5103
+#: Merge.rc:5102
 msgid "Middle side modification date."
 msgstr "Data di l’ultima mudificazione à u centru."
 
 #. IDS_COLDESC_EXTENSION
-#: Merge.rc:5104
+#: Merge.rc:5103
 msgid "File's extension."
 msgstr "Estensione di u schedariu."
 
 #. IDS_COLDESC_LSIZE
-#: Merge.rc:5105
+#: Merge.rc:5104
 msgid "Left file size in bytes."
 msgstr "Dimensione in ottetti di u schedariu à manu manca."
 
 #. IDS_COLDESC_RSIZE
-#: Merge.rc:5106
+#: Merge.rc:5105
 msgid "Right file size in bytes."
 msgstr "Dimensione in ottetti di u schedariu à manu diritta."
 
 #. IDS_COLDESC_MSIZE
-#: Merge.rc:5107
+#: Merge.rc:5106
 msgid "Middle file size in bytes."
 msgstr "Dimensione in ottetti di u schedariu à u centru."
 
 #. IDS_COLDESC_LSIZE_SHORT
-#: Merge.rc:5108
+#: Merge.rc:5107
 msgid "Left file size abbreviated."
 msgstr "Dimensione corta di u schedariu à manu manca."
 
 #. IDS_COLDESC_RSIZE_SHORT
-#: Merge.rc:5109
+#: Merge.rc:5108
 msgid "Right file size abbreviated."
 msgstr "Dimensione corta di u schedariu à manu diritta."
 
 #. IDS_COLDESC_MSIZE_SHORT
-#: Merge.rc:5110
+#: Merge.rc:5109
 msgid "Middle file size abbreviated."
 msgstr "Dimensione corta di u schedariu à u centru."
 
 #. IDS_COLDESC_LTIMEC
-#: Merge.rc:5116
+#: Merge.rc:5115
 msgid "Left side creation time."
 msgstr "Ora di creazione à manu manca."
 
 #. IDS_COLDESC_RTIMEC
-#: Merge.rc:5117
+#: Merge.rc:5116
 msgid "Right side creation time."
 msgstr "Ora di creazione à manu diritta."
 
 #. IDS_COLDESC_MTIMEC
-#: Merge.rc:5118
+#: Merge.rc:5117
 msgid "Middle side creation time."
 msgstr "Ora di creazione à u centru."
 
 #. IDS_COLDESC_NEWER
-#: Merge.rc:5119
+#: Merge.rc:5118
 msgid "Tells which side has newer modification date."
 msgstr "Indicheghja u latu chì hà a data di mudificazione à più recente."
 
 #. IDS_COLDESC_LVERSION
-#: Merge.rc:5120
+#: Merge.rc:5119
 msgid "Left side file version, only for some file types."
 msgstr "Versione di schedariu à manu manca, solu per certi tipi di schedariu."
 
 #. IDS_COLDESC_RVERSION
-#: Merge.rc:5121
+#: Merge.rc:5120
 msgid "Right side file version, only for some file types."
 msgstr "Versione di schedariu à manu diritta, solu per certi tipi di schedariu."
 
 #. IDS_COLDESC_MVERSION
-#: Merge.rc:5126
+#: Merge.rc:5125
 msgid "Middle side file version, only for some file types."
 msgstr "Versione di schedariu à u centru, solu per certi tipi di schedariu."
 
 #. IDS_COLDESC_RESULT_ABBR
-#: Merge.rc:5127
+#: Merge.rc:5126
 msgid "Short comparison result."
 msgstr "Risultatu di u paragone, forma corta."
 
 #. IDS_COLDESC_LATTRIBUTES
-#: Merge.rc:5128
+#: Merge.rc:5127
 msgid "Left side attributes."
 msgstr "Attributi à manu manca."
 
 #. IDS_COLDESC_RATTRIBUTES
-#: Merge.rc:5129
+#: Merge.rc:5128
 msgid "Right side attributes."
 msgstr "Attributi à manu diritta."
 
 #. IDS_COLDESC_MATTRIBUTES
-#: Merge.rc:5130
+#: Merge.rc:5129
 msgid "Middle side attributes."
 msgstr "Attributi à u centru."
 
 #. IDS_COLDESC_LEOL_TYPE
-#: Merge.rc:5131
+#: Merge.rc:5130
 msgid "Left side file EOL type."
 msgstr "Tipu di fine di linea à manu manca."
 
 #. IDS_COLDESC_REOL_TYPE
-#: Merge.rc:5132
+#: Merge.rc:5131
 msgid "Right side file EOL type."
 msgstr "Tipu di fine di linea à manu diritta."
 
 #. IDS_COLDESC_MEOL_TYPE
-#: Merge.rc:5133
+#: Merge.rc:5132
 msgid "Middle side file EOL type."
 msgstr "Tipu di fine di linea à u centru."
 
 #. IDS_COLDESC_LENCODING
-#: Merge.rc:5139
+#: Merge.rc:5138
 msgid "Left side encoding."
 msgstr "Cudificazione à manu manca."
 
 #. IDS_COLDESC_RENCODING
-#: Merge.rc:5140
+#: Merge.rc:5139
 msgid "Right side encoding."
 msgstr "Cudificazione à manu diritta."
 
 #. IDS_COLDESC_MENCODING
-#: Merge.rc:5141
+#: Merge.rc:5140
 msgid "Middle side encoding."
 msgstr "Cudificazione à u centru."
 
 #. IDS_COLDESC_NIDIFFS
-#: Merge.rc:5142
+#: Merge.rc:5141
 msgid "Number of ignored differences in file. Ignored and cannot be merged."
 msgstr "Numeru di sfarenze ignurate in u schedariu. Ignurate è ùn ponu micca fà parte d’una fusione."
 
 #. IDS_COLDESC_NSDIFFS
-#: Merge.rc:5143
+#: Merge.rc:5142
 msgid "Number of differences in file (excluding ignored)."
 msgstr "Numeru di sfarenze in u schedariu (escluendu quelle ignurate)."
 
 #. IDS_COLDESC_BINARY
-#: Merge.rc:5144
+#: Merge.rc:5143
 msgid "Shows an asterisk (*) if the file is binary."
 msgstr "Affisseghja un asteriscu (*) s’è u schedariu hè binariu."
 
 #. IDS_COLDESC_UNPACKER
-#: Merge.rc:5145
+#: Merge.rc:5144
 msgid "Unpacker plugin name or pipeline."
 msgstr "Nome o cundottu di u modulu d’estensione di u spacchittadore."
 
 #. IDS_COLDESC_PREDIFFER
-#: Merge.rc:5146
+#: Merge.rc:5145
 msgid "Prediffer plugin name or pipeline."
 msgstr "Nome o cundottu di u modulu d’estensione di u preparagone."
 
 #. IDS_DIRECTORY_REPORT_TITLE
-#: Merge.rc:5152
+#: Merge.rc:5151
 #, c-format
 msgid "Compare %1 with %2"
 msgstr "Paragunà %1 cù %2"
 
 #. IDS_DIRECTORY_REPORT_TITLE3
-#: Merge.rc:5153
+#: Merge.rc:5152
 #, c-format
 msgid "Compare %1 with %2 and %3"
 msgstr "Paragunà %1 cù %2 è %3"
 
 #. IDS_REPORT_COMMALIST
-#: Merge.rc:5154
+#: Merge.rc:5153
 msgid "Comma-separated list"
 msgstr "Lista staccata da virgule"
 
 #. IDS_REPORT_TABLIST
-#: Merge.rc:5155
+#: Merge.rc:5154
 msgid "Tab-separated list"
 msgstr "Lista staccata da tabulazioni"
 
 #. IDS_REPORT_SIMPLEHTML
-#: Merge.rc:5156
+#: Merge.rc:5155
 msgid "Simple HTML"
 msgstr "HTML simplice"
 
 #. IDS_REPORT_SIMPLEXML
-#: Merge.rc:5157
+#: Merge.rc:5156
 msgid "Simple XML"
 msgstr "XML simplice"
 
-#: Merge.rc:5159
+#: Merge.rc:5158
 msgid "Report file already exists. Overwrite?"
 msgstr "U schedariu di raportu esiste dighjà. Vulete rimpiazzà u schedariu esistente ?"
 
 #. IDS_REPORT_ERROR
-#: Merge.rc:5164
+#: Merge.rc:5163
 #, c-format
 msgid ""
 "Error creating the report:\n"
@@ -7213,27 +7208,27 @@ msgstr ""
 "%1"
 
 #. IDS_REPORT_SUCCESS
-#: Merge.rc:5165
+#: Merge.rc:5164
 msgid "Report created successfully."
 msgstr "U raportu hè statu creatu currettamente."
 
 #. IDS_SYNCPOINT_LASTBLOCK
-#: Merge.rc:5171
+#: Merge.rc:5170
 msgid "Cannot add a synchronization point at this line."
 msgstr "Ùn si pò micca aghjughje un puntu di sincrunizazione à sta linea."
 
 #. IDS_FILE_TO_ITSELF
-#: Merge.rc:5177
+#: Merge.rc:5176
 msgid "Same file is opened in both panes."
 msgstr "U listessu schedariu hè apertu in i dui pannelli."
 
 #. IDS_FILESSAME
-#: Merge.rc:5178
+#: Merge.rc:5177
 msgid "Selected files are identical."
 msgstr "I schedarii selezziunati sò identichi."
 
 #. IDS_FILESSAME_CURCFG
-#: Merge.rc:5179
+#: Merge.rc:5178
 msgid ""
 "Selected files are identical (with current settings).\r\n"
 "Checking binary identity..."
@@ -7242,7 +7237,7 @@ msgstr ""
 "Verificazione di l’identità binaria…"
 
 #. IDS_FILESSAME_BINERROR
-#: Merge.rc:5180
+#: Merge.rc:5179
 msgid ""
 "Selected files are identical (with current settings).\r\n"
 "But binary comparison failed."
@@ -7251,12 +7246,12 @@ msgstr ""
 "Ma u paragone binariu hè fiascatu."
 
 #. IDS_FILESSAME_BINSAME
-#: Merge.rc:5181
+#: Merge.rc:5180
 msgid "Selected files are identical (binary match)."
 msgstr "I schedarii selezziunati sò identichi (currispundenza binaria)."
 
 #. IDS_FILESSAME_BINDIFF
-#: Merge.rc:5182
+#: Merge.rc:5181
 msgid ""
 "Selected files are identical (with current settings).\r\n"
 "But differ at the binary level."
@@ -7265,17 +7260,17 @@ msgstr ""
 "Ma sò sfarenti à u livellu binariu."
 
 #. IDS_FILEERROR
-#: Merge.rc:5183
+#: Merge.rc:5182
 msgid "An error occurred while comparing files."
 msgstr "Un sbagliu hè accadutu durante u paragone di i schedarii."
 
 #. IDS_TEMP_FILEERROR
-#: Merge.rc:5184
+#: Merge.rc:5183
 msgid "Could not create temporary files. Check your temporary path settings."
 msgstr "Ùn si pò micca creà schedarii timpurarii. Verificate i vostri parametri di chjassu timpurariu."
 
 #. IDS_SUGGEST_IGNOREEOL
-#: Merge.rc:5185
+#: Merge.rc:5184
 msgid ""
 "Files use different EOL.\n"
 "\n"
@@ -7290,17 +7285,17 @@ msgstr ""
 "Attivà « Ignurà e sfarenze di fine di linea (Windows/Unix/Mac) » in a sezzione Paragunà di l’ozzioni."
 
 #. IDS_INVALID_DIRECTORY
-#: Merge.rc:5186
+#: Merge.rc:5185
 msgid "Selected folder is invalid."
 msgstr "U cartulare selezziunatu hè inaccettevule."
 
 #. IDS_CANNOT_OPEN_BINARYFILE
-#: Merge.rc:5187
+#: Merge.rc:5186
 msgid "Cannot open a binary file in Editor."
 msgstr "Ùn si pò micca apre un schedariu binariu in  l’editore."
 
 #. IDS_CREATE_PAIR_FOLDER
-#: Merge.rc:5188
+#: Merge.rc:5187
 #, c-format
 msgid ""
 "Create matching folder:\n"
@@ -7312,41 +7307,41 @@ msgstr ""
 "di l’altru latu è aprelu ?"
 
 #. IDS_CONFIRM_COPY_ALL_DIFFS
-#: Merge.rc:5189
+#: Merge.rc:5188
 msgid "Copy all differences to other file?"
 msgstr "Vulete cupià tutte e sfarenze in l’altru schedariu ?"
 
 #. IDS_MOVE_TO_NEXTFILE
-#: Merge.rc:5194
+#: Merge.rc:5193
 msgid "Move to next file?"
 msgstr "Vulete passà à u schedariu seguente ?"
 
 #. IDS_MOVE_TO_PREVFILE
-#: Merge.rc:5195
+#: Merge.rc:5194
 msgid "Move to previous file?"
 msgstr "Vulete passà à u schedariu precedente ?"
 
 #. IDS_MOVE_TO_NEXTPAGE
-#: Merge.rc:5196
+#: Merge.rc:5195
 msgid "Move to next page?"
 msgstr "Vulete passà à a pagina seguente ?"
 
 #. IDS_MOVE_TO_PREVPAGE
-#: Merge.rc:5197
+#: Merge.rc:5196
 msgid "Move to previous page?"
 msgstr "Vulete passà à a pagina precedente ?"
 
 #. IDS_MOVE_TO_FIRSTFILE
-#: Merge.rc:5198
+#: Merge.rc:5197
 msgid "Move to first file?"
 msgstr "Vulete passà à u primu schedariu ?"
 
 #. IDS_MOVE_TO_LASTFILE
-#: Merge.rc:5199
+#: Merge.rc:5198
 msgid "Move to last file?"
 msgstr "Vulete passà à l’ultimu schedariu ?"
 
-#: Merge.rc:5206
+#: Merge.rc:5205
 #, c-format
 msgid ""
 "Different codepages: left (cp%d), right (cp%d).\n"
@@ -7357,51 +7352,51 @@ msgstr ""
 "Affissera d’ogni pagina di codice (più bella) o cù quella predefinita da Windows (fusione più sicura) ?\n"
 "(Ricumandatu : pagina di codice predefinita da Windows)"
 
-#: Merge.rc:5208
+#: Merge.rc:5207
 msgid "Information lost due to encoding errors: both files"
 msgstr "Infurmazione persa per via di sbaglii di cudificazione : i dui schedarii"
 
-#: Merge.rc:5210
+#: Merge.rc:5209
 msgid "Information lost due to encoding errors: first file"
 msgstr "Infurmazione persa per via di sbaglii di cudificazione : primu schedariu"
 
-#: Merge.rc:5212
+#: Merge.rc:5211
 msgid "Information lost due to encoding errors: second file"
 msgstr "Infurmazione persa per via di sbaglii di cudificazione : secondu schedariu"
 
-#: Merge.rc:5214
+#: Merge.rc:5213
 msgid "Information lost due to encoding errors: third file"
 msgstr "Infurmazione persa per via di sbaglii di cudificazione : terzu schedariu"
 
 #. IDS_LINEDIFF_NODIFF
-#: Merge.rc:5220
+#: Merge.rc:5219
 msgid "No difference"
 msgstr "Nisuna sfarenza"
 
 #. IDS_LINEDIFF_NODIFF_CAPTION
-#: Merge.rc:5221
+#: Merge.rc:5220
 msgid "Line difference"
 msgstr "Sfarenza di linea"
 
 #. IDS_NUM_REPLACED
-#: Merge.rc:5227
+#: Merge.rc:5226
 #, c-format
 msgid "Replaced %1 string(s)."
 msgstr "%1 catena(e) rimpiazzata(e)."
 
 #. IDS_EDIT_TEXT_NOT_FOUND
-#: Merge.rc:5228
+#: Merge.rc:5227
 #, c-format
 msgid "Cannot find string \"%s\"."
 msgstr "Ùn si pò micca truvà a catena « %s »."
 
 #. IDS_MERGE_MODE
-#: Merge.rc:5234
+#: Merge.rc:5233
 msgid "Entering Merge Mode. Press F9 to turn off."
 msgstr "Entrata in u modu di fusione. Appughjate nant’à F9 per disattivallu."
 
 #. IDS_AUTO_MERGE
-#: Merge.rc:5240
+#: Merge.rc:5239
 #, c-format
 msgid ""
 "Automatic merges: %1\n"
@@ -7411,89 +7406,89 @@ msgstr ""
 "Cunflitti micca disciuplicati : %2"
 
 #. IDS_CODEPAGE_MERGED
-#: Merge.rc:5241
+#: Merge.rc:5240
 msgid "Codepage change merged."
 msgstr "Cambiamentu di pagina di codice pigliatu in contu in a fusione."
 
 #. IDS_CODEPAGE_CONFLICT
-#: Merge.rc:5242
+#: Merge.rc:5241
 msgid "Codepage changes are conflicting."
 msgstr "I cambiamenti di pagina di codice sò in cunflittu."
 
 #. IDS_EOL_MERGED
-#: Merge.rc:5243
+#: Merge.rc:5242
 msgid "EOL change merged."
 msgstr "Cambiamentu di fine di linea pigliatu in contu in a fusione."
 
 #. IDS_EOL_CONFLICT
-#: Merge.rc:5244
+#: Merge.rc:5243
 msgid "EOL changes are conflicting."
 msgstr "I cambiamenti di fine di linea sò in cunflittu."
 
 #. IDS_LOCBAR_CAPTION
-#: Merge.rc:5250
+#: Merge.rc:5249
 msgid "Location Pane"
 msgstr "Pannellu di pusizione"
 
 #. IDS_DIFFBAR_CAPTION
-#: Merge.rc:5251
+#: Merge.rc:5250
 msgid "Diff Pane"
 msgstr "Pannellu di e sfarenze"
 
 #. IDS_DIFF_SUCCEEDED
-#: Merge.rc:5258
+#: Merge.rc:5257
 msgid "Patch file written."
 msgstr "U schedariu di currezzioni hè statu scrittu."
 
 #. IDS_DIFF_FILEOVERWRITE
-#: Merge.rc:5259
+#: Merge.rc:5258
 msgid "Patch file already exists. Overwrite?"
 msgstr "U schedariu di currezzioni esiste dighjà. Vulete rimpiazzallu ?"
 
 #. IDS_DIFF_SELECTEDFILES
-#: Merge.rc:5260
+#: Merge.rc:5259
 #, c-format
 msgid "[%1 files selected]"
 msgstr "[%1 schedarii selezziunati]"
 
 #. IDS_DIFF_NORMAL
-#: Merge.rc:5261
+#: Merge.rc:5260
 msgid "Normal"
 msgstr "Nurmale"
 
 #. IDS_DIFF_CONTEXT
-#: Merge.rc:5262
+#: Merge.rc:5261
 msgid "Context"
 msgstr "Cuntestu"
 
 #. IDS_DIFF_UNIFIED
-#: Merge.rc:5263
+#: Merge.rc:5262
 msgid "Unified"
 msgstr "Unificatu"
 
 #. IDS_FILEWRITE_ERROR
-#: Merge.rc:5265
+#: Merge.rc:5264
 #, c-format
 msgid "Could not write to file %1."
 msgstr "Ùn si pò micca scrive in u schedariu %1."
 
 #. IDS_PATH_NOT_ABSOLUTE
-#: Merge.rc:5266
+#: Merge.rc:5265
 #, c-format
 msgid "Output path is not absolute: %1"
 msgstr "U chjassu d’esciuta ùn hè micca assulutu : %1"
 
 #. IDS_MUST_SPECIFY_OUTPUT
-#: Merge.rc:5267
+#: Merge.rc:5266
 msgid "Specify an output file."
 msgstr "Indicate un schedariu d’esciuta."
 
-#: Merge.rc:5269
+#: Merge.rc:5268
 msgid "Cannot create patch from binary files."
 msgstr "Ùn si pò creà un schedariu di currezzioni per i schedarii binarii."
 
 #. IDS_SAVEFILES_FORPATCH
-#: Merge.rc:5270
+#: Merge.rc:5269
 msgid ""
 "Save all files first.\n"
 "\n"
@@ -7504,22 +7499,22 @@ msgstr ""
 "A creazione d’un schedariu di currezzioni richiede ch’ella ùn ci sia micca cambiamenti non arregistrati."
 
 #. IDS_FOLDER_NOTEXIST
-#: Merge.rc:5271
+#: Merge.rc:5270
 msgid "Folder does not exist."
 msgstr "U cartulare ùn esiste micca."
 
 #. IDS_ARCHIVE_SUCCEEDED
-#: Merge.rc:5277
+#: Merge.rc:5276
 msgid "Archive file written."
 msgstr ""
 
 #. IDS_ARCHIVE_SAVEFILES
-#: Merge.rc:5278
+#: Merge.rc:5277
 msgid "Save all files first.\n\nCreating an archive requires no unsaved changes."
 msgstr ""
 
 #. IDS_NO_ZIP_SUPPORT
-#: Merge.rc:5283
+#: Merge.rc:5282
 msgid ""
 "Archive support not enabled.\n"
 "7-Zip and/or Merge7z*.dll not found.\n"
@@ -7530,37 +7525,37 @@ msgstr ""
 "Lighjite u manuale d’assistenza di l’archiviera."
 
 #. IDS_OPT_EXPORT_CAPTION
-#: Merge.rc:5284
+#: Merge.rc:5283
 msgid "Select file for export"
 msgstr "Selezziunà u schedariu per l’espurtazione"
 
 #. IDS_OPT_IMPORT_CAPTION
-#: Merge.rc:5285
+#: Merge.rc:5284
 msgid "Select file for import"
 msgstr "Selezziunà u schedariu per l’impurtazione"
 
 #. IDS_OPT_IMPORT_DONE
-#: Merge.rc:5286
+#: Merge.rc:5285
 msgid "Options imported from file."
 msgstr "L’ozzioni sò state impurtate da u schedariu."
 
 #. IDS_OPT_EXPORT_DONE
-#: Merge.rc:5287
+#: Merge.rc:5286
 msgid "Options exported to file."
 msgstr "L’ozzioni sò state espurtate in u schedariu."
 
 #. IDS_OPT_IMPORT_ERR
-#: Merge.rc:5288
+#: Merge.rc:5287
 msgid "Failed to import options from file."
 msgstr "Fiascu per impurtà (leghje) l’ozzioni da u schedariu."
 
 #. IDS_OPT_EXPORT_ERR
-#: Merge.rc:5289
+#: Merge.rc:5288
 msgid "Failed to write options to file."
 msgstr "Fiascu per espurtà (scrive) l’ozzioni in u schedariu."
 
 #. IDS_CLOSEALL_WINDOWS
-#: Merge.rc:5290
+#: Merge.rc:5289
 msgid ""
 "Close multiple compare windows?\n"
 "\n"
@@ -7571,34 +7566,34 @@ msgstr ""
 "Cuntinuà ?"
 
 #. IDS_EOL_BIN
-#: Merge.rc:5300
+#: Merge.rc:5299
 msgctxt "EOL Type"
 msgid "Binary"
 msgstr "Binariu"
 
 #. IDS_MARKER_COLOR_FMT
-#: Merge.rc:5305
+#: Merge.rc:5304
 #, c-format
 msgid "Marker Color %d"
 msgstr "Culore di u marcatore %d"
 
 #. IDS_MARKER_NEW_PATTERN
-#: Merge.rc:5306
+#: Merge.rc:5305
 msgid "New Pattern"
 msgstr "Novu mudellu"
 
 #. IDS_PLUGINSLIST_TYPE
-#: Merge.rc:5312
+#: Merge.rc:5311
 msgid "Type"
 msgstr "Tipu"
 
 #. IDS_PLUGINS_TYPE_EDITSCRIPT
-#: Merge.rc:5316
+#: Merge.rc:5315
 msgid "Editor script"
 msgstr "Scenariu d’editore"
 
 #. ID_SELECTLINEDIFF
-#: Merge.rc:5322
+#: Merge.rc:5321
 msgid ""
 "\n"
 "Difference in Current Line (F4)"
@@ -7607,7 +7602,7 @@ msgstr ""
 "Sfarenza nant’à a linea attuale (F4)"
 
 #. ID_OPTIONS
-#: Merge.rc:5323
+#: Merge.rc:5322
 msgid ""
 "\n"
 "Options"
@@ -7616,7 +7611,7 @@ msgstr ""
 "Ozzioni"
 
 #. ID_REFRESH
-#: Merge.rc:5324
+#: Merge.rc:5323
 msgid ""
 "\n"
 "Refresh (F5)"
@@ -7625,7 +7620,7 @@ msgstr ""
 "Attualizà (F5)"
 
 #. ID_PREVDIFF
-#: Merge.rc:5330
+#: Merge.rc:5329
 msgid ""
 "\n"
 "Previous Difference (Alt+Up)"
@@ -7634,7 +7629,7 @@ msgstr ""
 "Sfarenza precedente (Alt+Insù)"
 
 #. ID_NEXTDIFF
-#: Merge.rc:5331
+#: Merge.rc:5330
 msgid ""
 "\n"
 "Next Difference (Alt+Down)"
@@ -7643,7 +7638,7 @@ msgstr ""
 "Sfarenza seguente (Alt+Inghjò)"
 
 #. ID_PREVCONFLICT
-#: Merge.rc:5332
+#: Merge.rc:5331
 msgid ""
 "\n"
 "Previous Conflict (Alt+Shift+Up)"
@@ -7652,7 +7647,7 @@ msgstr ""
 "Cunflittu precedente (Alt+Maius+Insù)"
 
 #. ID_NEXTCONFLICT
-#: Merge.rc:5333
+#: Merge.rc:5332
 msgid ""
 "\n"
 "Next Conflict (Alt+Shift+Down)"
@@ -7661,7 +7656,7 @@ msgstr ""
 "Cunflittu seguente (Alt+Maius+Inghjò)"
 
 #. ID_FIRSTDIFF
-#: Merge.rc:5338
+#: Merge.rc:5337
 msgid ""
 "\n"
 "First Difference (Alt+Home)"
@@ -7670,7 +7665,7 @@ msgstr ""
 "Prima sfarenza (Alt+Accolta)"
 
 #. ID_CURDIFF
-#: Merge.rc:5339
+#: Merge.rc:5338
 msgid ""
 "\n"
 "Current Difference (Alt+Enter)"
@@ -7679,7 +7674,7 @@ msgstr ""
 "Sfarenza currente (Alt+Entr.)"
 
 #. ID_LASTDIFF
-#: Merge.rc:5340
+#: Merge.rc:5339
 msgid ""
 "\n"
 "Last Difference (Alt+End)"
@@ -7688,7 +7683,7 @@ msgstr ""
 "Ultima sfarenza (Alt+Fine)"
 
 #. ID_L2R
-#: Merge.rc:5341
+#: Merge.rc:5340
 msgid ""
 "\n"
 "Copy to Right (Alt+Right)"
@@ -7697,7 +7692,7 @@ msgstr ""
 "Cupià versu a diritta (Alt+Diritta)"
 
 #. ID_R2L
-#: Merge.rc:5342
+#: Merge.rc:5341
 msgid ""
 "\n"
 "Copy to Left (Alt+Left)"
@@ -7706,7 +7701,7 @@ msgstr ""
 "Cupià versu a manca (Alt+Manca)"
 
 #. ID_L2RNEXT
-#: Merge.rc:5343
+#: Merge.rc:5342
 msgid ""
 "\n"
 "Copy to Right and Advance (Ctrl+Alt+Right)"
@@ -7715,7 +7710,7 @@ msgstr ""
 "Cupià versu a diritta è avanzà (Ctrl+Alt+Diritta)"
 
 #. ID_R2LNEXT
-#: Merge.rc:5344
+#: Merge.rc:5343
 msgid ""
 "\n"
 "Copy to Left and Advance (Ctrl+Alt+Left)"
@@ -7724,7 +7719,7 @@ msgstr ""
 "Cupià versu a manca è avanzà (Ctrl+Alt+Manca)"
 
 #. ID_ALL_RIGHT
-#: Merge.rc:5345
+#: Merge.rc:5344
 msgid ""
 "\n"
 "Copy All to Right"
@@ -7733,7 +7728,7 @@ msgstr ""
 "Tuttu cupià versu a diritta"
 
 #. ID_ALL_LEFT
-#: Merge.rc:5346
+#: Merge.rc:5345
 msgid ""
 "\n"
 "Copy All to Left"
@@ -7742,7 +7737,7 @@ msgstr ""
 "Tuttu cupià versu a manca"
 
 #. ID_AUTO_MERGE
-#: Merge.rc:5347
+#: Merge.rc:5346
 msgid ""
 "\n"
 "Auto Merge (Ctrl+Alt+M)"
@@ -7751,7 +7746,7 @@ msgstr ""
 "Fusione autumatica (Ctrl+Alt+M)"
 
 #. ID_FIRSTFILE
-#: Merge.rc:5348
+#: Merge.rc:5347
 msgid ""
 "\n"
 "First File"
@@ -7760,7 +7755,7 @@ msgstr ""
 "Primu schedariu"
 
 #. ID_NEXTFILE
-#: Merge.rc:5349
+#: Merge.rc:5348
 msgid ""
 "\n"
 "Next File (Ctrl+F8)"
@@ -7769,7 +7764,7 @@ msgstr ""
 "Schedariu seguente (Ctrl+F8)"
 
 #. ID_LASTFILE
-#: Merge.rc:5350
+#: Merge.rc:5349
 msgid ""
 "\n"
 "Last File"
@@ -7778,7 +7773,7 @@ msgstr ""
 "Ultimu schedariu"
 
 #. ID_PREVFILE
-#: Merge.rc:5351
+#: Merge.rc:5350
 msgid ""
 "\n"
 "Previous File (Ctrl+F7)"
@@ -7787,142 +7782,142 @@ msgstr ""
 "Schedariu precedente (Ctrl+F7)"
 
 #. IDS_UNPACK_AUTO
-#: Merge.rc:5358
+#: Merge.rc:5357
 msgid "Adapted unpacker applied to both files (one needs extension)."
 msgstr "U spacchittadore adattatu hè appiecatu à i dui schedarii (solu unu richiede l’estensione)."
 
 #. IDS_NO_PREDIFFER
-#: Merge.rc:5359
+#: Merge.rc:5358
 msgid "No Prediffer (Normal)"
 msgstr "Nisunu preparagone (nurmale)"
 
 #. IDS_SUGGESTED_PLUGINS
-#: Merge.rc:5360
+#: Merge.rc:5359
 msgid "Suggested Plugins"
 msgstr "Moduli d’estensione cunsigliati"
 
 #. IDS_NOT_SUGGESTED_PLUGINS
-#: Merge.rc:5361
+#: Merge.rc:5360
 msgid "All Plugins"
 msgstr "Tutti i moduli d’estensione"
 
 #. IDS_PRIVATEBUILD_FMT
-#: Merge.rc:5367
+#: Merge.rc:5366
 #, c-format
 msgid "Private Build: %1"
 msgstr "Custruzzione privata : %1"
 
 #. IDS_ALLRIGHTS_RESERVED
-#: Merge.rc:5368
+#: Merge.rc:5367
 msgid " - All rights reserved."
 msgstr " - Tutti i diritti riservati."
 
 #. IDS_TITLE_PLUGINS_SETTINGS
-#: Merge.rc:5374
+#: Merge.rc:5373
 msgid "Plugin Settings"
 msgstr "Parametri di l’estensione"
 
 #. IDS_NO_SCT_SCRIPTS
-#: Merge.rc:5376
+#: Merge.rc:5375
 msgid "WSH not found - .sct scripts disabled"
 msgstr "Ùn si pò truvà WSH ; i scenarii .sct sò disattivati"
 
 #. IDS_LOCBAR_GOTOLINE_FMT
-#: Merge.rc:5384
+#: Merge.rc:5383
 #, c-format
 msgid "G&o to Line %1"
 msgstr "An&dà à a linea %1"
 
 #. IDS_GOTO_MOVED_LINE
-#: Merge.rc:5390
+#: Merge.rc:5389
 msgid "Go to Moved Line\tCtrl+Shift+G"
 msgstr "Andà à a linea dispiazzata\tCtrl+Maius+G"
 
 #. IDS_AUTOCOMPLETE_DISABLED
-#: Merge.rc:5396
+#: Merge.rc:5395
 msgctxt "Options dialog|General|Open dialog Auto completion"
 msgid "Disabled"
 msgstr "Disattivata"
 
 #. IDS_AUTOCOMPLETE_FILE_SYS
-#: Merge.rc:5397
+#: Merge.rc:5396
 msgid "From file system"
 msgstr "Da u sistema di schedariu"
 
 #. IDS_AUTOCOMPLETE_MRU
-#: Merge.rc:5398
+#: Merge.rc:5397
 msgid "From Most Recently Used list"
 msgstr "Da a lista di i schedarii recente"
 
 #. IDS_COLORSCHEME_PLAIN
-#: Merge.rc:5404
+#: Merge.rc:5403
 msgid "No Highlighting"
 msgstr "Nisunu sopralineamentu"
 
 #. IDS_COLORSCHEME_PO
-#: Merge.rc:5439
+#: Merge.rc:5438
 msgid "Portable Object"
 msgstr "Oggettu purtavule"
 
 #. IDS_COLORSCHEME_RSRC
-#: Merge.rc:5444
+#: Merge.rc:5443
 msgid "Resources"
 msgstr "Risorse"
 
 #. IDS_COLORSCHEME_SH
-#: Merge.rc:5448
+#: Merge.rc:5447
 msgid "Shell"
 msgstr "Shell"
 
 #. IDS_CLOSE_LEFT_TABS
-#: Merge.rc:5469
+#: Merge.rc:5468
 msgid "Close &Left Tabs"
 msgstr "Chjode l’unghjette à &manca"
 
 #. IDS_CLOSE_RIGHT_TABS
-#: Merge.rc:5470
+#: Merge.rc:5469
 msgid "Close R&ight Tabs"
 msgstr "Chjode l’unghjette à &diritta"
 
 #. IDS_CLOSE_OTHER_TABS
-#: Merge.rc:5471
+#: Merge.rc:5470
 msgid "Close &Other Tabs"
 msgstr "Chjode l’&altre unghjette"
 
 #. IDS_TABBAR_AUTO_MAXWIDTH
-#: Merge.rc:5472
+#: Merge.rc:5471
 msgid "Enable &Auto Max Width"
 msgstr "&Attivà a larghezza massima autumatica"
 
 #. IDS_WEBPAGE_MENU
-#: Merge.rc:5482
+#: Merge.rc:5481
 msgid "We&bpage"
 msgstr "Pagina we&b"
 
 #. IDS_VIEW_WRAP_TEXT
-#: Merge.rc:5487
+#: Merge.rc:5486
 msgid "W&rap Text"
 msgstr "&Ritornu autumaticu à a linea"
 
 #. IDS_NOTINSTALLED
-#: Merge.rc:5492
+#: Merge.rc:5491
 #, c-format
 msgid "%1 is not installed."
 msgstr "%1 ùn hè micca installatu."
 
 #. IDS_CREATE_FOLDER
-#: Merge.rc:5497
+#: Merge.rc:5496
 #, c-format
 msgid "%1 does not exist. Create it?"
 msgstr "%& ùn esiste micca. Vulete creallu ?"
 
 #. IDS_CREATE_FOLDER_ERROR
-#: Merge.rc:5498
+#: Merge.rc:5497
 msgid "Failed to create folder."
 msgstr "Impussibule di creà u cartulare."
 
 #. IDC_EXT_EDITOR_PATH
-#: Merge.rc:5503
+#: Merge.rc:5502
 msgid ""
 "Parameters:\n"
 "$file: Current file path\n"
@@ -7933,491 +7928,491 @@ msgstr ""
 "$linenum: numeru di linea attuale di u cursore"
 
 #. IDS_DIFF_ALGORITHM_DEFAULT
-#: Merge.rc:5508
+#: Merge.rc:5507
 msgid "default"
 msgstr "predefinita"
 
 #. IDS_DIFF_ALGORITHM_MINIMAL
-#: Merge.rc:5509
+#: Merge.rc:5508
 msgid "minimal"
 msgstr "minimale"
 
 #. IDS_DIFF_ALGORITHM_PATIENCE
-#: Merge.rc:5510
+#: Merge.rc:5509
 msgid "patience"
 msgstr "pazienza"
 
 #. IDS_DIFF_ALGORITHM_HISTOGRAM
-#: Merge.rc:5511
+#: Merge.rc:5510
 msgid "histogram"
 msgstr "graficu à barre"
 
 #. IDS_DIFF_ALGORITHM_NONE
-#: Merge.rc:5512
+#: Merge.rc:5511
 msgid "none"
 msgstr "nisuna"
 
 #. IDS_RENDERING_MODE_GDI
-#: Merge.rc:5517
+#: Merge.rc:5516
 msgid "GDI"
 msgstr "GDI"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_DEFAULT
-#: Merge.rc:5518
+#: Merge.rc:5517
 msgid "DirectWrite Default"
 msgstr "DirectWrite predefinitu"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_ALIASED
-#: Merge.rc:5519
+#: Merge.rc:5518
 msgid "DirectWrite Aliased"
 msgstr "DirectWrite merlatu"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_GDI_CLASSIC
-#: Merge.rc:5520
+#: Merge.rc:5519
 msgid "DirectWrite GDI Classic"
 msgstr "DirectWrite GDI classicu"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_GDI_NATURAL
-#: Merge.rc:5521
+#: Merge.rc:5520
 msgid "DirectWrite GDI Natural"
 msgstr "DirectWrite GDI naturale"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_NATURAL
-#: Merge.rc:5522
+#: Merge.rc:5521
 msgid "DirectWrite Natural"
 msgstr "DirectWrite naturale"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_NATURAL_SYMMETRIC
-#: Merge.rc:5523
+#: Merge.rc:5522
 msgid "DirectWrite Natural Symmetric"
 msgstr "DirectWrite naturale simetricu"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_DISABLED
-#: Merge.rc:5528
+#: Merge.rc:5527
 msgctxt "Options dialog|General|Close windows with Esc"
 msgid "Disabled"
 msgstr "Disattivata"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_1
-#: Merge.rc:5529
+#: Merge.rc:5528
 msgid "MDI child window or main window"
 msgstr "Finestra zitella o finestra principale MDI"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_2
-#: Merge.rc:5530
+#: Merge.rc:5529
 msgid "MDI child window only"
 msgstr "Finestra zitella MDI solu"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_3
-#: Merge.rc:5531
+#: Merge.rc:5530
 msgid "Close main window if only one MDI child window"
 msgstr "Chjode a finestra principale s’ella ci hè solu una finestra zitella MDI"
 
 #. IDS_DIFF_GROUP
-#: Merge.rc:5536
+#: Merge.rc:5535
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Diff"
 msgstr "Sfarenze"
 
 #. IDS_DIFF_HIGHLIGHT
-#: Merge.rc:5537
+#: Merge.rc:5536
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Highlight"
 msgstr "Sopralineamentu"
 
 #. IDS_DIFF_BLINK
-#: Merge.rc:5538
+#: Merge.rc:5537
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Blink"
 msgstr "Cinnulamentu"
 
 #. IDS_DIFF_BLOCKSIZE
-#: Merge.rc:5539
+#: Merge.rc:5538
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Block Size"
 msgstr "Dimensione di bloccu"
 
 #. IDS_DIFF_BLOCKALPHA
-#: Merge.rc:5540
+#: Merge.rc:5539
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Block Alpha"
 msgstr "Trasparenza di bloccu"
 
 #. IDS_DIFF_CDTHRESHOLD
-#: Merge.rc:5541
+#: Merge.rc:5540
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "CD Threshold"
 msgstr "Sogliu CD"
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION
-#: Merge.rc:5542
+#: Merge.rc:5541
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Ins/Del Detection"
 msgstr "Avventata d’inserzione è di squassatura"
 
 #. IDS_OVERLAY_MODE_NONE
-#: Merge.rc:5543 Merge.rc:5548
+#: Merge.rc:5542 Merge.rc:5547
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "None"
 msgstr "Nisunu"
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION_VERTICAL
-#: Merge.rc:5544
+#: Merge.rc:5543
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Vertical"
 msgstr "Verticale"
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION_HORIZONTAL
-#: Merge.rc:5545
+#: Merge.rc:5544
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Horizontal"
 msgstr "Orizuntale"
 
 #. IDS_OVERLAY_GROUP
-#: Merge.rc:5546
+#: Merge.rc:5545
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Overlay"
 msgstr "Accavalcatura"
 
 #. IDS_OVERLAY_ALPHA
-#: Merge.rc:5547
+#: Merge.rc:5546
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha"
 msgstr "Trasparenza alfa"
 
 #. IDS_OVERLAY_MODE_XOR
-#: Merge.rc:5549
+#: Merge.rc:5548
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "XOR"
 msgstr "O esclusivu (Xor)"
 
 #. IDS_OVERLAY_MODE_ALPHA
-#: Merge.rc:5550
+#: Merge.rc:5549
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha Blend"
 msgstr "Simulazione di trasparenza"
 
 #. IDS_OVERLAY_MODE_ALPHA_ANIMATION
-#: Merge.rc:5551
+#: Merge.rc:5550
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha Animation"
 msgstr "Simulazione di trasparenza animata"
 
 #. IDS_ZOOM
-#: Merge.rc:5552
+#: Merge.rc:5551
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Zoom"
 msgstr "Ingrandamentu"
 
 #. IDS_PAGE
-#: Merge.rc:5553
+#: Merge.rc:5552
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Page:"
 msgstr "Pagina :"
 
 #. IDS_IMGCMP_STATUS_PT_RGBA_FMT
-#: Merge.rc:5554
+#: Merge.rc:5553
 #, c-format
 msgid "Pt: (%d, %d)  RGBA: (%d, %d, %d, %d)  "
 msgstr "Pt : (%d, %d)  RGBA : (%d, %d, %d, %d)  "
 
 #. IDS_IMGCMP_STATUS_DIST1_FMT
-#: Merge.rc:5555
+#: Merge.rc:5554
 #, c-format
 msgid "Dist: %g  "
 msgstr "Dist : %g  "
 
 #. IDS_IMGCMP_STATUS_DIST2_FMT
-#: Merge.rc:5556
+#: Merge.rc:5555
 #, c-format
 msgid "Dist: %g, %g  "
 msgstr "Dist : %g, %g  "
 
 #. IDS_IMGCMP_STATUS_PAGE_ZOOM_SIZE_BPP_FMT
-#: Merge.rc:5557
+#: Merge.rc:5556
 #, c-format
 msgid "Page: %d/%d  Zoom: %d%%  %dx%dpx  %dbpp  "
 msgstr "Pagina : %d/%d  Ingrandamentu : %d%%  %dx%dpx  %dbpp  "
 
 #. IDS_IMGCMP_STATUS_RC_FMT
-#: Merge.rc:5558
+#: Merge.rc:5557
 #, c-format
 msgid "Rc: (%d, %d)  "
 msgstr "Rc : (%d, %d)  "
 
 #. IDS_IMGCMP_STATUS_FLIPPED_FMT
-#: Merge.rc:5559
+#: Merge.rc:5558
 #, c-format
 msgid "Flipped: %s  "
 msgstr "Rivultatu : %s  "
 
 #. IDS_IMGCMP_STATUS_ROTATED_FMT
-#: Merge.rc:5560
+#: Merge.rc:5559
 #, c-format
 msgid "Rotated: %d  "
 msgstr "Giratu : %d  "
 
 #. IDS_IMGCMP_REPORT_ALLPAGES
-#: Merge.rc:5561
+#: Merge.rc:5560
 msgid "All pages"
 msgstr "Tutte e pagine"
 
 #. IDS_IGNSUB_STR1
-#: Merge.rc:5566
+#: Merge.rc:5565
 msgid "<Edit here>"
 msgstr "<mudificate quì>"
 
 #. IDS_IGNSUB_STR2
-#: Merge.rc:5567
+#: Merge.rc:5566
 msgid "No differences found to select"
 msgstr "Ùn si pò truvà alcuna sfarenza à selezziunà"
 
 #. IDS_IGNSUB_STR3
-#: Merge.rc:5568
+#: Merge.rc:5567
 msgid "No differences found to add as substitution filter"
 msgstr "Ùn si pò truvà alcuna sfarenza à aghjunghje cum¹è filtru di sustituzione"
 
 #. IDS_IGNSUB_STR4
-#: Merge.rc:5569
+#: Merge.rc:5568
 msgid "The pair is already in the Substitution Filters list"
 msgstr "U coppiu si trova dighjà in a lista di i filtri di sustituzione"
 
 #. IDS_IGNSUB_STR5
-#: Merge.rc:5570
+#: Merge.rc:5569
 msgid "Add this change to Substitution Filters?"
 msgstr "Aghjunghje stu cambiamentu à i filtri di sustituzione ?"
 
 #. IDS_OCRRESULT_TEXTONLY
-#: Merge.rc:5575
+#: Merge.rc:5574
 msgid "Text only"
 msgstr "Testu solu"
 
 #. IDS_OCRRESULT_POS_LINE
-#: Merge.rc:5576
+#: Merge.rc:5575
 msgid "Line-by-line position and text"
 msgstr "Pusizione è testu linea à a linea"
 
 #. IDS_OCRRESULT_POS_WORD
-#: Merge.rc:5577
+#: Merge.rc:5576
 msgid "Word-by-word position and text"
 msgstr "Pusizione è testu parolla à a parolla"
 
 #. IDS_USERDATAFOLDER_APPDATA
-#: Merge.rc:5582
+#: Merge.rc:5581
 msgid "AppData (Roaming) folder"
 msgstr "Cartulare AppData (Roaming)"
 
 #. IDS_USERDATAFOLDER_INSTALL
-#: Merge.rc:5583
+#: Merge.rc:5582
 msgid "Install folder"
 msgstr "Cartulare d’installazione"
 
 #. IDS_USERDATAFOLDER_DOCUMENTS
-#: Merge.rc:5584
+#: Merge.rc:5583
 msgid "Documents folder"
 msgstr "Cartulare di i ducumenti"
 
 #. IDS_SINGLEINSTANCE_DISABLED
-#: Merge.rc:5589
+#: Merge.rc:5588
 msgctxt "Options dialog|General|Single instance mode"
 msgid "Disabled"
 msgstr "Disattivata"
 
 #. IDS_SINGLEINSTANCE_STR1
-#: Merge.rc:5590
+#: Merge.rc:5589
 msgid "Allow only one instance to run"
 msgstr "Permette l’esecuzione d’una instanza unica di u prugramma"
 
 #. IDS_CLIPBOARD_HISTORY
-#: Merge.rc:5591
+#: Merge.rc:5590
 msgid "Clipboard &History"
 msgstr "&Cronolugia di u preme’papei"
 
 #. IDS_SINGLEINSTANCE_STR2
-#: Merge.rc:5592
+#: Merge.rc:5591
 msgid "Allow only one instance; wait for termination"
 msgstr "Permette una instanza unica ; aspettà ch’ella si compii"
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_DISABLED
-#: Merge.rc:5597
+#: Merge.rc:5596
 msgctxt "Options dialog|General|Auto-reload modified files"
 msgid "Disabled"
 msgstr "Disattivatu"
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_STR1
-#: Merge.rc:5598
+#: Merge.rc:5597
 msgid "Only on window activated"
 msgstr "Solu quandu a finestra hè attivata"
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_STR2
-#: Merge.rc:5599
+#: Merge.rc:5598
 msgid "Immediately"
 msgstr "Subitu subitu"
 
 #. IDS_PLUGIN_ALL
-#: Merge.rc:5604
+#: Merge.rc:5603
 msgid "Al&l"
 msgstr "T&utti"
 
 #. IDS_PLUGIN_OTHERS
-#: Merge.rc:5605
+#: Merge.rc:5604
 msgid "&Others"
 msgstr "&L’altri moduli"
 
-#: Merge.rc:5607
+#: Merge.rc:5606
 #, c-format
 msgid "Missing plugin name in pipeline: %1"
 msgstr "Nome di modulu d’estensione assente in u cundottu : %1"
 
-#: Merge.rc:5609
+#: Merge.rc:5608
 #, c-format
 msgid "Missing quote in plugin pipeline: %1"
 msgstr "Marca di citazione assente in u cundottu di u modulu d’estensione : %1"
 
 #. IDS_PLUGIN_NAME_ALREADY_EXISTS
-#: Merge.rc:5610
+#: Merge.rc:5609
 #, c-format
 msgid "Plugin name '%1' already exists."
 msgstr "U nome di modulu d’estensione « %1 » esiste dighjà."
 
 #. IDS_PLUGIN_TITLE1
-#: Merge.rc:5611
+#: Merge.rc:5610
 msgid "Specify plugin arguments"
 msgstr "Indicate i parametri di u modulu d’estensione"
 
-#: Merge.rc:5613
+#: Merge.rc:5612
 #, c-format
 msgid "Plugin not found or invalid: %1"
 msgstr "U modulu d’estensione ùn si trova micca o hè inaccettevule : %1"
 
 #. IDS_PLUGIN_NOT_UNPACK
-#: Merge.rc:5614
+#: Merge.rc:5613
 #, c-format
 msgid "'%1' is not an unpacker plugin"
 msgstr "« %1 » ùn hè micca un modulu d’estensione di spacchittadore"
 
 #. IDS_PLUGIN_NOT_PREDIFF
-#: Merge.rc:5615
+#: Merge.rc:5614
 #, c-format
 msgid "'%1' is not a prediffer plugin"
 msgstr "« %1 » ùn hè micca un modulu d’estensione di preparagone"
 
-#: Merge.rc:5617
+#: Merge.rc:5616
 #, c-format
 msgid "Error prediffing '%1' with '%2'. Prediffing disabled."
 msgstr "Un sbagliu hè accadutu durante u preparagone di u schedariu « %1 » cù « %2 ». U preparagone hè disattivatu."
 
 #. IDS_PLUGIN_CIRCULAR_REFERENCE
-#: Merge.rc:5618
+#: Merge.rc:5617
 #, c-format
 msgid "Circular reference in plugin pipeline: %1"
 msgstr "Referenza circulare in u cundottu di modulu d’estensione : %1"
 
 #. IDS_PLUGIN_TYPE1
-#: Merge.rc:5619
+#: Merge.rc:5618
 msgid "URL Handler"
 msgstr "Ghjestiunariu d’indirizzu web"
 
 #. IDS_PLUGIN_TYPE2
-#: Merge.rc:5620
+#: Merge.rc:5619
 msgid "File Unpacker"
 msgstr "Spacchittadore di schedariu"
 
 #. IDS_PLUGIN_TYPE3
-#: Merge.rc:5621
+#: Merge.rc:5620
 msgid "File or Folder Unpacker"
 msgstr "Spacchittadore di schedariu o di cartulare"
 
 #. IDS_PLUGIN_TYPE5
-#: Merge.rc:5623
+#: Merge.rc:5622
 msgid "Alias for Unpacker"
 msgstr "Cugnome di u spacchittadore"
 
 #. IDS_PLUGIN_TYPE6
-#: Merge.rc:5624
+#: Merge.rc:5623
 msgid "Alias for Prediffer"
 msgstr "Cugnome di u preparagone"
 
 #. IDS_PLUGIN_TYPE7
-#: Merge.rc:5625
+#: Merge.rc:5624
 msgid "Alias for Editor script"
 msgstr "Cugnome di u scenariu d’editore"
 
 #. IDS_PLUGIN_ALIAS_DESC
-#: Merge.rc:5626
+#: Merge.rc:5625
 #, c-format
 msgid "Alias for plugin pipeline '%1'"
 msgstr "Cugnome di u cundottu di modulu d’estensione « %1 »"
 
 #. IDS_PLUGIN_NEW_DESC
-#: Merge.rc:5627
+#: Merge.rc:5626
 msgid "New plugin description"
 msgstr "Discrizzione nova di u modulu d’estensione"
 
 #. IDS_PLUGIN_TARGETS_ALL
-#: Merge.rc:5628
+#: Merge.rc:5627
 msgid "All"
 msgstr "Tutti"
 
 #. IDS_PLUGIN_TARGETS_1ST
-#: Merge.rc:5629
+#: Merge.rc:5628
 msgid "1st"
 msgstr "1ᵘ"
 
 #. IDS_PLUGIN_TARGETS_2ND
-#: Merge.rc:5630
+#: Merge.rc:5629
 msgid "2nd"
 msgstr "2ᵘ"
 
 #. IDS_PLUGIN_TARGETS_3RD
-#: Merge.rc:5631
+#: Merge.rc:5630
 msgid "3rd"
 msgstr "3ᵘ"
 
 #. IDS_PLUGIN_TARGETS_1ST_2ND
-#: Merge.rc:5632
+#: Merge.rc:5631
 msgid "1st and 2nd"
 msgstr "1ᵘ è 2ᵘ"
 
 #. IDS_PLUGIN_TARGETS_1ST_3RD
-#: Merge.rc:5633
+#: Merge.rc:5632
 msgid "1st and 3rd"
 msgstr "1ᵘ è 3ᵘ"
 
 #. IDS_PLUGIN_TARGETS_2ND_3RD
-#: Merge.rc:5634
+#: Merge.rc:5633
 msgid "2nd and 3rd"
 msgstr "2ᵘ è 3ᵘ"
 
 #. IDS_PLUGIN_CTRL_CLICK
-#: Merge.rc:5635
+#: Merge.rc:5634
 msgid "(Ctrl+Click to add to pipeline)"
 msgstr ""
 
 #. IDS_FILTER_APPLIED
-#: Merge.rc:5640
+#: Merge.rc:5639
 msgid "Filter applied"
 msgstr "Filtru appiecatu"
 
 #. IDS_FILTERMENU_COMPARE
-#: Merge.rc:5645
+#: Merge.rc:5644
 #, c-format
 msgid "Compare %1"
 msgstr "Paragunà %1"
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN2
-#: Merge.rc:5647
+#: Merge.rc:5646
 msgid "&Filter by This Column..."
 msgstr "&Filtru da sta culonna…"
 
 #. IDS_CLIPBOARDHISTORY_TIME
-#: Merge.rc:5652
+#: Merge.rc:5651
 #, c-format
 msgid "Clipboard at %s"
 msgstr "Preme’papei di u %s"
 
 #. IDS_CLIPBOARDHISTORY_DISABLED
-#: Merge.rc:5653
+#: Merge.rc:5652
 msgid ""
 "Clipboard history disabled.\r\n"
 "Enable: Windows logo key + V, then Turn on."
@@ -8425,115 +8420,115 @@ msgstr ""
 "A cronolugia di u preme’papei hè disattivata.\r\n"
 "Per attivalla, appughjate nant’à i tasti Windows + V è tandu cliccu nant’à « Attivà »."
 
-#: Merge.rc:5655
+#: Merge.rc:5654
 msgid "This system does not support clipboard history."
 msgstr "Stu sistema ùn accetta micca a cronolugia di u preme’papei."
 
-#: Merge.rc:5657
+#: Merge.rc:5656
 msgid "32-bit WinMerge does not support Clipboard Compare"
 msgstr "A versione 32-bit di WinMerge ùn accetta micca u paragone di preme’papei"
 
 #. IDS_WEBVIEW2_RUNTIME_NOT_INSTALLED
-#: Merge.rc:5662
+#: Merge.rc:5661
 msgid "WebView2 runtime not installed. Download it?"
 msgstr "L’ambiente d’esecuzione WebView2 ùn hè micca installatu. Vulete scaricallu ?"
 
 #. IDS_JUMPLIST_NEW_TEXT_COMPARE
-#: Merge.rc:5667
+#: Merge.rc:5666
 msgid "New Text Compare"
 msgstr "Paragone novu di testu"
 
 #. IDS_JUMPLIST_NEW_TABLE_COMPARE
-#: Merge.rc:5668
+#: Merge.rc:5667
 msgid "New Table Compare"
 msgstr "Paragone novu di tavulone"
 
 #. IDS_JUMPLIST_NEW_BINARY_COMPARE
-#: Merge.rc:5669
+#: Merge.rc:5668
 msgid "New Binary Compare"
 msgstr "Paragone binariu novu"
 
 #. IDS_JUMPLIST_NEW_IMAGE_COMPARE
-#: Merge.rc:5670
+#: Merge.rc:5669
 msgid "New Image Compare"
 msgstr "Paragone novu di fiura"
 
 #. IDS_JUMPLIST_NEW_WEBPAGE_COMPARE
-#: Merge.rc:5671
+#: Merge.rc:5670
 msgid "New Webpage Compare"
 msgstr "Paragone novu di pagina web"
 
 #. IDS_JUMPLIST_NEW_FOLDER_COMPARE
-#: Merge.rc:5672
+#: Merge.rc:5671
 msgid "New Folder Compare"
 msgstr "Paragone novu di cartulare"
 
 #. IDS_JUMPLIST_CLIPBOARD_COMPARE
-#: Merge.rc:5673
+#: Merge.rc:5672
 msgid "Clipboard Compare"
 msgstr "Paragone di preme’papei"
 
 #. IDS_PREVIEWBAR_PRINT
-#: Merge.rc:5678
+#: Merge.rc:5677
 msgid "&Print..."
 msgstr "&Stampà…"
 
 #. IDS_PREVIEWBAR_PREVPAGE
-#: Merge.rc:5680
+#: Merge.rc:5679
 msgid "Pre&v Page"
 msgstr "&Pagina precedente"
 
 #. IDS_PREVIEWBAR_TWOPAGE
-#: Merge.rc:5681
+#: Merge.rc:5680
 msgid "&Two Page"
 msgstr "&Duie pagine"
 
 #. IDS_PREVIEWBAR_ONEPAGE
-#: Merge.rc:5682
+#: Merge.rc:5681
 msgid "&One Page"
 msgstr "&Una pagina"
 
 #. IDS_PREVIEWBAR_ZOOMIN
-#: Merge.rc:5683
+#: Merge.rc:5682
 msgid "Zoom &In"
 msgstr "Ingrandamentu più &forte"
 
 #. IDS_PREVIEWBAR_ZOOMOUT
-#: Merge.rc:5684
+#: Merge.rc:5683
 msgid "Zoom &Out"
 msgstr "Ingrandamentu &menu forte"
 
 #. IDS_WEBPAGE_COMPARING
-#: Merge.rc:5690
+#: Merge.rc:5689
 msgid "Comparing..."
 msgstr "Paragone…"
 
 #. IDS_WEBPAGE_ZOOM
-#: Merge.rc:5691
+#: Merge.rc:5690
 msgid "Zoom:"
 msgstr "Ingrandamentu :"
 
 #. IDS_COPY_GRANULARITY_DIFFHUNK
-#: Merge.rc:5696
+#: Merge.rc:5695
 msgid "Diff hunk"
 msgstr "Gruppu di sfarenze"
 
 #. IDS_COPY_GRANULARITY_INLINE
-#: Merge.rc:5697
+#: Merge.rc:5696
 msgid "Inline diff"
 msgstr "Sfarenza framessa"
 
 #. IDS_COPY_GRANULARITY_LINE
-#: Merge.rc:5698
+#: Merge.rc:5697
 msgid "Line"
 msgstr "Linea"
 
-#: Merge.rc:5699
+#: Merge.rc:5698
 msgid "Character"
 msgstr "Caratteru"
 
 #. ID_MICE_PREVDIFF
-#: Merge.rc:5704
+#: Merge.rc:5703
 msgid ""
 "\n"
 "Previous Difference (Alt+Up)\n"
@@ -8546,7 +8541,7 @@ msgstr ""
 "(Alt+Rutulella di u topu insù)"
 
 #. ID_MICE_NEXTDIFF
-#: Merge.rc:5705
+#: Merge.rc:5704
 msgid ""
 "\n"
 "Next Difference (Alt+Down)\n"
@@ -8559,7 +8554,7 @@ msgstr ""
 "(Alt+Rutulella di u topu inghjò)"
 
 #. ID_MICE_L2R
-#: Merge.rc:5706
+#: Merge.rc:5705
 msgid ""
 "\n"
 "Copy to Right (Alt+Right)\n"
@@ -8573,7 +8568,7 @@ msgstr ""
 "(Alt+Maiusc+Rutulella inghjò)"
 
 #. ID_MICE_R2L
-#: Merge.rc:5707
+#: Merge.rc:5706
 msgid ""
 "\n"
 "Copy to Left (Alt+Left)\n"
@@ -8587,7 +8582,7 @@ msgstr ""
 "(Alt+Maiusc+Rutulella insù)"
 
 #. ID_MICE_L2RNEXT
-#: Merge.rc:5708
+#: Merge.rc:5707
 msgid ""
 "\n"
 "Copy to Right and Advance (Ctrl+Alt+Right)\n"
@@ -8600,7 +8595,7 @@ msgstr ""
 "(Ctrl+Alt+Maiusc+Rutulella inghjò)"
 
 #. ID_MICE_R2LNEXT
-#: Merge.rc:5709
+#: Merge.rc:5708
 msgid ""
 "\n"
 "Copy to Left and Advance (Ctrl+Alt+Left)\n"
@@ -8613,257 +8608,257 @@ msgstr ""
 "(Ctrl+Alt+Maiusc+Rutulella insù)"
 
 #. IDS_LOG_COMPARING_2
-#: Merge.rc:5719
+#: Merge.rc:5718
 #, c-format
 msgid "Comparing %1 with %2"
 msgstr "Paragone di %1 cù %2"
 
 #. IDS_LOG_COMPARING_3
-#: Merge.rc:5720
+#: Merge.rc:5719
 #, c-format
 msgid "Comparing %1 with %2 and %3"
 msgstr "Paragone di %1 cù %2 è %3"
 
 #. IDS_LOG_COMPARE_COMPLETED
-#: Merge.rc:5721
+#: Merge.rc:5720
 msgid "Comparison completed"
 msgstr "U paragone hè compiu"
 
 #. IDS_LOG_COMPARE_ERROR_2
-#: Merge.rc:5722
+#: Merge.rc:5721
 #, c-format
 msgid "Failed to compare %1 with %2: "
 msgstr "Fiascu per paragunà %1 cù %2 : "
 
 #. IDS_LOG_COMPARE_ERROR_3
-#: Merge.rc:5723
+#: Merge.rc:5722
 #, c-format
 msgid "Failed to compare %1 with %2 and %3: "
 msgstr "Fiascu per paragunà %1 cù %2 è %3 : "
 
 #. IDS_LOG_FILE_SAVED
-#: Merge.rc:5724
+#: Merge.rc:5723
 msgid "File saved"
 msgstr "U schedariu hè arregistratu"
 
 #. IDS_LOG_COPYING_FILES
-#: Merge.rc:5725
+#: Merge.rc:5724
 msgid "Copying files..."
 msgstr "Copia di i schedarii…"
 
 #. IDS_LOG_MOVING_FILES
-#: Merge.rc:5726
+#: Merge.rc:5725
 msgid "Moving files..."
 msgstr "Dispiazzamentu di i schedarii…"
 
 #. IDS_LOG_DELETING_FILES
-#: Merge.rc:5727
+#: Merge.rc:5726
 msgid "Deleting files..."
 msgstr "Squassatura di schedarii…"
 
 #. IDS_LOG_RECYCLEBIN
-#: Merge.rc:5728
+#: Merge.rc:5727
 msgid "Recycle Bin"
 msgstr "Curbella"
 
 #. IDS_LOG_PERMANENTLY_DELETED
-#: Merge.rc:5729
+#: Merge.rc:5728
 msgid "Permanently deleted"
 msgstr "Squassatu ab’eternu"
 
 #. IDS_LOG_FILEOPERATION_COMPLETED
-#: Merge.rc:5730
+#: Merge.rc:5729
 msgid "File operation completed successfully"
 msgstr "Operazione di schedariu compia currettamente"
 
 #. IDS_LOG_FILEOPERATION_CANCELED
-#: Merge.rc:5731
+#: Merge.rc:5730
 msgid "File operation canceled"
 msgstr "Operazione di schedariu abbandunata"
 
 #. IDS_FILTER_ERROR_NO_ERROR
-#: Merge.rc:5736
+#: Merge.rc:5735
 msgid "No error"
 msgstr "Nisunu sbagliu"
 
 #. IDS_FILTER_ERROR_EMPTY_EXPRESSION
-#: Merge.rc:5737
+#: Merge.rc:5736
 msgid "Filter expression is empty"
 msgstr "L’espressione di filtru hè viota"
 
 #. IDS_FILTER_ERROR_UNKNOWN_CHAR
-#: Merge.rc:5738
+#: Merge.rc:5737
 msgid "Unknown character in filter expression"
 msgstr "Caratteru scunnisciutu in l’espressione di filtru"
 
 #. IDS_FILTER_ERROR_UNTERMINATED_STRING
-#: Merge.rc:5739
+#: Merge.rc:5738
 msgid "Unterminated string literal"
 msgstr "Litterale di catena micca compia"
 
 #. IDS_FILTER_ERROR_SYNTAX_ERROR
-#: Merge.rc:5740
+#: Merge.rc:5739
 msgid "Syntax error in filter expression"
 msgstr "Sbagliu di sintassa in l’espressione di filtru"
 
 #. IDS_FILTER_ERROR_PARSE_FAILURE
-#: Merge.rc:5741
+#: Merge.rc:5740
 msgid "Failed to parse filter expression"
 msgstr "Fiascu per analizà l’espressione di filtru"
 
 #. IDS_FILTER_ERROR_INVALID_LITERAL
-#: Merge.rc:5742
+#: Merge.rc:5741
 msgid "Invalid literal value"
 msgstr "Valore litterale inaccettevule"
 
 #. IDS_FILTER_ERROR_INVALID_REGULAR_EXPRESSION
-#: Merge.rc:5743
+#: Merge.rc:5742
 msgid "Invalid regular expression"
 msgstr "Espressione regulare inaccettevule"
 
 #. IDS_FILTER_ERROR_UNDEFINED_IDENTIFIER
-#: Merge.rc:5744
+#: Merge.rc:5743
 msgid "Undefined identifier"
 msgstr "Identificatore indefinitu"
 
 #. IDS_FILTER_ERROR_INVALID_ARGUMENT_COUNT
-#: Merge.rc:5745
+#: Merge.rc:5744
 msgid "Invalid number of arguments"
 msgstr "Numeru inaccettevule di parametri"
 
 #. IDS_FILTER_ERROR_FILTER_NAME_NOT_FOUND
-#: Merge.rc:5746
+#: Merge.rc:5745
 msgid "Filter name not found"
 msgstr "Nome di filtru intruvevule"
 
 #. IDS_FILTER_ERROR_DIVIDE_BY_ZERO
-#: Merge.rc:5747
+#: Merge.rc:5746
 msgid "Division by zero in filter expression"
 msgstr "Divisione da zeru in l’espressione di filtru"
 
 #. IDS_FILTER_ERROR_UNKNOWN_ERROR
-#: Merge.rc:5748
+#: Merge.rc:5747
 msgid "Unknown error"
 msgstr "Sbagliu scunnisciutu"
 
 #. IDS_FILTER_ERROR_INVALID_PROPERTY_NAME
-#: Merge.rc:5749
+#: Merge.rc:5748
 msgid "Invalid property name"
 msgstr "Nome di pruprietà inaccettevule"
 
 #. IDS_FILTER_ERROR_INVALID_DIRECTIVE
-#: Merge.rc:5750
+#: Merge.rc:5749
 msgid "Invalid directive"
 msgstr "Direttiva inaccettevule"
 
 #. IDS_FILTER_OP_EQUALS
-#: Merge.rc:5755
+#: Merge.rc:5754
 msgid "Equals"
 msgstr "Hè uguale à"
 
 #. IDS_FILTER_OP_NOT_EQUALS
-#: Merge.rc:5756
+#: Merge.rc:5755
 msgid "Does not equal"
 msgstr "Ùn hè micca uguale à"
 
 #. IDS_FILTER_OP_LESS_THAN
-#: Merge.rc:5757
+#: Merge.rc:5756
 msgid "Less than"
 msgstr "Hè inferiore à"
 
 #. IDS_FILTER_OP_LESS_EQUAL
-#: Merge.rc:5758
+#: Merge.rc:5757
 msgid "Less than or equal to"
 msgstr "Hè inferiore o uguale à"
 
 #. IDS_FILTER_OP_GREATER_EQUAL
-#: Merge.rc:5759
+#: Merge.rc:5758
 msgid "Greater than or equal to"
 msgstr "Hè superiore o uguale à"
 
 #. IDS_FILTER_OP_GREATER_THAN
-#: Merge.rc:5760
+#: Merge.rc:5759
 msgid "Greater than"
 msgstr "Hè superiore à"
 
 #. IDS_FILTER_OP_BETWEEN
-#: Merge.rc:5761
+#: Merge.rc:5760
 msgid "Between"
 msgstr "Trà"
 
 #. IDS_FILTER_OP_NOT_BETWEEN
-#: Merge.rc:5762
+#: Merge.rc:5761
 msgid "Not Between"
 msgstr "Micca trà"
 
 #. IDS_FILTER_OP_CONTAINS
-#: Merge.rc:5763
+#: Merge.rc:5762
 msgid "Contains"
 msgstr "Cuntene"
 
 #. IDS_FILTER_OP_NOT_CONTAINS
-#: Merge.rc:5764
+#: Merge.rc:5763
 msgid "Not Contains"
 msgstr "Ùn cuntene micca"
 
 #. IDS_FILTER_OP_RECONTAINS
-#: Merge.rc:5765
+#: Merge.rc:5764
 msgid "Contains (regex)"
 msgstr "Cuntene (regex)"
 
 #. IDS_FILTER_OP_NOT_RECONTAINS
-#: Merge.rc:5766
+#: Merge.rc:5765
 msgid "Not Contains (regex)"
 msgstr "Ùn cuntene micca (regex)"
 
 #. IDS_FILTER_OP_LIKE
-#: Merge.rc:5767
+#: Merge.rc:5766
 msgid "Match (wildcard)"
 msgstr "Currisponde (caratteru genericu)"
 
 #. IDS_FILTER_OP_NOT_LIKE
-#: Merge.rc:5768
+#: Merge.rc:5767
 msgid "Not match (wildcard)"
 msgstr "Ùn currisponde (caratteru genericu)"
 
 #. IDS_FILTER_OP_MATCHES
-#: Merge.rc:5769
+#: Merge.rc:5768
 msgid "Match (regex)"
 msgstr "Currisponde (espressione regex)"
 
 #. IDS_FILTER_OP_NOT_MATCHES
-#: Merge.rc:5770
+#: Merge.rc:5769
 msgid "Not match (regex)"
 msgstr "Ùn currisponde (espressione regex)"
 
 #. IDS_COLORMODE_LIGHT
-#: Merge.rc:5775
+#: Merge.rc:5774
 msgid "Light"
 msgstr "Chjaru"
 
 #. IDS_COLORMODE_DARK
-#: Merge.rc:5776
+#: Merge.rc:5775
 msgid "Dark"
 msgstr "Scuru"
 
 #. IDS_COLORMODE_FOLLOWSYSTEM
-#: Merge.rc:5777
+#: Merge.rc:5776
 msgid "Follow system"
 msgstr "Seguità u sistema"
 
 #. IDS_EXAMPLE
-#: Merge.rc:5782
+#: Merge.rc:5781
 #, c-format
 msgid "e.g. %1"
 msgstr "p.i. %1"
 
 #. IDS_DETECTED_PREVIOUS_CRASH
-#: Merge.rc:5787
+#: Merge.rc:5786
 msgid "WinMerge detected a previous crash. Please report this if possible."
 msgstr "WinMerge hà scupertu un accidente scorsu. S’ella hè pussibule, ci vole à riferiscelu."
 
 #. IDS_REGEX_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5792
+#: Merge.rc:5791
 msgid ""
 "# Regex replacement list\r\n"
 "# Format: regex<TAB>replacement\r\n"
@@ -8878,7 +8873,7 @@ msgstr ""
 "(\\d{4})-(\\d{2})-(\\d{2})\t$1_$2_$3\\r\n"
 
 #. IDS_STRING_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5793
+#: Merge.rc:5792
 msgid ""
 "# Replacement list\r\n"
 "# Format: search<TAB>replacement\r\n"
@@ -8895,22 +8890,22 @@ msgstr ""
 "da2\tà2\\r\n"
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_ONLY
-#: Merge.rc:5798
+#: Merge.rc:5797
 msgid "Built-in only"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_FIRST
-#: Merge.rc:5799
+#: Merge.rc:5798
 msgid "Built-in first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_FIRST
-#: Merge.rc:5800
+#: Merge.rc:5799
 msgid "Tree-sitter first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_ONLY
-#: Merge.rc:5801
+#: Merge.rc:5800
 msgid "Tree-sitter only"
 msgstr ""
 

--- a/Translations/WinMerge/Croatian.po
+++ b/Translations/WinMerge/Croatian.po
@@ -21,7 +21,7 @@ msgstr ""
 "X-Poedit-Country: CROATIA\n"
 
 #. LANGUAGE, SUBLANGUAGE
-#: Merge.rc:26 Merge.rc:59 Merge.rc:5818
+#: Merge.rc:26 Merge.rc:59 Merge.rc:5817
 #, c-format
 msgid "LANG_ENGLISH, SUBLANG_ENGLISH_US"
 msgstr "LANG_CROATIAN, SUBLANG_DEFAULT"
@@ -171,7 +171,7 @@ msgstr "&Skripte"
 #. IDS_NO_EDIT_SCRIPTS
 #: Merge.rc:127 Merge.rc:352 Merge.rc:463 Merge.rc:673 Merge.rc:678
 #: Merge.rc:887 Merge.rc:899 Merge.rc:906 Merge.rc:963 Merge.rc:1210
-#: Merge.rc:5375
+#: Merge.rc:5374
 #, c-format
 msgid "< Empty >"
 msgstr "< ništa >"
@@ -238,7 +238,7 @@ msgid "Auto-Fit All Columns"
 msgstr ""
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN
-#: Merge.rc:153 Merge.rc:5646
+#: Merge.rc:153 Merge.rc:5645
 msgid "&Filter by This Column"
 msgstr ""
 
@@ -304,7 +304,7 @@ msgid "&Previous Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_NEXTPAGE
-#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5679
+#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5678
 #, c-format
 msgid "&Next Page"
 msgstr ""
@@ -572,7 +572,7 @@ msgstr ""
 #. IDS_IMAGE_MENU
 #: Merge.rc:329 Merge.rc:338 Merge.rc:432 Merge.rc:441 Merge.rc:609
 #: Merge.rc:618 Merge.rc:670 Merge.rc:960 Merge.rc:1187 Merge.rc:1200
-#: Merge.rc:5477
+#: Merge.rc:5476
 #, c-format
 msgid "&Image"
 msgstr ""
@@ -710,7 +710,7 @@ msgid "&Huge"
 msgstr ""
 
 #. IDS_VIEW_MENU_BAR
-#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5714
+#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5713
 msgid "Men&u Bar"
 msgstr ""
 
@@ -1473,7 +1473,7 @@ msgid "Lo&cation Pane"
 msgstr "Panel &položaja"
 
 #. IDS_OUTPUTBAR_CAPTION
-#: Merge.rc:782 Merge.rc:5252
+#: Merge.rc:782 Merge.rc:5251
 msgid "Output Pane"
 msgstr ""
 
@@ -1769,55 +1769,55 @@ msgid "Co&mpare As"
 msgstr ""
 
 #. IDS_COPY_LEFT_TO_MIDDLE2
-#: Merge.rc:968 Merge.rc:980 Merge.rc:4852
+#: Merge.rc:968 Merge.rc:980 Merge.rc:4851
 #, c-format
 msgid "Left to Middle (%1 of %2)"
 msgstr ""
 
 #. IDS_COPY_LEFT_TO_RIGHT2
-#: Merge.rc:969 Merge.rc:981 Merge.rc:4851
+#: Merge.rc:969 Merge.rc:981 Merge.rc:4850
 #, c-format
 msgid "Left to Right (%1 of %2)"
 msgstr "Lijevo do desno (%1 od %2)"
 
 #. IDS_MOVE_LEFT_TO2
-#: Merge.rc:970 Merge.rc:982 Merge.rc:1045 Merge.rc:4863 Merge.rc:4892
+#: Merge.rc:970 Merge.rc:982 Merge.rc:1045 Merge.rc:4862 Merge.rc:4891
 #, c-format
 msgid "Left to... (%1 of %2)"
 msgstr "Lijevo do... (%1 od %2)"
 
 #. IDS_COPY_MIDDLE_TO_LEFT2
-#: Merge.rc:971 Merge.rc:983 Merge.rc:4849
+#: Merge.rc:971 Merge.rc:983 Merge.rc:4848
 #, c-format
 msgid "Middle to Left (%1 of %2)"
 msgstr ""
 
 #. IDS_COPY_MIDDLE_TO_RIGHT2
-#: Merge.rc:972 Merge.rc:984 Merge.rc:4850
+#: Merge.rc:972 Merge.rc:984 Merge.rc:4849
 #, c-format
 msgid "Middle to Right (%1 of %2)"
 msgstr ""
 
 #. IDS_MOVE_MIDDLE_TO2
-#: Merge.rc:973 Merge.rc:985 Merge.rc:1046 Merge.rc:4864 Merge.rc:4893
+#: Merge.rc:973 Merge.rc:985 Merge.rc:1046 Merge.rc:4863 Merge.rc:4892
 #, c-format
 msgid "Middle to... (%1 of %2)"
 msgstr ""
 
 #. IDS_COPY_RIGHT_TO_MIDDLE2
-#: Merge.rc:974 Merge.rc:986 Merge.rc:4848
+#: Merge.rc:974 Merge.rc:986 Merge.rc:4847
 #, c-format
 msgid "Right to Middle (%1 of %2)"
 msgstr ""
 
 #. IDS_COPY_RIGHT_TO_LEFT2
-#: Merge.rc:975 Merge.rc:987 Merge.rc:4847
+#: Merge.rc:975 Merge.rc:987 Merge.rc:4846
 #, c-format
 msgid "Right to Left (%1 of %2)"
 msgstr "Desno do lijevo (%1 od %2)"
 
 #. IDS_MOVE_RIGHT_TO2
-#: Merge.rc:976 Merge.rc:988 Merge.rc:1047 Merge.rc:4865 Merge.rc:4894
+#: Merge.rc:976 Merge.rc:988 Merge.rc:1047 Merge.rc:4864 Merge.rc:4893
 #, c-format
 msgid "Right to... (%1 of %2)"
 msgstr "Desno do... (%1 od %2)"
@@ -1883,31 +1883,31 @@ msgid "Cop&y Paths"
 msgstr "Kopiraj &stazu"
 
 #. IDS_DEL_LEFT_FMT2
-#: Merge.rc:1026 Merge.rc:1035 Merge.rc:4880
+#: Merge.rc:1026 Merge.rc:1035 Merge.rc:4879
 #, c-format
 msgid "Left (%1 of %2)"
 msgstr "Lijevo (%1 od %2)"
 
 #. IDS_DEL_MIDDLE_FMT2
-#: Merge.rc:1027 Merge.rc:1036 Merge.rc:4881
+#: Merge.rc:1027 Merge.rc:1036 Merge.rc:4880
 #, c-format
 msgid "Middle (%1 of %2)"
 msgstr ""
 
 #. IDS_DEL_RIGHT_FMT2
-#: Merge.rc:1028 Merge.rc:1037 Merge.rc:4882
+#: Merge.rc:1028 Merge.rc:1037 Merge.rc:4881
 #, c-format
 msgid "Right (%1 of %2)"
 msgstr "Desno (%1 od %2)"
 
 #. IDS_DEL_BOTH_FMT2
-#: Merge.rc:1029 Merge.rc:1038 Merge.rc:4883
+#: Merge.rc:1029 Merge.rc:1038 Merge.rc:4882
 #, c-format
 msgid "Both (%1 of %2)"
 msgstr "Oba panela (%1 od %2)"
 
 #. IDS_DEL_ALL_FMT2
-#: Merge.rc:1030 Merge.rc:1039 Merge.rc:4888
+#: Merge.rc:1030 Merge.rc:1039 Merge.rc:4887
 #, c-format
 msgid "All (%1 of %2)"
 msgstr ""
@@ -1936,19 +1936,19 @@ msgid "&Zip"
 msgstr "&Zip"
 
 #. IDS_COPY_BOTH_TO2
-#: Merge.rc:1048 Merge.rc:4866
+#: Merge.rc:1048 Merge.rc:4865
 #, c-format
 msgid "Both to... (%1 of %2)"
 msgstr ""
 
 #. IDS_COPY_ALL_TO2
-#: Merge.rc:1049 Merge.rc:4867
+#: Merge.rc:1049 Merge.rc:4866
 #, c-format
 msgid "All to... (%1 of %2)"
 msgstr ""
 
 #. IDS_COPY_DIFFERENCES_TO2
-#: Merge.rc:1050 Merge.rc:4868
+#: Merge.rc:1050 Merge.rc:4867
 #, c-format
 msgid "Differences to... (%1 of %2)"
 msgstr ""
@@ -2021,13 +2021,13 @@ msgstr ""
 
 #. IDS_USERCHOICE_NONE
 #: Merge.rc:1088 Merge.rc:1094 Merge.rc:1836 Merge.rc:1840 Merge.rc:2031
-#: Merge.rc:2035 Merge.rc:5377
+#: Merge.rc:2035 Merge.rc:5376
 #, c-format
 msgid "<None>"
 msgstr "Ništa"
 
 #. IDS_USERCHOICE_AUTOMATIC
-#: Merge.rc:1089 Merge.rc:1095 Merge.rc:5378
+#: Merge.rc:1089 Merge.rc:1095 Merge.rc:5377
 #, c-format
 msgid "<Automatic>"
 msgstr "Automatski"
@@ -2979,13 +2979,13 @@ msgid "Text files only"
 msgstr ""
 
 #. IDS_EOL_NONE
-#: Merge.rc:1667 Merge.rc:1918 Merge.rc:5304
+#: Merge.rc:1667 Merge.rc:1918 Merge.rc:5303
 #, c-format
 msgid "None"
 msgstr "Ništa"
 
 #. IDS_EOL_MIXED
-#: Merge.rc:1668 Merge.rc:5299
+#: Merge.rc:1668 Merge.rc:5298
 #, c-format
 msgid "Mixed"
 msgstr "Mixed"
@@ -3259,14 +3259,14 @@ msgstr ""
 
 #. IDS_DIFFERENT
 #: Merge.rc:1904 Merge.rc:1988 Merge.rc:2866 Merge.rc:3036 Merge.rc:3077
-#: Merge.rc:5058
+#: Merge.rc:5057
 #, c-format
 msgid "Different"
 msgstr "Razlika"
 
 #. IDS_IDENTICAL
 #: Merge.rc:1905 Merge.rc:1989 Merge.rc:2865 Merge.rc:3055 Merge.rc:3116
-#: Merge.rc:5048
+#: Merge.rc:5047
 #, c-format
 msgid "Identical"
 msgstr "Identično"
@@ -3287,7 +3287,7 @@ msgid "Missing"
 msgstr ""
 
 #. IDS_MOVED
-#: Merge.rc:1910 Merge.rc:5076
+#: Merge.rc:1910 Merge.rc:5075
 msgid "Moved"
 msgstr ""
 
@@ -4115,7 +4115,7 @@ msgid "&Use custom system colors"
 msgstr ""
 
 #. IDS_PRPCAT_SYSTEM
-#: Merge.rc:2565 Merge.rc:4559 Merge.rc:4560 Merge.rc:5007
+#: Merge.rc:2565 Merge.rc:4559 Merge.rc:4560 Merge.rc:5006
 #, c-format
 msgid "System"
 msgstr "Sistem"
@@ -4566,7 +4566,7 @@ msgid "Items compared:"
 msgstr "Stavki uspoređeno:"
 
 #. IDS_PREVIEWBAR_CLOSE
-#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5685
+#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5684
 #, c-format
 msgid "&Close"
 msgstr "&Zatvori"
@@ -5253,7 +5253,7 @@ msgid "A&ppend timestamp"
 msgstr "&Dodaj datum i vrijeme"
 
 #. IDS_CONFIRM_COPY_CAPTION
-#: Merge.rc:3214 Merge.rc:4915
+#: Merge.rc:3214 Merge.rc:4914
 #, c-format
 msgid "Confirm Copy"
 msgstr "Potvrdite kopiranje"
@@ -5514,7 +5514,7 @@ msgid "&Character Set..."
 msgstr ""
 
 #. IDS_PRPCAT_IMAGE
-#: Merge.rc:3351 Merge.rc:4574 Merge.rc:5015
+#: Merge.rc:3351 Merge.rc:4574 Merge.rc:5014
 msgid "Image"
 msgstr ""
 
@@ -5918,7 +5918,7 @@ msgid "Project"
 msgstr ""
 
 #. IDS_COLHDR_NSDIFFS
-#: Merge.rc:4566 Merge.rc:4990
+#: Merge.rc:4566 Merge.rc:4989
 #, c-format
 msgid "Differences"
 msgstr "Razlike"
@@ -6078,13 +6078,13 @@ msgid "File Type"
 msgstr ""
 
 #. IDS_COLHDR_EXTENSION
-#: Merge.rc:4653 Merge.rc:4947
+#: Merge.rc:4653 Merge.rc:4946
 #, c-format
 msgid "Extension"
 msgstr "Tip"
 
 #. IDS_PRPCAT_MESSAGE
-#: Merge.rc:4659 Merge.rc:5019
+#: Merge.rc:4659 Merge.rc:5018
 msgid "Message"
 msgstr ""
 
@@ -6124,7 +6124,7 @@ msgid "Hidden Items"
 msgstr ""
 
 #. IDS_PLUGINSLIST_NAME
-#: Merge.rc:4680 Merge.rc:5311
+#: Merge.rc:4680 Merge.rc:5310
 #, c-format
 msgid "Name"
 msgstr "Naziv"
@@ -6148,7 +6148,7 @@ msgid "[F] "
 msgstr "[F] "
 
 #. IDS_PLUGINSLIST_DESC
-#: Merge.rc:4684 Merge.rc:5313
+#: Merge.rc:4684 Merge.rc:5312
 #, c-format
 msgid "Description"
 msgstr "Opis"
@@ -6320,171 +6320,165 @@ msgstr ""
 msgid "  Sel: %d | %d"
 msgstr ""
 
-#. IDS_MERGEMODE_MERGING
-#: Merge.rc:4734
-#, c-format
-msgid "Merge"
-msgstr "Usporedo"
-
 #. IDS_DIFF_NUMBER_STATUS_FMT
-#: Merge.rc:4735
+#: Merge.rc:4734
 #, c-format
 msgid "Difference %1 of %2"
 msgstr "Razlika:  %1 od %2"
 
 #. IDS_NO_DIFF_SEL_FMT
-#: Merge.rc:4736
+#: Merge.rc:4735
 #, c-format
 msgid "%1 Differences Found"
 msgstr "Nađeno razlika:  %1"
 
 #. IDS_1_DIFF_FOUND
-#: Merge.rc:4737
+#: Merge.rc:4736
 #, c-format
 msgid "1 Difference Found"
 msgstr "Nađeno razlika: 1"
 
 #. IDS_NO_ERR_SEL_FMT
-#: Merge.rc:4738
+#: Merge.rc:4737
 #, c-format
 msgid "%1 Errors Found"
 msgstr ""
 
 #. IDS_1_ERR_FOUND
-#: Merge.rc:4739
+#: Merge.rc:4738
 msgid "1 Error Found"
 msgstr ""
 
 #. IDS_STATUSBAR_READONLY, Abbreviation from "Read Only"
-#: Merge.rc:4740
+#: Merge.rc:4739
 #, c-format
 msgid "RO"
 msgstr "SČ"
 
 #. IDS_DIRVIEW_STATUS_FMT_FOCUS
-#: Merge.rc:4746
+#: Merge.rc:4745
 #, c-format
 msgid "Item %1 of %2"
 msgstr "Stavka %1 od %2"
 
 #. IDS_DIRVIEW_STATUS_FMT_NOFOCUS
-#: Merge.rc:4747
+#: Merge.rc:4746
 #, c-format
 msgid "Items: %1"
 msgstr "Stavke: %1"
 
 #. IDS_DIRVIEW_STATUS_COMPARING
-#: Merge.rc:4748
+#: Merge.rc:4747
 #, c-format
 msgid "Comparing items..."
 msgstr "Usporedba stavki..."
 
 #. IDS_ITEMS_PER_SEC
-#: Merge.rc:4749
+#: Merge.rc:4748
 #, c-format
 msgid "%.1f[items/sec]"
 msgstr ""
 
 #. IDS_ERROR_INCOMPARABLE
-#: Merge.rc:4755
+#: Merge.rc:4754
 msgid "Select two existing folders/files to compare."
 msgstr "Odaberite dvije datoteke ili mape za usporedbu."
 
 #. IDS_DIRSEL_TAG
-#: Merge.rc:4756
+#: Merge.rc:4755
 #, c-format
 msgid "Folder Selection"
 msgstr "Izbor mape"
 
 #. IDS_OPEN_FILESDIRS
-#: Merge.rc:4757
+#: Merge.rc:4756
 #, c-format
 msgid "Select two (or three) folders/files to compare."
 msgstr ""
 
 #. IDS_OPEN_LEFTINVALID
-#: Merge.rc:4758
+#: Merge.rc:4757
 #, c-format
 msgid "Left (1st) path is invalid!"
 msgstr ""
 
 #. IDS_OPEN_MIDDLEINVALID
-#: Merge.rc:4759
+#: Merge.rc:4758
 #, c-format
 msgid "Middle (2nd) path is invalid!"
 msgstr ""
 
 #. IDS_OPEN_RIGHTINVALID2
-#: Merge.rc:4760
+#: Merge.rc:4759
 #, c-format
 msgid "Right (2nd) path is invalid!"
 msgstr ""
 
 #. IDS_OPEN_RIGHTINVALID3
-#: Merge.rc:4761
+#: Merge.rc:4760
 #, c-format
 msgid "Right (3rd) path is invalid!"
 msgstr ""
 
 #. IDS_OPEN_BOTHINVALID
-#: Merge.rc:4762
+#: Merge.rc:4761
 #, c-format
 msgid "Both paths are invalid!"
 msgstr "Obje staze su krive!"
 
-#: Merge.rc:4764
+#: Merge.rc:4763
 #, c-format
 msgid "Left (1st) and Middle (2nd) paths are invalid!"
 msgstr ""
 
 #. IDS_OPEN_LEFTRIGHTINVALID
-#: Merge.rc:4765
+#: Merge.rc:4764
 #, c-format
 msgid "Left (1st) and Right (3rd) paths are invalid!"
 msgstr ""
 
-#: Merge.rc:4767
+#: Merge.rc:4766
 #, c-format
 msgid "Middle (2nd) and Right (3rd) paths are invalid!"
 msgstr ""
 
 #. IDS_OPEN_ALLINVALID
-#: Merge.rc:4768
+#: Merge.rc:4767
 #, c-format
 msgid "All paths are invalid!"
 msgstr ""
 
 #. IDS_OPEN_UNPACKERDISABLED
-#: Merge.rc:4769
+#: Merge.rc:4768
 msgid "Only enabled for file comparisons"
 msgstr ""
 
 #. IDS_OPEN_MISMATCH
-#: Merge.rc:4770
+#: Merge.rc:4769
 #, c-format
 msgid "Cannot compare file and folder!"
 msgstr "Ne mogu usporediti datoteku i mapu."
 
 #. IDS_ERROR_FILE_NOT_FOUND
-#: Merge.rc:4776
+#: Merge.rc:4775
 #, c-format
 msgid "File not found: %1"
 msgstr "Nema datoteke: %1"
 
 #. IDS_ERROR_FOLDER_NOT_FOUND
-#: Merge.rc:4777
+#: Merge.rc:4776
 #, c-format
 msgid "Folder not found: %1"
 msgstr ""
 
 #. IDS_ERROR_FILE_NOT_UNPACKED
-#: Merge.rc:4778
+#: Merge.rc:4777
 #, c-format
 msgid "File not unpacked: %1"
 msgstr "Datoteka nije raspakirana: %1"
 
 #. IDS_ERROR_FILEOPEN
-#: Merge.rc:4779
+#: Merge.rc:4778
 #, c-format
 msgid ""
 "Cannot open file\n"
@@ -6498,13 +6492,13 @@ msgstr ""
 "%2"
 
 #. IDS_ERROR_CONF_RESOLVE
-#: Merge.rc:4780
+#: Merge.rc:4779
 #, c-format
 msgid "Failed to parse conflict file."
 msgstr "Ne mogu podjeliti konfliktnu datoteku."
 
 #. IDS_NOT_CONFLICT_FILE
-#: Merge.rc:4781
+#: Merge.rc:4780
 #, c-format
 msgid "The file\n%1\nis not a conflict file."
 msgstr ""
@@ -6513,35 +6507,35 @@ msgstr ""
 "nije konfliktna."
 
 #. IDS_COMPARE_LARGE_FILES
-#: Merge.rc:4782
+#: Merge.rc:4781
 msgid "Comparing large files requires significant memory.\nShow only comparison results (not file contents)?"
 msgstr ""
 
 #. IDS_SAVE_AS_TITLE
-#: Merge.rc:4788
+#: Merge.rc:4787
 #, c-format
 msgid "Save As"
 msgstr "Pohrani kao"
 
 #. IDS_SAVE_FMT
-#: Merge.rc:4789
+#: Merge.rc:4788
 #, c-format
 msgid "Save changes to %1?"
 msgstr "Pohraniti izmjene %1?"
 
 #. IDS_SAVEREADONLY_FMT
-#: Merge.rc:4790
+#: Merge.rc:4789
 #, c-format
 msgid "%1 is read-only. Override? Or 'No' to save as new filename?"
 msgstr "%1 je označena smo za čitanje. Natpisati zaštićenu datoteku? (Stisnite 'Ne', za pohranu pod novim nazivom.)"
 
 #. IDS_ERROR_BACKUP
-#: Merge.rc:4791
+#: Merge.rc:4790
 #, c-format
 msgid "Error backing up file"
 msgstr "Greška pri stvaranju rezervne datoteke"
 
-#: Merge.rc:4793
+#: Merge.rc:4792
 #, c-format
 msgid ""
 "Unable to backup original file:\n"
@@ -6555,7 +6549,7 @@ msgstr ""
 "Nastaviti?"
 
 #. IDS_FILESAVE_FAILED
-#: Merge.rc:4794
+#: Merge.rc:4793
 #, c-format
 msgid "Saving file failed.\n%1\n%2\n\t- Use different filename (OK)\n\t- Abort (Cancel)?"
 msgstr ""
@@ -6566,7 +6560,7 @@ msgstr ""
 "\t- Pritisnite 'U redu' za pohranu pod drugim nazivom\n"
 "\t- ili pritisnite 'Odustajem' za prekid postupka."
 
-#: Merge.rc:4796
+#: Merge.rc:4795
 #, c-format
 msgid "Plugin '%2' cannot pack changes to left file into '%1'.\n\nOriginal unchanged. Save unpacked version?"
 msgstr ""
@@ -6576,12 +6570,12 @@ msgstr ""
 "\n"
 "Pohraniti nespakiranu verziju kao datoteku?"
 
-#: Merge.rc:4798
+#: Merge.rc:4797
 #, c-format
 msgid "Plugin '%2' cannot pack changes to middle file into '%1'.\n\nOriginal unchanged. Save unpacked version?"
 msgstr ""
 
-#: Merge.rc:4800
+#: Merge.rc:4799
 #, c-format
 msgid "Plugin '%2' cannot pack changes to right file into '%1'.\n\nOriginal unchanged. Save unpacked version?"
 msgstr ""
@@ -6592,7 +6586,7 @@ msgstr ""
 "Pohraniti nespakiranu verziju kao datoteku?"
 
 #. IDS_FILECHANGED_ONDISK
-#: Merge.rc:4801
+#: Merge.rc:4800
 #, c-format
 msgid ""
 "Another application updated\n"
@@ -6608,7 +6602,7 @@ msgstr ""
 "Natpisati datoteku?"
 
 #. IDS_SAVEREADONLY_MULTI
-#: Merge.rc:4802
+#: Merge.rc:4801
 #, c-format
 msgid ""
 "%1\n"
@@ -6618,7 +6612,7 @@ msgstr ""
 "je označena samo za čitanje. Natpisati zaštićenu stavku?"
 
 #. IDS_FILECHANGED_RESCAN
-#: Merge.rc:4803
+#: Merge.rc:4802
 #, c-format
 msgid "Another application updated\n%1\nsince last scan.\n\nReload?"
 msgstr ""
@@ -6629,25 +6623,25 @@ msgstr ""
 "Želite li ponovno učitanje datoteke?"
 
 #. IDS_SAVE_LEFT_AS
-#: Merge.rc:4804
+#: Merge.rc:4803
 #, c-format
 msgid "Save Left File As"
 msgstr "Pohrani lijevu datoteku kao"
 
 #. IDS_SAVE_MIDDLE_AS
-#: Merge.rc:4805
+#: Merge.rc:4804
 #, c-format
 msgid "Save Middle File As"
 msgstr ""
 
 #. IDS_SAVE_RIGHT_AS
-#: Merge.rc:4806
+#: Merge.rc:4805
 #, c-format
 msgid "Save Right File As"
 msgstr "Pohrani desnu datoteku kao"
 
 #. IDS_FILE_DISAPPEARED
-#: Merge.rc:4811
+#: Merge.rc:4810
 #, c-format
 msgid ""
 "File\n"
@@ -6659,7 +6653,7 @@ msgstr ""
 "je nestala. Za nastavak, pohranite kopiju."
 
 #. IDS_VIEWS_OUTOFSYNC
-#: Merge.rc:4817
+#: Merge.rc:4816
 #, c-format
 msgid ""
 "Cannot merge unsynched documents.\n"
@@ -6671,189 +6665,189 @@ msgstr ""
 "Osvježite dokumente prije nastavka."
 
 #. IDS_BREAK_ON_WHITESPACE
-#: Merge.rc:4822
+#: Merge.rc:4821
 msgid "Break at whitespace"
 msgstr "Stani na razmaku"
 
 #. IDS_BREAK_ON_PUNCTUATION
-#: Merge.rc:4823
+#: Merge.rc:4822
 msgid "Break at whitespace or punctuation"
 msgstr "Stani na razmaku ili interpunkciji"
 
 #. IDS_L2M
-#: Merge.rc:4829
+#: Merge.rc:4828
 msgid "Copy to &Middle\tAlt+Right"
 msgstr ""
 
 #. IDS_R2M
-#: Merge.rc:4830
+#: Merge.rc:4829
 msgid "Copy to &Middle\tAlt+Left"
 msgstr ""
 
 #. IDS_COPY_FROM_MIDDLE_R
-#: Merge.rc:4831
+#: Merge.rc:4830
 msgid "Copy from Middle\tAlt+Shift+Right"
 msgstr ""
 
 #. IDS_COPY_FROM_MIDDLE_L
-#: Merge.rc:4832
+#: Merge.rc:4831
 msgid "Copy from Middle\tAlt+Shift+Left"
 msgstr ""
 
 #. IDS_L2MNEXT
-#: Merge.rc:4833
+#: Merge.rc:4832
 msgid "Copy to Middle and Advance\tCtrl+Alt+Right"
 msgstr ""
 
 #. IDS_R2MNEXT
-#: Merge.rc:4834
+#: Merge.rc:4833
 msgid "Copy to Middle and Advance\tCtrl+Alt+Left"
 msgstr ""
 
 #. IDS_ALL_MIDDLE
-#: Merge.rc:4835
+#: Merge.rc:4834
 msgid "Copy All to Middle"
 msgstr ""
 
 #. IDS_COPY_RIGHT_TO_LEFT
-#: Merge.rc:4841
+#: Merge.rc:4840
 #, c-format
 msgid "Right to Left (%1)"
 msgstr "Desno do lijevo (%1)"
 
 #. IDS_COPY_RIGHT_TO_MIDDLE
-#: Merge.rc:4842
+#: Merge.rc:4841
 #, c-format
 msgid "Right to Middle (%1)"
 msgstr ""
 
 #. IDS_COPY_MIDDLE_TO_LEFT
-#: Merge.rc:4843
+#: Merge.rc:4842
 #, c-format
 msgid "Middle to Left (%1)"
 msgstr ""
 
 #. IDS_COPY_MIDDLE_TO_RIGHT
-#: Merge.rc:4844
+#: Merge.rc:4843
 #, c-format
 msgid "Middle to Right (%1)"
 msgstr ""
 
 #. IDS_COPY_LEFT_TO_RIGHT
-#: Merge.rc:4845
+#: Merge.rc:4844
 #, c-format
 msgid "Left to Right (%1)"
 msgstr "Lijevo do desno (%1)"
 
 #. IDS_COPY_LEFT_TO_MIDDLE
-#: Merge.rc:4846
+#: Merge.rc:4845
 #, c-format
 msgid "Left to Middle (%1)"
 msgstr ""
 
 #. IDS_MOVE_LEFT_TO
-#: Merge.rc:4857 Merge.rc:4889
+#: Merge.rc:4856 Merge.rc:4888
 #, c-format
 msgid "Left to... (%1)"
 msgstr "Lijevo do... (%1)"
 
 #. IDS_MOVE_MIDDLE_TO
-#: Merge.rc:4858 Merge.rc:4890
+#: Merge.rc:4857 Merge.rc:4889
 #, c-format
 msgid "Middle to... (%1)"
 msgstr ""
 
 #. IDS_MOVE_RIGHT_TO
-#: Merge.rc:4859 Merge.rc:4891
+#: Merge.rc:4858 Merge.rc:4890
 #, c-format
 msgid "Right to... (%1)"
 msgstr "Desno do... (%1)"
 
 #. IDS_COPY_BOTH_TO
-#: Merge.rc:4860
+#: Merge.rc:4859
 #, c-format
 msgid "Both to... (%1)"
 msgstr ""
 
 #. IDS_COPY_ALL_TO
-#: Merge.rc:4861
+#: Merge.rc:4860
 #, c-format
 msgid "All to... (%1)"
 msgstr ""
 
 #. IDS_COPY_DIFFERENCES_TO
-#: Merge.rc:4862
+#: Merge.rc:4861
 #, c-format
 msgid "Differences to... (%1)"
 msgstr ""
 
 #. IDS_ONLYDIFFITEMS_CONFIRM
-#: Merge.rc:4869
+#: Merge.rc:4868
 msgid "Some selected items are identical or skipped.\nProcess only items with differences?"
 msgstr ""
 
 #. IDS_DEL_LEFT_FMT
-#: Merge.rc:4875
+#: Merge.rc:4874
 #, c-format
 msgid "Left (%1)"
 msgstr "Lijevo (%1)"
 
 #. IDS_DEL_MIDDLE_FMT
-#: Merge.rc:4876
+#: Merge.rc:4875
 #, c-format
 msgid "Middle (%1)"
 msgstr ""
 
 #. IDS_DEL_RIGHT_FMT
-#: Merge.rc:4877
+#: Merge.rc:4876
 #, c-format
 msgid "Right (%1)"
 msgstr "Desno (%1)"
 
 #. IDS_DEL_BOTH_FMT
-#: Merge.rc:4878
+#: Merge.rc:4877
 #, c-format
 msgid "Both (%1)"
 msgstr "Oba panela (%1)"
 
 #. IDS_DEL_ALL_FMT
-#: Merge.rc:4879
+#: Merge.rc:4878
 #, c-format
 msgid "All (%1)"
 msgstr ""
 
 #. IDS_SELECT_DEST_LEFT
-#: Merge.rc:4895
+#: Merge.rc:4894
 #, c-format
 msgid "Left Side - Select Destination Folder:"
 msgstr "Lijeva strana - odaberite odredišnu mapu:"
 
 #. IDS_SELECT_DEST_MIDDLE
-#: Merge.rc:4896
+#: Merge.rc:4895
 #, c-format
 msgid "Middle Side - Select Destination Folder:"
 msgstr ""
 
 #. IDS_SELECT_DEST_RIGHT
-#: Merge.rc:4897
+#: Merge.rc:4896
 #, c-format
 msgid "Right Side - Select Destination Folder:"
 msgstr "Desna strana - odaberite odredišnu mapu:"
 
 #. IDS_FILES_AFFECTED_FMT
-#: Merge.rc:4898
+#: Merge.rc:4897
 #, c-format
 msgid "(%1 Files Affected)"
 msgstr "(%1 datoteka dorađeno)"
 
 #. IDS_FILES_AFFECTED_FMT2
-#: Merge.rc:4899
+#: Merge.rc:4898
 #, c-format
 msgid "(%1 of %2 Files Affected)"
 msgstr "(%1 od %2 datoteka dorađeno)"
 
 #. IDS_CONFIRM_DELETE_SINGLE
-#: Merge.rc:4905
+#: Merge.rc:4904
 #, c-format
 msgid ""
 "Are you sure you want to delete\n"
@@ -6865,18 +6859,18 @@ msgstr ""
 "%1 ?"
 
 #. IDS_CONFIRM_SINGLE_COPY
-#: Merge.rc:4906
+#: Merge.rc:4905
 msgid "Are you sure you want to copy?"
 msgstr "Kopirati? -"
 
 #. IDS_CONFIRM_MULTIPLE_COPY
-#: Merge.rc:4907
+#: Merge.rc:4906
 #, c-format
 msgid "Are you sure you want to copy %d items?"
 msgstr ""
 
 #. IDS_DIRCMP_NOTSYNC
-#: Merge.rc:4908
+#: Merge.rc:4907
 #, c-format
 msgid ""
 "Operation aborted!\n"
@@ -6896,873 +6890,873 @@ msgstr ""
 "Osvježite usporedbu."
 
 #. IDS_CONFIRM_SINGLE_MOVE
-#: Merge.rc:4913
+#: Merge.rc:4912
 msgid "Are you sure you want to move?"
 msgstr "Premjestiti?"
 
 #. IDS_CONFIRM_MULTIPLE_MOVE
-#: Merge.rc:4914
+#: Merge.rc:4913
 #, c-format
 msgid "Are you sure you want to move %d items?"
 msgstr "Premjestiti %d stavku?"
 
 #. IDS_CONFIRM_MOVE_CAPTION
-#: Merge.rc:4916
+#: Merge.rc:4915
 #, c-format
 msgid "Confirm Move"
 msgstr "Potvrdite premještanje"
 
-#: Merge.rc:4918
+#: Merge.rc:4917
 #, c-format
 msgid "Close the folder comparison window?"
 msgstr ""
 
-#: Merge.rc:4920
+#: Merge.rc:4919
 msgid "Close the folder comparison window, which took a long time?"
 msgstr ""
 
 #. IDS_ERROR_INVALID_DIR_FILE_NAME
-#: Merge.rc:4921
+#: Merge.rc:4920
 msgid "The file or folder name is invalid."
 msgstr ""
 
 #. IDS_ERROR_EXECUTE_FILE
-#: Merge.rc:4927
+#: Merge.rc:4926
 #, c-format
 msgid "Failed to execute external editor: %1"
 msgstr "Greška pri pokretanju vanjskog editora: %1"
 
 #. IDS_UNKNOWN_ARCHIVE_FORMAT
-#: Merge.rc:4933
+#: Merge.rc:4932
 #, c-format
 msgid "Unknown archive format"
 msgstr "Nepoznat oblik arhiva"
 
-#: Merge.rc:4935
+#: Merge.rc:4934
 msgid "Failed to extract archive.\nCompare as text file?"
 msgstr ""
 
 #. IDS_COLHDR_FILENAME
-#: Merge.rc:4941
+#: Merge.rc:4940
 #, c-format
 msgid "Filename"
 msgstr "Naziv datoteke"
 
 #. IDS_COLHDR_DIR
-#: Merge.rc:4942
+#: Merge.rc:4941
 msgctxt "DirView|ColumnHeader"
 msgid "Folder"
 msgstr "Mapa"
 
 #. IDS_COLHDR_RESULT
-#: Merge.rc:4943
+#: Merge.rc:4942
 #, c-format
 msgid "Comparison Result"
 msgstr "Rezultat usporedbe"
 
 #. IDS_COLHDR_LTIMEM
-#: Merge.rc:4944
+#: Merge.rc:4943
 #, c-format
 msgid "Left Date"
 msgstr "Datum lijevo"
 
 #. IDS_COLHDR_RTIMEM
-#: Merge.rc:4945
+#: Merge.rc:4944
 #, c-format
 msgid "Right Date"
 msgstr "Datum sadašnji"
 
 #. IDS_COLHDR_MTIMEM
-#: Merge.rc:4946
+#: Merge.rc:4945
 #, c-format
 msgid "Middle Date"
 msgstr ""
 
 #. IDS_COLHDR_LSIZE
-#: Merge.rc:4948
+#: Merge.rc:4947
 #, c-format
 msgid "Left Size"
 msgstr "Veličina lijevo"
 
 #. IDS_COLHDR_RSIZE
-#: Merge.rc:4949
+#: Merge.rc:4948
 #, c-format
 msgid "Right Size"
 msgstr "Veličina desno"
 
 #. IDS_COLHDR_MSIZE
-#: Merge.rc:4954
+#: Merge.rc:4953
 #, c-format
 msgid "Middle Size"
 msgstr ""
 
 #. IDS_COLHDR_RSIZE_SHORT
-#: Merge.rc:4955
+#: Merge.rc:4954
 #, c-format
 msgid "Right Size (Short)"
 msgstr "Veličina desno (skraćeno)"
 
 #. IDS_COLHDR_LSIZE_SHORT
-#: Merge.rc:4956
+#: Merge.rc:4955
 #, c-format
 msgid "Left Size (Short)"
 msgstr "Veličina lijevo (skraćeno)"
 
 #. IDS_COLHDR_MSIZE_SHORT
-#: Merge.rc:4957
+#: Merge.rc:4956
 #, c-format
 msgid "Middle Size (Short)"
 msgstr ""
 
 #. IDS_COLHDR_LTIMEC
-#: Merge.rc:4963
+#: Merge.rc:4962
 #, c-format
 msgid "Left Creation Time"
 msgstr "Tim lijeve datoteke"
 
 #. IDS_COLHDR_RTIMEC
-#: Merge.rc:4964
+#: Merge.rc:4963
 #, c-format
 msgid "Right Creation Time"
 msgstr "Tim desne datoteke"
 
 #. IDS_COLHDR_MTIMEC
-#: Merge.rc:4965
+#: Merge.rc:4964
 #, c-format
 msgid "Middle Creation Time"
 msgstr ""
 
 #. IDS_COLHDR_NEWER
-#: Merge.rc:4966
+#: Merge.rc:4965
 #, c-format
 msgid "Newer File"
 msgstr "Novija datoteka"
 
 #. IDS_COLHDR_LVERSION
-#: Merge.rc:4967
+#: Merge.rc:4966
 #, c-format
 msgid "Left File Version"
 msgstr "Verzija lijeve datoteke"
 
 #. IDS_COLHDR_RVERSION
-#: Merge.rc:4968
+#: Merge.rc:4967
 #, c-format
 msgid "Right File Version"
 msgstr "Verzija desne datoteke"
 
 #. IDS_COLHDR_MVERSION
-#: Merge.rc:4969
+#: Merge.rc:4968
 #, c-format
 msgid "Middle File Version"
 msgstr ""
 
 #. IDS_COLHDR_RESULT_ABBR
-#: Merge.rc:4970
+#: Merge.rc:4969
 #, c-format
 msgid "Short Result"
 msgstr "Rezultat skraćeno"
 
 #. IDS_COLHDR_LATTRIBUTES
-#: Merge.rc:4971
+#: Merge.rc:4970
 #, c-format
 msgid "Left Attributes"
 msgstr "Atributi lijevo"
 
 #. IDS_COLHDR_RATTRIBUTES
-#: Merge.rc:4972
+#: Merge.rc:4971
 #, c-format
 msgid "Right Attributes"
 msgstr "Atributi desno"
 
 #. IDS_COLHDR_MATTRIBUTES
-#: Merge.rc:4973
+#: Merge.rc:4972
 #, c-format
 msgid "Middle Attributes"
 msgstr ""
 
 #. IDS_COLHDR_LEOL_TYPE
-#: Merge.rc:4978
+#: Merge.rc:4977
 #, c-format
 msgid "Left EOL"
 msgstr "Završetak reda lijevo"
 
 #. IDS_COLHDR_MEOL_TYPE
-#: Merge.rc:4979
+#: Merge.rc:4978
 #, c-format
 msgid "Middle EOL"
 msgstr ""
 
 #. IDS_COLHDR_REOL_TYPE
-#: Merge.rc:4980
+#: Merge.rc:4979
 #, c-format
 msgid "Right EOL"
 msgstr "Završetak retka desne datoteke."
 
 #. IDS_COLHDR_LENCODING
-#: Merge.rc:4986
+#: Merge.rc:4985
 #, c-format
 msgid "Left Encoding"
 msgstr "Kodiranje lijevo"
 
 #. IDS_COLHDR_RENCODING
-#: Merge.rc:4987
+#: Merge.rc:4986
 #, c-format
 msgid "Right Encoding"
 msgstr "Kodiranje desno"
 
 #. IDS_COLHDR_MENCODING
-#: Merge.rc:4988
+#: Merge.rc:4987
 #, c-format
 msgid "Middle Encoding"
 msgstr ""
 
 #. IDS_COLHDR_NIDIFFS
-#: Merge.rc:4989
+#: Merge.rc:4988
 msgid "Ignored Diff"
 msgstr "Zanemari razlike"
 
 #. IDS_COLHDR_BINARY
-#: Merge.rc:4991
+#: Merge.rc:4990
 msgctxt "DirView|ColumnHeader"
 msgid "Binary"
 msgstr "Binarno"
 
 #. IDS_PLUGINS_TYPE_UNPACKER
-#: Merge.rc:4992 Merge.rc:5314
+#: Merge.rc:4991 Merge.rc:5313
 #, c-format
 msgid "Unpacker"
 msgstr "Raspakiravač"
 
 #. IDS_PLUGIN_TYPE4
-#: Merge.rc:4993 Merge.rc:5315 Merge.rc:5622
+#: Merge.rc:4992 Merge.rc:5314 Merge.rc:5621
 #, c-format
 msgid "Prediffer"
 msgstr "Prediffer"
 
 #. IDS_COLHDR_LEFT
-#: Merge.rc:4994
+#: Merge.rc:4993
 msgid "Left"
 msgstr ""
 
 #. IDS_COLHDR_MIDDLE
-#: Merge.rc:4995
+#: Merge.rc:4994
 msgid "Middle"
 msgstr ""
 
 #. IDS_COLHDR_RIGHT
-#: Merge.rc:4996
+#: Merge.rc:4995
 msgid "Right"
 msgstr ""
 
 #. IDS_COLHDR_DIFF
-#: Merge.rc:4997
+#: Merge.rc:4996
 msgid "Diff"
 msgstr ""
 
 #. IDS_COLHDR_LEFT_DUPLICATE
-#: Merge.rc:4998
+#: Merge.rc:4997
 msgid "Left Duplicate Count"
 msgstr ""
 
 #. IDS_COLHDR_RIGHT_DUPLICATE
-#: Merge.rc:4999
+#: Merge.rc:4998
 msgid "Right Duplicate Count"
 msgstr ""
 
 #. IDS_COLHDR_MIDDLE_DUPLICATE
-#: Merge.rc:5000
+#: Merge.rc:4999
 msgid "Middle Duplicate Count"
 msgstr ""
 
 #. IDS_COLHDR_MOVE
-#: Merge.rc:5001
+#: Merge.rc:5000
 msgid "Move"
 msgstr ""
 
 #. IDS_PRPCAT_AUDIO
-#: Merge.rc:5008
+#: Merge.rc:5007
 msgid "Audio"
 msgstr ""
 
 #. IDS_PRPCAT_CALENDAR
-#: Merge.rc:5009
+#: Merge.rc:5008
 msgid "Calendar"
 msgstr ""
 
 #. IDS_PRPCAT_COMMUNICATION
-#: Merge.rc:5010
+#: Merge.rc:5009
 msgid "Communication"
 msgstr ""
 
 #. IDS_PRPCAT_CONTACT
-#: Merge.rc:5011
+#: Merge.rc:5010
 msgid "Contact"
 msgstr ""
 
 #. IDS_PRPCAT_DEVICES
-#: Merge.rc:5012
+#: Merge.rc:5011
 msgid "Devices"
 msgstr ""
 
 #. IDS_PRPCAT_DOCUMENT
-#: Merge.rc:5013
+#: Merge.rc:5012
 msgid "Document"
 msgstr ""
 
 #. IDS_PRPCAT_HOME
-#: Merge.rc:5014
+#: Merge.rc:5013
 msgid "Home"
 msgstr ""
 
 #. IDS_PRPCAT_JOURNAL
-#: Merge.rc:5016
+#: Merge.rc:5015
 msgid "Journal"
 msgstr ""
 
 #. IDS_PRPCAT_LINK
-#: Merge.rc:5017
+#: Merge.rc:5016
 msgid "Link"
 msgstr ""
 
 #. IDS_PRPCAT_MEDIA
-#: Merge.rc:5018
+#: Merge.rc:5017
 msgid "Media"
 msgstr ""
 
 #. IDS_PRPCAT_MUSIC
-#: Merge.rc:5020
+#: Merge.rc:5019
 msgid "Music"
 msgstr ""
 
 #. IDS_PRPCAT_NOTE
-#: Merge.rc:5021
+#: Merge.rc:5020
 msgid "Note"
 msgstr ""
 
 #. IDS_PRPCAT_PHOTO
-#: Merge.rc:5022
+#: Merge.rc:5021
 msgid "Photo"
 msgstr ""
 
 #. IDS_PRPCAT_RECORDEDTV
-#: Merge.rc:5023
+#: Merge.rc:5022
 msgid "RecordedTV"
 msgstr ""
 
 #. IDS_PRPCAT_SEARCH
-#: Merge.rc:5024
+#: Merge.rc:5023
 msgid "Search"
 msgstr ""
 
 #. IDS_PRPCAT_SECURITY
-#: Merge.rc:5025
+#: Merge.rc:5024
 msgid "Security"
 msgstr ""
 
 #. IDS_PRPCAT_SOFTWARE
-#: Merge.rc:5026
+#: Merge.rc:5025
 msgid "Software"
 msgstr ""
 
 #. IDS_PRPCAT_TASK
-#: Merge.rc:5027
+#: Merge.rc:5026
 msgid "Task"
 msgstr ""
 
 #. IDS_PRPCAT_VIDEO
-#: Merge.rc:5028
+#: Merge.rc:5027
 msgid "Video"
 msgstr ""
 
 #. IDS_PRPCAT_HASH
-#: Merge.rc:5029
+#: Merge.rc:5028
 msgid "Hash"
 msgstr ""
 
 #. IDS_CANT_COMPARE_FILES
-#: Merge.rc:5035
+#: Merge.rc:5034
 #, c-format
 msgid "Unable to compare files"
 msgstr "Ne mogu usporediti datoteke"
 
 #. IDS_ABORTED_ITEM
-#: Merge.rc:5036
+#: Merge.rc:5035
 #, c-format
 msgid "Item aborted"
 msgstr "Odbačena stavka"
 
 #. IDS_FILE_SKIPPED
-#: Merge.rc:5037
+#: Merge.rc:5036
 #, c-format
 msgid "File skipped"
 msgstr "Izostavljene datoteke"
 
 #. IDS_DIR_SKIPPED
-#: Merge.rc:5038
+#: Merge.rc:5037
 #, c-format
 msgid "Folder skipped"
 msgstr "Izostavljene mape"
 
 #. IDS_LEFT_ONLY_IN_FMT
-#: Merge.rc:5039
+#: Merge.rc:5038
 #, c-format
 msgid "Left only: %1"
 msgstr "Samo lijevi: %1"
 
 #. IDS_MIDDLE_ONLY_IN_FMT
-#: Merge.rc:5040
+#: Merge.rc:5039
 #, c-format
 msgid "Middle only: %1"
 msgstr ""
 
 #. IDS_RIGHT_ONLY_IN_FMT
-#: Merge.rc:5041
+#: Merge.rc:5040
 #, c-format
 msgid "Right only: %1"
 msgstr "Samo desni: %1"
 
 #. IDS_DOES_NOT_EXIST_IN_FMT
-#: Merge.rc:5042
+#: Merge.rc:5041
 #, c-format
 msgid "Does not exist in %1"
 msgstr ""
 
 #. IDS_BIN_FILES_SAME
-#: Merge.rc:5043
+#: Merge.rc:5042
 #, c-format
 msgid "Binary files are identical"
 msgstr "Binarne datoteke su identične"
 
 #. IDS_BIN_FILES_DIFF
-#: Merge.rc:5049
+#: Merge.rc:5048
 #, c-format
 msgid "Binary files are different"
 msgstr "Binarne datoteke su različite"
 
 #. IDS_FILES_ARE_DIFFERENT
-#: Merge.rc:5050
+#: Merge.rc:5049
 #, c-format
 msgid "Files are different"
 msgstr "Datoteke su različite"
 
 #. IDS_FOLDERS_ARE_DIFFERENT
-#: Merge.rc:5051
+#: Merge.rc:5050
 #, c-format
 msgid "Folders are different"
 msgstr "Mape su različite"
 
 #. IDS_LEFTONLY
-#: Merge.rc:5052
+#: Merge.rc:5051
 #, c-format
 msgid "Left Only"
 msgstr "Samo lijevo"
 
 #. IDS_RIGHTONLY
-#: Merge.rc:5053
+#: Merge.rc:5052
 #, c-format
 msgid "Right Only"
 msgstr "Samo desno"
 
 #. IDS_MIDDLEONLY
-#: Merge.rc:5054
+#: Merge.rc:5053
 #, c-format
 msgid "Middle Only"
 msgstr ""
 
 #. IDS_NOITEMLEFT
-#: Merge.rc:5055
+#: Merge.rc:5054
 #, c-format
 msgid "No item in left"
 msgstr ""
 
 #. IDS_NOITEMRIGHT
-#: Merge.rc:5056
+#: Merge.rc:5055
 #, c-format
 msgid "No item in right"
 msgstr ""
 
 #. IDS_NOITEMMIDDLE
-#: Merge.rc:5057
+#: Merge.rc:5056
 #, c-format
 msgid "No item in middle"
 msgstr ""
 
 #. IDS_CMPRES_ERROR
-#: Merge.rc:5059
+#: Merge.rc:5058
 #, c-format
 msgid "Error"
 msgstr "Greška"
 
 #. IDS_TEXT_FILES_SAME
-#: Merge.rc:5060
+#: Merge.rc:5059
 #, c-format
 msgid "Text files are identical"
 msgstr "Tekstovi su identični"
 
 #. IDS_LEFTONLY_DIFF
-#: Merge.rc:5061
+#: Merge.rc:5060
 msgid " (Middle and right are identical)"
 msgstr ""
 
 #. IDS_MIDDLEONLY_DIFF
-#: Merge.rc:5062
+#: Merge.rc:5061
 msgid " (Left and right are identical)"
 msgstr ""
 
 #. IDS_RIGHTONLY_DIFF
-#: Merge.rc:5063
+#: Merge.rc:5062
 msgid " (Left and middle are identical)"
 msgstr ""
 
 #. IDS_PATH_MISMATCH
-#: Merge.rc:5064
+#: Merge.rc:5063
 msgid " (paths differ)"
 msgstr ""
 
 #. IDS_TEXT_FILES_DIFF
-#: Merge.rc:5065
+#: Merge.rc:5064
 #, c-format
 msgid "Text files are different"
 msgstr "Tekstovi su različiti"
 
 #. IDS_IMAGE_FILES_SAME
-#: Merge.rc:5066
+#: Merge.rc:5065
 msgid "Image files are identical"
 msgstr ""
 
 #. IDS_IMAGE_FILES_DIFF
-#: Merge.rc:5067
+#: Merge.rc:5066
 msgid "Image files are different"
 msgstr ""
 
 #. IDS_EXPR_DIFF
-#: Merge.rc:5068
+#: Merge.rc:5067
 #, c-format
 msgid "Files are different (expr: %1)"
 msgstr ""
 
 #. IDS_HASH_GROUP
-#: Merge.rc:5069
+#: Merge.rc:5068
 #, c-format
 msgid "Group%d"
 msgstr ""
 
 #. IDS_RENAME_MOVE_DETECTION_DISALBED
-#: Merge.rc:5070
+#: Merge.rc:5069
 msgctxt "Options dialog|Compare|Folder|Detect renames and moves"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_RENAME_MOVE_DETECTION_RENAME
-#: Merge.rc:5071
+#: Merge.rc:5070
 msgid "Detect renames"
 msgstr ""
 
 #. IDS_RENAME_MOVE_DETECTION_RENAME_MOVE
-#: Merge.rc:5072
+#: Merge.rc:5071
 msgid "Detect renames and moves"
 msgstr ""
 
 #. IDS_RENAME_MOVE_MERGE_MODE_RENAME
-#: Merge.rc:5073
+#: Merge.rc:5072
 msgid "Merge renames"
 msgstr ""
 
 #. IDS_RENAME_MOVE_MERGE_MODE_RENAME_MOVE
-#: Merge.rc:5074
+#: Merge.rc:5073
 msgid "Merge renames and moves"
 msgstr ""
 
 #. IDS_RENAMED
-#: Merge.rc:5075
+#: Merge.rc:5074
 msgid "Renamed"
 msgstr ""
 
 #. IDS_RENAMED_MOVED
-#: Merge.rc:5077
+#: Merge.rc:5076
 msgid "Renamed/Moved"
 msgstr ""
 
 #. IDS_RENAMED_MOVED_ITEMS
-#: Merge.rc:5078
+#: Merge.rc:5077
 #, c-format
 msgid "(%1 items)"
 msgstr ""
 
 #. IDS_RENAMED_MOVED_RESULT
-#: Merge.rc:5079
+#: Merge.rc:5078
 #, c-format
 msgid "%1 (set %2): "
 msgstr ""
 
 #. IDS_SWITCH_FLAT_MODE
-#: Merge.rc:5080
+#: Merge.rc:5079
 msgid "Some moved items have been merged.\nIn Tree Mode, these items may appear in positions that do not reflect the actual folder structure, which can be confusing.\nSwitch to Flat Mode?"
 msgstr ""
 
 #. IDS_ELAPSED_TIME
-#: Merge.rc:5086
+#: Merge.rc:5085
 #, c-format
 msgid "Elapsed time: %ld ms"
 msgstr "Proteklo vrijeme: %ld ms"
 
 #. IDS_STATUS_SELITEM1
-#: Merge.rc:5087
+#: Merge.rc:5086
 #, c-format
 msgid "1 item selected"
 msgstr "1 stavka označena"
 
 #. IDS_STATUS_SELITEMS
-#: Merge.rc:5088
+#: Merge.rc:5087
 #, c-format
 msgid "%1 items selected"
 msgstr "%1 stavki označeno"
 
 #. IDS_COLDESC_FILENAME
-#: Merge.rc:5094
+#: Merge.rc:5093
 #, c-format
 msgid "Filename or folder name."
 msgstr "Naziv datoteke ili mape."
 
 #. IDS_COLDESC_DIR
-#: Merge.rc:5095
+#: Merge.rc:5094
 #, c-format
 msgid "Subfolder name when subfolders are included."
 msgstr "Nazivi podmapa ako su podmape uključene."
 
 #. IDS_COLDESC_RESULT
-#: Merge.rc:5096
+#: Merge.rc:5095
 #, c-format
 msgid "Comparison result, long form."
 msgstr "Rezultat usporedbe, duži oblik."
 
 #. IDS_COLDESC_LTIMEM
-#: Merge.rc:5101
+#: Merge.rc:5100
 #, c-format
 msgid "Left side modification date."
 msgstr "Lijeva strana - datum promjene."
 
 #. IDS_COLDESC_RTIMEM
-#: Merge.rc:5102
+#: Merge.rc:5101
 #, c-format
 msgid "Right side modification date."
 msgstr "Desna strana - datum promjene."
 
 #. IDS_COLDESC_MTIMEM
-#: Merge.rc:5103
+#: Merge.rc:5102
 #, c-format
 msgid "Middle side modification date."
 msgstr ""
 
 #. IDS_COLDESC_EXTENSION
-#: Merge.rc:5104
+#: Merge.rc:5103
 #, c-format
 msgid "File's extension."
 msgstr "Tip (ekstenzija) datoteke"
 
 #. IDS_COLDESC_LSIZE
-#: Merge.rc:5105
+#: Merge.rc:5104
 #, c-format
 msgid "Left file size in bytes."
 msgstr "Veličina u bajtima, lijeve datoteke."
 
 #. IDS_COLDESC_RSIZE
-#: Merge.rc:5106
+#: Merge.rc:5105
 #, c-format
 msgid "Right file size in bytes."
 msgstr "Veličina u bajtima, desne datoteke."
 
 #. IDS_COLDESC_MSIZE
-#: Merge.rc:5107
+#: Merge.rc:5106
 #, c-format
 msgid "Middle file size in bytes."
 msgstr ""
 
 #. IDS_COLDESC_LSIZE_SHORT
-#: Merge.rc:5108
+#: Merge.rc:5107
 #, c-format
 msgid "Left file size abbreviated."
 msgstr "Skraćenice lijeve datoteke"
 
 #. IDS_COLDESC_RSIZE_SHORT
-#: Merge.rc:5109
+#: Merge.rc:5108
 #, c-format
 msgid "Right file size abbreviated."
 msgstr "Skraćenice desne datoteke"
 
 #. IDS_COLDESC_MSIZE_SHORT
-#: Merge.rc:5110
+#: Merge.rc:5109
 #, c-format
 msgid "Middle file size abbreviated."
 msgstr ""
 
 #. IDS_COLDESC_LTIMEC
-#: Merge.rc:5116
+#: Merge.rc:5115
 #, c-format
 msgid "Left side creation time."
 msgstr "Lijeva strana - vrijeme stvaranja."
 
 #. IDS_COLDESC_RTIMEC
-#: Merge.rc:5117
+#: Merge.rc:5116
 #, c-format
 msgid "Right side creation time."
 msgstr "Desna strana - vrijeme stvaranja."
 
 #. IDS_COLDESC_MTIMEC
-#: Merge.rc:5118
+#: Merge.rc:5117
 #, c-format
 msgid "Middle side creation time."
 msgstr ""
 
 #. IDS_COLDESC_NEWER
-#: Merge.rc:5119
+#: Merge.rc:5118
 #, c-format
 msgid "Tells which side has newer modification date."
 msgstr "Koja strana je promijenjena ranije?"
 
 #. IDS_COLDESC_LVERSION
-#: Merge.rc:5120
+#: Merge.rc:5119
 msgid "Left side file version, only for some file types."
 msgstr "Verzija na lijevoj strani, samo za neke tipove."
 
 #. IDS_COLDESC_RVERSION
-#: Merge.rc:5121
+#: Merge.rc:5120
 msgid "Right side file version, only for some file types."
 msgstr "Verzija na desnoj strani, samo za neke tipove."
 
 #. IDS_COLDESC_MVERSION
-#: Merge.rc:5126
+#: Merge.rc:5125
 msgid "Middle side file version, only for some file types."
 msgstr ""
 
 #. IDS_COLDESC_RESULT_ABBR
-#: Merge.rc:5127
+#: Merge.rc:5126
 #, c-format
 msgid "Short comparison result."
 msgstr "Rezultat usporedbe, kraći oblik."
 
 #. IDS_COLDESC_LATTRIBUTES
-#: Merge.rc:5128
+#: Merge.rc:5127
 #, c-format
 msgid "Left side attributes."
 msgstr "Atributi lijeve datoteke"
 
 #. IDS_COLDESC_RATTRIBUTES
-#: Merge.rc:5129
+#: Merge.rc:5128
 #, c-format
 msgid "Right side attributes."
 msgstr "Atributi desne strane"
 
 #. IDS_COLDESC_MATTRIBUTES
-#: Merge.rc:5130
+#: Merge.rc:5129
 #, c-format
 msgid "Middle side attributes."
 msgstr ""
 
 #. IDS_COLDESC_LEOL_TYPE
-#: Merge.rc:5131
+#: Merge.rc:5130
 msgid "Left side file EOL type."
 msgstr "Način završetka retka lijeve datoteke."
 
 #. IDS_COLDESC_REOL_TYPE
-#: Merge.rc:5132
+#: Merge.rc:5131
 msgid "Right side file EOL type."
 msgstr "Način završetka retka desne datoteke."
 
 #. IDS_COLDESC_MEOL_TYPE
-#: Merge.rc:5133
+#: Merge.rc:5132
 msgid "Middle side file EOL type."
 msgstr ""
 
 #. IDS_COLDESC_LENCODING
-#: Merge.rc:5139
+#: Merge.rc:5138
 #, c-format
 msgid "Left side encoding."
 msgstr "Kodirana lijeva strana"
 
 #. IDS_COLDESC_RENCODING
-#: Merge.rc:5140
+#: Merge.rc:5139
 #, c-format
 msgid "Right side encoding."
 msgstr "Kodiranje desne strane"
 
 #. IDS_COLDESC_MENCODING
-#: Merge.rc:5141
+#: Merge.rc:5140
 #, c-format
 msgid "Middle side encoding."
 msgstr ""
 
 #. IDS_COLDESC_NIDIFFS
-#: Merge.rc:5142
+#: Merge.rc:5141
 #, c-format
 msgid "Number of ignored differences in file. Ignored and cannot be merged."
 msgstr "Broj zanemarenih razlika u datoteci. Zanemarene razlike ne mogu biti spajane u WinMergeu."
 
 #. IDS_COLDESC_NSDIFFS
-#: Merge.rc:5143
+#: Merge.rc:5142
 #, c-format
 msgid "Number of differences in file (excluding ignored)."
 msgstr "Broj razlika u datoteci. Zanemarene razlike nisu uključene."
 
 #. IDS_COLDESC_BINARY
-#: Merge.rc:5144
+#: Merge.rc:5143
 #, c-format
 msgid "Shows an asterisk (*) if the file is binary."
 msgstr "Prikaži zvjezdicu (*) uz binarnu datoteku."
 
 #. IDS_COLDESC_UNPACKER
-#: Merge.rc:5145
+#: Merge.rc:5144
 msgid "Unpacker plugin name or pipeline."
 msgstr ""
 
 #. IDS_COLDESC_PREDIFFER
-#: Merge.rc:5146
+#: Merge.rc:5145
 msgid "Prediffer plugin name or pipeline."
 msgstr ""
 
 #. IDS_DIRECTORY_REPORT_TITLE
-#: Merge.rc:5152
+#: Merge.rc:5151
 #, c-format
 msgid "Compare %1 with %2"
 msgstr "Usporedi %1 s %2"
 
 #. IDS_DIRECTORY_REPORT_TITLE3
-#: Merge.rc:5153
+#: Merge.rc:5152
 #, c-format
 msgid "Compare %1 with %2 and %3"
 msgstr ""
 
 #. IDS_REPORT_COMMALIST
-#: Merge.rc:5154
+#: Merge.rc:5153
 #, c-format
 msgid "Comma-separated list"
 msgstr "Popis odvojen zarezom"
 
 #. IDS_REPORT_TABLIST
-#: Merge.rc:5155
+#: Merge.rc:5154
 #, c-format
 msgid "Tab-separated list"
 msgstr "Popis odvojen tabulatorom"
 
 #. IDS_REPORT_SIMPLEHTML
-#: Merge.rc:5156
+#: Merge.rc:5155
 #, c-format
 msgid "Simple HTML"
 msgstr "Jednostavni HTML"
 
 #. IDS_REPORT_SIMPLEXML
-#: Merge.rc:5157
+#: Merge.rc:5156
 #, c-format
 msgid "Simple XML"
 msgstr "Jednostavni HTML"
 
-#: Merge.rc:5159
+#: Merge.rc:5158
 #, c-format
 msgid "Report file already exists. Overwrite?"
 msgstr "Datoteka izvještaja već postoji. Natpisati?"
 
 #. IDS_REPORT_ERROR
-#: Merge.rc:5164
+#: Merge.rc:5163
 #, c-format
 msgid ""
 "Error creating the report:\n"
@@ -7772,62 +7766,62 @@ msgstr ""
 "%1"
 
 #. IDS_REPORT_SUCCESS
-#: Merge.rc:5165
+#: Merge.rc:5164
 #, c-format
 msgid "Report created successfully."
 msgstr "Izvještaj je uspješno stvoren."
 
 #. IDS_SYNCPOINT_LASTBLOCK
-#: Merge.rc:5171
+#: Merge.rc:5170
 msgid "Cannot add a synchronization point at this line."
 msgstr ""
 
 #. IDS_FILE_TO_ITSELF
-#: Merge.rc:5177
+#: Merge.rc:5176
 #, c-format
 msgid "Same file is opened in both panes."
 msgstr "Ista datoteka je otvorena u oba panela."
 
 #. IDS_FILESSAME
-#: Merge.rc:5178
+#: Merge.rc:5177
 #, c-format
 msgid "Selected files are identical."
 msgstr "Datoteke su identične."
 
 #. IDS_FILESSAME_CURCFG
-#: Merge.rc:5179
+#: Merge.rc:5178
 msgid "Selected files are identical (with current settings).\r\nChecking binary identity..."
 msgstr ""
 
 #. IDS_FILESSAME_BINERROR
-#: Merge.rc:5180
+#: Merge.rc:5179
 msgid "Selected files are identical (with current settings).\r\nBut binary comparison failed."
 msgstr ""
 
 #. IDS_FILESSAME_BINSAME
-#: Merge.rc:5181
+#: Merge.rc:5180
 msgid "Selected files are identical (binary match)."
 msgstr ""
 
 #. IDS_FILESSAME_BINDIFF
-#: Merge.rc:5182
+#: Merge.rc:5181
 msgid "Selected files are identical (with current settings).\r\nBut differ at the binary level."
 msgstr ""
 
 #. IDS_FILEERROR
-#: Merge.rc:5183
+#: Merge.rc:5182
 #, c-format
 msgid "An error occurred while comparing files."
 msgstr "Greška pri usporedbi datoteka."
 
 #. IDS_TEMP_FILEERROR
-#: Merge.rc:5184
+#: Merge.rc:5183
 #, c-format
 msgid "Could not create temporary files. Check your temporary path settings."
 msgstr "Ne mogu stvoriti privremenu datoteku. Provjerite postavke staze."
 
 #. IDS_SUGGEST_IGNOREEOL
-#: Merge.rc:5185
+#: Merge.rc:5184
 msgid "Files use different EOL.\n\nTreat all EOL as equivalent?\n\nSet 'Ignore EOL differences (Windows/Unix/Mac)' in Compare section of Options."
 msgstr ""
 "Datoteke se razlikuju prema prelazu u drugi redak.\n"
@@ -7837,19 +7831,19 @@ msgstr ""
 "Napomena: Želite li uvijek zadržati li različitost prijelaza u drugi redak, odaberite 'Zanemari različitost prijelaza u drugi redak (Windows/Unix/Mac)' u kartici usporedbi u oknu dijaloga 'Uređivanje/Postavke."
 
 #. IDS_INVALID_DIRECTORY
-#: Merge.rc:5186
+#: Merge.rc:5185
 #, c-format
 msgid "Selected folder is invalid."
 msgstr "Odabrana mapa je pogrešna."
 
 #. IDS_CANNOT_OPEN_BINARYFILE
-#: Merge.rc:5187
+#: Merge.rc:5186
 #, c-format
 msgid "Cannot open a binary file in Editor."
 msgstr "Ne mogu otvoriti binarnu datoteku u uređivaču"
 
 #. IDS_CREATE_PAIR_FOLDER
-#: Merge.rc:5188
+#: Merge.rc:5187
 #, c-format
 msgid "Create matching folder:\n%1\non the other side and open?"
 msgstr ""
@@ -7860,45 +7854,45 @@ msgstr ""
 "na drugoj strani i otvoriti je?"
 
 #. IDS_CONFIRM_COPY_ALL_DIFFS
-#: Merge.rc:5189
+#: Merge.rc:5188
 msgid "Copy all differences to other file?"
 msgstr ""
 
 #. IDS_MOVE_TO_NEXTFILE
-#: Merge.rc:5194
+#: Merge.rc:5193
 #, c-format
 msgid "Move to next file?"
 msgstr ""
 
 #. IDS_MOVE_TO_PREVFILE
-#: Merge.rc:5195
+#: Merge.rc:5194
 #, c-format
 msgid "Move to previous file?"
 msgstr ""
 
 #. IDS_MOVE_TO_NEXTPAGE
-#: Merge.rc:5196
+#: Merge.rc:5195
 #, c-format
 msgid "Move to next page?"
 msgstr ""
 
 #. IDS_MOVE_TO_PREVPAGE
-#: Merge.rc:5197
+#: Merge.rc:5196
 #, c-format
 msgid "Move to previous page?"
 msgstr ""
 
 #. IDS_MOVE_TO_FIRSTFILE
-#: Merge.rc:5198
+#: Merge.rc:5197
 msgid "Move to first file?"
 msgstr ""
 
 #. IDS_MOVE_TO_LASTFILE
-#: Merge.rc:5199
+#: Merge.rc:5198
 msgid "Move to last file?"
 msgstr ""
 
-#: Merge.rc:5206
+#: Merge.rc:5205
 #, c-format
 msgid "Different codepages: left (cp%d), right (cp%d).\nDisplay in codepage (better display) or default Windows codepage (safer merging)?\n(Recommended: default Windows codepage)"
 msgstr ""
@@ -7906,153 +7900,153 @@ msgstr ""
 "Prikaz svake datoteke u vlastitoj ks je ljepši, ali dovodi do teškoća prilikom spajanja ili kopiranja.\n"
 "Preporučamo obje datoteke prikazati u Windows prednamještenoj kodnoj stranici?"
 
-#: Merge.rc:5208
+#: Merge.rc:5207
 #, c-format
 msgid "Information lost due to encoding errors: both files"
 msgstr "Greškom pri kodiranju izgubljena je informacija: obje datoteke"
 
-#: Merge.rc:5210
+#: Merge.rc:5209
 #, c-format
 msgid "Information lost due to encoding errors: first file"
 msgstr ""
 
-#: Merge.rc:5212
+#: Merge.rc:5211
 #, c-format
 msgid "Information lost due to encoding errors: second file"
 msgstr ""
 
-#: Merge.rc:5214
+#: Merge.rc:5213
 #, c-format
 msgid "Information lost due to encoding errors: third file"
 msgstr ""
 
 #. IDS_LINEDIFF_NODIFF
-#: Merge.rc:5220
+#: Merge.rc:5219
 #, c-format
 msgid "No difference"
 msgstr "Nema razlike"
 
 #. IDS_LINEDIFF_NODIFF_CAPTION
-#: Merge.rc:5221
+#: Merge.rc:5220
 #, c-format
 msgid "Line difference"
 msgstr "Različiti redak"
 
 #. IDS_NUM_REPLACED
-#: Merge.rc:5227
+#: Merge.rc:5226
 #, c-format
 msgid "Replaced %1 string(s)."
 msgstr "Zamijenjeno %1 pojam (pojmova)."
 
 #. IDS_EDIT_TEXT_NOT_FOUND
-#: Merge.rc:5228
+#: Merge.rc:5227
 #, c-format
 msgid "Cannot find string \"%s\"."
 msgstr "Ne mogu naći pojam \"%s\"."
 
 #. IDS_MERGE_MODE
-#: Merge.rc:5234
+#: Merge.rc:5233
 msgid "Entering Merge Mode. Press F9 to turn off."
 msgstr ""
 
 #. IDS_AUTO_MERGE
-#: Merge.rc:5240
+#: Merge.rc:5239
 #, c-format
 msgid "Automatic merges: %1\nUnresolved conflicts: %2"
 msgstr ""
 
 #. IDS_CODEPAGE_MERGED
-#: Merge.rc:5241
+#: Merge.rc:5240
 msgid "Codepage change merged."
 msgstr ""
 
 #. IDS_CODEPAGE_CONFLICT
-#: Merge.rc:5242
+#: Merge.rc:5241
 msgid "Codepage changes are conflicting."
 msgstr ""
 
 #. IDS_EOL_MERGED
-#: Merge.rc:5243
+#: Merge.rc:5242
 msgid "EOL change merged."
 msgstr ""
 
 #. IDS_EOL_CONFLICT
-#: Merge.rc:5244
+#: Merge.rc:5243
 msgid "EOL changes are conflicting."
 msgstr ""
 
 #. IDS_LOCBAR_CAPTION
-#: Merge.rc:5250
+#: Merge.rc:5249
 #, c-format
 msgid "Location Pane"
 msgstr "Položaj panela"
 
 #. IDS_DIFFBAR_CAPTION
-#: Merge.rc:5251
+#: Merge.rc:5250
 #, c-format
 msgid "Diff Pane"
 msgstr "Panel razlika"
 
 #. IDS_DIFF_SUCCEEDED
-#: Merge.rc:5258
+#: Merge.rc:5257
 #, c-format
 msgid "Patch file written."
 msgstr "Datoteka razlika je pohranjena."
 
 #. IDS_DIFF_FILEOVERWRITE
-#: Merge.rc:5259
+#: Merge.rc:5258
 #, c-format
 msgid "Patch file already exists. Overwrite?"
 msgstr "Datoteka razlika već postoji. Natpisati?"
 
 #. IDS_DIFF_SELECTEDFILES
-#: Merge.rc:5260
+#: Merge.rc:5259
 #, c-format
 msgid "[%1 files selected]"
 msgstr "[%1 datoteka odabrano]"
 
 #. IDS_DIFF_NORMAL
-#: Merge.rc:5261
+#: Merge.rc:5260
 #, c-format
 msgid "Normal"
 msgstr "Uobičajeno"
 
 #. IDS_DIFF_CONTEXT
-#: Merge.rc:5262
+#: Merge.rc:5261
 #, c-format
 msgid "Context"
 msgstr "Detaljnije"
 
 #. IDS_DIFF_UNIFIED
-#: Merge.rc:5263
+#: Merge.rc:5262
 #, c-format
 msgid "Unified"
 msgstr "Združeno"
 
 #. IDS_FILEWRITE_ERROR
-#: Merge.rc:5265
+#: Merge.rc:5264
 #, c-format
 msgid "Could not write to file %1."
 msgstr "Ne mogu pohraniti u datoteku"
 
 #. IDS_PATH_NOT_ABSOLUTE
-#: Merge.rc:5266
+#: Merge.rc:5265
 #, c-format
 msgid "Output path is not absolute: %1"
 msgstr "Dana staza ne odgovara: %1"
 
 #. IDS_MUST_SPECIFY_OUTPUT
-#: Merge.rc:5267
+#: Merge.rc:5266
 msgid "Specify an output file."
 msgstr "Odredite izlaznu datoteku."
 
-#: Merge.rc:5269
+#: Merge.rc:5268
 #, c-format
 msgid "Cannot create patch from binary files."
 msgstr "Ne mogu stvoriti datoteku razlika iz binarnih datoteka"
 
 #. IDS_SAVEFILES_FORPATCH
-#: Merge.rc:5270
+#: Merge.rc:5269
 #, c-format
 msgid ""
 "Save all files first.\n"
@@ -8064,23 +8058,23 @@ msgstr ""
 "Prije stvaranja datoteke razlika, sve datoteke trebaju biti pohranjene."
 
 #. IDS_FOLDER_NOTEXIST
-#: Merge.rc:5271
+#: Merge.rc:5270
 #, c-format
 msgid "Folder does not exist."
 msgstr "Mapa ne postoji"
 
 #. IDS_ARCHIVE_SUCCEEDED
-#: Merge.rc:5277
+#: Merge.rc:5276
 msgid "Archive file written."
 msgstr ""
 
 #. IDS_ARCHIVE_SAVEFILES
-#: Merge.rc:5278
+#: Merge.rc:5277
 msgid "Save all files first.\n\nCreating an archive requires no unsaved changes."
 msgstr ""
 
 #. IDS_NO_ZIP_SUPPORT
-#: Merge.rc:5283
+#: Merge.rc:5282
 msgid "Archive support not enabled.\n7-Zip and/or Merge7z*.dll not found.\nSee manual for archive support."
 msgstr ""
 "Rad s arhivama nije omogućen.\n"
@@ -8088,43 +8082,43 @@ msgstr ""
 "Pregledajte upute kako omogućiti rad s arhivama."
 
 #. IDS_OPT_EXPORT_CAPTION
-#: Merge.rc:5284
+#: Merge.rc:5283
 #, c-format
 msgid "Select file for export"
 msgstr "Odabir datoteke za izvoz"
 
 #. IDS_OPT_IMPORT_CAPTION
-#: Merge.rc:5285
+#: Merge.rc:5284
 #, c-format
 msgid "Select file for import"
 msgstr "Odabir datoteke za uvoz"
 
 #. IDS_OPT_IMPORT_DONE
-#: Merge.rc:5286
+#: Merge.rc:5285
 #, c-format
 msgid "Options imported from file."
 msgstr "Uvoz postavki u datoteku"
 
 #. IDS_OPT_EXPORT_DONE
-#: Merge.rc:5287
+#: Merge.rc:5286
 #, c-format
 msgid "Options exported to file."
 msgstr "Izvoz postavki u datoteku"
 
 #. IDS_OPT_IMPORT_ERR
-#: Merge.rc:5288
+#: Merge.rc:5287
 #, c-format
 msgid "Failed to import options from file."
 msgstr "Greška pri učitanju postavki"
 
 #. IDS_OPT_EXPORT_ERR
-#: Merge.rc:5289
+#: Merge.rc:5288
 #, c-format
 msgid "Failed to write options to file."
 msgstr "Greška pri pohrani odabranih postavki."
 
 #. IDS_CLOSEALL_WINDOWS
-#: Merge.rc:5290
+#: Merge.rc:5289
 #, c-format
 msgid ""
 "Close multiple compare windows?\n"
@@ -8136,1209 +8130,1209 @@ msgstr ""
 "Nastaviti?"
 
 #. IDS_EOL_BIN
-#: Merge.rc:5300
+#: Merge.rc:5299
 msgctxt "EOL Type"
 msgid "Binary"
 msgstr "Binarno"
 
 #. IDS_MARKER_COLOR_FMT
-#: Merge.rc:5305
+#: Merge.rc:5304
 #, c-format
 msgid "Marker Color %d"
 msgstr ""
 
 #. IDS_MARKER_NEW_PATTERN
-#: Merge.rc:5306
+#: Merge.rc:5305
 msgid "New Pattern"
 msgstr ""
 
 #. IDS_PLUGINSLIST_TYPE
-#: Merge.rc:5312
+#: Merge.rc:5311
 #, c-format
 msgid "Type"
 msgstr "Tip"
 
 #. IDS_PLUGINS_TYPE_EDITSCRIPT
-#: Merge.rc:5316
+#: Merge.rc:5315
 #, c-format
 msgid "Editor script"
 msgstr "Uređivač skripti"
 
 #. ID_SELECTLINEDIFF
-#: Merge.rc:5322
+#: Merge.rc:5321
 #, c-format
 msgid "\nDifference in Current Line (F4)"
 msgstr ""
 
 #. ID_OPTIONS
-#: Merge.rc:5323
+#: Merge.rc:5322
 #, c-format
 msgid "\nOptions"
 msgstr ""
 
 #. ID_REFRESH
-#: Merge.rc:5324
+#: Merge.rc:5323
 #, c-format
 msgid "\nRefresh (F5)"
 msgstr ""
 
 #. ID_PREVDIFF
-#: Merge.rc:5330
+#: Merge.rc:5329
 #, c-format
 msgid "\nPrevious Difference (Alt+Up)"
 msgstr ""
 
 #. ID_NEXTDIFF
-#: Merge.rc:5331
+#: Merge.rc:5330
 #, c-format
 msgid "\nNext Difference (Alt+Down)"
 msgstr ""
 
 #. ID_PREVCONFLICT
-#: Merge.rc:5332
+#: Merge.rc:5331
 #, c-format
 msgid "\nPrevious Conflict (Alt+Shift+Up)"
 msgstr ""
 
 #. ID_NEXTCONFLICT
-#: Merge.rc:5333
+#: Merge.rc:5332
 #, c-format
 msgid "\nNext Conflict (Alt+Shift+Down)"
 msgstr ""
 
 #. ID_FIRSTDIFF
-#: Merge.rc:5338
+#: Merge.rc:5337
 #, c-format
 msgid "\nFirst Difference (Alt+Home)"
 msgstr ""
 
 #. ID_CURDIFF
-#: Merge.rc:5339
+#: Merge.rc:5338
 #, c-format
 msgid "\nCurrent Difference (Alt+Enter)"
 msgstr ""
 
 #. ID_LASTDIFF
-#: Merge.rc:5340
+#: Merge.rc:5339
 #, c-format
 msgid "\nLast Difference (Alt+End)"
 msgstr ""
 
 #. ID_L2R
-#: Merge.rc:5341
+#: Merge.rc:5340
 msgid "\nCopy to Right (Alt+Right)"
 msgstr ""
 
 #. ID_R2L
-#: Merge.rc:5342
+#: Merge.rc:5341
 msgid "\nCopy to Left (Alt+Left)"
 msgstr ""
 
 #. ID_L2RNEXT
-#: Merge.rc:5343
+#: Merge.rc:5342
 msgid "\nCopy to Right and Advance (Ctrl+Alt+Right)"
 msgstr ""
 
 #. ID_R2LNEXT
-#: Merge.rc:5344
+#: Merge.rc:5343
 msgid "\nCopy to Left and Advance (Ctrl+Alt+Left)"
 msgstr ""
 
 #. ID_ALL_RIGHT
-#: Merge.rc:5345
+#: Merge.rc:5344
 msgid "\nCopy All to Right"
 msgstr "\nKopiraj sve u desno"
 
 #. ID_ALL_LEFT
-#: Merge.rc:5346
+#: Merge.rc:5345
 msgid "\nCopy All to Left"
 msgstr "\nKopiraj sve u lijevo"
 
 #. ID_AUTO_MERGE
-#: Merge.rc:5347
+#: Merge.rc:5346
 #, c-format
 msgid "\nAuto Merge (Ctrl+Alt+M)"
 msgstr ""
 
 #. ID_FIRSTFILE
-#: Merge.rc:5348
+#: Merge.rc:5347
 msgid "\nFirst File"
 msgstr ""
 
 #. ID_NEXTFILE
-#: Merge.rc:5349
+#: Merge.rc:5348
 msgid "\nNext File (Ctrl+F8)"
 msgstr ""
 
 #. ID_LASTFILE
-#: Merge.rc:5350
+#: Merge.rc:5349
 msgid "\nLast File"
 msgstr ""
 
 #. ID_PREVFILE
-#: Merge.rc:5351
+#: Merge.rc:5350
 msgid "\nPrevious File (Ctrl+F7)"
 msgstr ""
 
 #. IDS_UNPACK_AUTO
-#: Merge.rc:5358
+#: Merge.rc:5357
 msgid "Adapted unpacker applied to both files (one needs extension)."
 msgstr "Arhiver će se koristiti za obje datoteke (jedna treba samo ekstenziju)."
 
 #. IDS_NO_PREDIFFER
-#: Merge.rc:5359
+#: Merge.rc:5358
 #, c-format
 msgid "No Prediffer (Normal)"
 msgstr "Bez dodataka (uobičajeno)"
 
 #. IDS_SUGGESTED_PLUGINS
-#: Merge.rc:5360
+#: Merge.rc:5359
 #, c-format
 msgid "Suggested Plugins"
 msgstr "Preporučljivi dodaci"
 
 #. IDS_NOT_SUGGESTED_PLUGINS
-#: Merge.rc:5361
+#: Merge.rc:5360
 msgid "All Plugins"
 msgstr ""
 
 #. IDS_PRIVATEBUILD_FMT
-#: Merge.rc:5367
+#: Merge.rc:5366
 #, c-format
 msgid "Private Build: %1"
 msgstr "Osobni uradak: %1"
 
 #. IDS_ALLRIGHTS_RESERVED
-#: Merge.rc:5368
+#: Merge.rc:5367
 msgid " - All rights reserved."
 msgstr ""
 
 #. IDS_TITLE_PLUGINS_SETTINGS
-#: Merge.rc:5374
+#: Merge.rc:5373
 #, c-format
 msgid "Plugin Settings"
 msgstr "Postavke dodataka"
 
 #. IDS_NO_SCT_SCRIPTS
-#: Merge.rc:5376
+#: Merge.rc:5375
 #, c-format
 msgid "WSH not found - .sct scripts disabled"
 msgstr "WSH dodatak nije nađen! - .sct skripte su onemogućene"
 
 #. IDS_LOCBAR_GOTOLINE_FMT
-#: Merge.rc:5384
+#: Merge.rc:5383
 #, c-format
 msgid "G&o to Line %1"
 msgstr "Idi &na redak"
 
 #. IDS_GOTO_MOVED_LINE
-#: Merge.rc:5390
+#: Merge.rc:5389
 msgid "Go to Moved Line\tCtrl+Shift+G"
 msgstr ""
 
 #. IDS_AUTOCOMPLETE_DISABLED
-#: Merge.rc:5396
+#: Merge.rc:5395
 msgctxt "Options dialog|General|Open dialog Auto completion"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_AUTOCOMPLETE_FILE_SYS
-#: Merge.rc:5397
+#: Merge.rc:5396
 #, c-format
 msgid "From file system"
 msgstr "Sistem datoteka"
 
 #. IDS_AUTOCOMPLETE_MRU
-#: Merge.rc:5398
+#: Merge.rc:5397
 #, c-format
 msgid "From Most Recently Used list"
 msgstr "Popis zadnje korištenih"
 
 #. IDS_COLORSCHEME_PLAIN
-#: Merge.rc:5404
+#: Merge.rc:5403
 #, c-format
 msgid "No Highlighting"
 msgstr "Nije označeno"
 
 #. IDS_COLORSCHEME_PO
-#: Merge.rc:5439
+#: Merge.rc:5438
 #, c-format
 msgid "Portable Object"
 msgstr "Prenosni objekt"
 
 #. IDS_COLORSCHEME_RSRC
-#: Merge.rc:5444
+#: Merge.rc:5443
 #, c-format
 msgid "Resources"
 msgstr "Resursi"
 
 #. IDS_COLORSCHEME_SH
-#: Merge.rc:5448
+#: Merge.rc:5447
 #, c-format
 msgid "Shell"
 msgstr "Shell"
 
 #. IDS_CLOSE_LEFT_TABS
-#: Merge.rc:5469
+#: Merge.rc:5468
 #, c-format
 msgid "Close &Left Tabs"
 msgstr ""
 
 #. IDS_CLOSE_RIGHT_TABS
-#: Merge.rc:5470
+#: Merge.rc:5469
 #, c-format
 msgid "Close R&ight Tabs"
 msgstr ""
 
 #. IDS_CLOSE_OTHER_TABS
-#: Merge.rc:5471
+#: Merge.rc:5470
 #, c-format
 msgid "Close &Other Tabs"
 msgstr ""
 
 #. IDS_TABBAR_AUTO_MAXWIDTH
-#: Merge.rc:5472
+#: Merge.rc:5471
 #, c-format
 msgid "Enable &Auto Max Width"
 msgstr ""
 
 #. IDS_WEBPAGE_MENU
-#: Merge.rc:5482
+#: Merge.rc:5481
 msgid "We&bpage"
 msgstr ""
 
 #. IDS_VIEW_WRAP_TEXT
-#: Merge.rc:5487
+#: Merge.rc:5486
 msgid "W&rap Text"
 msgstr ""
 
 #. IDS_NOTINSTALLED
-#: Merge.rc:5492
+#: Merge.rc:5491
 msgid "%1 is not installed."
 msgstr ""
 
 #. IDS_CREATE_FOLDER
-#: Merge.rc:5497
+#: Merge.rc:5496
 #, c-format
 msgid "%1 does not exist. Create it?"
 msgstr ""
 
 #. IDS_CREATE_FOLDER_ERROR
-#: Merge.rc:5498
+#: Merge.rc:5497
 #, c-format
 msgid "Failed to create folder."
 msgstr ""
 
 #. IDC_EXT_EDITOR_PATH
-#: Merge.rc:5503
+#: Merge.rc:5502
 #, c-format
 msgid "Parameters:\n$file: Current file path\n$linenum: Current cursor line number"
 msgstr ""
 
 #. IDS_DIFF_ALGORITHM_DEFAULT
-#: Merge.rc:5508
+#: Merge.rc:5507
 msgid "default"
 msgstr ""
 
 #. IDS_DIFF_ALGORITHM_MINIMAL
-#: Merge.rc:5509
+#: Merge.rc:5508
 msgid "minimal"
 msgstr ""
 
 #. IDS_DIFF_ALGORITHM_PATIENCE
-#: Merge.rc:5510
+#: Merge.rc:5509
 msgid "patience"
 msgstr ""
 
 #. IDS_DIFF_ALGORITHM_HISTOGRAM
-#: Merge.rc:5511
+#: Merge.rc:5510
 msgid "histogram"
 msgstr ""
 
 #. IDS_DIFF_ALGORITHM_NONE
-#: Merge.rc:5512
+#: Merge.rc:5511
 msgid "none"
 msgstr ""
 
 #. IDS_RENDERING_MODE_GDI
-#: Merge.rc:5517
+#: Merge.rc:5516
 msgid "GDI"
 msgstr ""
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_DEFAULT
-#: Merge.rc:5518
+#: Merge.rc:5517
 msgid "DirectWrite Default"
 msgstr ""
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_ALIASED
-#: Merge.rc:5519
+#: Merge.rc:5518
 msgid "DirectWrite Aliased"
 msgstr ""
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_GDI_CLASSIC
-#: Merge.rc:5520
+#: Merge.rc:5519
 msgid "DirectWrite GDI Classic"
 msgstr ""
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_GDI_NATURAL
-#: Merge.rc:5521
+#: Merge.rc:5520
 msgid "DirectWrite GDI Natural"
 msgstr ""
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_NATURAL
-#: Merge.rc:5522
+#: Merge.rc:5521
 msgid "DirectWrite Natural"
 msgstr ""
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_NATURAL_SYMMETRIC
-#: Merge.rc:5523
+#: Merge.rc:5522
 msgid "DirectWrite Natural Symmetric"
 msgstr ""
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_DISABLED
-#: Merge.rc:5528
+#: Merge.rc:5527
 msgctxt "Options dialog|General|Close windows with Esc"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_1
-#: Merge.rc:5529
+#: Merge.rc:5528
 msgid "MDI child window or main window"
 msgstr ""
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_2
-#: Merge.rc:5530
+#: Merge.rc:5529
 msgid "MDI child window only"
 msgstr ""
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_3
-#: Merge.rc:5531
+#: Merge.rc:5530
 msgid "Close main window if only one MDI child window"
 msgstr ""
 
 #. IDS_DIFF_GROUP
-#: Merge.rc:5536
+#: Merge.rc:5535
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Diff"
 msgstr ""
 
 #. IDS_DIFF_HIGHLIGHT
-#: Merge.rc:5537
+#: Merge.rc:5536
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Highlight"
 msgstr ""
 
 #. IDS_DIFF_BLINK
-#: Merge.rc:5538
+#: Merge.rc:5537
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Blink"
 msgstr ""
 
 #. IDS_DIFF_BLOCKSIZE
-#: Merge.rc:5539
+#: Merge.rc:5538
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Block Size"
 msgstr ""
 
 #. IDS_DIFF_BLOCKALPHA
-#: Merge.rc:5540
+#: Merge.rc:5539
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Block Alpha"
 msgstr ""
 
 #. IDS_DIFF_CDTHRESHOLD
-#: Merge.rc:5541
+#: Merge.rc:5540
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "CD Threshold"
 msgstr ""
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION
-#: Merge.rc:5542
+#: Merge.rc:5541
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Ins/Del Detection"
 msgstr ""
 
 #. IDS_OVERLAY_MODE_NONE
-#: Merge.rc:5543 Merge.rc:5548
+#: Merge.rc:5542 Merge.rc:5547
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "None"
 msgstr ""
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION_VERTICAL
-#: Merge.rc:5544
+#: Merge.rc:5543
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Vertical"
 msgstr ""
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION_HORIZONTAL
-#: Merge.rc:5545
+#: Merge.rc:5544
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Horizontal"
 msgstr ""
 
 #. IDS_OVERLAY_GROUP
-#: Merge.rc:5546
+#: Merge.rc:5545
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Overlay"
 msgstr ""
 
 #. IDS_OVERLAY_ALPHA
-#: Merge.rc:5547
+#: Merge.rc:5546
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha"
 msgstr ""
 
 #. IDS_OVERLAY_MODE_XOR
-#: Merge.rc:5549
+#: Merge.rc:5548
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "XOR"
 msgstr ""
 
 #. IDS_OVERLAY_MODE_ALPHA
-#: Merge.rc:5550
+#: Merge.rc:5549
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha Blend"
 msgstr ""
 
 #. IDS_OVERLAY_MODE_ALPHA_ANIMATION
-#: Merge.rc:5551
+#: Merge.rc:5550
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha Animation"
 msgstr ""
 
 #. IDS_ZOOM
-#: Merge.rc:5552
+#: Merge.rc:5551
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Zoom"
 msgstr ""
 
 #. IDS_PAGE
-#: Merge.rc:5553
+#: Merge.rc:5552
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Page:"
 msgstr ""
 
 #. IDS_IMGCMP_STATUS_PT_RGBA_FMT
-#: Merge.rc:5554
+#: Merge.rc:5553
 #, c-format
 msgid "Pt: (%d, %d)  RGBA: (%d, %d, %d, %d)  "
 msgstr ""
 
 #. IDS_IMGCMP_STATUS_DIST1_FMT
-#: Merge.rc:5555
+#: Merge.rc:5554
 #, c-format
 msgid "Dist: %g  "
 msgstr ""
 
 #. IDS_IMGCMP_STATUS_DIST2_FMT
-#: Merge.rc:5556
+#: Merge.rc:5555
 #, c-format
 msgid "Dist: %g, %g  "
 msgstr ""
 
 #. IDS_IMGCMP_STATUS_PAGE_ZOOM_SIZE_BPP_FMT
-#: Merge.rc:5557
+#: Merge.rc:5556
 #, c-format
 msgid "Page: %d/%d  Zoom: %d%%  %dx%dpx  %dbpp  "
 msgstr ""
 
 #. IDS_IMGCMP_STATUS_RC_FMT
-#: Merge.rc:5558
+#: Merge.rc:5557
 #, c-format
 msgid "Rc: (%d, %d)  "
 msgstr ""
 
 #. IDS_IMGCMP_STATUS_FLIPPED_FMT
-#: Merge.rc:5559
+#: Merge.rc:5558
 #, c-format
 msgid "Flipped: %s  "
 msgstr ""
 
 #. IDS_IMGCMP_STATUS_ROTATED_FMT
-#: Merge.rc:5560
+#: Merge.rc:5559
 #, c-format
 msgid "Rotated: %d  "
 msgstr ""
 
 #. IDS_IMGCMP_REPORT_ALLPAGES
-#: Merge.rc:5561
+#: Merge.rc:5560
 msgid "All pages"
 msgstr ""
 
 #. IDS_IGNSUB_STR1
-#: Merge.rc:5566
+#: Merge.rc:5565
 msgid "<Edit here>"
 msgstr ""
 
 #. IDS_IGNSUB_STR2
-#: Merge.rc:5567
+#: Merge.rc:5566
 msgid "No differences found to select"
 msgstr ""
 
 #. IDS_IGNSUB_STR3
-#: Merge.rc:5568
+#: Merge.rc:5567
 msgid "No differences found to add as substitution filter"
 msgstr ""
 
 #. IDS_IGNSUB_STR4
-#: Merge.rc:5569
+#: Merge.rc:5568
 msgid "The pair is already in the Substitution Filters list"
 msgstr ""
 
 #. IDS_IGNSUB_STR5
-#: Merge.rc:5570
+#: Merge.rc:5569
 msgid "Add this change to Substitution Filters?"
 msgstr ""
 
 #. IDS_OCRRESULT_TEXTONLY
-#: Merge.rc:5575
+#: Merge.rc:5574
 msgid "Text only"
 msgstr ""
 
 #. IDS_OCRRESULT_POS_LINE
-#: Merge.rc:5576
+#: Merge.rc:5575
 msgid "Line-by-line position and text"
 msgstr ""
 
 #. IDS_OCRRESULT_POS_WORD
-#: Merge.rc:5577
+#: Merge.rc:5576
 msgid "Word-by-word position and text"
 msgstr ""
 
 #. IDS_USERDATAFOLDER_APPDATA
-#: Merge.rc:5582
+#: Merge.rc:5581
 msgid "AppData (Roaming) folder"
 msgstr ""
 
 #. IDS_USERDATAFOLDER_INSTALL
-#: Merge.rc:5583
+#: Merge.rc:5582
 msgid "Install folder"
 msgstr ""
 
 #. IDS_USERDATAFOLDER_DOCUMENTS
-#: Merge.rc:5584
+#: Merge.rc:5583
 msgid "Documents folder"
 msgstr ""
 
 #. IDS_SINGLEINSTANCE_DISABLED
-#: Merge.rc:5589
+#: Merge.rc:5588
 msgctxt "Options dialog|General|Single instance mode"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_SINGLEINSTANCE_STR1
-#: Merge.rc:5590
+#: Merge.rc:5589
 #, c-format
 msgid "Allow only one instance to run"
 msgstr "Samo jedna instanca WinMerge-a"
 
 #. IDS_CLIPBOARD_HISTORY
-#: Merge.rc:5591
+#: Merge.rc:5590
 msgid "Clipboard &History"
 msgstr ""
 
 #. IDS_SINGLEINSTANCE_STR2
-#: Merge.rc:5592
+#: Merge.rc:5591
 msgid "Allow only one instance; wait for termination"
 msgstr ""
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_DISABLED
-#: Merge.rc:5597
+#: Merge.rc:5596
 msgctxt "Options dialog|General|Auto-reload modified files"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_STR1
-#: Merge.rc:5598
+#: Merge.rc:5597
 msgid "Only on window activated"
 msgstr ""
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_STR2
-#: Merge.rc:5599
+#: Merge.rc:5598
 msgid "Immediately"
 msgstr ""
 
 #. IDS_PLUGIN_ALL
-#: Merge.rc:5604
+#: Merge.rc:5603
 msgid "Al&l"
 msgstr ""
 
 #. IDS_PLUGIN_OTHERS
-#: Merge.rc:5605
+#: Merge.rc:5604
 msgid "&Others"
 msgstr ""
 
-#: Merge.rc:5607
+#: Merge.rc:5606
 #, c-format
 msgid "Missing plugin name in pipeline: %1"
 msgstr ""
 
-#: Merge.rc:5609
+#: Merge.rc:5608
 #, c-format
 msgid "Missing quote in plugin pipeline: %1"
 msgstr ""
 
 #. IDS_PLUGIN_NAME_ALREADY_EXISTS
-#: Merge.rc:5610
+#: Merge.rc:5609
 #, c-format
 msgid "Plugin name '%1' already exists."
 msgstr ""
 
 #. IDS_PLUGIN_TITLE1
-#: Merge.rc:5611
+#: Merge.rc:5610
 msgid "Specify plugin arguments"
 msgstr ""
 
-#: Merge.rc:5613
+#: Merge.rc:5612
 #, c-format
 msgid "Plugin not found or invalid: %1"
 msgstr ""
 
 #. IDS_PLUGIN_NOT_UNPACK
-#: Merge.rc:5614
+#: Merge.rc:5613
 #, c-format
 msgid "'%1' is not an unpacker plugin"
 msgstr ""
 
 #. IDS_PLUGIN_NOT_PREDIFF
-#: Merge.rc:5615
+#: Merge.rc:5614
 #, c-format
 msgid "'%1' is not a prediffer plugin"
 msgstr ""
 
-#: Merge.rc:5617
+#: Merge.rc:5616
 #, c-format
 msgid "Error prediffing '%1' with '%2'. Prediffing disabled."
 msgstr ""
 
 #. IDS_PLUGIN_CIRCULAR_REFERENCE
-#: Merge.rc:5618
+#: Merge.rc:5617
 #, c-format
 msgid "Circular reference in plugin pipeline: %1"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE1
-#: Merge.rc:5619
+#: Merge.rc:5618
 msgid "URL Handler"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE2
-#: Merge.rc:5620
+#: Merge.rc:5619
 msgid "File Unpacker"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE3
-#: Merge.rc:5621
+#: Merge.rc:5620
 msgid "File or Folder Unpacker"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE5
-#: Merge.rc:5623
+#: Merge.rc:5622
 msgid "Alias for Unpacker"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE6
-#: Merge.rc:5624
+#: Merge.rc:5623
 msgid "Alias for Prediffer"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE7
-#: Merge.rc:5625
+#: Merge.rc:5624
 msgid "Alias for Editor script"
 msgstr ""
 
 #. IDS_PLUGIN_ALIAS_DESC
-#: Merge.rc:5626
+#: Merge.rc:5625
 #, c-format
 msgid "Alias for plugin pipeline '%1'"
 msgstr ""
 
 #. IDS_PLUGIN_NEW_DESC
-#: Merge.rc:5627
+#: Merge.rc:5626
 msgid "New plugin description"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_ALL
-#: Merge.rc:5628
+#: Merge.rc:5627
 msgid "All"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_1ST
-#: Merge.rc:5629
+#: Merge.rc:5628
 msgid "1st"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_2ND
-#: Merge.rc:5630
+#: Merge.rc:5629
 msgid "2nd"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_3RD
-#: Merge.rc:5631
+#: Merge.rc:5630
 msgid "3rd"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_1ST_2ND
-#: Merge.rc:5632
+#: Merge.rc:5631
 msgid "1st and 2nd"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_1ST_3RD
-#: Merge.rc:5633
+#: Merge.rc:5632
 msgid "1st and 3rd"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_2ND_3RD
-#: Merge.rc:5634
+#: Merge.rc:5633
 msgid "2nd and 3rd"
 msgstr ""
 
 #. IDS_PLUGIN_CTRL_CLICK
-#: Merge.rc:5635
+#: Merge.rc:5634
 msgid "(Ctrl+Click to add to pipeline)"
 msgstr ""
 
 #. IDS_FILTER_APPLIED
-#: Merge.rc:5640
+#: Merge.rc:5639
 msgid "Filter applied"
 msgstr ""
 
 #. IDS_FILTERMENU_COMPARE
-#: Merge.rc:5645
+#: Merge.rc:5644
 #, c-format
 msgid "Compare %1"
 msgstr ""
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN2
-#: Merge.rc:5647
+#: Merge.rc:5646
 msgid "&Filter by This Column..."
 msgstr ""
 
 #. IDS_CLIPBOARDHISTORY_TIME
-#: Merge.rc:5652
+#: Merge.rc:5651
 #, c-format
 msgid "Clipboard at %s"
 msgstr ""
 
 #. IDS_CLIPBOARDHISTORY_DISABLED
-#: Merge.rc:5653
+#: Merge.rc:5652
 msgid "Clipboard history disabled.\r\nEnable: Windows logo key + V, then Turn on."
 msgstr ""
 
-#: Merge.rc:5655
+#: Merge.rc:5654
 msgid "This system does not support clipboard history."
 msgstr ""
 
-#: Merge.rc:5657
+#: Merge.rc:5656
 msgid "32-bit WinMerge does not support Clipboard Compare"
 msgstr ""
 
 #. IDS_WEBVIEW2_RUNTIME_NOT_INSTALLED
-#: Merge.rc:5662
+#: Merge.rc:5661
 msgid "WebView2 runtime not installed. Download it?"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_TEXT_COMPARE
-#: Merge.rc:5667
+#: Merge.rc:5666
 msgid "New Text Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_TABLE_COMPARE
-#: Merge.rc:5668
+#: Merge.rc:5667
 msgid "New Table Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_BINARY_COMPARE
-#: Merge.rc:5669
+#: Merge.rc:5668
 msgid "New Binary Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_IMAGE_COMPARE
-#: Merge.rc:5670
+#: Merge.rc:5669
 msgid "New Image Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_WEBPAGE_COMPARE
-#: Merge.rc:5671
+#: Merge.rc:5670
 msgid "New Webpage Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_FOLDER_COMPARE
-#: Merge.rc:5672
+#: Merge.rc:5671
 msgid "New Folder Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_CLIPBOARD_COMPARE
-#: Merge.rc:5673
+#: Merge.rc:5672
 msgid "Clipboard Compare"
 msgstr ""
 
 #. IDS_PREVIEWBAR_PRINT
-#: Merge.rc:5678
+#: Merge.rc:5677
 msgid "&Print..."
 msgstr ""
 
 #. IDS_PREVIEWBAR_PREVPAGE
-#: Merge.rc:5680
+#: Merge.rc:5679
 msgid "Pre&v Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_TWOPAGE
-#: Merge.rc:5681
+#: Merge.rc:5680
 msgid "&Two Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_ONEPAGE
-#: Merge.rc:5682
+#: Merge.rc:5681
 msgid "&One Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_ZOOMIN
-#: Merge.rc:5683
+#: Merge.rc:5682
 msgid "Zoom &In"
 msgstr ""
 
 #. IDS_PREVIEWBAR_ZOOMOUT
-#: Merge.rc:5684
+#: Merge.rc:5683
 msgid "Zoom &Out"
 msgstr ""
 
 #. IDS_WEBPAGE_COMPARING
-#: Merge.rc:5690
+#: Merge.rc:5689
 msgid "Comparing..."
 msgstr ""
 
 #. IDS_WEBPAGE_ZOOM
-#: Merge.rc:5691
+#: Merge.rc:5690
 msgid "Zoom:"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_DIFFHUNK
-#: Merge.rc:5696
+#: Merge.rc:5695
 msgid "Diff hunk"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_INLINE
-#: Merge.rc:5697
+#: Merge.rc:5696
 msgid "Inline diff"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_LINE
-#: Merge.rc:5698
+#: Merge.rc:5697
 msgid "Line"
 msgstr ""
 
-#: Merge.rc:5699
+#: Merge.rc:5698
 msgid "Character"
 msgstr ""
 
 #. ID_MICE_PREVDIFF
-#: Merge.rc:5704
+#: Merge.rc:5703
 msgid "\nPrevious Difference (Alt+Up)\n(Right Button+Wheel Up)\n(Alt+Wheel Up)"
 msgstr ""
 
 #. ID_MICE_NEXTDIFF
-#: Merge.rc:5705
+#: Merge.rc:5704
 msgid "\nNext Difference (Alt+Down)\n(Right Button+Wheel Down)\n(Alt+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_L2R
-#: Merge.rc:5706
+#: Merge.rc:5705
 msgid "\nCopy to Right (Alt+Right)\n(Right Button+Wheel Right)\n(Alt+Wheel Right)\n(Alt+Shift+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_R2L
-#: Merge.rc:5707
+#: Merge.rc:5706
 msgid "\nCopy to Left (Alt+Left)\n(Right Button+Wheel Left)\n(Alt+Wheel Left)\n(Alt+Shift+Wheel Up)"
 msgstr ""
 
 #. ID_MICE_L2RNEXT
-#: Merge.rc:5708
+#: Merge.rc:5707
 msgid "\nCopy to Right and Advance (Ctrl+Alt+Right)\n(Ctrl+Alt+Wheel Right)\n(Ctrl+Alt+Shift+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_R2LNEXT
-#: Merge.rc:5709
+#: Merge.rc:5708
 msgid "\nCopy to Left and Advance (Ctrl+Alt+Left)\n(Ctrl+Alt+Wheel Left)\n(Ctrl+Alt+Shift+Wheel Up)"
 msgstr ""
 
 #. IDS_LOG_COMPARING_2
-#: Merge.rc:5719
+#: Merge.rc:5718
 #, c-format
 msgid "Comparing %1 with %2"
 msgstr ""
 
 #. IDS_LOG_COMPARING_3
-#: Merge.rc:5720
+#: Merge.rc:5719
 #, c-format
 msgid "Comparing %1 with %2 and %3"
 msgstr ""
 
 #. IDS_LOG_COMPARE_COMPLETED
-#: Merge.rc:5721
+#: Merge.rc:5720
 msgid "Comparison completed"
 msgstr ""
 
 #. IDS_LOG_COMPARE_ERROR_2
-#: Merge.rc:5722
+#: Merge.rc:5721
 #, c-format
 msgid "Failed to compare %1 with %2: "
 msgstr ""
 
 #. IDS_LOG_COMPARE_ERROR_3
-#: Merge.rc:5723
+#: Merge.rc:5722
 #, c-format
 msgid "Failed to compare %1 with %2 and %3: "
 msgstr ""
 
 #. IDS_LOG_FILE_SAVED
-#: Merge.rc:5724
+#: Merge.rc:5723
 msgid "File saved"
 msgstr ""
 
 #. IDS_LOG_COPYING_FILES
-#: Merge.rc:5725
+#: Merge.rc:5724
 msgid "Copying files..."
 msgstr ""
 
 #. IDS_LOG_MOVING_FILES
-#: Merge.rc:5726
+#: Merge.rc:5725
 msgid "Moving files..."
 msgstr ""
 
 #. IDS_LOG_DELETING_FILES
-#: Merge.rc:5727
+#: Merge.rc:5726
 msgid "Deleting files..."
 msgstr ""
 
 #. IDS_LOG_RECYCLEBIN
-#: Merge.rc:5728
+#: Merge.rc:5727
 msgid "Recycle Bin"
 msgstr ""
 
 #. IDS_LOG_PERMANENTLY_DELETED
-#: Merge.rc:5729
+#: Merge.rc:5728
 msgid "Permanently deleted"
 msgstr ""
 
 #. IDS_LOG_FILEOPERATION_COMPLETED
-#: Merge.rc:5730
+#: Merge.rc:5729
 msgid "File operation completed successfully"
 msgstr ""
 
 #. IDS_LOG_FILEOPERATION_CANCELED
-#: Merge.rc:5731
+#: Merge.rc:5730
 msgid "File operation canceled"
 msgstr ""
 
 #. IDS_FILTER_ERROR_NO_ERROR
-#: Merge.rc:5736
+#: Merge.rc:5735
 msgid "No error"
 msgstr ""
 
 #. IDS_FILTER_ERROR_EMPTY_EXPRESSION
-#: Merge.rc:5737
+#: Merge.rc:5736
 msgid "Filter expression is empty"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNKNOWN_CHAR
-#: Merge.rc:5738
+#: Merge.rc:5737
 msgid "Unknown character in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNTERMINATED_STRING
-#: Merge.rc:5739
+#: Merge.rc:5738
 msgid "Unterminated string literal"
 msgstr ""
 
 #. IDS_FILTER_ERROR_SYNTAX_ERROR
-#: Merge.rc:5740
+#: Merge.rc:5739
 msgid "Syntax error in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_PARSE_FAILURE
-#: Merge.rc:5741
+#: Merge.rc:5740
 msgid "Failed to parse filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_LITERAL
-#: Merge.rc:5742
+#: Merge.rc:5741
 msgid "Invalid literal value"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_REGULAR_EXPRESSION
-#: Merge.rc:5743
+#: Merge.rc:5742
 msgid "Invalid regular expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNDEFINED_IDENTIFIER
-#: Merge.rc:5744
+#: Merge.rc:5743
 msgid "Undefined identifier"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_ARGUMENT_COUNT
-#: Merge.rc:5745
+#: Merge.rc:5744
 msgid "Invalid number of arguments"
 msgstr ""
 
 #. IDS_FILTER_ERROR_FILTER_NAME_NOT_FOUND
-#: Merge.rc:5746
+#: Merge.rc:5745
 msgid "Filter name not found"
 msgstr ""
 
 #. IDS_FILTER_ERROR_DIVIDE_BY_ZERO
-#: Merge.rc:5747
+#: Merge.rc:5746
 msgid "Division by zero in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNKNOWN_ERROR
-#: Merge.rc:5748
+#: Merge.rc:5747
 msgid "Unknown error"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_PROPERTY_NAME
-#: Merge.rc:5749
+#: Merge.rc:5748
 msgid "Invalid property name"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_DIRECTIVE
-#: Merge.rc:5750
+#: Merge.rc:5749
 msgid "Invalid directive"
 msgstr ""
 
 #. IDS_FILTER_OP_EQUALS
-#: Merge.rc:5755
+#: Merge.rc:5754
 msgid "Equals"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_EQUALS
-#: Merge.rc:5756
+#: Merge.rc:5755
 msgid "Does not equal"
 msgstr ""
 
 #. IDS_FILTER_OP_LESS_THAN
-#: Merge.rc:5757
+#: Merge.rc:5756
 msgid "Less than"
 msgstr ""
 
 #. IDS_FILTER_OP_LESS_EQUAL
-#: Merge.rc:5758
+#: Merge.rc:5757
 msgid "Less than or equal to"
 msgstr ""
 
 #. IDS_FILTER_OP_GREATER_EQUAL
-#: Merge.rc:5759
+#: Merge.rc:5758
 msgid "Greater than or equal to"
 msgstr ""
 
 #. IDS_FILTER_OP_GREATER_THAN
-#: Merge.rc:5760
+#: Merge.rc:5759
 msgid "Greater than"
 msgstr ""
 
 #. IDS_FILTER_OP_BETWEEN
-#: Merge.rc:5761
+#: Merge.rc:5760
 msgid "Between"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_BETWEEN
-#: Merge.rc:5762
+#: Merge.rc:5761
 msgid "Not Between"
 msgstr ""
 
 #. IDS_FILTER_OP_CONTAINS
-#: Merge.rc:5763
+#: Merge.rc:5762
 msgid "Contains"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_CONTAINS
-#: Merge.rc:5764
+#: Merge.rc:5763
 msgid "Not Contains"
 msgstr ""
 
 #. IDS_FILTER_OP_RECONTAINS
-#: Merge.rc:5765
+#: Merge.rc:5764
 msgid "Contains (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_RECONTAINS
-#: Merge.rc:5766
+#: Merge.rc:5765
 msgid "Not Contains (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_LIKE
-#: Merge.rc:5767
+#: Merge.rc:5766
 msgid "Match (wildcard)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_LIKE
-#: Merge.rc:5768
+#: Merge.rc:5767
 msgid "Not match (wildcard)"
 msgstr ""
 
 #. IDS_FILTER_OP_MATCHES
-#: Merge.rc:5769
+#: Merge.rc:5768
 msgid "Match (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_MATCHES
-#: Merge.rc:5770
+#: Merge.rc:5769
 msgid "Not match (regex)"
 msgstr ""
 
 #. IDS_COLORMODE_LIGHT
-#: Merge.rc:5775
+#: Merge.rc:5774
 msgid "Light"
 msgstr ""
 
 #. IDS_COLORMODE_DARK
-#: Merge.rc:5776
+#: Merge.rc:5775
 msgid "Dark"
 msgstr ""
 
 #. IDS_COLORMODE_FOLLOWSYSTEM
-#: Merge.rc:5777
+#: Merge.rc:5776
 msgid "Follow system"
 msgstr ""
 
 #. IDS_EXAMPLE
-#: Merge.rc:5782
+#: Merge.rc:5781
 #, c-format
 msgid "e.g. %1"
 msgstr ""
 
 #. IDS_DETECTED_PREVIOUS_CRASH
-#: Merge.rc:5787
+#: Merge.rc:5786
 msgid "WinMerge detected a previous crash. Please report this if possible."
 msgstr ""
 
 #. IDS_REGEX_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5792
+#: Merge.rc:5791
 msgid "# Regex replacement list\r\n# Format: regex<TAB>replacement\r\n# Backreferences like $1, $2 are supported\r\n\r\n(\\d{4})-(\\d{2})-(\\d{2})\t$1_$2_$3\r\n"
 msgstr ""
 
 #. IDS_STRING_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5793
+#: Merge.rc:5792
 msgid "# Replacement list\r\n# Format: search<TAB>replacement\r\n# Lines starting with # are ignored\r\n\r\nfrom1\tto1\r\nfrom2\tto2\r\n"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_ONLY
-#: Merge.rc:5798
+#: Merge.rc:5797
 msgid "Built-in only"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_FIRST
-#: Merge.rc:5799
+#: Merge.rc:5798
 msgid "Built-in first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_FIRST
-#: Merge.rc:5800
+#: Merge.rc:5799
 msgid "Tree-sitter first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_ONLY
-#: Merge.rc:5801
+#: Merge.rc:5800
 msgid "Tree-sitter only"
 msgstr ""
 

--- a/Translations/WinMerge/Czech.po
+++ b/Translations/WinMerge/Czech.po
@@ -21,7 +21,7 @@ msgstr ""
 "X-Poedit-Basepath: ../../Src/\n"
 
 #. LANGUAGE, SUBLANGUAGE
-#: Merge.rc:26 Merge.rc:59 Merge.rc:5818
+#: Merge.rc:26 Merge.rc:59 Merge.rc:5817
 #, c-format
 msgid "LANG_ENGLISH, SUBLANG_ENGLISH_US"
 msgstr "LANG_CZECH, SUBLANG_DEFAULT"
@@ -171,7 +171,7 @@ msgstr "Skrip&ty"
 #. IDS_NO_EDIT_SCRIPTS
 #: Merge.rc:127 Merge.rc:352 Merge.rc:463 Merge.rc:673 Merge.rc:678
 #: Merge.rc:887 Merge.rc:899 Merge.rc:906 Merge.rc:963 Merge.rc:1210
-#: Merge.rc:5375
+#: Merge.rc:5374
 #, c-format
 msgid "< Empty >"
 msgstr "< žádné >"
@@ -238,7 +238,7 @@ msgid "Auto-Fit All Columns"
 msgstr ""
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN
-#: Merge.rc:153 Merge.rc:5646
+#: Merge.rc:153 Merge.rc:5645
 msgid "&Filter by This Column"
 msgstr ""
 
@@ -304,7 +304,7 @@ msgid "&Previous Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_NEXTPAGE
-#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5679
+#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5678
 #, c-format
 msgid "&Next Page"
 msgstr ""
@@ -572,7 +572,7 @@ msgstr ""
 #. IDS_IMAGE_MENU
 #: Merge.rc:329 Merge.rc:338 Merge.rc:432 Merge.rc:441 Merge.rc:609
 #: Merge.rc:618 Merge.rc:670 Merge.rc:960 Merge.rc:1187 Merge.rc:1200
-#: Merge.rc:5477
+#: Merge.rc:5476
 #, c-format
 msgid "&Image"
 msgstr ""
@@ -710,7 +710,7 @@ msgid "&Huge"
 msgstr ""
 
 #. IDS_VIEW_MENU_BAR
-#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5714
+#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5713
 msgid "Men&u Bar"
 msgstr ""
 
@@ -1473,7 +1473,7 @@ msgid "Lo&cation Pane"
 msgstr "&Polohový panel"
 
 #. IDS_OUTPUTBAR_CAPTION
-#: Merge.rc:782 Merge.rc:5252
+#: Merge.rc:782 Merge.rc:5251
 msgid "Output Pane"
 msgstr ""
 
@@ -1769,55 +1769,55 @@ msgid "Co&mpare As"
 msgstr ""
 
 #. IDS_COPY_LEFT_TO_MIDDLE2
-#: Merge.rc:968 Merge.rc:980 Merge.rc:4852
+#: Merge.rc:968 Merge.rc:980 Merge.rc:4851
 #, c-format
 msgid "Left to Middle (%1 of %2)"
 msgstr ""
 
 #. IDS_COPY_LEFT_TO_RIGHT2
-#: Merge.rc:969 Merge.rc:981 Merge.rc:4851
+#: Merge.rc:969 Merge.rc:981 Merge.rc:4850
 #, c-format
 msgid "Left to Right (%1 of %2)"
 msgstr "&Levé doprava (%1 z %2)"
 
 #. IDS_MOVE_LEFT_TO2
-#: Merge.rc:970 Merge.rc:982 Merge.rc:1045 Merge.rc:4863 Merge.rc:4892
+#: Merge.rc:970 Merge.rc:982 Merge.rc:1045 Merge.rc:4862 Merge.rc:4891
 #, c-format
 msgid "Left to... (%1 of %2)"
 msgstr "L&evé do... (%1 z %2)"
 
 #. IDS_COPY_MIDDLE_TO_LEFT2
-#: Merge.rc:971 Merge.rc:983 Merge.rc:4849
+#: Merge.rc:971 Merge.rc:983 Merge.rc:4848
 #, c-format
 msgid "Middle to Left (%1 of %2)"
 msgstr ""
 
 #. IDS_COPY_MIDDLE_TO_RIGHT2
-#: Merge.rc:972 Merge.rc:984 Merge.rc:4850
+#: Merge.rc:972 Merge.rc:984 Merge.rc:4849
 #, c-format
 msgid "Middle to Right (%1 of %2)"
 msgstr ""
 
 #. IDS_MOVE_MIDDLE_TO2
-#: Merge.rc:973 Merge.rc:985 Merge.rc:1046 Merge.rc:4864 Merge.rc:4893
+#: Merge.rc:973 Merge.rc:985 Merge.rc:1046 Merge.rc:4863 Merge.rc:4892
 #, c-format
 msgid "Middle to... (%1 of %2)"
 msgstr ""
 
 #. IDS_COPY_RIGHT_TO_MIDDLE2
-#: Merge.rc:974 Merge.rc:986 Merge.rc:4848
+#: Merge.rc:974 Merge.rc:986 Merge.rc:4847
 #, c-format
 msgid "Right to Middle (%1 of %2)"
 msgstr ""
 
 #. IDS_COPY_RIGHT_TO_LEFT2
-#: Merge.rc:975 Merge.rc:987 Merge.rc:4847
+#: Merge.rc:975 Merge.rc:987 Merge.rc:4846
 #, c-format
 msgid "Right to Left (%1 of %2)"
 msgstr "P&ravé doleva (%1 z %2)"
 
 #. IDS_MOVE_RIGHT_TO2
-#: Merge.rc:976 Merge.rc:988 Merge.rc:1047 Merge.rc:4865 Merge.rc:4894
+#: Merge.rc:976 Merge.rc:988 Merge.rc:1047 Merge.rc:4864 Merge.rc:4893
 #, c-format
 msgid "Right to... (%1 of %2)"
 msgstr "Pr&avé do... (%1 z %2)"
@@ -1883,31 +1883,31 @@ msgid "Cop&y Paths"
 msgstr "Kopírovat &umístění souborů"
 
 #. IDS_DEL_LEFT_FMT2
-#: Merge.rc:1026 Merge.rc:1035 Merge.rc:4880
+#: Merge.rc:1026 Merge.rc:1035 Merge.rc:4879
 #, c-format
 msgid "Left (%1 of %2)"
 msgstr "&Levé (%1 z %2)"
 
 #. IDS_DEL_MIDDLE_FMT2
-#: Merge.rc:1027 Merge.rc:1036 Merge.rc:4881
+#: Merge.rc:1027 Merge.rc:1036 Merge.rc:4880
 #, c-format
 msgid "Middle (%1 of %2)"
 msgstr ""
 
 #. IDS_DEL_RIGHT_FMT2
-#: Merge.rc:1028 Merge.rc:1037 Merge.rc:4882
+#: Merge.rc:1028 Merge.rc:1037 Merge.rc:4881
 #, c-format
 msgid "Right (%1 of %2)"
 msgstr "P&ravé (%1 z %2)"
 
 #. IDS_DEL_BOTH_FMT2
-#: Merge.rc:1029 Merge.rc:1038 Merge.rc:4883
+#: Merge.rc:1029 Merge.rc:1038 Merge.rc:4882
 #, c-format
 msgid "Both (%1 of %2)"
 msgstr "O&boje (%1 z %2)"
 
 #. IDS_DEL_ALL_FMT2
-#: Merge.rc:1030 Merge.rc:1039 Merge.rc:4888
+#: Merge.rc:1030 Merge.rc:1039 Merge.rc:4887
 #, c-format
 msgid "All (%1 of %2)"
 msgstr ""
@@ -1936,19 +1936,19 @@ msgid "&Zip"
 msgstr "&Archivovat"
 
 #. IDS_COPY_BOTH_TO2
-#: Merge.rc:1048 Merge.rc:4866
+#: Merge.rc:1048 Merge.rc:4865
 #, c-format
 msgid "Both to... (%1 of %2)"
 msgstr ""
 
 #. IDS_COPY_ALL_TO2
-#: Merge.rc:1049 Merge.rc:4867
+#: Merge.rc:1049 Merge.rc:4866
 #, c-format
 msgid "All to... (%1 of %2)"
 msgstr ""
 
 #. IDS_COPY_DIFFERENCES_TO2
-#: Merge.rc:1050 Merge.rc:4868
+#: Merge.rc:1050 Merge.rc:4867
 #, c-format
 msgid "Differences to... (%1 of %2)"
 msgstr ""
@@ -2021,13 +2021,13 @@ msgstr ""
 
 #. IDS_USERCHOICE_NONE
 #: Merge.rc:1088 Merge.rc:1094 Merge.rc:1836 Merge.rc:1840 Merge.rc:2031
-#: Merge.rc:2035 Merge.rc:5377
+#: Merge.rc:2035 Merge.rc:5376
 #, c-format
 msgid "<None>"
 msgstr "<žádný>"
 
 #. IDS_USERCHOICE_AUTOMATIC
-#: Merge.rc:1089 Merge.rc:1095 Merge.rc:5378
+#: Merge.rc:1089 Merge.rc:1095 Merge.rc:5377
 #, c-format
 msgid "<Automatic>"
 msgstr "<automaticky>"
@@ -2979,13 +2979,13 @@ msgid "Text files only"
 msgstr ""
 
 #. IDS_EOL_NONE
-#: Merge.rc:1667 Merge.rc:1918 Merge.rc:5304
+#: Merge.rc:1667 Merge.rc:1918 Merge.rc:5303
 #, c-format
 msgid "None"
 msgstr "Žádný"
 
 #. IDS_EOL_MIXED
-#: Merge.rc:1668 Merge.rc:5299
+#: Merge.rc:1668 Merge.rc:5298
 #, c-format
 msgid "Mixed"
 msgstr "Různé"
@@ -3259,14 +3259,14 @@ msgstr ""
 
 #. IDS_DIFFERENT
 #: Merge.rc:1904 Merge.rc:1988 Merge.rc:2866 Merge.rc:3036 Merge.rc:3077
-#: Merge.rc:5058
+#: Merge.rc:5057
 #, c-format
 msgid "Different"
 msgstr "Rozdílné"
 
 #. IDS_IDENTICAL
 #: Merge.rc:1905 Merge.rc:1989 Merge.rc:2865 Merge.rc:3055 Merge.rc:3116
-#: Merge.rc:5048
+#: Merge.rc:5047
 #, c-format
 msgid "Identical"
 msgstr "Shodné"
@@ -3287,7 +3287,7 @@ msgid "Missing"
 msgstr ""
 
 #. IDS_MOVED
-#: Merge.rc:1910 Merge.rc:5076
+#: Merge.rc:1910 Merge.rc:5075
 msgid "Moved"
 msgstr ""
 
@@ -4115,7 +4115,7 @@ msgid "&Use custom system colors"
 msgstr ""
 
 #. IDS_PRPCAT_SYSTEM
-#: Merge.rc:2565 Merge.rc:4559 Merge.rc:4560 Merge.rc:5007
+#: Merge.rc:2565 Merge.rc:4559 Merge.rc:4560 Merge.rc:5006
 #, c-format
 msgid "System"
 msgstr "Systém"
@@ -4568,7 +4568,7 @@ msgid "Items compared:"
 msgstr "Porovnáno:"
 
 #. IDS_PREVIEWBAR_CLOSE
-#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5685
+#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5684
 #, c-format
 msgid "&Close"
 msgstr "&Zavřít"
@@ -5253,7 +5253,7 @@ msgid "A&ppend timestamp"
 msgstr "Připojit č&asové razítko"
 
 #. IDS_CONFIRM_COPY_CAPTION
-#: Merge.rc:3214 Merge.rc:4915
+#: Merge.rc:3214 Merge.rc:4914
 #, c-format
 msgid "Confirm Copy"
 msgstr "Potvrdit kopírování"
@@ -5514,7 +5514,7 @@ msgid "&Character Set..."
 msgstr ""
 
 #. IDS_PRPCAT_IMAGE
-#: Merge.rc:3351 Merge.rc:4574 Merge.rc:5015
+#: Merge.rc:3351 Merge.rc:4574 Merge.rc:5014
 msgid "Image"
 msgstr ""
 
@@ -5890,7 +5890,7 @@ msgid "Project"
 msgstr ""
 
 #. IDS_COLHDR_NSDIFFS
-#: Merge.rc:4566 Merge.rc:4990
+#: Merge.rc:4566 Merge.rc:4989
 #, c-format
 msgid "Differences"
 msgstr "Rozdíly"
@@ -6050,13 +6050,13 @@ msgid "File Type"
 msgstr ""
 
 #. IDS_COLHDR_EXTENSION
-#: Merge.rc:4653 Merge.rc:4947
+#: Merge.rc:4653 Merge.rc:4946
 #, c-format
 msgid "Extension"
 msgstr "Přípona"
 
 #. IDS_PRPCAT_MESSAGE
-#: Merge.rc:4659 Merge.rc:5019
+#: Merge.rc:4659 Merge.rc:5018
 msgid "Message"
 msgstr ""
 
@@ -6096,7 +6096,7 @@ msgid "Hidden Items"
 msgstr ""
 
 #. IDS_PLUGINSLIST_NAME
-#: Merge.rc:4680 Merge.rc:5311
+#: Merge.rc:4680 Merge.rc:5310
 #, c-format
 msgid "Name"
 msgstr "Název"
@@ -6120,7 +6120,7 @@ msgid "[F] "
 msgstr ""
 
 #. IDS_PLUGINSLIST_DESC
-#: Merge.rc:4684 Merge.rc:5313
+#: Merge.rc:4684 Merge.rc:5312
 #, c-format
 msgid "Description"
 msgstr "Popis"
@@ -6289,171 +6289,165 @@ msgstr ""
 msgid "  Sel: %d | %d"
 msgstr ""
 
-#. IDS_MERGEMODE_MERGING
-#: Merge.rc:4734
-#, c-format
-msgid "Merge"
-msgstr "Sloučit"
-
 #. IDS_DIFF_NUMBER_STATUS_FMT
-#: Merge.rc:4735
+#: Merge.rc:4734
 #, c-format
 msgid "Difference %1 of %2"
 msgstr "Rozdíl %1 z %2"
 
 #. IDS_NO_DIFF_SEL_FMT
-#: Merge.rc:4736
+#: Merge.rc:4735
 #, c-format
 msgid "%1 Differences Found"
 msgstr "Nalezeno %1 rozdílů"
 
 #. IDS_1_DIFF_FOUND
-#: Merge.rc:4737
+#: Merge.rc:4736
 #, c-format
 msgid "1 Difference Found"
 msgstr "Nalezen 1 rozdíl"
 
 #. IDS_NO_ERR_SEL_FMT
-#: Merge.rc:4738
+#: Merge.rc:4737
 #, c-format
 msgid "%1 Errors Found"
 msgstr ""
 
 #. IDS_1_ERR_FOUND
-#: Merge.rc:4739
+#: Merge.rc:4738
 msgid "1 Error Found"
 msgstr ""
 
 #. IDS_STATUSBAR_READONLY, Abbreviation from "Read Only"
-#: Merge.rc:4740
+#: Merge.rc:4739
 #, c-format
 msgid "RO"
 msgstr "Pro čtení"
 
 #. IDS_DIRVIEW_STATUS_FMT_FOCUS
-#: Merge.rc:4746
+#: Merge.rc:4745
 #, c-format
 msgid "Item %1 of %2"
 msgstr "Položka %1 z %2"
 
 #. IDS_DIRVIEW_STATUS_FMT_NOFOCUS
-#: Merge.rc:4747
+#: Merge.rc:4746
 #, c-format
 msgid "Items: %1"
 msgstr "Položek: %1"
 
 #. IDS_DIRVIEW_STATUS_COMPARING
-#: Merge.rc:4748
+#: Merge.rc:4747
 #, c-format
 msgid "Comparing items..."
 msgstr "Porovnávají se položky..."
 
 #. IDS_ITEMS_PER_SEC
-#: Merge.rc:4749
+#: Merge.rc:4748
 #, c-format
 msgid "%.1f[items/sec]"
 msgstr ""
 
 #. IDS_ERROR_INCOMPARABLE
-#: Merge.rc:4755
+#: Merge.rc:4754
 msgid "Select two existing folders/files to compare."
 msgstr "Vyberte dvě existující složky nebo soubory k porovnání."
 
 #. IDS_DIRSEL_TAG
-#: Merge.rc:4756
+#: Merge.rc:4755
 #, c-format
 msgid "Folder Selection"
 msgstr "Vybrat složku"
 
 #. IDS_OPEN_FILESDIRS
-#: Merge.rc:4757
+#: Merge.rc:4756
 #, c-format
 msgid "Select two (or three) folders/files to compare."
 msgstr ""
 
 #. IDS_OPEN_LEFTINVALID
-#: Merge.rc:4758
+#: Merge.rc:4757
 #, c-format
 msgid "Left (1st) path is invalid!"
 msgstr ""
 
 #. IDS_OPEN_MIDDLEINVALID
-#: Merge.rc:4759
+#: Merge.rc:4758
 #, c-format
 msgid "Middle (2nd) path is invalid!"
 msgstr ""
 
 #. IDS_OPEN_RIGHTINVALID2
-#: Merge.rc:4760
+#: Merge.rc:4759
 #, c-format
 msgid "Right (2nd) path is invalid!"
 msgstr ""
 
 #. IDS_OPEN_RIGHTINVALID3
-#: Merge.rc:4761
+#: Merge.rc:4760
 #, c-format
 msgid "Right (3rd) path is invalid!"
 msgstr ""
 
 #. IDS_OPEN_BOTHINVALID
-#: Merge.rc:4762
+#: Merge.rc:4761
 #, c-format
 msgid "Both paths are invalid!"
 msgstr "Obě cesty jsou chybné!"
 
-#: Merge.rc:4764
+#: Merge.rc:4763
 #, c-format
 msgid "Left (1st) and Middle (2nd) paths are invalid!"
 msgstr ""
 
 #. IDS_OPEN_LEFTRIGHTINVALID
-#: Merge.rc:4765
+#: Merge.rc:4764
 #, c-format
 msgid "Left (1st) and Right (3rd) paths are invalid!"
 msgstr ""
 
-#: Merge.rc:4767
+#: Merge.rc:4766
 #, c-format
 msgid "Middle (2nd) and Right (3rd) paths are invalid!"
 msgstr ""
 
 #. IDS_OPEN_ALLINVALID
-#: Merge.rc:4768
+#: Merge.rc:4767
 #, c-format
 msgid "All paths are invalid!"
 msgstr ""
 
 #. IDS_OPEN_UNPACKERDISABLED
-#: Merge.rc:4769
+#: Merge.rc:4768
 msgid "Only enabled for file comparisons"
 msgstr ""
 
 #. IDS_OPEN_MISMATCH
-#: Merge.rc:4770
+#: Merge.rc:4769
 #, c-format
 msgid "Cannot compare file and folder!"
 msgstr "Nelze porovnat soubor a složku!"
 
 #. IDS_ERROR_FILE_NOT_FOUND
-#: Merge.rc:4776
+#: Merge.rc:4775
 #, c-format
 msgid "File not found: %1"
 msgstr "Soubor nebyl nalezen: %1"
 
 #. IDS_ERROR_FOLDER_NOT_FOUND
-#: Merge.rc:4777
+#: Merge.rc:4776
 #, c-format
 msgid "Folder not found: %1"
 msgstr ""
 
 #. IDS_ERROR_FILE_NOT_UNPACKED
-#: Merge.rc:4778
+#: Merge.rc:4777
 #, c-format
 msgid "File not unpacked: %1"
 msgstr "Soubor nebyl převeden: %1"
 
 #. IDS_ERROR_FILEOPEN
-#: Merge.rc:4779
+#: Merge.rc:4778
 #, c-format
 msgid ""
 "Cannot open file\n"
@@ -6467,47 +6461,47 @@ msgstr ""
 "%2"
 
 #. IDS_ERROR_CONF_RESOLVE
-#: Merge.rc:4780
+#: Merge.rc:4779
 #, c-format
 msgid "Failed to parse conflict file."
 msgstr ""
 
 #. IDS_NOT_CONFLICT_FILE
-#: Merge.rc:4781
+#: Merge.rc:4780
 #, c-format
 msgid "The file\n%1\nis not a conflict file."
 msgstr ""
 
 #. IDS_COMPARE_LARGE_FILES
-#: Merge.rc:4782
+#: Merge.rc:4781
 msgid "Comparing large files requires significant memory.\nShow only comparison results (not file contents)?"
 msgstr ""
 
 #. IDS_SAVE_AS_TITLE
-#: Merge.rc:4788
+#: Merge.rc:4787
 #, c-format
 msgid "Save As"
 msgstr "Uložit jako"
 
 #. IDS_SAVE_FMT
-#: Merge.rc:4789
+#: Merge.rc:4788
 #, c-format
 msgid "Save changes to %1?"
 msgstr "Uložit změny do %1?"
 
 #. IDS_SAVEREADONLY_FMT
-#: Merge.rc:4790
+#: Merge.rc:4789
 #, c-format
 msgid "%1 is read-only. Override? Or 'No' to save as new filename?"
 msgstr "%1 je označen pouze pro čtení. Chcete nahradit tento soubor? (Neukládat pod novým názvem.)"
 
 #. IDS_ERROR_BACKUP
-#: Merge.rc:4791
+#: Merge.rc:4790
 #, c-format
 msgid "Error backing up file"
 msgstr "Chyba při zálohování souboru"
 
-#: Merge.rc:4793
+#: Merge.rc:4792
 #, c-format
 msgid ""
 "Unable to backup original file:\n"
@@ -6521,7 +6515,7 @@ msgstr ""
 "Chcete pokračovat?"
 
 #. IDS_FILESAVE_FAILED
-#: Merge.rc:4794
+#: Merge.rc:4793
 #, c-format
 msgid "Saving file failed.\n%1\n%2\n\t- Use different filename (OK)\n\t- Abort (Cancel)?"
 msgstr ""
@@ -6532,7 +6526,7 @@ msgstr ""
 "\t- použít jiný název souboru (stiskněte OK)\n"
 "\t- přerušit současnou operaci (stiskněte Storno)"
 
-#: Merge.rc:4796
+#: Merge.rc:4795
 #, c-format
 msgid "Plugin '%2' cannot pack changes to left file into '%1'.\n\nOriginal unchanged. Save unpacked version?"
 msgstr ""
@@ -6542,12 +6536,12 @@ msgstr ""
 "\n"
 "Chcete uložit převedenou verzi do jiného souboru?"
 
-#: Merge.rc:4798
+#: Merge.rc:4797
 #, c-format
 msgid "Plugin '%2' cannot pack changes to middle file into '%1'.\n\nOriginal unchanged. Save unpacked version?"
 msgstr ""
 
-#: Merge.rc:4800
+#: Merge.rc:4799
 #, c-format
 msgid "Plugin '%2' cannot pack changes to right file into '%1'.\n\nOriginal unchanged. Save unpacked version?"
 msgstr ""
@@ -6558,7 +6552,7 @@ msgstr ""
 "Chcete uložit převedenou verzi do jiného souboru?"
 
 #. IDS_FILECHANGED_ONDISK
-#: Merge.rc:4801
+#: Merge.rc:4800
 #, c-format
 msgid ""
 "Another application updated\n"
@@ -6574,7 +6568,7 @@ msgstr ""
 "Přepsat změněný soubor?"
 
 #. IDS_SAVEREADONLY_MULTI
-#: Merge.rc:4802
+#: Merge.rc:4801
 #, c-format
 msgid ""
 "%1\n"
@@ -6584,37 +6578,37 @@ msgstr ""
 "je označen pouze pro čtení. Chcete nahradit tuto položku?"
 
 #. IDS_FILECHANGED_RESCAN
-#: Merge.rc:4803
+#: Merge.rc:4802
 #, c-format
 msgid "Another application updated\n%1\nsince last scan.\n\nReload?"
 msgstr "Jiná aplikace provedla změny v souboru\n%1\nod jeho posledního prozkoumání aplikací WinMerge.\n\nChcete soubor načíst znovu?"
 
 #. IDS_SAVE_LEFT_AS
-#: Merge.rc:4804
+#: Merge.rc:4803
 #, c-format
 msgid "Save Left File As"
 msgstr "Uložit levý soubor jako"
 
 #. IDS_SAVE_MIDDLE_AS
-#: Merge.rc:4805
+#: Merge.rc:4804
 #, c-format
 msgid "Save Middle File As"
 msgstr ""
 
 #. IDS_SAVE_RIGHT_AS
-#: Merge.rc:4806
+#: Merge.rc:4805
 #, c-format
 msgid "Save Right File As"
 msgstr "Uložit pravý soubor jako"
 
 #. IDS_FILE_DISAPPEARED
-#: Merge.rc:4811
+#: Merge.rc:4810
 #, c-format
 msgid "File\n%1\nnot found. Save a copy to continue."
 msgstr "Soubor\n%1\nse ztratil. Pro pokračování prosím uložte kopii souboru."
 
 #. IDS_VIEWS_OUTOFSYNC
-#: Merge.rc:4817
+#: Merge.rc:4816
 #, c-format
 msgid ""
 "Cannot merge unsynched documents.\n"
@@ -6626,189 +6620,189 @@ msgstr ""
 "Před dalším pokračováním dokumenty obnovte."
 
 #. IDS_BREAK_ON_WHITESPACE
-#: Merge.rc:4822
+#: Merge.rc:4821
 msgid "Break at whitespace"
 msgstr "Přerušit v mezerách"
 
 #. IDS_BREAK_ON_PUNCTUATION
-#: Merge.rc:4823
+#: Merge.rc:4822
 msgid "Break at whitespace or punctuation"
 msgstr "Přerušit v mezerách nebo v interpunkci"
 
 #. IDS_L2M
-#: Merge.rc:4829
+#: Merge.rc:4828
 msgid "Copy to &Middle\tAlt+Right"
 msgstr ""
 
 #. IDS_R2M
-#: Merge.rc:4830
+#: Merge.rc:4829
 msgid "Copy to &Middle\tAlt+Left"
 msgstr ""
 
 #. IDS_COPY_FROM_MIDDLE_R
-#: Merge.rc:4831
+#: Merge.rc:4830
 msgid "Copy from Middle\tAlt+Shift+Right"
 msgstr ""
 
 #. IDS_COPY_FROM_MIDDLE_L
-#: Merge.rc:4832
+#: Merge.rc:4831
 msgid "Copy from Middle\tAlt+Shift+Left"
 msgstr ""
 
 #. IDS_L2MNEXT
-#: Merge.rc:4833
+#: Merge.rc:4832
 msgid "Copy to Middle and Advance\tCtrl+Alt+Right"
 msgstr ""
 
 #. IDS_R2MNEXT
-#: Merge.rc:4834
+#: Merge.rc:4833
 msgid "Copy to Middle and Advance\tCtrl+Alt+Left"
 msgstr ""
 
 #. IDS_ALL_MIDDLE
-#: Merge.rc:4835
+#: Merge.rc:4834
 msgid "Copy All to Middle"
 msgstr ""
 
 #. IDS_COPY_RIGHT_TO_LEFT
-#: Merge.rc:4841
+#: Merge.rc:4840
 #, c-format
 msgid "Right to Left (%1)"
 msgstr "P&ravé doleva (%1)"
 
 #. IDS_COPY_RIGHT_TO_MIDDLE
-#: Merge.rc:4842
+#: Merge.rc:4841
 #, c-format
 msgid "Right to Middle (%1)"
 msgstr ""
 
 #. IDS_COPY_MIDDLE_TO_LEFT
-#: Merge.rc:4843
+#: Merge.rc:4842
 #, c-format
 msgid "Middle to Left (%1)"
 msgstr ""
 
 #. IDS_COPY_MIDDLE_TO_RIGHT
-#: Merge.rc:4844
+#: Merge.rc:4843
 #, c-format
 msgid "Middle to Right (%1)"
 msgstr ""
 
 #. IDS_COPY_LEFT_TO_RIGHT
-#: Merge.rc:4845
+#: Merge.rc:4844
 #, c-format
 msgid "Left to Right (%1)"
 msgstr "&Levé doprava (%1)"
 
 #. IDS_COPY_LEFT_TO_MIDDLE
-#: Merge.rc:4846
+#: Merge.rc:4845
 #, c-format
 msgid "Left to Middle (%1)"
 msgstr ""
 
 #. IDS_MOVE_LEFT_TO
-#: Merge.rc:4857 Merge.rc:4889
+#: Merge.rc:4856 Merge.rc:4888
 #, c-format
 msgid "Left to... (%1)"
 msgstr "L&evé do... (%1)"
 
 #. IDS_MOVE_MIDDLE_TO
-#: Merge.rc:4858 Merge.rc:4890
+#: Merge.rc:4857 Merge.rc:4889
 #, c-format
 msgid "Middle to... (%1)"
 msgstr ""
 
 #. IDS_MOVE_RIGHT_TO
-#: Merge.rc:4859 Merge.rc:4891
+#: Merge.rc:4858 Merge.rc:4890
 #, c-format
 msgid "Right to... (%1)"
 msgstr "Pr&avé do... (%1)"
 
 #. IDS_COPY_BOTH_TO
-#: Merge.rc:4860
+#: Merge.rc:4859
 #, c-format
 msgid "Both to... (%1)"
 msgstr ""
 
 #. IDS_COPY_ALL_TO
-#: Merge.rc:4861
+#: Merge.rc:4860
 #, c-format
 msgid "All to... (%1)"
 msgstr ""
 
 #. IDS_COPY_DIFFERENCES_TO
-#: Merge.rc:4862
+#: Merge.rc:4861
 #, c-format
 msgid "Differences to... (%1)"
 msgstr ""
 
 #. IDS_ONLYDIFFITEMS_CONFIRM
-#: Merge.rc:4869
+#: Merge.rc:4868
 msgid "Some selected items are identical or skipped.\nProcess only items with differences?"
 msgstr ""
 
 #. IDS_DEL_LEFT_FMT
-#: Merge.rc:4875
+#: Merge.rc:4874
 #, c-format
 msgid "Left (%1)"
 msgstr "&Levé (%1)"
 
 #. IDS_DEL_MIDDLE_FMT
-#: Merge.rc:4876
+#: Merge.rc:4875
 #, c-format
 msgid "Middle (%1)"
 msgstr ""
 
 #. IDS_DEL_RIGHT_FMT
-#: Merge.rc:4877
+#: Merge.rc:4876
 #, c-format
 msgid "Right (%1)"
 msgstr "P&ravé (%1)"
 
 #. IDS_DEL_BOTH_FMT
-#: Merge.rc:4878
+#: Merge.rc:4877
 #, c-format
 msgid "Both (%1)"
 msgstr "O&boje (%1)"
 
 #. IDS_DEL_ALL_FMT
-#: Merge.rc:4879
+#: Merge.rc:4878
 #, c-format
 msgid "All (%1)"
 msgstr ""
 
 #. IDS_SELECT_DEST_LEFT
-#: Merge.rc:4895
+#: Merge.rc:4894
 #, c-format
 msgid "Left Side - Select Destination Folder:"
 msgstr "Zvolte cílovou složku pro položky z levé strany:"
 
 #. IDS_SELECT_DEST_MIDDLE
-#: Merge.rc:4896
+#: Merge.rc:4895
 #, c-format
 msgid "Middle Side - Select Destination Folder:"
 msgstr ""
 
 #. IDS_SELECT_DEST_RIGHT
-#: Merge.rc:4897
+#: Merge.rc:4896
 #, c-format
 msgid "Right Side - Select Destination Folder:"
 msgstr "Zvolte cílovou složku pro položky z pravé strany:"
 
 #. IDS_FILES_AFFECTED_FMT
-#: Merge.rc:4898
+#: Merge.rc:4897
 #, c-format
 msgid "(%1 Files Affected)"
 msgstr "(ovlivněno souborů: %1)"
 
 #. IDS_FILES_AFFECTED_FMT2
-#: Merge.rc:4899
+#: Merge.rc:4898
 #, c-format
 msgid "(%1 of %2 Files Affected)"
 msgstr "(ovlivněno souborů: %1 z %2)"
 
 #. IDS_CONFIRM_DELETE_SINGLE
-#: Merge.rc:4905
+#: Merge.rc:4904
 #, c-format
 msgid ""
 "Are you sure you want to delete\n"
@@ -6820,18 +6814,18 @@ msgstr ""
 "%1 ?"
 
 #. IDS_CONFIRM_SINGLE_COPY
-#: Merge.rc:4906
+#: Merge.rc:4905
 msgid "Are you sure you want to copy?"
 msgstr "Opravdu chcete zkopírovat?"
 
 #. IDS_CONFIRM_MULTIPLE_COPY
-#: Merge.rc:4907
+#: Merge.rc:4906
 #, c-format
 msgid "Are you sure you want to copy %d items?"
 msgstr "Opravdu chcete zkopírovat %d položek?"
 
 #. IDS_DIRCMP_NOTSYNC
-#: Merge.rc:4908
+#: Merge.rc:4907
 #, c-format
 msgid ""
 "Operation aborted!\n"
@@ -6851,873 +6845,873 @@ msgstr ""
 "Obnovte prosím porovnání."
 
 #. IDS_CONFIRM_SINGLE_MOVE
-#: Merge.rc:4913
+#: Merge.rc:4912
 msgid "Are you sure you want to move?"
 msgstr "Opravdu chcete přesunout?"
 
 #. IDS_CONFIRM_MULTIPLE_MOVE
-#: Merge.rc:4914
+#: Merge.rc:4913
 #, c-format
 msgid "Are you sure you want to move %d items?"
 msgstr "Opravdu chcete přesunout %d položek?"
 
 #. IDS_CONFIRM_MOVE_CAPTION
-#: Merge.rc:4916
+#: Merge.rc:4915
 #, c-format
 msgid "Confirm Move"
 msgstr "Potvrdit přesunutí"
 
-#: Merge.rc:4918
+#: Merge.rc:4917
 #, c-format
 msgid "Close the folder comparison window?"
 msgstr ""
 
-#: Merge.rc:4920
+#: Merge.rc:4919
 msgid "Close the folder comparison window, which took a long time?"
 msgstr ""
 
 #. IDS_ERROR_INVALID_DIR_FILE_NAME
-#: Merge.rc:4921
+#: Merge.rc:4920
 msgid "The file or folder name is invalid."
 msgstr ""
 
 #. IDS_ERROR_EXECUTE_FILE
-#: Merge.rc:4927
+#: Merge.rc:4926
 #, c-format
 msgid "Failed to execute external editor: %1"
 msgstr "Nelze spustit externí editor: %1"
 
 #. IDS_UNKNOWN_ARCHIVE_FORMAT
-#: Merge.rc:4933
+#: Merge.rc:4932
 #, c-format
 msgid "Unknown archive format"
 msgstr "Neznámý formát archivu"
 
-#: Merge.rc:4935
+#: Merge.rc:4934
 msgid "Failed to extract archive.\nCompare as text file?"
 msgstr ""
 
 #. IDS_COLHDR_FILENAME
-#: Merge.rc:4941
+#: Merge.rc:4940
 #, c-format
 msgid "Filename"
 msgstr "Název souboru"
 
 #. IDS_COLHDR_DIR
-#: Merge.rc:4942
+#: Merge.rc:4941
 msgctxt "DirView|ColumnHeader"
 msgid "Folder"
 msgstr "Složky"
 
 #. IDS_COLHDR_RESULT
-#: Merge.rc:4943
+#: Merge.rc:4942
 #, c-format
 msgid "Comparison Result"
 msgstr "Výsledek porovnání"
 
 #. IDS_COLHDR_LTIMEM
-#: Merge.rc:4944
+#: Merge.rc:4943
 #, c-format
 msgid "Left Date"
 msgstr "Datum vlevo"
 
 #. IDS_COLHDR_RTIMEM
-#: Merge.rc:4945
+#: Merge.rc:4944
 #, c-format
 msgid "Right Date"
 msgstr "Datum vpravo"
 
 #. IDS_COLHDR_MTIMEM
-#: Merge.rc:4946
+#: Merge.rc:4945
 #, c-format
 msgid "Middle Date"
 msgstr ""
 
 #. IDS_COLHDR_LSIZE
-#: Merge.rc:4948
+#: Merge.rc:4947
 #, c-format
 msgid "Left Size"
 msgstr "Velikost vlevo"
 
 #. IDS_COLHDR_RSIZE
-#: Merge.rc:4949
+#: Merge.rc:4948
 #, c-format
 msgid "Right Size"
 msgstr "Velikost vpravo"
 
 #. IDS_COLHDR_MSIZE
-#: Merge.rc:4954
+#: Merge.rc:4953
 #, c-format
 msgid "Middle Size"
 msgstr ""
 
 #. IDS_COLHDR_RSIZE_SHORT
-#: Merge.rc:4955
+#: Merge.rc:4954
 #, c-format
 msgid "Right Size (Short)"
 msgstr "Velikost vpravo (krátce)"
 
 #. IDS_COLHDR_LSIZE_SHORT
-#: Merge.rc:4956
+#: Merge.rc:4955
 #, c-format
 msgid "Left Size (Short)"
 msgstr "Velikost vlevo (krátce)"
 
 #. IDS_COLHDR_MSIZE_SHORT
-#: Merge.rc:4957
+#: Merge.rc:4956
 #, c-format
 msgid "Middle Size (Short)"
 msgstr ""
 
 #. IDS_COLHDR_LTIMEC
-#: Merge.rc:4963
+#: Merge.rc:4962
 #, c-format
 msgid "Left Creation Time"
 msgstr "Datum vytvoření vlevo"
 
 #. IDS_COLHDR_RTIMEC
-#: Merge.rc:4964
+#: Merge.rc:4963
 #, c-format
 msgid "Right Creation Time"
 msgstr "Datum vytvoření vpravo"
 
 #. IDS_COLHDR_MTIMEC
-#: Merge.rc:4965
+#: Merge.rc:4964
 #, c-format
 msgid "Middle Creation Time"
 msgstr ""
 
 #. IDS_COLHDR_NEWER
-#: Merge.rc:4966
+#: Merge.rc:4965
 #, c-format
 msgid "Newer File"
 msgstr "Novější soubor"
 
 #. IDS_COLHDR_LVERSION
-#: Merge.rc:4967
+#: Merge.rc:4966
 #, c-format
 msgid "Left File Version"
 msgstr "Verze souboru vlevo"
 
 #. IDS_COLHDR_RVERSION
-#: Merge.rc:4968
+#: Merge.rc:4967
 #, c-format
 msgid "Right File Version"
 msgstr "Verze souboru vpravo"
 
 #. IDS_COLHDR_MVERSION
-#: Merge.rc:4969
+#: Merge.rc:4968
 #, c-format
 msgid "Middle File Version"
 msgstr ""
 
 #. IDS_COLHDR_RESULT_ABBR
-#: Merge.rc:4970
+#: Merge.rc:4969
 #, c-format
 msgid "Short Result"
 msgstr "Stručný výsledek"
 
 #. IDS_COLHDR_LATTRIBUTES
-#: Merge.rc:4971
+#: Merge.rc:4970
 #, c-format
 msgid "Left Attributes"
 msgstr "Atributy vlevo"
 
 #. IDS_COLHDR_RATTRIBUTES
-#: Merge.rc:4972
+#: Merge.rc:4971
 #, c-format
 msgid "Right Attributes"
 msgstr "Atributy vpravo"
 
 #. IDS_COLHDR_MATTRIBUTES
-#: Merge.rc:4973
+#: Merge.rc:4972
 #, c-format
 msgid "Middle Attributes"
 msgstr ""
 
 #. IDS_COLHDR_LEOL_TYPE
-#: Merge.rc:4978
+#: Merge.rc:4977
 #, c-format
 msgid "Left EOL"
 msgstr "Konce řádků vlevo"
 
 #. IDS_COLHDR_MEOL_TYPE
-#: Merge.rc:4979
+#: Merge.rc:4978
 #, c-format
 msgid "Middle EOL"
 msgstr ""
 
 #. IDS_COLHDR_REOL_TYPE
-#: Merge.rc:4980
+#: Merge.rc:4979
 #, c-format
 msgid "Right EOL"
 msgstr "Konce řádků vpravo"
 
 #. IDS_COLHDR_LENCODING
-#: Merge.rc:4986
+#: Merge.rc:4985
 #, c-format
 msgid "Left Encoding"
 msgstr "Kódování vlevo"
 
 #. IDS_COLHDR_RENCODING
-#: Merge.rc:4987
+#: Merge.rc:4986
 #, c-format
 msgid "Right Encoding"
 msgstr "Kódování vpravo"
 
 #. IDS_COLHDR_MENCODING
-#: Merge.rc:4988
+#: Merge.rc:4987
 #, c-format
 msgid "Middle Encoding"
 msgstr ""
 
 #. IDS_COLHDR_NIDIFFS
-#: Merge.rc:4989
+#: Merge.rc:4988
 msgid "Ignored Diff"
 msgstr "Ignor. rozdílů"
 
 #. IDS_COLHDR_BINARY
-#: Merge.rc:4991
+#: Merge.rc:4990
 msgctxt "DirView|ColumnHeader"
 msgid "Binary"
 msgstr "Binární"
 
 #. IDS_PLUGINS_TYPE_UNPACKER
-#: Merge.rc:4992 Merge.rc:5314
+#: Merge.rc:4991 Merge.rc:5313
 #, c-format
 msgid "Unpacker"
 msgstr "Převaděč"
 
 #. IDS_PLUGIN_TYPE4
-#: Merge.rc:4993 Merge.rc:5315 Merge.rc:5622
+#: Merge.rc:4992 Merge.rc:5314 Merge.rc:5621
 #, c-format
 msgid "Prediffer"
 msgstr ""
 
 #. IDS_COLHDR_LEFT
-#: Merge.rc:4994
+#: Merge.rc:4993
 msgid "Left"
 msgstr ""
 
 #. IDS_COLHDR_MIDDLE
-#: Merge.rc:4995
+#: Merge.rc:4994
 msgid "Middle"
 msgstr ""
 
 #. IDS_COLHDR_RIGHT
-#: Merge.rc:4996
+#: Merge.rc:4995
 msgid "Right"
 msgstr ""
 
 #. IDS_COLHDR_DIFF
-#: Merge.rc:4997
+#: Merge.rc:4996
 msgid "Diff"
 msgstr ""
 
 #. IDS_COLHDR_LEFT_DUPLICATE
-#: Merge.rc:4998
+#: Merge.rc:4997
 msgid "Left Duplicate Count"
 msgstr ""
 
 #. IDS_COLHDR_RIGHT_DUPLICATE
-#: Merge.rc:4999
+#: Merge.rc:4998
 msgid "Right Duplicate Count"
 msgstr ""
 
 #. IDS_COLHDR_MIDDLE_DUPLICATE
-#: Merge.rc:5000
+#: Merge.rc:4999
 msgid "Middle Duplicate Count"
 msgstr ""
 
 #. IDS_COLHDR_MOVE
-#: Merge.rc:5001
+#: Merge.rc:5000
 msgid "Move"
 msgstr ""
 
 #. IDS_PRPCAT_AUDIO
-#: Merge.rc:5008
+#: Merge.rc:5007
 msgid "Audio"
 msgstr ""
 
 #. IDS_PRPCAT_CALENDAR
-#: Merge.rc:5009
+#: Merge.rc:5008
 msgid "Calendar"
 msgstr ""
 
 #. IDS_PRPCAT_COMMUNICATION
-#: Merge.rc:5010
+#: Merge.rc:5009
 msgid "Communication"
 msgstr ""
 
 #. IDS_PRPCAT_CONTACT
-#: Merge.rc:5011
+#: Merge.rc:5010
 msgid "Contact"
 msgstr ""
 
 #. IDS_PRPCAT_DEVICES
-#: Merge.rc:5012
+#: Merge.rc:5011
 msgid "Devices"
 msgstr ""
 
 #. IDS_PRPCAT_DOCUMENT
-#: Merge.rc:5013
+#: Merge.rc:5012
 msgid "Document"
 msgstr ""
 
 #. IDS_PRPCAT_HOME
-#: Merge.rc:5014
+#: Merge.rc:5013
 msgid "Home"
 msgstr ""
 
 #. IDS_PRPCAT_JOURNAL
-#: Merge.rc:5016
+#: Merge.rc:5015
 msgid "Journal"
 msgstr ""
 
 #. IDS_PRPCAT_LINK
-#: Merge.rc:5017
+#: Merge.rc:5016
 msgid "Link"
 msgstr ""
 
 #. IDS_PRPCAT_MEDIA
-#: Merge.rc:5018
+#: Merge.rc:5017
 msgid "Media"
 msgstr ""
 
 #. IDS_PRPCAT_MUSIC
-#: Merge.rc:5020
+#: Merge.rc:5019
 msgid "Music"
 msgstr ""
 
 #. IDS_PRPCAT_NOTE
-#: Merge.rc:5021
+#: Merge.rc:5020
 msgid "Note"
 msgstr ""
 
 #. IDS_PRPCAT_PHOTO
-#: Merge.rc:5022
+#: Merge.rc:5021
 msgid "Photo"
 msgstr ""
 
 #. IDS_PRPCAT_RECORDEDTV
-#: Merge.rc:5023
+#: Merge.rc:5022
 msgid "RecordedTV"
 msgstr ""
 
 #. IDS_PRPCAT_SEARCH
-#: Merge.rc:5024
+#: Merge.rc:5023
 msgid "Search"
 msgstr ""
 
 #. IDS_PRPCAT_SECURITY
-#: Merge.rc:5025
+#: Merge.rc:5024
 msgid "Security"
 msgstr ""
 
 #. IDS_PRPCAT_SOFTWARE
-#: Merge.rc:5026
+#: Merge.rc:5025
 msgid "Software"
 msgstr ""
 
 #. IDS_PRPCAT_TASK
-#: Merge.rc:5027
+#: Merge.rc:5026
 msgid "Task"
 msgstr ""
 
 #. IDS_PRPCAT_VIDEO
-#: Merge.rc:5028
+#: Merge.rc:5027
 msgid "Video"
 msgstr ""
 
 #. IDS_PRPCAT_HASH
-#: Merge.rc:5029
+#: Merge.rc:5028
 msgid "Hash"
 msgstr ""
 
 #. IDS_CANT_COMPARE_FILES
-#: Merge.rc:5035
+#: Merge.rc:5034
 #, c-format
 msgid "Unable to compare files"
 msgstr "Soubory nelze porovnat"
 
 #. IDS_ABORTED_ITEM
-#: Merge.rc:5036
+#: Merge.rc:5035
 #, c-format
 msgid "Item aborted"
 msgstr "Přerušeno"
 
 #. IDS_FILE_SKIPPED
-#: Merge.rc:5037
+#: Merge.rc:5036
 #, c-format
 msgid "File skipped"
 msgstr "Soubor přeskočen"
 
 #. IDS_DIR_SKIPPED
-#: Merge.rc:5038
+#: Merge.rc:5037
 #, c-format
 msgid "Folder skipped"
 msgstr "Složka přeskočena"
 
 #. IDS_LEFT_ONLY_IN_FMT
-#: Merge.rc:5039
+#: Merge.rc:5038
 #, c-format
 msgid "Left only: %1"
 msgstr "Pouze vlevo: %1"
 
 #. IDS_MIDDLE_ONLY_IN_FMT
-#: Merge.rc:5040
+#: Merge.rc:5039
 #, c-format
 msgid "Middle only: %1"
 msgstr ""
 
 #. IDS_RIGHT_ONLY_IN_FMT
-#: Merge.rc:5041
+#: Merge.rc:5040
 #, c-format
 msgid "Right only: %1"
 msgstr "Pouze vpravo: %1"
 
 #. IDS_DOES_NOT_EXIST_IN_FMT
-#: Merge.rc:5042
+#: Merge.rc:5041
 #, c-format
 msgid "Does not exist in %1"
 msgstr ""
 
 #. IDS_BIN_FILES_SAME
-#: Merge.rc:5043
+#: Merge.rc:5042
 #, c-format
 msgid "Binary files are identical"
 msgstr "Binární soubory jsou shodné"
 
 #. IDS_BIN_FILES_DIFF
-#: Merge.rc:5049
+#: Merge.rc:5048
 #, c-format
 msgid "Binary files are different"
 msgstr "Binární soubory jsou rozdílné"
 
 #. IDS_FILES_ARE_DIFFERENT
-#: Merge.rc:5050
+#: Merge.rc:5049
 #, c-format
 msgid "Files are different"
 msgstr "Soubory jsou rozdílné"
 
 #. IDS_FOLDERS_ARE_DIFFERENT
-#: Merge.rc:5051
+#: Merge.rc:5050
 #, c-format
 msgid "Folders are different"
 msgstr "Složky jsou rozdílné"
 
 #. IDS_LEFTONLY
-#: Merge.rc:5052
+#: Merge.rc:5051
 #, c-format
 msgid "Left Only"
 msgstr "Pouze vlevo"
 
 #. IDS_RIGHTONLY
-#: Merge.rc:5053
+#: Merge.rc:5052
 #, c-format
 msgid "Right Only"
 msgstr "Pouze vpravo"
 
 #. IDS_MIDDLEONLY
-#: Merge.rc:5054
+#: Merge.rc:5053
 #, c-format
 msgid "Middle Only"
 msgstr ""
 
 #. IDS_NOITEMLEFT
-#: Merge.rc:5055
+#: Merge.rc:5054
 #, c-format
 msgid "No item in left"
 msgstr ""
 
 #. IDS_NOITEMRIGHT
-#: Merge.rc:5056
+#: Merge.rc:5055
 #, c-format
 msgid "No item in right"
 msgstr ""
 
 #. IDS_NOITEMMIDDLE
-#: Merge.rc:5057
+#: Merge.rc:5056
 #, c-format
 msgid "No item in middle"
 msgstr ""
 
 #. IDS_CMPRES_ERROR
-#: Merge.rc:5059
+#: Merge.rc:5058
 #, c-format
 msgid "Error"
 msgstr "Chyba"
 
 #. IDS_TEXT_FILES_SAME
-#: Merge.rc:5060
+#: Merge.rc:5059
 #, c-format
 msgid "Text files are identical"
 msgstr "Textové soubory jsou shodné"
 
 #. IDS_LEFTONLY_DIFF
-#: Merge.rc:5061
+#: Merge.rc:5060
 msgid " (Middle and right are identical)"
 msgstr ""
 
 #. IDS_MIDDLEONLY_DIFF
-#: Merge.rc:5062
+#: Merge.rc:5061
 msgid " (Left and right are identical)"
 msgstr ""
 
 #. IDS_RIGHTONLY_DIFF
-#: Merge.rc:5063
+#: Merge.rc:5062
 msgid " (Left and middle are identical)"
 msgstr ""
 
 #. IDS_PATH_MISMATCH
-#: Merge.rc:5064
+#: Merge.rc:5063
 msgid " (paths differ)"
 msgstr ""
 
 #. IDS_TEXT_FILES_DIFF
-#: Merge.rc:5065
+#: Merge.rc:5064
 #, c-format
 msgid "Text files are different"
 msgstr "Textové soubory jsou rozdílné"
 
 #. IDS_IMAGE_FILES_SAME
-#: Merge.rc:5066
+#: Merge.rc:5065
 msgid "Image files are identical"
 msgstr ""
 
 #. IDS_IMAGE_FILES_DIFF
-#: Merge.rc:5067
+#: Merge.rc:5066
 msgid "Image files are different"
 msgstr ""
 
 #. IDS_EXPR_DIFF
-#: Merge.rc:5068
+#: Merge.rc:5067
 #, c-format
 msgid "Files are different (expr: %1)"
 msgstr ""
 
 #. IDS_HASH_GROUP
-#: Merge.rc:5069
+#: Merge.rc:5068
 #, c-format
 msgid "Group%d"
 msgstr ""
 
 #. IDS_RENAME_MOVE_DETECTION_DISALBED
-#: Merge.rc:5070
+#: Merge.rc:5069
 msgctxt "Options dialog|Compare|Folder|Detect renames and moves"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_RENAME_MOVE_DETECTION_RENAME
-#: Merge.rc:5071
+#: Merge.rc:5070
 msgid "Detect renames"
 msgstr ""
 
 #. IDS_RENAME_MOVE_DETECTION_RENAME_MOVE
-#: Merge.rc:5072
+#: Merge.rc:5071
 msgid "Detect renames and moves"
 msgstr ""
 
 #. IDS_RENAME_MOVE_MERGE_MODE_RENAME
-#: Merge.rc:5073
+#: Merge.rc:5072
 msgid "Merge renames"
 msgstr ""
 
 #. IDS_RENAME_MOVE_MERGE_MODE_RENAME_MOVE
-#: Merge.rc:5074
+#: Merge.rc:5073
 msgid "Merge renames and moves"
 msgstr ""
 
 #. IDS_RENAMED
-#: Merge.rc:5075
+#: Merge.rc:5074
 msgid "Renamed"
 msgstr ""
 
 #. IDS_RENAMED_MOVED
-#: Merge.rc:5077
+#: Merge.rc:5076
 msgid "Renamed/Moved"
 msgstr ""
 
 #. IDS_RENAMED_MOVED_ITEMS
-#: Merge.rc:5078
+#: Merge.rc:5077
 #, c-format
 msgid "(%1 items)"
 msgstr ""
 
 #. IDS_RENAMED_MOVED_RESULT
-#: Merge.rc:5079
+#: Merge.rc:5078
 #, c-format
 msgid "%1 (set %2): "
 msgstr ""
 
 #. IDS_SWITCH_FLAT_MODE
-#: Merge.rc:5080
+#: Merge.rc:5079
 msgid "Some moved items have been merged.\nIn Tree Mode, these items may appear in positions that do not reflect the actual folder structure, which can be confusing.\nSwitch to Flat Mode?"
 msgstr ""
 
 #. IDS_ELAPSED_TIME
-#: Merge.rc:5086
+#: Merge.rc:5085
 #, c-format
 msgid "Elapsed time: %ld ms"
 msgstr "Uplynulý čas: %ld ms"
 
 #. IDS_STATUS_SELITEM1
-#: Merge.rc:5087
+#: Merge.rc:5086
 #, c-format
 msgid "1 item selected"
 msgstr "Vybrána 1 položka"
 
 #. IDS_STATUS_SELITEMS
-#: Merge.rc:5088
+#: Merge.rc:5087
 #, c-format
 msgid "%1 items selected"
 msgstr "Vybráno %1 položek"
 
 #. IDS_COLDESC_FILENAME
-#: Merge.rc:5094
+#: Merge.rc:5093
 #, c-format
 msgid "Filename or folder name."
 msgstr "Název souboru nebo složky"
 
 #. IDS_COLDESC_DIR
-#: Merge.rc:5095
+#: Merge.rc:5094
 #, c-format
 msgid "Subfolder name when subfolders are included."
 msgstr "Název podsložky, pokud jsou porovnávány i soubory v podsložkách"
 
 #. IDS_COLDESC_RESULT
-#: Merge.rc:5096
+#: Merge.rc:5095
 #, c-format
 msgid "Comparison result, long form."
 msgstr "Výsledek porovnání, dlouhý popis"
 
 #. IDS_COLDESC_LTIMEM
-#: Merge.rc:5101
+#: Merge.rc:5100
 #, c-format
 msgid "Left side modification date."
 msgstr "Datum změny souboru na levé straně"
 
 #. IDS_COLDESC_RTIMEM
-#: Merge.rc:5102
+#: Merge.rc:5101
 #, c-format
 msgid "Right side modification date."
 msgstr "Datum změny souboru na pravé straně"
 
 #. IDS_COLDESC_MTIMEM
-#: Merge.rc:5103
+#: Merge.rc:5102
 #, c-format
 msgid "Middle side modification date."
 msgstr ""
 
 #. IDS_COLDESC_EXTENSION
-#: Merge.rc:5104
+#: Merge.rc:5103
 #, c-format
 msgid "File's extension."
 msgstr "Přípona souboru"
 
 #. IDS_COLDESC_LSIZE
-#: Merge.rc:5105
+#: Merge.rc:5104
 #, c-format
 msgid "Left file size in bytes."
 msgstr "Velikost souboru na levé straně v bytech"
 
 #. IDS_COLDESC_RSIZE
-#: Merge.rc:5106
+#: Merge.rc:5105
 #, c-format
 msgid "Right file size in bytes."
 msgstr "Velikost souboru na pravé straně v bytech"
 
 #. IDS_COLDESC_MSIZE
-#: Merge.rc:5107
+#: Merge.rc:5106
 #, c-format
 msgid "Middle file size in bytes."
 msgstr ""
 
 #. IDS_COLDESC_LSIZE_SHORT
-#: Merge.rc:5108
+#: Merge.rc:5107
 #, c-format
 msgid "Left file size abbreviated."
 msgstr "Velikost souboru na levé straně zkráceně"
 
 #. IDS_COLDESC_RSIZE_SHORT
-#: Merge.rc:5109
+#: Merge.rc:5108
 #, c-format
 msgid "Right file size abbreviated."
 msgstr "Velikost souboru na pravé straně zkráceně"
 
 #. IDS_COLDESC_MSIZE_SHORT
-#: Merge.rc:5110
+#: Merge.rc:5109
 #, c-format
 msgid "Middle file size abbreviated."
 msgstr ""
 
 #. IDS_COLDESC_LTIMEC
-#: Merge.rc:5116
+#: Merge.rc:5115
 #, c-format
 msgid "Left side creation time."
 msgstr "Datum vytvoření souboru na levé straně"
 
 #. IDS_COLDESC_RTIMEC
-#: Merge.rc:5117
+#: Merge.rc:5116
 #, c-format
 msgid "Right side creation time."
 msgstr "Datum vytvoření souboru na pravé straně"
 
 #. IDS_COLDESC_MTIMEC
-#: Merge.rc:5118
+#: Merge.rc:5117
 #, c-format
 msgid "Middle side creation time."
 msgstr ""
 
 #. IDS_COLDESC_NEWER
-#: Merge.rc:5119
+#: Merge.rc:5118
 #, c-format
 msgid "Tells which side has newer modification date."
 msgstr "Ukáže, na které straně je novější datum změny"
 
 #. IDS_COLDESC_LVERSION
-#: Merge.rc:5120
+#: Merge.rc:5119
 msgid "Left side file version, only for some file types."
 msgstr "Verze souboru na levé straně, pouze pro některé typy souborů"
 
 #. IDS_COLDESC_RVERSION
-#: Merge.rc:5121
+#: Merge.rc:5120
 msgid "Right side file version, only for some file types."
 msgstr "Verze souboru na pravé straně, pouze pro některé typy souborů"
 
 #. IDS_COLDESC_MVERSION
-#: Merge.rc:5126
+#: Merge.rc:5125
 msgid "Middle side file version, only for some file types."
 msgstr ""
 
 #. IDS_COLDESC_RESULT_ABBR
-#: Merge.rc:5127
+#: Merge.rc:5126
 #, c-format
 msgid "Short comparison result."
 msgstr "Stručný výsledek porovnání"
 
 #. IDS_COLDESC_LATTRIBUTES
-#: Merge.rc:5128
+#: Merge.rc:5127
 #, c-format
 msgid "Left side attributes."
 msgstr "Atributy souboru na levé straně"
 
 #. IDS_COLDESC_RATTRIBUTES
-#: Merge.rc:5129
+#: Merge.rc:5128
 #, c-format
 msgid "Right side attributes."
 msgstr "Atributy souboru na pravé straně"
 
 #. IDS_COLDESC_MATTRIBUTES
-#: Merge.rc:5130
+#: Merge.rc:5129
 #, c-format
 msgid "Middle side attributes."
 msgstr ""
 
 #. IDS_COLDESC_LEOL_TYPE
-#: Merge.rc:5131
+#: Merge.rc:5130
 msgid "Left side file EOL type."
 msgstr "Typ konce řádků v souboru na levé straně."
 
 #. IDS_COLDESC_REOL_TYPE
-#: Merge.rc:5132
+#: Merge.rc:5131
 msgid "Right side file EOL type."
 msgstr "Typ konce řádků v souboru na pravé straně."
 
 #. IDS_COLDESC_MEOL_TYPE
-#: Merge.rc:5133
+#: Merge.rc:5132
 msgid "Middle side file EOL type."
 msgstr ""
 
 #. IDS_COLDESC_LENCODING
-#: Merge.rc:5139
+#: Merge.rc:5138
 #, c-format
 msgid "Left side encoding."
 msgstr "Kódování souboru na levé straně"
 
 #. IDS_COLDESC_RENCODING
-#: Merge.rc:5140
+#: Merge.rc:5139
 #, c-format
 msgid "Right side encoding."
 msgstr "Kódování souboru na pravé straně"
 
 #. IDS_COLDESC_MENCODING
-#: Merge.rc:5141
+#: Merge.rc:5140
 #, c-format
 msgid "Middle side encoding."
 msgstr ""
 
 #. IDS_COLDESC_NIDIFFS
-#: Merge.rc:5142
+#: Merge.rc:5141
 #, c-format
 msgid "Number of ignored differences in file. Ignored and cannot be merged."
 msgstr "Počet ignorovaných rozdílů v souboru. Tyto rozdíly nelze sloučit."
 
 #. IDS_COLDESC_NSDIFFS
-#: Merge.rc:5143
+#: Merge.rc:5142
 #, c-format
 msgid "Number of differences in file (excluding ignored)."
 msgstr "Počet rozdílů v souboru. Neobsahuje ignorované rozdíly."
 
 #. IDS_COLDESC_BINARY
-#: Merge.rc:5144
+#: Merge.rc:5143
 #, c-format
 msgid "Shows an asterisk (*) if the file is binary."
 msgstr "Ukáže hvězdičku (*), pokud je soubor binární"
 
 #. IDS_COLDESC_UNPACKER
-#: Merge.rc:5145
+#: Merge.rc:5144
 msgid "Unpacker plugin name or pipeline."
 msgstr ""
 
 #. IDS_COLDESC_PREDIFFER
-#: Merge.rc:5146
+#: Merge.rc:5145
 msgid "Prediffer plugin name or pipeline."
 msgstr ""
 
 #. IDS_DIRECTORY_REPORT_TITLE
-#: Merge.rc:5152
+#: Merge.rc:5151
 #, c-format
 msgid "Compare %1 with %2"
 msgstr "Porovnání %1 s %2"
 
 #. IDS_DIRECTORY_REPORT_TITLE3
-#: Merge.rc:5153
+#: Merge.rc:5152
 #, c-format
 msgid "Compare %1 with %2 and %3"
 msgstr ""
 
 #. IDS_REPORT_COMMALIST
-#: Merge.rc:5154
+#: Merge.rc:5153
 #, c-format
 msgid "Comma-separated list"
 msgstr "Seznam oddělený čárkami"
 
 #. IDS_REPORT_TABLIST
-#: Merge.rc:5155
+#: Merge.rc:5154
 #, c-format
 msgid "Tab-separated list"
 msgstr "Seznam oddělený tabelátory"
 
 #. IDS_REPORT_SIMPLEHTML
-#: Merge.rc:5156
+#: Merge.rc:5155
 #, c-format
 msgid "Simple HTML"
 msgstr "Soubor HTML"
 
 #. IDS_REPORT_SIMPLEXML
-#: Merge.rc:5157
+#: Merge.rc:5156
 #, c-format
 msgid "Simple XML"
 msgstr "Soubor XML"
 
-#: Merge.rc:5159
+#: Merge.rc:5158
 #, c-format
 msgid "Report file already exists. Overwrite?"
 msgstr "Soubor protokolu již existuje. Chcete ho přepsat?"
 
 #. IDS_REPORT_ERROR
-#: Merge.rc:5164
+#: Merge.rc:5163
 #, c-format
 msgid ""
 "Error creating the report:\n"
@@ -7727,123 +7721,123 @@ msgstr ""
 "%1"
 
 #. IDS_REPORT_SUCCESS
-#: Merge.rc:5165
+#: Merge.rc:5164
 #, c-format
 msgid "Report created successfully."
 msgstr "Protokol byl úspěšně vytvořen."
 
 #. IDS_SYNCPOINT_LASTBLOCK
-#: Merge.rc:5171
+#: Merge.rc:5170
 msgid "Cannot add a synchronization point at this line."
 msgstr ""
 
 #. IDS_FILE_TO_ITSELF
-#: Merge.rc:5177
+#: Merge.rc:5176
 #, c-format
 msgid "Same file is opened in both panes."
 msgstr "V obou panelech je otevřen stejný soubor."
 
 #. IDS_FILESSAME
-#: Merge.rc:5178
+#: Merge.rc:5177
 #, c-format
 msgid "Selected files are identical."
 msgstr "Vybrané soubory jsou shodné."
 
 #. IDS_FILESSAME_CURCFG
-#: Merge.rc:5179
+#: Merge.rc:5178
 msgid "Selected files are identical (with current settings).\r\nChecking binary identity..."
 msgstr ""
 
 #. IDS_FILESSAME_BINERROR
-#: Merge.rc:5180
+#: Merge.rc:5179
 msgid "Selected files are identical (with current settings).\r\nBut binary comparison failed."
 msgstr ""
 
 #. IDS_FILESSAME_BINSAME
-#: Merge.rc:5181
+#: Merge.rc:5180
 msgid "Selected files are identical (binary match)."
 msgstr ""
 
 #. IDS_FILESSAME_BINDIFF
-#: Merge.rc:5182
+#: Merge.rc:5181
 msgid "Selected files are identical (with current settings).\r\nBut differ at the binary level."
 msgstr ""
 
 #. IDS_FILEERROR
-#: Merge.rc:5183
+#: Merge.rc:5182
 #, c-format
 msgid "An error occurred while comparing files."
 msgstr "Během porovnání souborů se vyskytla chyba."
 
 #. IDS_TEMP_FILEERROR
-#: Merge.rc:5184
+#: Merge.rc:5183
 #, c-format
 msgid "Could not create temporary files. Check your temporary path settings."
 msgstr "Nelze vytvořit dočasné soubory. Zkontrolujte nastavení cesty k dočasným souborům."
 
 #. IDS_SUGGEST_IGNOREEOL
-#: Merge.rc:5185
+#: Merge.rc:5184
 msgid "Files use different EOL.\n\nTreat all EOL as equivalent?\n\nSet 'Ignore EOL differences (Windows/Unix/Mac)' in Compare section of Options."
 msgstr ""
 
 #. IDS_INVALID_DIRECTORY
-#: Merge.rc:5186
+#: Merge.rc:5185
 #, c-format
 msgid "Selected folder is invalid."
 msgstr "Zvolená složka je chybná."
 
 #. IDS_CANNOT_OPEN_BINARYFILE
-#: Merge.rc:5187
+#: Merge.rc:5186
 #, c-format
 msgid "Cannot open a binary file in Editor."
 msgstr "Binární soubor nelze otevřít pro úpravy."
 
 #. IDS_CREATE_PAIR_FOLDER
-#: Merge.rc:5188
+#: Merge.rc:5187
 #, c-format
 msgid "Create matching folder:\n%1\non the other side and open?"
 msgstr "Složka existuje pouze na jedné straně a nelze ji otevřít.\n\nChcete vytvořit odpovídající složku na druhé straně a otevřít ji?"
 
 #. IDS_CONFIRM_COPY_ALL_DIFFS
-#: Merge.rc:5189
+#: Merge.rc:5188
 msgid "Copy all differences to other file?"
 msgstr ""
 
 #. IDS_MOVE_TO_NEXTFILE
-#: Merge.rc:5194
+#: Merge.rc:5193
 #, c-format
 msgid "Move to next file?"
 msgstr ""
 
 #. IDS_MOVE_TO_PREVFILE
-#: Merge.rc:5195
+#: Merge.rc:5194
 #, c-format
 msgid "Move to previous file?"
 msgstr ""
 
 #. IDS_MOVE_TO_NEXTPAGE
-#: Merge.rc:5196
+#: Merge.rc:5195
 #, c-format
 msgid "Move to next page?"
 msgstr ""
 
 #. IDS_MOVE_TO_PREVPAGE
-#: Merge.rc:5197
+#: Merge.rc:5196
 #, c-format
 msgid "Move to previous page?"
 msgstr ""
 
 #. IDS_MOVE_TO_FIRSTFILE
-#: Merge.rc:5198
+#: Merge.rc:5197
 msgid "Move to first file?"
 msgstr ""
 
 #. IDS_MOVE_TO_LASTFILE
-#: Merge.rc:5199
+#: Merge.rc:5198
 msgid "Move to last file?"
 msgstr ""
 
-#: Merge.rc:5206
+#: Merge.rc:5205
 #, c-format
 msgid "Different codepages: left (cp%d), right (cp%d).\nDisplay in codepage (better display) or default Windows codepage (safer merging)?\n(Recommended: default Windows codepage)"
 msgstr ""
@@ -7851,153 +7845,153 @@ msgstr ""
 "Zobrazení každého souboru v jeho znakové stránce poskytne lepší náhled, ale slučování nebo kopírování bude nebezpečné.\n"
 "Chcete kódování u obou souborů upravit na výchozí znakovou stránku Windows (doporučeno)?"
 
-#: Merge.rc:5208
+#: Merge.rc:5207
 #, c-format
 msgid "Information lost due to encoding errors: both files"
 msgstr "Došlo ke ztrátě informací způsobené chybami kódování u obou souborů."
 
-#: Merge.rc:5210
+#: Merge.rc:5209
 #, c-format
 msgid "Information lost due to encoding errors: first file"
 msgstr ""
 
-#: Merge.rc:5212
+#: Merge.rc:5211
 #, c-format
 msgid "Information lost due to encoding errors: second file"
 msgstr ""
 
-#: Merge.rc:5214
+#: Merge.rc:5213
 #, c-format
 msgid "Information lost due to encoding errors: third file"
 msgstr ""
 
 #. IDS_LINEDIFF_NODIFF
-#: Merge.rc:5220
+#: Merge.rc:5219
 #, c-format
 msgid "No difference"
 msgstr "Žádný rozdíl"
 
 #. IDS_LINEDIFF_NODIFF_CAPTION
-#: Merge.rc:5221
+#: Merge.rc:5220
 #, c-format
 msgid "Line difference"
 msgstr "Rozdíl v řádku"
 
 #. IDS_NUM_REPLACED
-#: Merge.rc:5227
+#: Merge.rc:5226
 #, c-format
 msgid "Replaced %1 string(s)."
 msgstr "Nahrazeno %1 řetězců."
 
 #. IDS_EDIT_TEXT_NOT_FOUND
-#: Merge.rc:5228
+#: Merge.rc:5227
 #, c-format
 msgid "Cannot find string \"%s\"."
 msgstr "Nelze najít řetězec \"%s\"."
 
 #. IDS_MERGE_MODE
-#: Merge.rc:5234
+#: Merge.rc:5233
 msgid "Entering Merge Mode. Press F9 to turn off."
 msgstr ""
 
 #. IDS_AUTO_MERGE
-#: Merge.rc:5240
+#: Merge.rc:5239
 #, c-format
 msgid "Automatic merges: %1\nUnresolved conflicts: %2"
 msgstr ""
 
 #. IDS_CODEPAGE_MERGED
-#: Merge.rc:5241
+#: Merge.rc:5240
 msgid "Codepage change merged."
 msgstr ""
 
 #. IDS_CODEPAGE_CONFLICT
-#: Merge.rc:5242
+#: Merge.rc:5241
 msgid "Codepage changes are conflicting."
 msgstr ""
 
 #. IDS_EOL_MERGED
-#: Merge.rc:5243
+#: Merge.rc:5242
 msgid "EOL change merged."
 msgstr ""
 
 #. IDS_EOL_CONFLICT
-#: Merge.rc:5244
+#: Merge.rc:5243
 msgid "EOL changes are conflicting."
 msgstr ""
 
 #. IDS_LOCBAR_CAPTION
-#: Merge.rc:5250
+#: Merge.rc:5249
 #, c-format
 msgid "Location Pane"
 msgstr "Poloha"
 
 #. IDS_DIFFBAR_CAPTION
-#: Merge.rc:5251
+#: Merge.rc:5250
 #, c-format
 msgid "Diff Pane"
 msgstr "Rozdíly"
 
 #. IDS_DIFF_SUCCEEDED
-#: Merge.rc:5258
+#: Merge.rc:5257
 #, c-format
 msgid "Patch file written."
 msgstr "Opravný soubor byl úspěšně vytvořen."
 
 #. IDS_DIFF_FILEOVERWRITE
-#: Merge.rc:5259
+#: Merge.rc:5258
 #, c-format
 msgid "Patch file already exists. Overwrite?"
 msgstr "Opravný soubor již existuje. Chcete ho přepsat?"
 
 #. IDS_DIFF_SELECTEDFILES
-#: Merge.rc:5260
+#: Merge.rc:5259
 #, c-format
 msgid "[%1 files selected]"
 msgstr "[vybráno %1 souborů]"
 
 #. IDS_DIFF_NORMAL
-#: Merge.rc:5261
+#: Merge.rc:5260
 #, c-format
 msgid "Normal"
 msgstr ""
 
 #. IDS_DIFF_CONTEXT
-#: Merge.rc:5262
+#: Merge.rc:5261
 #, c-format
 msgid "Context"
 msgstr ""
 
 #. IDS_DIFF_UNIFIED
-#: Merge.rc:5263
+#: Merge.rc:5262
 #, c-format
 msgid "Unified"
 msgstr ""
 
 #. IDS_FILEWRITE_ERROR
-#: Merge.rc:5265
+#: Merge.rc:5264
 #, c-format
 msgid "Could not write to file %1."
 msgstr "Nelze zapisovat do souboru %1."
 
 #. IDS_PATH_NOT_ABSOLUTE
-#: Merge.rc:5266
+#: Merge.rc:5265
 #, c-format
 msgid "Output path is not absolute: %1"
 msgstr "Zadaná cesta pro výstup není cesta k souboru: %1"
 
 #. IDS_MUST_SPECIFY_OUTPUT
-#: Merge.rc:5267
+#: Merge.rc:5266
 msgid "Specify an output file."
 msgstr "Zadejte výstupní soubor."
 
-#: Merge.rc:5269
+#: Merge.rc:5268
 #, c-format
 msgid "Cannot create patch from binary files."
 msgstr "Nelze vytvořit opravný soubor z binárních souborů."
 
 #. IDS_SAVEFILES_FORPATCH
-#: Merge.rc:5270
+#: Merge.rc:5269
 #, c-format
 msgid ""
 "Save all files first.\n"
@@ -8009,23 +8003,23 @@ msgstr ""
 "Vytvoření opravného souboru vyžaduje, aby v souborech nebyly žádné neuložené změny."
 
 #. IDS_FOLDER_NOTEXIST
-#: Merge.rc:5271
+#: Merge.rc:5270
 #, c-format
 msgid "Folder does not exist."
 msgstr "Složka neexistuje."
 
 #. IDS_ARCHIVE_SUCCEEDED
-#: Merge.rc:5277
+#: Merge.rc:5276
 msgid "Archive file written."
 msgstr ""
 
 #. IDS_ARCHIVE_SAVEFILES
-#: Merge.rc:5278
+#: Merge.rc:5277
 msgid "Save all files first.\n\nCreating an archive requires no unsaved changes."
 msgstr ""
 
 #. IDS_NO_ZIP_SUPPORT
-#: Merge.rc:5283
+#: Merge.rc:5282
 msgid "Archive support not enabled.\n7-Zip and/or Merge7z*.dll not found.\nSee manual for archive support."
 msgstr ""
 "Podpora archivace není dostupná.\n"
@@ -8034,43 +8028,43 @@ msgstr ""
 "Podívejte se do uživatelské příručky, kde najdete další informace o podpoře archivace a jak ji zpřístupnit."
 
 #. IDS_OPT_EXPORT_CAPTION
-#: Merge.rc:5284
+#: Merge.rc:5283
 #, c-format
 msgid "Select file for export"
 msgstr "Uložit nastavení"
 
 #. IDS_OPT_IMPORT_CAPTION
-#: Merge.rc:5285
+#: Merge.rc:5284
 #, c-format
 msgid "Select file for import"
 msgstr "Načíst nastavení"
 
 #. IDS_OPT_IMPORT_DONE
-#: Merge.rc:5286
+#: Merge.rc:5285
 #, c-format
 msgid "Options imported from file."
 msgstr "Nastavení bylo načteno ze souboru."
 
 #. IDS_OPT_EXPORT_DONE
-#: Merge.rc:5287
+#: Merge.rc:5286
 #, c-format
 msgid "Options exported to file."
 msgstr "Nastavení bylo uloženo do souboru."
 
 #. IDS_OPT_IMPORT_ERR
-#: Merge.rc:5288
+#: Merge.rc:5287
 #, c-format
 msgid "Failed to import options from file."
 msgstr "Načtení nastavení ze souboru se nezdařilo."
 
 #. IDS_OPT_EXPORT_ERR
-#: Merge.rc:5289
+#: Merge.rc:5288
 #, c-format
 msgid "Failed to write options to file."
 msgstr "Uložení nastavení do souboru se nezdařilo."
 
 #. IDS_CLOSEALL_WINDOWS
-#: Merge.rc:5290
+#: Merge.rc:5289
 #, c-format
 msgid ""
 "Close multiple compare windows?\n"
@@ -8082,1209 +8076,1209 @@ msgstr ""
 "Chcete pokračovat?"
 
 #. IDS_EOL_BIN
-#: Merge.rc:5300
+#: Merge.rc:5299
 msgctxt "EOL Type"
 msgid "Binary"
 msgstr "Binární"
 
 #. IDS_MARKER_COLOR_FMT
-#: Merge.rc:5305
+#: Merge.rc:5304
 #, c-format
 msgid "Marker Color %d"
 msgstr ""
 
 #. IDS_MARKER_NEW_PATTERN
-#: Merge.rc:5306
+#: Merge.rc:5305
 msgid "New Pattern"
 msgstr ""
 
 #. IDS_PLUGINSLIST_TYPE
-#: Merge.rc:5312
+#: Merge.rc:5311
 #, c-format
 msgid "Type"
 msgstr "Typ"
 
 #. IDS_PLUGINS_TYPE_EDITSCRIPT
-#: Merge.rc:5316
+#: Merge.rc:5315
 #, c-format
 msgid "Editor script"
 msgstr ""
 
 #. ID_SELECTLINEDIFF
-#: Merge.rc:5322
+#: Merge.rc:5321
 #, c-format
 msgid "\nDifference in Current Line (F4)"
 msgstr ""
 
 #. ID_OPTIONS
-#: Merge.rc:5323
+#: Merge.rc:5322
 #, c-format
 msgid "\nOptions"
 msgstr ""
 
 #. ID_REFRESH
-#: Merge.rc:5324
+#: Merge.rc:5323
 #, c-format
 msgid "\nRefresh (F5)"
 msgstr ""
 
 #. ID_PREVDIFF
-#: Merge.rc:5330
+#: Merge.rc:5329
 #, c-format
 msgid "\nPrevious Difference (Alt+Up)"
 msgstr ""
 
 #. ID_NEXTDIFF
-#: Merge.rc:5331
+#: Merge.rc:5330
 #, c-format
 msgid "\nNext Difference (Alt+Down)"
 msgstr ""
 
 #. ID_PREVCONFLICT
-#: Merge.rc:5332
+#: Merge.rc:5331
 #, c-format
 msgid "\nPrevious Conflict (Alt+Shift+Up)"
 msgstr ""
 
 #. ID_NEXTCONFLICT
-#: Merge.rc:5333
+#: Merge.rc:5332
 #, c-format
 msgid "\nNext Conflict (Alt+Shift+Down)"
 msgstr ""
 
 #. ID_FIRSTDIFF
-#: Merge.rc:5338
+#: Merge.rc:5337
 #, c-format
 msgid "\nFirst Difference (Alt+Home)"
 msgstr ""
 
 #. ID_CURDIFF
-#: Merge.rc:5339
+#: Merge.rc:5338
 #, c-format
 msgid "\nCurrent Difference (Alt+Enter)"
 msgstr ""
 
 #. ID_LASTDIFF
-#: Merge.rc:5340
+#: Merge.rc:5339
 #, c-format
 msgid "\nLast Difference (Alt+End)"
 msgstr ""
 
 #. ID_L2R
-#: Merge.rc:5341
+#: Merge.rc:5340
 msgid "\nCopy to Right (Alt+Right)"
 msgstr ""
 
 #. ID_R2L
-#: Merge.rc:5342
+#: Merge.rc:5341
 msgid "\nCopy to Left (Alt+Left)"
 msgstr ""
 
 #. ID_L2RNEXT
-#: Merge.rc:5343
+#: Merge.rc:5342
 msgid "\nCopy to Right and Advance (Ctrl+Alt+Right)"
 msgstr ""
 
 #. ID_R2LNEXT
-#: Merge.rc:5344
+#: Merge.rc:5343
 msgid "\nCopy to Left and Advance (Ctrl+Alt+Left)"
 msgstr ""
 
 #. ID_ALL_RIGHT
-#: Merge.rc:5345
+#: Merge.rc:5344
 msgid "\nCopy All to Right"
 msgstr "\nKopírovat vše doprava"
 
 #. ID_ALL_LEFT
-#: Merge.rc:5346
+#: Merge.rc:5345
 msgid "\nCopy All to Left"
 msgstr "\nKopírovat vše doleva"
 
 #. ID_AUTO_MERGE
-#: Merge.rc:5347
+#: Merge.rc:5346
 #, c-format
 msgid "\nAuto Merge (Ctrl+Alt+M)"
 msgstr ""
 
 #. ID_FIRSTFILE
-#: Merge.rc:5348
+#: Merge.rc:5347
 msgid "\nFirst File"
 msgstr ""
 
 #. ID_NEXTFILE
-#: Merge.rc:5349
+#: Merge.rc:5348
 msgid "\nNext File (Ctrl+F8)"
 msgstr ""
 
 #. ID_LASTFILE
-#: Merge.rc:5350
+#: Merge.rc:5349
 msgid "\nLast File"
 msgstr ""
 
 #. ID_PREVFILE
-#: Merge.rc:5351
+#: Merge.rc:5350
 msgid "\nPrevious File (Ctrl+F7)"
 msgstr ""
 
 #. IDS_UNPACK_AUTO
-#: Merge.rc:5358
+#: Merge.rc:5357
 msgid "Adapted unpacker applied to both files (one needs extension)."
 msgstr "Přizpůsobený převaděč bude použit pro oba soubory (podle přípony jednoho ze souborů)."
 
 #. IDS_NO_PREDIFFER
-#: Merge.rc:5359
+#: Merge.rc:5358
 #, c-format
 msgid "No Prediffer (Normal)"
 msgstr ""
 
 #. IDS_SUGGESTED_PLUGINS
-#: Merge.rc:5360
+#: Merge.rc:5359
 #, c-format
 msgid "Suggested Plugins"
 msgstr "Navržené pluginy"
 
 #. IDS_NOT_SUGGESTED_PLUGINS
-#: Merge.rc:5361
+#: Merge.rc:5360
 msgid "All Plugins"
 msgstr ""
 
 #. IDS_PRIVATEBUILD_FMT
-#: Merge.rc:5367
+#: Merge.rc:5366
 #, c-format
 msgid "Private Build: %1"
 msgstr ""
 
 #. IDS_ALLRIGHTS_RESERVED
-#: Merge.rc:5368
+#: Merge.rc:5367
 msgid " - All rights reserved."
 msgstr ""
 
 #. IDS_TITLE_PLUGINS_SETTINGS
-#: Merge.rc:5374
+#: Merge.rc:5373
 #, c-format
 msgid "Plugin Settings"
 msgstr "Nastavení pluginů"
 
 #. IDS_NO_SCT_SCRIPTS
-#: Merge.rc:5376
+#: Merge.rc:5375
 #, c-format
 msgid "WSH not found - .sct scripts disabled"
 msgstr "Program Windows Script Host nebyl nalezen - skripty .sct jsou vypnuté"
 
 #. IDS_LOCBAR_GOTOLINE_FMT
-#: Merge.rc:5384
+#: Merge.rc:5383
 #, c-format
 msgid "G&o to Line %1"
 msgstr "&Přejít na řádek %1"
 
 #. IDS_GOTO_MOVED_LINE
-#: Merge.rc:5390
+#: Merge.rc:5389
 msgid "Go to Moved Line\tCtrl+Shift+G"
 msgstr ""
 
 #. IDS_AUTOCOMPLETE_DISABLED
-#: Merge.rc:5396
+#: Merge.rc:5395
 msgctxt "Options dialog|General|Open dialog Auto completion"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_AUTOCOMPLETE_FILE_SYS
-#: Merge.rc:5397
+#: Merge.rc:5396
 #, c-format
 msgid "From file system"
 msgstr "Systém souborů"
 
 #. IDS_AUTOCOMPLETE_MRU
-#: Merge.rc:5398
+#: Merge.rc:5397
 #, c-format
 msgid "From Most Recently Used list"
 msgstr "Naposledy použité"
 
 #. IDS_COLORSCHEME_PLAIN
-#: Merge.rc:5404
+#: Merge.rc:5403
 #, c-format
 msgid "No Highlighting"
 msgstr "Žádné zvýraznění"
 
 #. IDS_COLORSCHEME_PO
-#: Merge.rc:5439
+#: Merge.rc:5438
 #, c-format
 msgid "Portable Object"
 msgstr ""
 
 #. IDS_COLORSCHEME_RSRC
-#: Merge.rc:5444
+#: Merge.rc:5443
 #, c-format
 msgid "Resources"
 msgstr ""
 
 #. IDS_COLORSCHEME_SH
-#: Merge.rc:5448
+#: Merge.rc:5447
 #, c-format
 msgid "Shell"
 msgstr ""
 
 #. IDS_CLOSE_LEFT_TABS
-#: Merge.rc:5469
+#: Merge.rc:5468
 #, c-format
 msgid "Close &Left Tabs"
 msgstr ""
 
 #. IDS_CLOSE_RIGHT_TABS
-#: Merge.rc:5470
+#: Merge.rc:5469
 #, c-format
 msgid "Close R&ight Tabs"
 msgstr ""
 
 #. IDS_CLOSE_OTHER_TABS
-#: Merge.rc:5471
+#: Merge.rc:5470
 #, c-format
 msgid "Close &Other Tabs"
 msgstr ""
 
 #. IDS_TABBAR_AUTO_MAXWIDTH
-#: Merge.rc:5472
+#: Merge.rc:5471
 #, c-format
 msgid "Enable &Auto Max Width"
 msgstr ""
 
 #. IDS_WEBPAGE_MENU
-#: Merge.rc:5482
+#: Merge.rc:5481
 msgid "We&bpage"
 msgstr ""
 
 #. IDS_VIEW_WRAP_TEXT
-#: Merge.rc:5487
+#: Merge.rc:5486
 msgid "W&rap Text"
 msgstr ""
 
 #. IDS_NOTINSTALLED
-#: Merge.rc:5492
+#: Merge.rc:5491
 msgid "%1 is not installed."
 msgstr ""
 
 #. IDS_CREATE_FOLDER
-#: Merge.rc:5497
+#: Merge.rc:5496
 #, c-format
 msgid "%1 does not exist. Create it?"
 msgstr ""
 
 #. IDS_CREATE_FOLDER_ERROR
-#: Merge.rc:5498
+#: Merge.rc:5497
 #, c-format
 msgid "Failed to create folder."
 msgstr ""
 
 #. IDC_EXT_EDITOR_PATH
-#: Merge.rc:5503
+#: Merge.rc:5502
 #, c-format
 msgid "Parameters:\n$file: Current file path\n$linenum: Current cursor line number"
 msgstr ""
 
 #. IDS_DIFF_ALGORITHM_DEFAULT
-#: Merge.rc:5508
+#: Merge.rc:5507
 msgid "default"
 msgstr ""
 
 #. IDS_DIFF_ALGORITHM_MINIMAL
-#: Merge.rc:5509
+#: Merge.rc:5508
 msgid "minimal"
 msgstr ""
 
 #. IDS_DIFF_ALGORITHM_PATIENCE
-#: Merge.rc:5510
+#: Merge.rc:5509
 msgid "patience"
 msgstr ""
 
 #. IDS_DIFF_ALGORITHM_HISTOGRAM
-#: Merge.rc:5511
+#: Merge.rc:5510
 msgid "histogram"
 msgstr ""
 
 #. IDS_DIFF_ALGORITHM_NONE
-#: Merge.rc:5512
+#: Merge.rc:5511
 msgid "none"
 msgstr ""
 
 #. IDS_RENDERING_MODE_GDI
-#: Merge.rc:5517
+#: Merge.rc:5516
 msgid "GDI"
 msgstr ""
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_DEFAULT
-#: Merge.rc:5518
+#: Merge.rc:5517
 msgid "DirectWrite Default"
 msgstr ""
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_ALIASED
-#: Merge.rc:5519
+#: Merge.rc:5518
 msgid "DirectWrite Aliased"
 msgstr ""
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_GDI_CLASSIC
-#: Merge.rc:5520
+#: Merge.rc:5519
 msgid "DirectWrite GDI Classic"
 msgstr ""
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_GDI_NATURAL
-#: Merge.rc:5521
+#: Merge.rc:5520
 msgid "DirectWrite GDI Natural"
 msgstr ""
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_NATURAL
-#: Merge.rc:5522
+#: Merge.rc:5521
 msgid "DirectWrite Natural"
 msgstr ""
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_NATURAL_SYMMETRIC
-#: Merge.rc:5523
+#: Merge.rc:5522
 msgid "DirectWrite Natural Symmetric"
 msgstr ""
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_DISABLED
-#: Merge.rc:5528
+#: Merge.rc:5527
 msgctxt "Options dialog|General|Close windows with Esc"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_1
-#: Merge.rc:5529
+#: Merge.rc:5528
 msgid "MDI child window or main window"
 msgstr ""
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_2
-#: Merge.rc:5530
+#: Merge.rc:5529
 msgid "MDI child window only"
 msgstr ""
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_3
-#: Merge.rc:5531
+#: Merge.rc:5530
 msgid "Close main window if only one MDI child window"
 msgstr ""
 
 #. IDS_DIFF_GROUP
-#: Merge.rc:5536
+#: Merge.rc:5535
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Diff"
 msgstr ""
 
 #. IDS_DIFF_HIGHLIGHT
-#: Merge.rc:5537
+#: Merge.rc:5536
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Highlight"
 msgstr ""
 
 #. IDS_DIFF_BLINK
-#: Merge.rc:5538
+#: Merge.rc:5537
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Blink"
 msgstr ""
 
 #. IDS_DIFF_BLOCKSIZE
-#: Merge.rc:5539
+#: Merge.rc:5538
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Block Size"
 msgstr ""
 
 #. IDS_DIFF_BLOCKALPHA
-#: Merge.rc:5540
+#: Merge.rc:5539
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Block Alpha"
 msgstr ""
 
 #. IDS_DIFF_CDTHRESHOLD
-#: Merge.rc:5541
+#: Merge.rc:5540
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "CD Threshold"
 msgstr ""
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION
-#: Merge.rc:5542
+#: Merge.rc:5541
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Ins/Del Detection"
 msgstr ""
 
 #. IDS_OVERLAY_MODE_NONE
-#: Merge.rc:5543 Merge.rc:5548
+#: Merge.rc:5542 Merge.rc:5547
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "None"
 msgstr ""
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION_VERTICAL
-#: Merge.rc:5544
+#: Merge.rc:5543
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Vertical"
 msgstr ""
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION_HORIZONTAL
-#: Merge.rc:5545
+#: Merge.rc:5544
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Horizontal"
 msgstr ""
 
 #. IDS_OVERLAY_GROUP
-#: Merge.rc:5546
+#: Merge.rc:5545
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Overlay"
 msgstr ""
 
 #. IDS_OVERLAY_ALPHA
-#: Merge.rc:5547
+#: Merge.rc:5546
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha"
 msgstr ""
 
 #. IDS_OVERLAY_MODE_XOR
-#: Merge.rc:5549
+#: Merge.rc:5548
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "XOR"
 msgstr ""
 
 #. IDS_OVERLAY_MODE_ALPHA
-#: Merge.rc:5550
+#: Merge.rc:5549
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha Blend"
 msgstr ""
 
 #. IDS_OVERLAY_MODE_ALPHA_ANIMATION
-#: Merge.rc:5551
+#: Merge.rc:5550
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha Animation"
 msgstr ""
 
 #. IDS_ZOOM
-#: Merge.rc:5552
+#: Merge.rc:5551
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Zoom"
 msgstr ""
 
 #. IDS_PAGE
-#: Merge.rc:5553
+#: Merge.rc:5552
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Page:"
 msgstr ""
 
 #. IDS_IMGCMP_STATUS_PT_RGBA_FMT
-#: Merge.rc:5554
+#: Merge.rc:5553
 #, c-format
 msgid "Pt: (%d, %d)  RGBA: (%d, %d, %d, %d)  "
 msgstr ""
 
 #. IDS_IMGCMP_STATUS_DIST1_FMT
-#: Merge.rc:5555
+#: Merge.rc:5554
 #, c-format
 msgid "Dist: %g  "
 msgstr ""
 
 #. IDS_IMGCMP_STATUS_DIST2_FMT
-#: Merge.rc:5556
+#: Merge.rc:5555
 #, c-format
 msgid "Dist: %g, %g  "
 msgstr ""
 
 #. IDS_IMGCMP_STATUS_PAGE_ZOOM_SIZE_BPP_FMT
-#: Merge.rc:5557
+#: Merge.rc:5556
 #, c-format
 msgid "Page: %d/%d  Zoom: %d%%  %dx%dpx  %dbpp  "
 msgstr ""
 
 #. IDS_IMGCMP_STATUS_RC_FMT
-#: Merge.rc:5558
+#: Merge.rc:5557
 #, c-format
 msgid "Rc: (%d, %d)  "
 msgstr ""
 
 #. IDS_IMGCMP_STATUS_FLIPPED_FMT
-#: Merge.rc:5559
+#: Merge.rc:5558
 #, c-format
 msgid "Flipped: %s  "
 msgstr ""
 
 #. IDS_IMGCMP_STATUS_ROTATED_FMT
-#: Merge.rc:5560
+#: Merge.rc:5559
 #, c-format
 msgid "Rotated: %d  "
 msgstr ""
 
 #. IDS_IMGCMP_REPORT_ALLPAGES
-#: Merge.rc:5561
+#: Merge.rc:5560
 msgid "All pages"
 msgstr ""
 
 #. IDS_IGNSUB_STR1
-#: Merge.rc:5566
+#: Merge.rc:5565
 msgid "<Edit here>"
 msgstr ""
 
 #. IDS_IGNSUB_STR2
-#: Merge.rc:5567
+#: Merge.rc:5566
 msgid "No differences found to select"
 msgstr ""
 
 #. IDS_IGNSUB_STR3
-#: Merge.rc:5568
+#: Merge.rc:5567
 msgid "No differences found to add as substitution filter"
 msgstr ""
 
 #. IDS_IGNSUB_STR4
-#: Merge.rc:5569
+#: Merge.rc:5568
 msgid "The pair is already in the Substitution Filters list"
 msgstr ""
 
 #. IDS_IGNSUB_STR5
-#: Merge.rc:5570
+#: Merge.rc:5569
 msgid "Add this change to Substitution Filters?"
 msgstr ""
 
 #. IDS_OCRRESULT_TEXTONLY
-#: Merge.rc:5575
+#: Merge.rc:5574
 msgid "Text only"
 msgstr ""
 
 #. IDS_OCRRESULT_POS_LINE
-#: Merge.rc:5576
+#: Merge.rc:5575
 msgid "Line-by-line position and text"
 msgstr ""
 
 #. IDS_OCRRESULT_POS_WORD
-#: Merge.rc:5577
+#: Merge.rc:5576
 msgid "Word-by-word position and text"
 msgstr ""
 
 #. IDS_USERDATAFOLDER_APPDATA
-#: Merge.rc:5582
+#: Merge.rc:5581
 msgid "AppData (Roaming) folder"
 msgstr ""
 
 #. IDS_USERDATAFOLDER_INSTALL
-#: Merge.rc:5583
+#: Merge.rc:5582
 msgid "Install folder"
 msgstr ""
 
 #. IDS_USERDATAFOLDER_DOCUMENTS
-#: Merge.rc:5584
+#: Merge.rc:5583
 msgid "Documents folder"
 msgstr ""
 
 #. IDS_SINGLEINSTANCE_DISABLED
-#: Merge.rc:5589
+#: Merge.rc:5588
 msgctxt "Options dialog|General|Single instance mode"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_SINGLEINSTANCE_STR1
-#: Merge.rc:5590
+#: Merge.rc:5589
 #, c-format
 msgid "Allow only one instance to run"
 msgstr "Povolit pouze jedno hlavní okno aplikace"
 
 #. IDS_CLIPBOARD_HISTORY
-#: Merge.rc:5591
+#: Merge.rc:5590
 msgid "Clipboard &History"
 msgstr ""
 
 #. IDS_SINGLEINSTANCE_STR2
-#: Merge.rc:5592
+#: Merge.rc:5591
 msgid "Allow only one instance; wait for termination"
 msgstr ""
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_DISABLED
-#: Merge.rc:5597
+#: Merge.rc:5596
 msgctxt "Options dialog|General|Auto-reload modified files"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_STR1
-#: Merge.rc:5598
+#: Merge.rc:5597
 msgid "Only on window activated"
 msgstr ""
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_STR2
-#: Merge.rc:5599
+#: Merge.rc:5598
 msgid "Immediately"
 msgstr ""
 
 #. IDS_PLUGIN_ALL
-#: Merge.rc:5604
+#: Merge.rc:5603
 msgid "Al&l"
 msgstr ""
 
 #. IDS_PLUGIN_OTHERS
-#: Merge.rc:5605
+#: Merge.rc:5604
 msgid "&Others"
 msgstr ""
 
-#: Merge.rc:5607
+#: Merge.rc:5606
 #, c-format
 msgid "Missing plugin name in pipeline: %1"
 msgstr ""
 
-#: Merge.rc:5609
+#: Merge.rc:5608
 #, c-format
 msgid "Missing quote in plugin pipeline: %1"
 msgstr ""
 
 #. IDS_PLUGIN_NAME_ALREADY_EXISTS
-#: Merge.rc:5610
+#: Merge.rc:5609
 #, c-format
 msgid "Plugin name '%1' already exists."
 msgstr ""
 
 #. IDS_PLUGIN_TITLE1
-#: Merge.rc:5611
+#: Merge.rc:5610
 msgid "Specify plugin arguments"
 msgstr ""
 
-#: Merge.rc:5613
+#: Merge.rc:5612
 #, c-format
 msgid "Plugin not found or invalid: %1"
 msgstr ""
 
 #. IDS_PLUGIN_NOT_UNPACK
-#: Merge.rc:5614
+#: Merge.rc:5613
 #, c-format
 msgid "'%1' is not an unpacker plugin"
 msgstr ""
 
 #. IDS_PLUGIN_NOT_PREDIFF
-#: Merge.rc:5615
+#: Merge.rc:5614
 #, c-format
 msgid "'%1' is not a prediffer plugin"
 msgstr ""
 
-#: Merge.rc:5617
+#: Merge.rc:5616
 #, c-format
 msgid "Error prediffing '%1' with '%2'. Prediffing disabled."
 msgstr ""
 
 #. IDS_PLUGIN_CIRCULAR_REFERENCE
-#: Merge.rc:5618
+#: Merge.rc:5617
 #, c-format
 msgid "Circular reference in plugin pipeline: %1"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE1
-#: Merge.rc:5619
+#: Merge.rc:5618
 msgid "URL Handler"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE2
-#: Merge.rc:5620
+#: Merge.rc:5619
 msgid "File Unpacker"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE3
-#: Merge.rc:5621
+#: Merge.rc:5620
 msgid "File or Folder Unpacker"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE5
-#: Merge.rc:5623
+#: Merge.rc:5622
 msgid "Alias for Unpacker"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE6
-#: Merge.rc:5624
+#: Merge.rc:5623
 msgid "Alias for Prediffer"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE7
-#: Merge.rc:5625
+#: Merge.rc:5624
 msgid "Alias for Editor script"
 msgstr ""
 
 #. IDS_PLUGIN_ALIAS_DESC
-#: Merge.rc:5626
+#: Merge.rc:5625
 #, c-format
 msgid "Alias for plugin pipeline '%1'"
 msgstr ""
 
 #. IDS_PLUGIN_NEW_DESC
-#: Merge.rc:5627
+#: Merge.rc:5626
 msgid "New plugin description"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_ALL
-#: Merge.rc:5628
+#: Merge.rc:5627
 msgid "All"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_1ST
-#: Merge.rc:5629
+#: Merge.rc:5628
 msgid "1st"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_2ND
-#: Merge.rc:5630
+#: Merge.rc:5629
 msgid "2nd"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_3RD
-#: Merge.rc:5631
+#: Merge.rc:5630
 msgid "3rd"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_1ST_2ND
-#: Merge.rc:5632
+#: Merge.rc:5631
 msgid "1st and 2nd"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_1ST_3RD
-#: Merge.rc:5633
+#: Merge.rc:5632
 msgid "1st and 3rd"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_2ND_3RD
-#: Merge.rc:5634
+#: Merge.rc:5633
 msgid "2nd and 3rd"
 msgstr ""
 
 #. IDS_PLUGIN_CTRL_CLICK
-#: Merge.rc:5635
+#: Merge.rc:5634
 msgid "(Ctrl+Click to add to pipeline)"
 msgstr ""
 
 #. IDS_FILTER_APPLIED
-#: Merge.rc:5640
+#: Merge.rc:5639
 msgid "Filter applied"
 msgstr ""
 
 #. IDS_FILTERMENU_COMPARE
-#: Merge.rc:5645
+#: Merge.rc:5644
 #, c-format
 msgid "Compare %1"
 msgstr ""
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN2
-#: Merge.rc:5647
+#: Merge.rc:5646
 msgid "&Filter by This Column..."
 msgstr ""
 
 #. IDS_CLIPBOARDHISTORY_TIME
-#: Merge.rc:5652
+#: Merge.rc:5651
 #, c-format
 msgid "Clipboard at %s"
 msgstr ""
 
 #. IDS_CLIPBOARDHISTORY_DISABLED
-#: Merge.rc:5653
+#: Merge.rc:5652
 msgid "Clipboard history disabled.\r\nEnable: Windows logo key + V, then Turn on."
 msgstr ""
 
-#: Merge.rc:5655
+#: Merge.rc:5654
 msgid "This system does not support clipboard history."
 msgstr ""
 
-#: Merge.rc:5657
+#: Merge.rc:5656
 msgid "32-bit WinMerge does not support Clipboard Compare"
 msgstr ""
 
 #. IDS_WEBVIEW2_RUNTIME_NOT_INSTALLED
-#: Merge.rc:5662
+#: Merge.rc:5661
 msgid "WebView2 runtime not installed. Download it?"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_TEXT_COMPARE
-#: Merge.rc:5667
+#: Merge.rc:5666
 msgid "New Text Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_TABLE_COMPARE
-#: Merge.rc:5668
+#: Merge.rc:5667
 msgid "New Table Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_BINARY_COMPARE
-#: Merge.rc:5669
+#: Merge.rc:5668
 msgid "New Binary Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_IMAGE_COMPARE
-#: Merge.rc:5670
+#: Merge.rc:5669
 msgid "New Image Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_WEBPAGE_COMPARE
-#: Merge.rc:5671
+#: Merge.rc:5670
 msgid "New Webpage Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_FOLDER_COMPARE
-#: Merge.rc:5672
+#: Merge.rc:5671
 msgid "New Folder Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_CLIPBOARD_COMPARE
-#: Merge.rc:5673
+#: Merge.rc:5672
 msgid "Clipboard Compare"
 msgstr ""
 
 #. IDS_PREVIEWBAR_PRINT
-#: Merge.rc:5678
+#: Merge.rc:5677
 msgid "&Print..."
 msgstr ""
 
 #. IDS_PREVIEWBAR_PREVPAGE
-#: Merge.rc:5680
+#: Merge.rc:5679
 msgid "Pre&v Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_TWOPAGE
-#: Merge.rc:5681
+#: Merge.rc:5680
 msgid "&Two Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_ONEPAGE
-#: Merge.rc:5682
+#: Merge.rc:5681
 msgid "&One Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_ZOOMIN
-#: Merge.rc:5683
+#: Merge.rc:5682
 msgid "Zoom &In"
 msgstr ""
 
 #. IDS_PREVIEWBAR_ZOOMOUT
-#: Merge.rc:5684
+#: Merge.rc:5683
 msgid "Zoom &Out"
 msgstr ""
 
 #. IDS_WEBPAGE_COMPARING
-#: Merge.rc:5690
+#: Merge.rc:5689
 msgid "Comparing..."
 msgstr ""
 
 #. IDS_WEBPAGE_ZOOM
-#: Merge.rc:5691
+#: Merge.rc:5690
 msgid "Zoom:"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_DIFFHUNK
-#: Merge.rc:5696
+#: Merge.rc:5695
 msgid "Diff hunk"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_INLINE
-#: Merge.rc:5697
+#: Merge.rc:5696
 msgid "Inline diff"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_LINE
-#: Merge.rc:5698
+#: Merge.rc:5697
 msgid "Line"
 msgstr ""
 
-#: Merge.rc:5699
+#: Merge.rc:5698
 msgid "Character"
 msgstr ""
 
 #. ID_MICE_PREVDIFF
-#: Merge.rc:5704
+#: Merge.rc:5703
 msgid "\nPrevious Difference (Alt+Up)\n(Right Button+Wheel Up)\n(Alt+Wheel Up)"
 msgstr ""
 
 #. ID_MICE_NEXTDIFF
-#: Merge.rc:5705
+#: Merge.rc:5704
 msgid "\nNext Difference (Alt+Down)\n(Right Button+Wheel Down)\n(Alt+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_L2R
-#: Merge.rc:5706
+#: Merge.rc:5705
 msgid "\nCopy to Right (Alt+Right)\n(Right Button+Wheel Right)\n(Alt+Wheel Right)\n(Alt+Shift+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_R2L
-#: Merge.rc:5707
+#: Merge.rc:5706
 msgid "\nCopy to Left (Alt+Left)\n(Right Button+Wheel Left)\n(Alt+Wheel Left)\n(Alt+Shift+Wheel Up)"
 msgstr ""
 
 #. ID_MICE_L2RNEXT
-#: Merge.rc:5708
+#: Merge.rc:5707
 msgid "\nCopy to Right and Advance (Ctrl+Alt+Right)\n(Ctrl+Alt+Wheel Right)\n(Ctrl+Alt+Shift+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_R2LNEXT
-#: Merge.rc:5709
+#: Merge.rc:5708
 msgid "\nCopy to Left and Advance (Ctrl+Alt+Left)\n(Ctrl+Alt+Wheel Left)\n(Ctrl+Alt+Shift+Wheel Up)"
 msgstr ""
 
 #. IDS_LOG_COMPARING_2
-#: Merge.rc:5719
+#: Merge.rc:5718
 #, c-format
 msgid "Comparing %1 with %2"
 msgstr ""
 
 #. IDS_LOG_COMPARING_3
-#: Merge.rc:5720
+#: Merge.rc:5719
 #, c-format
 msgid "Comparing %1 with %2 and %3"
 msgstr ""
 
 #. IDS_LOG_COMPARE_COMPLETED
-#: Merge.rc:5721
+#: Merge.rc:5720
 msgid "Comparison completed"
 msgstr ""
 
 #. IDS_LOG_COMPARE_ERROR_2
-#: Merge.rc:5722
+#: Merge.rc:5721
 #, c-format
 msgid "Failed to compare %1 with %2: "
 msgstr ""
 
 #. IDS_LOG_COMPARE_ERROR_3
-#: Merge.rc:5723
+#: Merge.rc:5722
 #, c-format
 msgid "Failed to compare %1 with %2 and %3: "
 msgstr ""
 
 #. IDS_LOG_FILE_SAVED
-#: Merge.rc:5724
+#: Merge.rc:5723
 msgid "File saved"
 msgstr ""
 
 #. IDS_LOG_COPYING_FILES
-#: Merge.rc:5725
+#: Merge.rc:5724
 msgid "Copying files..."
 msgstr ""
 
 #. IDS_LOG_MOVING_FILES
-#: Merge.rc:5726
+#: Merge.rc:5725
 msgid "Moving files..."
 msgstr ""
 
 #. IDS_LOG_DELETING_FILES
-#: Merge.rc:5727
+#: Merge.rc:5726
 msgid "Deleting files..."
 msgstr ""
 
 #. IDS_LOG_RECYCLEBIN
-#: Merge.rc:5728
+#: Merge.rc:5727
 msgid "Recycle Bin"
 msgstr ""
 
 #. IDS_LOG_PERMANENTLY_DELETED
-#: Merge.rc:5729
+#: Merge.rc:5728
 msgid "Permanently deleted"
 msgstr ""
 
 #. IDS_LOG_FILEOPERATION_COMPLETED
-#: Merge.rc:5730
+#: Merge.rc:5729
 msgid "File operation completed successfully"
 msgstr ""
 
 #. IDS_LOG_FILEOPERATION_CANCELED
-#: Merge.rc:5731
+#: Merge.rc:5730
 msgid "File operation canceled"
 msgstr ""
 
 #. IDS_FILTER_ERROR_NO_ERROR
-#: Merge.rc:5736
+#: Merge.rc:5735
 msgid "No error"
 msgstr ""
 
 #. IDS_FILTER_ERROR_EMPTY_EXPRESSION
-#: Merge.rc:5737
+#: Merge.rc:5736
 msgid "Filter expression is empty"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNKNOWN_CHAR
-#: Merge.rc:5738
+#: Merge.rc:5737
 msgid "Unknown character in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNTERMINATED_STRING
-#: Merge.rc:5739
+#: Merge.rc:5738
 msgid "Unterminated string literal"
 msgstr ""
 
 #. IDS_FILTER_ERROR_SYNTAX_ERROR
-#: Merge.rc:5740
+#: Merge.rc:5739
 msgid "Syntax error in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_PARSE_FAILURE
-#: Merge.rc:5741
+#: Merge.rc:5740
 msgid "Failed to parse filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_LITERAL
-#: Merge.rc:5742
+#: Merge.rc:5741
 msgid "Invalid literal value"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_REGULAR_EXPRESSION
-#: Merge.rc:5743
+#: Merge.rc:5742
 msgid "Invalid regular expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNDEFINED_IDENTIFIER
-#: Merge.rc:5744
+#: Merge.rc:5743
 msgid "Undefined identifier"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_ARGUMENT_COUNT
-#: Merge.rc:5745
+#: Merge.rc:5744
 msgid "Invalid number of arguments"
 msgstr ""
 
 #. IDS_FILTER_ERROR_FILTER_NAME_NOT_FOUND
-#: Merge.rc:5746
+#: Merge.rc:5745
 msgid "Filter name not found"
 msgstr ""
 
 #. IDS_FILTER_ERROR_DIVIDE_BY_ZERO
-#: Merge.rc:5747
+#: Merge.rc:5746
 msgid "Division by zero in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNKNOWN_ERROR
-#: Merge.rc:5748
+#: Merge.rc:5747
 msgid "Unknown error"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_PROPERTY_NAME
-#: Merge.rc:5749
+#: Merge.rc:5748
 msgid "Invalid property name"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_DIRECTIVE
-#: Merge.rc:5750
+#: Merge.rc:5749
 msgid "Invalid directive"
 msgstr ""
 
 #. IDS_FILTER_OP_EQUALS
-#: Merge.rc:5755
+#: Merge.rc:5754
 msgid "Equals"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_EQUALS
-#: Merge.rc:5756
+#: Merge.rc:5755
 msgid "Does not equal"
 msgstr ""
 
 #. IDS_FILTER_OP_LESS_THAN
-#: Merge.rc:5757
+#: Merge.rc:5756
 msgid "Less than"
 msgstr ""
 
 #. IDS_FILTER_OP_LESS_EQUAL
-#: Merge.rc:5758
+#: Merge.rc:5757
 msgid "Less than or equal to"
 msgstr ""
 
 #. IDS_FILTER_OP_GREATER_EQUAL
-#: Merge.rc:5759
+#: Merge.rc:5758
 msgid "Greater than or equal to"
 msgstr ""
 
 #. IDS_FILTER_OP_GREATER_THAN
-#: Merge.rc:5760
+#: Merge.rc:5759
 msgid "Greater than"
 msgstr ""
 
 #. IDS_FILTER_OP_BETWEEN
-#: Merge.rc:5761
+#: Merge.rc:5760
 msgid "Between"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_BETWEEN
-#: Merge.rc:5762
+#: Merge.rc:5761
 msgid "Not Between"
 msgstr ""
 
 #. IDS_FILTER_OP_CONTAINS
-#: Merge.rc:5763
+#: Merge.rc:5762
 msgid "Contains"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_CONTAINS
-#: Merge.rc:5764
+#: Merge.rc:5763
 msgid "Not Contains"
 msgstr ""
 
 #. IDS_FILTER_OP_RECONTAINS
-#: Merge.rc:5765
+#: Merge.rc:5764
 msgid "Contains (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_RECONTAINS
-#: Merge.rc:5766
+#: Merge.rc:5765
 msgid "Not Contains (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_LIKE
-#: Merge.rc:5767
+#: Merge.rc:5766
 msgid "Match (wildcard)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_LIKE
-#: Merge.rc:5768
+#: Merge.rc:5767
 msgid "Not match (wildcard)"
 msgstr ""
 
 #. IDS_FILTER_OP_MATCHES
-#: Merge.rc:5769
+#: Merge.rc:5768
 msgid "Match (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_MATCHES
-#: Merge.rc:5770
+#: Merge.rc:5769
 msgid "Not match (regex)"
 msgstr ""
 
 #. IDS_COLORMODE_LIGHT
-#: Merge.rc:5775
+#: Merge.rc:5774
 msgid "Light"
 msgstr ""
 
 #. IDS_COLORMODE_DARK
-#: Merge.rc:5776
+#: Merge.rc:5775
 msgid "Dark"
 msgstr ""
 
 #. IDS_COLORMODE_FOLLOWSYSTEM
-#: Merge.rc:5777
+#: Merge.rc:5776
 msgid "Follow system"
 msgstr ""
 
 #. IDS_EXAMPLE
-#: Merge.rc:5782
+#: Merge.rc:5781
 #, c-format
 msgid "e.g. %1"
 msgstr ""
 
 #. IDS_DETECTED_PREVIOUS_CRASH
-#: Merge.rc:5787
+#: Merge.rc:5786
 msgid "WinMerge detected a previous crash. Please report this if possible."
 msgstr ""
 
 #. IDS_REGEX_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5792
+#: Merge.rc:5791
 msgid "# Regex replacement list\r\n# Format: regex<TAB>replacement\r\n# Backreferences like $1, $2 are supported\r\n\r\n(\\d{4})-(\\d{2})-(\\d{2})\t$1_$2_$3\r\n"
 msgstr ""
 
 #. IDS_STRING_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5793
+#: Merge.rc:5792
 msgid "# Replacement list\r\n# Format: search<TAB>replacement\r\n# Lines starting with # are ignored\r\n\r\nfrom1\tto1\r\nfrom2\tto2\r\n"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_ONLY
-#: Merge.rc:5798
+#: Merge.rc:5797
 msgid "Built-in only"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_FIRST
-#: Merge.rc:5799
+#: Merge.rc:5798
 msgid "Built-in first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_FIRST
-#: Merge.rc:5800
+#: Merge.rc:5799
 msgid "Tree-sitter first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_ONLY
-#: Merge.rc:5801
+#: Merge.rc:5800
 msgid "Tree-sitter only"
 msgstr ""
 

--- a/Translations/WinMerge/Danish.po
+++ b/Translations/WinMerge/Danish.po
@@ -22,7 +22,7 @@ msgstr ""
 "X-Generator: Poedit 1.5.4\n"
 
 #. LANGUAGE, SUBLANGUAGE
-#: Merge.rc:26 Merge.rc:59 Merge.rc:5818
+#: Merge.rc:26 Merge.rc:59 Merge.rc:5817
 #, c-format
 msgid "LANG_ENGLISH, SUBLANG_ENGLISH_US"
 msgstr "LANG_DANISH, SUBLANG_DEFAULT"
@@ -172,7 +172,7 @@ msgstr "&Scripts"
 #. IDS_NO_EDIT_SCRIPTS
 #: Merge.rc:127 Merge.rc:352 Merge.rc:463 Merge.rc:673 Merge.rc:678
 #: Merge.rc:887 Merge.rc:899 Merge.rc:906 Merge.rc:963 Merge.rc:1210
-#: Merge.rc:5375
+#: Merge.rc:5374
 #, c-format
 msgid "< Empty >"
 msgstr "< Tom >"
@@ -239,7 +239,7 @@ msgid "Auto-Fit All Columns"
 msgstr ""
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN
-#: Merge.rc:153 Merge.rc:5646
+#: Merge.rc:153 Merge.rc:5645
 msgid "&Filter by This Column"
 msgstr ""
 
@@ -305,7 +305,7 @@ msgid "&Previous Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_NEXTPAGE
-#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5679
+#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5678
 #, c-format
 msgid "&Next Page"
 msgstr ""
@@ -573,7 +573,7 @@ msgstr "&Binær"
 #. IDS_IMAGE_MENU
 #: Merge.rc:329 Merge.rc:338 Merge.rc:432 Merge.rc:441 Merge.rc:609
 #: Merge.rc:618 Merge.rc:670 Merge.rc:960 Merge.rc:1187 Merge.rc:1200
-#: Merge.rc:5477
+#: Merge.rc:5476
 #, c-format
 msgid "&Image"
 msgstr ""
@@ -711,7 +711,7 @@ msgid "&Huge"
 msgstr ""
 
 #. IDS_VIEW_MENU_BAR
-#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5714
+#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5713
 msgid "Men&u Bar"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgid "Lo&cation Pane"
 msgstr "V&ertikalt panel"
 
 #. IDS_OUTPUTBAR_CAPTION
-#: Merge.rc:782 Merge.rc:5252
+#: Merge.rc:782 Merge.rc:5251
 msgid "Output Pane"
 msgstr ""
 
@@ -1770,55 +1770,55 @@ msgid "Co&mpare As"
 msgstr "Sa&mmenlign som"
 
 #. IDS_COPY_LEFT_TO_MIDDLE2
-#: Merge.rc:968 Merge.rc:980 Merge.rc:4852
+#: Merge.rc:968 Merge.rc:980 Merge.rc:4851
 #, c-format
 msgid "Left to Middle (%1 of %2)"
 msgstr ""
 
 #. IDS_COPY_LEFT_TO_RIGHT2
-#: Merge.rc:969 Merge.rc:981 Merge.rc:4851
+#: Merge.rc:969 Merge.rc:981 Merge.rc:4850
 #, c-format
 msgid "Left to Right (%1 of %2)"
 msgstr "Venstre til højre (%1 af %2)"
 
 #. IDS_MOVE_LEFT_TO2
-#: Merge.rc:970 Merge.rc:982 Merge.rc:1045 Merge.rc:4863 Merge.rc:4892
+#: Merge.rc:970 Merge.rc:982 Merge.rc:1045 Merge.rc:4862 Merge.rc:4891
 #, c-format
 msgid "Left to... (%1 of %2)"
 msgstr "Venstre til... (%1 af %2)"
 
 #. IDS_COPY_MIDDLE_TO_LEFT2
-#: Merge.rc:971 Merge.rc:983 Merge.rc:4849
+#: Merge.rc:971 Merge.rc:983 Merge.rc:4848
 #, c-format
 msgid "Middle to Left (%1 of %2)"
 msgstr ""
 
 #. IDS_COPY_MIDDLE_TO_RIGHT2
-#: Merge.rc:972 Merge.rc:984 Merge.rc:4850
+#: Merge.rc:972 Merge.rc:984 Merge.rc:4849
 #, c-format
 msgid "Middle to Right (%1 of %2)"
 msgstr ""
 
 #. IDS_MOVE_MIDDLE_TO2
-#: Merge.rc:973 Merge.rc:985 Merge.rc:1046 Merge.rc:4864 Merge.rc:4893
+#: Merge.rc:973 Merge.rc:985 Merge.rc:1046 Merge.rc:4863 Merge.rc:4892
 #, c-format
 msgid "Middle to... (%1 of %2)"
 msgstr ""
 
 #. IDS_COPY_RIGHT_TO_MIDDLE2
-#: Merge.rc:974 Merge.rc:986 Merge.rc:4848
+#: Merge.rc:974 Merge.rc:986 Merge.rc:4847
 #, c-format
 msgid "Right to Middle (%1 of %2)"
 msgstr ""
 
 #. IDS_COPY_RIGHT_TO_LEFT2
-#: Merge.rc:975 Merge.rc:987 Merge.rc:4847
+#: Merge.rc:975 Merge.rc:987 Merge.rc:4846
 #, c-format
 msgid "Right to Left (%1 of %2)"
 msgstr "Højre til venstre (%1 af %2)"
 
 #. IDS_MOVE_RIGHT_TO2
-#: Merge.rc:976 Merge.rc:988 Merge.rc:1047 Merge.rc:4865 Merge.rc:4894
+#: Merge.rc:976 Merge.rc:988 Merge.rc:1047 Merge.rc:4864 Merge.rc:4893
 #, c-format
 msgid "Right to... (%1 of %2)"
 msgstr "Højre til... (%1 af %2)"
@@ -1884,31 +1884,31 @@ msgid "Cop&y Paths"
 msgstr "K&opier stinavne"
 
 #. IDS_DEL_LEFT_FMT2
-#: Merge.rc:1026 Merge.rc:1035 Merge.rc:4880
+#: Merge.rc:1026 Merge.rc:1035 Merge.rc:4879
 #, c-format
 msgid "Left (%1 of %2)"
 msgstr "Venstre (%1 af %2)"
 
 #. IDS_DEL_MIDDLE_FMT2
-#: Merge.rc:1027 Merge.rc:1036 Merge.rc:4881
+#: Merge.rc:1027 Merge.rc:1036 Merge.rc:4880
 #, c-format
 msgid "Middle (%1 of %2)"
 msgstr ""
 
 #. IDS_DEL_RIGHT_FMT2
-#: Merge.rc:1028 Merge.rc:1037 Merge.rc:4882
+#: Merge.rc:1028 Merge.rc:1037 Merge.rc:4881
 #, c-format
 msgid "Right (%1 of %2)"
 msgstr "Højre (%1 af %2)"
 
 #. IDS_DEL_BOTH_FMT2
-#: Merge.rc:1029 Merge.rc:1038 Merge.rc:4883
+#: Merge.rc:1029 Merge.rc:1038 Merge.rc:4882
 #, c-format
 msgid "Both (%1 of %2)"
 msgstr "Begge (%1 af %2)"
 
 #. IDS_DEL_ALL_FMT2
-#: Merge.rc:1030 Merge.rc:1039 Merge.rc:4888
+#: Merge.rc:1030 Merge.rc:1039 Merge.rc:4887
 #, c-format
 msgid "All (%1 of %2)"
 msgstr ""
@@ -1937,19 +1937,19 @@ msgid "&Zip"
 msgstr "&Zip"
 
 #. IDS_COPY_BOTH_TO2
-#: Merge.rc:1048 Merge.rc:4866
+#: Merge.rc:1048 Merge.rc:4865
 #, c-format
 msgid "Both to... (%1 of %2)"
 msgstr ""
 
 #. IDS_COPY_ALL_TO2
-#: Merge.rc:1049 Merge.rc:4867
+#: Merge.rc:1049 Merge.rc:4866
 #, c-format
 msgid "All to... (%1 of %2)"
 msgstr ""
 
 #. IDS_COPY_DIFFERENCES_TO2
-#: Merge.rc:1050 Merge.rc:4868
+#: Merge.rc:1050 Merge.rc:4867
 #, c-format
 msgid "Differences to... (%1 of %2)"
 msgstr ""
@@ -2022,13 +2022,13 @@ msgstr ""
 
 #. IDS_USERCHOICE_NONE
 #: Merge.rc:1088 Merge.rc:1094 Merge.rc:1836 Merge.rc:1840 Merge.rc:2031
-#: Merge.rc:2035 Merge.rc:5377
+#: Merge.rc:2035 Merge.rc:5376
 #, c-format
 msgid "<None>"
 msgstr "<Ingen>"
 
 #. IDS_USERCHOICE_AUTOMATIC
-#: Merge.rc:1089 Merge.rc:1095 Merge.rc:5378
+#: Merge.rc:1089 Merge.rc:1095 Merge.rc:5377
 #, c-format
 msgid "<Automatic>"
 msgstr "<Automatisk>"
@@ -2980,13 +2980,13 @@ msgid "Text files only"
 msgstr ""
 
 #. IDS_EOL_NONE
-#: Merge.rc:1667 Merge.rc:1918 Merge.rc:5304
+#: Merge.rc:1667 Merge.rc:1918 Merge.rc:5303
 #, c-format
 msgid "None"
 msgstr "Ingen"
 
 #. IDS_EOL_MIXED
-#: Merge.rc:1668 Merge.rc:5299
+#: Merge.rc:1668 Merge.rc:5298
 #, c-format
 msgid "Mixed"
 msgstr "Mixed"
@@ -3260,14 +3260,14 @@ msgstr ""
 
 #. IDS_DIFFERENT
 #: Merge.rc:1904 Merge.rc:1988 Merge.rc:2866 Merge.rc:3036 Merge.rc:3077
-#: Merge.rc:5058
+#: Merge.rc:5057
 #, c-format
 msgid "Different"
 msgstr "Forskellige"
 
 #. IDS_IDENTICAL
 #: Merge.rc:1905 Merge.rc:1989 Merge.rc:2865 Merge.rc:3055 Merge.rc:3116
-#: Merge.rc:5048
+#: Merge.rc:5047
 #, c-format
 msgid "Identical"
 msgstr "Identiske"
@@ -3288,7 +3288,7 @@ msgid "Missing"
 msgstr ""
 
 #. IDS_MOVED
-#: Merge.rc:1910 Merge.rc:5076
+#: Merge.rc:1910 Merge.rc:5075
 msgid "Moved"
 msgstr ""
 
@@ -4116,7 +4116,7 @@ msgid "&Use custom system colors"
 msgstr ""
 
 #. IDS_PRPCAT_SYSTEM
-#: Merge.rc:2565 Merge.rc:4559 Merge.rc:4560 Merge.rc:5007
+#: Merge.rc:2565 Merge.rc:4559 Merge.rc:4560 Merge.rc:5006
 #, c-format
 msgid "System"
 msgstr "System"
@@ -4569,7 +4569,7 @@ msgid "Items compared:"
 msgstr "Emner sammenlignet:"
 
 #. IDS_PREVIEWBAR_CLOSE
-#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5685
+#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5684
 #, c-format
 msgid "&Close"
 msgstr "&Luk"
@@ -5258,7 +5258,7 @@ msgid "A&ppend timestamp"
 msgstr "T&ilføj tidsstempel"
 
 #. IDS_CONFIRM_COPY_CAPTION
-#: Merge.rc:3214 Merge.rc:4915
+#: Merge.rc:3214 Merge.rc:4914
 #, c-format
 msgid "Confirm Copy"
 msgstr "Bekræft kopi"
@@ -5519,7 +5519,7 @@ msgid "&Character Set..."
 msgstr ""
 
 #. IDS_PRPCAT_IMAGE
-#: Merge.rc:3351 Merge.rc:4574 Merge.rc:5015
+#: Merge.rc:3351 Merge.rc:4574 Merge.rc:5014
 msgid "Image"
 msgstr ""
 
@@ -5926,7 +5926,7 @@ msgid "Project"
 msgstr ""
 
 #. IDS_COLHDR_NSDIFFS
-#: Merge.rc:4566 Merge.rc:4990
+#: Merge.rc:4566 Merge.rc:4989
 #, c-format
 msgid "Differences"
 msgstr "Forskelle"
@@ -6090,13 +6090,13 @@ msgid "File Type"
 msgstr ""
 
 #. IDS_COLHDR_EXTENSION
-#: Merge.rc:4653 Merge.rc:4947
+#: Merge.rc:4653 Merge.rc:4946
 #, c-format
 msgid "Extension"
 msgstr "Udvidelse"
 
 #. IDS_PRPCAT_MESSAGE
-#: Merge.rc:4659 Merge.rc:5019
+#: Merge.rc:4659 Merge.rc:5018
 msgid "Message"
 msgstr ""
 
@@ -6136,7 +6136,7 @@ msgid "Hidden Items"
 msgstr ""
 
 #. IDS_PLUGINSLIST_NAME
-#: Merge.rc:4680 Merge.rc:5311
+#: Merge.rc:4680 Merge.rc:5310
 #, c-format
 msgid "Name"
 msgstr "Navn"
@@ -6160,7 +6160,7 @@ msgid "[F] "
 msgstr "[F]"
 
 #. IDS_PLUGINSLIST_DESC
-#: Merge.rc:4684 Merge.rc:5313
+#: Merge.rc:4684 Merge.rc:5312
 #, c-format
 msgid "Description"
 msgstr "Beskrivelse"
@@ -6332,171 +6332,165 @@ msgstr ""
 msgid "  Sel: %d | %d"
 msgstr ""
 
-#. IDS_MERGEMODE_MERGING
-#: Merge.rc:4734
-#, c-format
-msgid "Merge"
-msgstr "Flet"
-
 #. IDS_DIFF_NUMBER_STATUS_FMT
-#: Merge.rc:4735
+#: Merge.rc:4734
 #, c-format
 msgid "Difference %1 of %2"
 msgstr "Forskel %1 af %2"
 
 #. IDS_NO_DIFF_SEL_FMT
-#: Merge.rc:4736
+#: Merge.rc:4735
 #, c-format
 msgid "%1 Differences Found"
 msgstr "%1 forskelle fundet"
 
 #. IDS_1_DIFF_FOUND
-#: Merge.rc:4737
+#: Merge.rc:4736
 #, c-format
 msgid "1 Difference Found"
 msgstr "1 forskel fundet"
 
 #. IDS_NO_ERR_SEL_FMT
-#: Merge.rc:4738
+#: Merge.rc:4737
 #, c-format
 msgid "%1 Errors Found"
 msgstr ""
 
 #. IDS_1_ERR_FOUND
-#: Merge.rc:4739
+#: Merge.rc:4738
 msgid "1 Error Found"
 msgstr ""
 
 #. IDS_STATUSBAR_READONLY, Abbreviation from "Read Only"
-#: Merge.rc:4740
+#: Merge.rc:4739
 #, c-format
 msgid "RO"
 msgstr "RO"
 
 #. IDS_DIRVIEW_STATUS_FMT_FOCUS
-#: Merge.rc:4746
+#: Merge.rc:4745
 #, c-format
 msgid "Item %1 of %2"
 msgstr "Emne %1 of %2"
 
 #. IDS_DIRVIEW_STATUS_FMT_NOFOCUS
-#: Merge.rc:4747
+#: Merge.rc:4746
 #, c-format
 msgid "Items: %1"
 msgstr "Emner: %1"
 
 #. IDS_DIRVIEW_STATUS_COMPARING
-#: Merge.rc:4748
+#: Merge.rc:4747
 #, c-format
 msgid "Comparing items..."
 msgstr "Sammenligner emner..."
 
 #. IDS_ITEMS_PER_SEC
-#: Merge.rc:4749
+#: Merge.rc:4748
 #, c-format
 msgid "%.1f[items/sec]"
 msgstr ""
 
 #. IDS_ERROR_INCOMPARABLE
-#: Merge.rc:4755
+#: Merge.rc:4754
 msgid "Select two existing folders/files to compare."
 msgstr "Vælg to eksisterende mapper eller filer at sammenligne."
 
 #. IDS_DIRSEL_TAG
-#: Merge.rc:4756
+#: Merge.rc:4755
 #, c-format
 msgid "Folder Selection"
 msgstr "Valgt mappe"
 
 #. IDS_OPEN_FILESDIRS
-#: Merge.rc:4757
+#: Merge.rc:4756
 #, c-format
 msgid "Select two (or three) folders/files to compare."
 msgstr ""
 
 #. IDS_OPEN_LEFTINVALID
-#: Merge.rc:4758
+#: Merge.rc:4757
 #, c-format
 msgid "Left (1st) path is invalid!"
 msgstr ""
 
 #. IDS_OPEN_MIDDLEINVALID
-#: Merge.rc:4759
+#: Merge.rc:4758
 #, c-format
 msgid "Middle (2nd) path is invalid!"
 msgstr ""
 
 #. IDS_OPEN_RIGHTINVALID2
-#: Merge.rc:4760
+#: Merge.rc:4759
 #, c-format
 msgid "Right (2nd) path is invalid!"
 msgstr ""
 
 #. IDS_OPEN_RIGHTINVALID3
-#: Merge.rc:4761
+#: Merge.rc:4760
 #, c-format
 msgid "Right (3rd) path is invalid!"
 msgstr ""
 
 #. IDS_OPEN_BOTHINVALID
-#: Merge.rc:4762
+#: Merge.rc:4761
 #, c-format
 msgid "Both paths are invalid!"
 msgstr "Begge stier er ugyldige!"
 
-#: Merge.rc:4764
+#: Merge.rc:4763
 #, c-format
 msgid "Left (1st) and Middle (2nd) paths are invalid!"
 msgstr ""
 
 #. IDS_OPEN_LEFTRIGHTINVALID
-#: Merge.rc:4765
+#: Merge.rc:4764
 #, c-format
 msgid "Left (1st) and Right (3rd) paths are invalid!"
 msgstr ""
 
-#: Merge.rc:4767
+#: Merge.rc:4766
 #, c-format
 msgid "Middle (2nd) and Right (3rd) paths are invalid!"
 msgstr ""
 
 #. IDS_OPEN_ALLINVALID
-#: Merge.rc:4768
+#: Merge.rc:4767
 #, c-format
 msgid "All paths are invalid!"
 msgstr ""
 
 #. IDS_OPEN_UNPACKERDISABLED
-#: Merge.rc:4769
+#: Merge.rc:4768
 msgid "Only enabled for file comparisons"
 msgstr ""
 
 #. IDS_OPEN_MISMATCH
-#: Merge.rc:4770
+#: Merge.rc:4769
 #, c-format
 msgid "Cannot compare file and folder!"
 msgstr "Kan ikke sammenligne en fil og en mappe!"
 
 #. IDS_ERROR_FILE_NOT_FOUND
-#: Merge.rc:4776
+#: Merge.rc:4775
 #, c-format
 msgid "File not found: %1"
 msgstr "Fil ikke fundet: %1"
 
 #. IDS_ERROR_FOLDER_NOT_FOUND
-#: Merge.rc:4777
+#: Merge.rc:4776
 #, c-format
 msgid "Folder not found: %1"
 msgstr ""
 
 #. IDS_ERROR_FILE_NOT_UNPACKED
-#: Merge.rc:4778
+#: Merge.rc:4777
 #, c-format
 msgid "File not unpacked: %1"
 msgstr "Fil ikke udpakket: %1"
 
 #. IDS_ERROR_FILEOPEN
-#: Merge.rc:4779
+#: Merge.rc:4778
 #, c-format
 msgid ""
 "Cannot open file\n"
@@ -6510,13 +6504,13 @@ msgstr ""
 "%2"
 
 #. IDS_ERROR_CONF_RESOLVE
-#: Merge.rc:4780
+#: Merge.rc:4779
 #, c-format
 msgid "Failed to parse conflict file."
 msgstr "Kunne ikke fortolke konfliktfil"
 
 #. IDS_NOT_CONFLICT_FILE
-#: Merge.rc:4781
+#: Merge.rc:4780
 #, c-format
 msgid "The file\n%1\nis not a conflict file."
 msgstr ""
@@ -6525,24 +6519,24 @@ msgstr ""
 "er ikke en konfliktfil."
 
 #. IDS_COMPARE_LARGE_FILES
-#: Merge.rc:4782
+#: Merge.rc:4781
 msgid "Comparing large files requires significant memory.\nShow only comparison results (not file contents)?"
 msgstr ""
 
 #. IDS_SAVE_AS_TITLE
-#: Merge.rc:4788
+#: Merge.rc:4787
 #, c-format
 msgid "Save As"
 msgstr "Gem som"
 
 #. IDS_SAVE_FMT
-#: Merge.rc:4789
+#: Merge.rc:4788
 #, c-format
 msgid "Save changes to %1?"
 msgstr "Gem ændringer til %1?"
 
 #. IDS_SAVEREADONLY_FMT
-#: Merge.rc:4790
+#: Merge.rc:4789
 #, c-format
 msgid "%1 is read-only. Override? Or 'No' to save as new filename?"
 msgstr ""
@@ -6550,12 +6544,12 @@ msgstr ""
 "(Nej for at gemme til et andet filnavn.)"
 
 #. IDS_ERROR_BACKUP
-#: Merge.rc:4791
+#: Merge.rc:4790
 #, c-format
 msgid "Error backing up file"
 msgstr "Fejl under backup af filen"
 
-#: Merge.rc:4793
+#: Merge.rc:4792
 #, c-format
 msgid ""
 "Unable to backup original file:\n"
@@ -6569,7 +6563,7 @@ msgstr ""
 "Fortsæt alligevel?"
 
 #. IDS_FILESAVE_FAILED
-#: Merge.rc:4794
+#: Merge.rc:4793
 #, c-format
 msgid "Saving file failed.\n%1\n%2\n\t- Use different filename (OK)\n\t- Abort (Cancel)?"
 msgstr ""
@@ -6580,7 +6574,7 @@ msgstr ""
 "\t- bruge et andet filenavn (Tryk OK)\n"
 "\t- afbryd aktuel operation (Tryk Annuller)?"
 
-#: Merge.rc:4796
+#: Merge.rc:4795
 #, c-format
 msgid "Plugin '%2' cannot pack changes to left file into '%1'.\n\nOriginal unchanged. Save unpacked version?"
 msgstr ""
@@ -6591,12 +6585,12 @@ msgstr ""
 "\n"
 "Vil du gemme den udpakkede version under et andet filnavn?"
 
-#: Merge.rc:4798
+#: Merge.rc:4797
 #, c-format
 msgid "Plugin '%2' cannot pack changes to middle file into '%1'.\n\nOriginal unchanged. Save unpacked version?"
 msgstr ""
 
-#: Merge.rc:4800
+#: Merge.rc:4799
 #, c-format
 msgid "Plugin '%2' cannot pack changes to right file into '%1'.\n\nOriginal unchanged. Save unpacked version?"
 msgstr ""
@@ -6608,7 +6602,7 @@ msgstr ""
 "Vil du gemme den udpakkede version under et andet filnavn?"
 
 #. IDS_FILECHANGED_ONDISK
-#: Merge.rc:4801
+#: Merge.rc:4800
 #, c-format
 msgid ""
 "Another application updated\n"
@@ -6624,7 +6618,7 @@ msgstr ""
 "Vil du overskrive den ændrede fil?"
 
 #. IDS_SAVEREADONLY_MULTI
-#: Merge.rc:4802
+#: Merge.rc:4801
 #, c-format
 msgid ""
 "%1\n"
@@ -6635,7 +6629,7 @@ msgstr ""
 "alligevel?"
 
 #. IDS_FILECHANGED_RESCAN
-#: Merge.rc:4803
+#: Merge.rc:4802
 #, c-format
 msgid "Another application updated\n%1\nsince last scan.\n\nReload?"
 msgstr ""
@@ -6646,25 +6640,25 @@ msgstr ""
 "Vil du genindlæse filen?"
 
 #. IDS_SAVE_LEFT_AS
-#: Merge.rc:4804
+#: Merge.rc:4803
 #, c-format
 msgid "Save Left File As"
 msgstr "Gem venstre fil som"
 
 #. IDS_SAVE_MIDDLE_AS
-#: Merge.rc:4805
+#: Merge.rc:4804
 #, c-format
 msgid "Save Middle File As"
 msgstr ""
 
 #. IDS_SAVE_RIGHT_AS
-#: Merge.rc:4806
+#: Merge.rc:4805
 #, c-format
 msgid "Save Right File As"
 msgstr "Gem højre fil som"
 
 #. IDS_FILE_DISAPPEARED
-#: Merge.rc:4811
+#: Merge.rc:4810
 #, c-format
 msgid ""
 "File\n"
@@ -6676,7 +6670,7 @@ msgstr ""
 "er forsvundet. Gem en kopi af filen for at fortsætte."
 
 #. IDS_VIEWS_OUTOFSYNC
-#: Merge.rc:4817
+#: Merge.rc:4816
 #, c-format
 msgid ""
 "Cannot merge unsynched documents.\n"
@@ -6688,189 +6682,189 @@ msgstr ""
 "Opdater dokumenter før du fortsætter."
 
 #. IDS_BREAK_ON_WHITESPACE
-#: Merge.rc:4822
+#: Merge.rc:4821
 msgid "Break at whitespace"
 msgstr "Bryd ved mellemrum"
 
 #. IDS_BREAK_ON_PUNCTUATION
-#: Merge.rc:4823
+#: Merge.rc:4822
 msgid "Break at whitespace or punctuation"
 msgstr "Bryd ved mellemrum eller tegnsætning"
 
 #. IDS_L2M
-#: Merge.rc:4829
+#: Merge.rc:4828
 msgid "Copy to &Middle\tAlt+Right"
 msgstr ""
 
 #. IDS_R2M
-#: Merge.rc:4830
+#: Merge.rc:4829
 msgid "Copy to &Middle\tAlt+Left"
 msgstr ""
 
 #. IDS_COPY_FROM_MIDDLE_R
-#: Merge.rc:4831
+#: Merge.rc:4830
 msgid "Copy from Middle\tAlt+Shift+Right"
 msgstr ""
 
 #. IDS_COPY_FROM_MIDDLE_L
-#: Merge.rc:4832
+#: Merge.rc:4831
 msgid "Copy from Middle\tAlt+Shift+Left"
 msgstr ""
 
 #. IDS_L2MNEXT
-#: Merge.rc:4833
+#: Merge.rc:4832
 msgid "Copy to Middle and Advance\tCtrl+Alt+Right"
 msgstr ""
 
 #. IDS_R2MNEXT
-#: Merge.rc:4834
+#: Merge.rc:4833
 msgid "Copy to Middle and Advance\tCtrl+Alt+Left"
 msgstr ""
 
 #. IDS_ALL_MIDDLE
-#: Merge.rc:4835
+#: Merge.rc:4834
 msgid "Copy All to Middle"
 msgstr ""
 
 #. IDS_COPY_RIGHT_TO_LEFT
-#: Merge.rc:4841
+#: Merge.rc:4840
 #, c-format
 msgid "Right to Left (%1)"
 msgstr "Højre til venstre (%1)"
 
 #. IDS_COPY_RIGHT_TO_MIDDLE
-#: Merge.rc:4842
+#: Merge.rc:4841
 #, c-format
 msgid "Right to Middle (%1)"
 msgstr ""
 
 #. IDS_COPY_MIDDLE_TO_LEFT
-#: Merge.rc:4843
+#: Merge.rc:4842
 #, c-format
 msgid "Middle to Left (%1)"
 msgstr ""
 
 #. IDS_COPY_MIDDLE_TO_RIGHT
-#: Merge.rc:4844
+#: Merge.rc:4843
 #, c-format
 msgid "Middle to Right (%1)"
 msgstr ""
 
 #. IDS_COPY_LEFT_TO_RIGHT
-#: Merge.rc:4845
+#: Merge.rc:4844
 #, c-format
 msgid "Left to Right (%1)"
 msgstr "Venstre til højre (%1)"
 
 #. IDS_COPY_LEFT_TO_MIDDLE
-#: Merge.rc:4846
+#: Merge.rc:4845
 #, c-format
 msgid "Left to Middle (%1)"
 msgstr ""
 
 #. IDS_MOVE_LEFT_TO
-#: Merge.rc:4857 Merge.rc:4889
+#: Merge.rc:4856 Merge.rc:4888
 #, c-format
 msgid "Left to... (%1)"
 msgstr "Venstre til... (%1)"
 
 #. IDS_MOVE_MIDDLE_TO
-#: Merge.rc:4858 Merge.rc:4890
+#: Merge.rc:4857 Merge.rc:4889
 #, c-format
 msgid "Middle to... (%1)"
 msgstr ""
 
 #. IDS_MOVE_RIGHT_TO
-#: Merge.rc:4859 Merge.rc:4891
+#: Merge.rc:4858 Merge.rc:4890
 #, c-format
 msgid "Right to... (%1)"
 msgstr "Højre til... (%1)"
 
 #. IDS_COPY_BOTH_TO
-#: Merge.rc:4860
+#: Merge.rc:4859
 #, c-format
 msgid "Both to... (%1)"
 msgstr ""
 
 #. IDS_COPY_ALL_TO
-#: Merge.rc:4861
+#: Merge.rc:4860
 #, c-format
 msgid "All to... (%1)"
 msgstr ""
 
 #. IDS_COPY_DIFFERENCES_TO
-#: Merge.rc:4862
+#: Merge.rc:4861
 #, c-format
 msgid "Differences to... (%1)"
 msgstr ""
 
 #. IDS_ONLYDIFFITEMS_CONFIRM
-#: Merge.rc:4869
+#: Merge.rc:4868
 msgid "Some selected items are identical or skipped.\nProcess only items with differences?"
 msgstr ""
 
 #. IDS_DEL_LEFT_FMT
-#: Merge.rc:4875
+#: Merge.rc:4874
 #, c-format
 msgid "Left (%1)"
 msgstr "Venstre (%1)"
 
 #. IDS_DEL_MIDDLE_FMT
-#: Merge.rc:4876
+#: Merge.rc:4875
 #, c-format
 msgid "Middle (%1)"
 msgstr ""
 
 #. IDS_DEL_RIGHT_FMT
-#: Merge.rc:4877
+#: Merge.rc:4876
 #, c-format
 msgid "Right (%1)"
 msgstr "Højre (%1)"
 
 #. IDS_DEL_BOTH_FMT
-#: Merge.rc:4878
+#: Merge.rc:4877
 #, c-format
 msgid "Both (%1)"
 msgstr "Begge (%1)"
 
 #. IDS_DEL_ALL_FMT
-#: Merge.rc:4879
+#: Merge.rc:4878
 #, c-format
 msgid "All (%1)"
 msgstr ""
 
 #. IDS_SELECT_DEST_LEFT
-#: Merge.rc:4895
+#: Merge.rc:4894
 #, c-format
 msgid "Left Side - Select Destination Folder:"
 msgstr "Venstre side - vælg destinationsmappen"
 
 #. IDS_SELECT_DEST_MIDDLE
-#: Merge.rc:4896
+#: Merge.rc:4895
 #, c-format
 msgid "Middle Side - Select Destination Folder:"
 msgstr ""
 
 #. IDS_SELECT_DEST_RIGHT
-#: Merge.rc:4897
+#: Merge.rc:4896
 #, c-format
 msgid "Right Side - Select Destination Folder:"
 msgstr "Højre side - vælg destinationsmappen"
 
 #. IDS_FILES_AFFECTED_FMT
-#: Merge.rc:4898
+#: Merge.rc:4897
 #, c-format
 msgid "(%1 Files Affected)"
 msgstr "(%1 filer påvirket)"
 
 #. IDS_FILES_AFFECTED_FMT2
-#: Merge.rc:4899
+#: Merge.rc:4898
 #, c-format
 msgid "(%1 of %2 Files Affected)"
 msgstr "(%1 af %2 filer påvirket)"
 
 #. IDS_CONFIRM_DELETE_SINGLE
-#: Merge.rc:4905
+#: Merge.rc:4904
 #, c-format
 msgid ""
 "Are you sure you want to delete\n"
@@ -6882,18 +6876,18 @@ msgstr ""
 "%1 ?"
 
 #. IDS_CONFIRM_SINGLE_COPY
-#: Merge.rc:4906
+#: Merge.rc:4905
 msgid "Are you sure you want to copy?"
 msgstr "Er du sikker på du vil kopiere?"
 
 #. IDS_CONFIRM_MULTIPLE_COPY
-#: Merge.rc:4907
+#: Merge.rc:4906
 #, c-format
 msgid "Are you sure you want to copy %d items?"
 msgstr "Er du sikker på du vil kopiere %d emner?"
 
 #. IDS_DIRCMP_NOTSYNC
-#: Merge.rc:4908
+#: Merge.rc:4907
 #, c-format
 msgid ""
 "Operation aborted!\n"
@@ -6913,804 +6907,804 @@ msgstr ""
 "Opdater sammenligning."
 
 #. IDS_CONFIRM_SINGLE_MOVE
-#: Merge.rc:4913
+#: Merge.rc:4912
 msgid "Are you sure you want to move?"
 msgstr "Er du sikker på du vil flytte?"
 
 #. IDS_CONFIRM_MULTIPLE_MOVE
-#: Merge.rc:4914
+#: Merge.rc:4913
 #, c-format
 msgid "Are you sure you want to move %d items?"
 msgstr "Er du sikker på du vil flytte: %d emner?"
 
 #. IDS_CONFIRM_MOVE_CAPTION
-#: Merge.rc:4916
+#: Merge.rc:4915
 #, c-format
 msgid "Confirm Move"
 msgstr "Bekræft flytning"
 
-#: Merge.rc:4918
+#: Merge.rc:4917
 #, c-format
 msgid "Close the folder comparison window?"
 msgstr ""
 
-#: Merge.rc:4920
+#: Merge.rc:4919
 msgid "Close the folder comparison window, which took a long time?"
 msgstr ""
 
 #. IDS_ERROR_INVALID_DIR_FILE_NAME
-#: Merge.rc:4921
+#: Merge.rc:4920
 msgid "The file or folder name is invalid."
 msgstr ""
 
 #. IDS_ERROR_EXECUTE_FILE
-#: Merge.rc:4927
+#: Merge.rc:4926
 #, c-format
 msgid "Failed to execute external editor: %1"
 msgstr "Kunne ikke eksekvere ekstern editor: %1"
 
 #. IDS_UNKNOWN_ARCHIVE_FORMAT
-#: Merge.rc:4933
+#: Merge.rc:4932
 #, c-format
 msgid "Unknown archive format"
 msgstr "Ukendt arkivformat"
 
-#: Merge.rc:4935
+#: Merge.rc:4934
 msgid "Failed to extract archive.\nCompare as text file?"
 msgstr ""
 
 #. IDS_COLHDR_FILENAME
-#: Merge.rc:4941
+#: Merge.rc:4940
 #, c-format
 msgid "Filename"
 msgstr "Filnavn"
 
 #. IDS_COLHDR_DIR
-#: Merge.rc:4942
+#: Merge.rc:4941
 msgctxt "DirView|ColumnHeader"
 msgid "Folder"
 msgstr "Mappe"
 
 #. IDS_COLHDR_RESULT
-#: Merge.rc:4943
+#: Merge.rc:4942
 #, c-format
 msgid "Comparison Result"
 msgstr "Resultat af sammenligning"
 
 #. IDS_COLHDR_LTIMEM
-#: Merge.rc:4944
+#: Merge.rc:4943
 #, c-format
 msgid "Left Date"
 msgstr "Venstre dato"
 
 #. IDS_COLHDR_RTIMEM
-#: Merge.rc:4945
+#: Merge.rc:4944
 #, c-format
 msgid "Right Date"
 msgstr "Højre dato"
 
 #. IDS_COLHDR_MTIMEM
-#: Merge.rc:4946
+#: Merge.rc:4945
 #, c-format
 msgid "Middle Date"
 msgstr ""
 
 #. IDS_COLHDR_LSIZE
-#: Merge.rc:4948
+#: Merge.rc:4947
 #, c-format
 msgid "Left Size"
 msgstr "Venstre størrelse"
 
 #. IDS_COLHDR_RSIZE
-#: Merge.rc:4949
+#: Merge.rc:4948
 #, c-format
 msgid "Right Size"
 msgstr "Højre størrelse"
 
 #. IDS_COLHDR_MSIZE
-#: Merge.rc:4954
+#: Merge.rc:4953
 #, c-format
 msgid "Middle Size"
 msgstr ""
 
 #. IDS_COLHDR_RSIZE_SHORT
-#: Merge.rc:4955
+#: Merge.rc:4954
 #, c-format
 msgid "Right Size (Short)"
 msgstr "Højre størrelse (kort)"
 
 #. IDS_COLHDR_LSIZE_SHORT
-#: Merge.rc:4956
+#: Merge.rc:4955
 #, c-format
 msgid "Left Size (Short)"
 msgstr "Venstre størrelse (kort)"
 
 #. IDS_COLHDR_MSIZE_SHORT
-#: Merge.rc:4957
+#: Merge.rc:4956
 #, c-format
 msgid "Middle Size (Short)"
 msgstr ""
 
 #. IDS_COLHDR_LTIMEC
-#: Merge.rc:4963
+#: Merge.rc:4962
 #, c-format
 msgid "Left Creation Time"
 msgstr "Venstre oprettelsesdato"
 
 #. IDS_COLHDR_RTIMEC
-#: Merge.rc:4964
+#: Merge.rc:4963
 #, c-format
 msgid "Right Creation Time"
 msgstr "Højre oprettelsesdato"
 
 #. IDS_COLHDR_MTIMEC
-#: Merge.rc:4965
+#: Merge.rc:4964
 #, c-format
 msgid "Middle Creation Time"
 msgstr ""
 
 #. IDS_COLHDR_NEWER
-#: Merge.rc:4966
+#: Merge.rc:4965
 #, c-format
 msgid "Newer File"
 msgstr "Nyeste fil"
 
 #. IDS_COLHDR_LVERSION
-#: Merge.rc:4967
+#: Merge.rc:4966
 #, c-format
 msgid "Left File Version"
 msgstr "Venstre filversion"
 
 #. IDS_COLHDR_RVERSION
-#: Merge.rc:4968
+#: Merge.rc:4967
 #, c-format
 msgid "Right File Version"
 msgstr "Højre filversion"
 
 #. IDS_COLHDR_MVERSION
-#: Merge.rc:4969
+#: Merge.rc:4968
 #, c-format
 msgid "Middle File Version"
 msgstr ""
 
 #. IDS_COLHDR_RESULT_ABBR
-#: Merge.rc:4970
+#: Merge.rc:4969
 #, c-format
 msgid "Short Result"
 msgstr "Kort resultat"
 
 #. IDS_COLHDR_LATTRIBUTES
-#: Merge.rc:4971
+#: Merge.rc:4970
 #, c-format
 msgid "Left Attributes"
 msgstr "Venstre attributter"
 
 #. IDS_COLHDR_RATTRIBUTES
-#: Merge.rc:4972
+#: Merge.rc:4971
 #, c-format
 msgid "Right Attributes"
 msgstr "Højre attributter"
 
 #. IDS_COLHDR_MATTRIBUTES
-#: Merge.rc:4973
+#: Merge.rc:4972
 #, c-format
 msgid "Middle Attributes"
 msgstr ""
 
 #. IDS_COLHDR_LEOL_TYPE
-#: Merge.rc:4978
+#: Merge.rc:4977
 #, c-format
 msgid "Left EOL"
 msgstr "Venstre EOL"
 
 #. IDS_COLHDR_MEOL_TYPE
-#: Merge.rc:4979
+#: Merge.rc:4978
 #, c-format
 msgid "Middle EOL"
 msgstr ""
 
 #. IDS_COLHDR_REOL_TYPE
-#: Merge.rc:4980
+#: Merge.rc:4979
 #, c-format
 msgid "Right EOL"
 msgstr "Højre EOL"
 
 #. IDS_COLHDR_LENCODING
-#: Merge.rc:4986
+#: Merge.rc:4985
 #, c-format
 msgid "Left Encoding"
 msgstr "Venstre encoding"
 
 #. IDS_COLHDR_RENCODING
-#: Merge.rc:4987
+#: Merge.rc:4986
 #, c-format
 msgid "Right Encoding"
 msgstr "Højre encoding"
 
 #. IDS_COLHDR_MENCODING
-#: Merge.rc:4988
+#: Merge.rc:4987
 #, c-format
 msgid "Middle Encoding"
 msgstr ""
 
 #. IDS_COLHDR_NIDIFFS
-#: Merge.rc:4989
+#: Merge.rc:4988
 msgid "Ignored Diff"
 msgstr "Ignoreret forskel"
 
 #. IDS_COLHDR_BINARY
-#: Merge.rc:4991
+#: Merge.rc:4990
 msgctxt "DirView|ColumnHeader"
 msgid "Binary"
 msgstr "Binær"
 
 #. IDS_PLUGINS_TYPE_UNPACKER
-#: Merge.rc:4992 Merge.rc:5314
+#: Merge.rc:4991 Merge.rc:5313
 #, c-format
 msgid "Unpacker"
 msgstr "Udpakker"
 
 #. IDS_PLUGIN_TYPE4
-#: Merge.rc:4993 Merge.rc:5315 Merge.rc:5622
+#: Merge.rc:4992 Merge.rc:5314 Merge.rc:5621
 #, c-format
 msgid "Prediffer"
 msgstr "Prediffer"
 
 #. IDS_COLHDR_LEFT
-#: Merge.rc:4994
+#: Merge.rc:4993
 msgid "Left"
 msgstr ""
 
 #. IDS_COLHDR_MIDDLE
-#: Merge.rc:4995
+#: Merge.rc:4994
 msgid "Middle"
 msgstr ""
 
 #. IDS_COLHDR_RIGHT
-#: Merge.rc:4996
+#: Merge.rc:4995
 msgid "Right"
 msgstr ""
 
 #. IDS_COLHDR_DIFF
-#: Merge.rc:4997
+#: Merge.rc:4996
 msgid "Diff"
 msgstr ""
 
 #. IDS_COLHDR_LEFT_DUPLICATE
-#: Merge.rc:4998
+#: Merge.rc:4997
 msgid "Left Duplicate Count"
 msgstr ""
 
 #. IDS_COLHDR_RIGHT_DUPLICATE
-#: Merge.rc:4999
+#: Merge.rc:4998
 msgid "Right Duplicate Count"
 msgstr ""
 
 #. IDS_COLHDR_MIDDLE_DUPLICATE
-#: Merge.rc:5000
+#: Merge.rc:4999
 msgid "Middle Duplicate Count"
 msgstr ""
 
 #. IDS_COLHDR_MOVE
-#: Merge.rc:5001
+#: Merge.rc:5000
 msgid "Move"
 msgstr ""
 
 #. IDS_PRPCAT_AUDIO
-#: Merge.rc:5008
+#: Merge.rc:5007
 msgid "Audio"
 msgstr ""
 
 #. IDS_PRPCAT_CALENDAR
-#: Merge.rc:5009
+#: Merge.rc:5008
 msgid "Calendar"
 msgstr ""
 
 #. IDS_PRPCAT_COMMUNICATION
-#: Merge.rc:5010
+#: Merge.rc:5009
 msgid "Communication"
 msgstr ""
 
 #. IDS_PRPCAT_CONTACT
-#: Merge.rc:5011
+#: Merge.rc:5010
 msgid "Contact"
 msgstr ""
 
 #. IDS_PRPCAT_DEVICES
-#: Merge.rc:5012
+#: Merge.rc:5011
 msgid "Devices"
 msgstr ""
 
 #. IDS_PRPCAT_DOCUMENT
-#: Merge.rc:5013
+#: Merge.rc:5012
 msgid "Document"
 msgstr ""
 
 #. IDS_PRPCAT_HOME
-#: Merge.rc:5014
+#: Merge.rc:5013
 msgid "Home"
 msgstr ""
 
 #. IDS_PRPCAT_JOURNAL
-#: Merge.rc:5016
+#: Merge.rc:5015
 msgid "Journal"
 msgstr ""
 
 #. IDS_PRPCAT_LINK
-#: Merge.rc:5017
+#: Merge.rc:5016
 msgid "Link"
 msgstr ""
 
 #. IDS_PRPCAT_MEDIA
-#: Merge.rc:5018
+#: Merge.rc:5017
 msgid "Media"
 msgstr ""
 
 #. IDS_PRPCAT_MUSIC
-#: Merge.rc:5020
+#: Merge.rc:5019
 msgid "Music"
 msgstr ""
 
 #. IDS_PRPCAT_NOTE
-#: Merge.rc:5021
+#: Merge.rc:5020
 msgid "Note"
 msgstr ""
 
 #. IDS_PRPCAT_PHOTO
-#: Merge.rc:5022
+#: Merge.rc:5021
 msgid "Photo"
 msgstr ""
 
 #. IDS_PRPCAT_RECORDEDTV
-#: Merge.rc:5023
+#: Merge.rc:5022
 msgid "RecordedTV"
 msgstr ""
 
 #. IDS_PRPCAT_SEARCH
-#: Merge.rc:5024
+#: Merge.rc:5023
 msgid "Search"
 msgstr ""
 
 #. IDS_PRPCAT_SECURITY
-#: Merge.rc:5025
+#: Merge.rc:5024
 msgid "Security"
 msgstr ""
 
 #. IDS_PRPCAT_SOFTWARE
-#: Merge.rc:5026
+#: Merge.rc:5025
 msgid "Software"
 msgstr ""
 
 #. IDS_PRPCAT_TASK
-#: Merge.rc:5027
+#: Merge.rc:5026
 msgid "Task"
 msgstr ""
 
 #. IDS_PRPCAT_VIDEO
-#: Merge.rc:5028
+#: Merge.rc:5027
 msgid "Video"
 msgstr ""
 
 #. IDS_PRPCAT_HASH
-#: Merge.rc:5029
+#: Merge.rc:5028
 msgid "Hash"
 msgstr ""
 
 #. IDS_CANT_COMPARE_FILES
-#: Merge.rc:5035
+#: Merge.rc:5034
 #, c-format
 msgid "Unable to compare files"
 msgstr "Kan ikke sammenligne filer"
 
 #. IDS_ABORTED_ITEM
-#: Merge.rc:5036
+#: Merge.rc:5035
 #, c-format
 msgid "Item aborted"
 msgstr "Emne fortrudt"
 
 #. IDS_FILE_SKIPPED
-#: Merge.rc:5037
+#: Merge.rc:5036
 #, c-format
 msgid "File skipped"
 msgstr "Fil sprunget over"
 
 #. IDS_DIR_SKIPPED
-#: Merge.rc:5038
+#: Merge.rc:5037
 #, c-format
 msgid "Folder skipped"
 msgstr "Mappe sprunget over"
 
 #. IDS_LEFT_ONLY_IN_FMT
-#: Merge.rc:5039
+#: Merge.rc:5038
 #, c-format
 msgid "Left only: %1"
 msgstr "Venstre kun: %1"
 
 #. IDS_MIDDLE_ONLY_IN_FMT
-#: Merge.rc:5040
+#: Merge.rc:5039
 #, c-format
 msgid "Middle only: %1"
 msgstr ""
 
 #. IDS_RIGHT_ONLY_IN_FMT
-#: Merge.rc:5041
+#: Merge.rc:5040
 #, c-format
 msgid "Right only: %1"
 msgstr "Højre kun: %1"
 
 #. IDS_DOES_NOT_EXIST_IN_FMT
-#: Merge.rc:5042
+#: Merge.rc:5041
 #, c-format
 msgid "Does not exist in %1"
 msgstr ""
 
 #. IDS_BIN_FILES_SAME
-#: Merge.rc:5043
+#: Merge.rc:5042
 #, c-format
 msgid "Binary files are identical"
 msgstr "Binære filer er identiske"
 
 #. IDS_BIN_FILES_DIFF
-#: Merge.rc:5049
+#: Merge.rc:5048
 #, c-format
 msgid "Binary files are different"
 msgstr "Binære filer er forskellige"
 
 #. IDS_FILES_ARE_DIFFERENT
-#: Merge.rc:5050
+#: Merge.rc:5049
 #, c-format
 msgid "Files are different"
 msgstr "Filer er forskellige"
 
 #. IDS_FOLDERS_ARE_DIFFERENT
-#: Merge.rc:5051
+#: Merge.rc:5050
 #, c-format
 msgid "Folders are different"
 msgstr "Mapper er forskellige"
 
 #. IDS_LEFTONLY
-#: Merge.rc:5052
+#: Merge.rc:5051
 #, c-format
 msgid "Left Only"
 msgstr "Kun venstre"
 
 #. IDS_RIGHTONLY
-#: Merge.rc:5053
+#: Merge.rc:5052
 #, c-format
 msgid "Right Only"
 msgstr "Kun højre"
 
 #. IDS_MIDDLEONLY
-#: Merge.rc:5054
+#: Merge.rc:5053
 #, c-format
 msgid "Middle Only"
 msgstr ""
 
 #. IDS_NOITEMLEFT
-#: Merge.rc:5055
+#: Merge.rc:5054
 #, c-format
 msgid "No item in left"
 msgstr ""
 
 #. IDS_NOITEMRIGHT
-#: Merge.rc:5056
+#: Merge.rc:5055
 #, c-format
 msgid "No item in right"
 msgstr ""
 
 #. IDS_NOITEMMIDDLE
-#: Merge.rc:5057
+#: Merge.rc:5056
 #, c-format
 msgid "No item in middle"
 msgstr ""
 
 #. IDS_CMPRES_ERROR
-#: Merge.rc:5059
+#: Merge.rc:5058
 #, c-format
 msgid "Error"
 msgstr "Fejl"
 
 #. IDS_TEXT_FILES_SAME
-#: Merge.rc:5060
+#: Merge.rc:5059
 #, c-format
 msgid "Text files are identical"
 msgstr "Tekstfiler er identiske"
 
 #. IDS_LEFTONLY_DIFF
-#: Merge.rc:5061
+#: Merge.rc:5060
 msgid " (Middle and right are identical)"
 msgstr ""
 
 #. IDS_MIDDLEONLY_DIFF
-#: Merge.rc:5062
+#: Merge.rc:5061
 msgid " (Left and right are identical)"
 msgstr ""
 
 #. IDS_RIGHTONLY_DIFF
-#: Merge.rc:5063
+#: Merge.rc:5062
 msgid " (Left and middle are identical)"
 msgstr ""
 
 #. IDS_PATH_MISMATCH
-#: Merge.rc:5064
+#: Merge.rc:5063
 msgid " (paths differ)"
 msgstr ""
 
 #. IDS_TEXT_FILES_DIFF
-#: Merge.rc:5065
+#: Merge.rc:5064
 #, c-format
 msgid "Text files are different"
 msgstr "Tekstfiler er forskellige"
 
 #. IDS_IMAGE_FILES_SAME
-#: Merge.rc:5066
+#: Merge.rc:5065
 msgid "Image files are identical"
 msgstr ""
 
 #. IDS_IMAGE_FILES_DIFF
-#: Merge.rc:5067
+#: Merge.rc:5066
 msgid "Image files are different"
 msgstr ""
 
 #. IDS_EXPR_DIFF
-#: Merge.rc:5068
+#: Merge.rc:5067
 #, c-format
 msgid "Files are different (expr: %1)"
 msgstr ""
 
 #. IDS_HASH_GROUP
-#: Merge.rc:5069
+#: Merge.rc:5068
 #, c-format
 msgid "Group%d"
 msgstr ""
 
 #. IDS_RENAME_MOVE_DETECTION_DISALBED
-#: Merge.rc:5070
+#: Merge.rc:5069
 msgctxt "Options dialog|Compare|Folder|Detect renames and moves"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_RENAME_MOVE_DETECTION_RENAME
-#: Merge.rc:5071
+#: Merge.rc:5070
 msgid "Detect renames"
 msgstr ""
 
 #. IDS_RENAME_MOVE_DETECTION_RENAME_MOVE
-#: Merge.rc:5072
+#: Merge.rc:5071
 msgid "Detect renames and moves"
 msgstr ""
 
 #. IDS_RENAME_MOVE_MERGE_MODE_RENAME
-#: Merge.rc:5073
+#: Merge.rc:5072
 msgid "Merge renames"
 msgstr ""
 
 #. IDS_RENAME_MOVE_MERGE_MODE_RENAME_MOVE
-#: Merge.rc:5074
+#: Merge.rc:5073
 msgid "Merge renames and moves"
 msgstr ""
 
 #. IDS_RENAMED
-#: Merge.rc:5075
+#: Merge.rc:5074
 msgid "Renamed"
 msgstr ""
 
 #. IDS_RENAMED_MOVED
-#: Merge.rc:5077
+#: Merge.rc:5076
 msgid "Renamed/Moved"
 msgstr ""
 
 #. IDS_RENAMED_MOVED_ITEMS
-#: Merge.rc:5078
+#: Merge.rc:5077
 #, c-format
 msgid "(%1 items)"
 msgstr ""
 
 #. IDS_RENAMED_MOVED_RESULT
-#: Merge.rc:5079
+#: Merge.rc:5078
 #, c-format
 msgid "%1 (set %2): "
 msgstr ""
 
 #. IDS_SWITCH_FLAT_MODE
-#: Merge.rc:5080
+#: Merge.rc:5079
 msgid "Some moved items have been merged.\nIn Tree Mode, these items may appear in positions that do not reflect the actual folder structure, which can be confusing.\nSwitch to Flat Mode?"
 msgstr ""
 
 #. IDS_ELAPSED_TIME
-#: Merge.rc:5086
+#: Merge.rc:5085
 #, c-format
 msgid "Elapsed time: %ld ms"
 msgstr "Tid forløbet: %ld ms"
 
 #. IDS_STATUS_SELITEM1
-#: Merge.rc:5087
+#: Merge.rc:5086
 #, c-format
 msgid "1 item selected"
 msgstr "1 element valgt"
 
 #. IDS_STATUS_SELITEMS
-#: Merge.rc:5088
+#: Merge.rc:5087
 #, c-format
 msgid "%1 items selected"
 msgstr "%1 elementer valgt"
 
 #. IDS_COLDESC_FILENAME
-#: Merge.rc:5094
+#: Merge.rc:5093
 #, c-format
 msgid "Filename or folder name."
 msgstr "Filnavn eller mappenavn."
 
 #. IDS_COLDESC_DIR
-#: Merge.rc:5095
+#: Merge.rc:5094
 #, c-format
 msgid "Subfolder name when subfolders are included."
 msgstr "Undermappenavn når undermapper er inkluderet."
 
 #. IDS_COLDESC_RESULT
-#: Merge.rc:5096
+#: Merge.rc:5095
 #, c-format
 msgid "Comparison result, long form."
 msgstr "Resultat af sammenligning, lang form."
 
 #. IDS_COLDESC_LTIMEM
-#: Merge.rc:5101
+#: Merge.rc:5100
 #, c-format
 msgid "Left side modification date."
 msgstr "Venstre side ændringsdato."
 
 #. IDS_COLDESC_RTIMEM
-#: Merge.rc:5102
+#: Merge.rc:5101
 #, c-format
 msgid "Right side modification date."
 msgstr "Højre side ændringsdato."
 
 #. IDS_COLDESC_MTIMEM
-#: Merge.rc:5103
+#: Merge.rc:5102
 #, c-format
 msgid "Middle side modification date."
 msgstr ""
 
 #. IDS_COLDESC_EXTENSION
-#: Merge.rc:5104
+#: Merge.rc:5103
 #, c-format
 msgid "File's extension."
 msgstr "Filens extension."
 
 #. IDS_COLDESC_LSIZE
-#: Merge.rc:5105
+#: Merge.rc:5104
 #, c-format
 msgid "Left file size in bytes."
 msgstr "Venstre filstørrelse i bytes."
 
 #. IDS_COLDESC_RSIZE
-#: Merge.rc:5106
+#: Merge.rc:5105
 #, c-format
 msgid "Right file size in bytes."
 msgstr "Højre filstørrelse i bytes."
 
 #. IDS_COLDESC_MSIZE
-#: Merge.rc:5107
+#: Merge.rc:5106
 #, c-format
 msgid "Middle file size in bytes."
 msgstr ""
 
 #. IDS_COLDESC_LSIZE_SHORT
-#: Merge.rc:5108
+#: Merge.rc:5107
 #, c-format
 msgid "Left file size abbreviated."
 msgstr "Venstre filstørrelse forkortet."
 
 #. IDS_COLDESC_RSIZE_SHORT
-#: Merge.rc:5109
+#: Merge.rc:5108
 #, c-format
 msgid "Right file size abbreviated."
 msgstr "Højre filstørrelse forkortet."
 
 #. IDS_COLDESC_MSIZE_SHORT
-#: Merge.rc:5110
+#: Merge.rc:5109
 #, c-format
 msgid "Middle file size abbreviated."
 msgstr ""
 
 #. IDS_COLDESC_LTIMEC
-#: Merge.rc:5116
+#: Merge.rc:5115
 #, c-format
 msgid "Left side creation time."
 msgstr "Venstre side oprettelsesdato."
 
 #. IDS_COLDESC_RTIMEC
-#: Merge.rc:5117
+#: Merge.rc:5116
 #, c-format
 msgid "Right side creation time."
 msgstr "Højre side oprettelsesdato."
 
 #. IDS_COLDESC_MTIMEC
-#: Merge.rc:5118
+#: Merge.rc:5117
 #, c-format
 msgid "Middle side creation time."
 msgstr ""
 
 #. IDS_COLDESC_NEWER
-#: Merge.rc:5119
+#: Merge.rc:5118
 #, c-format
 msgid "Tells which side has newer modification date."
 msgstr "Fortæller hvilken side har den nyeste ændringsdato."
 
 #. IDS_COLDESC_LVERSION
-#: Merge.rc:5120
+#: Merge.rc:5119
 msgid "Left side file version, only for some file types."
 msgstr "Venstre side filversion, kun for nogle filtyper."
 
 #. IDS_COLDESC_RVERSION
-#: Merge.rc:5121
+#: Merge.rc:5120
 msgid "Right side file version, only for some file types."
 msgstr "Højre side filversion, kun for nogle filtyper."
 
 #. IDS_COLDESC_MVERSION
-#: Merge.rc:5126
+#: Merge.rc:5125
 msgid "Middle side file version, only for some file types."
 msgstr ""
 
 #. IDS_COLDESC_RESULT_ABBR
-#: Merge.rc:5127
+#: Merge.rc:5126
 #, c-format
 msgid "Short comparison result."
 msgstr "Kort resultat af sammenligning."
 
 #. IDS_COLDESC_LATTRIBUTES
-#: Merge.rc:5128
+#: Merge.rc:5127
 #, c-format
 msgid "Left side attributes."
 msgstr "Venstre side attributter."
 
 #. IDS_COLDESC_RATTRIBUTES
-#: Merge.rc:5129
+#: Merge.rc:5128
 #, c-format
 msgid "Right side attributes."
 msgstr "Højre side attributter."
 
 #. IDS_COLDESC_MATTRIBUTES
-#: Merge.rc:5130
+#: Merge.rc:5129
 #, c-format
 msgid "Middle side attributes."
 msgstr ""
 
 #. IDS_COLDESC_LEOL_TYPE
-#: Merge.rc:5131
+#: Merge.rc:5130
 msgid "Left side file EOL type."
 msgstr "Venstre sidefil EOL type."
 
 #. IDS_COLDESC_REOL_TYPE
-#: Merge.rc:5132
+#: Merge.rc:5131
 msgid "Right side file EOL type."
 msgstr "Højre sidefil EOL type."
 
 #. IDS_COLDESC_MEOL_TYPE
-#: Merge.rc:5133
+#: Merge.rc:5132
 msgid "Middle side file EOL type."
 msgstr ""
 
 #. IDS_COLDESC_LENCODING
-#: Merge.rc:5139
+#: Merge.rc:5138
 #, c-format
 msgid "Left side encoding."
 msgstr "Venstre side encoding."
 
 #. IDS_COLDESC_RENCODING
-#: Merge.rc:5140
+#: Merge.rc:5139
 #, c-format
 msgid "Right side encoding."
 msgstr "Højre side encoding."
 
 #. IDS_COLDESC_MENCODING
-#: Merge.rc:5141
+#: Merge.rc:5140
 #, c-format
 msgid "Middle side encoding."
 msgstr ""
 
 #. IDS_COLDESC_NIDIFFS
-#: Merge.rc:5142
+#: Merge.rc:5141
 #, c-format
 msgid "Number of ignored differences in file. Ignored and cannot be merged."
 msgstr ""
@@ -7718,70 +7712,70 @@ msgstr ""
 "og kan ikke blive flettet."
 
 #. IDS_COLDESC_NSDIFFS
-#: Merge.rc:5143
+#: Merge.rc:5142
 #, c-format
 msgid "Number of differences in file (excluding ignored)."
 
 #. IDS_COLDESC_BINARY
-#: Merge.rc:5144
+#: Merge.rc:5143
 #, c-format
 msgid "Shows an asterisk (*) if the file is binary."
 msgstr "Vis stjerne (*) hvis fil er binær."
 
 #. IDS_COLDESC_UNPACKER
-#: Merge.rc:5145
+#: Merge.rc:5144
 msgid "Unpacker plugin name or pipeline."
 msgstr ""
 
 #. IDS_COLDESC_PREDIFFER
-#: Merge.rc:5146
+#: Merge.rc:5145
 msgid "Prediffer plugin name or pipeline."
 msgstr ""
 
 #. IDS_DIRECTORY_REPORT_TITLE
-#: Merge.rc:5152
+#: Merge.rc:5151
 #, c-format
 msgid "Compare %1 with %2"
 msgstr "Sammenlign %1 med %2"
 
 #. IDS_DIRECTORY_REPORT_TITLE3
-#: Merge.rc:5153
+#: Merge.rc:5152
 #, c-format
 msgid "Compare %1 with %2 and %3"
 msgstr ""
 
 #. IDS_REPORT_COMMALIST
-#: Merge.rc:5154
+#: Merge.rc:5153
 #, c-format
 msgid "Comma-separated list"
 msgstr "Komma opdelt liste"
 
 #. IDS_REPORT_TABLIST
-#: Merge.rc:5155
+#: Merge.rc:5154
 #, c-format
 msgid "Tab-separated list"
 msgstr "Tab opdelt liste"
 
 #. IDS_REPORT_SIMPLEHTML
-#: Merge.rc:5156
+#: Merge.rc:5155
 #, c-format
 msgid "Simple HTML"
 msgstr "Simpel HTML"
 
 #. IDS_REPORT_SIMPLEXML
-#: Merge.rc:5157
+#: Merge.rc:5156
 #, c-format
 msgid "Simple XML"
 msgstr "Simpel XML"
 
-#: Merge.rc:5159
+#: Merge.rc:5158
 #, c-format
 msgid "Report file already exists. Overwrite?"
 msgstr ""
 "Rapportfilen eksisterer allerede. Ønsker du at overskrive eksisterende fil"
 
 #. IDS_REPORT_ERROR
-#: Merge.rc:5164
+#: Merge.rc:5163
 #, c-format
 msgid ""
 "Error creating the report:\n"
@@ -7791,56 +7785,56 @@ msgstr ""
 "%1"
 
 #. IDS_REPORT_SUCCESS
-#: Merge.rc:5165
+#: Merge.rc:5164
 #, c-format
 msgid "Report created successfully."
 msgstr "Rapporten blev oprettet succesfuldt."
 
 #. IDS_SYNCPOINT_LASTBLOCK
-#: Merge.rc:5171
+#: Merge.rc:5170
 msgid "Cannot add a synchronization point at this line."
 msgstr ""
 
 #. IDS_FILE_TO_ITSELF
-#: Merge.rc:5177
+#: Merge.rc:5176
 #, c-format
 msgid "Same file is opened in both panes."
 msgstr "Den samme fil er åbnet på begge sider."
 
 #. IDS_FILESSAME
-#: Merge.rc:5178
+#: Merge.rc:5177
 #, c-format
 msgid "Selected files are identical."
 msgstr "De valgte filer er identiske."
 
 #. IDS_FILESSAME_CURCFG
-#: Merge.rc:5179
+#: Merge.rc:5178
 msgid "Selected files are identical (with current settings).\r\nChecking binary identity..."
 msgstr ""
 
 #. IDS_FILESSAME_BINERROR
-#: Merge.rc:5180
+#: Merge.rc:5179
 msgid "Selected files are identical (with current settings).\r\nBut binary comparison failed."
 msgstr ""
 
 #. IDS_FILESSAME_BINSAME
-#: Merge.rc:5181
+#: Merge.rc:5180
 msgid "Selected files are identical (binary match)."
 msgstr ""
 
 #. IDS_FILESSAME_BINDIFF
-#: Merge.rc:5182
+#: Merge.rc:5181
 msgid "Selected files are identical (with current settings).\r\nBut differ at the binary level."
 msgstr ""
 
 #. IDS_FILEERROR
-#: Merge.rc:5183
+#: Merge.rc:5182
 #, c-format
 msgid "An error occurred while comparing files."
 msgstr "Der skete en fejl under sammenligning af filerne."
 
 #. IDS_TEMP_FILEERROR
-#: Merge.rc:5184
+#: Merge.rc:5183
 #, c-format
 msgid ""
 "Could not create temporary files. Check your temporary path settings."
@@ -7849,7 +7843,7 @@ msgstr ""
 "midlertidig (temp) mappe."
 
 #. IDS_SUGGEST_IGNOREEOL
-#: Merge.rc:5185
+#: Merge.rc:5184
 msgid "Files use different EOL.\n\nTreat all EOL as equivalent?\n\nSet 'Ignore EOL differences (Windows/Unix/Mac)' in Compare section of Options."
 msgstr ""
 "Disse filer anvender forskellige returtegn typer.\n"
@@ -7861,19 +7855,19 @@ msgstr ""
 "Sammenlign  (findes under Redigér)."
 
 #. IDS_INVALID_DIRECTORY
-#: Merge.rc:5186
+#: Merge.rc:5185
 #, c-format
 msgid "Selected folder is invalid."
 msgstr "Den valgte mappe er ugyldig."
 
 #. IDS_CANNOT_OPEN_BINARYFILE
-#: Merge.rc:5187
+#: Merge.rc:5186
 #, c-format
 msgid "Cannot open a binary file in Editor."
 msgstr "Kan ikke åbne en binær fil til editor."
 
 #. IDS_CREATE_PAIR_FOLDER
-#: Merge.rc:5188
+#: Merge.rc:5187
 #, c-format
 msgid "Create matching folder:\n%1\non the other side and open?"
 msgstr ""
@@ -7884,45 +7878,45 @@ msgstr ""
 "til den anden side og åbne disse mapper?"
 
 #. IDS_CONFIRM_COPY_ALL_DIFFS
-#: Merge.rc:5189
+#: Merge.rc:5188
 msgid "Copy all differences to other file?"
 msgstr ""
 
 #. IDS_MOVE_TO_NEXTFILE
-#: Merge.rc:5194
+#: Merge.rc:5193
 #, c-format
 msgid "Move to next file?"
 msgstr ""
 
 #. IDS_MOVE_TO_PREVFILE
-#: Merge.rc:5195
+#: Merge.rc:5194
 #, c-format
 msgid "Move to previous file?"
 msgstr ""
 
 #. IDS_MOVE_TO_NEXTPAGE
-#: Merge.rc:5196
+#: Merge.rc:5195
 #, c-format
 msgid "Move to next page?"
 msgstr ""
 
 #. IDS_MOVE_TO_PREVPAGE
-#: Merge.rc:5197
+#: Merge.rc:5196
 #, c-format
 msgid "Move to previous page?"
 msgstr ""
 
 #. IDS_MOVE_TO_FIRSTFILE
-#: Merge.rc:5198
+#: Merge.rc:5197
 msgid "Move to first file?"
 msgstr ""
 
 #. IDS_MOVE_TO_LASTFILE
-#: Merge.rc:5199
+#: Merge.rc:5198
 msgid "Move to last file?"
 msgstr ""
 
-#: Merge.rc:5206
+#: Merge.rc:5205
 #, c-format
 msgid "Different codepages: left (cp%d), right (cp%d).\nDisplay in codepage (better display) or default Windows codepage (safer merging)?\n(Recommended: default Windows codepage)"
 msgstr ""
@@ -7932,153 +7926,153 @@ msgstr ""
 "Vil du behandle begge filer som værende i standard Windows codepage "
 "(anbefalet)?"
 
-#: Merge.rc:5208
+#: Merge.rc:5207
 #, c-format
 msgid "Information lost due to encoding errors: both files"
 msgstr "Oplysninger tabt, på grund af kodnings fejl: begge filer"
 
-#: Merge.rc:5210
+#: Merge.rc:5209
 #, c-format
 msgid "Information lost due to encoding errors: first file"
 msgstr ""
 
-#: Merge.rc:5212
+#: Merge.rc:5211
 #, c-format
 msgid "Information lost due to encoding errors: second file"
 msgstr ""
 
-#: Merge.rc:5214
+#: Merge.rc:5213
 #, c-format
 msgid "Information lost due to encoding errors: third file"
 msgstr ""
 
 #. IDS_LINEDIFF_NODIFF
-#: Merge.rc:5220
+#: Merge.rc:5219
 #, c-format
 msgid "No difference"
 msgstr "Ingen forskel"
 
 #. IDS_LINEDIFF_NODIFF_CAPTION
-#: Merge.rc:5221
+#: Merge.rc:5220
 #, c-format
 msgid "Line difference"
 msgstr "Linje forskel"
 
 #. IDS_NUM_REPLACED
-#: Merge.rc:5227
+#: Merge.rc:5226
 #, c-format
 msgid "Replaced %1 string(s)."
 msgstr "Erstattet %1 streng(e)."
 
 #. IDS_EDIT_TEXT_NOT_FOUND
-#: Merge.rc:5228
+#: Merge.rc:5227
 #, c-format
 msgid "Cannot find string \"%s\"."
 msgstr "Kan ikke finde strengen \"%s\"."
 
 #. IDS_MERGE_MODE
-#: Merge.rc:5234
+#: Merge.rc:5233
 msgid "Entering Merge Mode. Press F9 to turn off."
 msgstr ""
 
 #. IDS_AUTO_MERGE
-#: Merge.rc:5240
+#: Merge.rc:5239
 #, c-format
 msgid "Automatic merges: %1\nUnresolved conflicts: %2"
 msgstr ""
 
 #. IDS_CODEPAGE_MERGED
-#: Merge.rc:5241
+#: Merge.rc:5240
 msgid "Codepage change merged."
 msgstr ""
 
 #. IDS_CODEPAGE_CONFLICT
-#: Merge.rc:5242
+#: Merge.rc:5241
 msgid "Codepage changes are conflicting."
 msgstr ""
 
 #. IDS_EOL_MERGED
-#: Merge.rc:5243
+#: Merge.rc:5242
 msgid "EOL change merged."
 msgstr ""
 
 #. IDS_EOL_CONFLICT
-#: Merge.rc:5244
+#: Merge.rc:5243
 msgid "EOL changes are conflicting."
 msgstr ""
 
 #. IDS_LOCBAR_CAPTION
-#: Merge.rc:5250
+#: Merge.rc:5249
 #, c-format
 msgid "Location Pane"
 msgstr "Placerings vindue"
 
 #. IDS_DIFFBAR_CAPTION
-#: Merge.rc:5251
+#: Merge.rc:5250
 #, c-format
 msgid "Diff Pane"
 msgstr "Forskels vindue"
 
 #. IDS_DIFF_SUCCEEDED
-#: Merge.rc:5258
+#: Merge.rc:5257
 #, c-format
 msgid "Patch file written."
 msgstr "Patch fil oprettet med succes."
 
 #. IDS_DIFF_FILEOVERWRITE
-#: Merge.rc:5259
+#: Merge.rc:5258
 #, c-format
 msgid "Patch file already exists. Overwrite?"
 msgstr "Denne patch fil eksisterer allerede. Vil du overskrive den?"
 
 #. IDS_DIFF_SELECTEDFILES
-#: Merge.rc:5260
+#: Merge.rc:5259
 #, c-format
 msgid "[%1 files selected]"
 msgstr "[%1 filer valgt]"
 
 #. IDS_DIFF_NORMAL
-#: Merge.rc:5261
+#: Merge.rc:5260
 #, c-format
 msgid "Normal"
 msgstr "Normal"
 
 #. IDS_DIFF_CONTEXT
-#: Merge.rc:5262
+#: Merge.rc:5261
 #, c-format
 msgid "Context"
 msgstr "Kontekst"
 
 #. IDS_DIFF_UNIFIED
-#: Merge.rc:5263
+#: Merge.rc:5262
 #, c-format
 msgid "Unified"
 msgstr "Samlet"
 
 #. IDS_FILEWRITE_ERROR
-#: Merge.rc:5265
+#: Merge.rc:5264
 #, c-format
 msgid "Could not write to file %1."
 msgstr "Kunne ikke skrive til fil %1."
 
 #. IDS_PATH_NOT_ABSOLUTE
-#: Merge.rc:5266
+#: Merge.rc:5265
 #, c-format
 msgid "Output path is not absolute: %1"
 msgstr "Den angivne output sti er ikke en endelig sti: %1"
 
 #. IDS_MUST_SPECIFY_OUTPUT
-#: Merge.rc:5267
+#: Merge.rc:5266
 msgid "Specify an output file."
 msgstr "Angiv en output fil."
 
-#: Merge.rc:5269
+#: Merge.rc:5268
 #, c-format
 msgid "Cannot create patch from binary files."
 msgstr "Kan ikke lave patch filer fra binære filer."
 
 #. IDS_SAVEFILES_FORPATCH
-#: Merge.rc:5270
+#: Merge.rc:5269
 #, c-format
 msgid ""
 "Save all files first.\n"
@@ -8090,23 +8084,23 @@ msgstr ""
 "Oprettelse af en patch kræver at alle ændringer i filen er gemt."
 
 #. IDS_FOLDER_NOTEXIST
-#: Merge.rc:5271
+#: Merge.rc:5270
 #, c-format
 msgid "Folder does not exist."
 msgstr "Mappen eksisterer ikke."
 
 #. IDS_ARCHIVE_SUCCEEDED
-#: Merge.rc:5277
+#: Merge.rc:5276
 msgid "Archive file written."
 msgstr ""
 
 #. IDS_ARCHIVE_SAVEFILES
-#: Merge.rc:5278
+#: Merge.rc:5277
 msgid "Save all files first.\n\nCreating an archive requires no unsaved changes."
 msgstr ""
 
 #. IDS_NO_ZIP_SUPPORT
-#: Merge.rc:5283
+#: Merge.rc:5282
 msgid "Archive support not enabled.\n7-Zip and/or Merge7z*.dll not found.\nSee manual for archive support."
 msgstr ""
 "Arkiv support er ikke aktiveret.\n"
@@ -8116,43 +8110,43 @@ msgstr ""
 "det."
 
 #. IDS_OPT_EXPORT_CAPTION
-#: Merge.rc:5284
+#: Merge.rc:5283
 #, c-format
 msgid "Select file for export"
 msgstr "Vælg fil til eksport"
 
 #. IDS_OPT_IMPORT_CAPTION
-#: Merge.rc:5285
+#: Merge.rc:5284
 #, c-format
 msgid "Select file for import"
 msgstr "Vælg fil til import"
 
 #. IDS_OPT_IMPORT_DONE
-#: Merge.rc:5286
+#: Merge.rc:5285
 #, c-format
 msgid "Options imported from file."
 msgstr "Indstillinger importeret fra filen."
 
 #. IDS_OPT_EXPORT_DONE
-#: Merge.rc:5287
+#: Merge.rc:5286
 #, c-format
 msgid "Options exported to file."
 msgstr "Indstillinger eksporteret til filen."
 
 #. IDS_OPT_IMPORT_ERR
-#: Merge.rc:5288
+#: Merge.rc:5287
 #, c-format
 msgid "Failed to import options from file."
 msgstr "Kunne ikke importere indstillinger fra filen."
 
 #. IDS_OPT_EXPORT_ERR
-#: Merge.rc:5289
+#: Merge.rc:5288
 #, c-format
 msgid "Failed to write options to file."
 msgstr "Kunne ikke skrive indstillinger til filen."
 
 #. IDS_CLOSEALL_WINDOWS
-#: Merge.rc:5290
+#: Merge.rc:5289
 #, c-format
 msgid ""
 "Close multiple compare windows?\n"
@@ -8164,1211 +8158,1211 @@ msgstr ""
 "Vil du fortsætte?"
 
 #. IDS_EOL_BIN
-#: Merge.rc:5300
+#: Merge.rc:5299
 msgctxt "EOL Type"
 msgid "Binary"
 msgstr "Binær"
 
 #. IDS_MARKER_COLOR_FMT
-#: Merge.rc:5305
+#: Merge.rc:5304
 #, c-format
 msgid "Marker Color %d"
 msgstr ""
 
 #. IDS_MARKER_NEW_PATTERN
-#: Merge.rc:5306
+#: Merge.rc:5305
 msgid "New Pattern"
 msgstr ""
 
 #. IDS_PLUGINSLIST_TYPE
-#: Merge.rc:5312
+#: Merge.rc:5311
 #, c-format
 msgid "Type"
 msgstr "Type"
 
 #. IDS_PLUGINS_TYPE_EDITSCRIPT
-#: Merge.rc:5316
+#: Merge.rc:5315
 #, c-format
 msgid "Editor script"
 msgstr "Editor script"
 
 #. ID_SELECTLINEDIFF
-#: Merge.rc:5322
+#: Merge.rc:5321
 #, c-format
 msgid "\nDifference in Current Line (F4)"
 msgstr ""
 
 #. ID_OPTIONS
-#: Merge.rc:5323
+#: Merge.rc:5322
 #, c-format
 msgid "\nOptions"
 msgstr ""
 
 #. ID_REFRESH
-#: Merge.rc:5324
+#: Merge.rc:5323
 #, c-format
 msgid "\nRefresh (F5)"
 msgstr ""
 
 #. ID_PREVDIFF
-#: Merge.rc:5330
+#: Merge.rc:5329
 #, c-format
 msgid "\nPrevious Difference (Alt+Up)"
 msgstr ""
 
 #. ID_NEXTDIFF
-#: Merge.rc:5331
+#: Merge.rc:5330
 #, c-format
 msgid "\nNext Difference (Alt+Down)"
 msgstr ""
 
 #. ID_PREVCONFLICT
-#: Merge.rc:5332
+#: Merge.rc:5331
 #, c-format
 msgid "\nPrevious Conflict (Alt+Shift+Up)"
 msgstr ""
 
 #. ID_NEXTCONFLICT
-#: Merge.rc:5333
+#: Merge.rc:5332
 #, c-format
 msgid "\nNext Conflict (Alt+Shift+Down)"
 msgstr ""
 
 #. ID_FIRSTDIFF
-#: Merge.rc:5338
+#: Merge.rc:5337
 #, c-format
 msgid "\nFirst Difference (Alt+Home)"
 msgstr ""
 
 #. ID_CURDIFF
-#: Merge.rc:5339
+#: Merge.rc:5338
 #, c-format
 msgid "\nCurrent Difference (Alt+Enter)"
 msgstr ""
 
 #. ID_LASTDIFF
-#: Merge.rc:5340
+#: Merge.rc:5339
 #, c-format
 msgid "\nLast Difference (Alt+End)"
 msgstr ""
 
 #. ID_L2R
-#: Merge.rc:5341
+#: Merge.rc:5340
 msgid "\nCopy to Right (Alt+Right)"
 msgstr ""
 
 #. ID_R2L
-#: Merge.rc:5342
+#: Merge.rc:5341
 msgid "\nCopy to Left (Alt+Left)"
 msgstr ""
 
 #. ID_L2RNEXT
-#: Merge.rc:5343
+#: Merge.rc:5342
 msgid "\nCopy to Right and Advance (Ctrl+Alt+Right)"
 msgstr ""
 
 #. ID_R2LNEXT
-#: Merge.rc:5344
+#: Merge.rc:5343
 msgid "\nCopy to Left and Advance (Ctrl+Alt+Left)"
 msgstr ""
 
 #. ID_ALL_RIGHT
-#: Merge.rc:5345
+#: Merge.rc:5344
 msgid "\nCopy All to Right"
 msgstr "\nKopier alt til højre"
 
 #. ID_ALL_LEFT
-#: Merge.rc:5346
+#: Merge.rc:5345
 msgid "\nCopy All to Left"
 msgstr "\nKopier alt til venstre"
 
 #. ID_AUTO_MERGE
-#: Merge.rc:5347
+#: Merge.rc:5346
 #, c-format
 msgid "\nAuto Merge (Ctrl+Alt+M)"
 msgstr ""
 
 #. ID_FIRSTFILE
-#: Merge.rc:5348
+#: Merge.rc:5347
 msgid "\nFirst File"
 msgstr ""
 
 #. ID_NEXTFILE
-#: Merge.rc:5349
+#: Merge.rc:5348
 msgid "\nNext File (Ctrl+F8)"
 msgstr ""
 
 #. ID_LASTFILE
-#: Merge.rc:5350
+#: Merge.rc:5349
 msgid "\nLast File"
 msgstr ""
 
 #. ID_PREVFILE
-#: Merge.rc:5351
+#: Merge.rc:5350
 msgid "\nPrevious File (Ctrl+F7)"
 msgstr ""
 
 #. IDS_UNPACK_AUTO
-#: Merge.rc:5358
+#: Merge.rc:5357
 msgid "Adapted unpacker applied to both files (one needs extension)."
 msgstr ""
 "Udpakkeren bruges på begge filer (kun den ene fil behøves en korrekt "
 "extension)."
 
 #. IDS_NO_PREDIFFER
-#: Merge.rc:5359
+#: Merge.rc:5358
 #, c-format
 msgid "No Prediffer (Normal)"
 msgstr "Ingen prediffer (normal)"
 
 #. IDS_SUGGESTED_PLUGINS
-#: Merge.rc:5360
+#: Merge.rc:5359
 #, c-format
 msgid "Suggested Plugins"
 msgstr "Anbefalede plugins"
 
 #. IDS_NOT_SUGGESTED_PLUGINS
-#: Merge.rc:5361
+#: Merge.rc:5360
 msgid "All Plugins"
 msgstr ""
 
 #. IDS_PRIVATEBUILD_FMT
-#: Merge.rc:5367
+#: Merge.rc:5366
 #, c-format
 msgid "Private Build: %1"
 msgstr "Privat Udgave: %1"
 
 #. IDS_ALLRIGHTS_RESERVED
-#: Merge.rc:5368
+#: Merge.rc:5367
 msgid " - All rights reserved."
 msgstr ""
 
 #. IDS_TITLE_PLUGINS_SETTINGS
-#: Merge.rc:5374
+#: Merge.rc:5373
 #, c-format
 msgid "Plugin Settings"
 msgstr "Plugin indstillinger"
 
 #. IDS_NO_SCT_SCRIPTS
-#: Merge.rc:5376
+#: Merge.rc:5375
 #, c-format
 msgid "WSH not found - .sct scripts disabled"
 msgstr "WSH ikke fundet - .sct scripts afbrudt"
 
 #. IDS_LOCBAR_GOTOLINE_FMT
-#: Merge.rc:5384
+#: Merge.rc:5383
 #, c-format
 msgid "G&o to Line %1"
 msgstr "G&å til linje %1"
 
 #. IDS_GOTO_MOVED_LINE
-#: Merge.rc:5390
+#: Merge.rc:5389
 msgid "Go to Moved Line\tCtrl+Shift+G"
 msgstr ""
 
 #. IDS_AUTOCOMPLETE_DISABLED
-#: Merge.rc:5396
+#: Merge.rc:5395
 msgctxt "Options dialog|General|Open dialog Auto completion"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_AUTOCOMPLETE_FILE_SYS
-#: Merge.rc:5397
+#: Merge.rc:5396
 #, c-format
 msgid "From file system"
 msgstr "Fra filsystem"
 
 #. IDS_AUTOCOMPLETE_MRU
-#: Merge.rc:5398
+#: Merge.rc:5397
 #, c-format
 msgid "From Most Recently Used list"
 msgstr "Fra MRU liste"
 
 #. IDS_COLORSCHEME_PLAIN
-#: Merge.rc:5404
+#: Merge.rc:5403
 #, c-format
 msgid "No Highlighting"
 msgstr "Ingen fremhævning"
 
 #. IDS_COLORSCHEME_PO
-#: Merge.rc:5439
+#: Merge.rc:5438
 #, c-format
 msgid "Portable Object"
 msgstr "Transportabelt Objekt"
 
 #. IDS_COLORSCHEME_RSRC
-#: Merge.rc:5444
+#: Merge.rc:5443
 #, c-format
 msgid "Resources"
 msgstr "Resourser"
 
 #. IDS_COLORSCHEME_SH
-#: Merge.rc:5448
+#: Merge.rc:5447
 #, c-format
 msgid "Shell"
 msgstr "Shell"
 
 #. IDS_CLOSE_LEFT_TABS
-#: Merge.rc:5469
+#: Merge.rc:5468
 #, c-format
 msgid "Close &Left Tabs"
 msgstr ""
 
 #. IDS_CLOSE_RIGHT_TABS
-#: Merge.rc:5470
+#: Merge.rc:5469
 #, c-format
 msgid "Close R&ight Tabs"
 msgstr ""
 
 #. IDS_CLOSE_OTHER_TABS
-#: Merge.rc:5471
+#: Merge.rc:5470
 #, c-format
 msgid "Close &Other Tabs"
 msgstr ""
 
 #. IDS_TABBAR_AUTO_MAXWIDTH
-#: Merge.rc:5472
+#: Merge.rc:5471
 #, c-format
 msgid "Enable &Auto Max Width"
 msgstr ""
 
 #. IDS_WEBPAGE_MENU
-#: Merge.rc:5482
+#: Merge.rc:5481
 msgid "We&bpage"
 msgstr ""
 
 #. IDS_VIEW_WRAP_TEXT
-#: Merge.rc:5487
+#: Merge.rc:5486
 msgid "W&rap Text"
 msgstr ""
 
 #. IDS_NOTINSTALLED
-#: Merge.rc:5492
+#: Merge.rc:5491
 msgid "%1 is not installed."
 msgstr ""
 
 #. IDS_CREATE_FOLDER
-#: Merge.rc:5497
+#: Merge.rc:5496
 #, c-format
 msgid "%1 does not exist. Create it?"
 msgstr ""
 
 #. IDS_CREATE_FOLDER_ERROR
-#: Merge.rc:5498
+#: Merge.rc:5497
 #, c-format
 msgid "Failed to create folder."
 msgstr ""
 
 #. IDC_EXT_EDITOR_PATH
-#: Merge.rc:5503
+#: Merge.rc:5502
 #, c-format
 msgid "Parameters:\n$file: Current file path\n$linenum: Current cursor line number"
 msgstr ""
 
 #. IDS_DIFF_ALGORITHM_DEFAULT
-#: Merge.rc:5508
+#: Merge.rc:5507
 msgid "default"
 msgstr ""
 
 #. IDS_DIFF_ALGORITHM_MINIMAL
-#: Merge.rc:5509
+#: Merge.rc:5508
 msgid "minimal"
 msgstr ""
 
 #. IDS_DIFF_ALGORITHM_PATIENCE
-#: Merge.rc:5510
+#: Merge.rc:5509
 msgid "patience"
 msgstr ""
 
 #. IDS_DIFF_ALGORITHM_HISTOGRAM
-#: Merge.rc:5511
+#: Merge.rc:5510
 msgid "histogram"
 msgstr ""
 
 #. IDS_DIFF_ALGORITHM_NONE
-#: Merge.rc:5512
+#: Merge.rc:5511
 msgid "none"
 msgstr ""
 
 #. IDS_RENDERING_MODE_GDI
-#: Merge.rc:5517
+#: Merge.rc:5516
 msgid "GDI"
 msgstr ""
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_DEFAULT
-#: Merge.rc:5518
+#: Merge.rc:5517
 msgid "DirectWrite Default"
 msgstr ""
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_ALIASED
-#: Merge.rc:5519
+#: Merge.rc:5518
 msgid "DirectWrite Aliased"
 msgstr ""
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_GDI_CLASSIC
-#: Merge.rc:5520
+#: Merge.rc:5519
 msgid "DirectWrite GDI Classic"
 msgstr ""
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_GDI_NATURAL
-#: Merge.rc:5521
+#: Merge.rc:5520
 msgid "DirectWrite GDI Natural"
 msgstr ""
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_NATURAL
-#: Merge.rc:5522
+#: Merge.rc:5521
 msgid "DirectWrite Natural"
 msgstr ""
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_NATURAL_SYMMETRIC
-#: Merge.rc:5523
+#: Merge.rc:5522
 msgid "DirectWrite Natural Symmetric"
 msgstr ""
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_DISABLED
-#: Merge.rc:5528
+#: Merge.rc:5527
 msgctxt "Options dialog|General|Close windows with Esc"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_1
-#: Merge.rc:5529
+#: Merge.rc:5528
 msgid "MDI child window or main window"
 msgstr ""
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_2
-#: Merge.rc:5530
+#: Merge.rc:5529
 msgid "MDI child window only"
 msgstr ""
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_3
-#: Merge.rc:5531
+#: Merge.rc:5530
 msgid "Close main window if only one MDI child window"
 msgstr ""
 
 #. IDS_DIFF_GROUP
-#: Merge.rc:5536
+#: Merge.rc:5535
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Diff"
 msgstr ""
 
 #. IDS_DIFF_HIGHLIGHT
-#: Merge.rc:5537
+#: Merge.rc:5536
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Highlight"
 msgstr ""
 
 #. IDS_DIFF_BLINK
-#: Merge.rc:5538
+#: Merge.rc:5537
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Blink"
 msgstr ""
 
 #. IDS_DIFF_BLOCKSIZE
-#: Merge.rc:5539
+#: Merge.rc:5538
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Block Size"
 msgstr ""
 
 #. IDS_DIFF_BLOCKALPHA
-#: Merge.rc:5540
+#: Merge.rc:5539
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Block Alpha"
 msgstr ""
 
 #. IDS_DIFF_CDTHRESHOLD
-#: Merge.rc:5541
+#: Merge.rc:5540
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "CD Threshold"
 msgstr ""
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION
-#: Merge.rc:5542
+#: Merge.rc:5541
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Ins/Del Detection"
 msgstr ""
 
 #. IDS_OVERLAY_MODE_NONE
-#: Merge.rc:5543 Merge.rc:5548
+#: Merge.rc:5542 Merge.rc:5547
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "None"
 msgstr ""
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION_VERTICAL
-#: Merge.rc:5544
+#: Merge.rc:5543
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Vertical"
 msgstr ""
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION_HORIZONTAL
-#: Merge.rc:5545
+#: Merge.rc:5544
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Horizontal"
 msgstr ""
 
 #. IDS_OVERLAY_GROUP
-#: Merge.rc:5546
+#: Merge.rc:5545
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Overlay"
 msgstr ""
 
 #. IDS_OVERLAY_ALPHA
-#: Merge.rc:5547
+#: Merge.rc:5546
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha"
 msgstr ""
 
 #. IDS_OVERLAY_MODE_XOR
-#: Merge.rc:5549
+#: Merge.rc:5548
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "XOR"
 msgstr ""
 
 #. IDS_OVERLAY_MODE_ALPHA
-#: Merge.rc:5550
+#: Merge.rc:5549
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha Blend"
 msgstr ""
 
 #. IDS_OVERLAY_MODE_ALPHA_ANIMATION
-#: Merge.rc:5551
+#: Merge.rc:5550
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha Animation"
 msgstr ""
 
 #. IDS_ZOOM
-#: Merge.rc:5552
+#: Merge.rc:5551
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Zoom"
 msgstr ""
 
 #. IDS_PAGE
-#: Merge.rc:5553
+#: Merge.rc:5552
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Page:"
 msgstr ""
 
 #. IDS_IMGCMP_STATUS_PT_RGBA_FMT
-#: Merge.rc:5554
+#: Merge.rc:5553
 #, c-format
 msgid "Pt: (%d, %d)  RGBA: (%d, %d, %d, %d)  "
 msgstr ""
 
 #. IDS_IMGCMP_STATUS_DIST1_FMT
-#: Merge.rc:5555
+#: Merge.rc:5554
 #, c-format
 msgid "Dist: %g  "
 msgstr ""
 
 #. IDS_IMGCMP_STATUS_DIST2_FMT
-#: Merge.rc:5556
+#: Merge.rc:5555
 #, c-format
 msgid "Dist: %g, %g  "
 msgstr ""
 
 #. IDS_IMGCMP_STATUS_PAGE_ZOOM_SIZE_BPP_FMT
-#: Merge.rc:5557
+#: Merge.rc:5556
 #, c-format
 msgid "Page: %d/%d  Zoom: %d%%  %dx%dpx  %dbpp  "
 msgstr ""
 
 #. IDS_IMGCMP_STATUS_RC_FMT
-#: Merge.rc:5558
+#: Merge.rc:5557
 #, c-format
 msgid "Rc: (%d, %d)  "
 msgstr ""
 
 #. IDS_IMGCMP_STATUS_FLIPPED_FMT
-#: Merge.rc:5559
+#: Merge.rc:5558
 #, c-format
 msgid "Flipped: %s  "
 msgstr ""
 
 #. IDS_IMGCMP_STATUS_ROTATED_FMT
-#: Merge.rc:5560
+#: Merge.rc:5559
 #, c-format
 msgid "Rotated: %d  "
 msgstr ""
 
 #. IDS_IMGCMP_REPORT_ALLPAGES
-#: Merge.rc:5561
+#: Merge.rc:5560
 msgid "All pages"
 msgstr ""
 
 #. IDS_IGNSUB_STR1
-#: Merge.rc:5566
+#: Merge.rc:5565
 msgid "<Edit here>"
 msgstr ""
 
 #. IDS_IGNSUB_STR2
-#: Merge.rc:5567
+#: Merge.rc:5566
 msgid "No differences found to select"
 msgstr ""
 
 #. IDS_IGNSUB_STR3
-#: Merge.rc:5568
+#: Merge.rc:5567
 msgid "No differences found to add as substitution filter"
 msgstr ""
 
 #. IDS_IGNSUB_STR4
-#: Merge.rc:5569
+#: Merge.rc:5568
 msgid "The pair is already in the Substitution Filters list"
 msgstr ""
 
 #. IDS_IGNSUB_STR5
-#: Merge.rc:5570
+#: Merge.rc:5569
 msgid "Add this change to Substitution Filters?"
 msgstr ""
 
 #. IDS_OCRRESULT_TEXTONLY
-#: Merge.rc:5575
+#: Merge.rc:5574
 msgid "Text only"
 msgstr ""
 
 #. IDS_OCRRESULT_POS_LINE
-#: Merge.rc:5576
+#: Merge.rc:5575
 msgid "Line-by-line position and text"
 msgstr ""
 
 #. IDS_OCRRESULT_POS_WORD
-#: Merge.rc:5577
+#: Merge.rc:5576
 msgid "Word-by-word position and text"
 msgstr ""
 
 #. IDS_USERDATAFOLDER_APPDATA
-#: Merge.rc:5582
+#: Merge.rc:5581
 msgid "AppData (Roaming) folder"
 msgstr ""
 
 #. IDS_USERDATAFOLDER_INSTALL
-#: Merge.rc:5583
+#: Merge.rc:5582
 msgid "Install folder"
 msgstr ""
 
 #. IDS_USERDATAFOLDER_DOCUMENTS
-#: Merge.rc:5584
+#: Merge.rc:5583
 msgid "Documents folder"
 msgstr ""
 
 #. IDS_SINGLEINSTANCE_DISABLED
-#: Merge.rc:5589
+#: Merge.rc:5588
 msgctxt "Options dialog|General|Single instance mode"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_SINGLEINSTANCE_STR1
-#: Merge.rc:5590
+#: Merge.rc:5589
 #, c-format
 msgid "Allow only one instance to run"
 msgstr "Tillad kun et eksempel ad gangen"
 
 #. IDS_CLIPBOARD_HISTORY
-#: Merge.rc:5591
+#: Merge.rc:5590
 msgid "Clipboard &History"
 msgstr ""
 
 #. IDS_SINGLEINSTANCE_STR2
-#: Merge.rc:5592
+#: Merge.rc:5591
 msgid "Allow only one instance; wait for termination"
 msgstr ""
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_DISABLED
-#: Merge.rc:5597
+#: Merge.rc:5596
 msgctxt "Options dialog|General|Auto-reload modified files"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_STR1
-#: Merge.rc:5598
+#: Merge.rc:5597
 msgid "Only on window activated"
 msgstr ""
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_STR2
-#: Merge.rc:5599
+#: Merge.rc:5598
 msgid "Immediately"
 msgstr ""
 
 #. IDS_PLUGIN_ALL
-#: Merge.rc:5604
+#: Merge.rc:5603
 msgid "Al&l"
 msgstr ""
 
 #. IDS_PLUGIN_OTHERS
-#: Merge.rc:5605
+#: Merge.rc:5604
 msgid "&Others"
 msgstr ""
 
-#: Merge.rc:5607
+#: Merge.rc:5606
 #, c-format
 msgid "Missing plugin name in pipeline: %1"
 msgstr ""
 
-#: Merge.rc:5609
+#: Merge.rc:5608
 #, c-format
 msgid "Missing quote in plugin pipeline: %1"
 msgstr ""
 
 #. IDS_PLUGIN_NAME_ALREADY_EXISTS
-#: Merge.rc:5610
+#: Merge.rc:5609
 #, c-format
 msgid "Plugin name '%1' already exists."
 msgstr ""
 
 #. IDS_PLUGIN_TITLE1
-#: Merge.rc:5611
+#: Merge.rc:5610
 msgid "Specify plugin arguments"
 msgstr ""
 
-#: Merge.rc:5613
+#: Merge.rc:5612
 #, c-format
 msgid "Plugin not found or invalid: %1"
 msgstr ""
 
 #. IDS_PLUGIN_NOT_UNPACK
-#: Merge.rc:5614
+#: Merge.rc:5613
 #, c-format
 msgid "'%1' is not an unpacker plugin"
 msgstr ""
 
 #. IDS_PLUGIN_NOT_PREDIFF
-#: Merge.rc:5615
+#: Merge.rc:5614
 #, c-format
 msgid "'%1' is not a prediffer plugin"
 msgstr ""
 
-#: Merge.rc:5617
+#: Merge.rc:5616
 #, c-format
 msgid "Error prediffing '%1' with '%2'. Prediffing disabled."
 msgstr ""
 
 #. IDS_PLUGIN_CIRCULAR_REFERENCE
-#: Merge.rc:5618
+#: Merge.rc:5617
 #, c-format
 msgid "Circular reference in plugin pipeline: %1"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE1
-#: Merge.rc:5619
+#: Merge.rc:5618
 msgid "URL Handler"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE2
-#: Merge.rc:5620
+#: Merge.rc:5619
 msgid "File Unpacker"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE3
-#: Merge.rc:5621
+#: Merge.rc:5620
 msgid "File or Folder Unpacker"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE5
-#: Merge.rc:5623
+#: Merge.rc:5622
 msgid "Alias for Unpacker"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE6
-#: Merge.rc:5624
+#: Merge.rc:5623
 msgid "Alias for Prediffer"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE7
-#: Merge.rc:5625
+#: Merge.rc:5624
 msgid "Alias for Editor script"
 msgstr ""
 
 #. IDS_PLUGIN_ALIAS_DESC
-#: Merge.rc:5626
+#: Merge.rc:5625
 #, c-format
 msgid "Alias for plugin pipeline '%1'"
 msgstr ""
 
 #. IDS_PLUGIN_NEW_DESC
-#: Merge.rc:5627
+#: Merge.rc:5626
 msgid "New plugin description"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_ALL
-#: Merge.rc:5628
+#: Merge.rc:5627
 msgid "All"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_1ST
-#: Merge.rc:5629
+#: Merge.rc:5628
 msgid "1st"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_2ND
-#: Merge.rc:5630
+#: Merge.rc:5629
 msgid "2nd"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_3RD
-#: Merge.rc:5631
+#: Merge.rc:5630
 msgid "3rd"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_1ST_2ND
-#: Merge.rc:5632
+#: Merge.rc:5631
 msgid "1st and 2nd"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_1ST_3RD
-#: Merge.rc:5633
+#: Merge.rc:5632
 msgid "1st and 3rd"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_2ND_3RD
-#: Merge.rc:5634
+#: Merge.rc:5633
 msgid "2nd and 3rd"
 msgstr ""
 
 #. IDS_PLUGIN_CTRL_CLICK
-#: Merge.rc:5635
+#: Merge.rc:5634
 msgid "(Ctrl+Click to add to pipeline)"
 msgstr ""
 
 #. IDS_FILTER_APPLIED
-#: Merge.rc:5640
+#: Merge.rc:5639
 msgid "Filter applied"
 msgstr ""
 
 #. IDS_FILTERMENU_COMPARE
-#: Merge.rc:5645
+#: Merge.rc:5644
 #, c-format
 msgid "Compare %1"
 msgstr ""
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN2
-#: Merge.rc:5647
+#: Merge.rc:5646
 msgid "&Filter by This Column..."
 msgstr ""
 
 #. IDS_CLIPBOARDHISTORY_TIME
-#: Merge.rc:5652
+#: Merge.rc:5651
 #, c-format
 msgid "Clipboard at %s"
 msgstr ""
 
 #. IDS_CLIPBOARDHISTORY_DISABLED
-#: Merge.rc:5653
+#: Merge.rc:5652
 msgid "Clipboard history disabled.\r\nEnable: Windows logo key + V, then Turn on."
 msgstr ""
 
-#: Merge.rc:5655
+#: Merge.rc:5654
 msgid "This system does not support clipboard history."
 msgstr ""
 
-#: Merge.rc:5657
+#: Merge.rc:5656
 msgid "32-bit WinMerge does not support Clipboard Compare"
 msgstr ""
 
 #. IDS_WEBVIEW2_RUNTIME_NOT_INSTALLED
-#: Merge.rc:5662
+#: Merge.rc:5661
 msgid "WebView2 runtime not installed. Download it?"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_TEXT_COMPARE
-#: Merge.rc:5667
+#: Merge.rc:5666
 msgid "New Text Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_TABLE_COMPARE
-#: Merge.rc:5668
+#: Merge.rc:5667
 msgid "New Table Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_BINARY_COMPARE
-#: Merge.rc:5669
+#: Merge.rc:5668
 msgid "New Binary Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_IMAGE_COMPARE
-#: Merge.rc:5670
+#: Merge.rc:5669
 msgid "New Image Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_WEBPAGE_COMPARE
-#: Merge.rc:5671
+#: Merge.rc:5670
 msgid "New Webpage Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_FOLDER_COMPARE
-#: Merge.rc:5672
+#: Merge.rc:5671
 msgid "New Folder Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_CLIPBOARD_COMPARE
-#: Merge.rc:5673
+#: Merge.rc:5672
 msgid "Clipboard Compare"
 msgstr ""
 
 #. IDS_PREVIEWBAR_PRINT
-#: Merge.rc:5678
+#: Merge.rc:5677
 msgid "&Print..."
 msgstr ""
 
 #. IDS_PREVIEWBAR_PREVPAGE
-#: Merge.rc:5680
+#: Merge.rc:5679
 msgid "Pre&v Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_TWOPAGE
-#: Merge.rc:5681
+#: Merge.rc:5680
 msgid "&Two Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_ONEPAGE
-#: Merge.rc:5682
+#: Merge.rc:5681
 msgid "&One Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_ZOOMIN
-#: Merge.rc:5683
+#: Merge.rc:5682
 msgid "Zoom &In"
 msgstr ""
 
 #. IDS_PREVIEWBAR_ZOOMOUT
-#: Merge.rc:5684
+#: Merge.rc:5683
 msgid "Zoom &Out"
 msgstr ""
 
 #. IDS_WEBPAGE_COMPARING
-#: Merge.rc:5690
+#: Merge.rc:5689
 msgid "Comparing..."
 msgstr ""
 
 #. IDS_WEBPAGE_ZOOM
-#: Merge.rc:5691
+#: Merge.rc:5690
 msgid "Zoom:"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_DIFFHUNK
-#: Merge.rc:5696
+#: Merge.rc:5695
 msgid "Diff hunk"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_INLINE
-#: Merge.rc:5697
+#: Merge.rc:5696
 msgid "Inline diff"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_LINE
-#: Merge.rc:5698
+#: Merge.rc:5697
 msgid "Line"
 msgstr ""
 
-#: Merge.rc:5699
+#: Merge.rc:5698
 msgid "Character"
 msgstr ""
 
 #. ID_MICE_PREVDIFF
-#: Merge.rc:5704
+#: Merge.rc:5703
 msgid "\nPrevious Difference (Alt+Up)\n(Right Button+Wheel Up)\n(Alt+Wheel Up)"
 msgstr ""
 
 #. ID_MICE_NEXTDIFF
-#: Merge.rc:5705
+#: Merge.rc:5704
 msgid "\nNext Difference (Alt+Down)\n(Right Button+Wheel Down)\n(Alt+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_L2R
-#: Merge.rc:5706
+#: Merge.rc:5705
 msgid "\nCopy to Right (Alt+Right)\n(Right Button+Wheel Right)\n(Alt+Wheel Right)\n(Alt+Shift+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_R2L
-#: Merge.rc:5707
+#: Merge.rc:5706
 msgid "\nCopy to Left (Alt+Left)\n(Right Button+Wheel Left)\n(Alt+Wheel Left)\n(Alt+Shift+Wheel Up)"
 msgstr ""
 
 #. ID_MICE_L2RNEXT
-#: Merge.rc:5708
+#: Merge.rc:5707
 msgid "\nCopy to Right and Advance (Ctrl+Alt+Right)\n(Ctrl+Alt+Wheel Right)\n(Ctrl+Alt+Shift+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_R2LNEXT
-#: Merge.rc:5709
+#: Merge.rc:5708
 msgid "\nCopy to Left and Advance (Ctrl+Alt+Left)\n(Ctrl+Alt+Wheel Left)\n(Ctrl+Alt+Shift+Wheel Up)"
 msgstr ""
 
 #. IDS_LOG_COMPARING_2
-#: Merge.rc:5719
+#: Merge.rc:5718
 #, c-format
 msgid "Comparing %1 with %2"
 msgstr ""
 
 #. IDS_LOG_COMPARING_3
-#: Merge.rc:5720
+#: Merge.rc:5719
 #, c-format
 msgid "Comparing %1 with %2 and %3"
 msgstr ""
 
 #. IDS_LOG_COMPARE_COMPLETED
-#: Merge.rc:5721
+#: Merge.rc:5720
 msgid "Comparison completed"
 msgstr ""
 
 #. IDS_LOG_COMPARE_ERROR_2
-#: Merge.rc:5722
+#: Merge.rc:5721
 #, c-format
 msgid "Failed to compare %1 with %2: "
 msgstr ""
 
 #. IDS_LOG_COMPARE_ERROR_3
-#: Merge.rc:5723
+#: Merge.rc:5722
 #, c-format
 msgid "Failed to compare %1 with %2 and %3: "
 msgstr ""
 
 #. IDS_LOG_FILE_SAVED
-#: Merge.rc:5724
+#: Merge.rc:5723
 msgid "File saved"
 msgstr ""
 
 #. IDS_LOG_COPYING_FILES
-#: Merge.rc:5725
+#: Merge.rc:5724
 msgid "Copying files..."
 msgstr ""
 
 #. IDS_LOG_MOVING_FILES
-#: Merge.rc:5726
+#: Merge.rc:5725
 msgid "Moving files..."
 msgstr ""
 
 #. IDS_LOG_DELETING_FILES
-#: Merge.rc:5727
+#: Merge.rc:5726
 msgid "Deleting files..."
 msgstr ""
 
 #. IDS_LOG_RECYCLEBIN
-#: Merge.rc:5728
+#: Merge.rc:5727
 msgid "Recycle Bin"
 msgstr ""
 
 #. IDS_LOG_PERMANENTLY_DELETED
-#: Merge.rc:5729
+#: Merge.rc:5728
 msgid "Permanently deleted"
 msgstr ""
 
 #. IDS_LOG_FILEOPERATION_COMPLETED
-#: Merge.rc:5730
+#: Merge.rc:5729
 msgid "File operation completed successfully"
 msgstr ""
 
 #. IDS_LOG_FILEOPERATION_CANCELED
-#: Merge.rc:5731
+#: Merge.rc:5730
 msgid "File operation canceled"
 msgstr ""
 
 #. IDS_FILTER_ERROR_NO_ERROR
-#: Merge.rc:5736
+#: Merge.rc:5735
 msgid "No error"
 msgstr ""
 
 #. IDS_FILTER_ERROR_EMPTY_EXPRESSION
-#: Merge.rc:5737
+#: Merge.rc:5736
 msgid "Filter expression is empty"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNKNOWN_CHAR
-#: Merge.rc:5738
+#: Merge.rc:5737
 msgid "Unknown character in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNTERMINATED_STRING
-#: Merge.rc:5739
+#: Merge.rc:5738
 msgid "Unterminated string literal"
 msgstr ""
 
 #. IDS_FILTER_ERROR_SYNTAX_ERROR
-#: Merge.rc:5740
+#: Merge.rc:5739
 msgid "Syntax error in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_PARSE_FAILURE
-#: Merge.rc:5741
+#: Merge.rc:5740
 msgid "Failed to parse filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_LITERAL
-#: Merge.rc:5742
+#: Merge.rc:5741
 msgid "Invalid literal value"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_REGULAR_EXPRESSION
-#: Merge.rc:5743
+#: Merge.rc:5742
 msgid "Invalid regular expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNDEFINED_IDENTIFIER
-#: Merge.rc:5744
+#: Merge.rc:5743
 msgid "Undefined identifier"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_ARGUMENT_COUNT
-#: Merge.rc:5745
+#: Merge.rc:5744
 msgid "Invalid number of arguments"
 msgstr ""
 
 #. IDS_FILTER_ERROR_FILTER_NAME_NOT_FOUND
-#: Merge.rc:5746
+#: Merge.rc:5745
 msgid "Filter name not found"
 msgstr ""
 
 #. IDS_FILTER_ERROR_DIVIDE_BY_ZERO
-#: Merge.rc:5747
+#: Merge.rc:5746
 msgid "Division by zero in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNKNOWN_ERROR
-#: Merge.rc:5748
+#: Merge.rc:5747
 msgid "Unknown error"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_PROPERTY_NAME
-#: Merge.rc:5749
+#: Merge.rc:5748
 msgid "Invalid property name"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_DIRECTIVE
-#: Merge.rc:5750
+#: Merge.rc:5749
 msgid "Invalid directive"
 msgstr ""
 
 #. IDS_FILTER_OP_EQUALS
-#: Merge.rc:5755
+#: Merge.rc:5754
 msgid "Equals"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_EQUALS
-#: Merge.rc:5756
+#: Merge.rc:5755
 msgid "Does not equal"
 msgstr ""
 
 #. IDS_FILTER_OP_LESS_THAN
-#: Merge.rc:5757
+#: Merge.rc:5756
 msgid "Less than"
 msgstr ""
 
 #. IDS_FILTER_OP_LESS_EQUAL
-#: Merge.rc:5758
+#: Merge.rc:5757
 msgid "Less than or equal to"
 msgstr ""
 
 #. IDS_FILTER_OP_GREATER_EQUAL
-#: Merge.rc:5759
+#: Merge.rc:5758
 msgid "Greater than or equal to"
 msgstr ""
 
 #. IDS_FILTER_OP_GREATER_THAN
-#: Merge.rc:5760
+#: Merge.rc:5759
 msgid "Greater than"
 msgstr ""
 
 #. IDS_FILTER_OP_BETWEEN
-#: Merge.rc:5761
+#: Merge.rc:5760
 msgid "Between"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_BETWEEN
-#: Merge.rc:5762
+#: Merge.rc:5761
 msgid "Not Between"
 msgstr ""
 
 #. IDS_FILTER_OP_CONTAINS
-#: Merge.rc:5763
+#: Merge.rc:5762
 msgid "Contains"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_CONTAINS
-#: Merge.rc:5764
+#: Merge.rc:5763
 msgid "Not Contains"
 msgstr ""
 
 #. IDS_FILTER_OP_RECONTAINS
-#: Merge.rc:5765
+#: Merge.rc:5764
 msgid "Contains (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_RECONTAINS
-#: Merge.rc:5766
+#: Merge.rc:5765
 msgid "Not Contains (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_LIKE
-#: Merge.rc:5767
+#: Merge.rc:5766
 msgid "Match (wildcard)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_LIKE
-#: Merge.rc:5768
+#: Merge.rc:5767
 msgid "Not match (wildcard)"
 msgstr ""
 
 #. IDS_FILTER_OP_MATCHES
-#: Merge.rc:5769
+#: Merge.rc:5768
 msgid "Match (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_MATCHES
-#: Merge.rc:5770
+#: Merge.rc:5769
 msgid "Not match (regex)"
 msgstr ""
 
 #. IDS_COLORMODE_LIGHT
-#: Merge.rc:5775
+#: Merge.rc:5774
 msgid "Light"
 msgstr ""
 
 #. IDS_COLORMODE_DARK
-#: Merge.rc:5776
+#: Merge.rc:5775
 msgid "Dark"
 msgstr ""
 
 #. IDS_COLORMODE_FOLLOWSYSTEM
-#: Merge.rc:5777
+#: Merge.rc:5776
 msgid "Follow system"
 msgstr ""
 
 #. IDS_EXAMPLE
-#: Merge.rc:5782
+#: Merge.rc:5781
 #, c-format
 msgid "e.g. %1"
 msgstr ""
 
 #. IDS_DETECTED_PREVIOUS_CRASH
-#: Merge.rc:5787
+#: Merge.rc:5786
 msgid "WinMerge detected a previous crash. Please report this if possible."
 msgstr ""
 
 #. IDS_REGEX_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5792
+#: Merge.rc:5791
 msgid "# Regex replacement list\r\n# Format: regex<TAB>replacement\r\n# Backreferences like $1, $2 are supported\r\n\r\n(\\d{4})-(\\d{2})-(\\d{2})\t$1_$2_$3\r\n"
 msgstr ""
 
 #. IDS_STRING_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5793
+#: Merge.rc:5792
 msgid "# Replacement list\r\n# Format: search<TAB>replacement\r\n# Lines starting with # are ignored\r\n\r\nfrom1\tto1\r\nfrom2\tto2\r\n"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_ONLY
-#: Merge.rc:5798
+#: Merge.rc:5797
 msgid "Built-in only"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_FIRST
-#: Merge.rc:5799
+#: Merge.rc:5798
 msgid "Built-in first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_FIRST
-#: Merge.rc:5800
+#: Merge.rc:5799
 msgid "Tree-sitter first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_ONLY
-#: Merge.rc:5801
+#: Merge.rc:5800
 msgid "Tree-sitter only"
 msgstr ""
 

--- a/Translations/WinMerge/Dutch.po
+++ b/Translations/WinMerge/Dutch.po
@@ -21,7 +21,7 @@ msgstr ""
 "X-Poedit-SourceCharset: UTF-8\n"
 
 #. LANGUAGE, SUBLANGUAGE
-#: Merge.rc:26 Merge.rc:59 Merge.rc:5818
+#: Merge.rc:26 Merge.rc:59 Merge.rc:5817
 msgid "LANG_ENGLISH, SUBLANG_ENGLISH_US"
 msgstr "LANG_DUTCH, SUBLANG_DUTCH"
 
@@ -163,7 +163,7 @@ msgstr "Scripts"
 #. IDS_NO_EDIT_SCRIPTS
 #: Merge.rc:127 Merge.rc:352 Merge.rc:463 Merge.rc:673 Merge.rc:678
 #: Merge.rc:887 Merge.rc:899 Merge.rc:906 Merge.rc:963 Merge.rc:1210
-#: Merge.rc:5375
+#: Merge.rc:5374
 msgid "< Empty >"
 msgstr "< Leeg >"
 
@@ -228,7 +228,7 @@ msgid "Auto-Fit All Columns"
 msgstr "Alle kolommen automatisch aanpassen"
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN
-#: Merge.rc:153 Merge.rc:5646
+#: Merge.rc:153 Merge.rc:5645
 msgid "&Filter by This Column"
 msgstr ""
 
@@ -289,7 +289,7 @@ msgid "&Previous Page"
 msgstr "Vorige pagina"
 
 #. IDS_PREVIEWBAR_NEXTPAGE
-#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5679
+#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5678
 msgid "&Next Page"
 msgstr "Volgende pagina"
 
@@ -540,7 +540,7 @@ msgstr "Binair"
 #. IDS_IMAGE_MENU
 #: Merge.rc:329 Merge.rc:338 Merge.rc:432 Merge.rc:441 Merge.rc:609
 #: Merge.rc:618 Merge.rc:670 Merge.rc:960 Merge.rc:1187 Merge.rc:1200
-#: Merge.rc:5477
+#: Merge.rc:5476
 msgid "&Image"
 msgstr "Afbeelding"
 
@@ -662,7 +662,7 @@ msgid "&Huge"
 msgstr "Enorm"
 
 #. IDS_VIEW_MENU_BAR
-#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5714
+#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5713
 msgid "Men&u Bar"
 msgstr ""
 
@@ -1317,7 +1317,7 @@ msgid "Lo&cation Pane"
 msgstr "Locatievenster"
 
 #. IDS_OUTPUTBAR_CAPTION
-#: Merge.rc:782 Merge.rc:5252
+#: Merge.rc:782 Merge.rc:5251
 msgid "Output Pane"
 msgstr ""
 
@@ -1580,55 +1580,55 @@ msgid "Co&mpare As"
 msgstr "Vergelijken als"
 
 #. IDS_COPY_LEFT_TO_MIDDLE2
-#: Merge.rc:968 Merge.rc:980 Merge.rc:4852
+#: Merge.rc:968 Merge.rc:980 Merge.rc:4851
 #, c-format
 msgid "Left to Middle (%1 of %2)"
 msgstr "Links naar midden (%1 van %2)"
 
 #. IDS_COPY_LEFT_TO_RIGHT2
-#: Merge.rc:969 Merge.rc:981 Merge.rc:4851
+#: Merge.rc:969 Merge.rc:981 Merge.rc:4850
 #, c-format
 msgid "Left to Right (%1 of %2)"
 msgstr "Links naar rechts (%1 van %2)"
 
 #. IDS_MOVE_LEFT_TO2
-#: Merge.rc:970 Merge.rc:982 Merge.rc:1045 Merge.rc:4863 Merge.rc:4892
+#: Merge.rc:970 Merge.rc:982 Merge.rc:1045 Merge.rc:4862 Merge.rc:4891
 #, c-format
 msgid "Left to... (%1 of %2)"
 msgstr "Van links naar... (%1 van %2)"
 
 #. IDS_COPY_MIDDLE_TO_LEFT2
-#: Merge.rc:971 Merge.rc:983 Merge.rc:4849
+#: Merge.rc:971 Merge.rc:983 Merge.rc:4848
 #, c-format
 msgid "Middle to Left (%1 of %2)"
 msgstr "Midden naar links (%1 van %2)"
 
 #. IDS_COPY_MIDDLE_TO_RIGHT2
-#: Merge.rc:972 Merge.rc:984 Merge.rc:4850
+#: Merge.rc:972 Merge.rc:984 Merge.rc:4849
 #, c-format
 msgid "Middle to Right (%1 of %2)"
 msgstr "Midden naar rechts (%1 van %2)"
 
 #. IDS_MOVE_MIDDLE_TO2
-#: Merge.rc:973 Merge.rc:985 Merge.rc:1046 Merge.rc:4864 Merge.rc:4893
+#: Merge.rc:973 Merge.rc:985 Merge.rc:1046 Merge.rc:4863 Merge.rc:4892
 #, c-format
 msgid "Middle to... (%1 of %2)"
 msgstr "Midden naar... (%1 van %2)"
 
 #. IDS_COPY_RIGHT_TO_MIDDLE2
-#: Merge.rc:974 Merge.rc:986 Merge.rc:4848
+#: Merge.rc:974 Merge.rc:986 Merge.rc:4847
 #, c-format
 msgid "Right to Middle (%1 of %2)"
 msgstr "Rechts naar midden (%1 van %2)"
 
 #. IDS_COPY_RIGHT_TO_LEFT2
-#: Merge.rc:975 Merge.rc:987 Merge.rc:4847
+#: Merge.rc:975 Merge.rc:987 Merge.rc:4846
 #, c-format
 msgid "Right to Left (%1 of %2)"
 msgstr "Rechts naar links (%1 van %2)"
 
 #. IDS_MOVE_RIGHT_TO2
-#: Merge.rc:976 Merge.rc:988 Merge.rc:1047 Merge.rc:4865 Merge.rc:4894
+#: Merge.rc:976 Merge.rc:988 Merge.rc:1047 Merge.rc:4864 Merge.rc:4893
 #, c-format
 msgid "Right to... (%1 of %2)"
 msgstr "Rechts naar... (%1 van %2)"
@@ -1684,31 +1684,31 @@ msgid "Cop&y Paths"
 msgstr "Padnamen kopiëren"
 
 #. IDS_DEL_LEFT_FMT2
-#: Merge.rc:1026 Merge.rc:1035 Merge.rc:4880
+#: Merge.rc:1026 Merge.rc:1035 Merge.rc:4879
 #, c-format
 msgid "Left (%1 of %2)"
 msgstr "Links (%1 van %2)"
 
 #. IDS_DEL_MIDDLE_FMT2
-#: Merge.rc:1027 Merge.rc:1036 Merge.rc:4881
+#: Merge.rc:1027 Merge.rc:1036 Merge.rc:4880
 #, c-format
 msgid "Middle (%1 of %2)"
 msgstr "Midden (%1 van %2)"
 
 #. IDS_DEL_RIGHT_FMT2
-#: Merge.rc:1028 Merge.rc:1037 Merge.rc:4882
+#: Merge.rc:1028 Merge.rc:1037 Merge.rc:4881
 #, c-format
 msgid "Right (%1 of %2)"
 msgstr "Rechts (%1 van %2)"
 
 #. IDS_DEL_BOTH_FMT2
-#: Merge.rc:1029 Merge.rc:1038 Merge.rc:4883
+#: Merge.rc:1029 Merge.rc:1038 Merge.rc:4882
 #, c-format
 msgid "Both (%1 of %2)"
 msgstr "Beide (%1 van %2)"
 
 #. IDS_DEL_ALL_FMT2
-#: Merge.rc:1030 Merge.rc:1039 Merge.rc:4888
+#: Merge.rc:1030 Merge.rc:1039 Merge.rc:4887
 #, c-format
 msgid "All (%1 of %2)"
 msgstr "Alle (%1 van %2)"
@@ -1734,19 +1734,19 @@ msgid "&Zip"
 msgstr "Zippen"
 
 #. IDS_COPY_BOTH_TO2
-#: Merge.rc:1048 Merge.rc:4866
+#: Merge.rc:1048 Merge.rc:4865
 #, c-format
 msgid "Both to... (%1 of %2)"
 msgstr "Beide naar... (%1 van %2)"
 
 #. IDS_COPY_ALL_TO2
-#: Merge.rc:1049 Merge.rc:4867
+#: Merge.rc:1049 Merge.rc:4866
 #, c-format
 msgid "All to... (%1 of %2)"
 msgstr "Alle naar... (%1 van %2)"
 
 #. IDS_COPY_DIFFERENCES_TO2
-#: Merge.rc:1050 Merge.rc:4868
+#: Merge.rc:1050 Merge.rc:4867
 #, c-format
 msgid "Differences to... (%1 of %2)"
 msgstr "Verschillen naar... (%1 van %2)"
@@ -1813,12 +1813,12 @@ msgstr "Instellingen uitpakker"
 
 #. IDS_USERCHOICE_NONE
 #: Merge.rc:1088 Merge.rc:1094 Merge.rc:1836 Merge.rc:1840 Merge.rc:2031
-#: Merge.rc:2035 Merge.rc:5377
+#: Merge.rc:2035 Merge.rc:5376
 msgid "<None>"
 msgstr "<None>"
 
 #. IDS_USERCHOICE_AUTOMATIC
-#: Merge.rc:1089 Merge.rc:1095 Merge.rc:5378
+#: Merge.rc:1089 Merge.rc:1095 Merge.rc:5377
 msgid "<Automatic>"
 msgstr "<Automatic>"
 
@@ -2748,12 +2748,12 @@ msgid "Text files only"
 msgstr ""
 
 #. IDS_EOL_NONE
-#: Merge.rc:1667 Merge.rc:1918 Merge.rc:5304
+#: Merge.rc:1667 Merge.rc:1918 Merge.rc:5303
 msgid "None"
 msgstr "Geen"
 
 #. IDS_EOL_MIXED
-#: Merge.rc:1668 Merge.rc:5299
+#: Merge.rc:1668 Merge.rc:5298
 msgid "Mixed"
 msgstr "Gemengd"
 
@@ -3025,13 +3025,13 @@ msgstr ""
 
 #. IDS_DIFFERENT
 #: Merge.rc:1904 Merge.rc:1988 Merge.rc:2866 Merge.rc:3036 Merge.rc:3077
-#: Merge.rc:5058
+#: Merge.rc:5057
 msgid "Different"
 msgstr "Verschillend"
 
 #. IDS_IDENTICAL
 #: Merge.rc:1905 Merge.rc:1989 Merge.rc:2865 Merge.rc:3055 Merge.rc:3116
-#: Merge.rc:5048
+#: Merge.rc:5047
 msgid "Identical"
 msgstr "Identiek"
 
@@ -3051,7 +3051,7 @@ msgid "Missing"
 msgstr ""
 
 #. IDS_MOVED
-#: Merge.rc:1910 Merge.rc:5076
+#: Merge.rc:1910 Merge.rc:5075
 msgid "Moved"
 msgstr ""
 
@@ -3792,7 +3792,7 @@ msgid "&Use custom system colors"
 msgstr ""
 
 #. IDS_PRPCAT_SYSTEM
-#: Merge.rc:2565 Merge.rc:4559 Merge.rc:4560 Merge.rc:5007
+#: Merge.rc:2565 Merge.rc:4559 Merge.rc:4560 Merge.rc:5006
 msgid "System"
 msgstr "Systeem"
 
@@ -4197,7 +4197,7 @@ msgid "Items compared:"
 msgstr "Items vergeleken:"
 
 #. IDS_PREVIEWBAR_CLOSE
-#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5685
+#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5684
 msgid "&Close"
 msgstr "Sluiten"
 
@@ -4822,7 +4822,7 @@ msgid "A&ppend timestamp"
 msgstr "Tijdstempel toevoegen"
 
 #. IDS_CONFIRM_COPY_CAPTION
-#: Merge.rc:3214 Merge.rc:4915
+#: Merge.rc:3214 Merge.rc:4914
 msgid "Confirm Copy"
 msgstr "Kopiëren bevestigen"
 
@@ -5059,7 +5059,7 @@ msgid "&Character Set..."
 msgstr "Tekenset..."
 
 #. IDS_PRPCAT_IMAGE
-#: Merge.rc:3351 Merge.rc:4574 Merge.rc:5015
+#: Merge.rc:3351 Merge.rc:4574 Merge.rc:5014
 msgid "Image"
 msgstr "Afbeelding"
 
@@ -5457,7 +5457,7 @@ msgid "Project"
 msgstr "Project"
 
 #. IDS_COLHDR_NSDIFFS
-#: Merge.rc:4566 Merge.rc:4990
+#: Merge.rc:4566 Merge.rc:4989
 msgid "Differences"
 msgstr "Verschillen"
 
@@ -5606,12 +5606,12 @@ msgid "File Type"
 msgstr "Bestandstype"
 
 #. IDS_COLHDR_EXTENSION
-#: Merge.rc:4653 Merge.rc:4947
+#: Merge.rc:4653 Merge.rc:4946
 msgid "Extension"
 msgstr "Extensie"
 
 #. IDS_PRPCAT_MESSAGE
-#: Merge.rc:4659 Merge.rc:5019
+#: Merge.rc:4659 Merge.rc:5018
 msgid "Message"
 msgstr "Bericht"
 
@@ -5651,7 +5651,7 @@ msgid "Hidden Items"
 msgstr "Verborgen items"
 
 #. IDS_PLUGINSLIST_NAME
-#: Merge.rc:4680 Merge.rc:5311
+#: Merge.rc:4680 Merge.rc:5310
 msgid "Name"
 msgstr "Naam"
 
@@ -5671,7 +5671,7 @@ msgid "[F] "
 msgstr "[F] "
 
 #. IDS_PLUGINSLIST_DESC
-#: Merge.rc:4684 Merge.rc:5313
+#: Merge.rc:4684 Merge.rc:5312
 msgid "Description"
 msgstr "Beschrijving"
 
@@ -5839,157 +5839,152 @@ msgstr "Regel: %s  Kolom: %d/%d  Teken: %d/%d"
 msgid "  Sel: %d | %d"
 msgstr "  Sel: %d | %d"
 
-#. IDS_MERGEMODE_MERGING
-#: Merge.rc:4734
-msgid "Merge"
-msgstr "Samenvoegen"
-
 #. IDS_DIFF_NUMBER_STATUS_FMT
-#: Merge.rc:4735
+#: Merge.rc:4734
 #, c-format
 msgid "Difference %1 of %2"
 msgstr "Verschil %1 van %2"
 
 #. IDS_NO_DIFF_SEL_FMT
-#: Merge.rc:4736
+#: Merge.rc:4735
 #, c-format
 msgid "%1 Differences Found"
 msgstr "%1 verschillen gevonden"
 
 #. IDS_1_DIFF_FOUND
-#: Merge.rc:4737
+#: Merge.rc:4736
 msgid "1 Difference Found"
 msgstr "Eén verschil gevonden"
 
 #. IDS_NO_ERR_SEL_FMT
-#: Merge.rc:4738
+#: Merge.rc:4737
 #, c-format
 msgid "%1 Errors Found"
 msgstr ""
 
 #. IDS_1_ERR_FOUND
-#: Merge.rc:4739
+#: Merge.rc:4738
 msgid "1 Error Found"
 msgstr ""
 
 #. IDS_STATUSBAR_READONLY, Abbreviation from "Read Only"
-#: Merge.rc:4740
+#: Merge.rc:4739
 msgid "RO"
 msgstr "AL"
 
 #. IDS_DIRVIEW_STATUS_FMT_FOCUS
-#: Merge.rc:4746
+#: Merge.rc:4745
 #, c-format
 msgid "Item %1 of %2"
 msgstr "Item %1 van %2"
 
 #. IDS_DIRVIEW_STATUS_FMT_NOFOCUS
-#: Merge.rc:4747
+#: Merge.rc:4746
 #, c-format
 msgid "Items: %1"
 msgstr "Items: %1"
 
 #. IDS_DIRVIEW_STATUS_COMPARING
-#: Merge.rc:4748
+#: Merge.rc:4747
 msgid "Comparing items..."
 msgstr "Items vergelijken..."
 
 #. IDS_ITEMS_PER_SEC
-#: Merge.rc:4749
+#: Merge.rc:4748
 #, c-format
 msgid "%.1f[items/sec]"
 msgstr "%.1f[items/sec]"
 
 #. IDS_ERROR_INCOMPARABLE
-#: Merge.rc:4755
+#: Merge.rc:4754
 msgid "Select two existing folders/files to compare."
 msgstr "Twee bestaande mappen of bestanden selecteren om te vergelijken."
 
 #. IDS_DIRSEL_TAG
-#: Merge.rc:4756
+#: Merge.rc:4755
 msgid "Folder Selection"
 msgstr "Mapselectie"
 
 #. IDS_OPEN_FILESDIRS
-#: Merge.rc:4757
+#: Merge.rc:4756
 msgid "Select two (or three) folders/files to compare."
 msgstr ""
 "Twee (of drie) mappen of twee (of drie) bestanden selecteren om te "
 "vergelijken."
 
 #. IDS_OPEN_LEFTINVALID
-#: Merge.rc:4758
+#: Merge.rc:4757
 msgid "Left (1st) path is invalid!"
 msgstr "Linker (1ste) pad is ongeldig!"
 
 #. IDS_OPEN_MIDDLEINVALID
-#: Merge.rc:4759
+#: Merge.rc:4758
 msgid "Middle (2nd) path is invalid!"
 msgstr "Middelste (2de) pad is ongeldig!"
 
 #. IDS_OPEN_RIGHTINVALID2
-#: Merge.rc:4760
+#: Merge.rc:4759
 msgid "Right (2nd) path is invalid!"
 msgstr "Rechter (2de) pad is ongeldig!"
 
 #. IDS_OPEN_RIGHTINVALID3
-#: Merge.rc:4761
+#: Merge.rc:4760
 msgid "Right (3rd) path is invalid!"
 msgstr "Rechter (3de) pad is ongeldig!"
 
 #. IDS_OPEN_BOTHINVALID
-#: Merge.rc:4762
+#: Merge.rc:4761
 msgid "Both paths are invalid!"
 msgstr "Beide paden zijn ongeldig!"
 
-#: Merge.rc:4764
+#: Merge.rc:4763
 msgid "Left (1st) and Middle (2nd) paths are invalid!"
 msgstr "Linker (1ste) en middelste (2de) pad zijn ongeldig!"
 
 #. IDS_OPEN_LEFTRIGHTINVALID
-#: Merge.rc:4765
+#: Merge.rc:4764
 msgid "Left (1st) and Right (3rd) paths are invalid!"
 msgstr "Linker (1ste) en rechter (3de) pad zijn ongeldig!"
 
-#: Merge.rc:4767
+#: Merge.rc:4766
 msgid "Middle (2nd) and Right (3rd) paths are invalid!"
 msgstr "MIddelste (2de) en rechter (3de) pad zijn ongeldig!"
 
 #. IDS_OPEN_ALLINVALID
-#: Merge.rc:4768
+#: Merge.rc:4767
 msgid "All paths are invalid!"
 msgstr "Alle paden zijn ongeldig!"
 
 #. IDS_OPEN_UNPACKERDISABLED
-#: Merge.rc:4769
+#: Merge.rc:4768
 msgid "Only enabled for file comparisons"
 msgstr "Alleen ingeschakeld voor bestandsvergelijkingen"
 
 #. IDS_OPEN_MISMATCH
-#: Merge.rc:4770
+#: Merge.rc:4769
 msgid "Cannot compare file and folder!"
 msgstr "Kan geen bestand met een map vergelijken!"
 
 #. IDS_ERROR_FILE_NOT_FOUND
-#: Merge.rc:4776
+#: Merge.rc:4775
 #, c-format
 msgid "File not found: %1"
 msgstr "Bestand niet gevonden: %1"
 
 #. IDS_ERROR_FOLDER_NOT_FOUND
-#: Merge.rc:4777
+#: Merge.rc:4776
 #, c-format
 msgid "Folder not found: %1"
 msgstr ""
 
 #. IDS_ERROR_FILE_NOT_UNPACKED
-#: Merge.rc:4778
+#: Merge.rc:4777
 #, c-format
 msgid "File not unpacked: %1"
 msgstr "Bestand niet uitgepakt: %1"
 
 #. IDS_ERROR_FILEOPEN
-#: Merge.rc:4779
+#: Merge.rc:4778
 #, c-format
 msgid ""
 "Cannot open file\n"
@@ -6003,12 +5998,12 @@ msgstr ""
 "%2"
 
 #. IDS_ERROR_CONF_RESOLVE
-#: Merge.rc:4780
+#: Merge.rc:4779
 msgid "Failed to parse conflict file."
 msgstr "Verwerken van conflictbestand mislukt."
 
 #. IDS_NOT_CONFLICT_FILE
-#: Merge.rc:4781
+#: Merge.rc:4780
 #, c-format
 msgid "The file\n%1\nis not a conflict file."
 msgstr ""
@@ -6017,7 +6012,7 @@ msgstr ""
 "is geen conflictbestand."
 
 #. IDS_COMPARE_LARGE_FILES
-#: Merge.rc:4782
+#: Merge.rc:4781
 msgid "Comparing large files requires significant memory.\nShow only comparison results (not file contents)?"
 msgstr ""
 "U staat op het punt om zeer grote bestanden te vergelijken.\n"
@@ -6026,18 +6021,18 @@ msgstr ""
 "\n"
 
 #. IDS_SAVE_AS_TITLE
-#: Merge.rc:4788
+#: Merge.rc:4787
 msgid "Save As"
 msgstr "Opslaan als"
 
 #. IDS_SAVE_FMT
-#: Merge.rc:4789
+#: Merge.rc:4788
 #, c-format
 msgid "Save changes to %1?"
 msgstr "Wijzigingen opslaan in %1?"
 
 #. IDS_SAVEREADONLY_FMT
-#: Merge.rc:4790
+#: Merge.rc:4789
 #, c-format
 msgid "%1 is read-only. Override? Or 'No' to save as new filename?"
 msgstr ""
@@ -6045,11 +6040,11 @@ msgstr ""
 "overschrijven? (Nee om op te slaan als nieuwe bestandsnaam)"
 
 #. IDS_ERROR_BACKUP
-#: Merge.rc:4791
+#: Merge.rc:4790
 msgid "Error backing up file"
 msgstr "Fout bij maken van reservekopie van bestand"
 
-#: Merge.rc:4793
+#: Merge.rc:4792
 #, c-format
 msgid ""
 "Unable to backup original file:\n"
@@ -6063,7 +6058,7 @@ msgstr ""
 "Toch doorgaan?"
 
 #. IDS_FILESAVE_FAILED
-#: Merge.rc:4794
+#: Merge.rc:4793
 #, c-format
 msgid "Saving file failed.\n%1\n%2\n\t- Use different filename (OK)\n\t- Abort (Cancel)?"
 msgstr ""
@@ -6074,7 +6069,7 @@ msgstr ""
 "\t- een andere bestandsnaam gebruiken? (Op 'ok' drukken)\n"
 "\t- de huidige handeling afbreken? (Op 'annuleren' drukken)"
 
-#: Merge.rc:4796
+#: Merge.rc:4795
 #, c-format
 msgid "Plugin '%2' cannot pack changes to left file into '%1'.\n\nOriginal unchanged. Save unpacked version?"
 msgstr ""
@@ -6084,7 +6079,7 @@ msgstr ""
 "\n"
 "Wilt u de uitgepakte versie in een ander bestand opslaan?"
 
-#: Merge.rc:4798
+#: Merge.rc:4797
 #, c-format
 msgid "Plugin '%2' cannot pack changes to middle file into '%1'.\n\nOriginal unchanged. Save unpacked version?"
 msgstr ""
@@ -6094,7 +6089,7 @@ msgstr ""
 "\n"
 "Wilt u de uitgepakte versie in een ander bestand opslaan?"
 
-#: Merge.rc:4800
+#: Merge.rc:4799
 #, c-format
 msgid "Plugin '%2' cannot pack changes to right file into '%1'.\n\nOriginal unchanged. Save unpacked version?"
 msgstr ""
@@ -6105,7 +6100,7 @@ msgstr ""
 "Wilt u de uitgepakte versie in een ander bestand opslaan?"
 
 #. IDS_FILECHANGED_ONDISK
-#: Merge.rc:4801
+#: Merge.rc:4800
 #, c-format
 msgid ""
 "Another application updated\n"
@@ -6121,7 +6116,7 @@ msgstr ""
 "Het gewijzigde bestand overschrijven?"
 
 #. IDS_SAVEREADONLY_MULTI
-#: Merge.rc:4802
+#: Merge.rc:4801
 #, c-format
 msgid ""
 "%1\n"
@@ -6131,7 +6126,7 @@ msgstr ""
 "is gemarkeerd als alleen-lezen. Wilt u het alleen-lezen item overschrijven?"
 
 #. IDS_FILECHANGED_RESCAN
-#: Merge.rc:4803
+#: Merge.rc:4802
 #, c-format
 msgid "Another application updated\n%1\nsince last scan.\n\nReload?"
 msgstr ""
@@ -6142,22 +6137,22 @@ msgstr ""
 "Wilt u het bestand opnieuw laden?"
 
 #. IDS_SAVE_LEFT_AS
-#: Merge.rc:4804
+#: Merge.rc:4803
 msgid "Save Left File As"
 msgstr "Linker bestand opslaan als"
 
 #. IDS_SAVE_MIDDLE_AS
-#: Merge.rc:4805
+#: Merge.rc:4804
 msgid "Save Middle File As"
 msgstr "Middelste bestand opslaan als"
 
 #. IDS_SAVE_RIGHT_AS
-#: Merge.rc:4806
+#: Merge.rc:4805
 msgid "Save Right File As"
 msgstr "Rechter bestand opslaan als"
 
 #. IDS_FILE_DISAPPEARED
-#: Merge.rc:4811
+#: Merge.rc:4810
 #, c-format
 msgid ""
 "File\n"
@@ -6169,7 +6164,7 @@ msgstr ""
 "is verdwenen. Sla een kopie van het bestand op om door te gaan."
 
 #. IDS_VIEWS_OUTOFSYNC
-#: Merge.rc:4817
+#: Merge.rc:4816
 msgid ""
 "Cannot merge unsynched documents.\n"
 "\n"
@@ -6180,186 +6175,186 @@ msgstr ""
 "Vernieuw documenten voordat u doorgaat."
 
 #. IDS_BREAK_ON_WHITESPACE
-#: Merge.rc:4822
+#: Merge.rc:4821
 msgid "Break at whitespace"
 msgstr "Afbreken bij witruimte"
 
 #. IDS_BREAK_ON_PUNCTUATION
-#: Merge.rc:4823
+#: Merge.rc:4822
 msgid "Break at whitespace or punctuation"
 msgstr "Afbreken bij witruimte of interpunctie"
 
 #. IDS_L2M
-#: Merge.rc:4829
+#: Merge.rc:4828
 msgid "Copy to &Middle\tAlt+Right"
 msgstr "Naar midden kopiëren\tAlt+Rechts"
 
 #. IDS_R2M
-#: Merge.rc:4830
+#: Merge.rc:4829
 msgid "Copy to &Middle\tAlt+Left"
 msgstr "Naar midden kopiëren\tAlt+Links"
 
 #. IDS_COPY_FROM_MIDDLE_R
-#: Merge.rc:4831
+#: Merge.rc:4830
 msgid "Copy from Middle\tAlt+Shift+Right"
 msgstr "Van midden kopiëren\tAlt+Shift+Rechts"
 
 #. IDS_COPY_FROM_MIDDLE_L
-#: Merge.rc:4832
+#: Merge.rc:4831
 msgid "Copy from Middle\tAlt+Shift+Left"
 msgstr "Van midden kopiëren\tAlt+Shift+Links"
 
 #. IDS_L2MNEXT
-#: Merge.rc:4833
+#: Merge.rc:4832
 msgid "Copy to Middle and Advance\tCtrl+Alt+Right"
 msgstr "Naar midden kopiëren en verder gaan\tCtrl+Alt+Rechts"
 
 #. IDS_R2MNEXT
-#: Merge.rc:4834
+#: Merge.rc:4833
 msgid "Copy to Middle and Advance\tCtrl+Alt+Left"
 msgstr "Naar midden kopiëren en verder gaan\tCtrl+Alt+Links"
 
 #. IDS_ALL_MIDDLE
-#: Merge.rc:4835
+#: Merge.rc:4834
 msgid "Copy All to Middle"
 msgstr "Alles naar midden kopiëren"
 
 #. IDS_COPY_RIGHT_TO_LEFT
-#: Merge.rc:4841
+#: Merge.rc:4840
 #, c-format
 msgid "Right to Left (%1)"
 msgstr "Rechts naar links (%1)"
 
 #. IDS_COPY_RIGHT_TO_MIDDLE
-#: Merge.rc:4842
+#: Merge.rc:4841
 #, c-format
 msgid "Right to Middle (%1)"
 msgstr "Rechts naar midden (%1)"
 
 #. IDS_COPY_MIDDLE_TO_LEFT
-#: Merge.rc:4843
+#: Merge.rc:4842
 #, c-format
 msgid "Middle to Left (%1)"
 msgstr "Midden naar links (%1)"
 
 #. IDS_COPY_MIDDLE_TO_RIGHT
-#: Merge.rc:4844
+#: Merge.rc:4843
 #, c-format
 msgid "Middle to Right (%1)"
 msgstr "Midden naar rechts (%1)"
 
 #. IDS_COPY_LEFT_TO_RIGHT
-#: Merge.rc:4845
+#: Merge.rc:4844
 #, c-format
 msgid "Left to Right (%1)"
 msgstr "Links naar rechts (%1)"
 
 #. IDS_COPY_LEFT_TO_MIDDLE
-#: Merge.rc:4846
+#: Merge.rc:4845
 #, c-format
 msgid "Left to Middle (%1)"
 msgstr "Links naar midden (%1)"
 
 #. IDS_MOVE_LEFT_TO
-#: Merge.rc:4857 Merge.rc:4889
+#: Merge.rc:4856 Merge.rc:4888
 #, c-format
 msgid "Left to... (%1)"
 msgstr "Links naar... (%1)"
 
 #. IDS_MOVE_MIDDLE_TO
-#: Merge.rc:4858 Merge.rc:4890
+#: Merge.rc:4857 Merge.rc:4889
 #, c-format
 msgid "Middle to... (%1)"
 msgstr "Midden naar... (%1)"
 
 #. IDS_MOVE_RIGHT_TO
-#: Merge.rc:4859 Merge.rc:4891
+#: Merge.rc:4858 Merge.rc:4890
 #, c-format
 msgid "Right to... (%1)"
 msgstr "Rechts naar... (%1)"
 
 #. IDS_COPY_BOTH_TO
-#: Merge.rc:4860
+#: Merge.rc:4859
 #, c-format
 msgid "Both to... (%1)"
 msgstr "Beide naar... (%1)"
 
 #. IDS_COPY_ALL_TO
-#: Merge.rc:4861
+#: Merge.rc:4860
 #, c-format
 msgid "All to... (%1)"
 msgstr "Alles naar... (%1)"
 
 #. IDS_COPY_DIFFERENCES_TO
-#: Merge.rc:4862
+#: Merge.rc:4861
 #, c-format
 msgid "Differences to... (%1)"
 msgstr "Verschillen naar... (%1)"
 
 #. IDS_ONLYDIFFITEMS_CONFIRM
-#: Merge.rc:4869
+#: Merge.rc:4868
 msgid "Some selected items are identical or skipped.\nProcess only items with differences?"
 msgstr ""
 
 #. IDS_DEL_LEFT_FMT
-#: Merge.rc:4875
+#: Merge.rc:4874
 #, c-format
 msgid "Left (%1)"
 msgstr "Links (%1)"
 
 #. IDS_DEL_MIDDLE_FMT
-#: Merge.rc:4876
+#: Merge.rc:4875
 #, c-format
 msgid "Middle (%1)"
 msgstr "Midden (%1)"
 
 #. IDS_DEL_RIGHT_FMT
-#: Merge.rc:4877
+#: Merge.rc:4876
 #, c-format
 msgid "Right (%1)"
 msgstr "Rechts (%1)"
 
 #. IDS_DEL_BOTH_FMT
-#: Merge.rc:4878
+#: Merge.rc:4877
 #, c-format
 msgid "Both (%1)"
 msgstr "Beide (%1)"
 
 #. IDS_DEL_ALL_FMT
-#: Merge.rc:4879
+#: Merge.rc:4878
 #, c-format
 msgid "All (%1)"
 msgstr "Alles (%1)"
 
 #. IDS_SELECT_DEST_LEFT
-#: Merge.rc:4895
+#: Merge.rc:4894
 msgid "Left Side - Select Destination Folder:"
 msgstr "Linkerkant - doelmap selecteren:"
 
 #. IDS_SELECT_DEST_MIDDLE
-#: Merge.rc:4896
+#: Merge.rc:4895
 msgid "Middle Side - Select Destination Folder:"
 msgstr "Midden - doelmap selecteren:"
 
 #. IDS_SELECT_DEST_RIGHT
-#: Merge.rc:4897
+#: Merge.rc:4896
 msgid "Right Side - Select Destination Folder:"
 msgstr "Rechterkant - doelmap selecteren:"
 
 #. IDS_FILES_AFFECTED_FMT
-#: Merge.rc:4898
+#: Merge.rc:4897
 #, c-format
 msgid "(%1 Files Affected)"
 msgstr "(%1 bestanden aangepast)"
 
 #. IDS_FILES_AFFECTED_FMT2
-#: Merge.rc:4899
+#: Merge.rc:4898
 #, c-format
 msgid "(%1 of %2 Files Affected)"
 msgstr "(%1 van %2 bestanden aangepast)"
 
 #. IDS_CONFIRM_DELETE_SINGLE
-#: Merge.rc:4905
+#: Merge.rc:4904
 #, c-format
 msgid ""
 "Are you sure you want to delete\n"
@@ -6368,18 +6363,18 @@ msgid ""
 msgstr "Weet u zeker dat u %1 wilt verwijderen?"
 
 #. IDS_CONFIRM_SINGLE_COPY
-#: Merge.rc:4906
+#: Merge.rc:4905
 msgid "Are you sure you want to copy?"
 msgstr "Weet u zeker dat u wilt kopiëren?"
 
 #. IDS_CONFIRM_MULTIPLE_COPY
-#: Merge.rc:4907
+#: Merge.rc:4906
 #, c-format
 msgid "Are you sure you want to copy %d items?"
 msgstr "Weet u zeker dat u %d items wilt kopiëren?"
 
 #. IDS_DIRCMP_NOTSYNC
-#: Merge.rc:4908
+#: Merge.rc:4907
 #, c-format
 msgid ""
 "Operation aborted!\n"
@@ -6399,48 +6394,48 @@ msgstr ""
 "Vernieuw de vergelijking."
 
 #. IDS_CONFIRM_SINGLE_MOVE
-#: Merge.rc:4913
+#: Merge.rc:4912
 msgid "Are you sure you want to move?"
 msgstr "Weet u zeker dat u wilt verplaatsen?"
 
 #. IDS_CONFIRM_MULTIPLE_MOVE
-#: Merge.rc:4914
+#: Merge.rc:4913
 #, c-format
 msgid "Are you sure you want to move %d items?"
 msgstr "Weet u zeker dat u %d items wilt verplaatsen?"
 
 #. IDS_CONFIRM_MOVE_CAPTION
-#: Merge.rc:4916
+#: Merge.rc:4915
 msgid "Confirm Move"
 msgstr "Verplaatsen bevestigen"
 
-#: Merge.rc:4918
+#: Merge.rc:4917
 msgid "Close the folder comparison window?"
 msgstr ""
 "U staat op het punt om het venster te sluiten dat mappen aan het vergelijken"
 " is. Weet u zeker dat u het venster wilt sluiten?"
 
-#: Merge.rc:4920
+#: Merge.rc:4919
 msgid "Close the folder comparison window, which took a long time?"
 msgstr ""
 
 #. IDS_ERROR_INVALID_DIR_FILE_NAME
-#: Merge.rc:4921
+#: Merge.rc:4920
 msgid "The file or folder name is invalid."
 msgstr "Bestands- of mapnaam is ongeldig."
 
 #. IDS_ERROR_EXECUTE_FILE
-#: Merge.rc:4927
+#: Merge.rc:4926
 #, c-format
 msgid "Failed to execute external editor: %1"
 msgstr "Uitvoeren externe editor mislukt: %1"
 
 #. IDS_UNKNOWN_ARCHIVE_FORMAT
-#: Merge.rc:4933
+#: Merge.rc:4932
 msgid "Unknown archive format"
 msgstr "Onbekend archiefformaat"
 
-#: Merge.rc:4935
+#: Merge.rc:4934
 msgid ""
 "Failed to extract archive.\n"
 "Compare as text file?"
@@ -6449,744 +6444,744 @@ msgstr ""
 "Wilt u de archiefbestanden als tekstbestanden vergelijken?"
 
 #. IDS_COLHDR_FILENAME
-#: Merge.rc:4941
+#: Merge.rc:4940
 msgid "Filename"
 msgstr "Bestandsnaam"
 
 #. IDS_COLHDR_DIR
-#: Merge.rc:4942
+#: Merge.rc:4941
 msgctxt "DirView|ColumnHeader"
 msgid "Folder"
 msgstr "Map"
 
 #. IDS_COLHDR_RESULT
-#: Merge.rc:4943
+#: Merge.rc:4942
 msgid "Comparison Result"
 msgstr "Vergelijkingsresultaat"
 
 #. IDS_COLHDR_LTIMEM
-#: Merge.rc:4944
+#: Merge.rc:4943
 msgid "Left Date"
 msgstr "Datum links"
 
 #. IDS_COLHDR_RTIMEM
-#: Merge.rc:4945
+#: Merge.rc:4944
 msgid "Right Date"
 msgstr "Datum rechts"
 
 #. IDS_COLHDR_MTIMEM
-#: Merge.rc:4946
+#: Merge.rc:4945
 msgid "Middle Date"
 msgstr "Datum midden"
 
 #. IDS_COLHDR_LSIZE
-#: Merge.rc:4948
+#: Merge.rc:4947
 msgid "Left Size"
 msgstr "Grootte links"
 
 #. IDS_COLHDR_RSIZE
-#: Merge.rc:4949
+#: Merge.rc:4948
 msgid "Right Size"
 msgstr "Grootte rechts"
 
 #. IDS_COLHDR_MSIZE
-#: Merge.rc:4954
+#: Merge.rc:4953
 msgid "Middle Size"
 msgstr "Grootte midden"
 
 #. IDS_COLHDR_RSIZE_SHORT
-#: Merge.rc:4955
+#: Merge.rc:4954
 msgid "Right Size (Short)"
 msgstr "Grootte rechts (kort)"
 
 #. IDS_COLHDR_LSIZE_SHORT
-#: Merge.rc:4956
+#: Merge.rc:4955
 msgid "Left Size (Short)"
 msgstr "Grootte links (kort)"
 
 #. IDS_COLHDR_MSIZE_SHORT
-#: Merge.rc:4957
+#: Merge.rc:4956
 msgid "Middle Size (Short)"
 msgstr "Grootte midden (kort)"
 
 #. IDS_COLHDR_LTIMEC
-#: Merge.rc:4963
+#: Merge.rc:4962
 msgid "Left Creation Time"
 msgstr "Aanmaaktijd links"
 
 #. IDS_COLHDR_RTIMEC
-#: Merge.rc:4964
+#: Merge.rc:4963
 msgid "Right Creation Time"
 msgstr "Aanmaaktijd rechts"
 
 #. IDS_COLHDR_MTIMEC
-#: Merge.rc:4965
+#: Merge.rc:4964
 msgid "Middle Creation Time"
 msgstr "Aanmaaktijd midden"
 
 #. IDS_COLHDR_NEWER
-#: Merge.rc:4966
+#: Merge.rc:4965
 msgid "Newer File"
 msgstr "Nieuwer bestand"
 
 #. IDS_COLHDR_LVERSION
-#: Merge.rc:4967
+#: Merge.rc:4966
 msgid "Left File Version"
 msgstr "Bestandsversie links"
 
 #. IDS_COLHDR_RVERSION
-#: Merge.rc:4968
+#: Merge.rc:4967
 msgid "Right File Version"
 msgstr "Bestandsversie rechts"
 
 #. IDS_COLHDR_MVERSION
-#: Merge.rc:4969
+#: Merge.rc:4968
 msgid "Middle File Version"
 msgstr "Bestandsversie midden"
 
 #. IDS_COLHDR_RESULT_ABBR
-#: Merge.rc:4970
+#: Merge.rc:4969
 msgid "Short Result"
 msgstr "Kort resultaat"
 
 #. IDS_COLHDR_LATTRIBUTES
-#: Merge.rc:4971
+#: Merge.rc:4970
 msgid "Left Attributes"
 msgstr "Attributen links"
 
 #. IDS_COLHDR_RATTRIBUTES
-#: Merge.rc:4972
+#: Merge.rc:4971
 msgid "Right Attributes"
 msgstr "Attributen rechts"
 
 #. IDS_COLHDR_MATTRIBUTES
-#: Merge.rc:4973
+#: Merge.rc:4972
 msgid "Middle Attributes"
 msgstr "Attributen midden"
 
 #. IDS_COLHDR_LEOL_TYPE
-#: Merge.rc:4978
+#: Merge.rc:4977
 msgid "Left EOL"
 msgstr "Links regeleinde"
 
 #. IDS_COLHDR_MEOL_TYPE
-#: Merge.rc:4979
+#: Merge.rc:4978
 msgid "Middle EOL"
 msgstr "Midden regeleinde"
 
 #. IDS_COLHDR_REOL_TYPE
-#: Merge.rc:4980
+#: Merge.rc:4979
 msgid "Right EOL"
 msgstr "Rechts regeleinde"
 
 #. IDS_COLHDR_LENCODING
-#: Merge.rc:4986
+#: Merge.rc:4985
 msgid "Left Encoding"
 msgstr "Tekenset links"
 
 #. IDS_COLHDR_RENCODING
-#: Merge.rc:4987
+#: Merge.rc:4986
 msgid "Right Encoding"
 msgstr "Tekenset rechts"
 
 #. IDS_COLHDR_MENCODING
-#: Merge.rc:4988
+#: Merge.rc:4987
 msgid "Middle Encoding"
 msgstr "Tekenset midden"
 
 #. IDS_COLHDR_NIDIFFS
-#: Merge.rc:4989
+#: Merge.rc:4988
 msgid "Ignored Diff"
 msgstr "Genegeerde verschillen"
 
 #. IDS_COLHDR_BINARY
-#: Merge.rc:4991
+#: Merge.rc:4990
 msgctxt "DirView|ColumnHeader"
 msgid "Binary"
 msgstr "Binair"
 
 #. IDS_PLUGINS_TYPE_UNPACKER
-#: Merge.rc:4992 Merge.rc:5314
+#: Merge.rc:4991 Merge.rc:5313
 msgid "Unpacker"
 msgstr "Uitpakker"
 
 #. IDS_PLUGIN_TYPE4
-#: Merge.rc:4993 Merge.rc:5315 Merge.rc:5622
+#: Merge.rc:4992 Merge.rc:5314 Merge.rc:5621
 msgid "Prediffer"
 msgstr "Voorvergelijken"
 
 #. IDS_COLHDR_LEFT
-#: Merge.rc:4994
+#: Merge.rc:4993
 msgid "Left"
 msgstr "Links"
 
 #. IDS_COLHDR_MIDDLE
-#: Merge.rc:4995
+#: Merge.rc:4994
 msgid "Middle"
 msgstr "Midden"
 
 #. IDS_COLHDR_RIGHT
-#: Merge.rc:4996
+#: Merge.rc:4995
 msgid "Right"
 msgstr "Rechts"
 
 #. IDS_COLHDR_DIFF
-#: Merge.rc:4997
+#: Merge.rc:4996
 msgid "Diff"
 msgstr "Verschil"
 
 #. IDS_COLHDR_LEFT_DUPLICATE
-#: Merge.rc:4998
+#: Merge.rc:4997
 msgid "Left Duplicate Count"
 msgstr "Aantal duplicaten links"
 
 #. IDS_COLHDR_RIGHT_DUPLICATE
-#: Merge.rc:4999
+#: Merge.rc:4998
 msgid "Right Duplicate Count"
 msgstr "Aantal duplicaten rechts"
 
 #. IDS_COLHDR_MIDDLE_DUPLICATE
-#: Merge.rc:5000
+#: Merge.rc:4999
 msgid "Middle Duplicate Count"
 msgstr "Aantal duplicaten midden"
 
 #. IDS_COLHDR_MOVE
-#: Merge.rc:5001
+#: Merge.rc:5000
 msgid "Move"
 msgstr "Verplaatsen"
 
 #. IDS_PRPCAT_AUDIO
-#: Merge.rc:5008
+#: Merge.rc:5007
 msgid "Audio"
 msgstr "Audio"
 
 #. IDS_PRPCAT_CALENDAR
-#: Merge.rc:5009
+#: Merge.rc:5008
 msgid "Calendar"
 msgstr "Kalender"
 
 #. IDS_PRPCAT_COMMUNICATION
-#: Merge.rc:5010
+#: Merge.rc:5009
 msgid "Communication"
 msgstr "Communicatie"
 
 #. IDS_PRPCAT_CONTACT
-#: Merge.rc:5011
+#: Merge.rc:5010
 msgid "Contact"
 msgstr "Contact"
 
 #. IDS_PRPCAT_DEVICES
-#: Merge.rc:5012
+#: Merge.rc:5011
 msgid "Devices"
 msgstr "Apparaten"
 
 #. IDS_PRPCAT_DOCUMENT
-#: Merge.rc:5013
+#: Merge.rc:5012
 msgid "Document"
 msgstr "Document"
 
 #. IDS_PRPCAT_HOME
-#: Merge.rc:5014
+#: Merge.rc:5013
 msgid "Home"
 msgstr "Thuis"
 
 #. IDS_PRPCAT_JOURNAL
-#: Merge.rc:5016
+#: Merge.rc:5015
 msgid "Journal"
 msgstr "Tijdschrift"
 
 #. IDS_PRPCAT_LINK
-#: Merge.rc:5017
+#: Merge.rc:5016
 msgid "Link"
 msgstr "Koppeling"
 
 #. IDS_PRPCAT_MEDIA
-#: Merge.rc:5018
+#: Merge.rc:5017
 msgid "Media"
 msgstr "Media"
 
 #. IDS_PRPCAT_MUSIC
-#: Merge.rc:5020
+#: Merge.rc:5019
 msgid "Music"
 msgstr "Muziek"
 
 #. IDS_PRPCAT_NOTE
-#: Merge.rc:5021
+#: Merge.rc:5020
 msgid "Note"
 msgstr "Notitie"
 
 #. IDS_PRPCAT_PHOTO
-#: Merge.rc:5022
+#: Merge.rc:5021
 msgid "Photo"
 msgstr "Foto"
 
 #. IDS_PRPCAT_RECORDEDTV
-#: Merge.rc:5023
+#: Merge.rc:5022
 msgid "RecordedTV"
 msgstr "Tv-opname"
 
 #. IDS_PRPCAT_SEARCH
-#: Merge.rc:5024
+#: Merge.rc:5023
 msgid "Search"
 msgstr "Zoeken"
 
 #. IDS_PRPCAT_SECURITY
-#: Merge.rc:5025
+#: Merge.rc:5024
 msgid "Security"
 msgstr "Beveiliging"
 
 #. IDS_PRPCAT_SOFTWARE
-#: Merge.rc:5026
+#: Merge.rc:5025
 msgid "Software"
 msgstr "Software"
 
 #. IDS_PRPCAT_TASK
-#: Merge.rc:5027
+#: Merge.rc:5026
 msgid "Task"
 msgstr "Taak"
 
 #. IDS_PRPCAT_VIDEO
-#: Merge.rc:5028
+#: Merge.rc:5027
 msgid "Video"
 msgstr "Video"
 
 #. IDS_PRPCAT_HASH
-#: Merge.rc:5029
+#: Merge.rc:5028
 msgid "Hash"
 msgstr "Hash"
 
 #. IDS_CANT_COMPARE_FILES
-#: Merge.rc:5035
+#: Merge.rc:5034
 msgid "Unable to compare files"
 msgstr "Kan bestanden niet vergelijken"
 
 #. IDS_ABORTED_ITEM
-#: Merge.rc:5036
+#: Merge.rc:5035
 msgid "Item aborted"
 msgstr "Item afgebroken"
 
 #. IDS_FILE_SKIPPED
-#: Merge.rc:5037
+#: Merge.rc:5036
 msgid "File skipped"
 msgstr "Bestand overgeslagen"
 
 #. IDS_DIR_SKIPPED
-#: Merge.rc:5038
+#: Merge.rc:5037
 msgid "Folder skipped"
 msgstr "Map overgeslagen"
 
 #. IDS_LEFT_ONLY_IN_FMT
-#: Merge.rc:5039
+#: Merge.rc:5038
 #, c-format
 msgid "Left only: %1"
 msgstr "Alleen links: %1"
 
 #. IDS_MIDDLE_ONLY_IN_FMT
-#: Merge.rc:5040
+#: Merge.rc:5039
 #, c-format
 msgid "Middle only: %1"
 msgstr "Alleen midden: %1"
 
 #. IDS_RIGHT_ONLY_IN_FMT
-#: Merge.rc:5041
+#: Merge.rc:5040
 #, c-format
 msgid "Right only: %1"
 msgstr "Alleen rechts: %1"
 
 #. IDS_DOES_NOT_EXIST_IN_FMT
-#: Merge.rc:5042
+#: Merge.rc:5041
 #, c-format
 msgid "Does not exist in %1"
 msgstr "Bestaat niet in %1"
 
 #. IDS_BIN_FILES_SAME
-#: Merge.rc:5043
+#: Merge.rc:5042
 msgid "Binary files are identical"
 msgstr "Binaire bestanden zijn identiek"
 
 #. IDS_BIN_FILES_DIFF
-#: Merge.rc:5049
+#: Merge.rc:5048
 msgid "Binary files are different"
 msgstr "Binaire bestanden zijn verschillend"
 
 #. IDS_FILES_ARE_DIFFERENT
-#: Merge.rc:5050
+#: Merge.rc:5049
 msgid "Files are different"
 msgstr "Bestanden zijn verschillend"
 
 #. IDS_FOLDERS_ARE_DIFFERENT
-#: Merge.rc:5051
+#: Merge.rc:5050
 msgid "Folders are different"
 msgstr "Mappen zijn verschillend"
 
 #. IDS_LEFTONLY
-#: Merge.rc:5052
+#: Merge.rc:5051
 msgid "Left Only"
 msgstr "Alleen links"
 
 #. IDS_RIGHTONLY
-#: Merge.rc:5053
+#: Merge.rc:5052
 msgid "Right Only"
 msgstr "Alleen rechts"
 
 #. IDS_MIDDLEONLY
-#: Merge.rc:5054
+#: Merge.rc:5053
 msgid "Middle Only"
 msgstr "Alleen midden"
 
 #. IDS_NOITEMLEFT
-#: Merge.rc:5055
+#: Merge.rc:5054
 msgid "No item in left"
 msgstr "Geen item links"
 
 #. IDS_NOITEMRIGHT
-#: Merge.rc:5056
+#: Merge.rc:5055
 msgid "No item in right"
 msgstr "Geen item rechts"
 
 #. IDS_NOITEMMIDDLE
-#: Merge.rc:5057
+#: Merge.rc:5056
 msgid "No item in middle"
 msgstr "Geen item in midden"
 
 #. IDS_CMPRES_ERROR
-#: Merge.rc:5059
+#: Merge.rc:5058
 msgid "Error"
 msgstr "Fout"
 
 #. IDS_TEXT_FILES_SAME
-#: Merge.rc:5060
+#: Merge.rc:5059
 msgid "Text files are identical"
 msgstr "Tekstbestanden zijn identiek"
 
 #. IDS_LEFTONLY_DIFF
-#: Merge.rc:5061
+#: Merge.rc:5060
 msgid " (Middle and right are identical)"
 msgstr " (Midden en rechts zijn identiek)"
 
 #. IDS_MIDDLEONLY_DIFF
-#: Merge.rc:5062
+#: Merge.rc:5061
 msgid " (Left and right are identical)"
 msgstr " (Links en rechts zijn identiek)"
 
 #. IDS_RIGHTONLY_DIFF
-#: Merge.rc:5063
+#: Merge.rc:5062
 msgid " (Left and middle are identical)"
 msgstr " (Links en midden zijn identiek)"
 
 #. IDS_PATH_MISMATCH
-#: Merge.rc:5064
+#: Merge.rc:5063
 msgid " (paths differ)"
 msgstr ""
 
 #. IDS_TEXT_FILES_DIFF
-#: Merge.rc:5065
+#: Merge.rc:5064
 msgid "Text files are different"
 msgstr "Tekstbestanden zijn verschillend"
 
 #. IDS_IMAGE_FILES_SAME
-#: Merge.rc:5066
+#: Merge.rc:5065
 msgid "Image files are identical"
 msgstr "Afbeeldingsbestanden zijn identiek"
 
 #. IDS_IMAGE_FILES_DIFF
-#: Merge.rc:5067
+#: Merge.rc:5066
 msgid "Image files are different"
 msgstr "Afbeeldingsbestanden zijn verschillend"
 
 #. IDS_EXPR_DIFF
-#: Merge.rc:5068
+#: Merge.rc:5067
 #, c-format
 msgid "Files are different (expr: %1)"
 msgstr ""
 
 #. IDS_HASH_GROUP
-#: Merge.rc:5069
+#: Merge.rc:5068
 #, c-format
 msgid "Group%d"
 msgstr "Groep%d"
 
 #. IDS_RENAME_MOVE_DETECTION_DISALBED
-#: Merge.rc:5070
+#: Merge.rc:5069
 msgctxt "Options dialog|Compare|Folder|Detect renames and moves"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_RENAME_MOVE_DETECTION_RENAME
-#: Merge.rc:5071
+#: Merge.rc:5070
 msgid "Detect renames"
 msgstr ""
 
 #. IDS_RENAME_MOVE_DETECTION_RENAME_MOVE
-#: Merge.rc:5072
+#: Merge.rc:5071
 msgid "Detect renames and moves"
 msgstr ""
 
 #. IDS_RENAME_MOVE_MERGE_MODE_RENAME
-#: Merge.rc:5073
+#: Merge.rc:5072
 msgid "Merge renames"
 msgstr ""
 
 #. IDS_RENAME_MOVE_MERGE_MODE_RENAME_MOVE
-#: Merge.rc:5074
+#: Merge.rc:5073
 msgid "Merge renames and moves"
 msgstr ""
 
 #. IDS_RENAMED
-#: Merge.rc:5075
+#: Merge.rc:5074
 msgid "Renamed"
 msgstr ""
 
 #. IDS_RENAMED_MOVED
-#: Merge.rc:5077
+#: Merge.rc:5076
 msgid "Renamed/Moved"
 msgstr ""
 
 #. IDS_RENAMED_MOVED_ITEMS
-#: Merge.rc:5078
+#: Merge.rc:5077
 #, c-format
 msgid "(%1 items)"
 msgstr ""
 
 #. IDS_RENAMED_MOVED_RESULT
-#: Merge.rc:5079
+#: Merge.rc:5078
 #, c-format
 msgid "%1 (set %2): "
 msgstr ""
 
 #. IDS_SWITCH_FLAT_MODE
-#: Merge.rc:5080
+#: Merge.rc:5079
 msgid "Some moved items have been merged.\nIn Tree Mode, these items may appear in positions that do not reflect the actual folder structure, which can be confusing.\nSwitch to Flat Mode?"
 msgstr ""
 
 #. IDS_ELAPSED_TIME
-#: Merge.rc:5086
+#: Merge.rc:5085
 #, c-format
 msgid "Elapsed time: %ld ms"
 msgstr "Verstreken tijd: %ld ms"
 
 #. IDS_STATUS_SELITEM1
-#: Merge.rc:5087
+#: Merge.rc:5086
 msgid "1 item selected"
 msgstr "1 item geselecteerd"
 
 #. IDS_STATUS_SELITEMS
-#: Merge.rc:5088
+#: Merge.rc:5087
 #, c-format
 msgid "%1 items selected"
 msgstr "%1 items geselecteerd"
 
 #. IDS_COLDESC_FILENAME
-#: Merge.rc:5094
+#: Merge.rc:5093
 msgid "Filename or folder name."
 msgstr "Bestandsnaam of mapnaam."
 
 #. IDS_COLDESC_DIR
-#: Merge.rc:5095
+#: Merge.rc:5094
 msgid "Subfolder name when subfolders are included."
 msgstr "Naam van submap als submappen bijgevoegd zijn."
 
 #. IDS_COLDESC_RESULT
-#: Merge.rc:5096
+#: Merge.rc:5095
 msgid "Comparison result, long form."
 msgstr "Vergelijkingsresultaat, lange vorm."
 
 #. IDS_COLDESC_LTIMEM
-#: Merge.rc:5101
+#: Merge.rc:5100
 msgid "Left side modification date."
 msgstr "Wijzigingsdatum linkerzijde."
 
 #. IDS_COLDESC_RTIMEM
-#: Merge.rc:5102
+#: Merge.rc:5101
 msgid "Right side modification date."
 msgstr "Wijzigingsdatum rechterzijde."
 
 #. IDS_COLDESC_MTIMEM
-#: Merge.rc:5103
+#: Merge.rc:5102
 msgid "Middle side modification date."
 msgstr "Wijzigingsdatum midden."
 
 #. IDS_COLDESC_EXTENSION
-#: Merge.rc:5104
+#: Merge.rc:5103
 msgid "File's extension."
 msgstr "Bestandsextensie."
 
 #. IDS_COLDESC_LSIZE
-#: Merge.rc:5105
+#: Merge.rc:5104
 msgid "Left file size in bytes."
 msgstr "Bestandsgrootte linkerzijde in bytes."
 
 #. IDS_COLDESC_RSIZE
-#: Merge.rc:5106
+#: Merge.rc:5105
 msgid "Right file size in bytes."
 msgstr "Bestandsgrootte rechterzijde in bytes."
 
 #. IDS_COLDESC_MSIZE
-#: Merge.rc:5107
+#: Merge.rc:5106
 msgid "Middle file size in bytes."
 msgstr "Bestandsgrootte midden in bytes."
 
 #. IDS_COLDESC_LSIZE_SHORT
-#: Merge.rc:5108
+#: Merge.rc:5107
 msgid "Left file size abbreviated."
 msgstr "Bestandsgrootte links ingekort."
 
 #. IDS_COLDESC_RSIZE_SHORT
-#: Merge.rc:5109
+#: Merge.rc:5108
 msgid "Right file size abbreviated."
 msgstr "Bestandsgrootte rechts ingekort."
 
 #. IDS_COLDESC_MSIZE_SHORT
-#: Merge.rc:5110
+#: Merge.rc:5109
 msgid "Middle file size abbreviated."
 msgstr "Bestandsgrootte midden ingekort."
 
 #. IDS_COLDESC_LTIMEC
-#: Merge.rc:5116
+#: Merge.rc:5115
 msgid "Left side creation time."
 msgstr "Aanmaaktijdstip linkerzijde."
 
 #. IDS_COLDESC_RTIMEC
-#: Merge.rc:5117
+#: Merge.rc:5116
 msgid "Right side creation time."
 msgstr "Aanmaaktijdstip rechterzijde."
 
 #. IDS_COLDESC_MTIMEC
-#: Merge.rc:5118
+#: Merge.rc:5117
 msgid "Middle side creation time."
 msgstr "Aanmaaktijdstip midden."
 
 #. IDS_COLDESC_NEWER
-#: Merge.rc:5119
+#: Merge.rc:5118
 msgid "Tells which side has newer modification date."
 msgstr "Geeft aan welke zijde het recentst gewijzigd is."
 
 #. IDS_COLDESC_LVERSION
-#: Merge.rc:5120
+#: Merge.rc:5119
 msgid "Left side file version, only for some file types."
 msgstr "Bestandsversie linkerzijde, alleen voor bepaalde bestandstypes."
 
 #. IDS_COLDESC_RVERSION
-#: Merge.rc:5121
+#: Merge.rc:5120
 msgid "Right side file version, only for some file types."
 msgstr "Bestandsversie rechterzijde, alleen voor bepaalde bestandstypes."
 
 #. IDS_COLDESC_MVERSION
-#: Merge.rc:5126
+#: Merge.rc:5125
 msgid "Middle side file version, only for some file types."
 msgstr "Bestandsversie midden, alleen voor bepaalde bestandstypes."
 
 #. IDS_COLDESC_RESULT_ABBR
-#: Merge.rc:5127
+#: Merge.rc:5126
 msgid "Short comparison result."
 msgstr "Kort vergelijkingsresultaat."
 
 #. IDS_COLDESC_LATTRIBUTES
-#: Merge.rc:5128
+#: Merge.rc:5127
 msgid "Left side attributes."
 msgstr "Attributen linkerzijde."
 
 #. IDS_COLDESC_RATTRIBUTES
-#: Merge.rc:5129
+#: Merge.rc:5128
 msgid "Right side attributes."
 msgstr "Attributen rechterzijde."
 
 #. IDS_COLDESC_MATTRIBUTES
-#: Merge.rc:5130
+#: Merge.rc:5129
 msgid "Middle side attributes."
 msgstr "Attributen midden."
 
 #. IDS_COLDESC_LEOL_TYPE
-#: Merge.rc:5131
+#: Merge.rc:5130
 msgid "Left side file EOL type."
 msgstr "Type regeleinde linker bestand."
 
 #. IDS_COLDESC_REOL_TYPE
-#: Merge.rc:5132
+#: Merge.rc:5131
 msgid "Right side file EOL type."
 msgstr "Type regeleinde rechter bestand."
 
 #. IDS_COLDESC_MEOL_TYPE
-#: Merge.rc:5133
+#: Merge.rc:5132
 msgid "Middle side file EOL type."
 msgstr "Type regeleinde middelste bestand."
 
 #. IDS_COLDESC_LENCODING
-#: Merge.rc:5139
+#: Merge.rc:5138
 msgid "Left side encoding."
 msgstr "Codering linkerzijde."
 
 #. IDS_COLDESC_RENCODING
-#: Merge.rc:5140
+#: Merge.rc:5139
 msgid "Right side encoding."
 msgstr "Codering rechterzijde."
 
 #. IDS_COLDESC_MENCODING
-#: Merge.rc:5141
+#: Merge.rc:5140
 msgid "Middle side encoding."
 msgstr "Codering midden."
 
 #. IDS_COLDESC_NIDIFFS
-#: Merge.rc:5142
+#: Merge.rc:5141
 msgid "Number of ignored differences in file. Ignored and cannot be merged."
 msgstr ""
 "Aantal genegeerde verschillen in bestand. Deze verschillen worden genegeerd "
 "door WinMerge en kunnen niet samengevoegd worden."
 
 #. IDS_COLDESC_NSDIFFS
-#: Merge.rc:5143
+#: Merge.rc:5142
 msgid "Number of differences in file (excluding ignored)."
 msgstr ""
 "Aantal verschillen in bestand. Dit aantal bevat geen genegeerde verschillen."
 
 #. IDS_COLDESC_BINARY
-#: Merge.rc:5144
+#: Merge.rc:5143
 msgid "Shows an asterisk (*) if the file is binary."
 msgstr "Geeft een asterisk (*) weer als het bestand binair is."
 
 #. IDS_COLDESC_UNPACKER
-#: Merge.rc:5145
+#: Merge.rc:5144
 msgid "Unpacker plugin name or pipeline."
 msgstr "Uitpakker pluginnaam of pipeline."
 
 #. IDS_COLDESC_PREDIFFER
-#: Merge.rc:5146
+#: Merge.rc:5145
 msgid "Prediffer plugin name or pipeline."
 msgstr "Voorvergelijking pluginnaam of pipeline."
 
 #. IDS_DIRECTORY_REPORT_TITLE
-#: Merge.rc:5152
+#: Merge.rc:5151
 #, c-format
 msgid "Compare %1 with %2"
 msgstr "%1 met %2 vergelijken"
 
 #. IDS_DIRECTORY_REPORT_TITLE3
-#: Merge.rc:5153
+#: Merge.rc:5152
 #, c-format
 msgid "Compare %1 with %2 and %3"
 msgstr "%1 vergelijken met %2 en %3"
 
 #. IDS_REPORT_COMMALIST
-#: Merge.rc:5154
+#: Merge.rc:5153
 msgid "Comma-separated list"
 msgstr "Komma-gescheiden lijst"
 
 #. IDS_REPORT_TABLIST
-#: Merge.rc:5155
+#: Merge.rc:5154
 msgid "Tab-separated list"
 msgstr "Tab-gescheiden lijst"
 
 #. IDS_REPORT_SIMPLEHTML
-#: Merge.rc:5156
+#: Merge.rc:5155
 msgid "Simple HTML"
 msgstr "Simpele HTML"
 
 #. IDS_REPORT_SIMPLEXML
-#: Merge.rc:5157
+#: Merge.rc:5156
 msgid "Simple XML"
 msgstr "Simpele XML"
 
-#: Merge.rc:5159
+#: Merge.rc:5158
 msgid ""
 "Report file already exists. Overwrite?"
 msgstr ""
@@ -7194,7 +7189,7 @@ msgstr ""
 "overschrijven?"
 
 #. IDS_REPORT_ERROR
-#: Merge.rc:5164
+#: Merge.rc:5163
 #, c-format
 msgid ""
 "Error creating the report:\n"
@@ -7204,52 +7199,52 @@ msgstr ""
 "%1"
 
 #. IDS_REPORT_SUCCESS
-#: Merge.rc:5165
+#: Merge.rc:5164
 msgid "Report created successfully."
 msgstr "Het rapport is met succes aangemaakt."
 
 #. IDS_SYNCPOINT_LASTBLOCK
-#: Merge.rc:5171
+#: Merge.rc:5170
 msgid "Cannot add a synchronization point at this line."
 msgstr "Kan geen synchronisatiepunt toevoegen op deze regel."
 
 #. IDS_FILE_TO_ITSELF
-#: Merge.rc:5177
+#: Merge.rc:5176
 msgid "Same file is opened in both panes."
 msgstr "Hetzelfde bestand is in beide vensters geopend."
 
 #. IDS_FILESSAME
-#: Merge.rc:5178
+#: Merge.rc:5177
 msgid "Selected files are identical."
 msgstr "De geselecteerde bestanden zijn identiek."
 
 #. IDS_FILESSAME_CURCFG
-#: Merge.rc:5179
+#: Merge.rc:5178
 msgid "Selected files are identical (with current settings).\r\nChecking binary identity..."
 msgstr ""
 
 #. IDS_FILESSAME_BINERROR
-#: Merge.rc:5180
+#: Merge.rc:5179
 msgid "Selected files are identical (with current settings).\r\nBut binary comparison failed."
 msgstr ""
 
 #. IDS_FILESSAME_BINSAME
-#: Merge.rc:5181
+#: Merge.rc:5180
 msgid "Selected files are identical (binary match)."
 msgstr ""
 
 #. IDS_FILESSAME_BINDIFF
-#: Merge.rc:5182
+#: Merge.rc:5181
 msgid "Selected files are identical (with current settings).\r\nBut differ at the binary level."
 msgstr ""
 
 #. IDS_FILEERROR
-#: Merge.rc:5183
+#: Merge.rc:5182
 msgid "An error occurred while comparing files."
 msgstr "Er trad een fout op bij het vergelijken van de bestanden."
 
 #. IDS_TEMP_FILEERROR
-#: Merge.rc:5184
+#: Merge.rc:5183
 msgid ""
 "Could not create temporary files. Check your temporary path settings."
 msgstr ""
@@ -7257,7 +7252,7 @@ msgstr ""
 " voor het pad van tijdelijke bestanden."
 
 #. IDS_SUGGEST_IGNOREEOL
-#: Merge.rc:5185
+#: Merge.rc:5184
 msgid "Files use different EOL.\n\nTreat all EOL as equivalent?\n\nSet 'Ignore EOL differences (Windows/Unix/Mac)' in Compare section of Options."
 msgstr ""
 "Deze bestanden gebruiken verschillende regeleinde-types.\n"
@@ -7267,17 +7262,17 @@ msgstr ""
 "Opmerking: Indien u op elk moment alle regeleinde-types als equivalent wilt behandelen, stel optie \"Regeleinde-verschillen negeren (Windows/Unix/Mac)\" dan in in de Vergelijken-tab van het opties-venster (beschikbaar onder Wijzigen/Opties)"
 
 #. IDS_INVALID_DIRECTORY
-#: Merge.rc:5186
+#: Merge.rc:5185
 msgid "Selected folder is invalid."
 msgstr "De geselecteerde map is ongeldig."
 
 #. IDS_CANNOT_OPEN_BINARYFILE
-#: Merge.rc:5187
+#: Merge.rc:5186
 msgid "Cannot open a binary file in Editor."
 msgstr "Kan geen binair bestand openen met de editor."
 
 #. IDS_CREATE_PAIR_FOLDER
-#: Merge.rc:5188
+#: Merge.rc:5187
 #, c-format
 msgid "Create matching folder:\n%1\non the other side and open?"
 msgstr ""
@@ -7288,42 +7283,42 @@ msgstr ""
 "aanmaken aan de andere kant en deze mappen openen?"
 
 #. IDS_CONFIRM_COPY_ALL_DIFFS
-#: Merge.rc:5189
+#: Merge.rc:5188
 msgid "Copy all differences to other file?"
 msgstr ""
 "Weet u zeker dat u alle verschillen naar het andere bestand wilt kopiëren?"
 
 #. IDS_MOVE_TO_NEXTFILE
-#: Merge.rc:5194
+#: Merge.rc:5193
 msgid "Move to next file?"
 msgstr "Wilt u naar het volgende bestand gaan?"
 
 #. IDS_MOVE_TO_PREVFILE
-#: Merge.rc:5195
+#: Merge.rc:5194
 msgid "Move to previous file?"
 msgstr "Wilt u naar het vorige bestand gaan?"
 
 #. IDS_MOVE_TO_NEXTPAGE
-#: Merge.rc:5196
+#: Merge.rc:5195
 msgid "Move to next page?"
 msgstr "Wilt u naar de volgende pagina gaan?"
 
 #. IDS_MOVE_TO_PREVPAGE
-#: Merge.rc:5197
+#: Merge.rc:5196
 msgid "Move to previous page?"
 msgstr "Wilt u naar de vorige pagina gaan?"
 
 #. IDS_MOVE_TO_FIRSTFILE
-#: Merge.rc:5198
+#: Merge.rc:5197
 msgid "Move to first file?"
 msgstr "Wilt u naar het eerste bestand gaan?"
 
 #. IDS_MOVE_TO_LASTFILE
-#: Merge.rc:5199
+#: Merge.rc:5198
 msgid "Move to last file?"
 msgstr "Wilt u naar het laatste bestand gaan?"
 
-#: Merge.rc:5206
+#: Merge.rc:5205
 #, c-format
 msgid "Different codepages: left (cp%d), right (cp%d).\nDisplay in codepage (better display) or default Windows codepage (safer merging)?\n(Recommended: default Windows codepage)"
 msgstr ""
@@ -7331,53 +7326,53 @@ msgstr ""
 "Elk bestand in zijn eigen tekenset weergeven zal resulteren in een betere weergave, maar samenvoegen/kopiëren zal gevaarlijk zijn.\n"
 "Wilt u beide bestanden behandelen alsof ze in de standaard Windows-tekenset zijn (aanbevolen)?"
 
-#: Merge.rc:5208
+#: Merge.rc:5207
 msgid "Information lost due to encoding errors: both files"
 msgstr "Informatie verloren gegaan wegens codeerfouten: beide bestanden"
 
-#: Merge.rc:5210
+#: Merge.rc:5209
 msgid "Information lost due to encoding errors: first file"
 msgstr "Informatie verloren gegaan wegens codeerfouten: eerste bestand"
 
-#: Merge.rc:5212
+#: Merge.rc:5211
 msgid "Information lost due to encoding errors: second file"
 msgstr "Informatie verloren gegaan wegens codeerfouten: tweede bestand"
 
-#: Merge.rc:5214
+#: Merge.rc:5213
 msgid "Information lost due to encoding errors: third file"
 msgstr "Informatie verloren gegaan wegens codeerfouten: derde bestand"
 
 #. IDS_LINEDIFF_NODIFF
-#: Merge.rc:5220
+#: Merge.rc:5219
 msgid "No difference"
 msgstr "Geen verschil"
 
 #. IDS_LINEDIFF_NODIFF_CAPTION
-#: Merge.rc:5221
+#: Merge.rc:5220
 msgid "Line difference"
 msgstr "Regelverschil"
 
 #. IDS_NUM_REPLACED
-#: Merge.rc:5227
+#: Merge.rc:5226
 #, c-format
 msgid "Replaced %1 string(s)."
 msgstr "%1 tekenreeks(en) vervangen."
 
 #. IDS_EDIT_TEXT_NOT_FOUND
-#: Merge.rc:5228
+#: Merge.rc:5227
 #, c-format
 msgid "Cannot find string \"%s\"."
 msgstr "Kan tekenreeks \"%s\" niet vinden."
 
 #. IDS_MERGE_MODE
-#: Merge.rc:5234
+#: Merge.rc:5233
 msgid "Entering Merge Mode. Press F9 to turn off."
 msgstr ""
 "U start nu de samenvoegmodus. Als u de samenvoegmodus wilt uitschakelen, "
 "drukt u op F9."
 
 #. IDS_AUTO_MERGE
-#: Merge.rc:5240
+#: Merge.rc:5239
 #, c-format
 msgid ""
 "Automatic merges: %1\n"
@@ -7387,89 +7382,89 @@ msgstr ""
 "Aantal niet-opgeloste conflicten: %2"
 
 #. IDS_CODEPAGE_MERGED
-#: Merge.rc:5241
+#: Merge.rc:5240
 msgid "Codepage change merged."
 msgstr "Wijziging van tekenset werd samengevoegd."
 
 #. IDS_CODEPAGE_CONFLICT
-#: Merge.rc:5242
+#: Merge.rc:5241
 msgid "Codepage changes are conflicting."
 msgstr "Wijzigingen van tekenset geven conflicten."
 
 #. IDS_EOL_MERGED
-#: Merge.rc:5243
+#: Merge.rc:5242
 msgid "EOL change merged."
 msgstr "Wijziging van regeleinde werd samengevoegd."
 
 #. IDS_EOL_CONFLICT
-#: Merge.rc:5244
+#: Merge.rc:5243
 msgid "EOL changes are conflicting."
 msgstr "Wijzigingen van regeleinde geven conflicten."
 
 #. IDS_LOCBAR_CAPTION
-#: Merge.rc:5250
+#: Merge.rc:5249
 msgid "Location Pane"
 msgstr "Locatievenster"
 
 #. IDS_DIFFBAR_CAPTION
-#: Merge.rc:5251
+#: Merge.rc:5250
 msgid "Diff Pane"
 msgstr "Verschilvenster"
 
 #. IDS_DIFF_SUCCEEDED
-#: Merge.rc:5258
+#: Merge.rc:5257
 msgid "Patch file written."
 msgstr "Patch-bestand succesvol geschreven."
 
 #. IDS_DIFF_FILEOVERWRITE
-#: Merge.rc:5259
+#: Merge.rc:5258
 msgid "Patch file already exists. Overwrite?"
 msgstr "Het patch-bestand bestaat al. Wilt u het overschrijven?"
 
 #. IDS_DIFF_SELECTEDFILES
-#: Merge.rc:5260
+#: Merge.rc:5259
 #, c-format
 msgid "[%1 files selected]"
 msgstr "[%1 bestanden geselecteerd]"
 
 #. IDS_DIFF_NORMAL
-#: Merge.rc:5261
+#: Merge.rc:5260
 msgid "Normal"
 msgstr "Normaal"
 
 #. IDS_DIFF_CONTEXT
-#: Merge.rc:5262
+#: Merge.rc:5261
 msgid "Context"
 msgstr "Context"
 
 #. IDS_DIFF_UNIFIED
-#: Merge.rc:5263
+#: Merge.rc:5262
 msgid "Unified"
 msgstr "Verenigd"
 
 #. IDS_FILEWRITE_ERROR
-#: Merge.rc:5265
+#: Merge.rc:5264
 #, c-format
 msgid "Could not write to file %1."
 msgstr "Kon niet schrijven naar bestand %1."
 
 #. IDS_PATH_NOT_ABSOLUTE
-#: Merge.rc:5266
+#: Merge.rc:5265
 #, c-format
 msgid "Output path is not absolute: %1"
 msgstr "Het opgegeven uitvoerpad is geen absoluut pad: %1"
 
 #. IDS_MUST_SPECIFY_OUTPUT
-#: Merge.rc:5267
+#: Merge.rc:5266
 msgid "Specify an output file."
 msgstr "Uitvoerbestand opgeven."
 
-#: Merge.rc:5269
+#: Merge.rc:5268
 msgid "Cannot create patch from binary files."
 msgstr "Kan geen patch-bestand aanmaken van binaire bestanden."
 
 #. IDS_SAVEFILES_FORPATCH
-#: Merge.rc:5270
+#: Merge.rc:5269
 msgid ""
 "Save all files first.\n"
 "\n"
@@ -7480,22 +7475,22 @@ msgstr ""
 "Een patch genereren vereist dat er geen niet-opgeslagen wijzigingen in bestanden zijn."
 
 #. IDS_FOLDER_NOTEXIST
-#: Merge.rc:5271
+#: Merge.rc:5270
 msgid "Folder does not exist."
 msgstr "Map bestaat niet."
 
 #. IDS_ARCHIVE_SUCCEEDED
-#: Merge.rc:5277
+#: Merge.rc:5276
 msgid "Archive file written."
 msgstr ""
 
 #. IDS_ARCHIVE_SAVEFILES
-#: Merge.rc:5278
+#: Merge.rc:5277
 msgid "Save all files first.\n\nCreating an archive requires no unsaved changes."
 msgstr ""
 
 #. IDS_NO_ZIP_SUPPORT
-#: Merge.rc:5283
+#: Merge.rc:5282
 msgid ""
 "Archive support not enabled.\n"
 "7-Zip and/or Merge7z*.dll not found.\n"
@@ -7506,37 +7501,37 @@ msgstr ""
 "Zie de handleiding voor meer info over archiefondersteuning en hoe het in te schakelen."
 
 #. IDS_OPT_EXPORT_CAPTION
-#: Merge.rc:5284
+#: Merge.rc:5283
 msgid "Select file for export"
 msgstr "Bestand selecteren voor exporteren"
 
 #. IDS_OPT_IMPORT_CAPTION
-#: Merge.rc:5285
+#: Merge.rc:5284
 msgid "Select file for import"
 msgstr "Bestand selecteren voor importeren"
 
 #. IDS_OPT_IMPORT_DONE
-#: Merge.rc:5286
+#: Merge.rc:5285
 msgid "Options imported from file."
 msgstr "Opties geïmporteerd uit het bestand."
 
 #. IDS_OPT_EXPORT_DONE
-#: Merge.rc:5287
+#: Merge.rc:5286
 msgid "Options exported to file."
 msgstr "Opties geëxporteerd naar het bestand."
 
 #. IDS_OPT_IMPORT_ERR
-#: Merge.rc:5288
+#: Merge.rc:5287
 msgid "Failed to import options from file."
 msgstr "Opties importeren van bestand mislukt."
 
 #. IDS_OPT_EXPORT_ERR
-#: Merge.rc:5289
+#: Merge.rc:5288
 msgid "Failed to write options to file."
 msgstr "Opties schrijven naar bestand mislukt."
 
 #. IDS_CLOSEALL_WINDOWS
-#: Merge.rc:5290
+#: Merge.rc:5289
 msgid ""
 "Close multiple compare windows?\n"
 "\n"
@@ -7547,34 +7542,34 @@ msgstr ""
 "Wilt u doorgaan?"
 
 #. IDS_EOL_BIN
-#: Merge.rc:5300
+#: Merge.rc:5299
 msgctxt "EOL Type"
 msgid "Binary"
 msgstr "Binair"
 
 #. IDS_MARKER_COLOR_FMT
-#: Merge.rc:5305
+#: Merge.rc:5304
 #, c-format
 msgid "Marker Color %d"
 msgstr "Markeringskleur %d"
 
 #. IDS_MARKER_NEW_PATTERN
-#: Merge.rc:5306
+#: Merge.rc:5305
 msgid "New Pattern"
 msgstr "Nieuw patroon"
 
 #. IDS_PLUGINSLIST_TYPE
-#: Merge.rc:5312
+#: Merge.rc:5311
 msgid "Type"
 msgstr "Type"
 
 #. IDS_PLUGINS_TYPE_EDITSCRIPT
-#: Merge.rc:5316
+#: Merge.rc:5315
 msgid "Editor script"
 msgstr "Editor-script"
 
 #. ID_SELECTLINEDIFF
-#: Merge.rc:5322
+#: Merge.rc:5321
 msgid ""
 "\n"
 "Difference in Current Line (F4)"
@@ -7583,7 +7578,7 @@ msgstr ""
 "Verschil in de huidige regel (F4)"
 
 #. ID_OPTIONS
-#: Merge.rc:5323
+#: Merge.rc:5322
 msgid ""
 "\n"
 "Options"
@@ -7592,7 +7587,7 @@ msgstr ""
 "Opties"
 
 #. ID_REFRESH
-#: Merge.rc:5324
+#: Merge.rc:5323
 msgid ""
 "\n"
 "Refresh (F5)"
@@ -7601,7 +7596,7 @@ msgstr ""
 "Vernieuwen (F5)"
 
 #. ID_PREVDIFF
-#: Merge.rc:5330
+#: Merge.rc:5329
 msgid ""
 "\n"
 "Previous Difference (Alt+Up)"
@@ -7610,7 +7605,7 @@ msgstr ""
 "Vorig verschil (Alt+Omhoog)"
 
 #. ID_NEXTDIFF
-#: Merge.rc:5331
+#: Merge.rc:5330
 msgid ""
 "\n"
 "Next Difference (Alt+Down)"
@@ -7619,7 +7614,7 @@ msgstr ""
 "Volgend verschil (Alt+Omlaag)"
 
 #. ID_PREVCONFLICT
-#: Merge.rc:5332
+#: Merge.rc:5331
 msgid ""
 "\n"
 "Previous Conflict (Alt+Shift+Up)"
@@ -7628,7 +7623,7 @@ msgstr ""
 "Vorig conflict (Alt+Shift+Omhoog)"
 
 #. ID_NEXTCONFLICT
-#: Merge.rc:5333
+#: Merge.rc:5332
 msgid ""
 "\n"
 "Next Conflict (Alt+Shift+Down)"
@@ -7637,7 +7632,7 @@ msgstr ""
 "Volgend conflict (Alt+Shift+Omlaag)"
 
 #. ID_FIRSTDIFF
-#: Merge.rc:5338
+#: Merge.rc:5337
 msgid ""
 "\n"
 "First Difference (Alt+Home)"
@@ -7646,7 +7641,7 @@ msgstr ""
 "Eerste verschil (Alt+Home)"
 
 #. ID_CURDIFF
-#: Merge.rc:5339
+#: Merge.rc:5338
 msgid ""
 "\n"
 "Current Difference (Alt+Enter)"
@@ -7655,7 +7650,7 @@ msgstr ""
 "Huidig verschil (Alt+Enter)"
 
 #. ID_LASTDIFF
-#: Merge.rc:5340
+#: Merge.rc:5339
 msgid ""
 "\n"
 "Last Difference (Alt+End)"
@@ -7664,7 +7659,7 @@ msgstr ""
 "Laatste verschil (Alt+End)"
 
 #. ID_L2R
-#: Merge.rc:5341
+#: Merge.rc:5340
 msgid ""
 "\n"
 "Copy to Right (Alt+Right)"
@@ -7673,7 +7668,7 @@ msgstr ""
 "Naar rechts kopiëren (Alt+Rechts)"
 
 #. ID_R2L
-#: Merge.rc:5342
+#: Merge.rc:5341
 msgid ""
 "\n"
 "Copy to Left (Alt+Left)"
@@ -7682,7 +7677,7 @@ msgstr ""
 "Naar links kopiëren (Alt+Links)"
 
 #. ID_L2RNEXT
-#: Merge.rc:5343
+#: Merge.rc:5342
 msgid ""
 "\n"
 "Copy to Right and Advance (Ctrl+Alt+Right)"
@@ -7691,7 +7686,7 @@ msgstr ""
 "Naar rechts kopiëren en verder gaan (Ctrl+Alt+Rechts)"
 
 #. ID_R2LNEXT
-#: Merge.rc:5344
+#: Merge.rc:5343
 msgid ""
 "\n"
 "Copy to Left and Advance (Ctrl+Alt+Left)"
@@ -7700,7 +7695,7 @@ msgstr ""
 "Naar links kopiëren en verder gaan (Ctrl+Alt+Links)"
 
 #. ID_ALL_RIGHT
-#: Merge.rc:5345
+#: Merge.rc:5344
 msgid ""
 "\n"
 "Copy All to Right"
@@ -7709,7 +7704,7 @@ msgstr ""
 "Alles naar rechts kopiëren"
 
 #. ID_ALL_LEFT
-#: Merge.rc:5346
+#: Merge.rc:5345
 msgid ""
 "\n"
 "Copy All to Left"
@@ -7718,7 +7713,7 @@ msgstr ""
 "Alles naar links kopiëren"
 
 #. ID_AUTO_MERGE
-#: Merge.rc:5347
+#: Merge.rc:5346
 msgid ""
 "\n"
 "Auto Merge (Ctrl+Alt+M)"
@@ -7727,7 +7722,7 @@ msgstr ""
 "Automatisch samenvoegen (Ctrl+Alt+M)"
 
 #. ID_FIRSTFILE
-#: Merge.rc:5348
+#: Merge.rc:5347
 msgid ""
 "\n"
 "First File"
@@ -7736,7 +7731,7 @@ msgstr ""
 "Eerste bestand"
 
 #. ID_NEXTFILE
-#: Merge.rc:5349
+#: Merge.rc:5348
 msgid ""
 "\n"
 "Next File (Ctrl+F8)"
@@ -7745,7 +7740,7 @@ msgstr ""
 "Volgend bestand (Ctrl+F8)"
 
 #. ID_LASTFILE
-#: Merge.rc:5350
+#: Merge.rc:5349
 msgid ""
 "\n"
 "Last File"
@@ -7754,7 +7749,7 @@ msgstr ""
 "Laatste bestand"
 
 #. ID_PREVFILE
-#: Merge.rc:5351
+#: Merge.rc:5350
 msgid ""
 "\n"
 "Previous File (Ctrl+F7)"
@@ -7763,144 +7758,144 @@ msgstr ""
 "Vorig bestand (Ctrl+F7)"
 
 #. IDS_UNPACK_AUTO
-#: Merge.rc:5358
+#: Merge.rc:5357
 msgid "Adapted unpacker applied to both files (one needs extension)."
 msgstr ""
 "De overgenomen uitpakker wordt toegepast op beide bestanden (één bestand "
 "heeft alleen maar de extensie nodig)."
 
 #. IDS_NO_PREDIFFER
-#: Merge.rc:5359
+#: Merge.rc:5358
 msgid "No Prediffer (Normal)"
 msgstr "Geen voorvergelijking (normaal)"
 
 #. IDS_SUGGESTED_PLUGINS
-#: Merge.rc:5360
+#: Merge.rc:5359
 msgid "Suggested Plugins"
 msgstr "Voorgestelde plugins"
 
 #. IDS_NOT_SUGGESTED_PLUGINS
-#: Merge.rc:5361
+#: Merge.rc:5360
 msgid "All Plugins"
 msgstr "Alle plugins"
 
 #. IDS_PRIVATEBUILD_FMT
-#: Merge.rc:5367
+#: Merge.rc:5366
 #, c-format
 msgid "Private Build: %1"
 msgstr "Privé-buld: %1"
 
 #. IDS_ALLRIGHTS_RESERVED
-#: Merge.rc:5368
+#: Merge.rc:5367
 msgid " - All rights reserved."
 msgstr ""
 
 #. IDS_TITLE_PLUGINS_SETTINGS
-#: Merge.rc:5374
+#: Merge.rc:5373
 msgid "Plugin Settings"
 msgstr "Plugin-instellingen"
 
 #. IDS_NO_SCT_SCRIPTS
-#: Merge.rc:5376
+#: Merge.rc:5375
 msgid "WSH not found - .sct scripts disabled"
 msgstr "WSH niet gevonden - .sct scripts uitgeschakeld"
 
 #. IDS_LOCBAR_GOTOLINE_FMT
-#: Merge.rc:5384
+#: Merge.rc:5383
 #, c-format
 msgid "G&o to Line %1"
 msgstr "Naar regel %1 gaan"
 
 #. IDS_GOTO_MOVED_LINE
-#: Merge.rc:5390
+#: Merge.rc:5389
 msgid "Go to Moved Line\tCtrl+Shift+G"
 msgstr "Naar verplaatste regel gaan\tCtrl+Shift+G"
 
 #. IDS_AUTOCOMPLETE_DISABLED
-#: Merge.rc:5396
+#: Merge.rc:5395
 msgctxt "Options dialog|General|Open dialog Auto completion"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_AUTOCOMPLETE_FILE_SYS
-#: Merge.rc:5397
+#: Merge.rc:5396
 msgid "From file system"
 msgstr "Van bestandssysteem"
 
 #. IDS_AUTOCOMPLETE_MRU
-#: Merge.rc:5398
+#: Merge.rc:5397
 msgid "From Most Recently Used list"
 msgstr "Uit lijst van recent gebruikt"
 
 #. IDS_COLORSCHEME_PLAIN
-#: Merge.rc:5404
+#: Merge.rc:5403
 msgid "No Highlighting"
 msgstr "Geen markering"
 
 #. IDS_COLORSCHEME_PO
-#: Merge.rc:5439
+#: Merge.rc:5438
 msgid "Portable Object"
 msgstr "Portable object"
 
 #. IDS_COLORSCHEME_RSRC
-#: Merge.rc:5444
+#: Merge.rc:5443
 msgid "Resources"
 msgstr "Bronnen"
 
 #. IDS_COLORSCHEME_SH
-#: Merge.rc:5448
+#: Merge.rc:5447
 msgid "Shell"
 msgstr "Shell"
 
 #. IDS_CLOSE_LEFT_TABS
-#: Merge.rc:5469
+#: Merge.rc:5468
 msgid "Close &Left Tabs"
 msgstr "Linker tabs sluiten"
 
 #. IDS_CLOSE_RIGHT_TABS
-#: Merge.rc:5470
+#: Merge.rc:5469
 msgid "Close R&ight Tabs"
 msgstr "Rechter tabs sluiten"
 
 #. IDS_CLOSE_OTHER_TABS
-#: Merge.rc:5471
+#: Merge.rc:5470
 msgid "Close &Other Tabs"
 msgstr "Andere tabs sluiten"
 
 #. IDS_TABBAR_AUTO_MAXWIDTH
-#: Merge.rc:5472
+#: Merge.rc:5471
 msgid "Enable &Auto Max Width"
 msgstr "Automatische maximale breedte inschakelen"
 
 #. IDS_WEBPAGE_MENU
-#: Merge.rc:5482
+#: Merge.rc:5481
 msgid "We&bpage"
 msgstr "Webpagina"
 
 #. IDS_VIEW_WRAP_TEXT
-#: Merge.rc:5487
+#: Merge.rc:5486
 msgid "W&rap Text"
 msgstr "Tekstterugloop"
 
 #. IDS_NOTINSTALLED
-#: Merge.rc:5492
+#: Merge.rc:5491
 #, c-format
 msgid "%1 is not installed."
 msgstr "%1 is niet geïnstalleerd."
 
 #. IDS_CREATE_FOLDER
-#: Merge.rc:5497
+#: Merge.rc:5496
 #, c-format
 msgid "%1 does not exist. Create it?"
 msgstr "%1 bestaat niet. Wilt u het aanmaken?"
 
 #. IDS_CREATE_FOLDER_ERROR
-#: Merge.rc:5498
+#: Merge.rc:5497
 msgid "Failed to create folder."
 msgstr "Map aanmaken mislukt."
 
 #. IDC_EXT_EDITOR_PATH
-#: Merge.rc:5503
+#: Merge.rc:5502
 msgid ""
 "Parameters:\n"
 "$file: Current file path\n"
@@ -7911,493 +7906,493 @@ msgstr ""
 "$linenum: regelnummer van de huidige cursorpositie"
 
 #. IDS_DIFF_ALGORITHM_DEFAULT
-#: Merge.rc:5508
+#: Merge.rc:5507
 msgid "default"
 msgstr "standaard"
 
 #. IDS_DIFF_ALGORITHM_MINIMAL
-#: Merge.rc:5509
+#: Merge.rc:5508
 msgid "minimal"
 msgstr "minimaal"
 
 #. IDS_DIFF_ALGORITHM_PATIENCE
-#: Merge.rc:5510
+#: Merge.rc:5509
 msgid "patience"
 msgstr "geduld"
 
 #. IDS_DIFF_ALGORITHM_HISTOGRAM
-#: Merge.rc:5511
+#: Merge.rc:5510
 msgid "histogram"
 msgstr "histogram"
 
 #. IDS_DIFF_ALGORITHM_NONE
-#: Merge.rc:5512
+#: Merge.rc:5511
 msgid "none"
 msgstr "geen"
 
 #. IDS_RENDERING_MODE_GDI
-#: Merge.rc:5517
+#: Merge.rc:5516
 msgid "GDI"
 msgstr "GDI"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_DEFAULT
-#: Merge.rc:5518
+#: Merge.rc:5517
 msgid "DirectWrite Default"
 msgstr "DirectWrite standaard"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_ALIASED
-#: Merge.rc:5519
+#: Merge.rc:5518
 msgid "DirectWrite Aliased"
 msgstr "DirectWrite aliased"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_GDI_CLASSIC
-#: Merge.rc:5520
+#: Merge.rc:5519
 msgid "DirectWrite GDI Classic"
 msgstr "DirectWrite GDI Classic"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_GDI_NATURAL
-#: Merge.rc:5521
+#: Merge.rc:5520
 msgid "DirectWrite GDI Natural"
 msgstr "DirectWrite GDI Natural"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_NATURAL
-#: Merge.rc:5522
+#: Merge.rc:5521
 msgid "DirectWrite Natural"
 msgstr "DirectWrite Natural"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_NATURAL_SYMMETRIC
-#: Merge.rc:5523
+#: Merge.rc:5522
 msgid "DirectWrite Natural Symmetric"
 msgstr "DirectWrite Natural Symmetric"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_DISABLED
-#: Merge.rc:5528
+#: Merge.rc:5527
 msgctxt "Options dialog|General|Close windows with Esc"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_1
-#: Merge.rc:5529
+#: Merge.rc:5528
 msgid "MDI child window or main window"
 msgstr "MDI-dochtervenster of hoofdvenster"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_2
-#: Merge.rc:5530
+#: Merge.rc:5529
 msgid "MDI child window only"
 msgstr "Alleen MDI-dochtervenster"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_3
-#: Merge.rc:5531
+#: Merge.rc:5530
 msgid "Close main window if only one MDI child window"
 msgstr "Hoofdvenster sluiten als er slechts één MDI-dochtervenster is"
 
 #. IDS_DIFF_GROUP
-#: Merge.rc:5536
+#: Merge.rc:5535
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Diff"
 msgstr "Verschil"
 
 #. IDS_DIFF_HIGHLIGHT
-#: Merge.rc:5537
+#: Merge.rc:5536
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Highlight"
 msgstr "Markeren"
 
 #. IDS_DIFF_BLINK
-#: Merge.rc:5538
+#: Merge.rc:5537
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Blink"
 msgstr "Knipperen"
 
 #. IDS_DIFF_BLOCKSIZE
-#: Merge.rc:5539
+#: Merge.rc:5538
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Block Size"
 msgstr "Blokgrootte"
 
 #. IDS_DIFF_BLOCKALPHA
-#: Merge.rc:5540
+#: Merge.rc:5539
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Block Alpha"
 msgstr "Alpha van blok"
 
 #. IDS_DIFF_CDTHRESHOLD
-#: Merge.rc:5541
+#: Merge.rc:5540
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "CD Threshold"
 msgstr "CD-drempel"
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION
-#: Merge.rc:5542
+#: Merge.rc:5541
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Ins/Del Detection"
 msgstr "Ins/Del-detectie"
 
 #. IDS_OVERLAY_MODE_NONE
-#: Merge.rc:5543 Merge.rc:5548
+#: Merge.rc:5542 Merge.rc:5547
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "None"
 msgstr "Geen"
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION_VERTICAL
-#: Merge.rc:5544
+#: Merge.rc:5543
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Vertical"
 msgstr "Verticaal"
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION_HORIZONTAL
-#: Merge.rc:5545
+#: Merge.rc:5544
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Horizontal"
 msgstr "Horizontaal"
 
 #. IDS_OVERLAY_GROUP
-#: Merge.rc:5546
+#: Merge.rc:5545
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Overlay"
 msgstr "Overlay"
 
 #. IDS_OVERLAY_ALPHA
-#: Merge.rc:5547
+#: Merge.rc:5546
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha"
 msgstr "Alpha"
 
 #. IDS_OVERLAY_MODE_XOR
-#: Merge.rc:5549
+#: Merge.rc:5548
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "XOR"
 msgstr "XOR"
 
 #. IDS_OVERLAY_MODE_ALPHA
-#: Merge.rc:5550
+#: Merge.rc:5549
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha Blend"
 msgstr "Alfa-blend"
 
 #. IDS_OVERLAY_MODE_ALPHA_ANIMATION
-#: Merge.rc:5551
+#: Merge.rc:5550
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha Animation"
 msgstr "Alfa-animatie"
 
 #. IDS_ZOOM
-#: Merge.rc:5552
+#: Merge.rc:5551
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Zoom"
 msgstr "Zoomen"
 
 #. IDS_PAGE
-#: Merge.rc:5553
+#: Merge.rc:5552
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Page:"
 msgstr "Pagina:"
 
 #. IDS_IMGCMP_STATUS_PT_RGBA_FMT
-#: Merge.rc:5554
+#: Merge.rc:5553
 #, c-format
 msgid "Pt: (%d, %d)  RGBA: (%d, %d, %d, %d)  "
 msgstr "Pt: (%d, %d)  RGBA: (%d, %d, %d, %d)  "
 
 #. IDS_IMGCMP_STATUS_DIST1_FMT
-#: Merge.rc:5555
+#: Merge.rc:5554
 #, c-format
 msgid "Dist: %g  "
 msgstr "Afstand: %g  "
 
 #. IDS_IMGCMP_STATUS_DIST2_FMT
-#: Merge.rc:5556
+#: Merge.rc:5555
 #, c-format
 msgid "Dist: %g, %g  "
 msgstr "Afstand: %g, %g  "
 
 #. IDS_IMGCMP_STATUS_PAGE_ZOOM_SIZE_BPP_FMT
-#: Merge.rc:5557
+#: Merge.rc:5556
 #, c-format
 msgid "Page: %d/%d  Zoom: %d%%  %dx%dpx  %dbpp  "
 msgstr "Pagina: %d/%d  Zoom: %d %%  %dx%d px  %d bpp  "
 
 #. IDS_IMGCMP_STATUS_RC_FMT
-#: Merge.rc:5558
+#: Merge.rc:5557
 #, c-format
 msgid "Rc: (%d, %d)  "
 msgstr "Rc: (%d, %d)  "
 
 #. IDS_IMGCMP_STATUS_FLIPPED_FMT
-#: Merge.rc:5559
+#: Merge.rc:5558
 #, c-format
 msgid "Flipped: %s  "
 msgstr "Omgedraaid: %s  "
 
 #. IDS_IMGCMP_STATUS_ROTATED_FMT
-#: Merge.rc:5560
+#: Merge.rc:5559
 #, c-format
 msgid "Rotated: %d  "
 msgstr "Geroteerd: %d  "
 
 #. IDS_IMGCMP_REPORT_ALLPAGES
-#: Merge.rc:5561
+#: Merge.rc:5560
 msgid "All pages"
 msgstr "Alle pagina's"
 
 #. IDS_IGNSUB_STR1
-#: Merge.rc:5566
+#: Merge.rc:5565
 msgid "<Edit here>"
 msgstr "<hier bewerken>"
 
 #. IDS_IGNSUB_STR2
-#: Merge.rc:5567
+#: Merge.rc:5566
 msgid "No differences found to select"
 msgstr "Geen verschillen gevonden om te selecteren"
 
 #. IDS_IGNSUB_STR3
-#: Merge.rc:5568
+#: Merge.rc:5567
 msgid "No differences found to add as substitution filter"
 msgstr "Geen verschillen gevonden om toe te voegen als vervangingsfilter"
 
 #. IDS_IGNSUB_STR4
-#: Merge.rc:5569
+#: Merge.rc:5568
 msgid "The pair is already in the Substitution Filters list"
 msgstr "Dit paar is al aanwezig in de lijst van vervangingsfilters"
 
 #. IDS_IGNSUB_STR5
-#: Merge.rc:5570
+#: Merge.rc:5569
 msgid "Add this change to Substitution Filters?"
 msgstr "Deze wijziging aan vervangingsfilters toevoegen?"
 
 #. IDS_OCRRESULT_TEXTONLY
-#: Merge.rc:5575
+#: Merge.rc:5574
 msgid "Text only"
 msgstr "Alleen tekst"
 
 #. IDS_OCRRESULT_POS_LINE
-#: Merge.rc:5576
+#: Merge.rc:5575
 msgid "Line-by-line position and text"
 msgstr "Positie en tekst regel per regel"
 
 #. IDS_OCRRESULT_POS_WORD
-#: Merge.rc:5577
+#: Merge.rc:5576
 msgid "Word-by-word position and text"
 msgstr "Positie en tekst woord voor woord"
 
 #. IDS_USERDATAFOLDER_APPDATA
-#: Merge.rc:5582
+#: Merge.rc:5581
 msgid "AppData (Roaming) folder"
 msgstr ""
 
 #. IDS_USERDATAFOLDER_INSTALL
-#: Merge.rc:5583
+#: Merge.rc:5582
 msgid "Install folder"
 msgstr "Installatiemap"
 
 #. IDS_USERDATAFOLDER_DOCUMENTS
-#: Merge.rc:5584
+#: Merge.rc:5583
 msgid "Documents folder"
 msgstr ""
 
 #. IDS_SINGLEINSTANCE_DISABLED
-#: Merge.rc:5589
+#: Merge.rc:5588
 msgctxt "Options dialog|General|Single instance mode"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_SINGLEINSTANCE_STR1
-#: Merge.rc:5590
+#: Merge.rc:5589
 msgid "Allow only one instance to run"
 msgstr "Slechts één draaiende instantie toestaan"
 
 #. IDS_CLIPBOARD_HISTORY
-#: Merge.rc:5591
+#: Merge.rc:5590
 msgid "Clipboard &History"
 msgstr ""
 
 #. IDS_SINGLEINSTANCE_STR2
-#: Merge.rc:5592
+#: Merge.rc:5591
 msgid "Allow only one instance; wait for termination"
 msgstr ""
 "Slechts één draaiende instantie toestaan en wachten totdat de instantie "
 "beëindigd is"
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_DISABLED
-#: Merge.rc:5597
+#: Merge.rc:5596
 msgctxt "Options dialog|General|Auto-reload modified files"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_STR1
-#: Merge.rc:5598
+#: Merge.rc:5597
 msgid "Only on window activated"
 msgstr "Alleen wanneer venster geactiveerd wordt"
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_STR2
-#: Merge.rc:5599
+#: Merge.rc:5598
 msgid "Immediately"
 msgstr "Onmiddellijk"
 
 #. IDS_PLUGIN_ALL
-#: Merge.rc:5604
+#: Merge.rc:5603
 msgid "Al&l"
 msgstr "Alles"
 
 #. IDS_PLUGIN_OTHERS
-#: Merge.rc:5605
+#: Merge.rc:5604
 msgid "&Others"
 msgstr "Andere"
 
-#: Merge.rc:5607
+#: Merge.rc:5606
 #, c-format
 msgid "Missing plugin name in pipeline: %1"
 msgstr "Ontbrekende pluginnaam of plugin-pipeline: %1"
 
-#: Merge.rc:5609
+#: Merge.rc:5608
 #, c-format
 msgid "Missing quote in plugin pipeline: %1"
 msgstr "Ontbrekend aanhalingsteken in plugin-pipeline: %1"
 
 #. IDS_PLUGIN_NAME_ALREADY_EXISTS
-#: Merge.rc:5610
+#: Merge.rc:5609
 #, c-format
 msgid "Plugin name '%1' already exists."
 msgstr "Pluginnaam '%1' bestaat al."
 
 #. IDS_PLUGIN_TITLE1
-#: Merge.rc:5611
+#: Merge.rc:5610
 msgid "Specify plugin arguments"
 msgstr "Plugin-argumenten opgeven"
 
-#: Merge.rc:5613
+#: Merge.rc:5612
 #, c-format
 msgid "Plugin not found or invalid: %1"
 msgstr "Plugin niet gevonden of ongeldig: %1"
 
 #. IDS_PLUGIN_NOT_UNPACK
-#: Merge.rc:5614
+#: Merge.rc:5613
 #, c-format
 msgid "'%1' is not an unpacker plugin"
 msgstr "'%1' is geen uitpak-plugin"
 
 #. IDS_PLUGIN_NOT_PREDIFF
-#: Merge.rc:5615
+#: Merge.rc:5614
 #, c-format
 msgid "'%1' is not a prediffer plugin"
 msgstr "'%1' is geen voorvergelijking-plugin"
 
-#: Merge.rc:5617
+#: Merge.rc:5616
 #, c-format
 msgid "Error prediffing '%1' with '%2'. Prediffing disabled."
 msgstr ""
 
 #. IDS_PLUGIN_CIRCULAR_REFERENCE
-#: Merge.rc:5618
+#: Merge.rc:5617
 #, c-format
 msgid "Circular reference in plugin pipeline: %1"
 msgstr "Circulaire referentie in plugin-pijplijn: %1"
 
 #. IDS_PLUGIN_TYPE1
-#: Merge.rc:5619
+#: Merge.rc:5618
 msgid "URL Handler"
 msgstr "URL-handler"
 
 #. IDS_PLUGIN_TYPE2
-#: Merge.rc:5620
+#: Merge.rc:5619
 msgid "File Unpacker"
 msgstr "Bestandsuitpakker:"
 
 #. IDS_PLUGIN_TYPE3
-#: Merge.rc:5621
+#: Merge.rc:5620
 msgid "File or Folder Unpacker"
 msgstr "Bestands- of mapuitpakker"
 
 #. IDS_PLUGIN_TYPE5
-#: Merge.rc:5623
+#: Merge.rc:5622
 msgid "Alias for Unpacker"
 msgstr "Alias voor uitpakker"
 
 #. IDS_PLUGIN_TYPE6
-#: Merge.rc:5624
+#: Merge.rc:5623
 msgid "Alias for Prediffer"
 msgstr "Alias voor voorvergelijking"
 
 #. IDS_PLUGIN_TYPE7
-#: Merge.rc:5625
+#: Merge.rc:5624
 msgid "Alias for Editor script"
 msgstr "Alias voor editor-script"
 
 #. IDS_PLUGIN_ALIAS_DESC
-#: Merge.rc:5626
+#: Merge.rc:5625
 #, c-format
 msgid "Alias for plugin pipeline '%1'"
 msgstr "Alias voor plugin-pijplijn '%1'"
 
 #. IDS_PLUGIN_NEW_DESC
-#: Merge.rc:5627
+#: Merge.rc:5626
 msgid "New plugin description"
 msgstr "Beschrijving nieuwe plugin"
 
 #. IDS_PLUGIN_TARGETS_ALL
-#: Merge.rc:5628
+#: Merge.rc:5627
 msgid "All"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_1ST
-#: Merge.rc:5629
+#: Merge.rc:5628
 msgid "1st"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_2ND
-#: Merge.rc:5630
+#: Merge.rc:5629
 msgid "2nd"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_3RD
-#: Merge.rc:5631
+#: Merge.rc:5630
 msgid "3rd"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_1ST_2ND
-#: Merge.rc:5632
+#: Merge.rc:5631
 msgid "1st and 2nd"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_1ST_3RD
-#: Merge.rc:5633
+#: Merge.rc:5632
 msgid "1st and 3rd"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_2ND_3RD
-#: Merge.rc:5634
+#: Merge.rc:5633
 msgid "2nd and 3rd"
 msgstr ""
 
 #. IDS_PLUGIN_CTRL_CLICK
-#: Merge.rc:5635
+#: Merge.rc:5634
 msgid "(Ctrl+Click to add to pipeline)"
 msgstr ""
 
 #. IDS_FILTER_APPLIED
-#: Merge.rc:5640
+#: Merge.rc:5639
 msgid "Filter applied"
 msgstr "Filter toegepast"
 
 #. IDS_FILTERMENU_COMPARE
-#: Merge.rc:5645
+#: Merge.rc:5644
 #, c-format
 msgid "Compare %1"
 msgstr ""
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN2
-#: Merge.rc:5647
+#: Merge.rc:5646
 msgid "&Filter by This Column..."
 msgstr ""
 
 #. IDS_CLIPBOARDHISTORY_TIME
-#: Merge.rc:5652
+#: Merge.rc:5651
 #, c-format
 msgid "Clipboard at %s"
 msgstr "Klembord op %s"
 
 #. IDS_CLIPBOARDHISTORY_DISABLED
-#: Merge.rc:5653
+#: Merge.rc:5652
 msgid ""
 "Clipboard history disabled.\r\n"
 "Enable: Windows logo key + V, then Turn on."
@@ -8405,115 +8400,115 @@ msgstr ""
 "De klembordgeschiedenis is uitgeschakeld.\n"
 "Om de klembordgeschiedenis in te schakelen, drukt u op de Windows-logotoets + V en klikt u vervolgens op de knop Inschakelen."
 
-#: Merge.rc:5655
+#: Merge.rc:5654
 msgid "This system does not support clipboard history."
 msgstr "Dit systeem ondersteunt geen klembordgeschiedenis."
 
-#: Merge.rc:5657
+#: Merge.rc:5656
 msgid "32-bit WinMerge does not support Clipboard Compare"
 msgstr "De 32-bit-versie van WinMerge ondersteunt geen klembordvergelijking"
 
 #. IDS_WEBVIEW2_RUNTIME_NOT_INSTALLED
-#: Merge.rc:5662
+#: Merge.rc:5661
 msgid "WebView2 runtime not installed. Download it?"
 msgstr "WebView2-runtime is niet geïnstalleerd. Wilt u het downloaden?"
 
 #. IDS_JUMPLIST_NEW_TEXT_COMPARE
-#: Merge.rc:5667
+#: Merge.rc:5666
 msgid "New Text Compare"
 msgstr "Nieuwe tekstvergelijking"
 
 #. IDS_JUMPLIST_NEW_TABLE_COMPARE
-#: Merge.rc:5668
+#: Merge.rc:5667
 msgid "New Table Compare"
 msgstr "Nieuwe tabelvergelijking"
 
 #. IDS_JUMPLIST_NEW_BINARY_COMPARE
-#: Merge.rc:5669
+#: Merge.rc:5668
 msgid "New Binary Compare"
 msgstr "Nieuwe binaire vergelijking"
 
 #. IDS_JUMPLIST_NEW_IMAGE_COMPARE
-#: Merge.rc:5670
+#: Merge.rc:5669
 msgid "New Image Compare"
 msgstr "Nieuwe afbeeldingsvergelijking"
 
 #. IDS_JUMPLIST_NEW_WEBPAGE_COMPARE
-#: Merge.rc:5671
+#: Merge.rc:5670
 msgid "New Webpage Compare"
 msgstr "Nieuwe webpagina-vergelijking"
 
 #. IDS_JUMPLIST_NEW_FOLDER_COMPARE
-#: Merge.rc:5672
+#: Merge.rc:5671
 msgid "New Folder Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_CLIPBOARD_COMPARE
-#: Merge.rc:5673
+#: Merge.rc:5672
 msgid "Clipboard Compare"
 msgstr "Klembordvergelijking"
 
 #. IDS_PREVIEWBAR_PRINT
-#: Merge.rc:5678
+#: Merge.rc:5677
 msgid "&Print..."
 msgstr "Afdrukken..."
 
 #. IDS_PREVIEWBAR_PREVPAGE
-#: Merge.rc:5680
+#: Merge.rc:5679
 msgid "Pre&v Page"
 msgstr "Vorige pagina"
 
 #. IDS_PREVIEWBAR_TWOPAGE
-#: Merge.rc:5681
+#: Merge.rc:5680
 msgid "&Two Page"
 msgstr "Twee pagina's"
 
 #. IDS_PREVIEWBAR_ONEPAGE
-#: Merge.rc:5682
+#: Merge.rc:5681
 msgid "&One Page"
 msgstr "Eén pagina"
 
 #. IDS_PREVIEWBAR_ZOOMIN
-#: Merge.rc:5683
+#: Merge.rc:5682
 msgid "Zoom &In"
 msgstr "Inzoomen"
 
 #. IDS_PREVIEWBAR_ZOOMOUT
-#: Merge.rc:5684
+#: Merge.rc:5683
 msgid "Zoom &Out"
 msgstr "Uitzoomen"
 
 #. IDS_WEBPAGE_COMPARING
-#: Merge.rc:5690
+#: Merge.rc:5689
 msgid "Comparing..."
 msgstr "Vergelijken..."
 
 #. IDS_WEBPAGE_ZOOM
-#: Merge.rc:5691
+#: Merge.rc:5690
 msgid "Zoom:"
 msgstr "Zoomen:"
 
 #. IDS_COPY_GRANULARITY_DIFFHUNK
-#: Merge.rc:5696
+#: Merge.rc:5695
 msgid "Diff hunk"
 msgstr "Verschil-hunk"
 
 #. IDS_COPY_GRANULARITY_INLINE
-#: Merge.rc:5697
+#: Merge.rc:5696
 msgid "Inline diff"
 msgstr "Inline-verschil"
 
 #. IDS_COPY_GRANULARITY_LINE
-#: Merge.rc:5698
+#: Merge.rc:5697
 msgid "Line"
 msgstr "Regel"
 
-#: Merge.rc:5699
+#: Merge.rc:5698
 msgid "Character"
 msgstr "Teken"
 
 #. ID_MICE_PREVDIFF
-#: Merge.rc:5704
+#: Merge.rc:5703
 msgid ""
 "\n"
 "Previous Difference (Alt+Up)\n"
@@ -8526,7 +8521,7 @@ msgstr ""
 "(Alt+Wiel omhoog)"
 
 #. ID_MICE_NEXTDIFF
-#: Merge.rc:5705
+#: Merge.rc:5704
 msgid ""
 "\n"
 "Next Difference (Alt+Down)\n"
@@ -8539,7 +8534,7 @@ msgstr ""
 "(Alt+Wiel omlaag)"
 
 #. ID_MICE_L2R
-#: Merge.rc:5706
+#: Merge.rc:5705
 msgid ""
 "\n"
 "Copy to Right (Alt+Right)\n"
@@ -8554,7 +8549,7 @@ msgstr ""
 "(Alt+Shift+Wiel omlaag)"
 
 #. ID_MICE_R2L
-#: Merge.rc:5707
+#: Merge.rc:5706
 msgid ""
 "\n"
 "Copy to Left (Alt+Left)\n"
@@ -8569,7 +8564,7 @@ msgstr ""
 "(Alt+Shift+Wiel omhoog)"
 
 #. ID_MICE_L2RNEXT
-#: Merge.rc:5708
+#: Merge.rc:5707
 msgid ""
 "\n"
 "Copy to Right and Advance (Ctrl+Alt+Right)\n"
@@ -8582,7 +8577,7 @@ msgstr ""
 "(Ctrl+Alt+Shift+Wiel omlaag)"
 
 #. ID_MICE_R2LNEXT
-#: Merge.rc:5709
+#: Merge.rc:5708
 msgid ""
 "\n"
 "Copy to Left and Advance (Ctrl+Alt+Left)\n"
@@ -8595,282 +8590,282 @@ msgstr ""
 "(Ctrl+Alt+Shift+Wiel omhoog)"
 
 #. IDS_LOG_COMPARING_2
-#: Merge.rc:5719
+#: Merge.rc:5718
 #, c-format
 msgid "Comparing %1 with %2"
 msgstr ""
 
 #. IDS_LOG_COMPARING_3
-#: Merge.rc:5720
+#: Merge.rc:5719
 #, c-format
 msgid "Comparing %1 with %2 and %3"
 msgstr ""
 
 #. IDS_LOG_COMPARE_COMPLETED
-#: Merge.rc:5721
+#: Merge.rc:5720
 msgid "Comparison completed"
 msgstr ""
 
 #. IDS_LOG_COMPARE_ERROR_2
-#: Merge.rc:5722
+#: Merge.rc:5721
 #, c-format
 msgid "Failed to compare %1 with %2: "
 msgstr ""
 
 #. IDS_LOG_COMPARE_ERROR_3
-#: Merge.rc:5723
+#: Merge.rc:5722
 #, c-format
 msgid "Failed to compare %1 with %2 and %3: "
 msgstr ""
 
 #. IDS_LOG_FILE_SAVED
-#: Merge.rc:5724
+#: Merge.rc:5723
 msgid "File saved"
 msgstr ""
 
 #. IDS_LOG_COPYING_FILES
-#: Merge.rc:5725
+#: Merge.rc:5724
 msgid "Copying files..."
 msgstr ""
 
 #. IDS_LOG_MOVING_FILES
-#: Merge.rc:5726
+#: Merge.rc:5725
 msgid "Moving files..."
 msgstr ""
 
 #. IDS_LOG_DELETING_FILES
-#: Merge.rc:5727
+#: Merge.rc:5726
 msgid "Deleting files..."
 msgstr ""
 
 #. IDS_LOG_RECYCLEBIN
-#: Merge.rc:5728
+#: Merge.rc:5727
 msgid "Recycle Bin"
 msgstr ""
 
 #. IDS_LOG_PERMANENTLY_DELETED
-#: Merge.rc:5729
+#: Merge.rc:5728
 msgid "Permanently deleted"
 msgstr ""
 
 #. IDS_LOG_FILEOPERATION_COMPLETED
-#: Merge.rc:5730
+#: Merge.rc:5729
 msgid "File operation completed successfully"
 msgstr ""
 
 #. IDS_LOG_FILEOPERATION_CANCELED
-#: Merge.rc:5731
+#: Merge.rc:5730
 msgid "File operation canceled"
 msgstr ""
 
 #. IDS_FILTER_ERROR_NO_ERROR
-#: Merge.rc:5736
+#: Merge.rc:5735
 msgid "No error"
 msgstr ""
 
 #. IDS_FILTER_ERROR_EMPTY_EXPRESSION
-#: Merge.rc:5737
+#: Merge.rc:5736
 msgid "Filter expression is empty"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNKNOWN_CHAR
-#: Merge.rc:5738
+#: Merge.rc:5737
 msgid "Unknown character in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNTERMINATED_STRING
-#: Merge.rc:5739
+#: Merge.rc:5738
 msgid "Unterminated string literal"
 msgstr ""
 
 #. IDS_FILTER_ERROR_SYNTAX_ERROR
-#: Merge.rc:5740
+#: Merge.rc:5739
 msgid "Syntax error in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_PARSE_FAILURE
-#: Merge.rc:5741
+#: Merge.rc:5740
 msgid "Failed to parse filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_LITERAL
-#: Merge.rc:5742
+#: Merge.rc:5741
 msgid "Invalid literal value"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_REGULAR_EXPRESSION
-#: Merge.rc:5743
+#: Merge.rc:5742
 msgid "Invalid regular expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNDEFINED_IDENTIFIER
-#: Merge.rc:5744
+#: Merge.rc:5743
 msgid "Undefined identifier"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_ARGUMENT_COUNT
-#: Merge.rc:5745
+#: Merge.rc:5744
 msgid "Invalid number of arguments"
 msgstr ""
 
 #. IDS_FILTER_ERROR_FILTER_NAME_NOT_FOUND
-#: Merge.rc:5746
+#: Merge.rc:5745
 msgid "Filter name not found"
 msgstr ""
 
 #. IDS_FILTER_ERROR_DIVIDE_BY_ZERO
-#: Merge.rc:5747
+#: Merge.rc:5746
 msgid "Division by zero in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNKNOWN_ERROR
-#: Merge.rc:5748
+#: Merge.rc:5747
 msgid "Unknown error"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_PROPERTY_NAME
-#: Merge.rc:5749
+#: Merge.rc:5748
 msgid "Invalid property name"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_DIRECTIVE
-#: Merge.rc:5750
+#: Merge.rc:5749
 msgid "Invalid directive"
 msgstr ""
 
 #. IDS_FILTER_OP_EQUALS
-#: Merge.rc:5755
+#: Merge.rc:5754
 msgid "Equals"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_EQUALS
-#: Merge.rc:5756
+#: Merge.rc:5755
 msgid "Does not equal"
 msgstr ""
 
 #. IDS_FILTER_OP_LESS_THAN
-#: Merge.rc:5757
+#: Merge.rc:5756
 msgid "Less than"
 msgstr ""
 
 #. IDS_FILTER_OP_LESS_EQUAL
-#: Merge.rc:5758
+#: Merge.rc:5757
 msgid "Less than or equal to"
 msgstr ""
 
 #. IDS_FILTER_OP_GREATER_EQUAL
-#: Merge.rc:5759
+#: Merge.rc:5758
 msgid "Greater than or equal to"
 msgstr ""
 
 #. IDS_FILTER_OP_GREATER_THAN
-#: Merge.rc:5760
+#: Merge.rc:5759
 msgid "Greater than"
 msgstr ""
 
 #. IDS_FILTER_OP_BETWEEN
-#: Merge.rc:5761
+#: Merge.rc:5760
 msgid "Between"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_BETWEEN
-#: Merge.rc:5762
+#: Merge.rc:5761
 msgid "Not Between"
 msgstr ""
 
 #. IDS_FILTER_OP_CONTAINS
-#: Merge.rc:5763
+#: Merge.rc:5762
 msgid "Contains"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_CONTAINS
-#: Merge.rc:5764
+#: Merge.rc:5763
 msgid "Not Contains"
 msgstr ""
 
 #. IDS_FILTER_OP_RECONTAINS
-#: Merge.rc:5765
+#: Merge.rc:5764
 msgid "Contains (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_RECONTAINS
-#: Merge.rc:5766
+#: Merge.rc:5765
 msgid "Not Contains (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_LIKE
-#: Merge.rc:5767
+#: Merge.rc:5766
 msgid "Match (wildcard)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_LIKE
-#: Merge.rc:5768
+#: Merge.rc:5767
 msgid "Not match (wildcard)"
 msgstr ""
 
 #. IDS_FILTER_OP_MATCHES
-#: Merge.rc:5769
+#: Merge.rc:5768
 msgid "Match (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_MATCHES
-#: Merge.rc:5770
+#: Merge.rc:5769
 msgid "Not match (regex)"
 msgstr ""
 
 #. IDS_COLORMODE_LIGHT
-#: Merge.rc:5775
+#: Merge.rc:5774
 msgid "Light"
 msgstr ""
 
 #. IDS_COLORMODE_DARK
-#: Merge.rc:5776
+#: Merge.rc:5775
 msgid "Dark"
 msgstr ""
 
 #. IDS_COLORMODE_FOLLOWSYSTEM
-#: Merge.rc:5777
+#: Merge.rc:5776
 msgid "Follow system"
 msgstr ""
 
 #. IDS_EXAMPLE
-#: Merge.rc:5782
+#: Merge.rc:5781
 #, c-format
 msgid "e.g. %1"
 msgstr ""
 
 #. IDS_DETECTED_PREVIOUS_CRASH
-#: Merge.rc:5787
+#: Merge.rc:5786
 msgid "WinMerge detected a previous crash. Please report this if possible."
 msgstr ""
 
 #. IDS_REGEX_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5792
+#: Merge.rc:5791
 msgid "# Regex replacement list\r\n# Format: regex<TAB>replacement\r\n# Backreferences like $1, $2 are supported\r\n\r\n(\\d{4})-(\\d{2})-(\\d{2})\t$1_$2_$3\r\n"
 msgstr ""
 
 #. IDS_STRING_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5793
+#: Merge.rc:5792
 msgid "# Replacement list\r\n# Format: search<TAB>replacement\r\n# Lines starting with # are ignored\r\n\r\nfrom1\tto1\r\nfrom2\tto2\r\n"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_ONLY
-#: Merge.rc:5798
+#: Merge.rc:5797
 msgid "Built-in only"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_FIRST
-#: Merge.rc:5799
+#: Merge.rc:5798
 msgid "Built-in first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_FIRST
-#: Merge.rc:5800
+#: Merge.rc:5799
 msgid "Tree-sitter first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_ONLY
-#: Merge.rc:5801
+#: Merge.rc:5800
 msgid "Tree-sitter only"
 msgstr ""
 

--- a/Translations/WinMerge/English.pot
+++ b/Translations/WinMerge/English.pot
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: WinMerge\n"
 "Report-Msgid-Bugs-To: https://github.com/WinMerge/winmerge/issues/\n"
-"POT-Creation-Date: 2026-08-08 23:06+0000\n"
+"POT-Creation-Date: 2026-08-10 12:45+0000\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: English <winmerge-translate@lists.sourceforge.net>\n"
@@ -17,7 +17,7 @@ msgstr ""
 "X-Poedit-Basepath: ../../Src/\n"
 
 #. LANGUAGE, SUBLANGUAGE
-#: Merge.rc:26 Merge.rc:59 Merge.rc:5818
+#: Merge.rc:26 Merge.rc:59 Merge.rc:5817
 msgid "LANG_ENGLISH, SUBLANG_ENGLISH_US"
 msgstr ""
 
@@ -159,7 +159,7 @@ msgstr ""
 #. IDS_NO_EDIT_SCRIPTS
 #: Merge.rc:127 Merge.rc:352 Merge.rc:463 Merge.rc:673 Merge.rc:678
 #: Merge.rc:887 Merge.rc:899 Merge.rc:906 Merge.rc:963 Merge.rc:1210
-#: Merge.rc:5375
+#: Merge.rc:5374
 msgid "< Empty >"
 msgstr ""
 
@@ -224,7 +224,7 @@ msgid "Auto-Fit All Columns"
 msgstr ""
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN
-#: Merge.rc:153 Merge.rc:5646
+#: Merge.rc:153 Merge.rc:5645
 msgid "&Filter by This Column"
 msgstr ""
 
@@ -285,7 +285,7 @@ msgid "&Previous Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_NEXTPAGE
-#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5679
+#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5678
 msgid "&Next Page"
 msgstr ""
 
@@ -536,7 +536,7 @@ msgstr ""
 #. IDS_IMAGE_MENU
 #: Merge.rc:329 Merge.rc:338 Merge.rc:432 Merge.rc:441 Merge.rc:609
 #: Merge.rc:618 Merge.rc:670 Merge.rc:960 Merge.rc:1187 Merge.rc:1200
-#: Merge.rc:5477
+#: Merge.rc:5476
 msgid "&Image"
 msgstr ""
 
@@ -658,7 +658,7 @@ msgid "&Huge"
 msgstr ""
 
 #. IDS_VIEW_MENU_BAR
-#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5714
+#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5713
 msgid "Men&u Bar"
 msgstr ""
 
@@ -1313,7 +1313,7 @@ msgid "Lo&cation Pane"
 msgstr ""
 
 #. IDS_OUTPUTBAR_CAPTION
-#: Merge.rc:782 Merge.rc:5252
+#: Merge.rc:782 Merge.rc:5251
 msgid "Output Pane"
 msgstr ""
 
@@ -1576,55 +1576,55 @@ msgid "Co&mpare As"
 msgstr ""
 
 #. IDS_COPY_LEFT_TO_MIDDLE2
-#: Merge.rc:968 Merge.rc:980 Merge.rc:4852
+#: Merge.rc:968 Merge.rc:980 Merge.rc:4851
 #, c-format
 msgid "Left to Middle (%1 of %2)"
 msgstr ""
 
 #. IDS_COPY_LEFT_TO_RIGHT2
-#: Merge.rc:969 Merge.rc:981 Merge.rc:4851
+#: Merge.rc:969 Merge.rc:981 Merge.rc:4850
 #, c-format
 msgid "Left to Right (%1 of %2)"
 msgstr ""
 
 #. IDS_MOVE_LEFT_TO2
-#: Merge.rc:970 Merge.rc:982 Merge.rc:1045 Merge.rc:4863 Merge.rc:4892
+#: Merge.rc:970 Merge.rc:982 Merge.rc:1045 Merge.rc:4862 Merge.rc:4891
 #, c-format
 msgid "Left to... (%1 of %2)"
 msgstr ""
 
 #. IDS_COPY_MIDDLE_TO_LEFT2
-#: Merge.rc:971 Merge.rc:983 Merge.rc:4849
+#: Merge.rc:971 Merge.rc:983 Merge.rc:4848
 #, c-format
 msgid "Middle to Left (%1 of %2)"
 msgstr ""
 
 #. IDS_COPY_MIDDLE_TO_RIGHT2
-#: Merge.rc:972 Merge.rc:984 Merge.rc:4850
+#: Merge.rc:972 Merge.rc:984 Merge.rc:4849
 #, c-format
 msgid "Middle to Right (%1 of %2)"
 msgstr ""
 
 #. IDS_MOVE_MIDDLE_TO2
-#: Merge.rc:973 Merge.rc:985 Merge.rc:1046 Merge.rc:4864 Merge.rc:4893
+#: Merge.rc:973 Merge.rc:985 Merge.rc:1046 Merge.rc:4863 Merge.rc:4892
 #, c-format
 msgid "Middle to... (%1 of %2)"
 msgstr ""
 
 #. IDS_COPY_RIGHT_TO_MIDDLE2
-#: Merge.rc:974 Merge.rc:986 Merge.rc:4848
+#: Merge.rc:974 Merge.rc:986 Merge.rc:4847
 #, c-format
 msgid "Right to Middle (%1 of %2)"
 msgstr ""
 
 #. IDS_COPY_RIGHT_TO_LEFT2
-#: Merge.rc:975 Merge.rc:987 Merge.rc:4847
+#: Merge.rc:975 Merge.rc:987 Merge.rc:4846
 #, c-format
 msgid "Right to Left (%1 of %2)"
 msgstr ""
 
 #. IDS_MOVE_RIGHT_TO2
-#: Merge.rc:976 Merge.rc:988 Merge.rc:1047 Merge.rc:4865 Merge.rc:4894
+#: Merge.rc:976 Merge.rc:988 Merge.rc:1047 Merge.rc:4864 Merge.rc:4893
 #, c-format
 msgid "Right to... (%1 of %2)"
 msgstr ""
@@ -1680,31 +1680,31 @@ msgid "Cop&y Paths"
 msgstr ""
 
 #. IDS_DEL_LEFT_FMT2
-#: Merge.rc:1026 Merge.rc:1035 Merge.rc:4880
+#: Merge.rc:1026 Merge.rc:1035 Merge.rc:4879
 #, c-format
 msgid "Left (%1 of %2)"
 msgstr ""
 
 #. IDS_DEL_MIDDLE_FMT2
-#: Merge.rc:1027 Merge.rc:1036 Merge.rc:4881
+#: Merge.rc:1027 Merge.rc:1036 Merge.rc:4880
 #, c-format
 msgid "Middle (%1 of %2)"
 msgstr ""
 
 #. IDS_DEL_RIGHT_FMT2
-#: Merge.rc:1028 Merge.rc:1037 Merge.rc:4882
+#: Merge.rc:1028 Merge.rc:1037 Merge.rc:4881
 #, c-format
 msgid "Right (%1 of %2)"
 msgstr ""
 
 #. IDS_DEL_BOTH_FMT2
-#: Merge.rc:1029 Merge.rc:1038 Merge.rc:4883
+#: Merge.rc:1029 Merge.rc:1038 Merge.rc:4882
 #, c-format
 msgid "Both (%1 of %2)"
 msgstr ""
 
 #. IDS_DEL_ALL_FMT2
-#: Merge.rc:1030 Merge.rc:1039 Merge.rc:4888
+#: Merge.rc:1030 Merge.rc:1039 Merge.rc:4887
 #, c-format
 msgid "All (%1 of %2)"
 msgstr ""
@@ -1730,19 +1730,19 @@ msgid "&Zip"
 msgstr ""
 
 #. IDS_COPY_BOTH_TO2
-#: Merge.rc:1048 Merge.rc:4866
+#: Merge.rc:1048 Merge.rc:4865
 #, c-format
 msgid "Both to... (%1 of %2)"
 msgstr ""
 
 #. IDS_COPY_ALL_TO2
-#: Merge.rc:1049 Merge.rc:4867
+#: Merge.rc:1049 Merge.rc:4866
 #, c-format
 msgid "All to... (%1 of %2)"
 msgstr ""
 
 #. IDS_COPY_DIFFERENCES_TO2
-#: Merge.rc:1050 Merge.rc:4868
+#: Merge.rc:1050 Merge.rc:4867
 #, c-format
 msgid "Differences to... (%1 of %2)"
 msgstr ""
@@ -1809,12 +1809,12 @@ msgstr ""
 
 #. IDS_USERCHOICE_NONE
 #: Merge.rc:1088 Merge.rc:1094 Merge.rc:1836 Merge.rc:1840 Merge.rc:2031
-#: Merge.rc:2035 Merge.rc:5377
+#: Merge.rc:2035 Merge.rc:5376
 msgid "<None>"
 msgstr ""
 
 #. IDS_USERCHOICE_AUTOMATIC
-#: Merge.rc:1089 Merge.rc:1095 Merge.rc:5378
+#: Merge.rc:1089 Merge.rc:1095 Merge.rc:5377
 msgid "<Automatic>"
 msgstr ""
 
@@ -2744,12 +2744,12 @@ msgid "Text files only"
 msgstr ""
 
 #. IDS_EOL_NONE
-#: Merge.rc:1667 Merge.rc:1918 Merge.rc:5304
+#: Merge.rc:1667 Merge.rc:1918 Merge.rc:5303
 msgid "None"
 msgstr ""
 
 #. IDS_EOL_MIXED
-#: Merge.rc:1668 Merge.rc:5299
+#: Merge.rc:1668 Merge.rc:5298
 msgid "Mixed"
 msgstr ""
 
@@ -3021,13 +3021,13 @@ msgstr ""
 
 #. IDS_DIFFERENT
 #: Merge.rc:1904 Merge.rc:1988 Merge.rc:2866 Merge.rc:3036 Merge.rc:3077
-#: Merge.rc:5058
+#: Merge.rc:5057
 msgid "Different"
 msgstr ""
 
 #. IDS_IDENTICAL
 #: Merge.rc:1905 Merge.rc:1989 Merge.rc:2865 Merge.rc:3055 Merge.rc:3116
-#: Merge.rc:5048
+#: Merge.rc:5047
 msgid "Identical"
 msgstr ""
 
@@ -3047,7 +3047,7 @@ msgid "Missing"
 msgstr ""
 
 #. IDS_MOVED
-#: Merge.rc:1910 Merge.rc:5076
+#: Merge.rc:1910 Merge.rc:5075
 msgid "Moved"
 msgstr ""
 
@@ -3783,7 +3783,7 @@ msgid "&Use custom system colors"
 msgstr ""
 
 #. IDS_PRPCAT_SYSTEM
-#: Merge.rc:2565 Merge.rc:4559 Merge.rc:4560 Merge.rc:5007
+#: Merge.rc:2565 Merge.rc:4559 Merge.rc:4560 Merge.rc:5006
 msgid "System"
 msgstr ""
 
@@ -4183,7 +4183,7 @@ msgid "Items compared:"
 msgstr ""
 
 #. IDS_PREVIEWBAR_CLOSE
-#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5685
+#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5684
 msgid "&Close"
 msgstr ""
 
@@ -4798,7 +4798,7 @@ msgid "A&ppend timestamp"
 msgstr ""
 
 #. IDS_CONFIRM_COPY_CAPTION
-#: Merge.rc:3214 Merge.rc:4915
+#: Merge.rc:3214 Merge.rc:4914
 msgid "Confirm Copy"
 msgstr ""
 
@@ -5035,7 +5035,7 @@ msgid "&Character Set..."
 msgstr ""
 
 #. IDS_PRPCAT_IMAGE
-#: Merge.rc:3351 Merge.rc:4574 Merge.rc:5015
+#: Merge.rc:3351 Merge.rc:4574 Merge.rc:5014
 msgid "Image"
 msgstr ""
 
@@ -5380,7 +5380,7 @@ msgid "Project"
 msgstr ""
 
 #. IDS_COLHDR_NSDIFFS
-#: Merge.rc:4566 Merge.rc:4990
+#: Merge.rc:4566 Merge.rc:4989
 msgid "Differences"
 msgstr ""
 
@@ -5522,12 +5522,12 @@ msgid "File Type"
 msgstr ""
 
 #. IDS_COLHDR_EXTENSION
-#: Merge.rc:4653 Merge.rc:4947
+#: Merge.rc:4653 Merge.rc:4946
 msgid "Extension"
 msgstr ""
 
 #. IDS_PRPCAT_MESSAGE
-#: Merge.rc:4659 Merge.rc:5019
+#: Merge.rc:4659 Merge.rc:5018
 msgid "Message"
 msgstr ""
 
@@ -5567,7 +5567,7 @@ msgid "Hidden Items"
 msgstr ""
 
 #. IDS_PLUGINSLIST_NAME
-#: Merge.rc:4680 Merge.rc:5311
+#: Merge.rc:4680 Merge.rc:5310
 msgid "Name"
 msgstr ""
 
@@ -5587,7 +5587,7 @@ msgid "[F] "
 msgstr ""
 
 #. IDS_PLUGINSLIST_DESC
-#: Merge.rc:4684 Merge.rc:5313
+#: Merge.rc:4684 Merge.rc:5312
 msgid "Description"
 msgstr ""
 
@@ -5713,2735 +5713,2730 @@ msgstr ""
 msgid "  Sel: %d | %d"
 msgstr ""
 
-#. IDS_MERGEMODE_MERGING
-#: Merge.rc:4734
-msgid "Merge"
-msgstr ""
-
 #. IDS_DIFF_NUMBER_STATUS_FMT
-#: Merge.rc:4735
+#: Merge.rc:4734
 #, c-format
 msgid "Difference %1 of %2"
 msgstr ""
 
 #. IDS_NO_DIFF_SEL_FMT
-#: Merge.rc:4736
+#: Merge.rc:4735
 #, c-format
 msgid "%1 Differences Found"
 msgstr ""
 
 #. IDS_1_DIFF_FOUND
-#: Merge.rc:4737
+#: Merge.rc:4736
 msgid "1 Difference Found"
 msgstr ""
 
 #. IDS_NO_ERR_SEL_FMT
-#: Merge.rc:4738
+#: Merge.rc:4737
 #, c-format
 msgid "%1 Errors Found"
 msgstr ""
 
 #. IDS_1_ERR_FOUND
-#: Merge.rc:4739
+#: Merge.rc:4738
 msgid "1 Error Found"
 msgstr ""
 
 #. IDS_STATUSBAR_READONLY, Abbreviation from "Read Only"
-#: Merge.rc:4740
+#: Merge.rc:4739
 msgid "RO"
 msgstr ""
 
 #. IDS_DIRVIEW_STATUS_FMT_FOCUS
-#: Merge.rc:4746
+#: Merge.rc:4745
 #, c-format
 msgid "Item %1 of %2"
 msgstr ""
 
 #. IDS_DIRVIEW_STATUS_FMT_NOFOCUS
-#: Merge.rc:4747
+#: Merge.rc:4746
 #, c-format
 msgid "Items: %1"
 msgstr ""
 
 #. IDS_DIRVIEW_STATUS_COMPARING
-#: Merge.rc:4748
+#: Merge.rc:4747
 msgid "Comparing items..."
 msgstr ""
 
 #. IDS_ITEMS_PER_SEC
-#: Merge.rc:4749
+#: Merge.rc:4748
 #, c-format
 msgid "%.1f[items/sec]"
 msgstr ""
 
 #. IDS_ERROR_INCOMPARABLE
-#: Merge.rc:4755
+#: Merge.rc:4754
 msgid "Select two existing folders/files to compare."
 msgstr ""
 
 #. IDS_DIRSEL_TAG
-#: Merge.rc:4756
+#: Merge.rc:4755
 msgid "Folder Selection"
 msgstr ""
 
 #. IDS_OPEN_FILESDIRS
-#: Merge.rc:4757
+#: Merge.rc:4756
 msgid "Select two (or three) folders/files to compare."
 msgstr ""
 
 #. IDS_OPEN_LEFTINVALID
-#: Merge.rc:4758
+#: Merge.rc:4757
 msgid "Left (1st) path is invalid!"
 msgstr ""
 
 #. IDS_OPEN_MIDDLEINVALID
-#: Merge.rc:4759
+#: Merge.rc:4758
 msgid "Middle (2nd) path is invalid!"
 msgstr ""
 
 #. IDS_OPEN_RIGHTINVALID2
-#: Merge.rc:4760
+#: Merge.rc:4759
 msgid "Right (2nd) path is invalid!"
 msgstr ""
 
 #. IDS_OPEN_RIGHTINVALID3
-#: Merge.rc:4761
+#: Merge.rc:4760
 msgid "Right (3rd) path is invalid!"
 msgstr ""
 
 #. IDS_OPEN_BOTHINVALID
-#: Merge.rc:4762
+#: Merge.rc:4761
 msgid "Both paths are invalid!"
 msgstr ""
 
-#: Merge.rc:4764
+#: Merge.rc:4763
 msgid "Left (1st) and Middle (2nd) paths are invalid!"
 msgstr ""
 
 #. IDS_OPEN_LEFTRIGHTINVALID
-#: Merge.rc:4765
+#: Merge.rc:4764
 msgid "Left (1st) and Right (3rd) paths are invalid!"
 msgstr ""
 
-#: Merge.rc:4767
+#: Merge.rc:4766
 msgid "Middle (2nd) and Right (3rd) paths are invalid!"
 msgstr ""
 
 #. IDS_OPEN_ALLINVALID
-#: Merge.rc:4768
+#: Merge.rc:4767
 msgid "All paths are invalid!"
 msgstr ""
 
 #. IDS_OPEN_UNPACKERDISABLED
-#: Merge.rc:4769
+#: Merge.rc:4768
 msgid "Only enabled for file comparisons"
 msgstr ""
 
 #. IDS_OPEN_MISMATCH
-#: Merge.rc:4770
+#: Merge.rc:4769
 msgid "Cannot compare file and folder!"
 msgstr ""
 
 #. IDS_ERROR_FILE_NOT_FOUND
-#: Merge.rc:4776
+#: Merge.rc:4775
 #, c-format
 msgid "File not found: %1"
 msgstr ""
 
 #. IDS_ERROR_FOLDER_NOT_FOUND
-#: Merge.rc:4777
+#: Merge.rc:4776
 #, c-format
 msgid "Folder not found: %1"
 msgstr ""
 
 #. IDS_ERROR_FILE_NOT_UNPACKED
-#: Merge.rc:4778
+#: Merge.rc:4777
 #, c-format
 msgid "File not unpacked: %1"
 msgstr ""
 
 #. IDS_ERROR_FILEOPEN
-#: Merge.rc:4779
+#: Merge.rc:4778
 #, c-format
 msgid "Cannot open file\n%1\n\n%2"
 msgstr ""
 
 #. IDS_ERROR_CONF_RESOLVE
-#: Merge.rc:4780
+#: Merge.rc:4779
 msgid "Failed to parse conflict file."
 msgstr ""
 
 #. IDS_NOT_CONFLICT_FILE
-#: Merge.rc:4781
+#: Merge.rc:4780
 #, c-format
 msgid "The file\n%1\nis not a conflict file."
 msgstr ""
 
 #. IDS_COMPARE_LARGE_FILES
-#: Merge.rc:4782
+#: Merge.rc:4781
 msgid "Comparing large files requires significant memory.\nShow only comparison results (not file contents)?"
 msgstr ""
 
 #. IDS_SAVE_AS_TITLE
-#: Merge.rc:4788
+#: Merge.rc:4787
 msgid "Save As"
 msgstr ""
 
 #. IDS_SAVE_FMT
-#: Merge.rc:4789
+#: Merge.rc:4788
 #, c-format
 msgid "Save changes to %1?"
 msgstr ""
 
 #. IDS_SAVEREADONLY_FMT
-#: Merge.rc:4790
+#: Merge.rc:4789
 #, c-format
 msgid "%1 is read-only. Override? Or 'No' to save as new filename?"
 msgstr ""
 
 #. IDS_ERROR_BACKUP
-#: Merge.rc:4791
+#: Merge.rc:4790
 msgid "Error backing up file"
 msgstr ""
 
-#: Merge.rc:4793
+#: Merge.rc:4792
 #, c-format
 msgid "Unable to backup original file:\n%1\n\nContinue anyway?"
 msgstr ""
 
 #. IDS_FILESAVE_FAILED
-#: Merge.rc:4794
+#: Merge.rc:4793
 #, c-format
 msgid "Saving file failed.\n%1\n%2\n\t- Use different filename (OK)\n\t- Abort (Cancel)?"
 msgstr ""
 
-#: Merge.rc:4796
+#: Merge.rc:4795
 #, c-format
 msgid "Plugin '%2' cannot pack changes to left file into '%1'.\n\nOriginal unchanged. Save unpacked version?"
 msgstr ""
 
-#: Merge.rc:4798
+#: Merge.rc:4797
 #, c-format
 msgid "Plugin '%2' cannot pack changes to middle file into '%1'.\n\nOriginal unchanged. Save unpacked version?"
 msgstr ""
 
-#: Merge.rc:4800
+#: Merge.rc:4799
 #, c-format
 msgid "Plugin '%2' cannot pack changes to right file into '%1'.\n\nOriginal unchanged. Save unpacked version?"
 msgstr ""
 
 #. IDS_FILECHANGED_ONDISK
-#: Merge.rc:4801
+#: Merge.rc:4800
 #, c-format
 msgid "Another application updated\n%1\nsince WinMerge loaded it.\n\nOverwrite?"
 msgstr ""
 
 #. IDS_SAVEREADONLY_MULTI
-#: Merge.rc:4802
+#: Merge.rc:4801
 #, c-format
 msgid "%1\nis read-only. Override?"
 msgstr ""
 
 #. IDS_FILECHANGED_RESCAN
-#: Merge.rc:4803
+#: Merge.rc:4802
 #, c-format
 msgid "Another application updated\n%1\nsince last scan.\n\nReload?"
 msgstr ""
 
 #. IDS_SAVE_LEFT_AS
-#: Merge.rc:4804
+#: Merge.rc:4803
 msgid "Save Left File As"
 msgstr ""
 
 #. IDS_SAVE_MIDDLE_AS
-#: Merge.rc:4805
+#: Merge.rc:4804
 msgid "Save Middle File As"
 msgstr ""
 
 #. IDS_SAVE_RIGHT_AS
-#: Merge.rc:4806
+#: Merge.rc:4805
 msgid "Save Right File As"
 msgstr ""
 
 #. IDS_FILE_DISAPPEARED
-#: Merge.rc:4811
+#: Merge.rc:4810
 #, c-format
 msgid "File\n%1\nnot found. Save a copy to continue."
 msgstr ""
 
 #. IDS_VIEWS_OUTOFSYNC
-#: Merge.rc:4817
+#: Merge.rc:4816
 msgid "Cannot merge unsynched documents.\n\nRefresh before continuing."
 msgstr ""
 
 #. IDS_BREAK_ON_WHITESPACE
-#: Merge.rc:4822
+#: Merge.rc:4821
 msgid "Break at whitespace"
 msgstr ""
 
 #. IDS_BREAK_ON_PUNCTUATION
-#: Merge.rc:4823
+#: Merge.rc:4822
 msgid "Break at whitespace or punctuation"
 msgstr ""
 
 #. IDS_L2M
-#: Merge.rc:4829
+#: Merge.rc:4828
 msgid "Copy to &Middle\tAlt+Right"
 msgstr ""
 
 #. IDS_R2M
-#: Merge.rc:4830
+#: Merge.rc:4829
 msgid "Copy to &Middle\tAlt+Left"
 msgstr ""
 
 #. IDS_COPY_FROM_MIDDLE_R
-#: Merge.rc:4831
+#: Merge.rc:4830
 msgid "Copy from Middle\tAlt+Shift+Right"
 msgstr ""
 
 #. IDS_COPY_FROM_MIDDLE_L
-#: Merge.rc:4832
+#: Merge.rc:4831
 msgid "Copy from Middle\tAlt+Shift+Left"
 msgstr ""
 
 #. IDS_L2MNEXT
-#: Merge.rc:4833
+#: Merge.rc:4832
 msgid "Copy to Middle and Advance\tCtrl+Alt+Right"
 msgstr ""
 
 #. IDS_R2MNEXT
-#: Merge.rc:4834
+#: Merge.rc:4833
 msgid "Copy to Middle and Advance\tCtrl+Alt+Left"
 msgstr ""
 
 #. IDS_ALL_MIDDLE
-#: Merge.rc:4835
+#: Merge.rc:4834
 msgid "Copy All to Middle"
 msgstr ""
 
 #. IDS_COPY_RIGHT_TO_LEFT
-#: Merge.rc:4841
+#: Merge.rc:4840
 #, c-format
 msgid "Right to Left (%1)"
 msgstr ""
 
 #. IDS_COPY_RIGHT_TO_MIDDLE
-#: Merge.rc:4842
+#: Merge.rc:4841
 #, c-format
 msgid "Right to Middle (%1)"
 msgstr ""
 
 #. IDS_COPY_MIDDLE_TO_LEFT
-#: Merge.rc:4843
+#: Merge.rc:4842
 #, c-format
 msgid "Middle to Left (%1)"
 msgstr ""
 
 #. IDS_COPY_MIDDLE_TO_RIGHT
-#: Merge.rc:4844
+#: Merge.rc:4843
 #, c-format
 msgid "Middle to Right (%1)"
 msgstr ""
 
 #. IDS_COPY_LEFT_TO_RIGHT
-#: Merge.rc:4845
+#: Merge.rc:4844
 #, c-format
 msgid "Left to Right (%1)"
 msgstr ""
 
 #. IDS_COPY_LEFT_TO_MIDDLE
-#: Merge.rc:4846
+#: Merge.rc:4845
 #, c-format
 msgid "Left to Middle (%1)"
 msgstr ""
 
 #. IDS_MOVE_LEFT_TO
-#: Merge.rc:4857 Merge.rc:4889
+#: Merge.rc:4856 Merge.rc:4888
 #, c-format
 msgid "Left to... (%1)"
 msgstr ""
 
 #. IDS_MOVE_MIDDLE_TO
-#: Merge.rc:4858 Merge.rc:4890
+#: Merge.rc:4857 Merge.rc:4889
 #, c-format
 msgid "Middle to... (%1)"
 msgstr ""
 
 #. IDS_MOVE_RIGHT_TO
-#: Merge.rc:4859 Merge.rc:4891
+#: Merge.rc:4858 Merge.rc:4890
 #, c-format
 msgid "Right to... (%1)"
 msgstr ""
 
 #. IDS_COPY_BOTH_TO
-#: Merge.rc:4860
+#: Merge.rc:4859
 #, c-format
 msgid "Both to... (%1)"
 msgstr ""
 
 #. IDS_COPY_ALL_TO
-#: Merge.rc:4861
+#: Merge.rc:4860
 #, c-format
 msgid "All to... (%1)"
 msgstr ""
 
 #. IDS_COPY_DIFFERENCES_TO
-#: Merge.rc:4862
+#: Merge.rc:4861
 #, c-format
 msgid "Differences to... (%1)"
 msgstr ""
 
 #. IDS_ONLYDIFFITEMS_CONFIRM
-#: Merge.rc:4869
+#: Merge.rc:4868
 msgid "Some selected items are identical or skipped.\nProcess only items with differences?"
 msgstr ""
 
 #. IDS_DEL_LEFT_FMT
-#: Merge.rc:4875
+#: Merge.rc:4874
 #, c-format
 msgid "Left (%1)"
 msgstr ""
 
 #. IDS_DEL_MIDDLE_FMT
-#: Merge.rc:4876
+#: Merge.rc:4875
 #, c-format
 msgid "Middle (%1)"
 msgstr ""
 
 #. IDS_DEL_RIGHT_FMT
-#: Merge.rc:4877
+#: Merge.rc:4876
 #, c-format
 msgid "Right (%1)"
 msgstr ""
 
 #. IDS_DEL_BOTH_FMT
-#: Merge.rc:4878
+#: Merge.rc:4877
 #, c-format
 msgid "Both (%1)"
 msgstr ""
 
 #. IDS_DEL_ALL_FMT
-#: Merge.rc:4879
+#: Merge.rc:4878
 #, c-format
 msgid "All (%1)"
 msgstr ""
 
 #. IDS_SELECT_DEST_LEFT
-#: Merge.rc:4895
+#: Merge.rc:4894
 msgid "Left Side - Select Destination Folder:"
 msgstr ""
 
 #. IDS_SELECT_DEST_MIDDLE
-#: Merge.rc:4896
+#: Merge.rc:4895
 msgid "Middle Side - Select Destination Folder:"
 msgstr ""
 
 #. IDS_SELECT_DEST_RIGHT
-#: Merge.rc:4897
+#: Merge.rc:4896
 msgid "Right Side - Select Destination Folder:"
 msgstr ""
 
 #. IDS_FILES_AFFECTED_FMT
-#: Merge.rc:4898
+#: Merge.rc:4897
 #, c-format
 msgid "(%1 Files Affected)"
 msgstr ""
 
 #. IDS_FILES_AFFECTED_FMT2
-#: Merge.rc:4899
+#: Merge.rc:4898
 #, c-format
 msgid "(%1 of %2 Files Affected)"
 msgstr ""
 
 #. IDS_CONFIRM_DELETE_SINGLE
-#: Merge.rc:4905
+#: Merge.rc:4904
 #, c-format
 msgid "Are you sure you want to delete\n\n%1 ?"
 msgstr ""
 
 #. IDS_CONFIRM_SINGLE_COPY
-#: Merge.rc:4906
+#: Merge.rc:4905
 msgid "Are you sure you want to copy?"
 msgstr ""
 
 #. IDS_CONFIRM_MULTIPLE_COPY
-#: Merge.rc:4907
+#: Merge.rc:4906
 #, c-format
 msgid "Are you sure you want to copy %d items?"
 msgstr ""
 
 #. IDS_DIRCMP_NOTSYNC
-#: Merge.rc:4908
+#: Merge.rc:4907
 #, c-format
 msgid "Operation aborted!\n\nFolder contents changed, path\n%1\nnot found.\n\nRefresh the compare."
 msgstr ""
 
 #. IDS_CONFIRM_SINGLE_MOVE
-#: Merge.rc:4913
+#: Merge.rc:4912
 msgid "Are you sure you want to move?"
 msgstr ""
 
 #. IDS_CONFIRM_MULTIPLE_MOVE
-#: Merge.rc:4914
+#: Merge.rc:4913
 #, c-format
 msgid "Are you sure you want to move %d items?"
 msgstr ""
 
 #. IDS_CONFIRM_MOVE_CAPTION
-#: Merge.rc:4916
+#: Merge.rc:4915
 msgid "Confirm Move"
 msgstr ""
 
-#: Merge.rc:4918
+#: Merge.rc:4917
 msgid "Close the folder comparison window?"
 msgstr ""
 
-#: Merge.rc:4920
+#: Merge.rc:4919
 msgid "Close the folder comparison window, which took a long time?"
 msgstr ""
 
 #. IDS_ERROR_INVALID_DIR_FILE_NAME
-#: Merge.rc:4921
+#: Merge.rc:4920
 msgid "The file or folder name is invalid."
 msgstr ""
 
 #. IDS_ERROR_EXECUTE_FILE
-#: Merge.rc:4927
+#: Merge.rc:4926
 #, c-format
 msgid "Failed to execute external editor: %1"
 msgstr ""
 
 #. IDS_UNKNOWN_ARCHIVE_FORMAT
-#: Merge.rc:4933
+#: Merge.rc:4932
 msgid "Unknown archive format"
 msgstr ""
 
-#: Merge.rc:4935
+#: Merge.rc:4934
 msgid "Failed to extract archive.\nCompare as text file?"
 msgstr ""
 
 #. IDS_COLHDR_FILENAME
-#: Merge.rc:4941
+#: Merge.rc:4940
 msgid "Filename"
 msgstr ""
 
 #. IDS_COLHDR_DIR
-#: Merge.rc:4942
+#: Merge.rc:4941
 msgctxt "DirView|ColumnHeader"
 msgid "Folder"
 msgstr ""
 
 #. IDS_COLHDR_RESULT
-#: Merge.rc:4943
+#: Merge.rc:4942
 msgid "Comparison Result"
 msgstr ""
 
 #. IDS_COLHDR_LTIMEM
-#: Merge.rc:4944
+#: Merge.rc:4943
 msgid "Left Date"
 msgstr ""
 
 #. IDS_COLHDR_RTIMEM
-#: Merge.rc:4945
+#: Merge.rc:4944
 msgid "Right Date"
 msgstr ""
 
 #. IDS_COLHDR_MTIMEM
-#: Merge.rc:4946
+#: Merge.rc:4945
 msgid "Middle Date"
 msgstr ""
 
 #. IDS_COLHDR_LSIZE
-#: Merge.rc:4948
+#: Merge.rc:4947
 msgid "Left Size"
 msgstr ""
 
 #. IDS_COLHDR_RSIZE
-#: Merge.rc:4949
+#: Merge.rc:4948
 msgid "Right Size"
 msgstr ""
 
 #. IDS_COLHDR_MSIZE
-#: Merge.rc:4954
+#: Merge.rc:4953
 msgid "Middle Size"
 msgstr ""
 
 #. IDS_COLHDR_RSIZE_SHORT
-#: Merge.rc:4955
+#: Merge.rc:4954
 msgid "Right Size (Short)"
 msgstr ""
 
 #. IDS_COLHDR_LSIZE_SHORT
-#: Merge.rc:4956
+#: Merge.rc:4955
 msgid "Left Size (Short)"
 msgstr ""
 
 #. IDS_COLHDR_MSIZE_SHORT
-#: Merge.rc:4957
+#: Merge.rc:4956
 msgid "Middle Size (Short)"
 msgstr ""
 
 #. IDS_COLHDR_LTIMEC
-#: Merge.rc:4963
+#: Merge.rc:4962
 msgid "Left Creation Time"
 msgstr ""
 
 #. IDS_COLHDR_RTIMEC
-#: Merge.rc:4964
+#: Merge.rc:4963
 msgid "Right Creation Time"
 msgstr ""
 
 #. IDS_COLHDR_MTIMEC
-#: Merge.rc:4965
+#: Merge.rc:4964
 msgid "Middle Creation Time"
 msgstr ""
 
 #. IDS_COLHDR_NEWER
-#: Merge.rc:4966
+#: Merge.rc:4965
 msgid "Newer File"
 msgstr ""
 
 #. IDS_COLHDR_LVERSION
-#: Merge.rc:4967
+#: Merge.rc:4966
 msgid "Left File Version"
 msgstr ""
 
 #. IDS_COLHDR_RVERSION
-#: Merge.rc:4968
+#: Merge.rc:4967
 msgid "Right File Version"
 msgstr ""
 
 #. IDS_COLHDR_MVERSION
-#: Merge.rc:4969
+#: Merge.rc:4968
 msgid "Middle File Version"
 msgstr ""
 
 #. IDS_COLHDR_RESULT_ABBR
-#: Merge.rc:4970
+#: Merge.rc:4969
 msgid "Short Result"
 msgstr ""
 
 #. IDS_COLHDR_LATTRIBUTES
-#: Merge.rc:4971
+#: Merge.rc:4970
 msgid "Left Attributes"
 msgstr ""
 
 #. IDS_COLHDR_RATTRIBUTES
-#: Merge.rc:4972
+#: Merge.rc:4971
 msgid "Right Attributes"
 msgstr ""
 
 #. IDS_COLHDR_MATTRIBUTES
-#: Merge.rc:4973
+#: Merge.rc:4972
 msgid "Middle Attributes"
 msgstr ""
 
 #. IDS_COLHDR_LEOL_TYPE
-#: Merge.rc:4978
+#: Merge.rc:4977
 msgid "Left EOL"
 msgstr ""
 
 #. IDS_COLHDR_MEOL_TYPE
-#: Merge.rc:4979
+#: Merge.rc:4978
 msgid "Middle EOL"
 msgstr ""
 
 #. IDS_COLHDR_REOL_TYPE
-#: Merge.rc:4980
+#: Merge.rc:4979
 msgid "Right EOL"
 msgstr ""
 
 #. IDS_COLHDR_LENCODING
-#: Merge.rc:4986
+#: Merge.rc:4985
 msgid "Left Encoding"
 msgstr ""
 
 #. IDS_COLHDR_RENCODING
-#: Merge.rc:4987
+#: Merge.rc:4986
 msgid "Right Encoding"
 msgstr ""
 
 #. IDS_COLHDR_MENCODING
-#: Merge.rc:4988
+#: Merge.rc:4987
 msgid "Middle Encoding"
 msgstr ""
 
 #. IDS_COLHDR_NIDIFFS
-#: Merge.rc:4989
+#: Merge.rc:4988
 msgid "Ignored Diff"
 msgstr ""
 
 #. IDS_COLHDR_BINARY
-#: Merge.rc:4991
+#: Merge.rc:4990
 msgctxt "DirView|ColumnHeader"
 msgid "Binary"
 msgstr ""
 
 #. IDS_PLUGINS_TYPE_UNPACKER
-#: Merge.rc:4992 Merge.rc:5314
+#: Merge.rc:4991 Merge.rc:5313
 msgid "Unpacker"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE4
-#: Merge.rc:4993 Merge.rc:5315 Merge.rc:5622
+#: Merge.rc:4992 Merge.rc:5314 Merge.rc:5621
 msgid "Prediffer"
 msgstr ""
 
 #. IDS_COLHDR_LEFT
-#: Merge.rc:4994
+#: Merge.rc:4993
 msgid "Left"
 msgstr ""
 
 #. IDS_COLHDR_MIDDLE
-#: Merge.rc:4995
+#: Merge.rc:4994
 msgid "Middle"
 msgstr ""
 
 #. IDS_COLHDR_RIGHT
-#: Merge.rc:4996
+#: Merge.rc:4995
 msgid "Right"
 msgstr ""
 
 #. IDS_COLHDR_DIFF
-#: Merge.rc:4997
+#: Merge.rc:4996
 msgid "Diff"
 msgstr ""
 
 #. IDS_COLHDR_LEFT_DUPLICATE
-#: Merge.rc:4998
+#: Merge.rc:4997
 msgid "Left Duplicate Count"
 msgstr ""
 
 #. IDS_COLHDR_RIGHT_DUPLICATE
-#: Merge.rc:4999
+#: Merge.rc:4998
 msgid "Right Duplicate Count"
 msgstr ""
 
 #. IDS_COLHDR_MIDDLE_DUPLICATE
-#: Merge.rc:5000
+#: Merge.rc:4999
 msgid "Middle Duplicate Count"
 msgstr ""
 
 #. IDS_COLHDR_MOVE
-#: Merge.rc:5001
+#: Merge.rc:5000
 msgid "Move"
 msgstr ""
 
 #. IDS_PRPCAT_AUDIO
-#: Merge.rc:5008
+#: Merge.rc:5007
 msgid "Audio"
 msgstr ""
 
 #. IDS_PRPCAT_CALENDAR
-#: Merge.rc:5009
+#: Merge.rc:5008
 msgid "Calendar"
 msgstr ""
 
 #. IDS_PRPCAT_COMMUNICATION
-#: Merge.rc:5010
+#: Merge.rc:5009
 msgid "Communication"
 msgstr ""
 
 #. IDS_PRPCAT_CONTACT
-#: Merge.rc:5011
+#: Merge.rc:5010
 msgid "Contact"
 msgstr ""
 
 #. IDS_PRPCAT_DEVICES
-#: Merge.rc:5012
+#: Merge.rc:5011
 msgid "Devices"
 msgstr ""
 
 #. IDS_PRPCAT_DOCUMENT
-#: Merge.rc:5013
+#: Merge.rc:5012
 msgid "Document"
 msgstr ""
 
 #. IDS_PRPCAT_HOME
-#: Merge.rc:5014
+#: Merge.rc:5013
 msgid "Home"
 msgstr ""
 
 #. IDS_PRPCAT_JOURNAL
-#: Merge.rc:5016
+#: Merge.rc:5015
 msgid "Journal"
 msgstr ""
 
 #. IDS_PRPCAT_LINK
-#: Merge.rc:5017
+#: Merge.rc:5016
 msgid "Link"
 msgstr ""
 
 #. IDS_PRPCAT_MEDIA
-#: Merge.rc:5018
+#: Merge.rc:5017
 msgid "Media"
 msgstr ""
 
 #. IDS_PRPCAT_MUSIC
-#: Merge.rc:5020
+#: Merge.rc:5019
 msgid "Music"
 msgstr ""
 
 #. IDS_PRPCAT_NOTE
-#: Merge.rc:5021
+#: Merge.rc:5020
 msgid "Note"
 msgstr ""
 
 #. IDS_PRPCAT_PHOTO
-#: Merge.rc:5022
+#: Merge.rc:5021
 msgid "Photo"
 msgstr ""
 
 #. IDS_PRPCAT_RECORDEDTV
-#: Merge.rc:5023
+#: Merge.rc:5022
 msgid "RecordedTV"
 msgstr ""
 
 #. IDS_PRPCAT_SEARCH
-#: Merge.rc:5024
+#: Merge.rc:5023
 msgid "Search"
 msgstr ""
 
 #. IDS_PRPCAT_SECURITY
-#: Merge.rc:5025
+#: Merge.rc:5024
 msgid "Security"
 msgstr ""
 
 #. IDS_PRPCAT_SOFTWARE
-#: Merge.rc:5026
+#: Merge.rc:5025
 msgid "Software"
 msgstr ""
 
 #. IDS_PRPCAT_TASK
-#: Merge.rc:5027
+#: Merge.rc:5026
 msgid "Task"
 msgstr ""
 
 #. IDS_PRPCAT_VIDEO
-#: Merge.rc:5028
+#: Merge.rc:5027
 msgid "Video"
 msgstr ""
 
 #. IDS_PRPCAT_HASH
-#: Merge.rc:5029
+#: Merge.rc:5028
 msgid "Hash"
 msgstr ""
 
 #. IDS_CANT_COMPARE_FILES
-#: Merge.rc:5035
+#: Merge.rc:5034
 msgid "Unable to compare files"
 msgstr ""
 
 #. IDS_ABORTED_ITEM
-#: Merge.rc:5036
+#: Merge.rc:5035
 msgid "Item aborted"
 msgstr ""
 
 #. IDS_FILE_SKIPPED
-#: Merge.rc:5037
+#: Merge.rc:5036
 msgid "File skipped"
 msgstr ""
 
 #. IDS_DIR_SKIPPED
-#: Merge.rc:5038
+#: Merge.rc:5037
 msgid "Folder skipped"
 msgstr ""
 
 #. IDS_LEFT_ONLY_IN_FMT
-#: Merge.rc:5039
+#: Merge.rc:5038
 #, c-format
 msgid "Left only: %1"
 msgstr ""
 
 #. IDS_MIDDLE_ONLY_IN_FMT
-#: Merge.rc:5040
+#: Merge.rc:5039
 #, c-format
 msgid "Middle only: %1"
 msgstr ""
 
 #. IDS_RIGHT_ONLY_IN_FMT
-#: Merge.rc:5041
+#: Merge.rc:5040
 #, c-format
 msgid "Right only: %1"
 msgstr ""
 
 #. IDS_DOES_NOT_EXIST_IN_FMT
-#: Merge.rc:5042
+#: Merge.rc:5041
 #, c-format
 msgid "Does not exist in %1"
 msgstr ""
 
 #. IDS_BIN_FILES_SAME
-#: Merge.rc:5043
+#: Merge.rc:5042
 msgid "Binary files are identical"
 msgstr ""
 
 #. IDS_BIN_FILES_DIFF
-#: Merge.rc:5049
+#: Merge.rc:5048
 msgid "Binary files are different"
 msgstr ""
 
 #. IDS_FILES_ARE_DIFFERENT
-#: Merge.rc:5050
+#: Merge.rc:5049
 msgid "Files are different"
 msgstr ""
 
 #. IDS_FOLDERS_ARE_DIFFERENT
-#: Merge.rc:5051
+#: Merge.rc:5050
 msgid "Folders are different"
 msgstr ""
 
 #. IDS_LEFTONLY
-#: Merge.rc:5052
+#: Merge.rc:5051
 msgid "Left Only"
 msgstr ""
 
 #. IDS_RIGHTONLY
-#: Merge.rc:5053
+#: Merge.rc:5052
 msgid "Right Only"
 msgstr ""
 
 #. IDS_MIDDLEONLY
-#: Merge.rc:5054
+#: Merge.rc:5053
 msgid "Middle Only"
 msgstr ""
 
 #. IDS_NOITEMLEFT
-#: Merge.rc:5055
+#: Merge.rc:5054
 msgid "No item in left"
 msgstr ""
 
 #. IDS_NOITEMRIGHT
-#: Merge.rc:5056
+#: Merge.rc:5055
 msgid "No item in right"
 msgstr ""
 
 #. IDS_NOITEMMIDDLE
-#: Merge.rc:5057
+#: Merge.rc:5056
 msgid "No item in middle"
 msgstr ""
 
 #. IDS_CMPRES_ERROR
-#: Merge.rc:5059
+#: Merge.rc:5058
 msgid "Error"
 msgstr ""
 
 #. IDS_TEXT_FILES_SAME
-#: Merge.rc:5060
+#: Merge.rc:5059
 msgid "Text files are identical"
 msgstr ""
 
 #. IDS_LEFTONLY_DIFF
-#: Merge.rc:5061
+#: Merge.rc:5060
 msgid " (Middle and right are identical)"
 msgstr ""
 
 #. IDS_MIDDLEONLY_DIFF
-#: Merge.rc:5062
+#: Merge.rc:5061
 msgid " (Left and right are identical)"
 msgstr ""
 
 #. IDS_RIGHTONLY_DIFF
-#: Merge.rc:5063
+#: Merge.rc:5062
 msgid " (Left and middle are identical)"
 msgstr ""
 
 #. IDS_PATH_MISMATCH
-#: Merge.rc:5064
+#: Merge.rc:5063
 msgid " (paths differ)"
 msgstr ""
 
 #. IDS_TEXT_FILES_DIFF
-#: Merge.rc:5065
+#: Merge.rc:5064
 msgid "Text files are different"
 msgstr ""
 
 #. IDS_IMAGE_FILES_SAME
-#: Merge.rc:5066
+#: Merge.rc:5065
 msgid "Image files are identical"
 msgstr ""
 
 #. IDS_IMAGE_FILES_DIFF
-#: Merge.rc:5067
+#: Merge.rc:5066
 msgid "Image files are different"
 msgstr ""
 
 #. IDS_EXPR_DIFF
-#: Merge.rc:5068
+#: Merge.rc:5067
 #, c-format
 msgid "Files are different (expr: %1)"
 msgstr ""
 
 #. IDS_HASH_GROUP
-#: Merge.rc:5069
+#: Merge.rc:5068
 #, c-format
 msgid "Group%d"
 msgstr ""
 
 #. IDS_RENAME_MOVE_DETECTION_DISALBED
-#: Merge.rc:5070
+#: Merge.rc:5069
 msgctxt "Options dialog|Compare|Folder|Detect renames and moves"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_RENAME_MOVE_DETECTION_RENAME
-#: Merge.rc:5071
+#: Merge.rc:5070
 msgid "Detect renames"
 msgstr ""
 
 #. IDS_RENAME_MOVE_DETECTION_RENAME_MOVE
-#: Merge.rc:5072
+#: Merge.rc:5071
 msgid "Detect renames and moves"
 msgstr ""
 
 #. IDS_RENAME_MOVE_MERGE_MODE_RENAME
-#: Merge.rc:5073
+#: Merge.rc:5072
 msgid "Merge renames"
 msgstr ""
 
 #. IDS_RENAME_MOVE_MERGE_MODE_RENAME_MOVE
-#: Merge.rc:5074
+#: Merge.rc:5073
 msgid "Merge renames and moves"
 msgstr ""
 
 #. IDS_RENAMED
-#: Merge.rc:5075
+#: Merge.rc:5074
 msgid "Renamed"
 msgstr ""
 
 #. IDS_RENAMED_MOVED
-#: Merge.rc:5077
+#: Merge.rc:5076
 msgid "Renamed/Moved"
 msgstr ""
 
 #. IDS_RENAMED_MOVED_ITEMS
-#: Merge.rc:5078
+#: Merge.rc:5077
 #, c-format
 msgid "(%1 items)"
 msgstr ""
 
 #. IDS_RENAMED_MOVED_RESULT
-#: Merge.rc:5079
+#: Merge.rc:5078
 #, c-format
 msgid "%1 (set %2): "
 msgstr ""
 
 #. IDS_SWITCH_FLAT_MODE
-#: Merge.rc:5080
+#: Merge.rc:5079
 msgid "Some moved items have been merged.\nIn Tree Mode, these items may appear in positions that do not reflect the actual folder structure, which can be confusing.\nSwitch to Flat Mode?"
 msgstr ""
 
 #. IDS_ELAPSED_TIME
-#: Merge.rc:5086
+#: Merge.rc:5085
 #, c-format
 msgid "Elapsed time: %ld ms"
 msgstr ""
 
 #. IDS_STATUS_SELITEM1
-#: Merge.rc:5087
+#: Merge.rc:5086
 msgid "1 item selected"
 msgstr ""
 
 #. IDS_STATUS_SELITEMS
-#: Merge.rc:5088
+#: Merge.rc:5087
 #, c-format
 msgid "%1 items selected"
 msgstr ""
 
 #. IDS_COLDESC_FILENAME
-#: Merge.rc:5094
+#: Merge.rc:5093
 msgid "Filename or folder name."
 msgstr ""
 
 #. IDS_COLDESC_DIR
-#: Merge.rc:5095
+#: Merge.rc:5094
 msgid "Subfolder name when subfolders are included."
 msgstr ""
 
 #. IDS_COLDESC_RESULT
-#: Merge.rc:5096
+#: Merge.rc:5095
 msgid "Comparison result, long form."
 msgstr ""
 
 #. IDS_COLDESC_LTIMEM
-#: Merge.rc:5101
+#: Merge.rc:5100
 msgid "Left side modification date."
 msgstr ""
 
 #. IDS_COLDESC_RTIMEM
-#: Merge.rc:5102
+#: Merge.rc:5101
 msgid "Right side modification date."
 msgstr ""
 
 #. IDS_COLDESC_MTIMEM
-#: Merge.rc:5103
+#: Merge.rc:5102
 msgid "Middle side modification date."
 msgstr ""
 
 #. IDS_COLDESC_EXTENSION
-#: Merge.rc:5104
+#: Merge.rc:5103
 msgid "File's extension."
 msgstr ""
 
 #. IDS_COLDESC_LSIZE
-#: Merge.rc:5105
+#: Merge.rc:5104
 msgid "Left file size in bytes."
 msgstr ""
 
 #. IDS_COLDESC_RSIZE
-#: Merge.rc:5106
+#: Merge.rc:5105
 msgid "Right file size in bytes."
 msgstr ""
 
 #. IDS_COLDESC_MSIZE
-#: Merge.rc:5107
+#: Merge.rc:5106
 msgid "Middle file size in bytes."
 msgstr ""
 
 #. IDS_COLDESC_LSIZE_SHORT
-#: Merge.rc:5108
+#: Merge.rc:5107
 msgid "Left file size abbreviated."
 msgstr ""
 
 #. IDS_COLDESC_RSIZE_SHORT
-#: Merge.rc:5109
+#: Merge.rc:5108
 msgid "Right file size abbreviated."
 msgstr ""
 
 #. IDS_COLDESC_MSIZE_SHORT
-#: Merge.rc:5110
+#: Merge.rc:5109
 msgid "Middle file size abbreviated."
 msgstr ""
 
 #. IDS_COLDESC_LTIMEC
-#: Merge.rc:5116
+#: Merge.rc:5115
 msgid "Left side creation time."
 msgstr ""
 
 #. IDS_COLDESC_RTIMEC
-#: Merge.rc:5117
+#: Merge.rc:5116
 msgid "Right side creation time."
 msgstr ""
 
 #. IDS_COLDESC_MTIMEC
-#: Merge.rc:5118
+#: Merge.rc:5117
 msgid "Middle side creation time."
 msgstr ""
 
 #. IDS_COLDESC_NEWER
-#: Merge.rc:5119
+#: Merge.rc:5118
 msgid "Tells which side has newer modification date."
 msgstr ""
 
 #. IDS_COLDESC_LVERSION
-#: Merge.rc:5120
+#: Merge.rc:5119
 msgid "Left side file version, only for some file types."
 msgstr ""
 
 #. IDS_COLDESC_RVERSION
-#: Merge.rc:5121
+#: Merge.rc:5120
 msgid "Right side file version, only for some file types."
 msgstr ""
 
 #. IDS_COLDESC_MVERSION
-#: Merge.rc:5126
+#: Merge.rc:5125
 msgid "Middle side file version, only for some file types."
 msgstr ""
 
 #. IDS_COLDESC_RESULT_ABBR
-#: Merge.rc:5127
+#: Merge.rc:5126
 msgid "Short comparison result."
 msgstr ""
 
 #. IDS_COLDESC_LATTRIBUTES
-#: Merge.rc:5128
+#: Merge.rc:5127
 msgid "Left side attributes."
 msgstr ""
 
 #. IDS_COLDESC_RATTRIBUTES
-#: Merge.rc:5129
+#: Merge.rc:5128
 msgid "Right side attributes."
 msgstr ""
 
 #. IDS_COLDESC_MATTRIBUTES
-#: Merge.rc:5130
+#: Merge.rc:5129
 msgid "Middle side attributes."
 msgstr ""
 
 #. IDS_COLDESC_LEOL_TYPE
-#: Merge.rc:5131
+#: Merge.rc:5130
 msgid "Left side file EOL type."
 msgstr ""
 
 #. IDS_COLDESC_REOL_TYPE
-#: Merge.rc:5132
+#: Merge.rc:5131
 msgid "Right side file EOL type."
 msgstr ""
 
 #. IDS_COLDESC_MEOL_TYPE
-#: Merge.rc:5133
+#: Merge.rc:5132
 msgid "Middle side file EOL type."
 msgstr ""
 
 #. IDS_COLDESC_LENCODING
-#: Merge.rc:5139
+#: Merge.rc:5138
 msgid "Left side encoding."
 msgstr ""
 
 #. IDS_COLDESC_RENCODING
-#: Merge.rc:5140
+#: Merge.rc:5139
 msgid "Right side encoding."
 msgstr ""
 
 #. IDS_COLDESC_MENCODING
-#: Merge.rc:5141
+#: Merge.rc:5140
 msgid "Middle side encoding."
 msgstr ""
 
 #. IDS_COLDESC_NIDIFFS
-#: Merge.rc:5142
+#: Merge.rc:5141
 msgid "Number of ignored differences in file. Ignored and cannot be merged."
 msgstr ""
 
 #. IDS_COLDESC_NSDIFFS
-#: Merge.rc:5143
+#: Merge.rc:5142
 msgid "Number of differences in file (excluding ignored)."
 msgstr ""
 
 #. IDS_COLDESC_BINARY
-#: Merge.rc:5144
+#: Merge.rc:5143
 msgid "Shows an asterisk (*) if the file is binary."
 msgstr ""
 
 #. IDS_COLDESC_UNPACKER
-#: Merge.rc:5145
+#: Merge.rc:5144
 msgid "Unpacker plugin name or pipeline."
 msgstr ""
 
 #. IDS_COLDESC_PREDIFFER
-#: Merge.rc:5146
+#: Merge.rc:5145
 msgid "Prediffer plugin name or pipeline."
 msgstr ""
 
 #. IDS_DIRECTORY_REPORT_TITLE
-#: Merge.rc:5152
+#: Merge.rc:5151
 #, c-format
 msgid "Compare %1 with %2"
 msgstr ""
 
 #. IDS_DIRECTORY_REPORT_TITLE3
-#: Merge.rc:5153
+#: Merge.rc:5152
 #, c-format
 msgid "Compare %1 with %2 and %3"
 msgstr ""
 
 #. IDS_REPORT_COMMALIST
-#: Merge.rc:5154
+#: Merge.rc:5153
 msgid "Comma-separated list"
 msgstr ""
 
 #. IDS_REPORT_TABLIST
-#: Merge.rc:5155
+#: Merge.rc:5154
 msgid "Tab-separated list"
 msgstr ""
 
 #. IDS_REPORT_SIMPLEHTML
-#: Merge.rc:5156
+#: Merge.rc:5155
 msgid "Simple HTML"
 msgstr ""
 
 #. IDS_REPORT_SIMPLEXML
-#: Merge.rc:5157
+#: Merge.rc:5156
 msgid "Simple XML"
 msgstr ""
 
-#: Merge.rc:5159
+#: Merge.rc:5158
 msgid "Report file already exists. Overwrite?"
 msgstr ""
 
 #. IDS_REPORT_ERROR
-#: Merge.rc:5164
+#: Merge.rc:5163
 #, c-format
 msgid "Error creating the report:\n%1"
 msgstr ""
 
 #. IDS_REPORT_SUCCESS
-#: Merge.rc:5165
+#: Merge.rc:5164
 msgid "Report created successfully."
 msgstr ""
 
 #. IDS_SYNCPOINT_LASTBLOCK
-#: Merge.rc:5171
+#: Merge.rc:5170
 msgid "Cannot add a synchronization point at this line."
 msgstr ""
 
 #. IDS_FILE_TO_ITSELF
-#: Merge.rc:5177
+#: Merge.rc:5176
 msgid "Same file is opened in both panes."
 msgstr ""
 
 #. IDS_FILESSAME
-#: Merge.rc:5178
+#: Merge.rc:5177
 msgid "Selected files are identical."
 msgstr ""
 
 #. IDS_FILESSAME_CURCFG
-#: Merge.rc:5179
+#: Merge.rc:5178
 msgid "Selected files are identical (with current settings).\r\nChecking binary identity..."
 msgstr ""
 
 #. IDS_FILESSAME_BINERROR
-#: Merge.rc:5180
+#: Merge.rc:5179
 msgid "Selected files are identical (with current settings).\r\nBut binary comparison failed."
 msgstr ""
 
 #. IDS_FILESSAME_BINSAME
-#: Merge.rc:5181
+#: Merge.rc:5180
 msgid "Selected files are identical (binary match)."
 msgstr ""
 
 #. IDS_FILESSAME_BINDIFF
-#: Merge.rc:5182
+#: Merge.rc:5181
 msgid "Selected files are identical (with current settings).\r\nBut differ at the binary level."
 msgstr ""
 
 #. IDS_FILEERROR
-#: Merge.rc:5183
+#: Merge.rc:5182
 msgid "An error occurred while comparing files."
 msgstr ""
 
 #. IDS_TEMP_FILEERROR
-#: Merge.rc:5184
+#: Merge.rc:5183
 msgid "Could not create temporary files. Check your temporary path settings."
 msgstr ""
 
 #. IDS_SUGGEST_IGNOREEOL
-#: Merge.rc:5185
+#: Merge.rc:5184
 msgid "Files use different EOL.\n\nTreat all EOL as equivalent?\n\nSet 'Ignore EOL differences (Windows/Unix/Mac)' in Compare section of Options."
 msgstr ""
 
 #. IDS_INVALID_DIRECTORY
-#: Merge.rc:5186
+#: Merge.rc:5185
 msgid "Selected folder is invalid."
 msgstr ""
 
 #. IDS_CANNOT_OPEN_BINARYFILE
-#: Merge.rc:5187
+#: Merge.rc:5186
 msgid "Cannot open a binary file in Editor."
 msgstr ""
 
 #. IDS_CREATE_PAIR_FOLDER
-#: Merge.rc:5188
+#: Merge.rc:5187
 #, c-format
 msgid "Create matching folder:\n%1\non the other side and open?"
 msgstr ""
 
 #. IDS_CONFIRM_COPY_ALL_DIFFS
-#: Merge.rc:5189
+#: Merge.rc:5188
 msgid "Copy all differences to other file?"
 msgstr ""
 
 #. IDS_MOVE_TO_NEXTFILE
-#: Merge.rc:5194
+#: Merge.rc:5193
 msgid "Move to next file?"
 msgstr ""
 
 #. IDS_MOVE_TO_PREVFILE
-#: Merge.rc:5195
+#: Merge.rc:5194
 msgid "Move to previous file?"
 msgstr ""
 
 #. IDS_MOVE_TO_NEXTPAGE
-#: Merge.rc:5196
+#: Merge.rc:5195
 msgid "Move to next page?"
 msgstr ""
 
 #. IDS_MOVE_TO_PREVPAGE
-#: Merge.rc:5197
+#: Merge.rc:5196
 msgid "Move to previous page?"
 msgstr ""
 
 #. IDS_MOVE_TO_FIRSTFILE
-#: Merge.rc:5198
+#: Merge.rc:5197
 msgid "Move to first file?"
 msgstr ""
 
 #. IDS_MOVE_TO_LASTFILE
-#: Merge.rc:5199
+#: Merge.rc:5198
 msgid "Move to last file?"
 msgstr ""
 
-#: Merge.rc:5206
+#: Merge.rc:5205
 #, c-format
 msgid "Different codepages: left (cp%d), right (cp%d).\nDisplay in codepage (better display) or default Windows codepage (safer merging)?\n(Recommended: default Windows codepage)"
 msgstr ""
 
-#: Merge.rc:5208
+#: Merge.rc:5207
 msgid "Information lost due to encoding errors: both files"
 msgstr ""
 
-#: Merge.rc:5210
+#: Merge.rc:5209
 msgid "Information lost due to encoding errors: first file"
 msgstr ""
 
-#: Merge.rc:5212
+#: Merge.rc:5211
 msgid "Information lost due to encoding errors: second file"
 msgstr ""
 
-#: Merge.rc:5214
+#: Merge.rc:5213
 msgid "Information lost due to encoding errors: third file"
 msgstr ""
 
 #. IDS_LINEDIFF_NODIFF
-#: Merge.rc:5220
+#: Merge.rc:5219
 msgid "No difference"
 msgstr ""
 
 #. IDS_LINEDIFF_NODIFF_CAPTION
-#: Merge.rc:5221
+#: Merge.rc:5220
 msgid "Line difference"
 msgstr ""
 
 #. IDS_NUM_REPLACED
-#: Merge.rc:5227
+#: Merge.rc:5226
 #, c-format
 msgid "Replaced %1 string(s)."
 msgstr ""
 
 #. IDS_EDIT_TEXT_NOT_FOUND
-#: Merge.rc:5228
+#: Merge.rc:5227
 #, c-format
 msgid "Cannot find string \"%s\"."
 msgstr ""
 
 #. IDS_MERGE_MODE
-#: Merge.rc:5234
+#: Merge.rc:5233
 msgid "Entering Merge Mode. Press F9 to turn off."
 msgstr ""
 
 #. IDS_AUTO_MERGE
-#: Merge.rc:5240
+#: Merge.rc:5239
 #, c-format
 msgid "Automatic merges: %1\nUnresolved conflicts: %2"
 msgstr ""
 
 #. IDS_CODEPAGE_MERGED
-#: Merge.rc:5241
+#: Merge.rc:5240
 msgid "Codepage change merged."
 msgstr ""
 
 #. IDS_CODEPAGE_CONFLICT
-#: Merge.rc:5242
+#: Merge.rc:5241
 msgid "Codepage changes are conflicting."
 msgstr ""
 
 #. IDS_EOL_MERGED
-#: Merge.rc:5243
+#: Merge.rc:5242
 msgid "EOL change merged."
 msgstr ""
 
 #. IDS_EOL_CONFLICT
-#: Merge.rc:5244
+#: Merge.rc:5243
 msgid "EOL changes are conflicting."
 msgstr ""
 
 #. IDS_LOCBAR_CAPTION
-#: Merge.rc:5250
+#: Merge.rc:5249
 msgid "Location Pane"
 msgstr ""
 
 #. IDS_DIFFBAR_CAPTION
-#: Merge.rc:5251
+#: Merge.rc:5250
 msgid "Diff Pane"
 msgstr ""
 
 #. IDS_DIFF_SUCCEEDED
-#: Merge.rc:5258
+#: Merge.rc:5257
 msgid "Patch file written."
 msgstr ""
 
 #. IDS_DIFF_FILEOVERWRITE
-#: Merge.rc:5259
+#: Merge.rc:5258
 msgid "Patch file already exists. Overwrite?"
 msgstr ""
 
 #. IDS_DIFF_SELECTEDFILES
-#: Merge.rc:5260
+#: Merge.rc:5259
 #, c-format
 msgid "[%1 files selected]"
 msgstr ""
 
 #. IDS_DIFF_NORMAL
-#: Merge.rc:5261
+#: Merge.rc:5260
 msgid "Normal"
 msgstr ""
 
 #. IDS_DIFF_CONTEXT
-#: Merge.rc:5262
+#: Merge.rc:5261
 msgid "Context"
 msgstr ""
 
 #. IDS_DIFF_UNIFIED
-#: Merge.rc:5263
+#: Merge.rc:5262
 msgid "Unified"
 msgstr ""
 
 #. IDS_FILEWRITE_ERROR
-#: Merge.rc:5265
+#: Merge.rc:5264
 #, c-format
 msgid "Could not write to file %1."
 msgstr ""
 
 #. IDS_PATH_NOT_ABSOLUTE
-#: Merge.rc:5266
+#: Merge.rc:5265
 #, c-format
 msgid "Output path is not absolute: %1"
 msgstr ""
 
 #. IDS_MUST_SPECIFY_OUTPUT
-#: Merge.rc:5267
+#: Merge.rc:5266
 msgid "Specify an output file."
 msgstr ""
 
-#: Merge.rc:5269
+#: Merge.rc:5268
 msgid "Cannot create patch from binary files."
 msgstr ""
 
 #. IDS_SAVEFILES_FORPATCH
-#: Merge.rc:5270
+#: Merge.rc:5269
 msgid "Save all files first.\n\nCreating a patch requires no unsaved changes."
 msgstr ""
 
 #. IDS_FOLDER_NOTEXIST
-#: Merge.rc:5271
+#: Merge.rc:5270
 msgid "Folder does not exist."
 msgstr ""
 
 #. IDS_ARCHIVE_SUCCEEDED
-#: Merge.rc:5277
+#: Merge.rc:5276
 msgid "Archive file written."
 msgstr ""
 
 #. IDS_ARCHIVE_SAVEFILES
-#: Merge.rc:5278
+#: Merge.rc:5277
 msgid "Save all files first.\n\nCreating an archive requires no unsaved changes."
 msgstr ""
 
 #. IDS_NO_ZIP_SUPPORT
-#: Merge.rc:5283
+#: Merge.rc:5282
 msgid "Archive support not enabled.\n7-Zip and/or Merge7z*.dll not found.\nSee manual for archive support."
 msgstr ""
 
 #. IDS_OPT_EXPORT_CAPTION
-#: Merge.rc:5284
+#: Merge.rc:5283
 msgid "Select file for export"
 msgstr ""
 
 #. IDS_OPT_IMPORT_CAPTION
-#: Merge.rc:5285
+#: Merge.rc:5284
 msgid "Select file for import"
 msgstr ""
 
 #. IDS_OPT_IMPORT_DONE
-#: Merge.rc:5286
+#: Merge.rc:5285
 msgid "Options imported from file."
 msgstr ""
 
 #. IDS_OPT_EXPORT_DONE
-#: Merge.rc:5287
+#: Merge.rc:5286
 msgid "Options exported to file."
 msgstr ""
 
 #. IDS_OPT_IMPORT_ERR
-#: Merge.rc:5288
+#: Merge.rc:5287
 msgid "Failed to import options from file."
 msgstr ""
 
 #. IDS_OPT_EXPORT_ERR
-#: Merge.rc:5289
+#: Merge.rc:5288
 msgid "Failed to write options to file."
 msgstr ""
 
 #. IDS_CLOSEALL_WINDOWS
-#: Merge.rc:5290
+#: Merge.rc:5289
 msgid "Close multiple compare windows?\n\nContinue?"
 msgstr ""
 
 #. IDS_EOL_BIN
-#: Merge.rc:5300
+#: Merge.rc:5299
 msgctxt "EOL Type"
 msgid "Binary"
 msgstr ""
 
 #. IDS_MARKER_COLOR_FMT
-#: Merge.rc:5305
+#: Merge.rc:5304
 #, c-format
 msgid "Marker Color %d"
 msgstr ""
 
 #. IDS_MARKER_NEW_PATTERN
-#: Merge.rc:5306
+#: Merge.rc:5305
 msgid "New Pattern"
 msgstr ""
 
 #. IDS_PLUGINSLIST_TYPE
-#: Merge.rc:5312
+#: Merge.rc:5311
 msgid "Type"
 msgstr ""
 
 #. IDS_PLUGINS_TYPE_EDITSCRIPT
-#: Merge.rc:5316
+#: Merge.rc:5315
 msgid "Editor script"
 msgstr ""
 
 #. ID_SELECTLINEDIFF
-#: Merge.rc:5322
+#: Merge.rc:5321
 msgid "\nDifference in Current Line (F4)"
 msgstr ""
 
 #. ID_OPTIONS
-#: Merge.rc:5323
+#: Merge.rc:5322
 msgid "\nOptions"
 msgstr ""
 
 #. ID_REFRESH
-#: Merge.rc:5324
+#: Merge.rc:5323
 msgid "\nRefresh (F5)"
 msgstr ""
 
 #. ID_PREVDIFF
-#: Merge.rc:5330
+#: Merge.rc:5329
 msgid "\nPrevious Difference (Alt+Up)"
 msgstr ""
 
 #. ID_NEXTDIFF
-#: Merge.rc:5331
+#: Merge.rc:5330
 msgid "\nNext Difference (Alt+Down)"
 msgstr ""
 
 #. ID_PREVCONFLICT
-#: Merge.rc:5332
+#: Merge.rc:5331
 msgid "\nPrevious Conflict (Alt+Shift+Up)"
 msgstr ""
 
 #. ID_NEXTCONFLICT
-#: Merge.rc:5333
+#: Merge.rc:5332
 msgid "\nNext Conflict (Alt+Shift+Down)"
 msgstr ""
 
 #. ID_FIRSTDIFF
-#: Merge.rc:5338
+#: Merge.rc:5337
 msgid "\nFirst Difference (Alt+Home)"
 msgstr ""
 
 #. ID_CURDIFF
-#: Merge.rc:5339
+#: Merge.rc:5338
 msgid "\nCurrent Difference (Alt+Enter)"
 msgstr ""
 
 #. ID_LASTDIFF
-#: Merge.rc:5340
+#: Merge.rc:5339
 msgid "\nLast Difference (Alt+End)"
 msgstr ""
 
 #. ID_L2R
-#: Merge.rc:5341
+#: Merge.rc:5340
 msgid "\nCopy to Right (Alt+Right)"
 msgstr ""
 
 #. ID_R2L
-#: Merge.rc:5342
+#: Merge.rc:5341
 msgid "\nCopy to Left (Alt+Left)"
 msgstr ""
 
 #. ID_L2RNEXT
-#: Merge.rc:5343
+#: Merge.rc:5342
 msgid "\nCopy to Right and Advance (Ctrl+Alt+Right)"
 msgstr ""
 
 #. ID_R2LNEXT
-#: Merge.rc:5344
+#: Merge.rc:5343
 msgid "\nCopy to Left and Advance (Ctrl+Alt+Left)"
 msgstr ""
 
 #. ID_ALL_RIGHT
-#: Merge.rc:5345
+#: Merge.rc:5344
 msgid "\nCopy All to Right"
 msgstr ""
 
 #. ID_ALL_LEFT
-#: Merge.rc:5346
+#: Merge.rc:5345
 msgid "\nCopy All to Left"
 msgstr ""
 
 #. ID_AUTO_MERGE
-#: Merge.rc:5347
+#: Merge.rc:5346
 msgid "\nAuto Merge (Ctrl+Alt+M)"
 msgstr ""
 
 #. ID_FIRSTFILE
-#: Merge.rc:5348
+#: Merge.rc:5347
 msgid "\nFirst File"
 msgstr ""
 
 #. ID_NEXTFILE
-#: Merge.rc:5349
+#: Merge.rc:5348
 msgid "\nNext File (Ctrl+F8)"
 msgstr ""
 
 #. ID_LASTFILE
-#: Merge.rc:5350
+#: Merge.rc:5349
 msgid "\nLast File"
 msgstr ""
 
 #. ID_PREVFILE
-#: Merge.rc:5351
+#: Merge.rc:5350
 msgid "\nPrevious File (Ctrl+F7)"
 msgstr ""
 
 #. IDS_UNPACK_AUTO
-#: Merge.rc:5358
+#: Merge.rc:5357
 msgid "Adapted unpacker applied to both files (one needs extension)."
 msgstr ""
 
 #. IDS_NO_PREDIFFER
-#: Merge.rc:5359
+#: Merge.rc:5358
 msgid "No Prediffer (Normal)"
 msgstr ""
 
 #. IDS_SUGGESTED_PLUGINS
-#: Merge.rc:5360
+#: Merge.rc:5359
 msgid "Suggested Plugins"
 msgstr ""
 
 #. IDS_NOT_SUGGESTED_PLUGINS
-#: Merge.rc:5361
+#: Merge.rc:5360
 msgid "All Plugins"
 msgstr ""
 
 #. IDS_PRIVATEBUILD_FMT
-#: Merge.rc:5367
+#: Merge.rc:5366
 #, c-format
 msgid "Private Build: %1"
 msgstr ""
 
 #. IDS_ALLRIGHTS_RESERVED
-#: Merge.rc:5368
+#: Merge.rc:5367
 msgid " - All rights reserved."
 msgstr ""
 
 #. IDS_TITLE_PLUGINS_SETTINGS
-#: Merge.rc:5374
+#: Merge.rc:5373
 msgid "Plugin Settings"
 msgstr ""
 
 #. IDS_NO_SCT_SCRIPTS
-#: Merge.rc:5376
+#: Merge.rc:5375
 msgid "WSH not found - .sct scripts disabled"
 msgstr ""
 
 #. IDS_LOCBAR_GOTOLINE_FMT
-#: Merge.rc:5384
+#: Merge.rc:5383
 #, c-format
 msgid "G&o to Line %1"
 msgstr ""
 
 #. IDS_GOTO_MOVED_LINE
-#: Merge.rc:5390
+#: Merge.rc:5389
 msgid "Go to Moved Line\tCtrl+Shift+G"
 msgstr ""
 
 #. IDS_AUTOCOMPLETE_DISABLED
-#: Merge.rc:5396
+#: Merge.rc:5395
 msgctxt "Options dialog|General|Open dialog Auto completion"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_AUTOCOMPLETE_FILE_SYS
-#: Merge.rc:5397
+#: Merge.rc:5396
 msgid "From file system"
 msgstr ""
 
 #. IDS_AUTOCOMPLETE_MRU
-#: Merge.rc:5398
+#: Merge.rc:5397
 msgid "From Most Recently Used list"
 msgstr ""
 
 #. IDS_COLORSCHEME_PLAIN
-#: Merge.rc:5404
+#: Merge.rc:5403
 msgid "No Highlighting"
 msgstr ""
 
 #. IDS_COLORSCHEME_PO
-#: Merge.rc:5439
+#: Merge.rc:5438
 msgid "Portable Object"
 msgstr ""
 
 #. IDS_COLORSCHEME_RSRC
-#: Merge.rc:5444
+#: Merge.rc:5443
 msgid "Resources"
 msgstr ""
 
 #. IDS_COLORSCHEME_SH
-#: Merge.rc:5448
+#: Merge.rc:5447
 msgid "Shell"
 msgstr ""
 
 #. IDS_CLOSE_LEFT_TABS
-#: Merge.rc:5469
+#: Merge.rc:5468
 msgid "Close &Left Tabs"
 msgstr ""
 
 #. IDS_CLOSE_RIGHT_TABS
-#: Merge.rc:5470
+#: Merge.rc:5469
 msgid "Close R&ight Tabs"
 msgstr ""
 
 #. IDS_CLOSE_OTHER_TABS
-#: Merge.rc:5471
+#: Merge.rc:5470
 msgid "Close &Other Tabs"
 msgstr ""
 
 #. IDS_TABBAR_AUTO_MAXWIDTH
-#: Merge.rc:5472
+#: Merge.rc:5471
 msgid "Enable &Auto Max Width"
 msgstr ""
 
 #. IDS_WEBPAGE_MENU
-#: Merge.rc:5482
+#: Merge.rc:5481
 msgid "We&bpage"
 msgstr ""
 
 #. IDS_VIEW_WRAP_TEXT
-#: Merge.rc:5487
+#: Merge.rc:5486
 msgid "W&rap Text"
 msgstr ""
 
 #. IDS_NOTINSTALLED
-#: Merge.rc:5492
+#: Merge.rc:5491
 #, c-format
 msgid "%1 is not installed."
 msgstr ""
 
 #. IDS_CREATE_FOLDER
-#: Merge.rc:5497
+#: Merge.rc:5496
 #, c-format
 msgid "%1 does not exist. Create it?"
 msgstr ""
 
 #. IDS_CREATE_FOLDER_ERROR
-#: Merge.rc:5498
+#: Merge.rc:5497
 msgid "Failed to create folder."
 msgstr ""
 
 #. IDC_EXT_EDITOR_PATH
-#: Merge.rc:5503
+#: Merge.rc:5502
 msgid "Parameters:\n$file: Current file path\n$linenum: Current cursor line number"
 msgstr ""
 
 #. IDS_DIFF_ALGORITHM_DEFAULT
-#: Merge.rc:5508
+#: Merge.rc:5507
 msgid "default"
 msgstr ""
 
 #. IDS_DIFF_ALGORITHM_MINIMAL
-#: Merge.rc:5509
+#: Merge.rc:5508
 msgid "minimal"
 msgstr ""
 
 #. IDS_DIFF_ALGORITHM_PATIENCE
-#: Merge.rc:5510
+#: Merge.rc:5509
 msgid "patience"
 msgstr ""
 
 #. IDS_DIFF_ALGORITHM_HISTOGRAM
-#: Merge.rc:5511
+#: Merge.rc:5510
 msgid "histogram"
 msgstr ""
 
 #. IDS_DIFF_ALGORITHM_NONE
-#: Merge.rc:5512
+#: Merge.rc:5511
 msgid "none"
 msgstr ""
 
 #. IDS_RENDERING_MODE_GDI
-#: Merge.rc:5517
+#: Merge.rc:5516
 msgid "GDI"
 msgstr ""
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_DEFAULT
-#: Merge.rc:5518
+#: Merge.rc:5517
 msgid "DirectWrite Default"
 msgstr ""
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_ALIASED
-#: Merge.rc:5519
+#: Merge.rc:5518
 msgid "DirectWrite Aliased"
 msgstr ""
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_GDI_CLASSIC
-#: Merge.rc:5520
+#: Merge.rc:5519
 msgid "DirectWrite GDI Classic"
 msgstr ""
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_GDI_NATURAL
-#: Merge.rc:5521
+#: Merge.rc:5520
 msgid "DirectWrite GDI Natural"
 msgstr ""
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_NATURAL
-#: Merge.rc:5522
+#: Merge.rc:5521
 msgid "DirectWrite Natural"
 msgstr ""
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_NATURAL_SYMMETRIC
-#: Merge.rc:5523
+#: Merge.rc:5522
 msgid "DirectWrite Natural Symmetric"
 msgstr ""
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_DISABLED
-#: Merge.rc:5528
+#: Merge.rc:5527
 msgctxt "Options dialog|General|Close windows with Esc"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_1
-#: Merge.rc:5529
+#: Merge.rc:5528
 msgid "MDI child window or main window"
 msgstr ""
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_2
-#: Merge.rc:5530
+#: Merge.rc:5529
 msgid "MDI child window only"
 msgstr ""
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_3
-#: Merge.rc:5531
+#: Merge.rc:5530
 msgid "Close main window if only one MDI child window"
 msgstr ""
 
 #. IDS_DIFF_GROUP
-#: Merge.rc:5536
+#: Merge.rc:5535
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Diff"
 msgstr ""
 
 #. IDS_DIFF_HIGHLIGHT
-#: Merge.rc:5537
+#: Merge.rc:5536
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Highlight"
 msgstr ""
 
 #. IDS_DIFF_BLINK
-#: Merge.rc:5538
+#: Merge.rc:5537
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Blink"
 msgstr ""
 
 #. IDS_DIFF_BLOCKSIZE
-#: Merge.rc:5539
+#: Merge.rc:5538
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Block Size"
 msgstr ""
 
 #. IDS_DIFF_BLOCKALPHA
-#: Merge.rc:5540
+#: Merge.rc:5539
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Block Alpha"
 msgstr ""
 
 #. IDS_DIFF_CDTHRESHOLD
-#: Merge.rc:5541
+#: Merge.rc:5540
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "CD Threshold"
 msgstr ""
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION
-#: Merge.rc:5542
+#: Merge.rc:5541
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Ins/Del Detection"
 msgstr ""
 
 #. IDS_OVERLAY_MODE_NONE
-#: Merge.rc:5543 Merge.rc:5548
+#: Merge.rc:5542 Merge.rc:5547
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "None"
 msgstr ""
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION_VERTICAL
-#: Merge.rc:5544
+#: Merge.rc:5543
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Vertical"
 msgstr ""
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION_HORIZONTAL
-#: Merge.rc:5545
+#: Merge.rc:5544
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Horizontal"
 msgstr ""
 
 #. IDS_OVERLAY_GROUP
-#: Merge.rc:5546
+#: Merge.rc:5545
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Overlay"
 msgstr ""
 
 #. IDS_OVERLAY_ALPHA
-#: Merge.rc:5547
+#: Merge.rc:5546
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha"
 msgstr ""
 
 #. IDS_OVERLAY_MODE_XOR
-#: Merge.rc:5549
+#: Merge.rc:5548
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "XOR"
 msgstr ""
 
 #. IDS_OVERLAY_MODE_ALPHA
-#: Merge.rc:5550
+#: Merge.rc:5549
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha Blend"
 msgstr ""
 
 #. IDS_OVERLAY_MODE_ALPHA_ANIMATION
-#: Merge.rc:5551
+#: Merge.rc:5550
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha Animation"
 msgstr ""
 
 #. IDS_ZOOM
-#: Merge.rc:5552
+#: Merge.rc:5551
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Zoom"
 msgstr ""
 
 #. IDS_PAGE
-#: Merge.rc:5553
+#: Merge.rc:5552
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Page:"
 msgstr ""
 
 #. IDS_IMGCMP_STATUS_PT_RGBA_FMT
-#: Merge.rc:5554
+#: Merge.rc:5553
 #, c-format
 msgid "Pt: (%d, %d)  RGBA: (%d, %d, %d, %d)  "
 msgstr ""
 
 #. IDS_IMGCMP_STATUS_DIST1_FMT
-#: Merge.rc:5555
+#: Merge.rc:5554
 #, c-format
 msgid "Dist: %g  "
 msgstr ""
 
 #. IDS_IMGCMP_STATUS_DIST2_FMT
-#: Merge.rc:5556
+#: Merge.rc:5555
 #, c-format
 msgid "Dist: %g, %g  "
 msgstr ""
 
 #. IDS_IMGCMP_STATUS_PAGE_ZOOM_SIZE_BPP_FMT
-#: Merge.rc:5557
+#: Merge.rc:5556
 #, c-format
 msgid "Page: %d/%d  Zoom: %d%%  %dx%dpx  %dbpp  "
 msgstr ""
 
 #. IDS_IMGCMP_STATUS_RC_FMT
-#: Merge.rc:5558
+#: Merge.rc:5557
 #, c-format
 msgid "Rc: (%d, %d)  "
 msgstr ""
 
 #. IDS_IMGCMP_STATUS_FLIPPED_FMT
-#: Merge.rc:5559
+#: Merge.rc:5558
 #, c-format
 msgid "Flipped: %s  "
 msgstr ""
 
 #. IDS_IMGCMP_STATUS_ROTATED_FMT
-#: Merge.rc:5560
+#: Merge.rc:5559
 #, c-format
 msgid "Rotated: %d  "
 msgstr ""
 
 #. IDS_IMGCMP_REPORT_ALLPAGES
-#: Merge.rc:5561
+#: Merge.rc:5560
 msgid "All pages"
 msgstr ""
 
 #. IDS_IGNSUB_STR1
-#: Merge.rc:5566
+#: Merge.rc:5565
 msgid "<Edit here>"
 msgstr ""
 
 #. IDS_IGNSUB_STR2
-#: Merge.rc:5567
+#: Merge.rc:5566
 msgid "No differences found to select"
 msgstr ""
 
 #. IDS_IGNSUB_STR3
-#: Merge.rc:5568
+#: Merge.rc:5567
 msgid "No differences found to add as substitution filter"
 msgstr ""
 
 #. IDS_IGNSUB_STR4
-#: Merge.rc:5569
+#: Merge.rc:5568
 msgid "The pair is already in the Substitution Filters list"
 msgstr ""
 
 #. IDS_IGNSUB_STR5
-#: Merge.rc:5570
+#: Merge.rc:5569
 msgid "Add this change to Substitution Filters?"
 msgstr ""
 
 #. IDS_OCRRESULT_TEXTONLY
-#: Merge.rc:5575
+#: Merge.rc:5574
 msgid "Text only"
 msgstr ""
 
 #. IDS_OCRRESULT_POS_LINE
-#: Merge.rc:5576
+#: Merge.rc:5575
 msgid "Line-by-line position and text"
 msgstr ""
 
 #. IDS_OCRRESULT_POS_WORD
-#: Merge.rc:5577
+#: Merge.rc:5576
 msgid "Word-by-word position and text"
 msgstr ""
 
 #. IDS_USERDATAFOLDER_APPDATA
-#: Merge.rc:5582
+#: Merge.rc:5581
 msgid "AppData (Roaming) folder"
 msgstr ""
 
 #. IDS_USERDATAFOLDER_INSTALL
-#: Merge.rc:5583
+#: Merge.rc:5582
 msgid "Install folder"
 msgstr ""
 
 #. IDS_USERDATAFOLDER_DOCUMENTS
-#: Merge.rc:5584
+#: Merge.rc:5583
 msgid "Documents folder"
 msgstr ""
 
 #. IDS_SINGLEINSTANCE_DISABLED
-#: Merge.rc:5589
+#: Merge.rc:5588
 msgctxt "Options dialog|General|Single instance mode"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_SINGLEINSTANCE_STR1
-#: Merge.rc:5590
+#: Merge.rc:5589
 msgid "Allow only one instance to run"
 msgstr ""
 
 #. IDS_CLIPBOARD_HISTORY
-#: Merge.rc:5591
+#: Merge.rc:5590
 msgid "Clipboard &History"
 msgstr ""
 
 #. IDS_SINGLEINSTANCE_STR2
-#: Merge.rc:5592
+#: Merge.rc:5591
 msgid "Allow only one instance; wait for termination"
 msgstr ""
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_DISABLED
-#: Merge.rc:5597
+#: Merge.rc:5596
 msgctxt "Options dialog|General|Auto-reload modified files"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_STR1
-#: Merge.rc:5598
+#: Merge.rc:5597
 msgid "Only on window activated"
 msgstr ""
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_STR2
-#: Merge.rc:5599
+#: Merge.rc:5598
 msgid "Immediately"
 msgstr ""
 
 #. IDS_PLUGIN_ALL
-#: Merge.rc:5604
+#: Merge.rc:5603
 msgid "Al&l"
 msgstr ""
 
 #. IDS_PLUGIN_OTHERS
-#: Merge.rc:5605
+#: Merge.rc:5604
 msgid "&Others"
 msgstr ""
 
-#: Merge.rc:5607
+#: Merge.rc:5606
 #, c-format
 msgid "Missing plugin name in pipeline: %1"
 msgstr ""
 
-#: Merge.rc:5609
+#: Merge.rc:5608
 #, c-format
 msgid "Missing quote in plugin pipeline: %1"
 msgstr ""
 
 #. IDS_PLUGIN_NAME_ALREADY_EXISTS
-#: Merge.rc:5610
+#: Merge.rc:5609
 #, c-format
 msgid "Plugin name '%1' already exists."
 msgstr ""
 
 #. IDS_PLUGIN_TITLE1
-#: Merge.rc:5611
+#: Merge.rc:5610
 msgid "Specify plugin arguments"
 msgstr ""
 
-#: Merge.rc:5613
+#: Merge.rc:5612
 #, c-format
 msgid "Plugin not found or invalid: %1"
 msgstr ""
 
 #. IDS_PLUGIN_NOT_UNPACK
-#: Merge.rc:5614
+#: Merge.rc:5613
 #, c-format
 msgid "'%1' is not an unpacker plugin"
 msgstr ""
 
 #. IDS_PLUGIN_NOT_PREDIFF
-#: Merge.rc:5615
+#: Merge.rc:5614
 #, c-format
 msgid "'%1' is not a prediffer plugin"
 msgstr ""
 
-#: Merge.rc:5617
+#: Merge.rc:5616
 #, c-format
 msgid "Error prediffing '%1' with '%2'. Prediffing disabled."
 msgstr ""
 
 #. IDS_PLUGIN_CIRCULAR_REFERENCE
-#: Merge.rc:5618
+#: Merge.rc:5617
 #, c-format
 msgid "Circular reference in plugin pipeline: %1"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE1
-#: Merge.rc:5619
+#: Merge.rc:5618
 msgid "URL Handler"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE2
-#: Merge.rc:5620
+#: Merge.rc:5619
 msgid "File Unpacker"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE3
-#: Merge.rc:5621
+#: Merge.rc:5620
 msgid "File or Folder Unpacker"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE5
-#: Merge.rc:5623
+#: Merge.rc:5622
 msgid "Alias for Unpacker"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE6
-#: Merge.rc:5624
+#: Merge.rc:5623
 msgid "Alias for Prediffer"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE7
-#: Merge.rc:5625
+#: Merge.rc:5624
 msgid "Alias for Editor script"
 msgstr ""
 
 #. IDS_PLUGIN_ALIAS_DESC
-#: Merge.rc:5626
+#: Merge.rc:5625
 #, c-format
 msgid "Alias for plugin pipeline '%1'"
 msgstr ""
 
 #. IDS_PLUGIN_NEW_DESC
-#: Merge.rc:5627
+#: Merge.rc:5626
 msgid "New plugin description"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_ALL
-#: Merge.rc:5628
+#: Merge.rc:5627
 msgid "All"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_1ST
-#: Merge.rc:5629
+#: Merge.rc:5628
 msgid "1st"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_2ND
-#: Merge.rc:5630
+#: Merge.rc:5629
 msgid "2nd"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_3RD
-#: Merge.rc:5631
+#: Merge.rc:5630
 msgid "3rd"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_1ST_2ND
-#: Merge.rc:5632
+#: Merge.rc:5631
 msgid "1st and 2nd"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_1ST_3RD
-#: Merge.rc:5633
+#: Merge.rc:5632
 msgid "1st and 3rd"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_2ND_3RD
-#: Merge.rc:5634
+#: Merge.rc:5633
 msgid "2nd and 3rd"
 msgstr ""
 
 #. IDS_PLUGIN_CTRL_CLICK
-#: Merge.rc:5635
+#: Merge.rc:5634
 msgid "(Ctrl+Click to add to pipeline)"
 msgstr ""
 
 #. IDS_FILTER_APPLIED
-#: Merge.rc:5640
+#: Merge.rc:5639
 msgid "Filter applied"
 msgstr ""
 
 #. IDS_FILTERMENU_COMPARE
-#: Merge.rc:5645
+#: Merge.rc:5644
 #, c-format
 msgid "Compare %1"
 msgstr ""
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN2
-#: Merge.rc:5647
+#: Merge.rc:5646
 msgid "&Filter by This Column..."
 msgstr ""
 
 #. IDS_CLIPBOARDHISTORY_TIME
-#: Merge.rc:5652
+#: Merge.rc:5651
 #, c-format
 msgid "Clipboard at %s"
 msgstr ""
 
 #. IDS_CLIPBOARDHISTORY_DISABLED
-#: Merge.rc:5653
+#: Merge.rc:5652
 msgid "Clipboard history disabled.\r\nEnable: Windows logo key + V, then Turn on."
 msgstr ""
 
-#: Merge.rc:5655
+#: Merge.rc:5654
 msgid "This system does not support clipboard history."
 msgstr ""
 
-#: Merge.rc:5657
+#: Merge.rc:5656
 msgid "32-bit WinMerge does not support Clipboard Compare"
 msgstr ""
 
 #. IDS_WEBVIEW2_RUNTIME_NOT_INSTALLED
-#: Merge.rc:5662
+#: Merge.rc:5661
 msgid "WebView2 runtime not installed. Download it?"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_TEXT_COMPARE
-#: Merge.rc:5667
+#: Merge.rc:5666
 msgid "New Text Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_TABLE_COMPARE
-#: Merge.rc:5668
+#: Merge.rc:5667
 msgid "New Table Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_BINARY_COMPARE
-#: Merge.rc:5669
+#: Merge.rc:5668
 msgid "New Binary Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_IMAGE_COMPARE
-#: Merge.rc:5670
+#: Merge.rc:5669
 msgid "New Image Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_WEBPAGE_COMPARE
-#: Merge.rc:5671
+#: Merge.rc:5670
 msgid "New Webpage Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_FOLDER_COMPARE
-#: Merge.rc:5672
+#: Merge.rc:5671
 msgid "New Folder Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_CLIPBOARD_COMPARE
-#: Merge.rc:5673
+#: Merge.rc:5672
 msgid "Clipboard Compare"
 msgstr ""
 
 #. IDS_PREVIEWBAR_PRINT
-#: Merge.rc:5678
+#: Merge.rc:5677
 msgid "&Print..."
 msgstr ""
 
 #. IDS_PREVIEWBAR_PREVPAGE
-#: Merge.rc:5680
+#: Merge.rc:5679
 msgid "Pre&v Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_TWOPAGE
-#: Merge.rc:5681
+#: Merge.rc:5680
 msgid "&Two Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_ONEPAGE
-#: Merge.rc:5682
+#: Merge.rc:5681
 msgid "&One Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_ZOOMIN
-#: Merge.rc:5683
+#: Merge.rc:5682
 msgid "Zoom &In"
 msgstr ""
 
 #. IDS_PREVIEWBAR_ZOOMOUT
-#: Merge.rc:5684
+#: Merge.rc:5683
 msgid "Zoom &Out"
 msgstr ""
 
 #. IDS_WEBPAGE_COMPARING
-#: Merge.rc:5690
+#: Merge.rc:5689
 msgid "Comparing..."
 msgstr ""
 
 #. IDS_WEBPAGE_ZOOM
-#: Merge.rc:5691
+#: Merge.rc:5690
 msgid "Zoom:"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_DIFFHUNK
-#: Merge.rc:5696
+#: Merge.rc:5695
 msgid "Diff hunk"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_INLINE
-#: Merge.rc:5697
+#: Merge.rc:5696
 msgid "Inline diff"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_LINE
-#: Merge.rc:5698
+#: Merge.rc:5697
 msgid "Line"
 msgstr ""
 
-#: Merge.rc:5699
+#: Merge.rc:5698
 msgid "Character"
 msgstr ""
 
 #. ID_MICE_PREVDIFF
-#: Merge.rc:5704
+#: Merge.rc:5703
 msgid "\nPrevious Difference (Alt+Up)\n(Right Button+Wheel Up)\n(Alt+Wheel Up)"
 msgstr ""
 
 #. ID_MICE_NEXTDIFF
-#: Merge.rc:5705
+#: Merge.rc:5704
 msgid "\nNext Difference (Alt+Down)\n(Right Button+Wheel Down)\n(Alt+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_L2R
-#: Merge.rc:5706
+#: Merge.rc:5705
 msgid "\nCopy to Right (Alt+Right)\n(Right Button+Wheel Right)\n(Alt+Wheel Right)\n(Alt+Shift+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_R2L
-#: Merge.rc:5707
+#: Merge.rc:5706
 msgid "\nCopy to Left (Alt+Left)\n(Right Button+Wheel Left)\n(Alt+Wheel Left)\n(Alt+Shift+Wheel Up)"
 msgstr ""
 
 #. ID_MICE_L2RNEXT
-#: Merge.rc:5708
+#: Merge.rc:5707
 msgid "\nCopy to Right and Advance (Ctrl+Alt+Right)\n(Ctrl+Alt+Wheel Right)\n(Ctrl+Alt+Shift+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_R2LNEXT
-#: Merge.rc:5709
+#: Merge.rc:5708
 msgid "\nCopy to Left and Advance (Ctrl+Alt+Left)\n(Ctrl+Alt+Wheel Left)\n(Ctrl+Alt+Shift+Wheel Up)"
 msgstr ""
 
 #. IDS_LOG_COMPARING_2
-#: Merge.rc:5719
+#: Merge.rc:5718
 #, c-format
 msgid "Comparing %1 with %2"
 msgstr ""
 
 #. IDS_LOG_COMPARING_3
-#: Merge.rc:5720
+#: Merge.rc:5719
 #, c-format
 msgid "Comparing %1 with %2 and %3"
 msgstr ""
 
 #. IDS_LOG_COMPARE_COMPLETED
-#: Merge.rc:5721
+#: Merge.rc:5720
 msgid "Comparison completed"
 msgstr ""
 
 #. IDS_LOG_COMPARE_ERROR_2
-#: Merge.rc:5722
+#: Merge.rc:5721
 #, c-format
 msgid "Failed to compare %1 with %2: "
 msgstr ""
 
 #. IDS_LOG_COMPARE_ERROR_3
-#: Merge.rc:5723
+#: Merge.rc:5722
 #, c-format
 msgid "Failed to compare %1 with %2 and %3: "
 msgstr ""
 
 #. IDS_LOG_FILE_SAVED
-#: Merge.rc:5724
+#: Merge.rc:5723
 msgid "File saved"
 msgstr ""
 
 #. IDS_LOG_COPYING_FILES
-#: Merge.rc:5725
+#: Merge.rc:5724
 msgid "Copying files..."
 msgstr ""
 
 #. IDS_LOG_MOVING_FILES
-#: Merge.rc:5726
+#: Merge.rc:5725
 msgid "Moving files..."
 msgstr ""
 
 #. IDS_LOG_DELETING_FILES
-#: Merge.rc:5727
+#: Merge.rc:5726
 msgid "Deleting files..."
 msgstr ""
 
 #. IDS_LOG_RECYCLEBIN
-#: Merge.rc:5728
+#: Merge.rc:5727
 msgid "Recycle Bin"
 msgstr ""
 
 #. IDS_LOG_PERMANENTLY_DELETED
-#: Merge.rc:5729
+#: Merge.rc:5728
 msgid "Permanently deleted"
 msgstr ""
 
 #. IDS_LOG_FILEOPERATION_COMPLETED
-#: Merge.rc:5730
+#: Merge.rc:5729
 msgid "File operation completed successfully"
 msgstr ""
 
 #. IDS_LOG_FILEOPERATION_CANCELED
-#: Merge.rc:5731
+#: Merge.rc:5730
 msgid "File operation canceled"
 msgstr ""
 
 #. IDS_FILTER_ERROR_NO_ERROR
-#: Merge.rc:5736
+#: Merge.rc:5735
 msgid "No error"
 msgstr ""
 
 #. IDS_FILTER_ERROR_EMPTY_EXPRESSION
-#: Merge.rc:5737
+#: Merge.rc:5736
 msgid "Filter expression is empty"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNKNOWN_CHAR
-#: Merge.rc:5738
+#: Merge.rc:5737
 msgid "Unknown character in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNTERMINATED_STRING
-#: Merge.rc:5739
+#: Merge.rc:5738
 msgid "Unterminated string literal"
 msgstr ""
 
 #. IDS_FILTER_ERROR_SYNTAX_ERROR
-#: Merge.rc:5740
+#: Merge.rc:5739
 msgid "Syntax error in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_PARSE_FAILURE
-#: Merge.rc:5741
+#: Merge.rc:5740
 msgid "Failed to parse filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_LITERAL
-#: Merge.rc:5742
+#: Merge.rc:5741
 msgid "Invalid literal value"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_REGULAR_EXPRESSION
-#: Merge.rc:5743
+#: Merge.rc:5742
 msgid "Invalid regular expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNDEFINED_IDENTIFIER
-#: Merge.rc:5744
+#: Merge.rc:5743
 msgid "Undefined identifier"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_ARGUMENT_COUNT
-#: Merge.rc:5745
+#: Merge.rc:5744
 msgid "Invalid number of arguments"
 msgstr ""
 
 #. IDS_FILTER_ERROR_FILTER_NAME_NOT_FOUND
-#: Merge.rc:5746
+#: Merge.rc:5745
 msgid "Filter name not found"
 msgstr ""
 
 #. IDS_FILTER_ERROR_DIVIDE_BY_ZERO
-#: Merge.rc:5747
+#: Merge.rc:5746
 msgid "Division by zero in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNKNOWN_ERROR
-#: Merge.rc:5748
+#: Merge.rc:5747
 msgid "Unknown error"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_PROPERTY_NAME
-#: Merge.rc:5749
+#: Merge.rc:5748
 msgid "Invalid property name"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_DIRECTIVE
-#: Merge.rc:5750
+#: Merge.rc:5749
 msgid "Invalid directive"
 msgstr ""
 
 #. IDS_FILTER_OP_EQUALS
-#: Merge.rc:5755
+#: Merge.rc:5754
 msgid "Equals"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_EQUALS
-#: Merge.rc:5756
+#: Merge.rc:5755
 msgid "Does not equal"
 msgstr ""
 
 #. IDS_FILTER_OP_LESS_THAN
-#: Merge.rc:5757
+#: Merge.rc:5756
 msgid "Less than"
 msgstr ""
 
 #. IDS_FILTER_OP_LESS_EQUAL
-#: Merge.rc:5758
+#: Merge.rc:5757
 msgid "Less than or equal to"
 msgstr ""
 
 #. IDS_FILTER_OP_GREATER_EQUAL
-#: Merge.rc:5759
+#: Merge.rc:5758
 msgid "Greater than or equal to"
 msgstr ""
 
 #. IDS_FILTER_OP_GREATER_THAN
-#: Merge.rc:5760
+#: Merge.rc:5759
 msgid "Greater than"
 msgstr ""
 
 #. IDS_FILTER_OP_BETWEEN
-#: Merge.rc:5761
+#: Merge.rc:5760
 msgid "Between"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_BETWEEN
-#: Merge.rc:5762
+#: Merge.rc:5761
 msgid "Not Between"
 msgstr ""
 
 #. IDS_FILTER_OP_CONTAINS
-#: Merge.rc:5763
+#: Merge.rc:5762
 msgid "Contains"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_CONTAINS
-#: Merge.rc:5764
+#: Merge.rc:5763
 msgid "Not Contains"
 msgstr ""
 
 #. IDS_FILTER_OP_RECONTAINS
-#: Merge.rc:5765
+#: Merge.rc:5764
 msgid "Contains (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_RECONTAINS
-#: Merge.rc:5766
+#: Merge.rc:5765
 msgid "Not Contains (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_LIKE
-#: Merge.rc:5767
+#: Merge.rc:5766
 msgid "Match (wildcard)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_LIKE
-#: Merge.rc:5768
+#: Merge.rc:5767
 msgid "Not match (wildcard)"
 msgstr ""
 
 #. IDS_FILTER_OP_MATCHES
-#: Merge.rc:5769
+#: Merge.rc:5768
 msgid "Match (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_MATCHES
-#: Merge.rc:5770
+#: Merge.rc:5769
 msgid "Not match (regex)"
 msgstr ""
 
 #. IDS_COLORMODE_LIGHT
-#: Merge.rc:5775
+#: Merge.rc:5774
 msgid "Light"
 msgstr ""
 
 #. IDS_COLORMODE_DARK
-#: Merge.rc:5776
+#: Merge.rc:5775
 msgid "Dark"
 msgstr ""
 
 #. IDS_COLORMODE_FOLLOWSYSTEM
-#: Merge.rc:5777
+#: Merge.rc:5776
 msgid "Follow system"
 msgstr ""
 
 #. IDS_EXAMPLE
-#: Merge.rc:5782
+#: Merge.rc:5781
 #, c-format
 msgid "e.g. %1"
 msgstr ""
 
 #. IDS_DETECTED_PREVIOUS_CRASH
-#: Merge.rc:5787
+#: Merge.rc:5786
 msgid "WinMerge detected a previous crash. Please report this if possible."
 msgstr ""
 
 #. IDS_REGEX_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5792
+#: Merge.rc:5791
 msgid "# Regex replacement list\r\n# Format: regex<TAB>replacement\r\n# Backreferences like $1, $2 are supported\r\n\r\n(\\d{4})-(\\d{2})-(\\d{2})\t$1_$2_$3\r\n"
 msgstr ""
 
 #. IDS_STRING_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5793
+#: Merge.rc:5792
 msgid "# Replacement list\r\n# Format: search<TAB>replacement\r\n# Lines starting with # are ignored\r\n\r\nfrom1\tto1\r\nfrom2\tto2\r\n"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_ONLY
-#: Merge.rc:5798
+#: Merge.rc:5797
 msgid "Built-in only"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_FIRST
-#: Merge.rc:5799
+#: Merge.rc:5798
 msgid "Built-in first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_FIRST
-#: Merge.rc:5800
+#: Merge.rc:5799
 msgid "Tree-sitter first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_ONLY
-#: Merge.rc:5801
+#: Merge.rc:5800
 msgid "Tree-sitter only"
 msgstr ""
 

--- a/Translations/WinMerge/Finnish.po
+++ b/Translations/WinMerge/Finnish.po
@@ -22,7 +22,7 @@ msgstr ""
 "X-Generator: Poedit 3.1.1\n"
 
 #. LANGUAGE, SUBLANGUAGE
-#: Merge.rc:26 Merge.rc:59 Merge.rc:5818
+#: Merge.rc:26 Merge.rc:59 Merge.rc:5817
 msgid "LANG_ENGLISH, SUBLANG_ENGLISH_US"
 msgstr "LANG_FINNISH, SUBLANG_DEFAULT"
 
@@ -164,7 +164,7 @@ msgstr "Skriptit"
 #. IDS_NO_EDIT_SCRIPTS
 #: Merge.rc:127 Merge.rc:352 Merge.rc:463 Merge.rc:673 Merge.rc:678
 #: Merge.rc:887 Merge.rc:899 Merge.rc:906 Merge.rc:963 Merge.rc:1210
-#: Merge.rc:5375
+#: Merge.rc:5374
 msgid "< Empty >"
 msgstr "< Tyhjä >"
 
@@ -230,7 +230,7 @@ msgid "Auto-Fit All Columns"
 msgstr "Sovita kaikki sarakkeet automaattisesti"
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN
-#: Merge.rc:153 Merge.rc:5646
+#: Merge.rc:153 Merge.rc:5645
 msgid "&Filter by This Column"
 msgstr ""
 
@@ -291,7 +291,7 @@ msgid "&Previous Page"
 msgstr "E&dellinen sivu"
 
 #. IDS_PREVIEWBAR_NEXTPAGE
-#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5679
+#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5678
 msgid "&Next Page"
 msgstr "Seu&raava sivu"
 
@@ -542,7 +542,7 @@ msgstr "Binääri"
 #. IDS_IMAGE_MENU
 #: Merge.rc:329 Merge.rc:338 Merge.rc:432 Merge.rc:441 Merge.rc:609
 #: Merge.rc:618 Merge.rc:670 Merge.rc:960 Merge.rc:1187 Merge.rc:1200
-#: Merge.rc:5477
+#: Merge.rc:5476
 msgid "&Image"
 msgstr "&Kuva"
 
@@ -664,7 +664,7 @@ msgid "&Huge"
 msgstr "&Valtava"
 
 #. IDS_VIEW_MENU_BAR
-#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5714
+#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5713
 msgid "Men&u Bar"
 msgstr ""
 
@@ -1319,7 +1319,7 @@ msgid "Lo&cation Pane"
 msgstr "Sijaintiruutu"
 
 #. IDS_OUTPUTBAR_CAPTION
-#: Merge.rc:782 Merge.rc:5252
+#: Merge.rc:782 Merge.rc:5251
 msgid "Output Pane"
 msgstr ""
 
@@ -1582,55 +1582,55 @@ msgid "Co&mpare As"
 msgstr "Vertaa >"
 
 #. IDS_COPY_LEFT_TO_MIDDLE2
-#: Merge.rc:968 Merge.rc:980 Merge.rc:4852
+#: Merge.rc:968 Merge.rc:980 Merge.rc:4851
 #, c-format
 msgid "Left to Middle (%1 of %2)"
 msgstr "Vasemmalta keskelle (%1 / %2)"
 
 #. IDS_COPY_LEFT_TO_RIGHT2
-#: Merge.rc:969 Merge.rc:981 Merge.rc:4851
+#: Merge.rc:969 Merge.rc:981 Merge.rc:4850
 #, c-format
 msgid "Left to Right (%1 of %2)"
 msgstr "Vasemmalta oikealle (%1 / %2)"
 
 #. IDS_MOVE_LEFT_TO2
-#: Merge.rc:970 Merge.rc:982 Merge.rc:1045 Merge.rc:4863 Merge.rc:4892
+#: Merge.rc:970 Merge.rc:982 Merge.rc:1045 Merge.rc:4862 Merge.rc:4891
 #, c-format
 msgid "Left to... (%1 of %2)"
 msgstr "Vasemmalta... (%1 / %2)"
 
 #. IDS_COPY_MIDDLE_TO_LEFT2
-#: Merge.rc:971 Merge.rc:983 Merge.rc:4849
+#: Merge.rc:971 Merge.rc:983 Merge.rc:4848
 #, c-format
 msgid "Middle to Left (%1 of %2)"
 msgstr "Keskeltä vasemmalle (%1 / %2)"
 
 #. IDS_COPY_MIDDLE_TO_RIGHT2
-#: Merge.rc:972 Merge.rc:984 Merge.rc:4850
+#: Merge.rc:972 Merge.rc:984 Merge.rc:4849
 #, c-format
 msgid "Middle to Right (%1 of %2)"
 msgstr "Vasemmalta oikealle (%1 / %2)"
 
 #. IDS_MOVE_MIDDLE_TO2
-#: Merge.rc:973 Merge.rc:985 Merge.rc:1046 Merge.rc:4864 Merge.rc:4893
+#: Merge.rc:973 Merge.rc:985 Merge.rc:1046 Merge.rc:4863 Merge.rc:4892
 #, c-format
 msgid "Middle to... (%1 of %2)"
 msgstr "Keskellä... (%1 / %2)"
 
 #. IDS_COPY_RIGHT_TO_MIDDLE2
-#: Merge.rc:974 Merge.rc:986 Merge.rc:4848
+#: Merge.rc:974 Merge.rc:986 Merge.rc:4847
 #, c-format
 msgid "Right to Middle (%1 of %2)"
 msgstr "Oikealta keskelle (%1 / %2)"
 
 #. IDS_COPY_RIGHT_TO_LEFT2
-#: Merge.rc:975 Merge.rc:987 Merge.rc:4847
+#: Merge.rc:975 Merge.rc:987 Merge.rc:4846
 #, c-format
 msgid "Right to Left (%1 of %2)"
 msgstr "Oikealta vasemmalle (%1 / %2)"
 
 #. IDS_MOVE_RIGHT_TO2
-#: Merge.rc:976 Merge.rc:988 Merge.rc:1047 Merge.rc:4865 Merge.rc:4894
+#: Merge.rc:976 Merge.rc:988 Merge.rc:1047 Merge.rc:4864 Merge.rc:4893
 #, c-format
 msgid "Right to... (%1 of %2)"
 msgstr "Oikealta... (%1 / %2)"
@@ -1686,31 +1686,31 @@ msgid "Cop&y Paths"
 msgstr "Kopioi polkunimet"
 
 #. IDS_DEL_LEFT_FMT2
-#: Merge.rc:1026 Merge.rc:1035 Merge.rc:4880
+#: Merge.rc:1026 Merge.rc:1035 Merge.rc:4879
 #, c-format
 msgid "Left (%1 of %2)"
 msgstr "Vasen (%1 / %2)"
 
 #. IDS_DEL_MIDDLE_FMT2
-#: Merge.rc:1027 Merge.rc:1036 Merge.rc:4881
+#: Merge.rc:1027 Merge.rc:1036 Merge.rc:4880
 #, c-format
 msgid "Middle (%1 of %2)"
 msgstr "Keskimmäinen (%1 / %2)"
 
 #. IDS_DEL_RIGHT_FMT2
-#: Merge.rc:1028 Merge.rc:1037 Merge.rc:4882
+#: Merge.rc:1028 Merge.rc:1037 Merge.rc:4881
 #, c-format
 msgid "Right (%1 of %2)"
 msgstr "Oikea (%1 / %2)"
 
 #. IDS_DEL_BOTH_FMT2
-#: Merge.rc:1029 Merge.rc:1038 Merge.rc:4883
+#: Merge.rc:1029 Merge.rc:1038 Merge.rc:4882
 #, c-format
 msgid "Both (%1 of %2)"
 msgstr "Molemmat (%1 / %2)"
 
 #. IDS_DEL_ALL_FMT2
-#: Merge.rc:1030 Merge.rc:1039 Merge.rc:4888
+#: Merge.rc:1030 Merge.rc:1039 Merge.rc:4887
 #, c-format
 msgid "All (%1 of %2)"
 msgstr "Kaikki (%1 / %2)"
@@ -1736,19 +1736,19 @@ msgid "&Zip"
 msgstr "Pakkaa"
 
 #. IDS_COPY_BOTH_TO2
-#: Merge.rc:1048 Merge.rc:4866
+#: Merge.rc:1048 Merge.rc:4865
 #, c-format
 msgid "Both to... (%1 of %2)"
 msgstr "Molemmat... (%1 / %2)"
 
 #. IDS_COPY_ALL_TO2
-#: Merge.rc:1049 Merge.rc:4867
+#: Merge.rc:1049 Merge.rc:4866
 #, c-format
 msgid "All to... (%1 of %2)"
 msgstr "Kaikki... (%1 / %2)"
 
 #. IDS_COPY_DIFFERENCES_TO2
-#: Merge.rc:1050 Merge.rc:4868
+#: Merge.rc:1050 Merge.rc:4867
 #, c-format
 msgid "Differences to... (%1 of %2)"
 msgstr "Eroavaisuudet... (%1 / %2)"
@@ -1815,12 +1815,12 @@ msgstr "Pakkauksen purkuasetukset"
 
 #. IDS_USERCHOICE_NONE
 #: Merge.rc:1088 Merge.rc:1094 Merge.rc:1836 Merge.rc:1840 Merge.rc:2031
-#: Merge.rc:2035 Merge.rc:5377
+#: Merge.rc:2035 Merge.rc:5376
 msgid "<None>"
 msgstr "<Ei mitään>"
 
 #. IDS_USERCHOICE_AUTOMATIC
-#: Merge.rc:1089 Merge.rc:1095 Merge.rc:5378
+#: Merge.rc:1089 Merge.rc:1095 Merge.rc:5377
 msgid "<Automatic>"
 msgstr "<Automaattinen>"
 
@@ -2750,12 +2750,12 @@ msgid "Text files only"
 msgstr ""
 
 #. IDS_EOL_NONE
-#: Merge.rc:1667 Merge.rc:1918 Merge.rc:5304
+#: Merge.rc:1667 Merge.rc:1918 Merge.rc:5303
 msgid "None"
 msgstr "Ei mitään"
 
 #. IDS_EOL_MIXED
-#: Merge.rc:1668 Merge.rc:5299
+#: Merge.rc:1668 Merge.rc:5298
 msgid "Mixed"
 msgstr "Sekoitettu"
 
@@ -3027,13 +3027,13 @@ msgstr ""
 
 #. IDS_DIFFERENT
 #: Merge.rc:1904 Merge.rc:1988 Merge.rc:2866 Merge.rc:3036 Merge.rc:3077
-#: Merge.rc:5058
+#: Merge.rc:5057
 msgid "Different"
 msgstr "Poikkeava"
 
 #. IDS_IDENTICAL
 #: Merge.rc:1905 Merge.rc:1989 Merge.rc:2865 Merge.rc:3055 Merge.rc:3116
-#: Merge.rc:5048
+#: Merge.rc:5047
 msgid "Identical"
 msgstr "Samanlainen"
 
@@ -3053,7 +3053,7 @@ msgid "Missing"
 msgstr ""
 
 #. IDS_MOVED
-#: Merge.rc:1910 Merge.rc:5076
+#: Merge.rc:1910 Merge.rc:5075
 msgid "Moved"
 msgstr ""
 
@@ -3793,7 +3793,7 @@ msgid "&Use custom system colors"
 msgstr ""
 
 #. IDS_PRPCAT_SYSTEM
-#: Merge.rc:2565 Merge.rc:4559 Merge.rc:4560 Merge.rc:5007
+#: Merge.rc:2565 Merge.rc:4559 Merge.rc:4560 Merge.rc:5006
 msgid "System"
 msgstr "Järjestelmä"
 
@@ -4198,7 +4198,7 @@ msgid "Items compared:"
 msgstr "Verratut kohteet:"
 
 #. IDS_PREVIEWBAR_CLOSE
-#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5685
+#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5684
 msgid "&Close"
 msgstr "Sulje"
 
@@ -4813,7 +4813,7 @@ msgid "A&ppend timestamp"
 msgstr "Liitä aikaleima"
 
 #. IDS_CONFIRM_COPY_CAPTION
-#: Merge.rc:3214 Merge.rc:4915
+#: Merge.rc:3214 Merge.rc:4914
 msgid "Confirm Copy"
 msgstr "Vahvista kopionti"
 
@@ -5056,7 +5056,7 @@ msgid "&Character Set..."
 msgstr "&Merkistö..."
 
 #. IDS_PRPCAT_IMAGE
-#: Merge.rc:3351 Merge.rc:4574 Merge.rc:5015
+#: Merge.rc:3351 Merge.rc:4574 Merge.rc:5014
 msgid "Image"
 msgstr "Kuva"
 
@@ -5452,7 +5452,7 @@ msgid "Project"
 msgstr "Projekti"
 
 #. IDS_COLHDR_NSDIFFS
-#: Merge.rc:4566 Merge.rc:4990
+#: Merge.rc:4566 Merge.rc:4989
 msgid "Differences"
 msgstr "Erilaisuudet"
 
@@ -5602,12 +5602,12 @@ msgid "File Type"
 msgstr "Tiedostotyyppi"
 
 #. IDS_COLHDR_EXTENSION
-#: Merge.rc:4653 Merge.rc:4947
+#: Merge.rc:4653 Merge.rc:4946
 msgid "Extension"
 msgstr "Pääte"
 
 #. IDS_PRPCAT_MESSAGE
-#: Merge.rc:4659 Merge.rc:5019
+#: Merge.rc:4659 Merge.rc:5018
 msgid "Message"
 msgstr "Viesti"
 
@@ -5647,7 +5647,7 @@ msgid "Hidden Items"
 msgstr "Piilotetut kohteet"
 
 #. IDS_PLUGINSLIST_NAME
-#: Merge.rc:4680 Merge.rc:5311
+#: Merge.rc:4680 Merge.rc:5310
 msgid "Name"
 msgstr "Nimi"
 
@@ -5667,7 +5667,7 @@ msgid "[F] "
 msgstr "[F] "
 
 #. IDS_PLUGINSLIST_DESC
-#: Merge.rc:4684 Merge.rc:5313
+#: Merge.rc:4684 Merge.rc:5312
 msgid "Description"
 msgstr "Kuvaus"
 
@@ -5828,157 +5828,152 @@ msgstr "Ln: %s  Col: %d/%d  Ch: %d/%d"
 msgid "  Sel: %d | %d"
 msgstr "  Val: %d | %d"
 
-#. IDS_MERGEMODE_MERGING
-#: Merge.rc:4734
-msgid "Merge"
-msgstr "Yhdistä"
-
 #. IDS_DIFF_NUMBER_STATUS_FMT
-#: Merge.rc:4735
+#: Merge.rc:4734
 #, c-format
 msgid "Difference %1 of %2"
 msgstr "Eroavuus %1 / %2"
 
 #. IDS_NO_DIFF_SEL_FMT
-#: Merge.rc:4736
+#: Merge.rc:4735
 #, c-format
 msgid "%1 Differences Found"
 msgstr "%1 eroa löytyi"
 
 #. IDS_1_DIFF_FOUND
-#: Merge.rc:4737
+#: Merge.rc:4736
 msgid "1 Difference Found"
 msgstr "1 ero löytyi"
 
 #. IDS_NO_ERR_SEL_FMT
-#: Merge.rc:4738
+#: Merge.rc:4737
 #, c-format
 msgid "%1 Errors Found"
 msgstr ""
 
 #. IDS_1_ERR_FOUND
-#: Merge.rc:4739
+#: Merge.rc:4738
 msgid "1 Error Found"
 msgstr ""
 
 #. IDS_STATUSBAR_READONLY, Abbreviation from "Read Only"
-#: Merge.rc:4740
+#: Merge.rc:4739
 msgid "RO"
 msgstr "RO"
 
 #. IDS_DIRVIEW_STATUS_FMT_FOCUS
-#: Merge.rc:4746
+#: Merge.rc:4745
 #, c-format
 msgid "Item %1 of %2"
 msgstr "Kohta %1 / %2"
 
 #. IDS_DIRVIEW_STATUS_FMT_NOFOCUS
-#: Merge.rc:4747
+#: Merge.rc:4746
 #, c-format
 msgid "Items: %1"
 msgstr "Kohdat: %1"
 
 #. IDS_DIRVIEW_STATUS_COMPARING
-#: Merge.rc:4748
+#: Merge.rc:4747
 msgid "Comparing items..."
 msgstr "Verrataan kohteita..."
 
 #. IDS_ITEMS_PER_SEC
-#: Merge.rc:4749
+#: Merge.rc:4748
 #, c-format
 msgid "%.1f[items/sec]"
 msgstr ""
 
 #. IDS_ERROR_INCOMPARABLE
-#: Merge.rc:4755
+#: Merge.rc:4754
 msgid "Select two existing folders/files to compare."
 msgstr "Valitse vertailuun kaksi olemassa olevaa kansioita tai tiedostoa."
 
 #. IDS_DIRSEL_TAG
-#: Merge.rc:4756
+#: Merge.rc:4755
 msgid "Folder Selection"
 msgstr "Kansion valinta"
 
 #. IDS_OPEN_FILESDIRS
-#: Merge.rc:4757
+#: Merge.rc:4756
 msgid "Select two (or three) folders/files to compare."
 msgstr ""
 "Valitse kaksi (tai kolme) kansiota tai kaksi (tai kolme) tiedostoa vertailua "
 "varten."
 
 #. IDS_OPEN_LEFTINVALID
-#: Merge.rc:4758
+#: Merge.rc:4757
 msgid "Left (1st) path is invalid!"
 msgstr "Vasen (1.) polku ei kelpaa!"
 
 #. IDS_OPEN_MIDDLEINVALID
-#: Merge.rc:4759
+#: Merge.rc:4758
 msgid "Middle (2nd) path is invalid!"
 msgstr "Keskimmäinen (2.) polku ei kelpaa!"
 
 #. IDS_OPEN_RIGHTINVALID2
-#: Merge.rc:4760
+#: Merge.rc:4759
 msgid "Right (2nd) path is invalid!"
 msgstr "Oikea (2.) polku ei kelpaa!"
 
 #. IDS_OPEN_RIGHTINVALID3
-#: Merge.rc:4761
+#: Merge.rc:4760
 msgid "Right (3rd) path is invalid!"
 msgstr "Oikea (3.) polku ei kelpaa!"
 
 #. IDS_OPEN_BOTHINVALID
-#: Merge.rc:4762
+#: Merge.rc:4761
 msgid "Both paths are invalid!"
 msgstr "Kummatkin polut ovat virheellisiä!"
 
-#: Merge.rc:4764
+#: Merge.rc:4763
 msgid "Left (1st) and Middle (2nd) paths are invalid!"
 msgstr "Vasen (1.) ja keskimmäinen (2.) polut eivät kelpaa!"
 
 #. IDS_OPEN_LEFTRIGHTINVALID
-#: Merge.rc:4765
+#: Merge.rc:4764
 msgid "Left (1st) and Right (3rd) paths are invalid!"
 msgstr "Vasen (1.) ja oikea (3.) polut ovat virheellisiä!"
 
-#: Merge.rc:4767
+#: Merge.rc:4766
 msgid "Middle (2nd) and Right (3rd) paths are invalid!"
 msgstr "Keskimmäinen (2.) ja oikea (3.) polut ovat virheellisiä!"
 
 #. IDS_OPEN_ALLINVALID
-#: Merge.rc:4768
+#: Merge.rc:4767
 msgid "All paths are invalid!"
 msgstr "Kaikki polut ovat virheellisiä!"
 
 #. IDS_OPEN_UNPACKERDISABLED
-#: Merge.rc:4769
+#: Merge.rc:4768
 msgid "Only enabled for file comparisons"
 msgstr "Käytössä vain tiedostojen vertailussa"
 
 #. IDS_OPEN_MISMATCH
-#: Merge.rc:4770
+#: Merge.rc:4769
 msgid "Cannot compare file and folder!"
 msgstr "Tiedostoa ja kansiota ei voi verrata!"
 
 #. IDS_ERROR_FILE_NOT_FOUND
-#: Merge.rc:4776
+#: Merge.rc:4775
 #, c-format
 msgid "File not found: %1"
 msgstr "Tiedostoa ei löytynyt: %1"
 
 #. IDS_ERROR_FOLDER_NOT_FOUND
-#: Merge.rc:4777
+#: Merge.rc:4776
 #, c-format
 msgid "Folder not found: %1"
 msgstr ""
 
 #. IDS_ERROR_FILE_NOT_UNPACKED
-#: Merge.rc:4778
+#: Merge.rc:4777
 #, c-format
 msgid "File not unpacked: %1"
 msgstr "Tiedostoa ei ole purettu: %1"
 
 #. IDS_ERROR_FILEOPEN
-#: Merge.rc:4779
+#: Merge.rc:4778
 #, c-format
 msgid ""
 "Cannot open file\n"
@@ -5992,12 +5987,12 @@ msgstr ""
 "%2"
 
 #. IDS_ERROR_CONF_RESOLVE
-#: Merge.rc:4780
+#: Merge.rc:4779
 msgid "Failed to parse conflict file."
 msgstr "Ristiriitatiedoston jäsennys epäonnistui."
 
 #. IDS_NOT_CONFLICT_FILE
-#: Merge.rc:4781
+#: Merge.rc:4780
 #, c-format
 msgid "The file\n%1\nis not a conflict file."
 msgstr ""
@@ -6006,7 +6001,7 @@ msgstr ""
 "ei ole ristiriitatiedosto."
 
 #. IDS_COMPARE_LARGE_FILES
-#: Merge.rc:4782
+#: Merge.rc:4781
 msgid "Comparing large files requires significant memory.\nShow only comparison results (not file contents)?"
 msgstr ""
 "Olet vertaamassa hyvin suuria tiedostoja.\n"
@@ -6015,18 +6010,18 @@ msgstr ""
 "\n"
 
 #. IDS_SAVE_AS_TITLE
-#: Merge.rc:4788
+#: Merge.rc:4787
 msgid "Save As"
 msgstr "Tallenna nimellä"
 
 #. IDS_SAVE_FMT
-#: Merge.rc:4789
+#: Merge.rc:4788
 #, c-format
 msgid "Save changes to %1?"
 msgstr "Tallennetaanko muutokset tiedostoon %1?"
 
 #. IDS_SAVEREADONLY_FMT
-#: Merge.rc:4790
+#: Merge.rc:4789
 #, c-format
 msgid "%1 is read-only. Override? Or 'No' to save as new filename?"
 msgstr ""
@@ -6034,11 +6029,11 @@ msgstr ""
 "tarkoita 'Tallenna nimellä'"
 
 #. IDS_ERROR_BACKUP
-#: Merge.rc:4791
+#: Merge.rc:4790
 msgid "Error backing up file"
 msgstr "Virhe varmuuskopioinnissa"
 
-#: Merge.rc:4793
+#: Merge.rc:4792
 #, c-format
 msgid ""
 "Unable to backup original file:\n"
@@ -6052,7 +6047,7 @@ msgstr ""
 "Jatketaanko?"
 
 #. IDS_FILESAVE_FAILED
-#: Merge.rc:4794
+#: Merge.rc:4793
 #, c-format
 msgid "Saving file failed.\n%1\n%2\n\t- Use different filename (OK)\n\t- Abort (Cancel)?"
 msgstr ""
@@ -6063,7 +6058,7 @@ msgstr ""
 "\t- käyttää eri tiedostonimeä (paina Ok)\n"
 "\t- keskeyttää nykyisen työvaiheen (paina Peruuta)?"
 
-#: Merge.rc:4796
+#: Merge.rc:4795
 #, c-format
 msgid "Plugin '%2' cannot pack changes to left file into '%1'.\n\nOriginal unchanged. Save unpacked version?"
 msgstr ""
@@ -6073,7 +6068,7 @@ msgstr ""
 "\n"
 "Haluatko tallentaa puretun version toiseen tiedostoon?"
 
-#: Merge.rc:4798
+#: Merge.rc:4797
 #, c-format
 msgid "Plugin '%2' cannot pack changes to middle file into '%1'.\n\nOriginal unchanged. Save unpacked version?"
 msgstr ""
@@ -6084,7 +6079,7 @@ msgstr ""
 "\n"
 "Haluatko tallentaa puretun version toiseen tiedostoon?"
 
-#: Merge.rc:4800
+#: Merge.rc:4799
 #, c-format
 msgid "Plugin '%2' cannot pack changes to right file into '%1'.\n\nOriginal unchanged. Save unpacked version?"
 msgstr ""
@@ -6095,7 +6090,7 @@ msgstr ""
 "Haluatko tallentaa puretun version toiseen tiedostoon?"
 
 #. IDS_FILECHANGED_ONDISK
-#: Merge.rc:4801
+#: Merge.rc:4800
 #, c-format
 msgid ""
 "Another application updated\n"
@@ -6111,7 +6106,7 @@ msgstr ""
 "Korvataanko muuttunut tiedosto?"
 
 #. IDS_SAVEREADONLY_MULTI
-#: Merge.rc:4802
+#: Merge.rc:4801
 #, c-format
 msgid ""
 "%1\n"
@@ -6121,7 +6116,7 @@ msgstr ""
 "on merkitty vain luku-tilaan. Haluatko ohittaa vain-luku kohteen?"
 
 #. IDS_FILECHANGED_RESCAN
-#: Merge.rc:4803
+#: Merge.rc:4802
 #, c-format
 msgid "Another application updated\n%1\nsince last scan.\n\nReload?"
 msgstr ""
@@ -6132,22 +6127,22 @@ msgstr ""
 "Haluatko uudelleenladata tiedoston?"
 
 #. IDS_SAVE_LEFT_AS
-#: Merge.rc:4804
+#: Merge.rc:4803
 msgid "Save Left File As"
 msgstr "Tallenna vasen tiedosto nimellä"
 
 #. IDS_SAVE_MIDDLE_AS
-#: Merge.rc:4805
+#: Merge.rc:4804
 msgid "Save Middle File As"
 msgstr "Tallenna keskimmäinen tiedosto nimellä"
 
 #. IDS_SAVE_RIGHT_AS
-#: Merge.rc:4806
+#: Merge.rc:4805
 msgid "Save Right File As"
 msgstr "Talleta oikea tiedosto nimellä"
 
 #. IDS_FILE_DISAPPEARED
-#: Merge.rc:4811
+#: Merge.rc:4810
 #, c-format
 msgid ""
 "File\n"
@@ -6159,7 +6154,7 @@ msgstr ""
 "on kadonnut. Tallenna kopio tiedostosta jatkaaksesi."
 
 #. IDS_VIEWS_OUTOFSYNC
-#: Merge.rc:4817
+#: Merge.rc:4816
 msgid ""
 "Cannot merge unsynched documents.\n"
 "\n"
@@ -6170,186 +6165,186 @@ msgstr ""
 "Päivitä asiakirjat ennen jatkamista."
 
 #. IDS_BREAK_ON_WHITESPACE
-#: Merge.rc:4822
+#: Merge.rc:4821
 msgid "Break at whitespace"
 msgstr "Rivinvaihto tyhjätilamerkissä"
 
 #. IDS_BREAK_ON_PUNCTUATION
-#: Merge.rc:4823
+#: Merge.rc:4822
 msgid "Break at whitespace or punctuation"
 msgstr "Rivinvaihto tyhjätilassa tai pilkutuksessa"
 
 #. IDS_L2M
-#: Merge.rc:4829
+#: Merge.rc:4828
 msgid "Copy to &Middle\tAlt+Right"
 msgstr "Kopioi &keskelle\tAlt+Oikea"
 
 #. IDS_R2M
-#: Merge.rc:4830
+#: Merge.rc:4829
 msgid "Copy to &Middle\tAlt+Left"
 msgstr "Kopioi &keskelle\tAlt+Vasen"
 
 #. IDS_COPY_FROM_MIDDLE_R
-#: Merge.rc:4831
+#: Merge.rc:4830
 msgid "Copy from Middle\tAlt+Shift+Right"
 msgstr "Kopioi keskeltä\tAlt+Shift+Oikea"
 
 #. IDS_COPY_FROM_MIDDLE_L
-#: Merge.rc:4832
+#: Merge.rc:4831
 msgid "Copy from Middle\tAlt+Shift+Left"
 msgstr "Kopioi keskeltä\tAlt+Shift+Vasen"
 
 #. IDS_L2MNEXT
-#: Merge.rc:4833
+#: Merge.rc:4832
 msgid "Copy to Middle and Advance\tCtrl+Alt+Right"
 msgstr "Kopioi keskelle ja etene\tCtrl+Alt+Oikea"
 
 #. IDS_R2MNEXT
-#: Merge.rc:4834
+#: Merge.rc:4833
 msgid "Copy to Middle and Advance\tCtrl+Alt+Left"
 msgstr "Kopioi keskelle ja etene\tCtrl+Alt+Vasen"
 
 #. IDS_ALL_MIDDLE
-#: Merge.rc:4835
+#: Merge.rc:4834
 msgid "Copy All to Middle"
 msgstr "Kopioi kaikki keskelle"
 
 #. IDS_COPY_RIGHT_TO_LEFT
-#: Merge.rc:4841
+#: Merge.rc:4840
 #, c-format
 msgid "Right to Left (%1)"
 msgstr "Oikealta vasemmalle (%1)"
 
 #. IDS_COPY_RIGHT_TO_MIDDLE
-#: Merge.rc:4842
+#: Merge.rc:4841
 #, c-format
 msgid "Right to Middle (%1)"
 msgstr "Oikealta keskelle (%1)"
 
 #. IDS_COPY_MIDDLE_TO_LEFT
-#: Merge.rc:4843
+#: Merge.rc:4842
 #, c-format
 msgid "Middle to Left (%1)"
 msgstr "Keskeltä vasemmalle (%1)"
 
 #. IDS_COPY_MIDDLE_TO_RIGHT
-#: Merge.rc:4844
+#: Merge.rc:4843
 #, c-format
 msgid "Middle to Right (%1)"
 msgstr "Keskeltä oikealle (%1)"
 
 #. IDS_COPY_LEFT_TO_RIGHT
-#: Merge.rc:4845
+#: Merge.rc:4844
 #, c-format
 msgid "Left to Right (%1)"
 msgstr "Vasemmalta oikealle (%1)"
 
 #. IDS_COPY_LEFT_TO_MIDDLE
-#: Merge.rc:4846
+#: Merge.rc:4845
 #, c-format
 msgid "Left to Middle (%1)"
 msgstr "Vasemmalle keskelle (%1)"
 
 #. IDS_MOVE_LEFT_TO
-#: Merge.rc:4857 Merge.rc:4889
+#: Merge.rc:4856 Merge.rc:4888
 #, c-format
 msgid "Left to... (%1)"
 msgstr "Vasemmalta... (%1)"
 
 #. IDS_MOVE_MIDDLE_TO
-#: Merge.rc:4858 Merge.rc:4890
+#: Merge.rc:4857 Merge.rc:4889
 #, c-format
 msgid "Middle to... (%1)"
 msgstr "Keskellä... (%1)"
 
 #. IDS_MOVE_RIGHT_TO
-#: Merge.rc:4859 Merge.rc:4891
+#: Merge.rc:4858 Merge.rc:4890
 #, c-format
 msgid "Right to... (%1)"
 msgstr "Oikealta... (%1)"
 
 #. IDS_COPY_BOTH_TO
-#: Merge.rc:4860
+#: Merge.rc:4859
 #, c-format
 msgid "Both to... (%1)"
 msgstr "Molemmat... (%1)"
 
 #. IDS_COPY_ALL_TO
-#: Merge.rc:4861
+#: Merge.rc:4860
 #, c-format
 msgid "All to... (%1)"
 msgstr "Kaikki... (%1)"
 
 #. IDS_COPY_DIFFERENCES_TO
-#: Merge.rc:4862
+#: Merge.rc:4861
 #, c-format
 msgid "Differences to... (%1)"
 msgstr "Erot... (%1)"
 
 #. IDS_ONLYDIFFITEMS_CONFIRM
-#: Merge.rc:4869
+#: Merge.rc:4868
 msgid "Some selected items are identical or skipped.\nProcess only items with differences?"
 msgstr ""
 
 #. IDS_DEL_LEFT_FMT
-#: Merge.rc:4875
+#: Merge.rc:4874
 #, c-format
 msgid "Left (%1)"
 msgstr "Vasen (%1)"
 
 #. IDS_DEL_MIDDLE_FMT
-#: Merge.rc:4876
+#: Merge.rc:4875
 #, c-format
 msgid "Middle (%1)"
 msgstr "Keskimmäinen (%1)"
 
 #. IDS_DEL_RIGHT_FMT
-#: Merge.rc:4877
+#: Merge.rc:4876
 #, c-format
 msgid "Right (%1)"
 msgstr "Oikea (%1)"
 
 #. IDS_DEL_BOTH_FMT
-#: Merge.rc:4878
+#: Merge.rc:4877
 #, c-format
 msgid "Both (%1)"
 msgstr "Molemmat (%1)"
 
 #. IDS_DEL_ALL_FMT
-#: Merge.rc:4879
+#: Merge.rc:4878
 #, c-format
 msgid "All (%1)"
 msgstr "Kaikki (%1)"
 
 #. IDS_SELECT_DEST_LEFT
-#: Merge.rc:4895
+#: Merge.rc:4894
 msgid "Left Side - Select Destination Folder:"
 msgstr "Vasen puoli - valitse kohdekansio:"
 
 #. IDS_SELECT_DEST_MIDDLE
-#: Merge.rc:4896
+#: Merge.rc:4895
 msgid "Middle Side - Select Destination Folder:"
 msgstr "Keskimmäinen - valitse kohdekansio:"
 
 #. IDS_SELECT_DEST_RIGHT
-#: Merge.rc:4897
+#: Merge.rc:4896
 msgid "Right Side - Select Destination Folder:"
 msgstr "Oikea puoli - valitse kohdekansio:"
 
 #. IDS_FILES_AFFECTED_FMT
-#: Merge.rc:4898
+#: Merge.rc:4897
 #, c-format
 msgid "(%1 Files Affected)"
 msgstr "(%1 tiedostoa muokattu)"
 
 #. IDS_FILES_AFFECTED_FMT2
-#: Merge.rc:4899
+#: Merge.rc:4898
 #, c-format
 msgid "(%1 of %2 Files Affected)"
 msgstr "(%1 / %2 tiedostoon vaikutettu)"
 
 #. IDS_CONFIRM_DELETE_SINGLE
-#: Merge.rc:4905
+#: Merge.rc:4904
 #, c-format
 msgid ""
 "Are you sure you want to delete\n"
@@ -6361,18 +6356,18 @@ msgstr ""
 "%1 ?"
 
 #. IDS_CONFIRM_SINGLE_COPY
-#: Merge.rc:4906
+#: Merge.rc:4905
 msgid "Are you sure you want to copy?"
 msgstr "Oletko varma, että haluat kopioida?"
 
 #. IDS_CONFIRM_MULTIPLE_COPY
-#: Merge.rc:4907
+#: Merge.rc:4906
 #, c-format
 msgid "Are you sure you want to copy %d items?"
 msgstr "Oletko varma, että haluat kopioida %d kohdetta?"
 
 #. IDS_DIRCMP_NOTSYNC
-#: Merge.rc:4908
+#: Merge.rc:4907
 #, c-format
 msgid ""
 "Operation aborted!\n"
@@ -6392,47 +6387,47 @@ msgstr ""
 "Päivitä vertailu."
 
 #. IDS_CONFIRM_SINGLE_MOVE
-#: Merge.rc:4913
+#: Merge.rc:4912
 msgid "Are you sure you want to move?"
 msgstr "Oletko varma, että haluat siirtää?"
 
 #. IDS_CONFIRM_MULTIPLE_MOVE
-#: Merge.rc:4914
+#: Merge.rc:4913
 #, c-format
 msgid "Are you sure you want to move %d items?"
 msgstr "Oletko varma, että haluat siirtää %d kohdetta?"
 
 #. IDS_CONFIRM_MOVE_CAPTION
-#: Merge.rc:4916
+#: Merge.rc:4915
 msgid "Confirm Move"
 msgstr "Vahvista siirto"
 
-#: Merge.rc:4918
+#: Merge.rc:4917
 msgid "Close the folder comparison window?"
 msgstr ""
 "Olet sulkemassa kansioiden vertailuikkunaa. Haluatko varmasti sulkea ikkunan?"
 
-#: Merge.rc:4920
+#: Merge.rc:4919
 msgid "Close the folder comparison window, which took a long time?"
 msgstr ""
 
 #. IDS_ERROR_INVALID_DIR_FILE_NAME
-#: Merge.rc:4921
+#: Merge.rc:4920
 msgid "The file or folder name is invalid."
 msgstr "Tiedoston tai kansion nimi on virheellinen."
 
 #. IDS_ERROR_EXECUTE_FILE
-#: Merge.rc:4927
+#: Merge.rc:4926
 #, c-format
 msgid "Failed to execute external editor: %1"
 msgstr "Ulkoisen editorin ajo epäonnistui: %1"
 
 #. IDS_UNKNOWN_ARCHIVE_FORMAT
-#: Merge.rc:4933
+#: Merge.rc:4932
 msgid "Unknown archive format"
 msgstr "Tuntematon arkistomuoto"
 
-#: Merge.rc:4935
+#: Merge.rc:4934
 msgid ""
 "Failed to extract archive.\n"
 "Compare as text file?"
@@ -6441,747 +6436,747 @@ msgstr ""
 "Haluatko verrata arkistotiedostoja tekstitiedostoina?"
 
 #. IDS_COLHDR_FILENAME
-#: Merge.rc:4941
+#: Merge.rc:4940
 msgid "Filename"
 msgstr "Tiedostonimi"
 
 #. IDS_COLHDR_DIR
-#: Merge.rc:4942
+#: Merge.rc:4941
 msgctxt "DirView|ColumnHeader"
 msgid "Folder"
 msgstr "Kansio"
 
 #. IDS_COLHDR_RESULT
-#: Merge.rc:4943
+#: Merge.rc:4942
 msgid "Comparison Result"
 msgstr "Vertailutulokset"
 
 #. IDS_COLHDR_LTIMEM
-#: Merge.rc:4944
+#: Merge.rc:4943
 msgid "Left Date"
 msgstr "Vasen päiväys"
 
 #. IDS_COLHDR_RTIMEM
-#: Merge.rc:4945
+#: Merge.rc:4944
 msgid "Right Date"
 msgstr "Oikea päiväys"
 
 #. IDS_COLHDR_MTIMEM
-#: Merge.rc:4946
+#: Merge.rc:4945
 msgid "Middle Date"
 msgstr "Keskimmäinen päivä"
 
 #. IDS_COLHDR_LSIZE
-#: Merge.rc:4948
+#: Merge.rc:4947
 msgid "Left Size"
 msgstr "Vasen koko"
 
 #. IDS_COLHDR_RSIZE
-#: Merge.rc:4949
+#: Merge.rc:4948
 msgid "Right Size"
 msgstr "Oikea koko"
 
 #. IDS_COLHDR_MSIZE
-#: Merge.rc:4954
+#: Merge.rc:4953
 msgid "Middle Size"
 msgstr "Keskimmäinen koko"
 
 #. IDS_COLHDR_RSIZE_SHORT
-#: Merge.rc:4955
+#: Merge.rc:4954
 msgid "Right Size (Short)"
 msgstr "Oikea koko (lyhyt)"
 
 #. IDS_COLHDR_LSIZE_SHORT
-#: Merge.rc:4956
+#: Merge.rc:4955
 msgid "Left Size (Short)"
 msgstr "Vasen koko (lyhyt)"
 
 #. IDS_COLHDR_MSIZE_SHORT
-#: Merge.rc:4957
+#: Merge.rc:4956
 msgid "Middle Size (Short)"
 msgstr "Keskimmäinen koko (lyhyt)"
 
 #. IDS_COLHDR_LTIMEC
-#: Merge.rc:4963
+#: Merge.rc:4962
 msgid "Left Creation Time"
 msgstr "Vasen luontiaika"
 
 #. IDS_COLHDR_RTIMEC
-#: Merge.rc:4964
+#: Merge.rc:4963
 msgid "Right Creation Time"
 msgstr "Oikea luontiaika"
 
 #. IDS_COLHDR_MTIMEC
-#: Merge.rc:4965
+#: Merge.rc:4964
 msgid "Middle Creation Time"
 msgstr "Keskimmäinen luontiaika"
 
 #. IDS_COLHDR_NEWER
-#: Merge.rc:4966
+#: Merge.rc:4965
 msgid "Newer File"
 msgstr "Uudempi tiedosto"
 
 #. IDS_COLHDR_LVERSION
-#: Merge.rc:4967
+#: Merge.rc:4966
 msgid "Left File Version"
 msgstr "Vasen tiedostoversio"
 
 #. IDS_COLHDR_RVERSION
-#: Merge.rc:4968
+#: Merge.rc:4967
 msgid "Right File Version"
 msgstr "Oikea tiedostoversio"
 
 #. IDS_COLHDR_MVERSION
-#: Merge.rc:4969
+#: Merge.rc:4968
 msgid "Middle File Version"
 msgstr "Keskimmäinen tiedostoversio"
 
 #. IDS_COLHDR_RESULT_ABBR
-#: Merge.rc:4970
+#: Merge.rc:4969
 msgid "Short Result"
 msgstr "Lyhyt tulos"
 
 #. IDS_COLHDR_LATTRIBUTES
-#: Merge.rc:4971
+#: Merge.rc:4970
 msgid "Left Attributes"
 msgstr "Vasemmat määritteet"
 
 #. IDS_COLHDR_RATTRIBUTES
-#: Merge.rc:4972
+#: Merge.rc:4971
 msgid "Right Attributes"
 msgstr "Oikeat määritteet"
 
 #. IDS_COLHDR_MATTRIBUTES
-#: Merge.rc:4973
+#: Merge.rc:4972
 msgid "Middle Attributes"
 msgstr "Keskimmäinen attribuutit"
 
 #. IDS_COLHDR_LEOL_TYPE
-#: Merge.rc:4978
+#: Merge.rc:4977
 msgid "Left EOL"
 msgstr "Vasen EOL"
 
 #. IDS_COLHDR_MEOL_TYPE
-#: Merge.rc:4979
+#: Merge.rc:4978
 msgid "Middle EOL"
 msgstr "Keskimmäinen EOL"
 
 #. IDS_COLHDR_REOL_TYPE
-#: Merge.rc:4980
+#: Merge.rc:4979
 msgid "Right EOL"
 msgstr "Oikea EOL"
 
 #. IDS_COLHDR_LENCODING
-#: Merge.rc:4986
+#: Merge.rc:4985
 msgid "Left Encoding"
 msgstr "Vasen koodaus"
 
 #. IDS_COLHDR_RENCODING
-#: Merge.rc:4987
+#: Merge.rc:4986
 msgid "Right Encoding"
 msgstr "Oikea koodaus"
 
 #. IDS_COLHDR_MENCODING
-#: Merge.rc:4988
+#: Merge.rc:4987
 msgid "Middle Encoding"
 msgstr "Keskimmäinen koodaus"
 
 #. IDS_COLHDR_NIDIFFS
-#: Merge.rc:4989
+#: Merge.rc:4988
 msgid "Ignored Diff"
 msgstr "Ohitetut erot"
 
 #. IDS_COLHDR_BINARY
-#: Merge.rc:4991
+#: Merge.rc:4990
 msgctxt "DirView|ColumnHeader"
 msgid "Binary"
 msgstr "Binääri"
 
 #. IDS_PLUGINS_TYPE_UNPACKER
-#: Merge.rc:4992 Merge.rc:5314
+#: Merge.rc:4991 Merge.rc:5313
 msgid "Unpacker"
 msgstr "Purkaja"
 
 #. IDS_PLUGIN_TYPE4
-#: Merge.rc:4993 Merge.rc:5315 Merge.rc:5622
+#: Merge.rc:4992 Merge.rc:5314 Merge.rc:5621
 msgid "Prediffer"
 msgstr "Esivertailu"
 
 #. IDS_COLHDR_LEFT
-#: Merge.rc:4994
+#: Merge.rc:4993
 msgid "Left"
 msgstr "Vasen"
 
 #. IDS_COLHDR_MIDDLE
-#: Merge.rc:4995
+#: Merge.rc:4994
 msgid "Middle"
 msgstr "Keski"
 
 #. IDS_COLHDR_RIGHT
-#: Merge.rc:4996
+#: Merge.rc:4995
 msgid "Right"
 msgstr "Oikea"
 
 #. IDS_COLHDR_DIFF
-#: Merge.rc:4997
+#: Merge.rc:4996
 msgid "Diff"
 msgstr "Ero"
 
 #. IDS_COLHDR_LEFT_DUPLICATE
-#: Merge.rc:4998
+#: Merge.rc:4997
 msgid "Left Duplicate Count"
 msgstr "Vasen kaksoiskappaleiden määrä"
 
 #. IDS_COLHDR_RIGHT_DUPLICATE
-#: Merge.rc:4999
+#: Merge.rc:4998
 msgid "Right Duplicate Count"
 msgstr "Oikea kaksoiskappaleiden määrä"
 
 #. IDS_COLHDR_MIDDLE_DUPLICATE
-#: Merge.rc:5000
+#: Merge.rc:4999
 msgid "Middle Duplicate Count"
 msgstr "Keskimmäinen kaksoiskappaleiden määrä"
 
 #. IDS_COLHDR_MOVE
-#: Merge.rc:5001
+#: Merge.rc:5000
 msgid "Move"
 msgstr "Siirrä"
 
 #. IDS_PRPCAT_AUDIO
-#: Merge.rc:5008
+#: Merge.rc:5007
 msgid "Audio"
 msgstr "Audio"
 
 #. IDS_PRPCAT_CALENDAR
-#: Merge.rc:5009
+#: Merge.rc:5008
 msgid "Calendar"
 msgstr "Kalenteri"
 
 #. IDS_PRPCAT_COMMUNICATION
-#: Merge.rc:5010
+#: Merge.rc:5009
 msgid "Communication"
 msgstr "Viestintä"
 
 #. IDS_PRPCAT_CONTACT
-#: Merge.rc:5011
+#: Merge.rc:5010
 msgid "Contact"
 msgstr "Yhteystieto"
 
 #. IDS_PRPCAT_DEVICES
-#: Merge.rc:5012
+#: Merge.rc:5011
 msgid "Devices"
 msgstr "Laitteet"
 
 #. IDS_PRPCAT_DOCUMENT
-#: Merge.rc:5013
+#: Merge.rc:5012
 msgid "Document"
 msgstr "Dokumentti"
 
 #. IDS_PRPCAT_HOME
-#: Merge.rc:5014
+#: Merge.rc:5013
 msgid "Home"
 msgstr "Koti"
 
 #. IDS_PRPCAT_JOURNAL
-#: Merge.rc:5016
+#: Merge.rc:5015
 msgid "Journal"
 msgstr "Aikakauslehti"
 
 #. IDS_PRPCAT_LINK
-#: Merge.rc:5017
+#: Merge.rc:5016
 msgid "Link"
 msgstr "Linkki"
 
 #. IDS_PRPCAT_MEDIA
-#: Merge.rc:5018
+#: Merge.rc:5017
 msgid "Media"
 msgstr "Media"
 
 #. IDS_PRPCAT_MUSIC
-#: Merge.rc:5020
+#: Merge.rc:5019
 msgid "Music"
 msgstr "Musiikki"
 
 #. IDS_PRPCAT_NOTE
-#: Merge.rc:5021
+#: Merge.rc:5020
 msgid "Note"
 msgstr "Huomautus"
 
 #. IDS_PRPCAT_PHOTO
-#: Merge.rc:5022
+#: Merge.rc:5021
 msgid "Photo"
 msgstr "Valokuva"
 
 #. IDS_PRPCAT_RECORDEDTV
-#: Merge.rc:5023
+#: Merge.rc:5022
 msgid "RecordedTV"
 msgstr "TallennettuTV"
 
 #. IDS_PRPCAT_SEARCH
-#: Merge.rc:5024
+#: Merge.rc:5023
 msgid "Search"
 msgstr "Haku"
 
 #. IDS_PRPCAT_SECURITY
-#: Merge.rc:5025
+#: Merge.rc:5024
 msgid "Security"
 msgstr "Turvallisuus"
 
 #. IDS_PRPCAT_SOFTWARE
-#: Merge.rc:5026
+#: Merge.rc:5025
 msgid "Software"
 msgstr "Ohjelmisto"
 
 #. IDS_PRPCAT_TASK
-#: Merge.rc:5027
+#: Merge.rc:5026
 msgid "Task"
 msgstr "Tehtävä"
 
 #. IDS_PRPCAT_VIDEO
-#: Merge.rc:5028
+#: Merge.rc:5027
 msgid "Video"
 msgstr "Video"
 
 #. IDS_PRPCAT_HASH
-#: Merge.rc:5029
+#: Merge.rc:5028
 msgid "Hash"
 msgstr "Tiiviste (hash)"
 
 #. IDS_CANT_COMPARE_FILES
-#: Merge.rc:5035
+#: Merge.rc:5034
 msgid "Unable to compare files"
 msgstr "Tiedostoja ei voi verrata"
 
 #. IDS_ABORTED_ITEM
-#: Merge.rc:5036
+#: Merge.rc:5035
 msgid "Item aborted"
 msgstr "Kohde keskeytetty"
 
 #. IDS_FILE_SKIPPED
-#: Merge.rc:5037
+#: Merge.rc:5036
 msgid "File skipped"
 msgstr "Tiedosto ohitettu"
 
 #. IDS_DIR_SKIPPED
-#: Merge.rc:5038
+#: Merge.rc:5037
 msgid "Folder skipped"
 msgstr "Kansio ohitettu"
 
 #. IDS_LEFT_ONLY_IN_FMT
-#: Merge.rc:5039
+#: Merge.rc:5038
 #, c-format
 msgid "Left only: %1"
 msgstr "Vain vasen: %1"
 
 #. IDS_MIDDLE_ONLY_IN_FMT
-#: Merge.rc:5040
+#: Merge.rc:5039
 #, c-format
 msgid "Middle only: %1"
 msgstr "Vain keskimmäinen: %1"
 
 #. IDS_RIGHT_ONLY_IN_FMT
-#: Merge.rc:5041
+#: Merge.rc:5040
 #, c-format
 msgid "Right only: %1"
 msgstr "Vain oikea: %1"
 
 #. IDS_DOES_NOT_EXIST_IN_FMT
-#: Merge.rc:5042
+#: Merge.rc:5041
 #, c-format
 msgid "Does not exist in %1"
 msgstr "Ei ole kohteessa %1"
 
 #. IDS_BIN_FILES_SAME
-#: Merge.rc:5043
+#: Merge.rc:5042
 msgid "Binary files are identical"
 msgstr "Binaaritiedostot ovat samanlaisia"
 
 #. IDS_BIN_FILES_DIFF
-#: Merge.rc:5049
+#: Merge.rc:5048
 msgid "Binary files are different"
 msgstr "Binaaritiedostot ovat erilaisia"
 
 #. IDS_FILES_ARE_DIFFERENT
-#: Merge.rc:5050
+#: Merge.rc:5049
 msgid "Files are different"
 msgstr "Tiedostot ovat erilaisia"
 
 #. IDS_FOLDERS_ARE_DIFFERENT
-#: Merge.rc:5051
+#: Merge.rc:5050
 msgid "Folders are different"
 msgstr "Kansiot ovat erilaisia"
 
 #. IDS_LEFTONLY
-#: Merge.rc:5052
+#: Merge.rc:5051
 msgid "Left Only"
 msgstr "Vain vasen"
 
 #. IDS_RIGHTONLY
-#: Merge.rc:5053
+#: Merge.rc:5052
 msgid "Right Only"
 msgstr "Vain oikea"
 
 #. IDS_MIDDLEONLY
-#: Merge.rc:5054
+#: Merge.rc:5053
 msgid "Middle Only"
 msgstr "Vain keskimmäinen"
 
 #. IDS_NOITEMLEFT
-#: Merge.rc:5055
+#: Merge.rc:5054
 msgid "No item in left"
 msgstr "Ei kohdetta vasemmalla"
 
 #. IDS_NOITEMRIGHT
-#: Merge.rc:5056
+#: Merge.rc:5055
 msgid "No item in right"
 msgstr "Ei kohdetta oikealla"
 
 #. IDS_NOITEMMIDDLE
-#: Merge.rc:5057
+#: Merge.rc:5056
 msgid "No item in middle"
 msgstr "Ei kohdetta keskellä"
 
 #. IDS_CMPRES_ERROR
-#: Merge.rc:5059
+#: Merge.rc:5058
 msgid "Error"
 msgstr "Virhe"
 
 #. IDS_TEXT_FILES_SAME
-#: Merge.rc:5060
+#: Merge.rc:5059
 msgid "Text files are identical"
 msgstr "Tekstitiedostot ovat samanlaisia"
 
 #. IDS_LEFTONLY_DIFF
-#: Merge.rc:5061
+#: Merge.rc:5060
 msgid " (Middle and right are identical)"
 msgstr ""
 
 #. IDS_MIDDLEONLY_DIFF
-#: Merge.rc:5062
+#: Merge.rc:5061
 msgid " (Left and right are identical)"
 msgstr ""
 
 #. IDS_RIGHTONLY_DIFF
-#: Merge.rc:5063
+#: Merge.rc:5062
 msgid " (Left and middle are identical)"
 msgstr ""
 
 #. IDS_PATH_MISMATCH
-#: Merge.rc:5064
+#: Merge.rc:5063
 msgid " (paths differ)"
 msgstr ""
 
 #. IDS_TEXT_FILES_DIFF
-#: Merge.rc:5065
+#: Merge.rc:5064
 msgid "Text files are different"
 msgstr "Tekstitiedostot ovat erilaisia"
 
 #. IDS_IMAGE_FILES_SAME
-#: Merge.rc:5066
+#: Merge.rc:5065
 msgid "Image files are identical"
 msgstr "Kuvatiedostot ovat identtiset"
 
 #. IDS_IMAGE_FILES_DIFF
-#: Merge.rc:5067
+#: Merge.rc:5066
 msgid "Image files are different"
 msgstr "Kuvatiedostot ovat erilaisia"
 
 #. IDS_EXPR_DIFF
-#: Merge.rc:5068
+#: Merge.rc:5067
 #, c-format
 msgid "Files are different (expr: %1)"
 msgstr ""
 
 #. IDS_HASH_GROUP
-#: Merge.rc:5069
+#: Merge.rc:5068
 #, c-format
 msgid "Group%d"
 msgstr "Ryhmä%d"
 
 #. IDS_RENAME_MOVE_DETECTION_DISALBED
-#: Merge.rc:5070
+#: Merge.rc:5069
 msgctxt "Options dialog|Compare|Folder|Detect renames and moves"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_RENAME_MOVE_DETECTION_RENAME
-#: Merge.rc:5071
+#: Merge.rc:5070
 msgid "Detect renames"
 msgstr ""
 
 #. IDS_RENAME_MOVE_DETECTION_RENAME_MOVE
-#: Merge.rc:5072
+#: Merge.rc:5071
 msgid "Detect renames and moves"
 msgstr ""
 
 #. IDS_RENAME_MOVE_MERGE_MODE_RENAME
-#: Merge.rc:5073
+#: Merge.rc:5072
 msgid "Merge renames"
 msgstr ""
 
 #. IDS_RENAME_MOVE_MERGE_MODE_RENAME_MOVE
-#: Merge.rc:5074
+#: Merge.rc:5073
 msgid "Merge renames and moves"
 msgstr ""
 
 #. IDS_RENAMED
-#: Merge.rc:5075
+#: Merge.rc:5074
 msgid "Renamed"
 msgstr ""
 
 #. IDS_RENAMED_MOVED
-#: Merge.rc:5077
+#: Merge.rc:5076
 msgid "Renamed/Moved"
 msgstr ""
 
 #. IDS_RENAMED_MOVED_ITEMS
-#: Merge.rc:5078
+#: Merge.rc:5077
 #, c-format
 msgid "(%1 items)"
 msgstr ""
 
 #. IDS_RENAMED_MOVED_RESULT
-#: Merge.rc:5079
+#: Merge.rc:5078
 #, c-format
 msgid "%1 (set %2): "
 msgstr ""
 
 #. IDS_SWITCH_FLAT_MODE
-#: Merge.rc:5080
+#: Merge.rc:5079
 msgid "Some moved items have been merged.\nIn Tree Mode, these items may appear in positions that do not reflect the actual folder structure, which can be confusing.\nSwitch to Flat Mode?"
 msgstr ""
 
 #. IDS_ELAPSED_TIME
-#: Merge.rc:5086
+#: Merge.rc:5085
 #, c-format
 msgid "Elapsed time: %ld ms"
 msgstr "Kulunut aika: %ld ms"
 
 #. IDS_STATUS_SELITEM1
-#: Merge.rc:5087
+#: Merge.rc:5086
 msgid "1 item selected"
 msgstr "1 kohde valittu"
 
 #. IDS_STATUS_SELITEMS
-#: Merge.rc:5088
+#: Merge.rc:5087
 #, c-format
 msgid "%1 items selected"
 msgstr "%1 kohdetta valittu"
 
 #. IDS_COLDESC_FILENAME
-#: Merge.rc:5094
+#: Merge.rc:5093
 msgid "Filename or folder name."
 msgstr "Tiedosto- tai kansionimi."
 
 #. IDS_COLDESC_DIR
-#: Merge.rc:5095
+#: Merge.rc:5094
 msgid "Subfolder name when subfolders are included."
 msgstr "Alikansion nimi, kun alikansiot ovat mukana."
 
 #. IDS_COLDESC_RESULT
-#: Merge.rc:5096
+#: Merge.rc:5095
 msgid "Comparison result, long form."
 msgstr "Vertailutulokset, pitkä muoto."
 
 #. IDS_COLDESC_LTIMEM
-#: Merge.rc:5101
+#: Merge.rc:5100
 msgid "Left side modification date."
 msgstr "Vasemman muokkauspäivä."
 
 #. IDS_COLDESC_RTIMEM
-#: Merge.rc:5102
+#: Merge.rc:5101
 msgid "Right side modification date."
 msgstr "Oikean muokkauspäivä."
 
 #. IDS_COLDESC_MTIMEM
-#: Merge.rc:5103
+#: Merge.rc:5102
 msgid "Middle side modification date."
 msgstr "Keskimmäinen sivu muokkauspäivä."
 
 #. IDS_COLDESC_EXTENSION
-#: Merge.rc:5104
+#: Merge.rc:5103
 msgid "File's extension."
 msgstr "Tiedostopäätteet."
 
 #. IDS_COLDESC_LSIZE
-#: Merge.rc:5105
+#: Merge.rc:5104
 msgid "Left file size in bytes."
 msgstr "Vasemman tiedoston koko tavuina."
 
 #. IDS_COLDESC_RSIZE
-#: Merge.rc:5106
+#: Merge.rc:5105
 msgid "Right file size in bytes."
 msgstr "Oikean tiedoston koko tavuina."
 
 #. IDS_COLDESC_MSIZE
-#: Merge.rc:5107
+#: Merge.rc:5106
 msgid "Middle file size in bytes."
 msgstr "Keskimmäinen tiedostokoko tavuina."
 
 #. IDS_COLDESC_LSIZE_SHORT
-#: Merge.rc:5108
+#: Merge.rc:5107
 msgid "Left file size abbreviated."
 msgstr "Vasen tiedostokoko lyhennettynä."
 
 #. IDS_COLDESC_RSIZE_SHORT
-#: Merge.rc:5109
+#: Merge.rc:5108
 msgid "Right file size abbreviated."
 msgstr "Oikea tiedostokoko lyhennettynä."
 
 #. IDS_COLDESC_MSIZE_SHORT
-#: Merge.rc:5110
+#: Merge.rc:5109
 msgid "Middle file size abbreviated."
 msgstr "Keskimmäinen tiedosto koko lyhennetty."
 
 #. IDS_COLDESC_LTIMEC
-#: Merge.rc:5116
+#: Merge.rc:5115
 msgid "Left side creation time."
 msgstr "Vasemman puolen luontiaika."
 
 #. IDS_COLDESC_RTIMEC
-#: Merge.rc:5117
+#: Merge.rc:5116
 msgid "Right side creation time."
 msgstr "Oikean puolen luontiaika."
 
 #. IDS_COLDESC_MTIMEC
-#: Merge.rc:5118
+#: Merge.rc:5117
 msgid "Middle side creation time."
 msgstr "Keskimmäisen sivun luontiaika."
 
 #. IDS_COLDESC_NEWER
-#: Merge.rc:5119
+#: Merge.rc:5118
 msgid "Tells which side has newer modification date."
 msgstr "Kertoo kummallako puolella on uudempi muutospäivä."
 
 #. IDS_COLDESC_LVERSION
-#: Merge.rc:5120
+#: Merge.rc:5119
 msgid "Left side file version, only for some file types."
 msgstr ""
 
 #. IDS_COLDESC_RVERSION
-#: Merge.rc:5121
+#: Merge.rc:5120
 msgid "Right side file version, only for some file types."
 msgstr ""
 
 #. IDS_COLDESC_MVERSION
-#: Merge.rc:5126
+#: Merge.rc:5125
 msgid "Middle side file version, only for some file types."
 msgstr ""
 
 #. IDS_COLDESC_RESULT_ABBR
-#: Merge.rc:5127
+#: Merge.rc:5126
 msgid "Short comparison result."
 msgstr "Lyhyt vertailutulos."
 
 #. IDS_COLDESC_LATTRIBUTES
-#: Merge.rc:5128
+#: Merge.rc:5127
 msgid "Left side attributes."
 msgstr "Vasemman puolen määritteet."
 
 #. IDS_COLDESC_RATTRIBUTES
-#: Merge.rc:5129
+#: Merge.rc:5128
 msgid "Right side attributes."
 msgstr "Oikean puolen määritteet."
 
 #. IDS_COLDESC_MATTRIBUTES
-#: Merge.rc:5130
+#: Merge.rc:5129
 msgid "Middle side attributes."
 msgstr "Keskimmäinen sivu määritteet."
 
 #. IDS_COLDESC_LEOL_TYPE
-#: Merge.rc:5131
+#: Merge.rc:5130
 msgid "Left side file EOL type."
 msgstr "Vasemman tiedoston EOL-tyyppi."
 
 #. IDS_COLDESC_REOL_TYPE
-#: Merge.rc:5132
+#: Merge.rc:5131
 msgid "Right side file EOL type."
 msgstr "Oikean tiedoston EOL-tyyppi."
 
 #. IDS_COLDESC_MEOL_TYPE
-#: Merge.rc:5133
+#: Merge.rc:5132
 msgid "Middle side file EOL type."
 msgstr "Keskimmäinen sivu tiedosto EOL-tyyppi."
 
 #. IDS_COLDESC_LENCODING
-#: Merge.rc:5139
+#: Merge.rc:5138
 msgid "Left side encoding."
 msgstr "Vasemman puolen koodaus."
 
 #. IDS_COLDESC_RENCODING
-#: Merge.rc:5140
+#: Merge.rc:5139
 msgid "Right side encoding."
 msgstr "Oikean puolen koodaus."
 
 #. IDS_COLDESC_MENCODING
-#: Merge.rc:5141
+#: Merge.rc:5140
 msgid "Middle side encoding."
 msgstr "Keskimmäinen sivu koodaus."
 
 #. IDS_COLDESC_NIDIFFS
-#: Merge.rc:5142
+#: Merge.rc:5141
 msgid "Number of ignored differences in file. Ignored and cannot be merged."
 msgstr ""
 "Tiedostossa useita ohitettuja eroja. WinMerge on ohittanut nämä erot, eikä "
 "niitä voi yhdistää."
 
 #. IDS_COLDESC_NSDIFFS
-#: Merge.rc:5143
+#: Merge.rc:5142
 msgid "Number of differences in file (excluding ignored)."
 
 #. IDS_COLDESC_BINARY
-#: Merge.rc:5144
+#: Merge.rc:5143
 msgid "Shows an asterisk (*) if the file is binary."
 msgstr "Näyttää tähden(*), jos tiedosto on binäärinen."
 
 #. IDS_COLDESC_UNPACKER
-#: Merge.rc:5145
+#: Merge.rc:5144
 msgid "Unpacker plugin name or pipeline."
 msgstr "Pakkauksen purkuohjelman laajennuksen nimi tai putki."
 
 #. IDS_COLDESC_PREDIFFER
-#: Merge.rc:5146
+#: Merge.rc:5145
 msgid "Prediffer plugin name or pipeline."
 msgstr "Ennakointilaajennuksen nimi tai putki."
 
 #. IDS_DIRECTORY_REPORT_TITLE
-#: Merge.rc:5152
+#: Merge.rc:5151
 #, c-format
 msgid "Compare %1 with %2"
 msgstr "Vertaa %1 -> %2"
 
 #. IDS_DIRECTORY_REPORT_TITLE3
-#: Merge.rc:5153
+#: Merge.rc:5152
 #, c-format
 msgid "Compare %1 with %2 and %3"
 msgstr "Vertaa %1 -> %2 -> %3"
 
 #. IDS_REPORT_COMMALIST
-#: Merge.rc:5154
+#: Merge.rc:5153
 msgid "Comma-separated list"
 msgstr "Pilkuilla erotettu lista"
 
 #. IDS_REPORT_TABLIST
-#: Merge.rc:5155
+#: Merge.rc:5154
 msgid "Tab-separated list"
 msgstr "Sarkain erotettu lista"
 
 #. IDS_REPORT_SIMPLEHTML
-#: Merge.rc:5156
+#: Merge.rc:5155
 msgid "Simple HTML"
 msgstr "Yksinkertainen HTML"
 
 #. IDS_REPORT_SIMPLEXML
-#: Merge.rc:5157
+#: Merge.rc:5156
 msgid "Simple XML"
 msgstr "Yksinkertainen XML"
 
-#: Merge.rc:5159
+#: Merge.rc:5158
 msgid "Report file already exists. Overwrite?"
 msgstr "Raportti on jo olemassa. Haluatko korvata sen sisällön?"
 
 #. IDS_REPORT_ERROR
-#: Merge.rc:5164
+#: Merge.rc:5163
 #, c-format
 msgid ""
 "Error creating the report:\n"
@@ -7191,59 +7186,59 @@ msgstr ""
 "%1"
 
 #. IDS_REPORT_SUCCESS
-#: Merge.rc:5165
+#: Merge.rc:5164
 msgid "Report created successfully."
 msgstr "Raportin luominen onnistui."
 
 #. IDS_SYNCPOINT_LASTBLOCK
-#: Merge.rc:5171
+#: Merge.rc:5170
 msgid "Cannot add a synchronization point at this line."
 msgstr "Synkronointipistettä ei voi lisätä tällä rivillä."
 
 #. IDS_FILE_TO_ITSELF
-#: Merge.rc:5177
+#: Merge.rc:5176
 msgid "Same file is opened in both panes."
 msgstr "Sama tiedosto on avatttu molemmissa paneeleissa."
 
 #. IDS_FILESSAME
-#: Merge.rc:5178
+#: Merge.rc:5177
 msgid "Selected files are identical."
 msgstr "Valitut tiedostot ovat identtisiä."
 
 #. IDS_FILESSAME_CURCFG
-#: Merge.rc:5179
+#: Merge.rc:5178
 msgid "Selected files are identical (with current settings).\r\nChecking binary identity..."
 msgstr ""
 
 #. IDS_FILESSAME_BINERROR
-#: Merge.rc:5180
+#: Merge.rc:5179
 msgid "Selected files are identical (with current settings).\r\nBut binary comparison failed."
 msgstr ""
 
 #. IDS_FILESSAME_BINSAME
-#: Merge.rc:5181
+#: Merge.rc:5180
 msgid "Selected files are identical (binary match)."
 msgstr ""
 
 #. IDS_FILESSAME_BINDIFF
-#: Merge.rc:5182
+#: Merge.rc:5181
 msgid "Selected files are identical (with current settings).\r\nBut differ at the binary level."
 msgstr ""
 
 #. IDS_FILEERROR
-#: Merge.rc:5183
+#: Merge.rc:5182
 msgid "An error occurred while comparing files."
 msgstr "Virhe tiedostojen vertaamisessa."
 
 #. IDS_TEMP_FILEERROR
-#: Merge.rc:5184
+#: Merge.rc:5183
 msgid ""
 "Could not create temporary files. Check your temporary path settings."
 msgstr ""
 "Väliaikaisia tiedostoja ei voi luoda. Tarkista väliaikaiset polkuasetukset."
 
 #. IDS_SUGGEST_IGNOREEOL
-#: Merge.rc:5185
+#: Merge.rc:5184
 msgid "Files use different EOL.\n\nTreat all EOL as equivalent?\n\nSet 'Ignore EOL differences (Windows/Unix/Mac)' in Compare section of Options."
 msgstr ""
 "Nämä tiedostot käyttävät erilaisia rivinvaihtotyyppejä.\n"
@@ -7255,17 +7250,17 @@ msgstr ""
 "välilehden Asetukset-valintaikkunassa (Muokkaa/Asetukset)."
 
 #. IDS_INVALID_DIRECTORY
-#: Merge.rc:5186
+#: Merge.rc:5185
 msgid "Selected folder is invalid."
 msgstr "Valittu kansio ei kelpaa."
 
 #. IDS_CANNOT_OPEN_BINARYFILE
-#: Merge.rc:5187
+#: Merge.rc:5186
 msgid "Cannot open a binary file in Editor."
 msgstr "Binaaritiedostoa voi avata editoriin."
 
 #. IDS_CREATE_PAIR_FOLDER
-#: Merge.rc:5188
+#: Merge.rc:5187
 #, c-format
 msgid "Create matching folder:\n%1\non the other side and open?"
 msgstr ""
@@ -7276,41 +7271,41 @@ msgstr ""
 "toiselle puolelle ja avata nämä kansiot?"
 
 #. IDS_CONFIRM_COPY_ALL_DIFFS
-#: Merge.rc:5189
+#: Merge.rc:5188
 msgid "Copy all differences to other file?"
 msgstr ""
 
 #. IDS_MOVE_TO_NEXTFILE
-#: Merge.rc:5194
+#: Merge.rc:5193
 msgid "Move to next file?"
 msgstr "Haluatko siirtyä seuraavaan tiedostoon?"
 
 #. IDS_MOVE_TO_PREVFILE
-#: Merge.rc:5195
+#: Merge.rc:5194
 msgid "Move to previous file?"
 msgstr "Haluatko siirtyä edelliseen tiedostoon?"
 
 #. IDS_MOVE_TO_NEXTPAGE
-#: Merge.rc:5196
+#: Merge.rc:5195
 msgid "Move to next page?"
 msgstr "Haluatko siirtyä seuraavalle sivulle?"
 
 #. IDS_MOVE_TO_PREVPAGE
-#: Merge.rc:5197
+#: Merge.rc:5196
 msgid "Move to previous page?"
 msgstr "Haluatko siirtyä edelliselle sivulle?"
 
 #. IDS_MOVE_TO_FIRSTFILE
-#: Merge.rc:5198
+#: Merge.rc:5197
 msgid "Move to first file?"
 msgstr "Haluatko siirtyä ensimmäiseen tiedostoon?"
 
 #. IDS_MOVE_TO_LASTFILE
-#: Merge.rc:5199
+#: Merge.rc:5198
 msgid "Move to last file?"
 msgstr "Haluatko siirtyä viimeiseen tiedostoon?"
 
-#: Merge.rc:5206
+#: Merge.rc:5205
 #, c-format
 msgid "Different codepages: left (cp%d), right (cp%d).\nDisplay in codepage (better display) or default Windows codepage (safer merging)?\n(Recommended: default Windows codepage)"
 msgstr ""
@@ -7319,53 +7314,53 @@ msgstr ""
 "yhdistäminen/kopiointi on vaarallista.\n"
 "Haluatko käsitellä molemmat tiedostot Windowsin oletusmerkistöllä (suositus)?"
 
-#: Merge.rc:5208
+#: Merge.rc:5207
 msgid "Information lost due to encoding errors: both files"
 msgstr "Tietoja menetettiin koodausvirheistä johtuen: molemmat tiedostot"
 
-#: Merge.rc:5210
+#: Merge.rc:5209
 msgid "Information lost due to encoding errors: first file"
 msgstr "Koodausvirheiden vuoksi menetetyt tiedot: ensimmäinen tiedosto"
 
-#: Merge.rc:5212
+#: Merge.rc:5211
 msgid "Information lost due to encoding errors: second file"
 msgstr "Koodausvirheiden vuoksi menetetyt tiedot: toinen tiedosto"
 
-#: Merge.rc:5214
+#: Merge.rc:5213
 msgid "Information lost due to encoding errors: third file"
 msgstr "Koodausvirheiden vuoksi menetetyt tiedot: kolmas tiedosto"
 
 #. IDS_LINEDIFF_NODIFF
-#: Merge.rc:5220
+#: Merge.rc:5219
 msgid "No difference"
 msgstr "Ei eroja"
 
 #. IDS_LINEDIFF_NODIFF_CAPTION
-#: Merge.rc:5221
+#: Merge.rc:5220
 msgid "Line difference"
 msgstr "Rivien välinen ero"
 
 #. IDS_NUM_REPLACED
-#: Merge.rc:5227
+#: Merge.rc:5226
 #, c-format
 msgid "Replaced %1 string(s)."
 msgstr "Korvattu %1 merkkijono(a)."
 
 #. IDS_EDIT_TEXT_NOT_FOUND
-#: Merge.rc:5228
+#: Merge.rc:5227
 #, c-format
 msgid "Cannot find string \"%s\"."
 msgstr "Merkkijonoa \"%s\" ei löydy."
 
 #. IDS_MERGE_MODE
-#: Merge.rc:5234
+#: Merge.rc:5233
 msgid "Entering Merge Mode. Press F9 to turn off."
 msgstr ""
 "Olet nyt siirtymässä yhdistämistilaan. Jos haluat poistua yhdistämistilasta, "
 "paina F9-näppäintä."
 
 #. IDS_AUTO_MERGE
-#: Merge.rc:5240
+#: Merge.rc:5239
 #, c-format
 msgid ""
 "Automatic merges: %1\n"
@@ -7375,89 +7370,89 @@ msgstr ""
 "Ratkaisemattomien ristiriitojen määrä: %2"
 
 #. IDS_CODEPAGE_MERGED
-#: Merge.rc:5241
+#: Merge.rc:5240
 msgid "Codepage change merged."
 msgstr "Koodisivun muutos on yhdistetty."
 
 #. IDS_CODEPAGE_CONFLICT
-#: Merge.rc:5242
+#: Merge.rc:5241
 msgid "Codepage changes are conflicting."
 msgstr "Koodisivun muutokset ovat ristiriitaisia."
 
 #. IDS_EOL_MERGED
-#: Merge.rc:5243
+#: Merge.rc:5242
 msgid "EOL change merged."
 msgstr "EOL-muutos on yhdistetty."
 
 #. IDS_EOL_CONFLICT
-#: Merge.rc:5244
+#: Merge.rc:5243
 msgid "EOL changes are conflicting."
 msgstr "EOL-muutokset ovat ristiriitaisia."
 
 #. IDS_LOCBAR_CAPTION
-#: Merge.rc:5250
+#: Merge.rc:5249
 msgid "Location Pane"
 msgstr "Sijaintiruutu"
 
 #. IDS_DIFFBAR_CAPTION
-#: Merge.rc:5251
+#: Merge.rc:5250
 msgid "Diff Pane"
 msgstr "Eroavuusruutu"
 
 #. IDS_DIFF_SUCCEEDED
-#: Merge.rc:5258
+#: Merge.rc:5257
 msgid "Patch file written."
 msgstr "Paikkaustiedoston kirjoitus onnistui."
 
 #. IDS_DIFF_FILEOVERWRITE
-#: Merge.rc:5259
+#: Merge.rc:5258
 msgid "Patch file already exists. Overwrite?"
 msgstr "Paikkaustiedosto on jo olemassa. Haluatko korvata sen?"
 
 #. IDS_DIFF_SELECTEDFILES
-#: Merge.rc:5260
+#: Merge.rc:5259
 #, c-format
 msgid "[%1 files selected]"
 msgstr "[%1 tiedostoa valittu]"
 
 #. IDS_DIFF_NORMAL
-#: Merge.rc:5261
+#: Merge.rc:5260
 msgid "Normal"
 msgstr "Normaali"
 
 #. IDS_DIFF_CONTEXT
-#: Merge.rc:5262
+#: Merge.rc:5261
 msgid "Context"
 msgstr "Konteksti"
 
 #. IDS_DIFF_UNIFIED
-#: Merge.rc:5263
+#: Merge.rc:5262
 msgid "Unified"
 msgstr "Yhtenäistetty"
 
 #. IDS_FILEWRITE_ERROR
-#: Merge.rc:5265
+#: Merge.rc:5264
 #, c-format
 msgid "Could not write to file %1."
 msgstr "Ei voitu kirjoittaa tiedostoon %1."
 
 #. IDS_PATH_NOT_ABSOLUTE
-#: Merge.rc:5266
+#: Merge.rc:5265
 #, c-format
 msgid "Output path is not absolute: %1"
 msgstr "Määritetty kohdepolku ei ole absoluuttinen polku: %1"
 
 #. IDS_MUST_SPECIFY_OUTPUT
-#: Merge.rc:5267
+#: Merge.rc:5266
 msgid "Specify an output file."
 msgstr "Määrittele kohdetiedost."
 
-#: Merge.rc:5269
+#: Merge.rc:5268
 msgid "Cannot create patch from binary files."
 msgstr "Paikkaustiedostoa ei voi luoda binääritiedostoista."
 
 #. IDS_SAVEFILES_FORPATCH
-#: Merge.rc:5270
+#: Merge.rc:5269
 msgid ""
 "Save all files first.\n"
 "\n"
@@ -7469,22 +7464,22 @@ msgstr ""
 "tallentamattomia muutoksia."
 
 #. IDS_FOLDER_NOTEXIST
-#: Merge.rc:5271
+#: Merge.rc:5270
 msgid "Folder does not exist."
 msgstr "Kansiota ei ole olemassa."
 
 #. IDS_ARCHIVE_SUCCEEDED
-#: Merge.rc:5277
+#: Merge.rc:5276
 msgid "Archive file written."
 msgstr ""
 
 #. IDS_ARCHIVE_SAVEFILES
-#: Merge.rc:5278
+#: Merge.rc:5277
 msgid "Save all files first.\n\nCreating an archive requires no unsaved changes."
 msgstr ""
 
 #. IDS_NO_ZIP_SUPPORT
-#: Merge.rc:5283
+#: Merge.rc:5282
 msgid "Archive support not enabled.\n7-Zip and/or Merge7z*.dll not found.\nSee manual for archive support."
 msgstr ""
 "Arkistotuki ei ole käytössä.\n"
@@ -7493,37 +7488,37 @@ msgstr ""
 "Katso käyttöohjeesta lisätietoja arkistotuesta ja kuinka se otetaan käyttöön."
 
 #. IDS_OPT_EXPORT_CAPTION
-#: Merge.rc:5284
+#: Merge.rc:5283
 msgid "Select file for export"
 msgstr "Valitse vietävä tiedosto"
 
 #. IDS_OPT_IMPORT_CAPTION
-#: Merge.rc:5285
+#: Merge.rc:5284
 msgid "Select file for import"
 msgstr "Valitse tuotava tiedosto"
 
 #. IDS_OPT_IMPORT_DONE
-#: Merge.rc:5286
+#: Merge.rc:5285
 msgid "Options imported from file."
 msgstr "Asetukset tuotu tiedostosta."
 
 #. IDS_OPT_EXPORT_DONE
-#: Merge.rc:5287
+#: Merge.rc:5286
 msgid "Options exported to file."
 msgstr "Asetukset viety tiedostoon."
 
 #. IDS_OPT_IMPORT_ERR
-#: Merge.rc:5288
+#: Merge.rc:5287
 msgid "Failed to import options from file."
 msgstr "Asetuksien tuonti tiedostosta epäonnistui."
 
 #. IDS_OPT_EXPORT_ERR
-#: Merge.rc:5289
+#: Merge.rc:5288
 msgid "Failed to write options to file."
 msgstr "Asetuksien kirjoitus tiedostoon epäonnistui."
 
 #. IDS_CLOSEALL_WINDOWS
-#: Merge.rc:5290
+#: Merge.rc:5289
 msgid ""
 "Close multiple compare windows?\n"
 "\n"
@@ -7534,34 +7529,34 @@ msgstr ""
 "Haluatko jatkaa?"
 
 #. IDS_EOL_BIN
-#: Merge.rc:5300
+#: Merge.rc:5299
 msgctxt "EOL Type"
 msgid "Binary"
 msgstr "Binääri"
 
 #. IDS_MARKER_COLOR_FMT
-#: Merge.rc:5305
+#: Merge.rc:5304
 #, c-format
 msgid "Marker Color %d"
 msgstr "Merkin väri %d"
 
 #. IDS_MARKER_NEW_PATTERN
-#: Merge.rc:5306
+#: Merge.rc:5305
 msgid "New Pattern"
 msgstr "Uusi kuvio"
 
 #. IDS_PLUGINSLIST_TYPE
-#: Merge.rc:5312
+#: Merge.rc:5311
 msgid "Type"
 msgstr "Tyyppi"
 
 #. IDS_PLUGINS_TYPE_EDITSCRIPT
-#: Merge.rc:5316
+#: Merge.rc:5315
 msgid "Editor script"
 msgstr "Muokkainskripti"
 
 #. ID_SELECTLINEDIFF
-#: Merge.rc:5322
+#: Merge.rc:5321
 msgid ""
 "\n"
 "Difference in Current Line (F4)"
@@ -7570,7 +7565,7 @@ msgstr ""
 "Ero nykyisessä rivissä (F4)"
 
 #. ID_OPTIONS
-#: Merge.rc:5323
+#: Merge.rc:5322
 msgid ""
 "\n"
 "Options"
@@ -7579,7 +7574,7 @@ msgstr ""
 "Asetukset"
 
 #. ID_REFRESH
-#: Merge.rc:5324
+#: Merge.rc:5323
 msgid ""
 "\n"
 "Refresh (F5)"
@@ -7588,7 +7583,7 @@ msgstr ""
 "Päivitä (F5)"
 
 #. ID_PREVDIFF
-#: Merge.rc:5330
+#: Merge.rc:5329
 msgid ""
 "\n"
 "Previous Difference (Alt+Up)"
@@ -7597,7 +7592,7 @@ msgstr ""
 "Edellinen ero (Alt+Up)"
 
 #. ID_NEXTDIFF
-#: Merge.rc:5331
+#: Merge.rc:5330
 msgid ""
 "\n"
 "Next Difference (Alt+Down)"
@@ -7606,7 +7601,7 @@ msgstr ""
 "Seuraava ero (Alt+Down)"
 
 #. ID_PREVCONFLICT
-#: Merge.rc:5332
+#: Merge.rc:5331
 msgid ""
 "\n"
 "Previous Conflict (Alt+Shift+Up)"
@@ -7615,7 +7610,7 @@ msgstr ""
 "Edellinen ristiriita (Alt+Shift+Up)"
 
 #. ID_NEXTCONFLICT
-#: Merge.rc:5333
+#: Merge.rc:5332
 msgid ""
 "\n"
 "Next Conflict (Alt+Shift+Down)"
@@ -7624,7 +7619,7 @@ msgstr ""
 "Seuraava ristiriita (Alt+Shift+Down)"
 
 #. ID_FIRSTDIFF
-#: Merge.rc:5338
+#: Merge.rc:5337
 msgid ""
 "\n"
 "First Difference (Alt+Home)"
@@ -7633,7 +7628,7 @@ msgstr ""
 "Ensimmäinen ero (Alt+Home)"
 
 #. ID_CURDIFF
-#: Merge.rc:5339
+#: Merge.rc:5338
 msgid ""
 "\n"
 "Current Difference (Alt+Enter)"
@@ -7642,7 +7637,7 @@ msgstr ""
 "Nykyinen ero (Alt+Enter)"
 
 #. ID_LASTDIFF
-#: Merge.rc:5340
+#: Merge.rc:5339
 msgid ""
 "\n"
 "Last Difference (Alt+End)"
@@ -7651,37 +7646,37 @@ msgstr ""
 "Viimeinen ero (Alt+End)"
 
 #. ID_L2R
-#: Merge.rc:5341
+#: Merge.rc:5340
 msgid "\nCopy to Right (Alt+Right)"
 msgstr ""
 
 #. ID_R2L
-#: Merge.rc:5342
+#: Merge.rc:5341
 msgid "\nCopy to Left (Alt+Left)"
 msgstr ""
 
 #. ID_L2RNEXT
-#: Merge.rc:5343
+#: Merge.rc:5342
 msgid "\nCopy to Right and Advance (Ctrl+Alt+Right)"
 msgstr ""
 
 #. ID_R2LNEXT
-#: Merge.rc:5344
+#: Merge.rc:5343
 msgid "\nCopy to Left and Advance (Ctrl+Alt+Left)"
 msgstr ""
 
 #. ID_ALL_RIGHT
-#: Merge.rc:5345
+#: Merge.rc:5344
 msgid "\nCopy All to Right"
 msgstr ""
 
 #. ID_ALL_LEFT
-#: Merge.rc:5346
+#: Merge.rc:5345
 msgid "\nCopy All to Left"
 msgstr ""
 
 #. ID_AUTO_MERGE
-#: Merge.rc:5347
+#: Merge.rc:5346
 msgid ""
 "\n"
 "Auto Merge (Ctrl+Alt+M)"
@@ -7690,7 +7685,7 @@ msgstr ""
 "Yhdistä automaattisesti (Ctrl+Alt+M)"
 
 #. ID_FIRSTFILE
-#: Merge.rc:5348
+#: Merge.rc:5347
 msgid ""
 "\n"
 "First File"
@@ -7699,7 +7694,7 @@ msgstr ""
 "Ensimmäinen tiedosto"
 
 #. ID_NEXTFILE
-#: Merge.rc:5349
+#: Merge.rc:5348
 msgid ""
 "\n"
 "Next File (Ctrl+F8)"
@@ -7708,7 +7703,7 @@ msgstr ""
 "Seuraava tiedosto (Ctrl+F8)"
 
 #. ID_LASTFILE
-#: Merge.rc:5350
+#: Merge.rc:5349
 msgid ""
 "\n"
 "Last File"
@@ -7717,7 +7712,7 @@ msgstr ""
 "Viimeinen tiedosto"
 
 #. ID_PREVFILE
-#: Merge.rc:5351
+#: Merge.rc:5350
 msgid ""
 "\n"
 "Previous File (Ctrl+F7)"
@@ -7726,143 +7721,143 @@ msgstr ""
 "Edellinen tiedosto (Ctrl+F7)"
 
 #. IDS_UNPACK_AUTO
-#: Merge.rc:5358
+#: Merge.rc:5357
 msgid "Adapted unpacker applied to both files (one needs extension)."
 msgstr ""
 "Mukautettua purkajaa käytetään molempiin tiedostoihin (vain yksi tiedosto "
 "tarvitsee päätteen)."
 
 #. IDS_NO_PREDIFFER
-#: Merge.rc:5359
+#: Merge.rc:5358
 msgid "No Prediffer (Normal)"
 msgstr "Ei esivertailua (normaali)"
 
 #. IDS_SUGGESTED_PLUGINS
-#: Merge.rc:5360
+#: Merge.rc:5359
 msgid "Suggested Plugins"
 msgstr "Suositellut lisäosat"
 
 #. IDS_NOT_SUGGESTED_PLUGINS
-#: Merge.rc:5361
+#: Merge.rc:5360
 msgid "All Plugins"
 msgstr "Kaikki laajennukset"
 
 #. IDS_PRIVATEBUILD_FMT
-#: Merge.rc:5367
+#: Merge.rc:5366
 #, c-format
 msgid "Private Build: %1"
 msgstr "Yksityinen rakenne: %1"
 
 #. IDS_ALLRIGHTS_RESERVED
-#: Merge.rc:5368
+#: Merge.rc:5367
 msgid " - All rights reserved."
 msgstr ""
 
 #. IDS_TITLE_PLUGINS_SETTINGS
-#: Merge.rc:5374
+#: Merge.rc:5373
 msgid "Plugin Settings"
 msgstr "Lisäosien asetukset"
 
 #. IDS_NO_SCT_SCRIPTS
-#: Merge.rc:5376
+#: Merge.rc:5375
 msgid "WSH not found - .sct scripts disabled"
 msgstr "WSH ei löytynyt - .sct skriptit poistettu käytöstä"
 
 #. IDS_LOCBAR_GOTOLINE_FMT
-#: Merge.rc:5384
+#: Merge.rc:5383
 #, c-format
 msgid "G&o to Line %1"
 msgstr "Siirry riville %1"
 
 #. IDS_GOTO_MOVED_LINE
-#: Merge.rc:5390
+#: Merge.rc:5389
 msgid "Go to Moved Line\tCtrl+Shift+G"
 msgstr "Siirry siirrettyyn riviin\tCtrl+Shift+G"
 
 #. IDS_AUTOCOMPLETE_DISABLED
-#: Merge.rc:5396
+#: Merge.rc:5395
 msgctxt "Options dialog|General|Open dialog Auto completion"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_AUTOCOMPLETE_FILE_SYS
-#: Merge.rc:5397
+#: Merge.rc:5396
 msgid "From file system"
 msgstr "Tiedostojärjestelmästä"
 
 #. IDS_AUTOCOMPLETE_MRU
-#: Merge.rc:5398
+#: Merge.rc:5397
 msgid "From Most Recently Used list"
 msgstr "MRU listalta"
 
 #. IDS_COLORSCHEME_PLAIN
-#: Merge.rc:5404
+#: Merge.rc:5403
 msgid "No Highlighting"
 msgstr "Ei korostusta"
 
 #. IDS_COLORSCHEME_PO
-#: Merge.rc:5439
+#: Merge.rc:5438
 msgid "Portable Object"
 msgstr "Siirrettävä objekti"
 
 #. IDS_COLORSCHEME_RSRC
-#: Merge.rc:5444
+#: Merge.rc:5443
 msgid "Resources"
 msgstr "Resurssit"
 
 #. IDS_COLORSCHEME_SH
-#: Merge.rc:5448
+#: Merge.rc:5447
 msgid "Shell"
 msgstr "Shell"
 
 #. IDS_CLOSE_LEFT_TABS
-#: Merge.rc:5469
+#: Merge.rc:5468
 msgid "Close &Left Tabs"
 msgstr "Sulje vasemmat väli&lehdet"
 
 #. IDS_CLOSE_RIGHT_TABS
-#: Merge.rc:5470
+#: Merge.rc:5469
 msgid "Close R&ight Tabs"
 msgstr "Sulje oikeat väl&ilehdet"
 
 #. IDS_CLOSE_OTHER_TABS
-#: Merge.rc:5471
+#: Merge.rc:5470
 msgid "Close &Other Tabs"
 msgstr "Sulje &muut välilehdet"
 
 #. IDS_TABBAR_AUTO_MAXWIDTH
-#: Merge.rc:5472
+#: Merge.rc:5471
 msgid "Enable &Auto Max Width"
 msgstr "Käytä &automaattista maksimi leveyttä"
 
 #. IDS_WEBPAGE_MENU
-#: Merge.rc:5482
+#: Merge.rc:5481
 msgid "We&bpage"
 msgstr "Ver&kkosivu"
 
 #. IDS_VIEW_WRAP_TEXT
-#: Merge.rc:5487
+#: Merge.rc:5486
 msgid "W&rap Text"
 msgstr ""
 
 #. IDS_NOTINSTALLED
-#: Merge.rc:5492
+#: Merge.rc:5491
 msgid "%1 is not installed."
 msgstr "%1 ei ole asennettu."
 
 #. IDS_CREATE_FOLDER
-#: Merge.rc:5497
+#: Merge.rc:5496
 #, c-format
 msgid "%1 does not exist. Create it?"
 msgstr "%1 ei ole. Haluatko luoda sen?"
 
 #. IDS_CREATE_FOLDER_ERROR
-#: Merge.rc:5498
+#: Merge.rc:5497
 msgid "Failed to create folder."
 msgstr "Kansiota ei voitu luoda."
 
 #. IDC_EXT_EDITOR_PATH
-#: Merge.rc:5503
+#: Merge.rc:5502
 msgid ""
 "Parameters:\n"
 "$file: Current file path\n"
@@ -7873,308 +7868,308 @@ msgstr ""
 "$linenum: Kohdistimen nykyisen sijainnin rivinumero"
 
 #. IDS_DIFF_ALGORITHM_DEFAULT
-#: Merge.rc:5508
+#: Merge.rc:5507
 msgid "default"
 msgstr "oletus"
 
 #. IDS_DIFF_ALGORITHM_MINIMAL
-#: Merge.rc:5509
+#: Merge.rc:5508
 msgid "minimal"
 msgstr "minimaalinen"
 
 #. IDS_DIFF_ALGORITHM_PATIENCE
-#: Merge.rc:5510
+#: Merge.rc:5509
 msgid "patience"
 msgstr "kärsivällisyyttä"
 
 #. IDS_DIFF_ALGORITHM_HISTOGRAM
-#: Merge.rc:5511
+#: Merge.rc:5510
 msgid "histogram"
 msgstr "histogrammi"
 
 #. IDS_DIFF_ALGORITHM_NONE
-#: Merge.rc:5512
+#: Merge.rc:5511
 msgid "none"
 msgstr "ei mikään"
 
 #. IDS_RENDERING_MODE_GDI
-#: Merge.rc:5517
+#: Merge.rc:5516
 msgid "GDI"
 msgstr "GDI"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_DEFAULT
-#: Merge.rc:5518
+#: Merge.rc:5517
 msgid "DirectWrite Default"
 msgstr "DirectWrite oletus"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_ALIASED
-#: Merge.rc:5519
+#: Merge.rc:5518
 msgid "DirectWrite Aliased"
 msgstr "DirectWrite alias"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_GDI_CLASSIC
-#: Merge.rc:5520
+#: Merge.rc:5519
 msgid "DirectWrite GDI Classic"
 msgstr "DirectWrite GDI klassinen"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_GDI_NATURAL
-#: Merge.rc:5521
+#: Merge.rc:5520
 msgid "DirectWrite GDI Natural"
 msgstr "DirectWrite GDI luonnollinen"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_NATURAL
-#: Merge.rc:5522
+#: Merge.rc:5521
 msgid "DirectWrite Natural"
 msgstr "DirectWrite luonnollinen"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_NATURAL_SYMMETRIC
-#: Merge.rc:5523
+#: Merge.rc:5522
 msgid "DirectWrite Natural Symmetric"
 msgstr "DirectWrite Natural symmetrinen"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_DISABLED
-#: Merge.rc:5528
+#: Merge.rc:5527
 msgctxt "Options dialog|General|Close windows with Esc"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_1
-#: Merge.rc:5529
+#: Merge.rc:5528
 msgid "MDI child window or main window"
 msgstr "MDI ali-ikkuna tai pääikkuna"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_2
-#: Merge.rc:5530
+#: Merge.rc:5529
 msgid "MDI child window only"
 msgstr "Vain MDI ali-ikkuna"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_3
-#: Merge.rc:5531
+#: Merge.rc:5530
 msgid "Close main window if only one MDI child window"
 msgstr "Sulje pääikkuna, jos on vain yksi MDI ali-ikkuna"
 
 #. IDS_DIFF_GROUP
-#: Merge.rc:5536
+#: Merge.rc:5535
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Diff"
 msgstr "Ero"
 
 #. IDS_DIFF_HIGHLIGHT
-#: Merge.rc:5537
+#: Merge.rc:5536
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Highlight"
 msgstr "Korostus"
 
 #. IDS_DIFF_BLINK
-#: Merge.rc:5538
+#: Merge.rc:5537
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Blink"
 msgstr "Vilkku"
 
 #. IDS_DIFF_BLOCKSIZE
-#: Merge.rc:5539
+#: Merge.rc:5538
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Block Size"
 msgstr "Lohkon koko"
 
 #. IDS_DIFF_BLOCKALPHA
-#: Merge.rc:5540
+#: Merge.rc:5539
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Block Alpha"
 msgstr "Lohko Alfa"
 
 #. IDS_DIFF_CDTHRESHOLD
-#: Merge.rc:5541
+#: Merge.rc:5540
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "CD Threshold"
 msgstr "CD kynnys"
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION
-#: Merge.rc:5542
+#: Merge.rc:5541
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Ins/Del Detection"
 msgstr "Ins/Del-tunnistus"
 
 #. IDS_OVERLAY_MODE_NONE
-#: Merge.rc:5543 Merge.rc:5548
+#: Merge.rc:5542 Merge.rc:5547
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "None"
 msgstr "Ei mikään"
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION_VERTICAL
-#: Merge.rc:5544
+#: Merge.rc:5543
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Vertical"
 msgstr "Pystysuora"
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION_HORIZONTAL
-#: Merge.rc:5545
+#: Merge.rc:5544
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Horizontal"
 msgstr "Vaakasuora"
 
 #. IDS_OVERLAY_GROUP
-#: Merge.rc:5546
+#: Merge.rc:5545
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Overlay"
 msgstr "Peite (Overlay)"
 
 #. IDS_OVERLAY_ALPHA
-#: Merge.rc:5547
+#: Merge.rc:5546
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha"
 msgstr "Alfa"
 
 #. IDS_OVERLAY_MODE_XOR
-#: Merge.rc:5549
+#: Merge.rc:5548
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "XOR"
 msgstr "XOR"
 
 #. IDS_OVERLAY_MODE_ALPHA
-#: Merge.rc:5550
+#: Merge.rc:5549
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha Blend"
 msgstr "Alfasekoitus"
 
 #. IDS_OVERLAY_MODE_ALPHA_ANIMATION
-#: Merge.rc:5551
+#: Merge.rc:5550
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha Animation"
 msgstr "Alfa-animaatio"
 
 #. IDS_ZOOM
-#: Merge.rc:5552
+#: Merge.rc:5551
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Zoom"
 msgstr "Suurennus"
 
 #. IDS_PAGE
-#: Merge.rc:5553
+#: Merge.rc:5552
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Page:"
 msgstr "Sivu:"
 
 #. IDS_IMGCMP_STATUS_PT_RGBA_FMT
-#: Merge.rc:5554
+#: Merge.rc:5553
 #, c-format
 msgid "Pt: (%d, %d)  RGBA: (%d, %d, %d, %d)  "
 msgstr "Pt: (%d, %d)  RGBA: (%d, %d, %d, %d)  "
 
 #. IDS_IMGCMP_STATUS_DIST1_FMT
-#: Merge.rc:5555
+#: Merge.rc:5554
 #, c-format
 msgid "Dist: %g  "
 msgstr "Dist: %g  "
 
 #. IDS_IMGCMP_STATUS_DIST2_FMT
-#: Merge.rc:5556
+#: Merge.rc:5555
 #, c-format
 msgid "Dist: %g, %g  "
 msgstr "Dist: %g, %g  "
 
 #. IDS_IMGCMP_STATUS_PAGE_ZOOM_SIZE_BPP_FMT
-#: Merge.rc:5557
+#: Merge.rc:5556
 #, c-format
 msgid "Page: %d/%d  Zoom: %d%%  %dx%dpx  %dbpp  "
 msgstr ""
 
 #. IDS_IMGCMP_STATUS_RC_FMT
-#: Merge.rc:5558
+#: Merge.rc:5557
 #, c-format
 msgid "Rc: (%d, %d)  "
 msgstr "Rc: (%d, %d)  "
 
 #. IDS_IMGCMP_STATUS_FLIPPED_FMT
-#: Merge.rc:5559
+#: Merge.rc:5558
 #, c-format
 msgid "Flipped: %s  "
 msgstr "Käännetty: %s "
 
 #. IDS_IMGCMP_STATUS_ROTATED_FMT
-#: Merge.rc:5560
+#: Merge.rc:5559
 #, c-format
 msgid "Rotated: %d  "
 msgstr "Kierretty: %d "
 
 #. IDS_IMGCMP_REPORT_ALLPAGES
-#: Merge.rc:5561
+#: Merge.rc:5560
 msgid "All pages"
 msgstr "Kaikki sivut"
 
 #. IDS_IGNSUB_STR1
-#: Merge.rc:5566
+#: Merge.rc:5565
 msgid "<Edit here>"
 msgstr "<Muokkaa tässä>"
 
 #. IDS_IGNSUB_STR2
-#: Merge.rc:5567
+#: Merge.rc:5566
 msgid "No differences found to select"
 msgstr "Valittavissa olevia eroja ei löydy"
 
 #. IDS_IGNSUB_STR3
-#: Merge.rc:5568
+#: Merge.rc:5567
 msgid "No differences found to add as substitution filter"
 msgstr ""
 
 #. IDS_IGNSUB_STR4
-#: Merge.rc:5569
+#: Merge.rc:5568
 msgid "The pair is already in the Substitution Filters list"
 msgstr ""
 
 #. IDS_IGNSUB_STR5
-#: Merge.rc:5570
+#: Merge.rc:5569
 msgid "Add this change to Substitution Filters?"
 msgstr ""
 
 #. IDS_OCRRESULT_TEXTONLY
-#: Merge.rc:5575
+#: Merge.rc:5574
 msgid "Text only"
 msgstr "Vain teksti"
 
 #. IDS_OCRRESULT_POS_LINE
-#: Merge.rc:5576
+#: Merge.rc:5575
 msgid "Line-by-line position and text"
 msgstr "Rivikohtainen sijainti ja teksti"
 
 #. IDS_OCRRESULT_POS_WORD
-#: Merge.rc:5577
+#: Merge.rc:5576
 msgid "Word-by-word position and text"
 msgstr "Sanakohtainen sijainti ja teksti"
 
 #. IDS_USERDATAFOLDER_APPDATA
-#: Merge.rc:5582
+#: Merge.rc:5581
 msgid "AppData (Roaming) folder"
 msgstr ""
 
 #. IDS_USERDATAFOLDER_INSTALL
-#: Merge.rc:5583
+#: Merge.rc:5582
 msgid "Install folder"
 msgstr "Asennuskansio"
 
 #. IDS_USERDATAFOLDER_DOCUMENTS
-#: Merge.rc:5584
+#: Merge.rc:5583
 msgid "Documents folder"
 msgstr ""
 
 #. IDS_SINGLEINSTANCE_DISABLED
-#: Merge.rc:5589
+#: Merge.rc:5588
 msgctxt "Options dialog|General|Single instance mode"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_SINGLEINSTANCE_STR1
-#: Merge.rc:5590
+#: Merge.rc:5589
 msgid "Allow only one instance to run"
 msgstr ""
 
 #. IDS_CLIPBOARD_HISTORY
-#: Merge.rc:5591
+#: Merge.rc:5590
 msgid "Clipboard &History"
 msgstr ""
 
 #. IDS_SINGLEINSTANCE_STR2
-#: Merge.rc:5592
+#: Merge.rc:5591
 msgid ""
 "Allow only one instance; wait for termination"
 msgstr ""
@@ -8182,602 +8177,602 @@ msgstr ""
 "lopetetaan"
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_DISABLED
-#: Merge.rc:5597
+#: Merge.rc:5596
 msgctxt "Options dialog|General|Auto-reload modified files"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_STR1
-#: Merge.rc:5598
+#: Merge.rc:5597
 msgid "Only on window activated"
 msgstr ""
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_STR2
-#: Merge.rc:5599
+#: Merge.rc:5598
 msgid "Immediately"
 msgstr ""
 
 #. IDS_PLUGIN_ALL
-#: Merge.rc:5604
+#: Merge.rc:5603
 msgid "Al&l"
 msgstr "K&aikki"
 
 #. IDS_PLUGIN_OTHERS
-#: Merge.rc:5605
+#: Merge.rc:5604
 msgid "&Others"
 msgstr "&Muut"
 
-#: Merge.rc:5607
+#: Merge.rc:5606
 #, c-format
 msgid "Missing plugin name in pipeline: %1"
 msgstr "Puuttuva lisäosan nimi laajennusputkessa: %1"
 
-#: Merge.rc:5609
+#: Merge.rc:5608
 #, c-format
 msgid "Missing quote in plugin pipeline: %1"
 msgstr "Puuttuva lainausmerkki laajennusputkessa: %1"
 
 #. IDS_PLUGIN_NAME_ALREADY_EXISTS
-#: Merge.rc:5610
+#: Merge.rc:5609
 #, c-format
 msgid "Plugin name '%1' already exists."
 msgstr ""
 
 #. IDS_PLUGIN_TITLE1
-#: Merge.rc:5611
+#: Merge.rc:5610
 msgid "Specify plugin arguments"
 msgstr "Määritä laajennuksen argumentit"
 
-#: Merge.rc:5613
+#: Merge.rc:5612
 #, c-format
 msgid "Plugin not found or invalid: %1"
 msgstr ""
 
 #. IDS_PLUGIN_NOT_UNPACK
-#: Merge.rc:5614
+#: Merge.rc:5613
 #, c-format
 msgid "'%1' is not an unpacker plugin"
 msgstr ""
 
 #. IDS_PLUGIN_NOT_PREDIFF
-#: Merge.rc:5615
+#: Merge.rc:5614
 #, c-format
 msgid "'%1' is not a prediffer plugin"
 msgstr ""
 
-#: Merge.rc:5617
+#: Merge.rc:5616
 #, c-format
 msgid "Error prediffing '%1' with '%2'. Prediffing disabled."
 msgstr ""
 
 #. IDS_PLUGIN_CIRCULAR_REFERENCE
-#: Merge.rc:5618
+#: Merge.rc:5617
 #, c-format
 msgid "Circular reference in plugin pipeline: %1"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE1
-#: Merge.rc:5619
+#: Merge.rc:5618
 msgid "URL Handler"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE2
-#: Merge.rc:5620
+#: Merge.rc:5619
 msgid "File Unpacker"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE3
-#: Merge.rc:5621
+#: Merge.rc:5620
 msgid "File or Folder Unpacker"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE5
-#: Merge.rc:5623
+#: Merge.rc:5622
 msgid "Alias for Unpacker"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE6
-#: Merge.rc:5624
+#: Merge.rc:5623
 msgid "Alias for Prediffer"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE7
-#: Merge.rc:5625
+#: Merge.rc:5624
 msgid "Alias for Editor script"
 msgstr ""
 
 #. IDS_PLUGIN_ALIAS_DESC
-#: Merge.rc:5626
+#: Merge.rc:5625
 #, c-format
 msgid "Alias for plugin pipeline '%1'"
 msgstr ""
 
 #. IDS_PLUGIN_NEW_DESC
-#: Merge.rc:5627
+#: Merge.rc:5626
 msgid "New plugin description"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_ALL
-#: Merge.rc:5628
+#: Merge.rc:5627
 msgid "All"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_1ST
-#: Merge.rc:5629
+#: Merge.rc:5628
 msgid "1st"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_2ND
-#: Merge.rc:5630
+#: Merge.rc:5629
 msgid "2nd"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_3RD
-#: Merge.rc:5631
+#: Merge.rc:5630
 msgid "3rd"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_1ST_2ND
-#: Merge.rc:5632
+#: Merge.rc:5631
 msgid "1st and 2nd"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_1ST_3RD
-#: Merge.rc:5633
+#: Merge.rc:5632
 msgid "1st and 3rd"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_2ND_3RD
-#: Merge.rc:5634
+#: Merge.rc:5633
 msgid "2nd and 3rd"
 msgstr ""
 
 #. IDS_PLUGIN_CTRL_CLICK
-#: Merge.rc:5635
+#: Merge.rc:5634
 msgid "(Ctrl+Click to add to pipeline)"
 msgstr ""
 
 #. IDS_FILTER_APPLIED
-#: Merge.rc:5640
+#: Merge.rc:5639
 msgid "Filter applied"
 msgstr "Sovellettu suodatin"
 
 #. IDS_FILTERMENU_COMPARE
-#: Merge.rc:5645
+#: Merge.rc:5644
 #, c-format
 msgid "Compare %1"
 msgstr ""
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN2
-#: Merge.rc:5647
+#: Merge.rc:5646
 msgid "&Filter by This Column..."
 msgstr ""
 
 #. IDS_CLIPBOARDHISTORY_TIME
-#: Merge.rc:5652
+#: Merge.rc:5651
 #, c-format
 msgid "Clipboard at %s"
 msgstr "Leikepöytä %s"
 
 #. IDS_CLIPBOARDHISTORY_DISABLED
-#: Merge.rc:5653
+#: Merge.rc:5652
 msgid "Clipboard history disabled.\r\nEnable: Windows logo key + V, then Turn on."
 msgstr ""
 
-#: Merge.rc:5655
+#: Merge.rc:5654
 msgid "This system does not support clipboard history."
 msgstr "Tämä järjestelmä ei tue leikepöydän historiaa."
 
-#: Merge.rc:5657
+#: Merge.rc:5656
 msgid "32-bit WinMerge does not support Clipboard Compare"
 msgstr "WinMergen 32-bittinen versio ei tue leikepöytävertailua"
 
 #. IDS_WEBVIEW2_RUNTIME_NOT_INSTALLED
-#: Merge.rc:5662
+#: Merge.rc:5661
 msgid "WebView2 runtime not installed. Download it?"
 msgstr "WebView2-runtimea ei ole asennettu. Haluatko ladata sen?"
 
 #. IDS_JUMPLIST_NEW_TEXT_COMPARE
-#: Merge.rc:5667
+#: Merge.rc:5666
 msgid "New Text Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_TABLE_COMPARE
-#: Merge.rc:5668
+#: Merge.rc:5667
 msgid "New Table Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_BINARY_COMPARE
-#: Merge.rc:5669
+#: Merge.rc:5668
 msgid "New Binary Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_IMAGE_COMPARE
-#: Merge.rc:5670
+#: Merge.rc:5669
 msgid "New Image Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_WEBPAGE_COMPARE
-#: Merge.rc:5671
+#: Merge.rc:5670
 msgid "New Webpage Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_FOLDER_COMPARE
-#: Merge.rc:5672
+#: Merge.rc:5671
 msgid "New Folder Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_CLIPBOARD_COMPARE
-#: Merge.rc:5673
+#: Merge.rc:5672
 msgid "Clipboard Compare"
 msgstr ""
 
 #. IDS_PREVIEWBAR_PRINT
-#: Merge.rc:5678
+#: Merge.rc:5677
 msgid "&Print..."
 msgstr ""
 
 #. IDS_PREVIEWBAR_PREVPAGE
-#: Merge.rc:5680
+#: Merge.rc:5679
 msgid "Pre&v Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_TWOPAGE
-#: Merge.rc:5681
+#: Merge.rc:5680
 msgid "&Two Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_ONEPAGE
-#: Merge.rc:5682
+#: Merge.rc:5681
 msgid "&One Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_ZOOMIN
-#: Merge.rc:5683
+#: Merge.rc:5682
 msgid "Zoom &In"
 msgstr ""
 
 #. IDS_PREVIEWBAR_ZOOMOUT
-#: Merge.rc:5684
+#: Merge.rc:5683
 msgid "Zoom &Out"
 msgstr ""
 
 #. IDS_WEBPAGE_COMPARING
-#: Merge.rc:5690
+#: Merge.rc:5689
 msgid "Comparing..."
 msgstr ""
 
 #. IDS_WEBPAGE_ZOOM
-#: Merge.rc:5691
+#: Merge.rc:5690
 msgid "Zoom:"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_DIFFHUNK
-#: Merge.rc:5696
+#: Merge.rc:5695
 msgid "Diff hunk"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_INLINE
-#: Merge.rc:5697
+#: Merge.rc:5696
 msgid "Inline diff"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_LINE
-#: Merge.rc:5698
+#: Merge.rc:5697
 msgid "Line"
 msgstr ""
 
-#: Merge.rc:5699
+#: Merge.rc:5698
 msgid "Character"
 msgstr ""
 
 #. ID_MICE_PREVDIFF
-#: Merge.rc:5704
+#: Merge.rc:5703
 msgid "\nPrevious Difference (Alt+Up)\n(Right Button+Wheel Up)\n(Alt+Wheel Up)"
 msgstr ""
 
 #. ID_MICE_NEXTDIFF
-#: Merge.rc:5705
+#: Merge.rc:5704
 msgid "\nNext Difference (Alt+Down)\n(Right Button+Wheel Down)\n(Alt+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_L2R
-#: Merge.rc:5706
+#: Merge.rc:5705
 msgid "\nCopy to Right (Alt+Right)\n(Right Button+Wheel Right)\n(Alt+Wheel Right)\n(Alt+Shift+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_R2L
-#: Merge.rc:5707
+#: Merge.rc:5706
 msgid "\nCopy to Left (Alt+Left)\n(Right Button+Wheel Left)\n(Alt+Wheel Left)\n(Alt+Shift+Wheel Up)"
 msgstr ""
 
 #. ID_MICE_L2RNEXT
-#: Merge.rc:5708
+#: Merge.rc:5707
 msgid "\nCopy to Right and Advance (Ctrl+Alt+Right)\n(Ctrl+Alt+Wheel Right)\n(Ctrl+Alt+Shift+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_R2LNEXT
-#: Merge.rc:5709
+#: Merge.rc:5708
 msgid "\nCopy to Left and Advance (Ctrl+Alt+Left)\n(Ctrl+Alt+Wheel Left)\n(Ctrl+Alt+Shift+Wheel Up)"
 msgstr ""
 
 #. IDS_LOG_COMPARING_2
-#: Merge.rc:5719
+#: Merge.rc:5718
 #, c-format
 msgid "Comparing %1 with %2"
 msgstr ""
 
 #. IDS_LOG_COMPARING_3
-#: Merge.rc:5720
+#: Merge.rc:5719
 #, c-format
 msgid "Comparing %1 with %2 and %3"
 msgstr ""
 
 #. IDS_LOG_COMPARE_COMPLETED
-#: Merge.rc:5721
+#: Merge.rc:5720
 msgid "Comparison completed"
 msgstr ""
 
 #. IDS_LOG_COMPARE_ERROR_2
-#: Merge.rc:5722
+#: Merge.rc:5721
 #, c-format
 msgid "Failed to compare %1 with %2: "
 msgstr ""
 
 #. IDS_LOG_COMPARE_ERROR_3
-#: Merge.rc:5723
+#: Merge.rc:5722
 #, c-format
 msgid "Failed to compare %1 with %2 and %3: "
 msgstr ""
 
 #. IDS_LOG_FILE_SAVED
-#: Merge.rc:5724
+#: Merge.rc:5723
 msgid "File saved"
 msgstr ""
 
 #. IDS_LOG_COPYING_FILES
-#: Merge.rc:5725
+#: Merge.rc:5724
 msgid "Copying files..."
 msgstr ""
 
 #. IDS_LOG_MOVING_FILES
-#: Merge.rc:5726
+#: Merge.rc:5725
 msgid "Moving files..."
 msgstr ""
 
 #. IDS_LOG_DELETING_FILES
-#: Merge.rc:5727
+#: Merge.rc:5726
 msgid "Deleting files..."
 msgstr ""
 
 #. IDS_LOG_RECYCLEBIN
-#: Merge.rc:5728
+#: Merge.rc:5727
 msgid "Recycle Bin"
 msgstr ""
 
 #. IDS_LOG_PERMANENTLY_DELETED
-#: Merge.rc:5729
+#: Merge.rc:5728
 msgid "Permanently deleted"
 msgstr ""
 
 #. IDS_LOG_FILEOPERATION_COMPLETED
-#: Merge.rc:5730
+#: Merge.rc:5729
 msgid "File operation completed successfully"
 msgstr ""
 
 #. IDS_LOG_FILEOPERATION_CANCELED
-#: Merge.rc:5731
+#: Merge.rc:5730
 msgid "File operation canceled"
 msgstr ""
 
 #. IDS_FILTER_ERROR_NO_ERROR
-#: Merge.rc:5736
+#: Merge.rc:5735
 msgid "No error"
 msgstr ""
 
 #. IDS_FILTER_ERROR_EMPTY_EXPRESSION
-#: Merge.rc:5737
+#: Merge.rc:5736
 msgid "Filter expression is empty"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNKNOWN_CHAR
-#: Merge.rc:5738
+#: Merge.rc:5737
 msgid "Unknown character in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNTERMINATED_STRING
-#: Merge.rc:5739
+#: Merge.rc:5738
 msgid "Unterminated string literal"
 msgstr ""
 
 #. IDS_FILTER_ERROR_SYNTAX_ERROR
-#: Merge.rc:5740
+#: Merge.rc:5739
 msgid "Syntax error in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_PARSE_FAILURE
-#: Merge.rc:5741
+#: Merge.rc:5740
 msgid "Failed to parse filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_LITERAL
-#: Merge.rc:5742
+#: Merge.rc:5741
 msgid "Invalid literal value"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_REGULAR_EXPRESSION
-#: Merge.rc:5743
+#: Merge.rc:5742
 msgid "Invalid regular expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNDEFINED_IDENTIFIER
-#: Merge.rc:5744
+#: Merge.rc:5743
 msgid "Undefined identifier"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_ARGUMENT_COUNT
-#: Merge.rc:5745
+#: Merge.rc:5744
 msgid "Invalid number of arguments"
 msgstr ""
 
 #. IDS_FILTER_ERROR_FILTER_NAME_NOT_FOUND
-#: Merge.rc:5746
+#: Merge.rc:5745
 msgid "Filter name not found"
 msgstr ""
 
 #. IDS_FILTER_ERROR_DIVIDE_BY_ZERO
-#: Merge.rc:5747
+#: Merge.rc:5746
 msgid "Division by zero in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNKNOWN_ERROR
-#: Merge.rc:5748
+#: Merge.rc:5747
 msgid "Unknown error"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_PROPERTY_NAME
-#: Merge.rc:5749
+#: Merge.rc:5748
 msgid "Invalid property name"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_DIRECTIVE
-#: Merge.rc:5750
+#: Merge.rc:5749
 msgid "Invalid directive"
 msgstr ""
 
 #. IDS_FILTER_OP_EQUALS
-#: Merge.rc:5755
+#: Merge.rc:5754
 msgid "Equals"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_EQUALS
-#: Merge.rc:5756
+#: Merge.rc:5755
 msgid "Does not equal"
 msgstr ""
 
 #. IDS_FILTER_OP_LESS_THAN
-#: Merge.rc:5757
+#: Merge.rc:5756
 msgid "Less than"
 msgstr ""
 
 #. IDS_FILTER_OP_LESS_EQUAL
-#: Merge.rc:5758
+#: Merge.rc:5757
 msgid "Less than or equal to"
 msgstr ""
 
 #. IDS_FILTER_OP_GREATER_EQUAL
-#: Merge.rc:5759
+#: Merge.rc:5758
 msgid "Greater than or equal to"
 msgstr ""
 
 #. IDS_FILTER_OP_GREATER_THAN
-#: Merge.rc:5760
+#: Merge.rc:5759
 msgid "Greater than"
 msgstr ""
 
 #. IDS_FILTER_OP_BETWEEN
-#: Merge.rc:5761
+#: Merge.rc:5760
 msgid "Between"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_BETWEEN
-#: Merge.rc:5762
+#: Merge.rc:5761
 msgid "Not Between"
 msgstr ""
 
 #. IDS_FILTER_OP_CONTAINS
-#: Merge.rc:5763
+#: Merge.rc:5762
 msgid "Contains"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_CONTAINS
-#: Merge.rc:5764
+#: Merge.rc:5763
 msgid "Not Contains"
 msgstr ""
 
 #. IDS_FILTER_OP_RECONTAINS
-#: Merge.rc:5765
+#: Merge.rc:5764
 msgid "Contains (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_RECONTAINS
-#: Merge.rc:5766
+#: Merge.rc:5765
 msgid "Not Contains (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_LIKE
-#: Merge.rc:5767
+#: Merge.rc:5766
 msgid "Match (wildcard)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_LIKE
-#: Merge.rc:5768
+#: Merge.rc:5767
 msgid "Not match (wildcard)"
 msgstr ""
 
 #. IDS_FILTER_OP_MATCHES
-#: Merge.rc:5769
+#: Merge.rc:5768
 msgid "Match (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_MATCHES
-#: Merge.rc:5770
+#: Merge.rc:5769
 msgid "Not match (regex)"
 msgstr ""
 
 #. IDS_COLORMODE_LIGHT
-#: Merge.rc:5775
+#: Merge.rc:5774
 msgid "Light"
 msgstr ""
 
 #. IDS_COLORMODE_DARK
-#: Merge.rc:5776
+#: Merge.rc:5775
 msgid "Dark"
 msgstr ""
 
 #. IDS_COLORMODE_FOLLOWSYSTEM
-#: Merge.rc:5777
+#: Merge.rc:5776
 msgid "Follow system"
 msgstr ""
 
 #. IDS_EXAMPLE
-#: Merge.rc:5782
+#: Merge.rc:5781
 #, c-format
 msgid "e.g. %1"
 msgstr ""
 
 #. IDS_DETECTED_PREVIOUS_CRASH
-#: Merge.rc:5787
+#: Merge.rc:5786
 msgid "WinMerge detected a previous crash. Please report this if possible."
 msgstr ""
 
 #. IDS_REGEX_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5792
+#: Merge.rc:5791
 msgid "# Regex replacement list\r\n# Format: regex<TAB>replacement\r\n# Backreferences like $1, $2 are supported\r\n\r\n(\\d{4})-(\\d{2})-(\\d{2})\t$1_$2_$3\r\n"
 msgstr ""
 
 #. IDS_STRING_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5793
+#: Merge.rc:5792
 msgid "# Replacement list\r\n# Format: search<TAB>replacement\r\n# Lines starting with # are ignored\r\n\r\nfrom1\tto1\r\nfrom2\tto2\r\n"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_ONLY
-#: Merge.rc:5798
+#: Merge.rc:5797
 msgid "Built-in only"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_FIRST
-#: Merge.rc:5799
+#: Merge.rc:5798
 msgid "Built-in first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_FIRST
-#: Merge.rc:5800
+#: Merge.rc:5799
 msgid "Tree-sitter first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_ONLY
-#: Merge.rc:5801
+#: Merge.rc:5800
 msgid "Tree-sitter only"
 msgstr ""
 

--- a/Translations/WinMerge/French.po
+++ b/Translations/WinMerge/French.po
@@ -30,7 +30,7 @@ msgstr ""
 "X-Poedit-Basepath: ../../Src\n"
 
 #. LANGUAGE, SUBLANGUAGE
-#: Merge.rc:26 Merge.rc:59 Merge.rc:5818
+#: Merge.rc:26 Merge.rc:59 Merge.rc:5817
 msgid "LANG_ENGLISH, SUBLANG_ENGLISH_US"
 msgstr "LANG_FRENCH, SUBLANG_FRENCH"
 
@@ -172,7 +172,7 @@ msgstr "Appli&quer un script"
 #. IDS_NO_EDIT_SCRIPTS
 #: Merge.rc:127 Merge.rc:352 Merge.rc:463 Merge.rc:673 Merge.rc:678
 #: Merge.rc:887 Merge.rc:899 Merge.rc:906 Merge.rc:963 Merge.rc:1210
-#: Merge.rc:5375
+#: Merge.rc:5374
 msgid "< Empty >"
 msgstr "< Vide >"
 
@@ -237,7 +237,7 @@ msgid "Auto-Fit All Columns"
 msgstr "Ajuster automatiquement toutes les colonnes"
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN
-#: Merge.rc:153 Merge.rc:5646
+#: Merge.rc:153 Merge.rc:5645
 msgid "&Filter by This Column"
 msgstr "&Filtrer par cette colonne"
 
@@ -298,7 +298,7 @@ msgid "&Previous Page"
 msgstr "Page &précédente"
 
 #. IDS_PREVIEWBAR_NEXTPAGE
-#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5679
+#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5678
 msgid "&Next Page"
 msgstr "Page &suivante"
 
@@ -549,7 +549,7 @@ msgstr "&Binaire"
 #. IDS_IMAGE_MENU
 #: Merge.rc:329 Merge.rc:338 Merge.rc:432 Merge.rc:441 Merge.rc:609
 #: Merge.rc:618 Merge.rc:670 Merge.rc:960 Merge.rc:1187 Merge.rc:1200
-#: Merge.rc:5477
+#: Merge.rc:5476
 msgid "&Image"
 msgstr "&Image"
 
@@ -671,7 +671,7 @@ msgid "&Huge"
 msgstr "&Très grande"
 
 #. IDS_VIEW_MENU_BAR
-#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5714
+#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5713
 msgid "Men&u Bar"
 msgstr "Barre de men&u"
 
@@ -1326,7 +1326,7 @@ msgid "Lo&cation Pane"
 msgstr "Panneau de lo&calisation"
 
 #. IDS_OUTPUTBAR_CAPTION
-#: Merge.rc:782 Merge.rc:5252
+#: Merge.rc:782 Merge.rc:5251
 msgid "Output Pane"
 msgstr "Panneau de sortie"
 
@@ -1589,55 +1589,55 @@ msgid "Co&mpare As"
 msgstr "Co&mparer comme un(e)"
 
 #. IDS_COPY_LEFT_TO_MIDDLE2
-#: Merge.rc:968 Merge.rc:980 Merge.rc:4852
+#: Merge.rc:968 Merge.rc:980 Merge.rc:4851
 #, c-format
 msgid "Left to Middle (%1 of %2)"
 msgstr "Gauche vers Milieu (%1 de %2)"
 
 #. IDS_COPY_LEFT_TO_RIGHT2
-#: Merge.rc:969 Merge.rc:981 Merge.rc:4851
+#: Merge.rc:969 Merge.rc:981 Merge.rc:4850
 #, c-format
 msgid "Left to Right (%1 of %2)"
 msgstr "Gauche vers Droite (%1 de %2)"
 
 #. IDS_MOVE_LEFT_TO2
-#: Merge.rc:970 Merge.rc:982 Merge.rc:1045 Merge.rc:4863 Merge.rc:4892
+#: Merge.rc:970 Merge.rc:982 Merge.rc:1045 Merge.rc:4862 Merge.rc:4891
 #, c-format
 msgid "Left to... (%1 of %2)"
 msgstr "Gauche vers... (%1 de %2)"
 
 #. IDS_COPY_MIDDLE_TO_LEFT2
-#: Merge.rc:971 Merge.rc:983 Merge.rc:4849
+#: Merge.rc:971 Merge.rc:983 Merge.rc:4848
 #, c-format
 msgid "Middle to Left (%1 of %2)"
 msgstr "Milieu vers Gauche (%1 de %2)"
 
 #. IDS_COPY_MIDDLE_TO_RIGHT2
-#: Merge.rc:972 Merge.rc:984 Merge.rc:4850
+#: Merge.rc:972 Merge.rc:984 Merge.rc:4849
 #, c-format
 msgid "Middle to Right (%1 of %2)"
 msgstr "Milieu vers Droite (%1 de %2)"
 
 #. IDS_MOVE_MIDDLE_TO2
-#: Merge.rc:973 Merge.rc:985 Merge.rc:1046 Merge.rc:4864 Merge.rc:4893
+#: Merge.rc:973 Merge.rc:985 Merge.rc:1046 Merge.rc:4863 Merge.rc:4892
 #, c-format
 msgid "Middle to... (%1 of %2)"
 msgstr "Milieu vers... (%1 de %2)"
 
 #. IDS_COPY_RIGHT_TO_MIDDLE2
-#: Merge.rc:974 Merge.rc:986 Merge.rc:4848
+#: Merge.rc:974 Merge.rc:986 Merge.rc:4847
 #, c-format
 msgid "Right to Middle (%1 of %2)"
 msgstr "Droite vers Milieu (%1 de %2)"
 
 #. IDS_COPY_RIGHT_TO_LEFT2
-#: Merge.rc:975 Merge.rc:987 Merge.rc:4847
+#: Merge.rc:975 Merge.rc:987 Merge.rc:4846
 #, c-format
 msgid "Right to Left (%1 of %2)"
 msgstr "Droite vers Gauche (%1 de %2)"
 
 #. IDS_MOVE_RIGHT_TO2
-#: Merge.rc:976 Merge.rc:988 Merge.rc:1047 Merge.rc:4865 Merge.rc:4894
+#: Merge.rc:976 Merge.rc:988 Merge.rc:1047 Merge.rc:4864 Merge.rc:4893
 #, c-format
 msgid "Right to... (%1 of %2)"
 msgstr "Droite vers... (%1 de %2)"
@@ -1693,31 +1693,31 @@ msgid "Cop&y Paths"
 msgstr "Cop&ier les chemins"
 
 #. IDS_DEL_LEFT_FMT2
-#: Merge.rc:1026 Merge.rc:1035 Merge.rc:4880
+#: Merge.rc:1026 Merge.rc:1035 Merge.rc:4879
 #, c-format
 msgid "Left (%1 of %2)"
 msgstr "Gauche (%1 de %2)"
 
 #. IDS_DEL_MIDDLE_FMT2
-#: Merge.rc:1027 Merge.rc:1036 Merge.rc:4881
+#: Merge.rc:1027 Merge.rc:1036 Merge.rc:4880
 #, c-format
 msgid "Middle (%1 of %2)"
 msgstr "Milieu (%1 de %2)"
 
 #. IDS_DEL_RIGHT_FMT2
-#: Merge.rc:1028 Merge.rc:1037 Merge.rc:4882
+#: Merge.rc:1028 Merge.rc:1037 Merge.rc:4881
 #, c-format
 msgid "Right (%1 of %2)"
 msgstr "Droite (%1 de %2)"
 
 #. IDS_DEL_BOTH_FMT2
-#: Merge.rc:1029 Merge.rc:1038 Merge.rc:4883
+#: Merge.rc:1029 Merge.rc:1038 Merge.rc:4882
 #, c-format
 msgid "Both (%1 of %2)"
 msgstr "Les deux (%1 de %2)"
 
 #. IDS_DEL_ALL_FMT2
-#: Merge.rc:1030 Merge.rc:1039 Merge.rc:4888
+#: Merge.rc:1030 Merge.rc:1039 Merge.rc:4887
 #, c-format
 msgid "All (%1 of %2)"
 msgstr "Tous (%1 de %2)"
@@ -1743,19 +1743,19 @@ msgid "&Zip"
 msgstr "Co&mpresser"
 
 #. IDS_COPY_BOTH_TO2
-#: Merge.rc:1048 Merge.rc:4866
+#: Merge.rc:1048 Merge.rc:4865
 #, c-format
 msgid "Both to... (%1 of %2)"
 msgstr "Les deux vers... (%1 de %2)"
 
 #. IDS_COPY_ALL_TO2
-#: Merge.rc:1049 Merge.rc:4867
+#: Merge.rc:1049 Merge.rc:4866
 #, c-format
 msgid "All to... (%1 of %2)"
 msgstr "Tous vers... (%1 de %2)"
 
 #. IDS_COPY_DIFFERENCES_TO2
-#: Merge.rc:1050 Merge.rc:4868
+#: Merge.rc:1050 Merge.rc:4867
 #, c-format
 msgid "Differences to... (%1 of %2)"
 msgstr "Différences vers... (%1 de %2)"
@@ -1822,12 +1822,12 @@ msgstr "Paramètres du décompresseur"
 
 #. IDS_USERCHOICE_NONE
 #: Merge.rc:1088 Merge.rc:1094 Merge.rc:1836 Merge.rc:1840 Merge.rc:2031
-#: Merge.rc:2035 Merge.rc:5377
+#: Merge.rc:2035 Merge.rc:5376
 msgid "<None>"
 msgstr "<Aucun>"
 
 #. IDS_USERCHOICE_AUTOMATIC
-#: Merge.rc:1089 Merge.rc:1095 Merge.rc:5378
+#: Merge.rc:1089 Merge.rc:1095 Merge.rc:5377
 msgid "<Automatic>"
 msgstr "<Automatique>"
 
@@ -2757,12 +2757,12 @@ msgid "Text files only"
 msgstr "Fichiers texte uniquement"
 
 #. IDS_EOL_NONE
-#: Merge.rc:1667 Merge.rc:1918 Merge.rc:5304
+#: Merge.rc:1667 Merge.rc:1918 Merge.rc:5303
 msgid "None"
 msgstr "Aucun"
 
 #. IDS_EOL_MIXED
-#: Merge.rc:1668 Merge.rc:5299
+#: Merge.rc:1668 Merge.rc:5298
 msgid "Mixed"
 msgstr "Combiné"
 
@@ -3034,13 +3034,13 @@ msgstr "É&tat de la ligne"
 
 #. IDS_DIFFERENT
 #: Merge.rc:1904 Merge.rc:1988 Merge.rc:2866 Merge.rc:3036 Merge.rc:3077
-#: Merge.rc:5058
+#: Merge.rc:5057
 msgid "Different"
 msgstr "Différent"
 
 #. IDS_IDENTICAL
 #: Merge.rc:1905 Merge.rc:1989 Merge.rc:2865 Merge.rc:3055 Merge.rc:3116
-#: Merge.rc:5048
+#: Merge.rc:5047
 msgid "Identical"
 msgstr "Identique"
 
@@ -3060,7 +3060,7 @@ msgid "Missing"
 msgstr "Manquant"
 
 #. IDS_MOVED
-#: Merge.rc:1910 Merge.rc:5076
+#: Merge.rc:1910 Merge.rc:5075
 msgid "Moved"
 msgstr "Déplacé"
 
@@ -3798,7 +3798,7 @@ msgid "&Use custom system colors"
 msgstr "&Utiliser les couleurs du système personnalisées"
 
 #. IDS_PRPCAT_SYSTEM
-#: Merge.rc:2565 Merge.rc:4559 Merge.rc:4560 Merge.rc:5007
+#: Merge.rc:2565 Merge.rc:4559 Merge.rc:4560 Merge.rc:5006
 msgid "System"
 msgstr "Système"
 
@@ -4198,7 +4198,7 @@ msgid "Items compared:"
 msgstr "Éléments comparés :"
 
 #. IDS_PREVIEWBAR_CLOSE
-#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5685
+#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5684
 msgid "&Close"
 msgstr "&Fermer"
 
@@ -4821,7 +4821,7 @@ msgid "A&ppend timestamp"
 msgstr "Ajouter un &horodatage"
 
 #. IDS_CONFIRM_COPY_CAPTION
-#: Merge.rc:3214 Merge.rc:4915
+#: Merge.rc:3214 Merge.rc:4914
 msgid "Confirm Copy"
 msgstr "Confirmer la copie"
 
@@ -5058,7 +5058,7 @@ msgid "&Character Set..."
 msgstr "En&codage..."
 
 #. IDS_PRPCAT_IMAGE
-#: Merge.rc:3351 Merge.rc:4574 Merge.rc:5015
+#: Merge.rc:3351 Merge.rc:4574 Merge.rc:5014
 msgid "Image"
 msgstr "Image"
 
@@ -5463,7 +5463,7 @@ msgid "Project"
 msgstr "Projet"
 
 #. IDS_COLHDR_NSDIFFS
-#: Merge.rc:4566 Merge.rc:4990
+#: Merge.rc:4566 Merge.rc:4989
 msgid "Differences"
 msgstr "Différences"
 
@@ -5605,12 +5605,12 @@ msgid "File Type"
 msgstr "Type de fichier"
 
 #. IDS_COLHDR_EXTENSION
-#: Merge.rc:4653 Merge.rc:4947
+#: Merge.rc:4653 Merge.rc:4946
 msgid "Extension"
 msgstr "Extension"
 
 #. IDS_PRPCAT_MESSAGE
-#: Merge.rc:4659 Merge.rc:5019
+#: Merge.rc:4659 Merge.rc:5018
 msgid "Message"
 msgstr "Message"
 
@@ -5650,7 +5650,7 @@ msgid "Hidden Items"
 msgstr "Éléments cachés"
 
 #. IDS_PLUGINSLIST_NAME
-#: Merge.rc:4680 Merge.rc:5311
+#: Merge.rc:4680 Merge.rc:5310
 msgid "Name"
 msgstr "Nom"
 
@@ -5670,7 +5670,7 @@ msgid "[F] "
 msgstr "[F] "
 
 #. IDS_PLUGINSLIST_DESC
-#: Merge.rc:4684 Merge.rc:5313
+#: Merge.rc:4684 Merge.rc:5312
 msgid "Description"
 msgstr "Description"
 
@@ -5838,155 +5838,150 @@ msgstr "Ln: %s  Col: %d/%d  Ch: %d/%d"
 msgid "  Sel: %d | %d"
 msgstr "  Sél: %d | %d"
 
-#. IDS_MERGEMODE_MERGING
-#: Merge.rc:4734
-msgid "Merge"
-msgstr "Fusion"
-
 #. IDS_DIFF_NUMBER_STATUS_FMT
-#: Merge.rc:4735
+#: Merge.rc:4734
 #, c-format
 msgid "Difference %1 of %2"
 msgstr "Différence %1 de %2"
 
 #. IDS_NO_DIFF_SEL_FMT
-#: Merge.rc:4736
+#: Merge.rc:4735
 #, c-format
 msgid "%1 Differences Found"
 msgstr "%1 différences trouvées"
 
 #. IDS_1_DIFF_FOUND
-#: Merge.rc:4737
+#: Merge.rc:4736
 msgid "1 Difference Found"
 msgstr "1 différence trouvée"
 
 #. IDS_NO_ERR_SEL_FMT
-#: Merge.rc:4738
+#: Merge.rc:4737
 #, c-format
 msgid "%1 Errors Found"
 msgstr "%1 Erreurs trouvées"
 
 #. IDS_1_ERR_FOUND
-#: Merge.rc:4739
+#: Merge.rc:4738
 msgid "1 Error Found"
 msgstr "1 erreur trouvée"
 
 #. IDS_STATUSBAR_READONLY, Abbreviation from "Read Only"
-#: Merge.rc:4740
+#: Merge.rc:4739
 msgid "RO"
 msgstr "LS"
 
 #. IDS_DIRVIEW_STATUS_FMT_FOCUS
-#: Merge.rc:4746
+#: Merge.rc:4745
 #, c-format
 msgid "Item %1 of %2"
 msgstr "Élément %1 de %2"
 
 #. IDS_DIRVIEW_STATUS_FMT_NOFOCUS
-#: Merge.rc:4747
+#: Merge.rc:4746
 #, c-format
 msgid "Items: %1"
 msgstr "Éléments : %1"
 
 #. IDS_DIRVIEW_STATUS_COMPARING
-#: Merge.rc:4748
+#: Merge.rc:4747
 msgid "Comparing items..."
 msgstr "Comparaison des éléments en cours..."
 
 #. IDS_ITEMS_PER_SEC
-#: Merge.rc:4749
+#: Merge.rc:4748
 #, c-format
 msgid "%.1f[items/sec]"
 msgstr "%.1f[éléments/sec]"
 
 #. IDS_ERROR_INCOMPARABLE
-#: Merge.rc:4755
+#: Merge.rc:4754
 msgid "Select two existing folders/files to compare."
 msgstr "Sélectionnez deux fichiers ou dossiers existants à comparer."
 
 #. IDS_DIRSEL_TAG
-#: Merge.rc:4756
+#: Merge.rc:4755
 msgid "Folder Selection"
 msgstr "Sélection de dossier"
 
 #. IDS_OPEN_FILESDIRS
-#: Merge.rc:4757
+#: Merge.rc:4756
 msgid "Select two (or three) folders/files to compare."
 msgstr "Sélectionnez deux (ou trois) dossiers/fichiers à comparer."
 
 #. IDS_OPEN_LEFTINVALID
-#: Merge.rc:4758
+#: Merge.rc:4757
 msgid "Left (1st) path is invalid!"
 msgstr "Le chemin de Gauche (1er) est invalide !"
 
 #. IDS_OPEN_MIDDLEINVALID
-#: Merge.rc:4759
+#: Merge.rc:4758
 msgid "Middle (2nd) path is invalid!"
 msgstr "Le chemin du Milieu (2ème) est invalide !"
 
 #. IDS_OPEN_RIGHTINVALID2
-#: Merge.rc:4760
+#: Merge.rc:4759
 msgid "Right (2nd) path is invalid!"
 msgstr "Le chemin de Droite (2ème) est invalide !"
 
 #. IDS_OPEN_RIGHTINVALID3
-#: Merge.rc:4761
+#: Merge.rc:4760
 msgid "Right (3rd) path is invalid!"
 msgstr "Le chemin de Droite (3ème) est invalide !"
 
 #. IDS_OPEN_BOTHINVALID
-#: Merge.rc:4762
+#: Merge.rc:4761
 msgid "Both paths are invalid!"
 msgstr "Les deux chemins sont invalides !"
 
-#: Merge.rc:4764
+#: Merge.rc:4763
 msgid "Left (1st) and Middle (2nd) paths are invalid!"
 msgstr "Les chemins de Gauche (1er) et du Milieu (2ème) sont invalides !"
 
 #. IDS_OPEN_LEFTRIGHTINVALID
-#: Merge.rc:4765
+#: Merge.rc:4764
 msgid "Left (1st) and Right (3rd) paths are invalid!"
 msgstr "Les chemins de Gauche (1er) et de Droite (3ème) sont invalides !"
 
-#: Merge.rc:4767
+#: Merge.rc:4766
 msgid "Middle (2nd) and Right (3rd) paths are invalid!"
 msgstr "Les chemins du Milieu (2ème) et de Droite (3ème) sont invalides !"
 
 #. IDS_OPEN_ALLINVALID
-#: Merge.rc:4768
+#: Merge.rc:4767
 msgid "All paths are invalid!"
 msgstr "Tous les chemins sont invalides !"
 
 #. IDS_OPEN_UNPACKERDISABLED
-#: Merge.rc:4769
+#: Merge.rc:4768
 msgid "Only enabled for file comparisons"
 msgstr "Activé uniquement pour les comparaisons de fichiers"
 
 #. IDS_OPEN_MISMATCH
-#: Merge.rc:4770
+#: Merge.rc:4769
 msgid "Cannot compare file and folder!"
 msgstr "Impossible de comparer un fichier avec un dossier !"
 
 #. IDS_ERROR_FILE_NOT_FOUND
-#: Merge.rc:4776
+#: Merge.rc:4775
 #, c-format
 msgid "File not found: %1"
 msgstr "Fichier non trouvé : %1"
 
 #. IDS_ERROR_FOLDER_NOT_FOUND
-#: Merge.rc:4777
+#: Merge.rc:4776
 #, c-format
 msgid "Folder not found: %1"
 msgstr "Dossier non trouvé : %1"
 
 #. IDS_ERROR_FILE_NOT_UNPACKED
-#: Merge.rc:4778
+#: Merge.rc:4777
 #, c-format
 msgid "File not unpacked: %1"
 msgstr "Fichier non décompressé : %1"
 
 #. IDS_ERROR_FILEOPEN
-#: Merge.rc:4779
+#: Merge.rc:4778
 #, c-format
 msgid ""
 "Cannot open file\n"
@@ -6000,12 +5995,12 @@ msgstr ""
 "%2"
 
 #. IDS_ERROR_CONF_RESOLVE
-#: Merge.rc:4780
+#: Merge.rc:4779
 msgid "Failed to parse conflict file."
 msgstr "Échec de l'analyse du fichier en conflit."
 
 #. IDS_NOT_CONFLICT_FILE
-#: Merge.rc:4781
+#: Merge.rc:4780
 #, c-format
 msgid ""
 "The file\n"
@@ -6017,7 +6012,7 @@ msgstr ""
 "'est pas un fichier en conflit."
 
 #. IDS_COMPARE_LARGE_FILES
-#: Merge.rc:4782
+#: Merge.rc:4781
 msgid ""
 "Comparing large files requires significant memory.\n"
 "Show only comparison results (not file contents)?"
@@ -6026,28 +6021,28 @@ msgstr ""
 "Afficher uniquement les résultats de la comparaison (pas le contenu du fichier) ?"
 
 #. IDS_SAVE_AS_TITLE
-#: Merge.rc:4788
+#: Merge.rc:4787
 msgid "Save As"
 msgstr "Enregistrer sous"
 
 #. IDS_SAVE_FMT
-#: Merge.rc:4789
+#: Merge.rc:4788
 #, c-format
 msgid "Save changes to %1?"
 msgstr "Enregistrer les changements de %1 ?"
 
 #. IDS_SAVEREADONLY_FMT
-#: Merge.rc:4790
+#: Merge.rc:4789
 #, c-format
 msgid "%1 is read-only. Override? Or 'No' to save as new filename?"
 msgstr "%1 est en lecture seule. Outrepasser? ou \"Non\" pour enregistrer sous un nouveau nom de fichier ?"
 
 #. IDS_ERROR_BACKUP
-#: Merge.rc:4791
+#: Merge.rc:4790
 msgid "Error backing up file"
 msgstr "Erreur lors de la sauvegarde du fichier"
 
-#: Merge.rc:4793
+#: Merge.rc:4792
 #, c-format
 msgid ""
 "Unable to backup original file:\n"
@@ -6061,7 +6056,7 @@ msgstr ""
 "Continuer quand même ?"
 
 #. IDS_FILESAVE_FAILED
-#: Merge.rc:4794
+#: Merge.rc:4793
 #, c-format
 msgid ""
 "Saving file failed.\n"
@@ -6076,7 +6071,7 @@ msgstr ""
 "\t- Utiliser un autre nom de fichier (OK)\n"
 "\t- Abandonner (Annuler) ?)"
 
-#: Merge.rc:4796
+#: Merge.rc:4795
 #, c-format
 msgid ""
 "Plugin '%2' cannot pack changes to left file into '%1'.\n"
@@ -6087,7 +6082,7 @@ msgstr ""
 "\n"
 "Original inchangé. Enregistrer la version décompressée ?"
 
-#: Merge.rc:4798
+#: Merge.rc:4797
 #, c-format
 msgid ""
 "Plugin '%2' cannot pack changes to middle file into '%1'.\n"
@@ -6098,7 +6093,7 @@ msgstr ""
 "\n"
 "Original inchangé. Enregistrer la version décompressée ?"
 
-#: Merge.rc:4800
+#: Merge.rc:4799
 #, c-format
 msgid ""
 "Plugin '%2' cannot pack changes to right file into '%1'.\n"
@@ -6110,7 +6105,7 @@ msgstr ""
 "Original inchangé. Enregistrer la version décompressée ?"
 
 #. IDS_FILECHANGED_ONDISK
-#: Merge.rc:4801
+#: Merge.rc:4800
 #, c-format
 msgid ""
 "Another application updated\n"
@@ -6126,7 +6121,7 @@ msgstr ""
 "Écraser ?"
 
 #. IDS_SAVEREADONLY_MULTI
-#: Merge.rc:4802
+#: Merge.rc:4801
 #, c-format
 msgid ""
 "%1\n"
@@ -6136,7 +6131,7 @@ msgstr ""
 "est en lecture seule. Outrepasser?"
 
 #. IDS_FILECHANGED_RESCAN
-#: Merge.rc:4803
+#: Merge.rc:4802
 #, c-format
 msgid ""
 "Another application updated\n"
@@ -6152,22 +6147,22 @@ msgstr ""
 "Recharger ?"
 
 #. IDS_SAVE_LEFT_AS
-#: Merge.rc:4804
+#: Merge.rc:4803
 msgid "Save Left File As"
 msgstr "Enregistrer le fichier de Gauche sous"
 
 #. IDS_SAVE_MIDDLE_AS
-#: Merge.rc:4805
+#: Merge.rc:4804
 msgid "Save Middle File As"
 msgstr "Enregistrer fichier du Milieu sous"
 
 #. IDS_SAVE_RIGHT_AS
-#: Merge.rc:4806
+#: Merge.rc:4805
 msgid "Save Right File As"
 msgstr "Enregistrer le fichier de Droite sous"
 
 #. IDS_FILE_DISAPPEARED
-#: Merge.rc:4811
+#: Merge.rc:4810
 #, c-format
 msgid ""
 "File\n"
@@ -6179,7 +6174,7 @@ msgstr ""
 "on trouvé. Sauvegardez une copie pour continuer."
 
 #. IDS_VIEWS_OUTOFSYNC
-#: Merge.rc:4817
+#: Merge.rc:4816
 msgid ""
 "Cannot merge unsynched documents.\n"
 "\n"
@@ -6190,124 +6185,124 @@ msgstr ""
 "Actualisez avant de continuer."
 
 #. IDS_BREAK_ON_WHITESPACE
-#: Merge.rc:4822
+#: Merge.rc:4821
 msgid "Break at whitespace"
 msgstr "Coupure à l'espacement"
 
 #. IDS_BREAK_ON_PUNCTUATION
-#: Merge.rc:4823
+#: Merge.rc:4822
 msgid "Break at whitespace or punctuation"
 msgstr "Coupure à l'espacement ou la ponctuation"
 
 #. IDS_L2M
-#: Merge.rc:4829
+#: Merge.rc:4828
 msgid "Copy to &Middle\tAlt+Right"
 msgstr "Copier vers le &Milieu\tAlt+Droite"
 
 #. IDS_R2M
-#: Merge.rc:4830
+#: Merge.rc:4829
 msgid "Copy to &Middle\tAlt+Left"
 msgstr "Copier vers le &Milieu\tAlt+Gauche"
 
 #. IDS_COPY_FROM_MIDDLE_R
-#: Merge.rc:4831
+#: Merge.rc:4830
 msgid "Copy from Middle\tAlt+Shift+Right"
 msgstr "Copier depuis le &Milieu\tAlt+Maj+Droite"
 
 #. IDS_COPY_FROM_MIDDLE_L
-#: Merge.rc:4832
+#: Merge.rc:4831
 msgid "Copy from Middle\tAlt+Shift+Left"
 msgstr "Copier depuis le Milieu\tAlt+Maj+Gauche"
 
 #. IDS_L2MNEXT
-#: Merge.rc:4833
+#: Merge.rc:4832
 msgid "Copy to Middle and Advance\tCtrl+Alt+Right"
 msgstr "Copier vers le Milieu et Avancer\tCtrl+Alt+Droite"
 
 #. IDS_R2MNEXT
-#: Merge.rc:4834
+#: Merge.rc:4833
 msgid "Copy to Middle and Advance\tCtrl+Alt+Left"
 msgstr "Copier vers le Milieu et Avancer\tCtrl+Alt+Gauche"
 
 #. IDS_ALL_MIDDLE
-#: Merge.rc:4835
+#: Merge.rc:4834
 msgid "Copy All to Middle"
 msgstr "Tout copier vers le Milieu"
 
 #. IDS_COPY_RIGHT_TO_LEFT
-#: Merge.rc:4841
+#: Merge.rc:4840
 #, c-format
 msgid "Right to Left (%1)"
 msgstr "De Droite vers Gauche (%1)"
 
 #. IDS_COPY_RIGHT_TO_MIDDLE
-#: Merge.rc:4842
+#: Merge.rc:4841
 #, c-format
 msgid "Right to Middle (%1)"
 msgstr "De Droite vers Milieu (%1)"
 
 #. IDS_COPY_MIDDLE_TO_LEFT
-#: Merge.rc:4843
+#: Merge.rc:4842
 #, c-format
 msgid "Middle to Left (%1)"
 msgstr "De Milieu vers Gauche (%1)"
 
 #. IDS_COPY_MIDDLE_TO_RIGHT
-#: Merge.rc:4844
+#: Merge.rc:4843
 #, c-format
 msgid "Middle to Right (%1)"
 msgstr "De Milieu vers Droite (%1)"
 
 #. IDS_COPY_LEFT_TO_RIGHT
-#: Merge.rc:4845
+#: Merge.rc:4844
 #, c-format
 msgid "Left to Right (%1)"
 msgstr "De Gauche vers Droite (%1)"
 
 #. IDS_COPY_LEFT_TO_MIDDLE
-#: Merge.rc:4846
+#: Merge.rc:4845
 #, c-format
 msgid "Left to Middle (%1)"
 msgstr "De Gauche vers Milieu (%1)"
 
 #. IDS_MOVE_LEFT_TO
-#: Merge.rc:4857 Merge.rc:4889
+#: Merge.rc:4856 Merge.rc:4888
 #, c-format
 msgid "Left to... (%1)"
 msgstr "De Gauche vers... (%1)"
 
 #. IDS_MOVE_MIDDLE_TO
-#: Merge.rc:4858 Merge.rc:4890
+#: Merge.rc:4857 Merge.rc:4889
 #, c-format
 msgid "Middle to... (%1)"
 msgstr "De Milieu vers... (%1)"
 
 #. IDS_MOVE_RIGHT_TO
-#: Merge.rc:4859 Merge.rc:4891
+#: Merge.rc:4858 Merge.rc:4890
 #, c-format
 msgid "Right to... (%1)"
 msgstr "De Droite vers... (%1)"
 
 #. IDS_COPY_BOTH_TO
-#: Merge.rc:4860
+#: Merge.rc:4859
 #, c-format
 msgid "Both to... (%1)"
 msgstr "Les deux vers… (%1)"
 
 #. IDS_COPY_ALL_TO
-#: Merge.rc:4861
+#: Merge.rc:4860
 #, c-format
 msgid "All to... (%1)"
 msgstr "Tout vers... (%1)"
 
 #. IDS_COPY_DIFFERENCES_TO
-#: Merge.rc:4862
+#: Merge.rc:4861
 #, c-format
 msgid "Differences to... (%1)"
 msgstr "Différences vers... (%1)"
 
 #. IDS_ONLYDIFFITEMS_CONFIRM
-#: Merge.rc:4869
+#: Merge.rc:4868
 msgid ""
 "Some selected items are identical or skipped.\n"
 "Process only items with differences?"
@@ -6316,64 +6311,64 @@ msgstr ""
 "Traiter uniquement les éléments présentant des différences ?"
 
 #. IDS_DEL_LEFT_FMT
-#: Merge.rc:4875
+#: Merge.rc:4874
 #, c-format
 msgid "Left (%1)"
 msgstr "Gauche (%1)"
 
 #. IDS_DEL_MIDDLE_FMT
-#: Merge.rc:4876
+#: Merge.rc:4875
 #, c-format
 msgid "Middle (%1)"
 msgstr "Milieu (%1)"
 
 #. IDS_DEL_RIGHT_FMT
-#: Merge.rc:4877
+#: Merge.rc:4876
 #, c-format
 msgid "Right (%1)"
 msgstr "Droite (%1)"
 
 #. IDS_DEL_BOTH_FMT
-#: Merge.rc:4878
+#: Merge.rc:4877
 #, c-format
 msgid "Both (%1)"
 msgstr "Les deux (%1)"
 
 #. IDS_DEL_ALL_FMT
-#: Merge.rc:4879
+#: Merge.rc:4878
 #, c-format
 msgid "All (%1)"
 msgstr "Tout (%1)"
 
 #. IDS_SELECT_DEST_LEFT
-#: Merge.rc:4895
+#: Merge.rc:4894
 msgid "Left Side - Select Destination Folder:"
 msgstr "Panneau Gauche - choisir le dossier de destination :"
 
 #. IDS_SELECT_DEST_MIDDLE
-#: Merge.rc:4896
+#: Merge.rc:4895
 msgid "Middle Side - Select Destination Folder:"
 msgstr "Panneau Milieu - choisir le dossier de destination :"
 
 #. IDS_SELECT_DEST_RIGHT
-#: Merge.rc:4897
+#: Merge.rc:4896
 msgid "Right Side - Select Destination Folder:"
 msgstr "Panneau Droite - choisir le dossier de destination :"
 
 #. IDS_FILES_AFFECTED_FMT
-#: Merge.rc:4898
+#: Merge.rc:4897
 #, c-format
 msgid "(%1 Files Affected)"
 msgstr "(%1 fichiers concernés)"
 
 #. IDS_FILES_AFFECTED_FMT2
-#: Merge.rc:4899
+#: Merge.rc:4898
 #, c-format
 msgid "(%1 of %2 Files Affected)"
 msgstr "(%1 de %2 fichiers concernés)"
 
 #. IDS_CONFIRM_DELETE_SINGLE
-#: Merge.rc:4905
+#: Merge.rc:4904
 #, c-format
 msgid ""
 "Are you sure you want to delete\n"
@@ -6385,18 +6380,18 @@ msgstr ""
 "%1 ?"
 
 #. IDS_CONFIRM_SINGLE_COPY
-#: Merge.rc:4906
+#: Merge.rc:4905
 msgid "Are you sure you want to copy?"
 msgstr "Êtes-vous sûr de vouloir copier ?"
 
 #. IDS_CONFIRM_MULTIPLE_COPY
-#: Merge.rc:4907
+#: Merge.rc:4906
 #, c-format
 msgid "Are you sure you want to copy %d items?"
 msgstr "Êtes-vous sûr de vouloir copier %d éléments ?"
 
 #. IDS_DIRCMP_NOTSYNC
-#: Merge.rc:4908
+#: Merge.rc:4907
 #, c-format
 msgid ""
 "Operation aborted!\n"
@@ -6416,46 +6411,46 @@ msgstr ""
 "Actualisez la comparaison."
 
 #. IDS_CONFIRM_SINGLE_MOVE
-#: Merge.rc:4913
+#: Merge.rc:4912
 msgid "Are you sure you want to move?"
 msgstr "Êtes-vous sûr de vouloir déplacer ?"
 
 #. IDS_CONFIRM_MULTIPLE_MOVE
-#: Merge.rc:4914
+#: Merge.rc:4913
 #, c-format
 msgid "Are you sure you want to move %d items?"
 msgstr "Êtes-vous sûr de vouloir déplacer %d éléments ?"
 
 #. IDS_CONFIRM_MOVE_CAPTION
-#: Merge.rc:4916
+#: Merge.rc:4915
 msgid "Confirm Move"
 msgstr "Confirmer le déplacement"
 
-#: Merge.rc:4918
+#: Merge.rc:4917
 msgid "Close the folder comparison window?"
 msgstr "Fermer la fenêtre de comparaison des dossiers ?"
 
-#: Merge.rc:4920
+#: Merge.rc:4919
 msgid "Close the folder comparison window, which took a long time?"
 msgstr "Fermer la fenêtre de comparaison de dossiers, qui a pris beaucoup de temps ?"
 
 #. IDS_ERROR_INVALID_DIR_FILE_NAME
-#: Merge.rc:4921
+#: Merge.rc:4920
 msgid "The file or folder name is invalid."
 msgstr "Le nom du fichier ou dossier est invalide."
 
 #. IDS_ERROR_EXECUTE_FILE
-#: Merge.rc:4927
+#: Merge.rc:4926
 #, c-format
 msgid "Failed to execute external editor: %1"
 msgstr "Échec de l'exécution de l'éditeur externe : %1"
 
 #. IDS_UNKNOWN_ARCHIVE_FORMAT
-#: Merge.rc:4933
+#: Merge.rc:4932
 msgid "Unknown archive format"
 msgstr "Format d'archives inconnu"
 
-#: Merge.rc:4935
+#: Merge.rc:4934
 msgid ""
 "Failed to extract archive.\n"
 "Compare as text file?"
@@ -6464,513 +6459,513 @@ msgstr ""
 "Comparer en tant que fichier texte ?"
 
 #. IDS_COLHDR_FILENAME
-#: Merge.rc:4941
+#: Merge.rc:4940
 msgid "Filename"
 msgstr "Nom du fichier"
 
 #. IDS_COLHDR_DIR
-#: Merge.rc:4942
+#: Merge.rc:4941
 msgctxt "DirView|ColumnHeader"
 msgid "Folder"
 msgstr "Dossier"
 
 #. IDS_COLHDR_RESULT
-#: Merge.rc:4943
+#: Merge.rc:4942
 msgid "Comparison Result"
 msgstr "Résultat de la comparaison"
 
 #. IDS_COLHDR_LTIMEM
-#: Merge.rc:4944
+#: Merge.rc:4943
 msgid "Left Date"
 msgstr "Date Gauche"
 
 #. IDS_COLHDR_RTIMEM
-#: Merge.rc:4945
+#: Merge.rc:4944
 msgid "Right Date"
 msgstr "Date Droite"
 
 #. IDS_COLHDR_MTIMEM
-#: Merge.rc:4946
+#: Merge.rc:4945
 msgid "Middle Date"
 msgstr "Date Milieu"
 
 #. IDS_COLHDR_LSIZE
-#: Merge.rc:4948
+#: Merge.rc:4947
 msgid "Left Size"
 msgstr "Taille Gauche"
 
 #. IDS_COLHDR_RSIZE
-#: Merge.rc:4949
+#: Merge.rc:4948
 msgid "Right Size"
 msgstr "Taille Droite"
 
 #. IDS_COLHDR_MSIZE
-#: Merge.rc:4954
+#: Merge.rc:4953
 msgid "Middle Size"
 msgstr "Taille Milieu"
 
 #. IDS_COLHDR_RSIZE_SHORT
-#: Merge.rc:4955
+#: Merge.rc:4954
 msgid "Right Size (Short)"
 msgstr "Taille Droite (abrégée)"
 
 #. IDS_COLHDR_LSIZE_SHORT
-#: Merge.rc:4956
+#: Merge.rc:4955
 msgid "Left Size (Short)"
 msgstr "Taille Gauche (abrégée)"
 
 #. IDS_COLHDR_MSIZE_SHORT
-#: Merge.rc:4957
+#: Merge.rc:4956
 msgid "Middle Size (Short)"
 msgstr "Taille Milieu (abrégée)"
 
 #. IDS_COLHDR_LTIMEC
-#: Merge.rc:4963
+#: Merge.rc:4962
 msgid "Left Creation Time"
 msgstr "Heure créa. Gauche"
 
 #. IDS_COLHDR_RTIMEC
-#: Merge.rc:4964
+#: Merge.rc:4963
 msgid "Right Creation Time"
 msgstr "Heure créa. Droite"
 
 #. IDS_COLHDR_MTIMEC
-#: Merge.rc:4965
+#: Merge.rc:4964
 msgid "Middle Creation Time"
 msgstr "Heure créa. Milieu"
 
 #. IDS_COLHDR_NEWER
-#: Merge.rc:4966
+#: Merge.rc:4965
 msgid "Newer File"
 msgstr "Plus récent"
 
 #. IDS_COLHDR_LVERSION
-#: Merge.rc:4967
+#: Merge.rc:4966
 msgid "Left File Version"
 msgstr "Version fichier Gauche"
 
 #. IDS_COLHDR_RVERSION
-#: Merge.rc:4968
+#: Merge.rc:4967
 msgid "Right File Version"
 msgstr "Version fichier Droite"
 
 #. IDS_COLHDR_MVERSION
-#: Merge.rc:4969
+#: Merge.rc:4968
 msgid "Middle File Version"
 msgstr "Version fichier Milieu"
 
 #. IDS_COLHDR_RESULT_ABBR
-#: Merge.rc:4970
+#: Merge.rc:4969
 msgid "Short Result"
 msgstr "Résultat court"
 
 #. IDS_COLHDR_LATTRIBUTES
-#: Merge.rc:4971
+#: Merge.rc:4970
 msgid "Left Attributes"
 msgstr "Attributs Gauche"
 
 #. IDS_COLHDR_RATTRIBUTES
-#: Merge.rc:4972
+#: Merge.rc:4971
 msgid "Right Attributes"
 msgstr "Attributs Droite"
 
 #. IDS_COLHDR_MATTRIBUTES
-#: Merge.rc:4973
+#: Merge.rc:4972
 msgid "Middle Attributes"
 msgstr "Attributs Milieu"
 
 #. IDS_COLHDR_LEOL_TYPE
-#: Merge.rc:4978
+#: Merge.rc:4977
 msgid "Left EOL"
 msgstr "EOL Gauche"
 
 #. IDS_COLHDR_MEOL_TYPE
-#: Merge.rc:4979
+#: Merge.rc:4978
 msgid "Middle EOL"
 msgstr "EOL Milieu"
 
 #. IDS_COLHDR_REOL_TYPE
-#: Merge.rc:4980
+#: Merge.rc:4979
 msgid "Right EOL"
 msgstr "EOL Droite"
 
 #. IDS_COLHDR_LENCODING
-#: Merge.rc:4986
+#: Merge.rc:4985
 msgid "Left Encoding"
 msgstr "Encodage Gauche"
 
 #. IDS_COLHDR_RENCODING
-#: Merge.rc:4987
+#: Merge.rc:4986
 msgid "Right Encoding"
 msgstr "Encodage Droite"
 
 #. IDS_COLHDR_MENCODING
-#: Merge.rc:4988
+#: Merge.rc:4987
 msgid "Middle Encoding"
 msgstr "Encodage Milieu"
 
 #. IDS_COLHDR_NIDIFFS
-#: Merge.rc:4989
+#: Merge.rc:4988
 msgid "Ignored Diff"
 msgstr "Différences ignorées"
 
 #. IDS_COLHDR_BINARY
-#: Merge.rc:4991
+#: Merge.rc:4990
 msgctxt "DirView|ColumnHeader"
 msgid "Binary"
 msgstr "Binaire"
 
 #. IDS_PLUGINS_TYPE_UNPACKER
-#: Merge.rc:4992 Merge.rc:5314
+#: Merge.rc:4991 Merge.rc:5313
 msgid "Unpacker"
 msgstr "Décompresseur"
 
 #. IDS_PLUGIN_TYPE4
-#: Merge.rc:4993 Merge.rc:5315 Merge.rc:5622
+#: Merge.rc:4992 Merge.rc:5314 Merge.rc:5621
 msgid "Prediffer"
 msgstr "Précomparaison"
 
 #. IDS_COLHDR_LEFT
-#: Merge.rc:4994
+#: Merge.rc:4993
 msgid "Left"
 msgstr "Gauche"
 
 #. IDS_COLHDR_MIDDLE
-#: Merge.rc:4995
+#: Merge.rc:4994
 msgid "Middle"
 msgstr "Milieu"
 
 #. IDS_COLHDR_RIGHT
-#: Merge.rc:4996
+#: Merge.rc:4995
 msgid "Right"
 msgstr "Droite"
 
 #. IDS_COLHDR_DIFF
-#: Merge.rc:4997
+#: Merge.rc:4996
 msgid "Diff"
 msgstr "Différence"
 
 #. IDS_COLHDR_LEFT_DUPLICATE
-#: Merge.rc:4998
+#: Merge.rc:4997
 msgid "Left Duplicate Count"
 msgstr "Nombre de doublons à Gauche"
 
 #. IDS_COLHDR_RIGHT_DUPLICATE
-#: Merge.rc:4999
+#: Merge.rc:4998
 msgid "Right Duplicate Count"
 msgstr "Nombre de doublons à Droite"
 
 #. IDS_COLHDR_MIDDLE_DUPLICATE
-#: Merge.rc:5000
+#: Merge.rc:4999
 msgid "Middle Duplicate Count"
 msgstr "Nombre de doublons au Milieu"
 
 #. IDS_COLHDR_MOVE
-#: Merge.rc:5001
+#: Merge.rc:5000
 msgid "Move"
 msgstr "Déplacer"
 
 #. IDS_PRPCAT_AUDIO
-#: Merge.rc:5008
+#: Merge.rc:5007
 msgid "Audio"
 msgstr "Audio"
 
 #. IDS_PRPCAT_CALENDAR
-#: Merge.rc:5009
+#: Merge.rc:5008
 msgid "Calendar"
 msgstr "Calendrier"
 
 #. IDS_PRPCAT_COMMUNICATION
-#: Merge.rc:5010
+#: Merge.rc:5009
 msgid "Communication"
 msgstr "Communication"
 
 #. IDS_PRPCAT_CONTACT
-#: Merge.rc:5011
+#: Merge.rc:5010
 msgid "Contact"
 msgstr "Contact"
 
 #. IDS_PRPCAT_DEVICES
-#: Merge.rc:5012
+#: Merge.rc:5011
 msgid "Devices"
 msgstr "Appareils"
 
 #. IDS_PRPCAT_DOCUMENT
-#: Merge.rc:5013
+#: Merge.rc:5012
 msgid "Document"
 msgstr "Document"
 
 #. IDS_PRPCAT_HOME
-#: Merge.rc:5014
+#: Merge.rc:5013
 msgid "Home"
 msgstr "Accueil"
 
 #. IDS_PRPCAT_JOURNAL
-#: Merge.rc:5016
+#: Merge.rc:5015
 msgid "Journal"
 msgstr "Journal"
 
 #. IDS_PRPCAT_LINK
-#: Merge.rc:5017
+#: Merge.rc:5016
 msgid "Link"
 msgstr "Lien"
 
 #. IDS_PRPCAT_MEDIA
-#: Merge.rc:5018
+#: Merge.rc:5017
 msgid "Media"
 msgstr "Média"
 
 #. IDS_PRPCAT_MUSIC
-#: Merge.rc:5020
+#: Merge.rc:5019
 msgid "Music"
 msgstr "Musique"
 
 #. IDS_PRPCAT_NOTE
-#: Merge.rc:5021
+#: Merge.rc:5020
 msgid "Note"
 msgstr "Note"
 
 #. IDS_PRPCAT_PHOTO
-#: Merge.rc:5022
+#: Merge.rc:5021
 msgid "Photo"
 msgstr "Photo"
 
 #. IDS_PRPCAT_RECORDEDTV
-#: Merge.rc:5023
+#: Merge.rc:5022
 msgid "RecordedTV"
 msgstr "Enregistrement TV"
 
 #. IDS_PRPCAT_SEARCH
-#: Merge.rc:5024
+#: Merge.rc:5023
 msgid "Search"
 msgstr "Recherche"
 
 #. IDS_PRPCAT_SECURITY
-#: Merge.rc:5025
+#: Merge.rc:5024
 msgid "Security"
 msgstr "Sécurité"
 
 #. IDS_PRPCAT_SOFTWARE
-#: Merge.rc:5026
+#: Merge.rc:5025
 msgid "Software"
 msgstr "Logiciel"
 
 #. IDS_PRPCAT_TASK
-#: Merge.rc:5027
+#: Merge.rc:5026
 msgid "Task"
 msgstr "Tâche"
 
 #. IDS_PRPCAT_VIDEO
-#: Merge.rc:5028
+#: Merge.rc:5027
 msgid "Video"
 msgstr "Vidéo"
 
 #. IDS_PRPCAT_HASH
-#: Merge.rc:5029
+#: Merge.rc:5028
 msgid "Hash"
 msgstr "Hachage"
 
 #. IDS_CANT_COMPARE_FILES
-#: Merge.rc:5035
+#: Merge.rc:5034
 msgid "Unable to compare files"
 msgstr "Impossible de comparer les fichiers"
 
 #. IDS_ABORTED_ITEM
-#: Merge.rc:5036
+#: Merge.rc:5035
 msgid "Item aborted"
 msgstr "Élément abandonné"
 
 #. IDS_FILE_SKIPPED
-#: Merge.rc:5037
+#: Merge.rc:5036
 msgid "File skipped"
 msgstr "Fichier ignoré"
 
 #. IDS_DIR_SKIPPED
-#: Merge.rc:5038
+#: Merge.rc:5037
 msgid "Folder skipped"
 msgstr "Dossier ignoré"
 
 #. IDS_LEFT_ONLY_IN_FMT
-#: Merge.rc:5039
+#: Merge.rc:5038
 #, c-format
 msgid "Left only: %1"
 msgstr "Gauche uniquement : %1"
 
 #. IDS_MIDDLE_ONLY_IN_FMT
-#: Merge.rc:5040
+#: Merge.rc:5039
 #, c-format
 msgid "Middle only: %1"
 msgstr "Milieu uniquement : %1"
 
 #. IDS_RIGHT_ONLY_IN_FMT
-#: Merge.rc:5041
+#: Merge.rc:5040
 #, c-format
 msgid "Right only: %1"
 msgstr "Droite uniquement : %1"
 
 #. IDS_DOES_NOT_EXIST_IN_FMT
-#: Merge.rc:5042
+#: Merge.rc:5041
 #, c-format
 msgid "Does not exist in %1"
 msgstr "N'existe pas dans %1"
 
 #. IDS_BIN_FILES_SAME
-#: Merge.rc:5043
+#: Merge.rc:5042
 msgid "Binary files are identical"
 msgstr "Les fichiers binaires sont identiques"
 
 #. IDS_BIN_FILES_DIFF
-#: Merge.rc:5049
+#: Merge.rc:5048
 msgid "Binary files are different"
 msgstr "Les fichiers binaires sont différents"
 
 #. IDS_FILES_ARE_DIFFERENT
-#: Merge.rc:5050
+#: Merge.rc:5049
 msgid "Files are different"
 msgstr "Les fichiers sont différents"
 
 #. IDS_FOLDERS_ARE_DIFFERENT
-#: Merge.rc:5051
+#: Merge.rc:5050
 msgid "Folders are different"
 msgstr "Les dossiers sont différents"
 
 #. IDS_LEFTONLY
-#: Merge.rc:5052
+#: Merge.rc:5051
 msgid "Left Only"
 msgstr "À Gauche uniquement"
 
 #. IDS_RIGHTONLY
-#: Merge.rc:5053
+#: Merge.rc:5052
 msgid "Right Only"
 msgstr "À Droite uniquement"
 
 #. IDS_MIDDLEONLY
-#: Merge.rc:5054
+#: Merge.rc:5053
 msgid "Middle Only"
 msgstr "Au Milieu uniquement"
 
 #. IDS_NOITEMLEFT
-#: Merge.rc:5055
+#: Merge.rc:5054
 msgid "No item in left"
 msgstr "Aucun élément à Gauche"
 
 #. IDS_NOITEMRIGHT
-#: Merge.rc:5056
+#: Merge.rc:5055
 msgid "No item in right"
 msgstr "Aucun élément à Droite"
 
 #. IDS_NOITEMMIDDLE
-#: Merge.rc:5057
+#: Merge.rc:5056
 msgid "No item in middle"
 msgstr "Aucun élément au Milieu"
 
 #. IDS_CMPRES_ERROR
-#: Merge.rc:5059
+#: Merge.rc:5058
 msgid "Error"
 msgstr "Erreur"
 
 #. IDS_TEXT_FILES_SAME
-#: Merge.rc:5060
+#: Merge.rc:5059
 msgid "Text files are identical"
 msgstr "Les fichiers texte sont identiques"
 
 #. IDS_LEFTONLY_DIFF
-#: Merge.rc:5061
+#: Merge.rc:5060
 msgid " (Middle and right are identical)"
 msgstr " (Milieu et Droite sont identiques)"
 
 #. IDS_MIDDLEONLY_DIFF
-#: Merge.rc:5062
+#: Merge.rc:5061
 msgid " (Left and right are identical)"
 msgstr " (Gauche et Droite sont identiques)"
 
 #. IDS_RIGHTONLY_DIFF
-#: Merge.rc:5063
+#: Merge.rc:5062
 msgid " (Left and middle are identical)"
 msgstr " (Gauche et Milieu sont identiques)"
 
 #. IDS_PATH_MISMATCH
-#: Merge.rc:5064
+#: Merge.rc:5063
 msgid " (paths differ)"
 msgstr " (différences des chemins)"
 
 #. IDS_TEXT_FILES_DIFF
-#: Merge.rc:5065
+#: Merge.rc:5064
 msgid "Text files are different"
 msgstr "Les fichiers texte sont différents"
 
 #. IDS_IMAGE_FILES_SAME
-#: Merge.rc:5066
+#: Merge.rc:5065
 msgid "Image files are identical"
 msgstr "Les fichiers image sont identiques"
 
 #. IDS_IMAGE_FILES_DIFF
-#: Merge.rc:5067
+#: Merge.rc:5066
 msgid "Image files are different"
 msgstr "Les fichiers image sont différents"
 
 #. IDS_EXPR_DIFF
-#: Merge.rc:5068
+#: Merge.rc:5067
 #, c-format
 msgid "Files are different (expr: %1)"
 msgstr "Les fichiers sont différents (expr : %1)"
 
 #. IDS_HASH_GROUP
-#: Merge.rc:5069
+#: Merge.rc:5068
 #, c-format
 msgid "Group%d"
 msgstr "Groupe%d"
 
 #. IDS_RENAME_MOVE_DETECTION_DISALBED
-#: Merge.rc:5070
+#: Merge.rc:5069
 msgctxt "Options dialog|Compare|Folder|Detect renames and moves"
 msgid "Disabled"
 msgstr "Désactivée"
 
 #. IDS_RENAME_MOVE_DETECTION_RENAME
-#: Merge.rc:5071
+#: Merge.rc:5070
 msgid "Detect renames"
 msgstr "Détecter les renommages"
 
 #. IDS_RENAME_MOVE_DETECTION_RENAME_MOVE
-#: Merge.rc:5072
+#: Merge.rc:5071
 msgid "Detect renames and moves"
 msgstr "Détecter les renommages et les déplacements"
 
 #. IDS_RENAME_MOVE_MERGE_MODE_RENAME
-#: Merge.rc:5073
+#: Merge.rc:5072
 msgid "Merge renames"
 msgstr "Fusionner les renommages"
 
 #. IDS_RENAME_MOVE_MERGE_MODE_RENAME_MOVE
-#: Merge.rc:5074
+#: Merge.rc:5073
 msgid "Merge renames and moves"
 msgstr "Fusionner les renommages et les déplacements"
 
 #. IDS_RENAMED
-#: Merge.rc:5075
+#: Merge.rc:5074
 msgid "Renamed"
 msgstr "Renommé"
 
 #. IDS_RENAMED_MOVED
-#: Merge.rc:5077
+#: Merge.rc:5076
 msgid "Renamed/Moved"
 msgstr "Renommé/Déplacé"
 
 #. IDS_RENAMED_MOVED_ITEMS
-#: Merge.rc:5078
+#: Merge.rc:5077
 #, c-format
 msgid "(%1 items)"
 msgstr "(%1 éléments)"
 
 #. IDS_RENAMED_MOVED_RESULT
-#: Merge.rc:5079
+#: Merge.rc:5078
 #, c-format
 msgid "%1 (set %2): "
 msgstr "%1 (ensemble %2) : "
 
 #. IDS_SWITCH_FLAT_MODE
-#: Merge.rc:5080
+#: Merge.rc:5079
 msgid ""
 "Some moved items have been merged.\n"
 "In Tree Mode, these items may appear in positions that do not reflect the actual folder structure, which can be confusing.\n"
@@ -6981,235 +6976,235 @@ msgstr ""
 "Passer en mode Plat ?"
 
 #. IDS_ELAPSED_TIME
-#: Merge.rc:5086
+#: Merge.rc:5085
 #, c-format
 msgid "Elapsed time: %ld ms"
 msgstr "Temps écoulé: %ld ms"
 
 #. IDS_STATUS_SELITEM1
-#: Merge.rc:5087
+#: Merge.rc:5086
 msgid "1 item selected"
 msgstr "1 élément sélectionné"
 
 #. IDS_STATUS_SELITEMS
-#: Merge.rc:5088
+#: Merge.rc:5087
 #, c-format
 msgid "%1 items selected"
 msgstr "%1 éléments sélectionnés"
 
 #. IDS_COLDESC_FILENAME
-#: Merge.rc:5094
+#: Merge.rc:5093
 msgid "Filename or folder name."
 msgstr "Nom de fichier ou dossier."
 
 #. IDS_COLDESC_DIR
-#: Merge.rc:5095
+#: Merge.rc:5094
 msgid "Subfolder name when subfolders are included."
 msgstr "Nom du sous-dossier lorsque ceux-ci sont inclus."
 
 #. IDS_COLDESC_RESULT
-#: Merge.rc:5096
+#: Merge.rc:5095
 msgid "Comparison result, long form."
 msgstr "Resultat de la comparaison, format étendu."
 
 #. IDS_COLDESC_LTIMEM
-#: Merge.rc:5101
+#: Merge.rc:5100
 msgid "Left side modification date."
 msgstr "Date de modification du panneau Gauche."
 
 #. IDS_COLDESC_RTIMEM
-#: Merge.rc:5102
+#: Merge.rc:5101
 msgid "Right side modification date."
 msgstr "Date de modification du panneau Droite."
 
 #. IDS_COLDESC_MTIMEM
-#: Merge.rc:5103
+#: Merge.rc:5102
 msgid "Middle side modification date."
 msgstr "Date modification du panneau Milieu."
 
 #. IDS_COLDESC_EXTENSION
-#: Merge.rc:5104
+#: Merge.rc:5103
 msgid "File's extension."
 msgstr "Extension du fichier."
 
 #. IDS_COLDESC_LSIZE
-#: Merge.rc:5105
+#: Merge.rc:5104
 msgid "Left file size in bytes."
 msgstr "Taille du fichier du panneau Gauche en octets."
 
 #. IDS_COLDESC_RSIZE
-#: Merge.rc:5106
+#: Merge.rc:5105
 msgid "Right file size in bytes."
 msgstr "Taille du fichier du panneau Droite en octets."
 
 #. IDS_COLDESC_MSIZE
-#: Merge.rc:5107
+#: Merge.rc:5106
 msgid "Middle file size in bytes."
 msgstr "Taille du fichier du panneau Milieu en octets."
 
 #. IDS_COLDESC_LSIZE_SHORT
-#: Merge.rc:5108
+#: Merge.rc:5107
 msgid "Left file size abbreviated."
 msgstr "Taille du fichier du panneau Gauche abrégée."
 
 #. IDS_COLDESC_RSIZE_SHORT
-#: Merge.rc:5109
+#: Merge.rc:5108
 msgid "Right file size abbreviated."
 msgstr "Taille du fichier du panneau Droite abrégée."
 
 #. IDS_COLDESC_MSIZE_SHORT
-#: Merge.rc:5110
+#: Merge.rc:5109
 msgid "Middle file size abbreviated."
 msgstr "Taille du fichier du panneau Milieu abrégée."
 
 #. IDS_COLDESC_LTIMEC
-#: Merge.rc:5116
+#: Merge.rc:5115
 msgid "Left side creation time."
 msgstr "Date de création du panneau Gauche."
 
 #. IDS_COLDESC_RTIMEC
-#: Merge.rc:5117
+#: Merge.rc:5116
 msgid "Right side creation time."
 msgstr "Date de création du panneau Droite."
 
 #. IDS_COLDESC_MTIMEC
-#: Merge.rc:5118
+#: Merge.rc:5117
 msgid "Middle side creation time."
 msgstr "Date de création du panneau Milieu."
 
 #. IDS_COLDESC_NEWER
-#: Merge.rc:5119
+#: Merge.rc:5118
 msgid "Tells which side has newer modification date."
 msgstr "Indique le panneau ayant la date de modification la plus récente."
 
 #. IDS_COLDESC_LVERSION
-#: Merge.rc:5120
+#: Merge.rc:5119
 msgid "Left side file version, only for some file types."
 msgstr "Version du fichier du panneau Gauche, uniquement pour certain types de fichiers."
 
 #. IDS_COLDESC_RVERSION
-#: Merge.rc:5121
+#: Merge.rc:5120
 msgid "Right side file version, only for some file types."
 msgstr "Version du fichier du panneau Droite, uniquement pour certain types de fichiers."
 
 #. IDS_COLDESC_MVERSION
-#: Merge.rc:5126
+#: Merge.rc:5125
 msgid "Middle side file version, only for some file types."
 msgstr "Version du fichier du panneau Milieu, uniquement pour certain types de fichiers."
 
 #. IDS_COLDESC_RESULT_ABBR
-#: Merge.rc:5127
+#: Merge.rc:5126
 msgid "Short comparison result."
 msgstr "Résultat de la comparaison, format abrégé."
 
 #. IDS_COLDESC_LATTRIBUTES
-#: Merge.rc:5128
+#: Merge.rc:5127
 msgid "Left side attributes."
 msgstr "Attributs du panneau Gauche."
 
 #. IDS_COLDESC_RATTRIBUTES
-#: Merge.rc:5129
+#: Merge.rc:5128
 msgid "Right side attributes."
 msgstr "Attributs du panneau Droite."
 
 #. IDS_COLDESC_MATTRIBUTES
-#: Merge.rc:5130
+#: Merge.rc:5129
 msgid "Middle side attributes."
 msgstr "Attributs du panneau Milieu."
 
 #. IDS_COLDESC_LEOL_TYPE
-#: Merge.rc:5131
+#: Merge.rc:5130
 msgid "Left side file EOL type."
 msgstr "Type d'EOL du panneau Gauche."
 
 #. IDS_COLDESC_REOL_TYPE
-#: Merge.rc:5132
+#: Merge.rc:5131
 msgid "Right side file EOL type."
 msgstr "Type d'EOL du panneau Droite."
 
 #. IDS_COLDESC_MEOL_TYPE
-#: Merge.rc:5133
+#: Merge.rc:5132
 msgid "Middle side file EOL type."
 msgstr "Type d'EOL du panneau Milieu."
 
 #. IDS_COLDESC_LENCODING
-#: Merge.rc:5139
+#: Merge.rc:5138
 msgid "Left side encoding."
 msgstr "Encodage du panneau Gauche."
 
 #. IDS_COLDESC_RENCODING
-#: Merge.rc:5140
+#: Merge.rc:5139
 msgid "Right side encoding."
 msgstr "Encodage du panneau Droite."
 
 #. IDS_COLDESC_MENCODING
-#: Merge.rc:5141
+#: Merge.rc:5140
 msgid "Middle side encoding."
 msgstr "Encodage du panneau Milieu."
 
 #. IDS_COLDESC_NIDIFFS
-#: Merge.rc:5142
+#: Merge.rc:5141
 msgid "Number of ignored differences in file. Ignored and cannot be merged."
 msgstr "Nombre de différences ignorées dans le fichier. Ignoré et ne peut pas être fusionné."
 
 #. IDS_COLDESC_NSDIFFS
-#: Merge.rc:5143
+#: Merge.rc:5142
 msgid "Number of differences in file (excluding ignored)."
 msgstr "Nombre de différences dans le fichier (sauf ignorées)."
 
 #. IDS_COLDESC_BINARY
-#: Merge.rc:5144
+#: Merge.rc:5143
 msgid "Shows an asterisk (*) if the file is binary."
 msgstr "Affiche un astérisque (*) si le fichier est binaire."
 
 #. IDS_COLDESC_UNPACKER
-#: Merge.rc:5145
+#: Merge.rc:5144
 msgid "Unpacker plugin name or pipeline."
 msgstr "Nom du plug-in ou pipeline de décompression."
 
 #. IDS_COLDESC_PREDIFFER
-#: Merge.rc:5146
+#: Merge.rc:5145
 msgid "Prediffer plugin name or pipeline."
 msgstr "Précomparer le nom du plug-in ou du pipeline."
 
 #. IDS_DIRECTORY_REPORT_TITLE
-#: Merge.rc:5152
+#: Merge.rc:5151
 #, c-format
 msgid "Compare %1 with %2"
 msgstr "Comparer %1 avec %2"
 
 #. IDS_DIRECTORY_REPORT_TITLE3
-#: Merge.rc:5153
+#: Merge.rc:5152
 #, c-format
 msgid "Compare %1 with %2 and %3"
 msgstr "Comparer %1 avec %2 et %3"
 
 #. IDS_REPORT_COMMALIST
-#: Merge.rc:5154
+#: Merge.rc:5153
 msgid "Comma-separated list"
 msgstr "Liste délimitée par des virgules"
 
 #. IDS_REPORT_TABLIST
-#: Merge.rc:5155
+#: Merge.rc:5154
 msgid "Tab-separated list"
 msgstr "Liste délimitée par des tabulations"
 
 #. IDS_REPORT_SIMPLEHTML
-#: Merge.rc:5156
+#: Merge.rc:5155
 msgid "Simple HTML"
 msgstr "HTML simple"
 
 #. IDS_REPORT_SIMPLEXML
-#: Merge.rc:5157
+#: Merge.rc:5156
 msgid "Simple XML"
 msgstr "XML simple"
 
-#: Merge.rc:5159
+#: Merge.rc:5158
 msgid "Report file already exists. Overwrite?"
 msgstr "Le fichier de rapport existe déjà. Écraser ?"
 
 #. IDS_REPORT_ERROR
-#: Merge.rc:5164
+#: Merge.rc:5163
 #, c-format
 msgid ""
 "Error creating the report:\n"
@@ -7219,27 +7214,27 @@ msgstr ""
 "%1"
 
 #. IDS_REPORT_SUCCESS
-#: Merge.rc:5165
+#: Merge.rc:5164
 msgid "Report created successfully."
 msgstr "Rapport créé avec succès."
 
 #. IDS_SYNCPOINT_LASTBLOCK
-#: Merge.rc:5171
+#: Merge.rc:5170
 msgid "Cannot add a synchronization point at this line."
 msgstr "Impossible d'ajouter un point de synchronisation sur cette ligne."
 
 #. IDS_FILE_TO_ITSELF
-#: Merge.rc:5177
+#: Merge.rc:5176
 msgid "Same file is opened in both panes."
 msgstr "Le même fichier est ouvert dans les deux panneaux."
 
 #. IDS_FILESSAME
-#: Merge.rc:5178
+#: Merge.rc:5177
 msgid "Selected files are identical."
 msgstr "Les fichiers sélectionnés sont identiques."
 
 #. IDS_FILESSAME_CURCFG
-#: Merge.rc:5179
+#: Merge.rc:5178
 msgid ""
 "Selected files are identical (with current settings).\r\n"
 "Checking binary identity..."
@@ -7248,7 +7243,7 @@ msgstr ""
 "Vérification de l'identité binaire..."
 
 #. IDS_FILESSAME_BINERROR
-#: Merge.rc:5180
+#: Merge.rc:5179
 msgid ""
 "Selected files are identical (with current settings).\r\n"
 "But binary comparison failed."
@@ -7257,12 +7252,12 @@ msgstr ""
 "Mais la comparaison binaire a échoué."
 
 #. IDS_FILESSAME_BINSAME
-#: Merge.rc:5181
+#: Merge.rc:5180
 msgid "Selected files are identical (binary match)."
 msgstr "Les fichiers sélectionnés sont identiques (correspondance binaire)."
 
 #. IDS_FILESSAME_BINDIFF
-#: Merge.rc:5182
+#: Merge.rc:5181
 msgid ""
 "Selected files are identical (with current settings).\r\n"
 "But differ at the binary level."
@@ -7271,17 +7266,17 @@ msgstr ""
 "Mais diffèrent au niveau binaire."
 
 #. IDS_FILEERROR
-#: Merge.rc:5183
+#: Merge.rc:5182
 msgid "An error occurred while comparing files."
 msgstr "Une erreur s'est produite lors de la comparaison des fichiers."
 
 #. IDS_TEMP_FILEERROR
-#: Merge.rc:5184
+#: Merge.rc:5183
 msgid "Could not create temporary files. Check your temporary path settings."
 msgstr "Impossible de créer des fichiers temporaires. Vérifiez vos paramètres de chemin temporaire."
 
 #. IDS_SUGGEST_IGNOREEOL
-#: Merge.rc:5185
+#: Merge.rc:5184
 msgid ""
 "Files use different EOL.\n"
 "\n"
@@ -7296,17 +7291,17 @@ msgstr ""
 "Définissez \"Ignorer les différences d'EOL (Windows/Unix/Mac)\" dans la section Comparer sous Préférences."
 
 #. IDS_INVALID_DIRECTORY
-#: Merge.rc:5186
+#: Merge.rc:5185
 msgid "Selected folder is invalid."
 msgstr "Le dossier sélectionné est invalide."
 
 #. IDS_CANNOT_OPEN_BINARYFILE
-#: Merge.rc:5187
+#: Merge.rc:5186
 msgid "Cannot open a binary file in Editor."
 msgstr "Impossible d'ouvrir un fichier binaire avec l'éditeur."
 
 #. IDS_CREATE_PAIR_FOLDER
-#: Merge.rc:5188
+#: Merge.rc:5187
 #, c-format
 msgid ""
 "Create matching folder:\n"
@@ -7318,41 +7313,41 @@ msgstr ""
 "de l'autre côté et l'ouvrir ?"
 
 #. IDS_CONFIRM_COPY_ALL_DIFFS
-#: Merge.rc:5189
+#: Merge.rc:5188
 msgid "Copy all differences to other file?"
 msgstr "Copier toutes les différences dans un autre fichier ?"
 
 #. IDS_MOVE_TO_NEXTFILE
-#: Merge.rc:5194
+#: Merge.rc:5193
 msgid "Move to next file?"
 msgstr "Passer au fichier suivant ?"
 
 #. IDS_MOVE_TO_PREVFILE
-#: Merge.rc:5195
+#: Merge.rc:5194
 msgid "Move to previous file?"
 msgstr "Passer au fichier précédent ?"
 
 #. IDS_MOVE_TO_NEXTPAGE
-#: Merge.rc:5196
+#: Merge.rc:5195
 msgid "Move to next page?"
 msgstr "Passer à la page suivante ?"
 
 #. IDS_MOVE_TO_PREVPAGE
-#: Merge.rc:5197
+#: Merge.rc:5196
 msgid "Move to previous page?"
 msgstr "Passer à la page précédente ?"
 
 #. IDS_MOVE_TO_FIRSTFILE
-#: Merge.rc:5198
+#: Merge.rc:5197
 msgid "Move to first file?"
 msgstr "Passer au premier fichier ?"
 
 #. IDS_MOVE_TO_LASTFILE
-#: Merge.rc:5199
+#: Merge.rc:5198
 msgid "Move to last file?"
 msgstr "Passer au dernier fichier ?"
 
-#: Merge.rc:5206
+#: Merge.rc:5205
 #, c-format
 msgid ""
 "Different codepages: left (cp%d), right (cp%d).\n"
@@ -7363,51 +7358,51 @@ msgstr ""
 "Affichage dans la page de codes (meilleur affichage) ou page de codes Windows par défaut (fusion plus sûre) ?\n"
 "(Recommandé : page de codes Windows par défaut)"
 
-#: Merge.rc:5208
+#: Merge.rc:5207
 msgid "Information lost due to encoding errors: both files"
 msgstr "Information perdue à cause d'erreurs d'encodage: pour les deux fichiers"
 
-#: Merge.rc:5210
+#: Merge.rc:5209
 msgid "Information lost due to encoding errors: first file"
 msgstr "Information perdue à cause d'erreurs d'encodage : premier fichier"
 
-#: Merge.rc:5212
+#: Merge.rc:5211
 msgid "Information lost due to encoding errors: second file"
 msgstr "Information perdue à cause d'erreurs d'encodage : second fichier"
 
-#: Merge.rc:5214
+#: Merge.rc:5213
 msgid "Information lost due to encoding errors: third file"
 msgstr "Information perdue à cause d'erreurs d'encodage : troisième fichier"
 
 #. IDS_LINEDIFF_NODIFF
-#: Merge.rc:5220
+#: Merge.rc:5219
 msgid "No difference"
 msgstr "Aucune différence"
 
 #. IDS_LINEDIFF_NODIFF_CAPTION
-#: Merge.rc:5221
+#: Merge.rc:5220
 msgid "Line difference"
 msgstr "Ligne différente"
 
 #. IDS_NUM_REPLACED
-#: Merge.rc:5227
+#: Merge.rc:5226
 #, c-format
 msgid "Replaced %1 string(s)."
 msgstr "%1 remplacement(s) effectué(s)."
 
 #. IDS_EDIT_TEXT_NOT_FOUND
-#: Merge.rc:5228
+#: Merge.rc:5227
 #, c-format
 msgid "Cannot find string \"%s\"."
 msgstr "Chaîne \"%s\" non trouvée."
 
 #. IDS_MERGE_MODE
-#: Merge.rc:5234
+#: Merge.rc:5233
 msgid "Entering Merge Mode. Press F9 to turn off."
 msgstr "Entrée en mode fusion. Appuyez sur F9 pour désactiver."
 
 #. IDS_AUTO_MERGE
-#: Merge.rc:5240
+#: Merge.rc:5239
 #, c-format
 msgid ""
 "Automatic merges: %1\n"
@@ -7417,89 +7412,89 @@ msgstr ""
 "Conflits non résolus : %2"
 
 #. IDS_CODEPAGE_MERGED
-#: Merge.rc:5241
+#: Merge.rc:5240
 msgid "Codepage change merged."
 msgstr "Le changement de page de code a été fusionné."
 
 #. IDS_CODEPAGE_CONFLICT
-#: Merge.rc:5242
+#: Merge.rc:5241
 msgid "Codepage changes are conflicting."
 msgstr "Les changements de page de code sont en conflits."
 
 #. IDS_EOL_MERGED
-#: Merge.rc:5243
+#: Merge.rc:5242
 msgid "EOL change merged."
 msgstr "Les changements d'EOL ont été fusionnés."
 
 #. IDS_EOL_CONFLICT
-#: Merge.rc:5244
+#: Merge.rc:5243
 msgid "EOL changes are conflicting."
 msgstr "Les changements d'EOL sont en conflits."
 
 #. IDS_LOCBAR_CAPTION
-#: Merge.rc:5250
+#: Merge.rc:5249
 msgid "Location Pane"
 msgstr "Panneau de localisation"
 
 #. IDS_DIFFBAR_CAPTION
-#: Merge.rc:5251
+#: Merge.rc:5250
 msgid "Diff Pane"
 msgstr "Panneau des différences"
 
 #. IDS_DIFF_SUCCEEDED
-#: Merge.rc:5258
+#: Merge.rc:5257
 msgid "Patch file written."
 msgstr "Le fichier de retouche a été écrit avec succès."
 
 #. IDS_DIFF_FILEOVERWRITE
-#: Merge.rc:5259
+#: Merge.rc:5258
 msgid "Patch file already exists. Overwrite?"
 msgstr "Le fichier de retouche existe déja. L'écraser ?"
 
 #. IDS_DIFF_SELECTEDFILES
-#: Merge.rc:5260
+#: Merge.rc:5259
 #, c-format
 msgid "[%1 files selected]"
 msgstr "[%1 fichiers sélectionnés]"
 
 #. IDS_DIFF_NORMAL
-#: Merge.rc:5261
+#: Merge.rc:5260
 msgid "Normal"
 msgstr "Normal"
 
 #. IDS_DIFF_CONTEXT
-#: Merge.rc:5262
+#: Merge.rc:5261
 msgid "Context"
 msgstr "Contexte"
 
 #. IDS_DIFF_UNIFIED
-#: Merge.rc:5263
+#: Merge.rc:5262
 msgid "Unified"
 msgstr "Unifié"
 
 #. IDS_FILEWRITE_ERROR
-#: Merge.rc:5265
+#: Merge.rc:5264
 #, c-format
 msgid "Could not write to file %1."
 msgstr "Impossible d'écrire dans le fichier %1."
 
 #. IDS_PATH_NOT_ABSOLUTE
-#: Merge.rc:5266
+#: Merge.rc:5265
 #, c-format
 msgid "Output path is not absolute: %1"
 msgstr "Le chemin spécifié n'est pas un chemin absolu : %1"
 
 #. IDS_MUST_SPECIFY_OUTPUT
-#: Merge.rc:5267
+#: Merge.rc:5266
 msgid "Specify an output file."
 msgstr "Indiquer un fichier de sortie."
 
-#: Merge.rc:5269
+#: Merge.rc:5268
 msgid "Cannot create patch from binary files."
 msgstr "Impossible de créer un fichier de retouche depuis un fichier binaire."
 
 #. IDS_SAVEFILES_FORPATCH
-#: Merge.rc:5270
+#: Merge.rc:5269
 msgid ""
 "Save all files first.\n"
 "\n"
@@ -7507,17 +7502,17 @@ msgid ""
 msgstr "Sauvegardez d'abord tous les fichiers.\\in\\La création d'une retouche nécessite que toute modification soit enregistrée."
 
 #. IDS_FOLDER_NOTEXIST
-#: Merge.rc:5271
+#: Merge.rc:5270
 msgid "Folder does not exist."
 msgstr "Le dossier n'existe pas."
 
 #. IDS_ARCHIVE_SUCCEEDED
-#: Merge.rc:5277
+#: Merge.rc:5276
 msgid "Archive file written."
 msgstr "Fichier d'archive créé."
 
 #. IDS_ARCHIVE_SAVEFILES
-#: Merge.rc:5278
+#: Merge.rc:5277
 msgid ""
 "Save all files first.\n"
 "\n"
@@ -7528,7 +7523,7 @@ msgstr ""
 "La création d'une archive requiert aucune modification non enregistrée."
 
 #. IDS_NO_ZIP_SUPPORT
-#: Merge.rc:5283
+#: Merge.rc:5282
 msgid ""
 "Archive support not enabled.\n"
 "7-Zip and/or Merge7z*.dll not found.\n"
@@ -7539,37 +7534,37 @@ msgstr ""
 "Voir le manuel pour la prise en charge des archives."
 
 #. IDS_OPT_EXPORT_CAPTION
-#: Merge.rc:5284
+#: Merge.rc:5283
 msgid "Select file for export"
 msgstr "Sélectionner le fichier pour exportation"
 
 #. IDS_OPT_IMPORT_CAPTION
-#: Merge.rc:5285
+#: Merge.rc:5284
 msgid "Select file for import"
 msgstr "Sélectionner le fichier pour importation"
 
 #. IDS_OPT_IMPORT_DONE
-#: Merge.rc:5286
+#: Merge.rc:5285
 msgid "Options imported from file."
 msgstr "Préférences importées depuis le fichier."
 
 #. IDS_OPT_EXPORT_DONE
-#: Merge.rc:5287
+#: Merge.rc:5286
 msgid "Options exported to file."
 msgstr "Préférences exportées vers le fichier."
 
 #. IDS_OPT_IMPORT_ERR
-#: Merge.rc:5288
+#: Merge.rc:5287
 msgid "Failed to import options from file."
 msgstr "Échec de l'importation des préférences à partir du fichier."
 
 #. IDS_OPT_EXPORT_ERR
-#: Merge.rc:5289
+#: Merge.rc:5288
 msgid "Failed to write options to file."
 msgstr "Échec de l'écriture des préférences dans le fichier."
 
 #. IDS_CLOSEALL_WINDOWS
-#: Merge.rc:5290
+#: Merge.rc:5289
 msgid ""
 "Close multiple compare windows?\n"
 "\n"
@@ -7580,34 +7575,34 @@ msgstr ""
 "Continuer ?"
 
 #. IDS_EOL_BIN
-#: Merge.rc:5300
+#: Merge.rc:5299
 msgctxt "EOL Type"
 msgid "Binary"
 msgstr "Binaire"
 
 #. IDS_MARKER_COLOR_FMT
-#: Merge.rc:5305
+#: Merge.rc:5304
 #, c-format
 msgid "Marker Color %d"
 msgstr "Couleur du marqueur %d"
 
 #. IDS_MARKER_NEW_PATTERN
-#: Merge.rc:5306
+#: Merge.rc:5305
 msgid "New Pattern"
 msgstr "Nouveau modèle"
 
 #. IDS_PLUGINSLIST_TYPE
-#: Merge.rc:5312
+#: Merge.rc:5311
 msgid "Type"
 msgstr "Type"
 
 #. IDS_PLUGINS_TYPE_EDITSCRIPT
-#: Merge.rc:5316
+#: Merge.rc:5315
 msgid "Editor script"
 msgstr "Éditeur de script"
 
 #. ID_SELECTLINEDIFF
-#: Merge.rc:5322
+#: Merge.rc:5321
 msgid ""
 "\n"
 "Difference in Current Line (F4)"
@@ -7616,7 +7611,7 @@ msgstr ""
 "Différence sur la ligne courante (F4)"
 
 #. ID_OPTIONS
-#: Merge.rc:5323
+#: Merge.rc:5322
 msgid ""
 "\n"
 "Options"
@@ -7625,7 +7620,7 @@ msgstr ""
 "Préférences"
 
 #. ID_REFRESH
-#: Merge.rc:5324
+#: Merge.rc:5323
 msgid ""
 "\n"
 "Refresh (F5)"
@@ -7634,7 +7629,7 @@ msgstr ""
 "Actualiser (F5)"
 
 #. ID_PREVDIFF
-#: Merge.rc:5330
+#: Merge.rc:5329
 msgid ""
 "\n"
 "Previous Difference (Alt+Up)"
@@ -7643,7 +7638,7 @@ msgstr ""
 "Différence précédente (Alt+Haut)"
 
 #. ID_NEXTDIFF
-#: Merge.rc:5331
+#: Merge.rc:5330
 msgid ""
 "\n"
 "Next Difference (Alt+Down)"
@@ -7652,7 +7647,7 @@ msgstr ""
 "Différence suivante (Alt+Bas)"
 
 #. ID_PREVCONFLICT
-#: Merge.rc:5332
+#: Merge.rc:5331
 msgid ""
 "\n"
 "Previous Conflict (Alt+Shift+Up)"
@@ -7661,7 +7656,7 @@ msgstr ""
 "Conflit précédent (Alt+Maj+Haut)"
 
 #. ID_NEXTCONFLICT
-#: Merge.rc:5333
+#: Merge.rc:5332
 msgid ""
 "\n"
 "Next Conflict (Alt+Shift+Down)"
@@ -7670,7 +7665,7 @@ msgstr ""
 "Conflit suivant (Alt+Maj+Bas)"
 
 #. ID_FIRSTDIFF
-#: Merge.rc:5338
+#: Merge.rc:5337
 msgid ""
 "\n"
 "First Difference (Alt+Home)"
@@ -7679,7 +7674,7 @@ msgstr ""
 "Première différence (Alt+Début)"
 
 #. ID_CURDIFF
-#: Merge.rc:5339
+#: Merge.rc:5338
 msgid ""
 "\n"
 "Current Difference (Alt+Enter)"
@@ -7688,7 +7683,7 @@ msgstr ""
 "Différence courante (Alt+Entrée)"
 
 #. ID_LASTDIFF
-#: Merge.rc:5340
+#: Merge.rc:5339
 msgid ""
 "\n"
 "Last Difference (Alt+End)"
@@ -7697,7 +7692,7 @@ msgstr ""
 "Dernière différence (Alt+Fin)"
 
 #. ID_L2R
-#: Merge.rc:5341
+#: Merge.rc:5340
 msgid ""
 "\n"
 "Copy to Right (Alt+Right)"
@@ -7706,7 +7701,7 @@ msgstr ""
 "Copier vers la Droite (Alt+Droite)"
 
 #. ID_R2L
-#: Merge.rc:5342
+#: Merge.rc:5341
 msgid ""
 "\n"
 "Copy to Left (Alt+Left)"
@@ -7715,7 +7710,7 @@ msgstr ""
 "Copier vers la Gauche (Alt+Gauche)"
 
 #. ID_L2RNEXT
-#: Merge.rc:5343
+#: Merge.rc:5342
 msgid ""
 "\n"
 "Copy to Right and Advance (Ctrl+Alt+Right)"
@@ -7724,7 +7719,7 @@ msgstr ""
 "Copier vers la Droite et Avancer (Ctrl+Alt+Droite)"
 
 #. ID_R2LNEXT
-#: Merge.rc:5344
+#: Merge.rc:5343
 msgid ""
 "\n"
 "Copy to Left and Advance (Ctrl+Alt+Left)"
@@ -7733,7 +7728,7 @@ msgstr ""
 "Copier vers la Gauche et Avancer (Ctrl+Alt+Gauche)"
 
 #. ID_ALL_RIGHT
-#: Merge.rc:5345
+#: Merge.rc:5344
 msgid ""
 "\n"
 "Copy All to Right"
@@ -7742,7 +7737,7 @@ msgstr ""
 "Tout copier vers la Droite"
 
 #. ID_ALL_LEFT
-#: Merge.rc:5346
+#: Merge.rc:5345
 msgid ""
 "\n"
 "Copy All to Left"
@@ -7751,7 +7746,7 @@ msgstr ""
 "Tout copier vers la Gauche"
 
 #. ID_AUTO_MERGE
-#: Merge.rc:5347
+#: Merge.rc:5346
 msgid ""
 "\n"
 "Auto Merge (Ctrl+Alt+M)"
@@ -7760,7 +7755,7 @@ msgstr ""
 "Fusionner automatiquement (Ctrl+Alt+M)"
 
 #. ID_FIRSTFILE
-#: Merge.rc:5348
+#: Merge.rc:5347
 msgid ""
 "\n"
 "First File"
@@ -7769,7 +7764,7 @@ msgstr ""
 "Premier fichier"
 
 #. ID_NEXTFILE
-#: Merge.rc:5349
+#: Merge.rc:5348
 msgid ""
 "\n"
 "Next File (Ctrl+F8)"
@@ -7778,7 +7773,7 @@ msgstr ""
 "Fichier suivant (Ctrl+F8)"
 
 #. ID_LASTFILE
-#: Merge.rc:5350
+#: Merge.rc:5349
 msgid ""
 "\n"
 "Last File"
@@ -7787,7 +7782,7 @@ msgstr ""
 "Dernier fichier"
 
 #. ID_PREVFILE
-#: Merge.rc:5351
+#: Merge.rc:5350
 msgid ""
 "\n"
 "Previous File (Ctrl+F7)"
@@ -7796,142 +7791,142 @@ msgstr ""
 "Fichier précédent (Ctrl+F7)"
 
 #. IDS_UNPACK_AUTO
-#: Merge.rc:5358
+#: Merge.rc:5357
 msgid "Adapted unpacker applied to both files (one needs extension)."
 msgstr "Le décompresseur approprié est appliqué aux deux fichiers (un seul fichier nécessite une extension)."
 
 #. IDS_NO_PREDIFFER
-#: Merge.rc:5359
+#: Merge.rc:5358
 msgid "No Prediffer (Normal)"
 msgstr "Aucune précomparaison (normal)"
 
 #. IDS_SUGGESTED_PLUGINS
-#: Merge.rc:5360
+#: Merge.rc:5359
 msgid "Suggested Plugins"
 msgstr "Plug-ins suggérés"
 
 #. IDS_NOT_SUGGESTED_PLUGINS
-#: Merge.rc:5361
+#: Merge.rc:5360
 msgid "All Plugins"
 msgstr "Tous les plug-ins"
 
 #. IDS_PRIVATEBUILD_FMT
-#: Merge.rc:5367
+#: Merge.rc:5366
 #, c-format
 msgid "Private Build: %1"
 msgstr "Compilation privée : %1"
 
 #. IDS_ALLRIGHTS_RESERVED
-#: Merge.rc:5368
+#: Merge.rc:5367
 msgid " - All rights reserved."
 msgstr " - Tous droits réservés."
 
 #. IDS_TITLE_PLUGINS_SETTINGS
-#: Merge.rc:5374
+#: Merge.rc:5373
 msgid "Plugin Settings"
 msgstr "Paramètres des plug-ins"
 
 #. IDS_NO_SCT_SCRIPTS
-#: Merge.rc:5376
+#: Merge.rc:5375
 msgid "WSH not found - .sct scripts disabled"
 msgstr "WSH non trouvé - les scripts .sct sont désactivés"
 
 #. IDS_LOCBAR_GOTOLINE_FMT
-#: Merge.rc:5384
+#: Merge.rc:5383
 #, c-format
 msgid "G&o to Line %1"
 msgstr "Atteindre la ligne %1"
 
 #. IDS_GOTO_MOVED_LINE
-#: Merge.rc:5390
+#: Merge.rc:5389
 msgid "Go to Moved Line\tCtrl+Shift+G"
 msgstr "Aller à la ligne déplacée\tCtrl+Maj+G"
 
 #. IDS_AUTOCOMPLETE_DISABLED
-#: Merge.rc:5396
+#: Merge.rc:5395
 msgctxt "Options dialog|General|Open dialog Auto completion"
 msgid "Disabled"
 msgstr "Désactivé"
 
 #. IDS_AUTOCOMPLETE_FILE_SYS
-#: Merge.rc:5397
+#: Merge.rc:5396
 msgid "From file system"
 msgstr "A partir du système de fichier"
 
 #. IDS_AUTOCOMPLETE_MRU
-#: Merge.rc:5398
+#: Merge.rc:5397
 msgid "From Most Recently Used list"
 msgstr "A partir de la liste des fichiers récents"
 
 #. IDS_COLORSCHEME_PLAIN
-#: Merge.rc:5404
+#: Merge.rc:5403
 msgid "No Highlighting"
 msgstr "Aucune surbrillance"
 
 #. IDS_COLORSCHEME_PO
-#: Merge.rc:5439
+#: Merge.rc:5438
 msgid "Portable Object"
 msgstr "Objet portable"
 
 #. IDS_COLORSCHEME_RSRC
-#: Merge.rc:5444
+#: Merge.rc:5443
 msgid "Resources"
 msgstr "Ressources"
 
 #. IDS_COLORSCHEME_SH
-#: Merge.rc:5448
+#: Merge.rc:5447
 msgid "Shell"
 msgstr "Shell"
 
 #. IDS_CLOSE_LEFT_TABS
-#: Merge.rc:5469
+#: Merge.rc:5468
 msgid "Close &Left Tabs"
 msgstr "Fermer l'ong&let de Gauche"
 
 #. IDS_CLOSE_RIGHT_TABS
-#: Merge.rc:5470
+#: Merge.rc:5469
 msgid "Close R&ight Tabs"
 msgstr "Fermer l'onglet de Dro&ite"
 
 #. IDS_CLOSE_OTHER_TABS
-#: Merge.rc:5471
+#: Merge.rc:5470
 msgid "Close &Other Tabs"
 msgstr "Fermer les autres &onglets"
 
 #. IDS_TABBAR_AUTO_MAXWIDTH
-#: Merge.rc:5472
+#: Merge.rc:5471
 msgid "Enable &Auto Max Width"
 msgstr "Activer largeur max. &auto."
 
 #. IDS_WEBPAGE_MENU
-#: Merge.rc:5482
+#: Merge.rc:5481
 msgid "We&bpage"
 msgstr "Page We&b"
 
 #. IDS_VIEW_WRAP_TEXT
-#: Merge.rc:5487
+#: Merge.rc:5486
 msgid "W&rap Text"
 msgstr "Habilla&ge de texte"
 
 #. IDS_NOTINSTALLED
-#: Merge.rc:5492
+#: Merge.rc:5491
 #, c-format
 msgid "%1 is not installed."
 msgstr "%1 n'est pas installé."
 
 #. IDS_CREATE_FOLDER
-#: Merge.rc:5497
+#: Merge.rc:5496
 #, c-format
 msgid "%1 does not exist. Create it?"
 msgstr "%1 n'existe pas. Le créer ?"
 
 #. IDS_CREATE_FOLDER_ERROR
-#: Merge.rc:5498
+#: Merge.rc:5497
 msgid "Failed to create folder."
 msgstr "Échec de la création du dossier."
 
 #. IDC_EXT_EDITOR_PATH
-#: Merge.rc:5503
+#: Merge.rc:5502
 msgid ""
 "Parameters:\n"
 "$file: Current file path\n"
@@ -7942,491 +7937,491 @@ msgstr ""
 "$linenum : numéro de ligne actuel du curseur"
 
 #. IDS_DIFF_ALGORITHM_DEFAULT
-#: Merge.rc:5508
+#: Merge.rc:5507
 msgid "default"
 msgstr "par défaut"
 
 #. IDS_DIFF_ALGORITHM_MINIMAL
-#: Merge.rc:5509
+#: Merge.rc:5508
 msgid "minimal"
 msgstr "minimal"
 
 #. IDS_DIFF_ALGORITHM_PATIENCE
-#: Merge.rc:5510
+#: Merge.rc:5509
 msgid "patience"
 msgstr "patience"
 
 #. IDS_DIFF_ALGORITHM_HISTOGRAM
-#: Merge.rc:5511
+#: Merge.rc:5510
 msgid "histogram"
 msgstr "histogramme"
 
 #. IDS_DIFF_ALGORITHM_NONE
-#: Merge.rc:5512
+#: Merge.rc:5511
 msgid "none"
 msgstr "aucun"
 
 #. IDS_RENDERING_MODE_GDI
-#: Merge.rc:5517
+#: Merge.rc:5516
 msgid "GDI"
 msgstr "GDI"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_DEFAULT
-#: Merge.rc:5518
+#: Merge.rc:5517
 msgid "DirectWrite Default"
 msgstr "DirectWrite par défaut"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_ALIASED
-#: Merge.rc:5519
+#: Merge.rc:5518
 msgid "DirectWrite Aliased"
 msgstr "DirectWrite aliasé"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_GDI_CLASSIC
-#: Merge.rc:5520
+#: Merge.rc:5519
 msgid "DirectWrite GDI Classic"
 msgstr "DirectWrite GDI classique"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_GDI_NATURAL
-#: Merge.rc:5521
+#: Merge.rc:5520
 msgid "DirectWrite GDI Natural"
 msgstr "DirectWrite GDI naturel"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_NATURAL
-#: Merge.rc:5522
+#: Merge.rc:5521
 msgid "DirectWrite Natural"
 msgstr "DirectWrite naturel"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_NATURAL_SYMMETRIC
-#: Merge.rc:5523
+#: Merge.rc:5522
 msgid "DirectWrite Natural Symmetric"
 msgstr "DirectWrite symétrique naturel"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_DISABLED
-#: Merge.rc:5528
+#: Merge.rc:5527
 msgctxt "Options dialog|General|Close windows with Esc"
 msgid "Disabled"
 msgstr "Désactivé"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_1
-#: Merge.rc:5529
+#: Merge.rc:5528
 msgid "MDI child window or main window"
 msgstr "Fenêtre enfant MDI ou fenêtre principale"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_2
-#: Merge.rc:5530
+#: Merge.rc:5529
 msgid "MDI child window only"
 msgstr "Fenêtre enfant MDI uniquement"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_3
-#: Merge.rc:5531
+#: Merge.rc:5530
 msgid "Close main window if only one MDI child window"
 msgstr "Fermer la fenêtre principale s'il n'y a qu'une seule fenêtre enfant MDI"
 
 #. IDS_DIFF_GROUP
-#: Merge.rc:5536
+#: Merge.rc:5535
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Diff"
 msgstr "Différence"
 
 #. IDS_DIFF_HIGHLIGHT
-#: Merge.rc:5537
+#: Merge.rc:5536
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Highlight"
 msgstr "Surbrillance"
 
 #. IDS_DIFF_BLINK
-#: Merge.rc:5538
+#: Merge.rc:5537
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Blink"
 msgstr "Clignotement"
 
 #. IDS_DIFF_BLOCKSIZE
-#: Merge.rc:5539
+#: Merge.rc:5538
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Block Size"
 msgstr "Taille du bloc"
 
 #. IDS_DIFF_BLOCKALPHA
-#: Merge.rc:5540
+#: Merge.rc:5539
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Block Alpha"
 msgstr "Alpha du bloc"
 
 #. IDS_DIFF_CDTHRESHOLD
-#: Merge.rc:5541
+#: Merge.rc:5540
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "CD Threshold"
 msgstr "Seuil CD"
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION
-#: Merge.rc:5542
+#: Merge.rc:5541
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Ins/Del Detection"
 msgstr "Détection Insér./Suppr."
 
 #. IDS_OVERLAY_MODE_NONE
-#: Merge.rc:5543 Merge.rc:5548
+#: Merge.rc:5542 Merge.rc:5547
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "None"
 msgstr "Aucun"
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION_VERTICAL
-#: Merge.rc:5544
+#: Merge.rc:5543
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Vertical"
 msgstr "Vertical"
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION_HORIZONTAL
-#: Merge.rc:5545
+#: Merge.rc:5544
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Horizontal"
 msgstr "Horizontal"
 
 #. IDS_OVERLAY_GROUP
-#: Merge.rc:5546
+#: Merge.rc:5545
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Overlay"
 msgstr "Recouvrir"
 
 #. IDS_OVERLAY_ALPHA
-#: Merge.rc:5547
+#: Merge.rc:5546
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha"
 msgstr "Alpha"
 
 #. IDS_OVERLAY_MODE_XOR
-#: Merge.rc:5549
+#: Merge.rc:5548
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "XOR"
 msgstr "XOR"
 
 #. IDS_OVERLAY_MODE_ALPHA
-#: Merge.rc:5550
+#: Merge.rc:5549
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha Blend"
 msgstr "Mélange alpha"
 
 #. IDS_OVERLAY_MODE_ALPHA_ANIMATION
-#: Merge.rc:5551
+#: Merge.rc:5550
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha Animation"
 msgstr "Animation alpha"
 
 #. IDS_ZOOM
-#: Merge.rc:5552
+#: Merge.rc:5551
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Zoom"
 msgstr "Zoom"
 
 #. IDS_PAGE
-#: Merge.rc:5553
+#: Merge.rc:5552
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Page:"
 msgstr "Page :"
 
 #. IDS_IMGCMP_STATUS_PT_RGBA_FMT
-#: Merge.rc:5554
+#: Merge.rc:5553
 #, c-format
 msgid "Pt: (%d, %d)  RGBA: (%d, %d, %d, %d)  "
 msgstr "Pt : (%d, %d)  RGBA : (%d, %d, %d, %d)  "
 
 #. IDS_IMGCMP_STATUS_DIST1_FMT
-#: Merge.rc:5555
+#: Merge.rc:5554
 #, c-format
 msgid "Dist: %g  "
 msgstr "Dist : %g  "
 
 #. IDS_IMGCMP_STATUS_DIST2_FMT
-#: Merge.rc:5556
+#: Merge.rc:5555
 #, c-format
 msgid "Dist: %g, %g  "
 msgstr "Dist : %g, %g  "
 
 #. IDS_IMGCMP_STATUS_PAGE_ZOOM_SIZE_BPP_FMT
-#: Merge.rc:5557
+#: Merge.rc:5556
 #, c-format
 msgid "Page: %d/%d  Zoom: %d%%  %dx%dpx  %dbpp  "
 msgstr "Page : %d/%d  Zoom : %d%%  %dx%dpx  %dbpp  "
 
 #. IDS_IMGCMP_STATUS_RC_FMT
-#: Merge.rc:5558
+#: Merge.rc:5557
 #, c-format
 msgid "Rc: (%d, %d)  "
 msgstr "Rc : (%d, %d)  "
 
 #. IDS_IMGCMP_STATUS_FLIPPED_FMT
-#: Merge.rc:5559
+#: Merge.rc:5558
 #, c-format
 msgid "Flipped: %s  "
 msgstr "Inversé : %s  "
 
 #. IDS_IMGCMP_STATUS_ROTATED_FMT
-#: Merge.rc:5560
+#: Merge.rc:5559
 #, c-format
 msgid "Rotated: %d  "
 msgstr "Rotation : %d  "
 
 #. IDS_IMGCMP_REPORT_ALLPAGES
-#: Merge.rc:5561
+#: Merge.rc:5560
 msgid "All pages"
 msgstr "Toutes les pages"
 
 #. IDS_IGNSUB_STR1
-#: Merge.rc:5566
+#: Merge.rc:5565
 msgid "<Edit here>"
 msgstr "<Modifier ici>"
 
 #. IDS_IGNSUB_STR2
-#: Merge.rc:5567
+#: Merge.rc:5566
 msgid "No differences found to select"
 msgstr "Aucune différence trouvée à sélectionner"
 
 #. IDS_IGNSUB_STR3
-#: Merge.rc:5568
+#: Merge.rc:5567
 msgid "No differences found to add as substitution filter"
 msgstr "Aucune différence trouvée à ajouter comme filtre de substitution"
 
 #. IDS_IGNSUB_STR4
-#: Merge.rc:5569
+#: Merge.rc:5568
 msgid "The pair is already in the Substitution Filters list"
 msgstr "La paire est déjà présente dans la liste des filtres de substitution"
 
 #. IDS_IGNSUB_STR5
-#: Merge.rc:5570
+#: Merge.rc:5569
 msgid "Add this change to Substitution Filters?"
 msgstr "Ajouter cette modification aux filtres de substitution ?"
 
 #. IDS_OCRRESULT_TEXTONLY
-#: Merge.rc:5575
+#: Merge.rc:5574
 msgid "Text only"
 msgstr "Texte uniquement"
 
 #. IDS_OCRRESULT_POS_LINE
-#: Merge.rc:5576
+#: Merge.rc:5575
 msgid "Line-by-line position and text"
 msgstr "Position et texte ligne par ligne"
 
 #. IDS_OCRRESULT_POS_WORD
-#: Merge.rc:5577
+#: Merge.rc:5576
 msgid "Word-by-word position and text"
 msgstr "Position et texte mot par mot"
 
 #. IDS_USERDATAFOLDER_APPDATA
-#: Merge.rc:5582
+#: Merge.rc:5581
 msgid "AppData (Roaming) folder"
 msgstr "Dossier AppData (Roaming)"
 
 #. IDS_USERDATAFOLDER_INSTALL
-#: Merge.rc:5583
+#: Merge.rc:5582
 msgid "Install folder"
 msgstr "Dossier d'installation"
 
 #. IDS_USERDATAFOLDER_DOCUMENTS
-#: Merge.rc:5584
+#: Merge.rc:5583
 msgid "Documents folder"
 msgstr "Dossier Documents"
 
 #. IDS_SINGLEINSTANCE_DISABLED
-#: Merge.rc:5589
+#: Merge.rc:5588
 msgctxt "Options dialog|General|Single instance mode"
 msgid "Disabled"
 msgstr "Désactivé"
 
 #. IDS_SINGLEINSTANCE_STR1
-#: Merge.rc:5590
+#: Merge.rc:5589
 msgid "Allow only one instance to run"
 msgstr "Permettre une seule instance en exécution"
 
 #. IDS_CLIPBOARD_HISTORY
-#: Merge.rc:5591
+#: Merge.rc:5590
 msgid "Clipboard &History"
 msgstr "&Historique du presse-papiers"
 
 #. IDS_SINGLEINSTANCE_STR2
-#: Merge.rc:5592
+#: Merge.rc:5591
 msgid "Allow only one instance; wait for termination"
 msgstr "Permettre une seule instance; attendre que l'instance se termine"
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_DISABLED
-#: Merge.rc:5597
+#: Merge.rc:5596
 msgctxt "Options dialog|General|Auto-reload modified files"
 msgid "Disabled"
 msgstr "Désactivé"
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_STR1
-#: Merge.rc:5598
+#: Merge.rc:5597
 msgid "Only on window activated"
 msgstr "Uniquement sur la fenêtre activée"
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_STR2
-#: Merge.rc:5599
+#: Merge.rc:5598
 msgid "Immediately"
 msgstr "Immédiatement"
 
 #. IDS_PLUGIN_ALL
-#: Merge.rc:5604
+#: Merge.rc:5603
 msgid "Al&l"
 msgstr "To&us"
 
 #. IDS_PLUGIN_OTHERS
-#: Merge.rc:5605
+#: Merge.rc:5604
 msgid "&Others"
 msgstr "&Autres"
 
-#: Merge.rc:5607
+#: Merge.rc:5606
 #, c-format
 msgid "Missing plugin name in pipeline: %1"
 msgstr "Nom du plug-in manquant dans le pipeline : %1"
 
-#: Merge.rc:5609
+#: Merge.rc:5608
 #, c-format
 msgid "Missing quote in plugin pipeline: %1"
 msgstr "Guillemet manquant dans le pipeline du plug-in : %1"
 
 #. IDS_PLUGIN_NAME_ALREADY_EXISTS
-#: Merge.rc:5610
+#: Merge.rc:5609
 #, c-format
 msgid "Plugin name '%1' already exists."
 msgstr "Le nom du plug-in '%1' existe déjà."
 
 #. IDS_PLUGIN_TITLE1
-#: Merge.rc:5611
+#: Merge.rc:5610
 msgid "Specify plugin arguments"
 msgstr "Spécifier les arguments du plug-in"
 
-#: Merge.rc:5613
+#: Merge.rc:5612
 #, c-format
 msgid "Plugin not found or invalid: %1"
 msgstr "Plug-in introuvable ou invalide : %1"
 
 #. IDS_PLUGIN_NOT_UNPACK
-#: Merge.rc:5614
+#: Merge.rc:5613
 #, c-format
 msgid "'%1' is not an unpacker plugin"
 msgstr "'%1' n'est pas un plug-in de décompression"
 
 #. IDS_PLUGIN_NOT_PREDIFF
-#: Merge.rc:5615
+#: Merge.rc:5614
 #, c-format
 msgid "'%1' is not a prediffer plugin"
 msgstr "'%1' n'est pas un plug-in de prédifférence"
 
-#: Merge.rc:5617
+#: Merge.rc:5616
 #, c-format
 msgid "Error prediffing '%1' with '%2'. Prediffing disabled."
 msgstr "Erreur lors de la prédifférence de '%1' avec '%2'. Prédifférence désactivée."
 
 #. IDS_PLUGIN_CIRCULAR_REFERENCE
-#: Merge.rc:5618
+#: Merge.rc:5617
 #, c-format
 msgid "Circular reference in plugin pipeline: %1"
 msgstr "Référence circulaire dans le pipeline du plug-in : %1"
 
 #. IDS_PLUGIN_TYPE1
-#: Merge.rc:5619
+#: Merge.rc:5618
 msgid "URL Handler"
 msgstr "Gestionnaire d'URL"
 
 #. IDS_PLUGIN_TYPE2
-#: Merge.rc:5620
+#: Merge.rc:5619
 msgid "File Unpacker"
 msgstr "Décompresseur de fichiers"
 
 #. IDS_PLUGIN_TYPE3
-#: Merge.rc:5621
+#: Merge.rc:5620
 msgid "File or Folder Unpacker"
 msgstr "Décompresseur de fichiers ou dossiers"
 
 #. IDS_PLUGIN_TYPE5
-#: Merge.rc:5623
+#: Merge.rc:5622
 msgid "Alias for Unpacker"
 msgstr "Alias pour le décompresseur"
 
 #. IDS_PLUGIN_TYPE6
-#: Merge.rc:5624
+#: Merge.rc:5623
 msgid "Alias for Prediffer"
 msgstr "Alias pour la précomparaison"
 
 #. IDS_PLUGIN_TYPE7
-#: Merge.rc:5625
+#: Merge.rc:5624
 msgid "Alias for Editor script"
 msgstr "Alias pour l'éditeur de script"
 
 #. IDS_PLUGIN_ALIAS_DESC
-#: Merge.rc:5626
+#: Merge.rc:5625
 #, c-format
 msgid "Alias for plugin pipeline '%1'"
 msgstr "Alias pour le pipeline du plug-in '%1'"
 
 #. IDS_PLUGIN_NEW_DESC
-#: Merge.rc:5627
+#: Merge.rc:5626
 msgid "New plugin description"
 msgstr "Description du nouveau plug-in"
 
 #. IDS_PLUGIN_TARGETS_ALL
-#: Merge.rc:5628
+#: Merge.rc:5627
 msgid "All"
 msgstr "Tous"
 
 #. IDS_PLUGIN_TARGETS_1ST
-#: Merge.rc:5629
+#: Merge.rc:5628
 msgid "1st"
 msgstr "1er"
 
 #. IDS_PLUGIN_TARGETS_2ND
-#: Merge.rc:5630
+#: Merge.rc:5629
 msgid "2nd"
 msgstr "2ème"
 
 #. IDS_PLUGIN_TARGETS_3RD
-#: Merge.rc:5631
+#: Merge.rc:5630
 msgid "3rd"
 msgstr "3ème"
 
 #. IDS_PLUGIN_TARGETS_1ST_2ND
-#: Merge.rc:5632
+#: Merge.rc:5631
 msgid "1st and 2nd"
 msgstr "1er et 2ème"
 
 #. IDS_PLUGIN_TARGETS_1ST_3RD
-#: Merge.rc:5633
+#: Merge.rc:5632
 msgid "1st and 3rd"
 msgstr "1er et 3ème"
 
 #. IDS_PLUGIN_TARGETS_2ND_3RD
-#: Merge.rc:5634
+#: Merge.rc:5633
 msgid "2nd and 3rd"
 msgstr "2ème et 3ème"
 
 #. IDS_PLUGIN_CTRL_CLICK
-#: Merge.rc:5635
+#: Merge.rc:5634
 msgid "(Ctrl+Click to add to pipeline)"
 msgstr ""
 
 #. IDS_FILTER_APPLIED
-#: Merge.rc:5640
+#: Merge.rc:5639
 msgid "Filter applied"
 msgstr "Filtre appliqué"
 
 #. IDS_FILTERMENU_COMPARE
-#: Merge.rc:5645
+#: Merge.rc:5644
 #, c-format
 msgid "Compare %1"
 msgstr "Comparer %1"
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN2
-#: Merge.rc:5647
+#: Merge.rc:5646
 msgid "&Filter by This Column..."
 msgstr "&Filtrer par cette colonne..."
 
 #. IDS_CLIPBOARDHISTORY_TIME
-#: Merge.rc:5652
+#: Merge.rc:5651
 #, c-format
 msgid "Clipboard at %s"
 msgstr "Presse-papiers à %s"
 
 #. IDS_CLIPBOARDHISTORY_DISABLED
-#: Merge.rc:5653
+#: Merge.rc:5652
 msgid ""
 "Clipboard history disabled.\r\n"
 "Enable: Windows logo key + V, then Turn on."
@@ -8434,115 +8429,115 @@ msgstr ""
 "L'historique du presse-papiers est désactivé.\r\n"
 "Pour l'activer : appuyez sur la touche de logo Windows + V, puis cliquez sur Activer."
 
-#: Merge.rc:5655
+#: Merge.rc:5654
 msgid "This system does not support clipboard history."
 msgstr "Ce système ne prend pas en charge l'historique du presse-papiers."
 
-#: Merge.rc:5657
+#: Merge.rc:5656
 msgid "32-bit WinMerge does not support Clipboard Compare"
 msgstr "La version 32 bits de WinMerge ne prend pas en charge la comparaison du presse-papiers"
 
 #. IDS_WEBVIEW2_RUNTIME_NOT_INSTALLED
-#: Merge.rc:5662
+#: Merge.rc:5661
 msgid "WebView2 runtime not installed. Download it?"
 msgstr "Le runtime WebView2 n'est pas installé. Voulez-vous le télécharger ?"
 
 #. IDS_JUMPLIST_NEW_TEXT_COMPARE
-#: Merge.rc:5667
+#: Merge.rc:5666
 msgid "New Text Compare"
 msgstr "Nouvelle comparaison de texte"
 
 #. IDS_JUMPLIST_NEW_TABLE_COMPARE
-#: Merge.rc:5668
+#: Merge.rc:5667
 msgid "New Table Compare"
 msgstr "Nouvelle comparaison de tableau"
 
 #. IDS_JUMPLIST_NEW_BINARY_COMPARE
-#: Merge.rc:5669
+#: Merge.rc:5668
 msgid "New Binary Compare"
 msgstr "Nouvelle comparaison de binaire"
 
 #. IDS_JUMPLIST_NEW_IMAGE_COMPARE
-#: Merge.rc:5670
+#: Merge.rc:5669
 msgid "New Image Compare"
 msgstr "Nouvelle comparaison d'image"
 
 #. IDS_JUMPLIST_NEW_WEBPAGE_COMPARE
-#: Merge.rc:5671
+#: Merge.rc:5670
 msgid "New Webpage Compare"
 msgstr "Nouvelle comparaison de page Web"
 
 #. IDS_JUMPLIST_NEW_FOLDER_COMPARE
-#: Merge.rc:5672
+#: Merge.rc:5671
 msgid "New Folder Compare"
 msgstr "Comparer le nouveau dossier"
 
 #. IDS_JUMPLIST_CLIPBOARD_COMPARE
-#: Merge.rc:5673
+#: Merge.rc:5672
 msgid "Clipboard Compare"
 msgstr "Comparer le presse-papiers"
 
 #. IDS_PREVIEWBAR_PRINT
-#: Merge.rc:5678
+#: Merge.rc:5677
 msgid "&Print..."
 msgstr "Im&primer..."
 
 #. IDS_PREVIEWBAR_PREVPAGE
-#: Merge.rc:5680
+#: Merge.rc:5679
 msgid "Pre&v Page"
 msgstr "Page pré&c."
 
 #. IDS_PREVIEWBAR_TWOPAGE
-#: Merge.rc:5681
+#: Merge.rc:5680
 msgid "&Two Page"
 msgstr "&Deux pages"
 
 #. IDS_PREVIEWBAR_ONEPAGE
-#: Merge.rc:5682
+#: Merge.rc:5681
 msgid "&One Page"
 msgstr "&Une page"
 
 #. IDS_PREVIEWBAR_ZOOMIN
-#: Merge.rc:5683
+#: Merge.rc:5682
 msgid "Zoom &In"
 msgstr "Zoom a&vant"
 
 #. IDS_PREVIEWBAR_ZOOMOUT
-#: Merge.rc:5684
+#: Merge.rc:5683
 msgid "Zoom &Out"
 msgstr "Zoom a&rrière"
 
 #. IDS_WEBPAGE_COMPARING
-#: Merge.rc:5690
+#: Merge.rc:5689
 msgid "Comparing..."
 msgstr "Comparaison en cours..."
 
 #. IDS_WEBPAGE_ZOOM
-#: Merge.rc:5691
+#: Merge.rc:5690
 msgid "Zoom:"
 msgstr "Zoom  :"
 
 #. IDS_COPY_GRANULARITY_DIFFHUNK
-#: Merge.rc:5696
+#: Merge.rc:5695
 msgid "Diff hunk"
 msgstr "Différence en bloc"
 
 #. IDS_COPY_GRANULARITY_INLINE
-#: Merge.rc:5697
+#: Merge.rc:5696
 msgid "Inline diff"
 msgstr "Différence en ligne"
 
 #. IDS_COPY_GRANULARITY_LINE
-#: Merge.rc:5698
+#: Merge.rc:5697
 msgid "Line"
 msgstr "Ligne"
 
-#: Merge.rc:5699
+#: Merge.rc:5698
 msgid "Character"
 msgstr "Caractère"
 
 #. ID_MICE_PREVDIFF
-#: Merge.rc:5704
+#: Merge.rc:5703
 msgid ""
 "\n"
 "Previous Difference (Alt+Up)\n"
@@ -8555,7 +8550,7 @@ msgstr ""
 "(Alt+Molette vers le haut)"
 
 #. ID_MICE_NEXTDIFF
-#: Merge.rc:5705
+#: Merge.rc:5704
 msgid ""
 "\n"
 "Next Difference (Alt+Down)\n"
@@ -8568,7 +8563,7 @@ msgstr ""
 "(Alt+Molette vers le bas)"
 
 #. ID_MICE_L2R
-#: Merge.rc:5706
+#: Merge.rc:5705
 msgid ""
 "\n"
 "Copy to Right (Alt+Right)\n"
@@ -8583,7 +8578,7 @@ msgstr ""
 "(Alt+Maj+Molette vers le bas)"
 
 #. ID_MICE_R2L
-#: Merge.rc:5707
+#: Merge.rc:5706
 msgid ""
 "\n"
 "Copy to Left (Alt+Left)\n"
@@ -8598,7 +8593,7 @@ msgstr ""
 "(Alt+Maj+Molette haut)"
 
 #. ID_MICE_L2RNEXT
-#: Merge.rc:5708
+#: Merge.rc:5707
 msgid ""
 "\n"
 "Copy to Right and Advance (Ctrl+Alt+Right)\n"
@@ -8611,7 +8606,7 @@ msgstr ""
 "(Ctrl+Alt+Maj+Molette vers le bas)"
 
 #. ID_MICE_R2LNEXT
-#: Merge.rc:5709
+#: Merge.rc:5708
 msgid ""
 "\n"
 "Copy to Left and Advance (Ctrl+Alt+Left)\n"
@@ -8624,257 +8619,257 @@ msgstr ""
 "(Ctrl+Alt+Maj+Molette haut)"
 
 #. IDS_LOG_COMPARING_2
-#: Merge.rc:5719
+#: Merge.rc:5718
 #, c-format
 msgid "Comparing %1 with %2"
 msgstr "Comparaison de %1 avec %2"
 
 #. IDS_LOG_COMPARING_3
-#: Merge.rc:5720
+#: Merge.rc:5719
 #, c-format
 msgid "Comparing %1 with %2 and %3"
 msgstr "Comparaison de %1 avec %2 et %3"
 
 #. IDS_LOG_COMPARE_COMPLETED
-#: Merge.rc:5721
+#: Merge.rc:5720
 msgid "Comparison completed"
 msgstr "Comparaison terminée"
 
 #. IDS_LOG_COMPARE_ERROR_2
-#: Merge.rc:5722
+#: Merge.rc:5721
 #, c-format
 msgid "Failed to compare %1 with %2: "
 msgstr "Échec de la comparaison de %1 avec %2 : "
 
 #. IDS_LOG_COMPARE_ERROR_3
-#: Merge.rc:5723
+#: Merge.rc:5722
 #, c-format
 msgid "Failed to compare %1 with %2 and %3: "
 msgstr "Échec de la comparaison de %1 avec %2 et %3 : "
 
 #. IDS_LOG_FILE_SAVED
-#: Merge.rc:5724
+#: Merge.rc:5723
 msgid "File saved"
 msgstr "Fichier enregistré"
 
 #. IDS_LOG_COPYING_FILES
-#: Merge.rc:5725
+#: Merge.rc:5724
 msgid "Copying files..."
 msgstr "Copie de fichiers en cours..."
 
 #. IDS_LOG_MOVING_FILES
-#: Merge.rc:5726
+#: Merge.rc:5725
 msgid "Moving files..."
 msgstr "Déplacement de fichiers en cours..."
 
 #. IDS_LOG_DELETING_FILES
-#: Merge.rc:5727
+#: Merge.rc:5726
 msgid "Deleting files..."
 msgstr "Suppression de fichiers en cours..."
 
 #. IDS_LOG_RECYCLEBIN
-#: Merge.rc:5728
+#: Merge.rc:5727
 msgid "Recycle Bin"
 msgstr "Corbeille"
 
 #. IDS_LOG_PERMANENTLY_DELETED
-#: Merge.rc:5729
+#: Merge.rc:5728
 msgid "Permanently deleted"
 msgstr "Supprimé définitivement"
 
 #. IDS_LOG_FILEOPERATION_COMPLETED
-#: Merge.rc:5730
+#: Merge.rc:5729
 msgid "File operation completed successfully"
 msgstr "L'opération sur le fichier s'est déroulé avec succès"
 
 #. IDS_LOG_FILEOPERATION_CANCELED
-#: Merge.rc:5731
+#: Merge.rc:5730
 msgid "File operation canceled"
 msgstr "L'opération sur le fichier a été annulée"
 
 #. IDS_FILTER_ERROR_NO_ERROR
-#: Merge.rc:5736
+#: Merge.rc:5735
 msgid "No error"
 msgstr "Aucune erreur"
 
 #. IDS_FILTER_ERROR_EMPTY_EXPRESSION
-#: Merge.rc:5737
+#: Merge.rc:5736
 msgid "Filter expression is empty"
 msgstr "L'expression de filtre est vide"
 
 #. IDS_FILTER_ERROR_UNKNOWN_CHAR
-#: Merge.rc:5738
+#: Merge.rc:5737
 msgid "Unknown character in filter expression"
 msgstr "Caractère inconnu dans l'expression du filtre"
 
 #. IDS_FILTER_ERROR_UNTERMINATED_STRING
-#: Merge.rc:5739
+#: Merge.rc:5738
 msgid "Unterminated string literal"
 msgstr "Littéral de chaîne non terminé"
 
 #. IDS_FILTER_ERROR_SYNTAX_ERROR
-#: Merge.rc:5740
+#: Merge.rc:5739
 msgid "Syntax error in filter expression"
 msgstr "Erreur de syntaxe dans l'expression du filtre"
 
 #. IDS_FILTER_ERROR_PARSE_FAILURE
-#: Merge.rc:5741
+#: Merge.rc:5740
 msgid "Failed to parse filter expression"
 msgstr "Échec de l'analyse de l'expression du filtre"
 
 #. IDS_FILTER_ERROR_INVALID_LITERAL
-#: Merge.rc:5742
+#: Merge.rc:5741
 msgid "Invalid literal value"
 msgstr "Valeur littérale non valide"
 
 #. IDS_FILTER_ERROR_INVALID_REGULAR_EXPRESSION
-#: Merge.rc:5743
+#: Merge.rc:5742
 msgid "Invalid regular expression"
 msgstr "Expression régulière invalide"
 
 #. IDS_FILTER_ERROR_UNDEFINED_IDENTIFIER
-#: Merge.rc:5744
+#: Merge.rc:5743
 msgid "Undefined identifier"
 msgstr "Identifiant non défini"
 
 #. IDS_FILTER_ERROR_INVALID_ARGUMENT_COUNT
-#: Merge.rc:5745
+#: Merge.rc:5744
 msgid "Invalid number of arguments"
 msgstr "Nombre d'arguments invalide"
 
 #. IDS_FILTER_ERROR_FILTER_NAME_NOT_FOUND
-#: Merge.rc:5746
+#: Merge.rc:5745
 msgid "Filter name not found"
 msgstr "Nom du filtre introuvable"
 
 #. IDS_FILTER_ERROR_DIVIDE_BY_ZERO
-#: Merge.rc:5747
+#: Merge.rc:5746
 msgid "Division by zero in filter expression"
 msgstr "Division par zéro dans l'expression du filtre"
 
 #. IDS_FILTER_ERROR_UNKNOWN_ERROR
-#: Merge.rc:5748
+#: Merge.rc:5747
 msgid "Unknown error"
 msgstr "Erreur inconnue"
 
 #. IDS_FILTER_ERROR_INVALID_PROPERTY_NAME
-#: Merge.rc:5749
+#: Merge.rc:5748
 msgid "Invalid property name"
 msgstr "Nom de propriété invalide"
 
 #. IDS_FILTER_ERROR_INVALID_DIRECTIVE
-#: Merge.rc:5750
+#: Merge.rc:5749
 msgid "Invalid directive"
 msgstr "Directive invalide"
 
 #. IDS_FILTER_OP_EQUALS
-#: Merge.rc:5755
+#: Merge.rc:5754
 msgid "Equals"
 msgstr "Égal"
 
 #. IDS_FILTER_OP_NOT_EQUALS
-#: Merge.rc:5756
+#: Merge.rc:5755
 msgid "Does not equal"
 msgstr "N'est pas égal"
 
 #. IDS_FILTER_OP_LESS_THAN
-#: Merge.rc:5757
+#: Merge.rc:5756
 msgid "Less than"
 msgstr "Inférieur à"
 
 #. IDS_FILTER_OP_LESS_EQUAL
-#: Merge.rc:5758
+#: Merge.rc:5757
 msgid "Less than or equal to"
 msgstr "Inférieur ou égal à"
 
 #. IDS_FILTER_OP_GREATER_EQUAL
-#: Merge.rc:5759
+#: Merge.rc:5758
 msgid "Greater than or equal to"
 msgstr "Supérieur ou égal à"
 
 #. IDS_FILTER_OP_GREATER_THAN
-#: Merge.rc:5760
+#: Merge.rc:5759
 msgid "Greater than"
 msgstr "Supérieur à"
 
 #. IDS_FILTER_OP_BETWEEN
-#: Merge.rc:5761
+#: Merge.rc:5760
 msgid "Between"
 msgstr "Entre"
 
 #. IDS_FILTER_OP_NOT_BETWEEN
-#: Merge.rc:5762
+#: Merge.rc:5761
 msgid "Not Between"
 msgstr "Pas entre"
 
 #. IDS_FILTER_OP_CONTAINS
-#: Merge.rc:5763
+#: Merge.rc:5762
 msgid "Contains"
 msgstr "Contient"
 
 #. IDS_FILTER_OP_NOT_CONTAINS
-#: Merge.rc:5764
+#: Merge.rc:5763
 msgid "Not Contains"
 msgstr "Ne contient pas"
 
 #. IDS_FILTER_OP_RECONTAINS
-#: Merge.rc:5765
+#: Merge.rc:5764
 msgid "Contains (regex)"
 msgstr "Contient (regex)"
 
 #. IDS_FILTER_OP_NOT_RECONTAINS
-#: Merge.rc:5766
+#: Merge.rc:5765
 msgid "Not Contains (regex)"
 msgstr "Ne contient pas (regex)"
 
 #. IDS_FILTER_OP_LIKE
-#: Merge.rc:5767
+#: Merge.rc:5766
 msgid "Match (wildcard)"
 msgstr "Correspond (caractère générique)"
 
 #. IDS_FILTER_OP_NOT_LIKE
-#: Merge.rc:5768
+#: Merge.rc:5767
 msgid "Not match (wildcard)"
 msgstr "Ne correspond pas (caractère générique)"
 
 #. IDS_FILTER_OP_MATCHES
-#: Merge.rc:5769
+#: Merge.rc:5768
 msgid "Match (regex)"
 msgstr "Correspond (regex)"
 
 #. IDS_FILTER_OP_NOT_MATCHES
-#: Merge.rc:5770
+#: Merge.rc:5769
 msgid "Not match (regex)"
 msgstr "Ne correspond pas (regex)"
 
 #. IDS_COLORMODE_LIGHT
-#: Merge.rc:5775
+#: Merge.rc:5774
 msgid "Light"
 msgstr "Clair"
 
 #. IDS_COLORMODE_DARK
-#: Merge.rc:5776
+#: Merge.rc:5775
 msgid "Dark"
 msgstr "Foncé"
 
 #. IDS_COLORMODE_FOLLOWSYSTEM
-#: Merge.rc:5777
+#: Merge.rc:5776
 msgid "Follow system"
 msgstr "Suivre le système"
 
 #. IDS_EXAMPLE
-#: Merge.rc:5782
+#: Merge.rc:5781
 #, c-format
 msgid "e.g. %1"
 msgstr "p. ex. %1"
 
 #. IDS_DETECTED_PREVIOUS_CRASH
-#: Merge.rc:5787
+#: Merge.rc:5786
 msgid "WinMerge detected a previous crash. Please report this if possible."
 msgstr "WinMerge a détecté un plantage précédent. Veuillez le signaler si possible."
 
 #. IDS_REGEX_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5792
+#: Merge.rc:5791
 msgid ""
 "# Regex replacement list\r\n"
 "# Format: regex<TAB>replacement\r\n"
@@ -8890,7 +8885,7 @@ msgstr ""
 "\v\n"
 
 #. IDS_STRING_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5793
+#: Merge.rc:5792
 msgid ""
 "# Replacement list\r\n"
 "# Format: search<TAB>replacement\r\n"
@@ -8907,22 +8902,22 @@ msgstr ""
 "\v\n"
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_ONLY
-#: Merge.rc:5798
+#: Merge.rc:5797
 msgid "Built-in only"
 msgstr "Intégré uniquement"
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_FIRST
-#: Merge.rc:5799
+#: Merge.rc:5798
 msgid "Built-in first"
 msgstr "Intégré en premier"
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_FIRST
-#: Merge.rc:5800
+#: Merge.rc:5799
 msgid "Tree-sitter first"
 msgstr "Tree-sitter en premier"
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_ONLY
-#: Merge.rc:5801
+#: Merge.rc:5800
 msgid "Tree-sitter only"
 msgstr "Tree-sitter uniquement"
 

--- a/Translations/WinMerge/Galician.po
+++ b/Translations/WinMerge/Galician.po
@@ -24,7 +24,7 @@ msgstr ""
 "X-Generator: Poedit 3.4.1\n"
 
 #. LANGUAGE, SUBLANGUAGE
-#: Merge.rc:26 Merge.rc:59 Merge.rc:5818
+#: Merge.rc:26 Merge.rc:59 Merge.rc:5817
 msgid "LANG_ENGLISH, SUBLANG_ENGLISH_US"
 msgstr "LANG_GALICIAN, SUBLANG_DEFAULT"
 
@@ -166,7 +166,7 @@ msgstr "&Scripts"
 #. IDS_NO_EDIT_SCRIPTS
 #: Merge.rc:127 Merge.rc:352 Merge.rc:463 Merge.rc:673 Merge.rc:678
 #: Merge.rc:887 Merge.rc:899 Merge.rc:906 Merge.rc:963 Merge.rc:1210
-#: Merge.rc:5375
+#: Merge.rc:5374
 msgid "< Empty >"
 msgstr "< Baleiro >"
 
@@ -231,7 +231,7 @@ msgid "Auto-Fit All Columns"
 msgstr "Auto axustar todas as columnas"
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN
-#: Merge.rc:153 Merge.rc:5646
+#: Merge.rc:153 Merge.rc:5645
 msgid "&Filter by This Column"
 msgstr ""
 
@@ -292,7 +292,7 @@ msgid "&Previous Page"
 msgstr "&Páxina anterior"
 
 #. IDS_PREVIEWBAR_NEXTPAGE
-#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5679
+#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5678
 msgid "&Next Page"
 msgstr "Páxi&na seguinte"
 
@@ -543,7 +543,7 @@ msgstr "&Binario"
 #. IDS_IMAGE_MENU
 #: Merge.rc:329 Merge.rc:338 Merge.rc:432 Merge.rc:441 Merge.rc:609
 #: Merge.rc:618 Merge.rc:670 Merge.rc:960 Merge.rc:1187 Merge.rc:1200
-#: Merge.rc:5477
+#: Merge.rc:5476
 msgid "&Image"
 msgstr "&Imaxe"
 
@@ -665,7 +665,7 @@ msgid "&Huge"
 msgstr "&Enorme"
 
 #. IDS_VIEW_MENU_BAR
-#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5714
+#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5713
 msgid "Men&u Bar"
 msgstr ""
 
@@ -1320,7 +1320,7 @@ msgid "Lo&cation Pane"
 msgstr "Panel de localiza&ción"
 
 #. IDS_OUTPUTBAR_CAPTION
-#: Merge.rc:782 Merge.rc:5252
+#: Merge.rc:782 Merge.rc:5251
 msgid "Output Pane"
 msgstr ""
 
@@ -1583,55 +1583,55 @@ msgid "Co&mpare As"
 msgstr "Co&mparar como"
 
 #. IDS_COPY_LEFT_TO_MIDDLE2
-#: Merge.rc:968 Merge.rc:980 Merge.rc:4852
+#: Merge.rc:968 Merge.rc:980 Merge.rc:4851
 #, c-format
 msgid "Left to Middle (%1 of %2)"
 msgstr "Esquerdo ao central (%1 de %2)"
 
 #. IDS_COPY_LEFT_TO_RIGHT2
-#: Merge.rc:969 Merge.rc:981 Merge.rc:4851
+#: Merge.rc:969 Merge.rc:981 Merge.rc:4850
 #, c-format
 msgid "Left to Right (%1 of %2)"
 msgstr "Esquerdo ao dereito (%1 de %2)"
 
 #. IDS_MOVE_LEFT_TO2
-#: Merge.rc:970 Merge.rc:982 Merge.rc:1045 Merge.rc:4863 Merge.rc:4892
+#: Merge.rc:970 Merge.rc:982 Merge.rc:1045 Merge.rc:4862 Merge.rc:4891
 #, c-format
 msgid "Left to... (%1 of %2)"
 msgstr "Esquerdo a... (%1 de %2)"
 
 #. IDS_COPY_MIDDLE_TO_LEFT2
-#: Merge.rc:971 Merge.rc:983 Merge.rc:4849
+#: Merge.rc:971 Merge.rc:983 Merge.rc:4848
 #, c-format
 msgid "Middle to Left (%1 of %2)"
 msgstr "Central ao esquerdo (%1 de %2)"
 
 #. IDS_COPY_MIDDLE_TO_RIGHT2
-#: Merge.rc:972 Merge.rc:984 Merge.rc:4850
+#: Merge.rc:972 Merge.rc:984 Merge.rc:4849
 #, c-format
 msgid "Middle to Right (%1 of %2)"
 msgstr "Do central ao dereito (%1 de %2)"
 
 #. IDS_MOVE_MIDDLE_TO2
-#: Merge.rc:973 Merge.rc:985 Merge.rc:1046 Merge.rc:4864 Merge.rc:4893
+#: Merge.rc:973 Merge.rc:985 Merge.rc:1046 Merge.rc:4863 Merge.rc:4892
 #, c-format
 msgid "Middle to... (%1 of %2)"
 msgstr "Central a... (%1 de %2)"
 
 #. IDS_COPY_RIGHT_TO_MIDDLE2
-#: Merge.rc:974 Merge.rc:986 Merge.rc:4848
+#: Merge.rc:974 Merge.rc:986 Merge.rc:4847
 #, c-format
 msgid "Right to Middle (%1 of %2)"
 msgstr "Dereito ao central (%1 de %2)"
 
 #. IDS_COPY_RIGHT_TO_LEFT2
-#: Merge.rc:975 Merge.rc:987 Merge.rc:4847
+#: Merge.rc:975 Merge.rc:987 Merge.rc:4846
 #, c-format
 msgid "Right to Left (%1 of %2)"
 msgstr "Dereito ao esquerdo (%1 de %2)"
 
 #. IDS_MOVE_RIGHT_TO2
-#: Merge.rc:976 Merge.rc:988 Merge.rc:1047 Merge.rc:4865 Merge.rc:4894
+#: Merge.rc:976 Merge.rc:988 Merge.rc:1047 Merge.rc:4864 Merge.rc:4893
 #, c-format
 msgid "Right to... (%1 of %2)"
 msgstr "Dereito a... (%1 de %2)"
@@ -1687,31 +1687,31 @@ msgid "Cop&y Paths"
 msgstr "Copiar nomes da &ruta"
 
 #. IDS_DEL_LEFT_FMT2
-#: Merge.rc:1026 Merge.rc:1035 Merge.rc:4880
+#: Merge.rc:1026 Merge.rc:1035 Merge.rc:4879
 #, c-format
 msgid "Left (%1 of %2)"
 msgstr "Esquerdo (%1 de %2)"
 
 #. IDS_DEL_MIDDLE_FMT2
-#: Merge.rc:1027 Merge.rc:1036 Merge.rc:4881
+#: Merge.rc:1027 Merge.rc:1036 Merge.rc:4880
 #, c-format
 msgid "Middle (%1 of %2)"
 msgstr "Central (%1 de %2)"
 
 #. IDS_DEL_RIGHT_FMT2
-#: Merge.rc:1028 Merge.rc:1037 Merge.rc:4882
+#: Merge.rc:1028 Merge.rc:1037 Merge.rc:4881
 #, c-format
 msgid "Right (%1 of %2)"
 msgstr "Dereito (%1 de %2)"
 
 #. IDS_DEL_BOTH_FMT2
-#: Merge.rc:1029 Merge.rc:1038 Merge.rc:4883
+#: Merge.rc:1029 Merge.rc:1038 Merge.rc:4882
 #, c-format
 msgid "Both (%1 of %2)"
 msgstr "Ambos (%1 de %2)"
 
 #. IDS_DEL_ALL_FMT2
-#: Merge.rc:1030 Merge.rc:1039 Merge.rc:4888
+#: Merge.rc:1030 Merge.rc:1039 Merge.rc:4887
 #, c-format
 msgid "All (%1 of %2)"
 msgstr "Todo (%1 de %2)"
@@ -1737,19 +1737,19 @@ msgid "&Zip"
 msgstr "&Zip"
 
 #. IDS_COPY_BOTH_TO2
-#: Merge.rc:1048 Merge.rc:4866
+#: Merge.rc:1048 Merge.rc:4865
 #, c-format
 msgid "Both to... (%1 of %2)"
 msgstr "Ambos a... (%1 de %2)"
 
 #. IDS_COPY_ALL_TO2
-#: Merge.rc:1049 Merge.rc:4867
+#: Merge.rc:1049 Merge.rc:4866
 #, c-format
 msgid "All to... (%1 of %2)"
 msgstr "Todo a... (%1 de %2)"
 
 #. IDS_COPY_DIFFERENCES_TO2
-#: Merge.rc:1050 Merge.rc:4868
+#: Merge.rc:1050 Merge.rc:4867
 #, c-format
 msgid "Differences to... (%1 of %2)"
 msgstr "Diferenzas a... (%1 de %2)"
@@ -1816,12 +1816,12 @@ msgstr "Opcións do desempaquetador"
 
 #. IDS_USERCHOICE_NONE
 #: Merge.rc:1088 Merge.rc:1094 Merge.rc:1836 Merge.rc:1840 Merge.rc:2031
-#: Merge.rc:2035 Merge.rc:5377
+#: Merge.rc:2035 Merge.rc:5376
 msgid "<None>"
 msgstr "<Ningún>"
 
 #. IDS_USERCHOICE_AUTOMATIC
-#: Merge.rc:1089 Merge.rc:1095 Merge.rc:5378
+#: Merge.rc:1089 Merge.rc:1095 Merge.rc:5377
 msgid "<Automatic>"
 msgstr "<Automático>"
 
@@ -2751,12 +2751,12 @@ msgid "Text files only"
 msgstr ""
 
 #. IDS_EOL_NONE
-#: Merge.rc:1667 Merge.rc:1918 Merge.rc:5304
+#: Merge.rc:1667 Merge.rc:1918 Merge.rc:5303
 msgid "None"
 msgstr "Ningún"
 
 #. IDS_EOL_MIXED
-#: Merge.rc:1668 Merge.rc:5299
+#: Merge.rc:1668 Merge.rc:5298
 msgid "Mixed"
 msgstr "Mesturado"
 
@@ -3028,13 +3028,13 @@ msgstr ""
 
 #. IDS_DIFFERENT
 #: Merge.rc:1904 Merge.rc:1988 Merge.rc:2866 Merge.rc:3036 Merge.rc:3077
-#: Merge.rc:5058
+#: Merge.rc:5057
 msgid "Different"
 msgstr "Diferente"
 
 #. IDS_IDENTICAL
 #: Merge.rc:1905 Merge.rc:1989 Merge.rc:2865 Merge.rc:3055 Merge.rc:3116
-#: Merge.rc:5048
+#: Merge.rc:5047
 msgid "Identical"
 msgstr "Iguais"
 
@@ -3054,7 +3054,7 @@ msgid "Missing"
 msgstr ""
 
 #. IDS_MOVED
-#: Merge.rc:1910 Merge.rc:5076
+#: Merge.rc:1910 Merge.rc:5075
 msgid "Moved"
 msgstr ""
 
@@ -3790,7 +3790,7 @@ msgid "&Use custom system colors"
 msgstr ""
 
 #. IDS_PRPCAT_SYSTEM
-#: Merge.rc:2565 Merge.rc:4559 Merge.rc:4560 Merge.rc:5007
+#: Merge.rc:2565 Merge.rc:4559 Merge.rc:4560 Merge.rc:5006
 msgid "System"
 msgstr "Sistema"
 
@@ -4190,7 +4190,7 @@ msgid "Items compared:"
 msgstr "Elementos comparados:"
 
 #. IDS_PREVIEWBAR_CLOSE
-#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5685
+#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5684
 msgid "&Close"
 msgstr "Pe&char"
 
@@ -4813,7 +4813,7 @@ msgid "A&ppend timestamp"
 msgstr "Añadir marca de tem&po"
 
 #. IDS_CONFIRM_COPY_CAPTION
-#: Merge.rc:3214 Merge.rc:4915
+#: Merge.rc:3214 Merge.rc:4914
 msgid "Confirm Copy"
 msgstr "Confirmar copia"
 
@@ -5050,7 +5050,7 @@ msgid "&Character Set..."
 msgstr "&Conxunto de caracteres..."
 
 #. IDS_PRPCAT_IMAGE
-#: Merge.rc:3351 Merge.rc:4574 Merge.rc:5015
+#: Merge.rc:3351 Merge.rc:4574 Merge.rc:5014
 msgid "Image"
 msgstr "Imaxe"
 
@@ -5443,7 +5443,7 @@ msgid "Project"
 msgstr "Proxecto"
 
 #. IDS_COLHDR_NSDIFFS
-#: Merge.rc:4566 Merge.rc:4990
+#: Merge.rc:4566 Merge.rc:4989
 msgid "Differences"
 msgstr "Diferenzas"
 
@@ -5588,12 +5588,12 @@ msgid "File Type"
 msgstr "Tipo de ficheiro"
 
 #. IDS_COLHDR_EXTENSION
-#: Merge.rc:4653 Merge.rc:4947
+#: Merge.rc:4653 Merge.rc:4946
 msgid "Extension"
 msgstr "Extensión"
 
 #. IDS_PRPCAT_MESSAGE
-#: Merge.rc:4659 Merge.rc:5019
+#: Merge.rc:4659 Merge.rc:5018
 msgid "Message"
 msgstr "Mensaxe"
 
@@ -5633,7 +5633,7 @@ msgid "Hidden Items"
 msgstr "Elementos ocultos"
 
 #. IDS_PLUGINSLIST_NAME
-#: Merge.rc:4680 Merge.rc:5311
+#: Merge.rc:4680 Merge.rc:5310
 msgid "Name"
 msgstr "Nome"
 
@@ -5653,7 +5653,7 @@ msgid "[F] "
 msgstr "[F] "
 
 #. IDS_PLUGINSLIST_DESC
-#: Merge.rc:4684 Merge.rc:5313
+#: Merge.rc:4684 Merge.rc:5312
 msgid "Description"
 msgstr "Descrición"
 
@@ -5821,155 +5821,150 @@ msgstr "Liña: %s  Columna: %d/%d  Carácter: %d/%d"
 msgid "  Sel: %d | %d"
 msgstr "  Selec.: %d | %d"
 
-#. IDS_MERGEMODE_MERGING
-#: Merge.rc:4734
-msgid "Merge"
-msgstr "Mesturar"
-
 #. IDS_DIFF_NUMBER_STATUS_FMT
-#: Merge.rc:4735
+#: Merge.rc:4734
 #, c-format
 msgid "Difference %1 of %2"
 msgstr "Diferenza %1 de %2"
 
 #. IDS_NO_DIFF_SEL_FMT
-#: Merge.rc:4736
+#: Merge.rc:4735
 #, c-format
 msgid "%1 Differences Found"
 msgstr "%1 diferenzas atopadas"
 
 #. IDS_1_DIFF_FOUND
-#: Merge.rc:4737
+#: Merge.rc:4736
 msgid "1 Difference Found"
 msgstr "1 diferenza atopada"
 
 #. IDS_NO_ERR_SEL_FMT
-#: Merge.rc:4738
+#: Merge.rc:4737
 #, c-format
 msgid "%1 Errors Found"
 msgstr ""
 
 #. IDS_1_ERR_FOUND
-#: Merge.rc:4739
+#: Merge.rc:4738
 msgid "1 Error Found"
 msgstr ""
 
 #. IDS_STATUSBAR_READONLY, Abbreviation from "Read Only"
-#: Merge.rc:4740
+#: Merge.rc:4739
 msgid "RO"
 msgstr "SL"
 
 #. IDS_DIRVIEW_STATUS_FMT_FOCUS
-#: Merge.rc:4746
+#: Merge.rc:4745
 #, c-format
 msgid "Item %1 of %2"
 msgstr "Elemento %1 de %2"
 
 #. IDS_DIRVIEW_STATUS_FMT_NOFOCUS
-#: Merge.rc:4747
+#: Merge.rc:4746
 #, c-format
 msgid "Items: %1"
 msgstr "Elementos: %1"
 
 #. IDS_DIRVIEW_STATUS_COMPARING
-#: Merge.rc:4748
+#: Merge.rc:4747
 msgid "Comparing items..."
 msgstr "Comparando elementos..."
 
 #. IDS_ITEMS_PER_SEC
-#: Merge.rc:4749
+#: Merge.rc:4748
 #, c-format
 msgid "%.1f[items/sec]"
 msgstr "%.1f[elementos/seg]"
 
 #. IDS_ERROR_INCOMPARABLE
-#: Merge.rc:4755
+#: Merge.rc:4754
 msgid "Select two existing folders/files to compare."
 msgstr "Seleccione dúas carpetas ou ficheiros para comparar."
 
 #. IDS_DIRSEL_TAG
-#: Merge.rc:4756
+#: Merge.rc:4755
 msgid "Folder Selection"
 msgstr "Selección de carpeta"
 
 #. IDS_OPEN_FILESDIRS
-#: Merge.rc:4757
+#: Merge.rc:4756
 msgid "Select two (or three) folders/files to compare."
 msgstr "Seleccione dúas (ou tres) carpetas ou dous (ou tres) ficheiros para comparar."
 
 #. IDS_OPEN_LEFTINVALID
-#: Merge.rc:4758
+#: Merge.rc:4757
 msgid "Left (1st) path is invalid!"
 msgstr "¡A ruta do esquerdo (1º) non é válida!"
 
 #. IDS_OPEN_MIDDLEINVALID
-#: Merge.rc:4759
+#: Merge.rc:4758
 msgid "Middle (2nd) path is invalid!"
 msgstr "¡A ruta do central (2º) non é válida!"
 
 #. IDS_OPEN_RIGHTINVALID2
-#: Merge.rc:4760
+#: Merge.rc:4759
 msgid "Right (2nd) path is invalid!"
 msgstr "¡A ruta do dereito (2º) non é válida!"
 
 #. IDS_OPEN_RIGHTINVALID3
-#: Merge.rc:4761
+#: Merge.rc:4760
 msgid "Right (3rd) path is invalid!"
 msgstr "¡A ruta do dereito (3º) non é válida!"
 
 #. IDS_OPEN_BOTHINVALID
-#: Merge.rc:4762
+#: Merge.rc:4761
 msgid "Both paths are invalid!"
 msgstr "¡Ambas rutas non son válidas!"
 
-#: Merge.rc:4764
+#: Merge.rc:4763
 msgid "Left (1st) and Middle (2nd) paths are invalid!"
 msgstr "¡As rutas do esquerdo (1º) e central (2º) non son válidas!"
 
 #. IDS_OPEN_LEFTRIGHTINVALID
-#: Merge.rc:4765
+#: Merge.rc:4764
 msgid "Left (1st) and Right (3rd) paths are invalid!"
 msgstr "¡As rutas do esquerdo (1º) e dereito (3º) non son válidas!"
 
-#: Merge.rc:4767
+#: Merge.rc:4766
 msgid "Middle (2nd) and Right (3rd) paths are invalid!"
 msgstr "¡As rutas do central (2º) e dereito (3º) non son válidas!"
 
 #. IDS_OPEN_ALLINVALID
-#: Merge.rc:4768
+#: Merge.rc:4767
 msgid "All paths are invalid!"
 msgstr "¡Ningunha ruta é válida!"
 
 #. IDS_OPEN_UNPACKERDISABLED
-#: Merge.rc:4769
+#: Merge.rc:4768
 msgid "Only enabled for file comparisons"
 msgstr "Habilitar só para comparar ficheiros"
 
 #. IDS_OPEN_MISMATCH
-#: Merge.rc:4770
+#: Merge.rc:4769
 msgid "Cannot compare file and folder!"
 msgstr "¡Non se pode comparar un ficheiro cunha carpeta!"
 
 #. IDS_ERROR_FILE_NOT_FOUND
-#: Merge.rc:4776
+#: Merge.rc:4775
 #, c-format
 msgid "File not found: %1"
 msgstr "Ficheiro non atopado: %1"
 
 #. IDS_ERROR_FOLDER_NOT_FOUND
-#: Merge.rc:4777
+#: Merge.rc:4776
 #, c-format
 msgid "Folder not found: %1"
 msgstr ""
 
 #. IDS_ERROR_FILE_NOT_UNPACKED
-#: Merge.rc:4778
+#: Merge.rc:4777
 #, c-format
 msgid "File not unpacked: %1"
 msgstr "Ficheiro non desempaquetado: %1"
 
 #. IDS_ERROR_FILEOPEN
-#: Merge.rc:4779
+#: Merge.rc:4778
 #, c-format
 msgid ""
 "Cannot open file\n"
@@ -5983,12 +5978,12 @@ msgstr ""
 "%2"
 
 #. IDS_ERROR_CONF_RESOLVE
-#: Merge.rc:4780
+#: Merge.rc:4779
 msgid "Failed to parse conflict file."
 msgstr "Non se puido analizar o ficheiro de conflito."
 
 #. IDS_NOT_CONFLICT_FILE
-#: Merge.rc:4781
+#: Merge.rc:4780
 #, c-format
 msgid "The file\n%1\nis not a conflict file."
 msgstr ""
@@ -5997,7 +5992,7 @@ msgstr ""
 "non é conflitivo."
 
 #. IDS_COMPARE_LARGE_FILES
-#: Merge.rc:4782
+#: Merge.rc:4781
 msgid "Comparing large files requires significant memory.\nShow only comparison results (not file contents)?"
 msgstr ""
 "Vai comparar dous ficheiros moi grandes.\n"
@@ -6006,28 +6001,28 @@ msgstr ""
 "\n"
 
 #. IDS_SAVE_AS_TITLE
-#: Merge.rc:4788
+#: Merge.rc:4787
 msgid "Save As"
 msgstr "Gardar como"
 
 #. IDS_SAVE_FMT
-#: Merge.rc:4789
+#: Merge.rc:4788
 #, c-format
 msgid "Save changes to %1?"
 msgstr "Quere gardar os cambios en %1?"
 
 #. IDS_SAVEREADONLY_FMT
-#: Merge.rc:4790
+#: Merge.rc:4789
 #, c-format
 msgid "%1 is read-only. Override? Or 'No' to save as new filename?"
 msgstr "%1 está definido como de só lectura. Desexa anular a marca de só lectura? (Seleccione 'Non' para gardalo cun novo nome de arquivo)."
 
 #. IDS_ERROR_BACKUP
-#: Merge.rc:4791
+#: Merge.rc:4790
 msgid "Error backing up file"
 msgstr "Erro ao facer unha copia de seguridade do ficheiro"
 
-#: Merge.rc:4793
+#: Merge.rc:4792
 #, c-format
 msgid ""
 "Unable to backup original file:\n"
@@ -6041,7 +6036,7 @@ msgstr ""
 "Continuar de todas formas?"
 
 #. IDS_FILESAVE_FAILED
-#: Merge.rc:4794
+#: Merge.rc:4793
 #, c-format
 msgid "Saving file failed.\n%1\n%2\n\t- Use different filename (OK)\n\t- Abort (Cancel)?"
 msgstr ""
@@ -6052,7 +6047,7 @@ msgstr ""
 "\t- usar un nome de ficheiro distinto (prema Aceptar)\n"
 "\t- cancelar a operación (prema Cancelar)"
 
-#: Merge.rc:4796
+#: Merge.rc:4795
 #, c-format
 msgid "Plugin '%2' cannot pack changes to left file into '%1'.\n\nOriginal unchanged. Save unpacked version?"
 msgstr ""
@@ -6062,7 +6057,7 @@ msgstr ""
 "\n"
 "Desexa gardar a versión sin empaquetar noutro ficheiro?"
 
-#: Merge.rc:4798
+#: Merge.rc:4797
 #, c-format
 msgid "Plugin '%2' cannot pack changes to middle file into '%1'.\n\nOriginal unchanged. Save unpacked version?"
 msgstr ""
@@ -6072,7 +6067,7 @@ msgstr ""
 "\n"
 "Desexa gardar a versión sin empaquetar noutro ficheiro?"
 
-#: Merge.rc:4800
+#: Merge.rc:4799
 #, c-format
 msgid "Plugin '%2' cannot pack changes to right file into '%1'.\n\nOriginal unchanged. Save unpacked version?"
 msgstr ""
@@ -6083,7 +6078,7 @@ msgstr ""
 "Desexa gardar a versión sin empaquetar noutro ficheiro?"
 
 #. IDS_FILECHANGED_ONDISK
-#: Merge.rc:4801
+#: Merge.rc:4800
 #, c-format
 msgid ""
 "Another application updated\n"
@@ -6099,7 +6094,7 @@ msgstr ""
 "Quere sobrescribir o ficheiro cambiado?"
 
 #. IDS_SAVEREADONLY_MULTI
-#: Merge.rc:4802
+#: Merge.rc:4801
 #, c-format
 msgid ""
 "%1\n"
@@ -6109,7 +6104,7 @@ msgstr ""
 "é de só lectura. Desexa anular esa opción e sobrescribilo?"
 
 #. IDS_FILECHANGED_RESCAN
-#: Merge.rc:4803
+#: Merge.rc:4802
 #, c-format
 msgid "Another application updated\n%1\nsince last scan.\n\nReload?"
 msgstr ""
@@ -6120,22 +6115,22 @@ msgstr ""
 "Desexa recargalo?"
 
 #. IDS_SAVE_LEFT_AS
-#: Merge.rc:4804
+#: Merge.rc:4803
 msgid "Save Left File As"
 msgstr "Gardar o ficheiro esquerdo como"
 
 #. IDS_SAVE_MIDDLE_AS
-#: Merge.rc:4805
+#: Merge.rc:4804
 msgid "Save Middle File As"
 msgstr "Gardar o ficheiro central como"
 
 #. IDS_SAVE_RIGHT_AS
-#: Merge.rc:4806
+#: Merge.rc:4805
 msgid "Save Right File As"
 msgstr "Gardar o ficheiro dereito como"
 
 #. IDS_FILE_DISAPPEARED
-#: Merge.rc:4811
+#: Merge.rc:4810
 #, c-format
 msgid ""
 "File\n"
@@ -6147,7 +6142,7 @@ msgstr ""
 "desapareceu. Por favor, garde unha copia do ficheiro para continuar."
 
 #. IDS_VIEWS_OUTOFSYNC
-#: Merge.rc:4817
+#: Merge.rc:4816
 msgid ""
 "Cannot merge unsynched documents.\n"
 "\n"
@@ -6158,186 +6153,186 @@ msgstr ""
 "Actualíceos antes de seguir."
 
 #. IDS_BREAK_ON_WHITESPACE
-#: Merge.rc:4822
+#: Merge.rc:4821
 msgid "Break at whitespace"
 msgstr "Deter en espazo en branco"
 
 #. IDS_BREAK_ON_PUNCTUATION
-#: Merge.rc:4823
+#: Merge.rc:4822
 msgid "Break at whitespace or punctuation"
 msgstr "Deter en espazo en branco ou puntuación"
 
 #. IDS_L2M
-#: Merge.rc:4829
+#: Merge.rc:4828
 msgid "Copy to &Middle\tAlt+Right"
 msgstr "Copiar ao cen&tral\tAlt+Dereita"
 
 #. IDS_R2M
-#: Merge.rc:4830
+#: Merge.rc:4829
 msgid "Copy to &Middle\tAlt+Left"
 msgstr "Copiar ao &central\tAlt+Esquerda"
 
 #. IDS_COPY_FROM_MIDDLE_R
-#: Merge.rc:4831
+#: Merge.rc:4830
 msgid "Copy from Middle\tAlt+Shift+Right"
 msgstr "Copiar desde o central\tAlt+Maiús+Dereita"
 
 #. IDS_COPY_FROM_MIDDLE_L
-#: Merge.rc:4832
+#: Merge.rc:4831
 msgid "Copy from Middle\tAlt+Shift+Left"
 msgstr "Copiar desde o central\tAlt+Maiús+Esquerda"
 
 #. IDS_L2MNEXT
-#: Merge.rc:4833
+#: Merge.rc:4832
 msgid "Copy to Middle and Advance\tCtrl+Alt+Right"
 msgstr "Copiar ao central e avanzar\tCtrl+Alt+Dereita"
 
 #. IDS_R2MNEXT
-#: Merge.rc:4834
+#: Merge.rc:4833
 msgid "Copy to Middle and Advance\tCtrl+Alt+Left"
 msgstr "Copiar ao central e avanzar\tCtrl+Alt+Esquerda"
 
 #. IDS_ALL_MIDDLE
-#: Merge.rc:4835
+#: Merge.rc:4834
 msgid "Copy All to Middle"
 msgstr "Copiar todo no central"
 
 #. IDS_COPY_RIGHT_TO_LEFT
-#: Merge.rc:4841
+#: Merge.rc:4840
 #, c-format
 msgid "Right to Left (%1)"
 msgstr "Dereito ao esquerdo (%1)"
 
 #. IDS_COPY_RIGHT_TO_MIDDLE
-#: Merge.rc:4842
+#: Merge.rc:4841
 #, c-format
 msgid "Right to Middle (%1)"
 msgstr "Dereito ao central (%1)"
 
 #. IDS_COPY_MIDDLE_TO_LEFT
-#: Merge.rc:4843
+#: Merge.rc:4842
 #, c-format
 msgid "Middle to Left (%1)"
 msgstr "Central ao esquerdo (%1)"
 
 #. IDS_COPY_MIDDLE_TO_RIGHT
-#: Merge.rc:4844
+#: Merge.rc:4843
 #, c-format
 msgid "Middle to Right (%1)"
 msgstr "Central ao dereito (%1)"
 
 #. IDS_COPY_LEFT_TO_RIGHT
-#: Merge.rc:4845
+#: Merge.rc:4844
 #, c-format
 msgid "Left to Right (%1)"
 msgstr "Esquerdo ao dereito (%1)"
 
 #. IDS_COPY_LEFT_TO_MIDDLE
-#: Merge.rc:4846
+#: Merge.rc:4845
 #, c-format
 msgid "Left to Middle (%1)"
 msgstr "Esquerdo ao central (%1)"
 
 #. IDS_MOVE_LEFT_TO
-#: Merge.rc:4857 Merge.rc:4889
+#: Merge.rc:4856 Merge.rc:4888
 #, c-format
 msgid "Left to... (%1)"
 msgstr "Esquerdo ao... (%1)"
 
 #. IDS_MOVE_MIDDLE_TO
-#: Merge.rc:4858 Merge.rc:4890
+#: Merge.rc:4857 Merge.rc:4889
 #, c-format
 msgid "Middle to... (%1)"
 msgstr "Central ao... (%1)"
 
 #. IDS_MOVE_RIGHT_TO
-#: Merge.rc:4859 Merge.rc:4891
+#: Merge.rc:4858 Merge.rc:4890
 #, c-format
 msgid "Right to... (%1)"
 msgstr "Dereito ao... (%1)"
 
 #. IDS_COPY_BOTH_TO
-#: Merge.rc:4860
+#: Merge.rc:4859
 #, c-format
 msgid "Both to... (%1)"
 msgstr "Ambos a... (%1)"
 
 #. IDS_COPY_ALL_TO
-#: Merge.rc:4861
+#: Merge.rc:4860
 #, c-format
 msgid "All to... (%1)"
 msgstr "Todo a... (%1)"
 
 #. IDS_COPY_DIFFERENCES_TO
-#: Merge.rc:4862
+#: Merge.rc:4861
 #, c-format
 msgid "Differences to... (%1)"
 msgstr "Diferenzas a... (%1)"
 
 #. IDS_ONLYDIFFITEMS_CONFIRM
-#: Merge.rc:4869
+#: Merge.rc:4868
 msgid "Some selected items are identical or skipped.\nProcess only items with differences?"
 msgstr ""
 
 #. IDS_DEL_LEFT_FMT
-#: Merge.rc:4875
+#: Merge.rc:4874
 #, c-format
 msgid "Left (%1)"
 msgstr "Esquerdo (%1)"
 
 #. IDS_DEL_MIDDLE_FMT
-#: Merge.rc:4876
+#: Merge.rc:4875
 #, c-format
 msgid "Middle (%1)"
 msgstr "Central (%1)"
 
 #. IDS_DEL_RIGHT_FMT
-#: Merge.rc:4877
+#: Merge.rc:4876
 #, c-format
 msgid "Right (%1)"
 msgstr "Dereito (%1)"
 
 #. IDS_DEL_BOTH_FMT
-#: Merge.rc:4878
+#: Merge.rc:4877
 #, c-format
 msgid "Both (%1)"
 msgstr "Ambos (%1)"
 
 #. IDS_DEL_ALL_FMT
-#: Merge.rc:4879
+#: Merge.rc:4878
 #, c-format
 msgid "All (%1)"
 msgstr "Todo (%1)"
 
 #. IDS_SELECT_DEST_LEFT
-#: Merge.rc:4895
+#: Merge.rc:4894
 msgid "Left Side - Select Destination Folder:"
 msgstr "Esquerdo - Seleccione carpeta de destino:"
 
 #. IDS_SELECT_DEST_MIDDLE
-#: Merge.rc:4896
+#: Merge.rc:4895
 msgid "Middle Side - Select Destination Folder:"
 msgstr "Central - Seleccione carpeta de destino:"
 
 #. IDS_SELECT_DEST_RIGHT
-#: Merge.rc:4897
+#: Merge.rc:4896
 msgid "Right Side - Select Destination Folder:"
 msgstr "Dereito - Seleccione carpeta de destino:"
 
 #. IDS_FILES_AFFECTED_FMT
-#: Merge.rc:4898
+#: Merge.rc:4897
 #, c-format
 msgid "(%1 Files Affected)"
 msgstr "(%1 ficheiros afectados)"
 
 #. IDS_FILES_AFFECTED_FMT2
-#: Merge.rc:4899
+#: Merge.rc:4898
 #, c-format
 msgid "(%1 of %2 Files Affected)"
 msgstr "(%1 de %2 ficheiros afectados)"
 
 #. IDS_CONFIRM_DELETE_SINGLE
-#: Merge.rc:4905
+#: Merge.rc:4904
 #, c-format
 msgid ""
 "Are you sure you want to delete\n"
@@ -6349,18 +6344,18 @@ msgstr ""
 "%1?"
 
 #. IDS_CONFIRM_SINGLE_COPY
-#: Merge.rc:4906
+#: Merge.rc:4905
 msgid "Are you sure you want to copy?"
 msgstr "Seguro que quere copiar?"
 
 #. IDS_CONFIRM_MULTIPLE_COPY
-#: Merge.rc:4907
+#: Merge.rc:4906
 #, c-format
 msgid "Are you sure you want to copy %d items?"
 msgstr "Seguro que quere copiar %d elementos?"
 
 #. IDS_DIRCMP_NOTSYNC
-#: Merge.rc:4908
+#: Merge.rc:4907
 #, c-format
 msgid ""
 "Operation aborted!\n"
@@ -6380,46 +6375,46 @@ msgstr ""
 "Actualice a comparación."
 
 #. IDS_CONFIRM_SINGLE_MOVE
-#: Merge.rc:4913
+#: Merge.rc:4912
 msgid "Are you sure you want to move?"
 msgstr "Seguro que quere mover?"
 
 #. IDS_CONFIRM_MULTIPLE_MOVE
-#: Merge.rc:4914
+#: Merge.rc:4913
 #, c-format
 msgid "Are you sure you want to move %d items?"
 msgstr "Seguro que quere mover %d elementos?"
 
 #. IDS_CONFIRM_MOVE_CAPTION
-#: Merge.rc:4916
+#: Merge.rc:4915
 msgid "Confirm Move"
 msgstr "Confirmar movemento"
 
-#: Merge.rc:4918
+#: Merge.rc:4917
 msgid "Close the folder comparison window?"
 msgstr "Vai pechar a ventá de comparación de carpetas. Seguro que quere cerrala?"
 
-#: Merge.rc:4920
+#: Merge.rc:4919
 msgid "Close the folder comparison window, which took a long time?"
 msgstr "Vai pechar a ventá de comparación de carpetas que precisou dun unha gran cantidade de tempo. Seguro que quere pechala?"
 
 #. IDS_ERROR_INVALID_DIR_FILE_NAME
-#: Merge.rc:4921
+#: Merge.rc:4920
 msgid "The file or folder name is invalid."
 msgstr "O nome do arquivo ou carpeta non é válido."
 
 #. IDS_ERROR_EXECUTE_FILE
-#: Merge.rc:4927
+#: Merge.rc:4926
 #, c-format
 msgid "Failed to execute external editor: %1"
 msgstr "Non se puido executar o editor externo %1"
 
 #. IDS_UNKNOWN_ARCHIVE_FORMAT
-#: Merge.rc:4933
+#: Merge.rc:4932
 msgid "Unknown archive format"
 msgstr "Formato de arquivo descoñecido"
 
-#: Merge.rc:4935
+#: Merge.rc:4934
 msgid ""
 "Failed to extract archive.\n"
 "Compare as text file?"
@@ -6428,746 +6423,746 @@ msgstr ""
 "Quere comparar os ficheiros do arquivo como ficheiros de texto?"
 
 #. IDS_COLHDR_FILENAME
-#: Merge.rc:4941
+#: Merge.rc:4940
 msgid "Filename"
 msgstr "Nome do ficheiro"
 
 #. IDS_COLHDR_DIR
-#: Merge.rc:4942
+#: Merge.rc:4941
 msgctxt "DirView|ColumnHeader"
 msgid "Folder"
 msgstr "Carpeta"
 
 #. IDS_COLHDR_RESULT
-#: Merge.rc:4943
+#: Merge.rc:4942
 msgid "Comparison Result"
 msgstr "Resultado da comparación"
 
 #. IDS_COLHDR_LTIMEM
-#: Merge.rc:4944
+#: Merge.rc:4943
 msgid "Left Date"
 msgstr "Data do esquerdo"
 
 #. IDS_COLHDR_RTIMEM
-#: Merge.rc:4945
+#: Merge.rc:4944
 msgid "Right Date"
 msgstr "Data do dereito"
 
 #. IDS_COLHDR_MTIMEM
-#: Merge.rc:4946
+#: Merge.rc:4945
 msgid "Middle Date"
 msgstr "Data do central"
 
 #. IDS_COLHDR_LSIZE
-#: Merge.rc:4948
+#: Merge.rc:4947
 msgid "Left Size"
 msgstr "Tamaño do esquerdo"
 
 #. IDS_COLHDR_RSIZE
-#: Merge.rc:4949
+#: Merge.rc:4948
 msgid "Right Size"
 msgstr "Tamaño do dereito"
 
 #. IDS_COLHDR_MSIZE
-#: Merge.rc:4954
+#: Merge.rc:4953
 msgid "Middle Size"
 msgstr "Tamaño do central"
 
 #. IDS_COLHDR_RSIZE_SHORT
-#: Merge.rc:4955
+#: Merge.rc:4954
 msgid "Right Size (Short)"
 msgstr "Tamaño do dereito (curto)"
 
 #. IDS_COLHDR_LSIZE_SHORT
-#: Merge.rc:4956
+#: Merge.rc:4955
 msgid "Left Size (Short)"
 msgstr "Tamaño do esquerdo (curto)"
 
 #. IDS_COLHDR_MSIZE_SHORT
-#: Merge.rc:4957
+#: Merge.rc:4956
 msgid "Middle Size (Short)"
 msgstr "Tamaño do central (curto)"
 
 #. IDS_COLHDR_LTIMEC
-#: Merge.rc:4963
+#: Merge.rc:4962
 msgid "Left Creation Time"
 msgstr "Data de creación do esquerdo"
 
 #. IDS_COLHDR_RTIMEC
-#: Merge.rc:4964
+#: Merge.rc:4963
 msgid "Right Creation Time"
 msgstr "Data de creación do dereito"
 
 #. IDS_COLHDR_MTIMEC
-#: Merge.rc:4965
+#: Merge.rc:4964
 msgid "Middle Creation Time"
 msgstr "Data de creación do central"
 
 #. IDS_COLHDR_NEWER
-#: Merge.rc:4966
+#: Merge.rc:4965
 msgid "Newer File"
 msgstr "Ficheiro máis recente"
 
 #. IDS_COLHDR_LVERSION
-#: Merge.rc:4967
+#: Merge.rc:4966
 msgid "Left File Version"
 msgstr "Versión do ficheiro esquerdo"
 
 #. IDS_COLHDR_RVERSION
-#: Merge.rc:4968
+#: Merge.rc:4967
 msgid "Right File Version"
 msgstr "Versión do ficheiro dereito"
 
 #. IDS_COLHDR_MVERSION
-#: Merge.rc:4969
+#: Merge.rc:4968
 msgid "Middle File Version"
 msgstr "Versión do ficheiro central"
 
 #. IDS_COLHDR_RESULT_ABBR
-#: Merge.rc:4970
+#: Merge.rc:4969
 msgid "Short Result"
 msgstr "Resultado curto"
 
 #. IDS_COLHDR_LATTRIBUTES
-#: Merge.rc:4971
+#: Merge.rc:4970
 msgid "Left Attributes"
 msgstr "Atributos do esquerdo"
 
 #. IDS_COLHDR_RATTRIBUTES
-#: Merge.rc:4972
+#: Merge.rc:4971
 msgid "Right Attributes"
 msgstr "Atributos do dereito"
 
 #. IDS_COLHDR_MATTRIBUTES
-#: Merge.rc:4973
+#: Merge.rc:4972
 msgid "Middle Attributes"
 msgstr "Atributos do central"
 
 #. IDS_COLHDR_LEOL_TYPE
-#: Merge.rc:4978
+#: Merge.rc:4977
 msgid "Left EOL"
 msgstr "EOL do esquerdo"
 
 #. IDS_COLHDR_MEOL_TYPE
-#: Merge.rc:4979
+#: Merge.rc:4978
 msgid "Middle EOL"
 msgstr "EOL do central"
 
 #. IDS_COLHDR_REOL_TYPE
-#: Merge.rc:4980
+#: Merge.rc:4979
 msgid "Right EOL"
 msgstr "EOL do dereito"
 
 #. IDS_COLHDR_LENCODING
-#: Merge.rc:4986
+#: Merge.rc:4985
 msgid "Left Encoding"
 msgstr "Codificación do esquerdo"
 
 #. IDS_COLHDR_RENCODING
-#: Merge.rc:4987
+#: Merge.rc:4986
 msgid "Right Encoding"
 msgstr "Codificación do dereito"
 
 #. IDS_COLHDR_MENCODING
-#: Merge.rc:4988
+#: Merge.rc:4987
 msgid "Middle Encoding"
 msgstr "Codificación do central"
 
 #. IDS_COLHDR_NIDIFFS
-#: Merge.rc:4989
+#: Merge.rc:4988
 msgid "Ignored Diff"
 msgstr "Difs. ignoradas"
 
 #. IDS_COLHDR_BINARY
-#: Merge.rc:4991
+#: Merge.rc:4990
 msgctxt "DirView|ColumnHeader"
 msgid "Binary"
 msgstr "Binario"
 
 #. IDS_PLUGINS_TYPE_UNPACKER
-#: Merge.rc:4992 Merge.rc:5314
+#: Merge.rc:4991 Merge.rc:5313
 msgid "Unpacker"
 msgstr "Desempaquetador"
 
 #. IDS_PLUGIN_TYPE4
-#: Merge.rc:4993 Merge.rc:5315 Merge.rc:5622
+#: Merge.rc:4992 Merge.rc:5314 Merge.rc:5621
 msgid "Prediffer"
 msgstr "Precomparación"
 
 #. IDS_COLHDR_LEFT
-#: Merge.rc:4994
+#: Merge.rc:4993
 msgid "Left"
 msgstr "Esquerdo"
 
 #. IDS_COLHDR_MIDDLE
-#: Merge.rc:4995
+#: Merge.rc:4994
 msgid "Middle"
 msgstr "Central"
 
 #. IDS_COLHDR_RIGHT
-#: Merge.rc:4996
+#: Merge.rc:4995
 msgid "Right"
 msgstr "Dereito"
 
 #. IDS_COLHDR_DIFF
-#: Merge.rc:4997
+#: Merge.rc:4996
 msgid "Diff"
 msgstr "Diferenza"
 
 #. IDS_COLHDR_LEFT_DUPLICATE
-#: Merge.rc:4998
+#: Merge.rc:4997
 msgid "Left Duplicate Count"
 msgstr "Contador de duplicados no esquerdo"
 
 #. IDS_COLHDR_RIGHT_DUPLICATE
-#: Merge.rc:4999
+#: Merge.rc:4998
 msgid "Right Duplicate Count"
 msgstr "Contador de duplicados no dereito"
 
 #. IDS_COLHDR_MIDDLE_DUPLICATE
-#: Merge.rc:5000
+#: Merge.rc:4999
 msgid "Middle Duplicate Count"
 msgstr "Contador de duplicados no central"
 
 #. IDS_COLHDR_MOVE
-#: Merge.rc:5001
+#: Merge.rc:5000
 msgid "Move"
 msgstr "Mover"
 
 #. IDS_PRPCAT_AUDIO
-#: Merge.rc:5008
+#: Merge.rc:5007
 msgid "Audio"
 msgstr "Audio"
 
 #. IDS_PRPCAT_CALENDAR
-#: Merge.rc:5009
+#: Merge.rc:5008
 msgid "Calendar"
 msgstr "Calendario"
 
 #. IDS_PRPCAT_COMMUNICATION
-#: Merge.rc:5010
+#: Merge.rc:5009
 msgid "Communication"
 msgstr "Comunicación"
 
 #. IDS_PRPCAT_CONTACT
-#: Merge.rc:5011
+#: Merge.rc:5010
 msgid "Contact"
 msgstr "Contacto"
 
 #. IDS_PRPCAT_DEVICES
-#: Merge.rc:5012
+#: Merge.rc:5011
 msgid "Devices"
 msgstr "Dispositivos"
 
 #. IDS_PRPCAT_DOCUMENT
-#: Merge.rc:5013
+#: Merge.rc:5012
 msgid "Document"
 msgstr "Documento"
 
 #. IDS_PRPCAT_HOME
-#: Merge.rc:5014
+#: Merge.rc:5013
 msgid "Home"
 msgstr "Inicio"
 
 #. IDS_PRPCAT_JOURNAL
-#: Merge.rc:5016
+#: Merge.rc:5015
 msgid "Journal"
 msgstr "Diario"
 
 #. IDS_PRPCAT_LINK
-#: Merge.rc:5017
+#: Merge.rc:5016
 msgid "Link"
 msgstr "Ligazón"
 
 #. IDS_PRPCAT_MEDIA
-#: Merge.rc:5018
+#: Merge.rc:5017
 msgid "Media"
 msgstr "Medios"
 
 #. IDS_PRPCAT_MUSIC
-#: Merge.rc:5020
+#: Merge.rc:5019
 msgid "Music"
 msgstr "Música"
 
 #. IDS_PRPCAT_NOTE
-#: Merge.rc:5021
+#: Merge.rc:5020
 msgid "Note"
 msgstr "Nota"
 
 #. IDS_PRPCAT_PHOTO
-#: Merge.rc:5022
+#: Merge.rc:5021
 msgid "Photo"
 msgstr "Fotografía"
 
 #. IDS_PRPCAT_RECORDEDTV
-#: Merge.rc:5023
+#: Merge.rc:5022
 msgid "RecordedTV"
 msgstr "TV gravada"
 
 #. IDS_PRPCAT_SEARCH
-#: Merge.rc:5024
+#: Merge.rc:5023
 msgid "Search"
 msgstr "Buscar"
 
 #. IDS_PRPCAT_SECURITY
-#: Merge.rc:5025
+#: Merge.rc:5024
 msgid "Security"
 msgstr "Seguridade"
 
 #. IDS_PRPCAT_SOFTWARE
-#: Merge.rc:5026
+#: Merge.rc:5025
 msgid "Software"
 msgstr "Software"
 
 #. IDS_PRPCAT_TASK
-#: Merge.rc:5027
+#: Merge.rc:5026
 msgid "Task"
 msgstr "Tarefa"
 
 #. IDS_PRPCAT_VIDEO
-#: Merge.rc:5028
+#: Merge.rc:5027
 msgid "Video"
 msgstr "Vídeo"
 
 #. IDS_PRPCAT_HASH
-#: Merge.rc:5029
+#: Merge.rc:5028
 msgid "Hash"
 msgstr "Suma de verificación"
 
 #. IDS_CANT_COMPARE_FILES
-#: Merge.rc:5035
+#: Merge.rc:5034
 msgid "Unable to compare files"
 msgstr "Non se puideron comparar os ficheiros"
 
 #. IDS_ABORTED_ITEM
-#: Merge.rc:5036
+#: Merge.rc:5035
 msgid "Item aborted"
 msgstr "Elemento cancelado"
 
 #. IDS_FILE_SKIPPED
-#: Merge.rc:5037
+#: Merge.rc:5036
 msgid "File skipped"
 msgstr "Ficheiro omitido"
 
 #. IDS_DIR_SKIPPED
-#: Merge.rc:5038
+#: Merge.rc:5037
 msgid "Folder skipped"
 msgstr "Carpeta omitida"
 
 #. IDS_LEFT_ONLY_IN_FMT
-#: Merge.rc:5039
+#: Merge.rc:5038
 #, c-format
 msgid "Left only: %1"
 msgstr "Só esquerdo: %1"
 
 #. IDS_MIDDLE_ONLY_IN_FMT
-#: Merge.rc:5040
+#: Merge.rc:5039
 #, c-format
 msgid "Middle only: %1"
 msgstr "Só central: %1"
 
 #. IDS_RIGHT_ONLY_IN_FMT
-#: Merge.rc:5041
+#: Merge.rc:5040
 #, c-format
 msgid "Right only: %1"
 msgstr "Só dereito: %1"
 
 #. IDS_DOES_NOT_EXIST_IN_FMT
-#: Merge.rc:5042
+#: Merge.rc:5041
 #, c-format
 msgid "Does not exist in %1"
 msgstr "Non existe en %1"
 
 #. IDS_BIN_FILES_SAME
-#: Merge.rc:5043
+#: Merge.rc:5042
 msgid "Binary files are identical"
 msgstr "Os ficheiros binarios son idénticos"
 
 #. IDS_BIN_FILES_DIFF
-#: Merge.rc:5049
+#: Merge.rc:5048
 msgid "Binary files are different"
 msgstr "Os ficheiros binarios son diferentes"
 
 #. IDS_FILES_ARE_DIFFERENT
-#: Merge.rc:5050
+#: Merge.rc:5049
 msgid "Files are different"
 msgstr "Os ficheiros son diferentes"
 
 #. IDS_FOLDERS_ARE_DIFFERENT
-#: Merge.rc:5051
+#: Merge.rc:5050
 msgid "Folders are different"
 msgstr "As carpetas son diferentes"
 
 #. IDS_LEFTONLY
-#: Merge.rc:5052
+#: Merge.rc:5051
 msgid "Left Only"
 msgstr "Só esquerdo"
 
 #. IDS_RIGHTONLY
-#: Merge.rc:5053
+#: Merge.rc:5052
 msgid "Right Only"
 msgstr "Só dereito"
 
 #. IDS_MIDDLEONLY
-#: Merge.rc:5054
+#: Merge.rc:5053
 msgid "Middle Only"
 msgstr "Só central"
 
 #. IDS_NOITEMLEFT
-#: Merge.rc:5055
+#: Merge.rc:5054
 msgid "No item in left"
 msgstr "Esquerdo baleiro"
 
 #. IDS_NOITEMRIGHT
-#: Merge.rc:5056
+#: Merge.rc:5055
 msgid "No item in right"
 msgstr "Dereito baleiro"
 
 #. IDS_NOITEMMIDDLE
-#: Merge.rc:5057
+#: Merge.rc:5056
 msgid "No item in middle"
 msgstr "Central baleiro"
 
 #. IDS_CMPRES_ERROR
-#: Merge.rc:5059
+#: Merge.rc:5058
 msgid "Error"
 msgstr "Erro"
 
 #. IDS_TEXT_FILES_SAME
-#: Merge.rc:5060
+#: Merge.rc:5059
 msgid "Text files are identical"
 msgstr "Os ficheiros de texto son idénticos"
 
 #. IDS_LEFTONLY_DIFF
-#: Merge.rc:5061
+#: Merge.rc:5060
 msgid " (Middle and right are identical)"
 msgstr " (Central e dereito son idénticos)"
 
 #. IDS_MIDDLEONLY_DIFF
-#: Merge.rc:5062
+#: Merge.rc:5061
 msgid " (Left and right are identical)"
 msgstr " (Esquerdo e dereito son idénticos)"
 
 #. IDS_RIGHTONLY_DIFF
-#: Merge.rc:5063
+#: Merge.rc:5062
 msgid " (Left and middle are identical)"
 msgstr " (Esquerdo e central son idénticos)"
 
 #. IDS_PATH_MISMATCH
-#: Merge.rc:5064
+#: Merge.rc:5063
 msgid " (paths differ)"
 msgstr ""
 
 #. IDS_TEXT_FILES_DIFF
-#: Merge.rc:5065
+#: Merge.rc:5064
 msgid "Text files are different"
 msgstr "Os ficheiros de texto son diferentes"
 
 #. IDS_IMAGE_FILES_SAME
-#: Merge.rc:5066
+#: Merge.rc:5065
 msgid "Image files are identical"
 msgstr "Os ficheiros de imaxe son iguais"
 
 #. IDS_IMAGE_FILES_DIFF
-#: Merge.rc:5067
+#: Merge.rc:5066
 msgid "Image files are different"
 msgstr "Os ficheiros de imaxe son diferentes"
 
 #. IDS_EXPR_DIFF
-#: Merge.rc:5068
+#: Merge.rc:5067
 #, c-format
 msgid "Files are different (expr: %1)"
 msgstr ""
 
 #. IDS_HASH_GROUP
-#: Merge.rc:5069
+#: Merge.rc:5068
 #, c-format
 msgid "Group%d"
 msgstr "Grupo%d"
 
 #. IDS_RENAME_MOVE_DETECTION_DISALBED
-#: Merge.rc:5070
+#: Merge.rc:5069
 msgctxt "Options dialog|Compare|Folder|Detect renames and moves"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_RENAME_MOVE_DETECTION_RENAME
-#: Merge.rc:5071
+#: Merge.rc:5070
 msgid "Detect renames"
 msgstr ""
 
 #. IDS_RENAME_MOVE_DETECTION_RENAME_MOVE
-#: Merge.rc:5072
+#: Merge.rc:5071
 msgid "Detect renames and moves"
 msgstr ""
 
 #. IDS_RENAME_MOVE_MERGE_MODE_RENAME
-#: Merge.rc:5073
+#: Merge.rc:5072
 msgid "Merge renames"
 msgstr ""
 
 #. IDS_RENAME_MOVE_MERGE_MODE_RENAME_MOVE
-#: Merge.rc:5074
+#: Merge.rc:5073
 msgid "Merge renames and moves"
 msgstr ""
 
 #. IDS_RENAMED
-#: Merge.rc:5075
+#: Merge.rc:5074
 msgid "Renamed"
 msgstr ""
 
 #. IDS_RENAMED_MOVED
-#: Merge.rc:5077
+#: Merge.rc:5076
 msgid "Renamed/Moved"
 msgstr ""
 
 #. IDS_RENAMED_MOVED_ITEMS
-#: Merge.rc:5078
+#: Merge.rc:5077
 #, c-format
 msgid "(%1 items)"
 msgstr ""
 
 #. IDS_RENAMED_MOVED_RESULT
-#: Merge.rc:5079
+#: Merge.rc:5078
 #, c-format
 msgid "%1 (set %2): "
 msgstr ""
 
 #. IDS_SWITCH_FLAT_MODE
-#: Merge.rc:5080
+#: Merge.rc:5079
 msgid "Some moved items have been merged.\nIn Tree Mode, these items may appear in positions that do not reflect the actual folder structure, which can be confusing.\nSwitch to Flat Mode?"
 msgstr ""
 
 #. IDS_ELAPSED_TIME
-#: Merge.rc:5086
+#: Merge.rc:5085
 #, c-format
 msgid "Elapsed time: %ld ms"
 msgstr "Tempo transcorrido: %ld ms"
 
 #. IDS_STATUS_SELITEM1
-#: Merge.rc:5087
+#: Merge.rc:5086
 msgid "1 item selected"
 msgstr "1 elemento seleccionado"
 
 #. IDS_STATUS_SELITEMS
-#: Merge.rc:5088
+#: Merge.rc:5087
 #, c-format
 msgid "%1 items selected"
 msgstr "%1 elementos seleccionados"
 
 #. IDS_COLDESC_FILENAME
-#: Merge.rc:5094
+#: Merge.rc:5093
 msgid "Filename or folder name."
 msgstr "Nome do ficheiro ou carpeta."
 
 #. IDS_COLDESC_DIR
-#: Merge.rc:5095
+#: Merge.rc:5094
 msgid "Subfolder name when subfolders are included."
 msgstr "Nome da subcarpeta cando as subcarpetas están incluídas."
 
 #. IDS_COLDESC_RESULT
-#: Merge.rc:5096
+#: Merge.rc:5095
 msgid "Comparison result, long form."
 msgstr "Resultado da comparación, formato largo."
 
 #. IDS_COLDESC_LTIMEM
-#: Merge.rc:5101
+#: Merge.rc:5100
 msgid "Left side modification date."
 msgstr "Data de modificación do esquerdo."
 
 #. IDS_COLDESC_RTIMEM
-#: Merge.rc:5102
+#: Merge.rc:5101
 msgid "Right side modification date."
 msgstr "Data de modificación do dereito."
 
 #. IDS_COLDESC_MTIMEM
-#: Merge.rc:5103
+#: Merge.rc:5102
 msgid "Middle side modification date."
 msgstr "Data de modificación do central."
 
 #. IDS_COLDESC_EXTENSION
-#: Merge.rc:5104
+#: Merge.rc:5103
 msgid "File's extension."
 msgstr "Extensión do ficheiro."
 
 #. IDS_COLDESC_LSIZE
-#: Merge.rc:5105
+#: Merge.rc:5104
 msgid "Left file size in bytes."
 msgstr "Tamaño do ficheiro esquerdo en bytes."
 
 #. IDS_COLDESC_RSIZE
-#: Merge.rc:5106
+#: Merge.rc:5105
 msgid "Right file size in bytes."
 msgstr "Tamaño do ficheiro dereito en bytes."
 
 #. IDS_COLDESC_MSIZE
-#: Merge.rc:5107
+#: Merge.rc:5106
 msgid "Middle file size in bytes."
 msgstr "Tamaño do ficheiro central en bytes."
 
 #. IDS_COLDESC_LSIZE_SHORT
-#: Merge.rc:5108
+#: Merge.rc:5107
 msgid "Left file size abbreviated."
 msgstr "Tamaño abreviado do ficheiro esquerdo."
 
 #. IDS_COLDESC_RSIZE_SHORT
-#: Merge.rc:5109
+#: Merge.rc:5108
 msgid "Right file size abbreviated."
 msgstr "Tamaño abreviado do ficheiro dereito."
 
 #. IDS_COLDESC_MSIZE_SHORT
-#: Merge.rc:5110
+#: Merge.rc:5109
 msgid "Middle file size abbreviated."
 msgstr "Tamaño abreviado do ficheiro central."
 
 #. IDS_COLDESC_LTIMEC
-#: Merge.rc:5116
+#: Merge.rc:5115
 msgid "Left side creation time."
 msgstr "Data de creación do esquerdo."
 
 #. IDS_COLDESC_RTIMEC
-#: Merge.rc:5117
+#: Merge.rc:5116
 msgid "Right side creation time."
 msgstr "Data de creación do dereito."
 
 #. IDS_COLDESC_MTIMEC
-#: Merge.rc:5118
+#: Merge.rc:5117
 msgid "Middle side creation time."
 msgstr "Data de creación do central."
 
 #. IDS_COLDESC_NEWER
-#: Merge.rc:5119
+#: Merge.rc:5118
 msgid "Tells which side has newer modification date."
 msgstr "Indica que lado ten a data de modificación máis recente."
 
 #. IDS_COLDESC_LVERSION
-#: Merge.rc:5120
+#: Merge.rc:5119
 msgid "Left side file version, only for some file types."
 msgstr "Versión do ficheiro esquerdo, só para algúns tipos de ficheiro."
 
 #. IDS_COLDESC_RVERSION
-#: Merge.rc:5121
+#: Merge.rc:5120
 msgid "Right side file version, only for some file types."
 msgstr "Versión do ficheiro dereito, só para algúns tipos de ficheiro."
 
 #. IDS_COLDESC_MVERSION
-#: Merge.rc:5126
+#: Merge.rc:5125
 msgid "Middle side file version, only for some file types."
 msgstr "Versión do ficheiro central, só para algúns tipos de ficheiro."
 
 #. IDS_COLDESC_RESULT_ABBR
-#: Merge.rc:5127
+#: Merge.rc:5126
 msgid "Short comparison result."
 msgstr "Resultados curtos da comparación."
 
 #. IDS_COLDESC_LATTRIBUTES
-#: Merge.rc:5128
+#: Merge.rc:5127
 msgid "Left side attributes."
 msgstr "Atributos do esquerdo."
 
 #. IDS_COLDESC_RATTRIBUTES
-#: Merge.rc:5129
+#: Merge.rc:5128
 msgid "Right side attributes."
 msgstr "Atributos do dereito."
 
 #. IDS_COLDESC_MATTRIBUTES
-#: Merge.rc:5130
+#: Merge.rc:5129
 msgid "Middle side attributes."
 msgstr "Atributos do central."
 
 #. IDS_COLDESC_LEOL_TYPE
-#: Merge.rc:5131
+#: Merge.rc:5130
 msgid "Left side file EOL type."
 msgstr "Tipo de EOL do ficheiro esquerdo."
 
 #. IDS_COLDESC_REOL_TYPE
-#: Merge.rc:5132
+#: Merge.rc:5131
 msgid "Right side file EOL type."
 msgstr "Tipo de EOL do ficheiro dereito."
 
 #. IDS_COLDESC_MEOL_TYPE
-#: Merge.rc:5133
+#: Merge.rc:5132
 msgid "Middle side file EOL type."
 msgstr "Tipo de EOL do ficheiro central."
 
 #. IDS_COLDESC_LENCODING
-#: Merge.rc:5139
+#: Merge.rc:5138
 msgid "Left side encoding."
 msgstr "Codificación do esquerdo."
 
 #. IDS_COLDESC_RENCODING
-#: Merge.rc:5140
+#: Merge.rc:5139
 msgid "Right side encoding."
 msgstr "Codificación do dereito."
 
 #. IDS_COLDESC_MENCODING
-#: Merge.rc:5141
+#: Merge.rc:5140
 msgid "Middle side encoding."
 msgstr "Codificación do central."
 
 #. IDS_COLDESC_NIDIFFS
-#: Merge.rc:5142
+#: Merge.rc:5141
 msgid "Number of ignored differences in file. Ignored and cannot be merged."
 msgstr "Número de diferenzas ignoradas no ficheiro. WinMerge ignora estas diferenzas e non se poden mesturar."
 
 #. IDS_COLDESC_NSDIFFS
-#: Merge.rc:5143
+#: Merge.rc:5142
 msgid "Number of differences in file (excluding ignored)."
 msgstr "Número de diferenzas no ficheiro. Este número non inclúe as diferenzas ignoradas."
 
 #. IDS_COLDESC_BINARY
-#: Merge.rc:5144
+#: Merge.rc:5143
 msgid "Shows an asterisk (*) if the file is binary."
 msgstr "Mostra un asterisco (*) se o ficheiro é binario."
 
 #. IDS_COLDESC_UNPACKER
-#: Merge.rc:5145
+#: Merge.rc:5144
 msgid "Unpacker plugin name or pipeline."
 msgstr "Nome do complemento desempaquetador ou pipeline."
 
 #. IDS_COLDESC_PREDIFFER
-#: Merge.rc:5146
+#: Merge.rc:5145
 msgid "Prediffer plugin name or pipeline."
 msgstr "Nome do complemento de precomparación ou pipeline."
 
 #. IDS_DIRECTORY_REPORT_TITLE
-#: Merge.rc:5152
+#: Merge.rc:5151
 #, c-format
 msgid "Compare %1 with %2"
 msgstr "Comparar %1 con %2"
 
 #. IDS_DIRECTORY_REPORT_TITLE3
-#: Merge.rc:5153
+#: Merge.rc:5152
 #, c-format
 msgid "Compare %1 with %2 and %3"
 msgstr "Comparar %1 con %2 e con %3"
 
 #. IDS_REPORT_COMMALIST
-#: Merge.rc:5154
+#: Merge.rc:5153
 msgid "Comma-separated list"
 msgstr "Listaxe separada por comas"
 
 #. IDS_REPORT_TABLIST
-#: Merge.rc:5155
+#: Merge.rc:5154
 msgid "Tab-separated list"
 msgstr "Listaxe separada por tabulacións"
 
 #. IDS_REPORT_SIMPLEHTML
-#: Merge.rc:5156
+#: Merge.rc:5155
 msgid "Simple HTML"
 msgstr "HTML simple"
 
 #. IDS_REPORT_SIMPLEXML
-#: Merge.rc:5157
+#: Merge.rc:5156
 msgid "Simple XML"
 msgstr "XML simple"
 
-#: Merge.rc:5159
+#: Merge.rc:5158
 msgid "Report file already exists. Overwrite?"
 msgstr "O ficheiro de informe xa existe. Quere sobrescribilo?"
 
 #. IDS_REPORT_ERROR
-#: Merge.rc:5164
+#: Merge.rc:5163
 #, c-format
 msgid ""
 "Error creating the report:\n"
@@ -7177,57 +7172,57 @@ msgstr ""
 "%1"
 
 #. IDS_REPORT_SUCCESS
-#: Merge.rc:5165
+#: Merge.rc:5164
 msgid "Report created successfully."
 msgstr "O informe creouse satisfactoriamente."
 
 #. IDS_SYNCPOINT_LASTBLOCK
-#: Merge.rc:5171
+#: Merge.rc:5170
 msgid "Cannot add a synchronization point at this line."
 msgstr "Non se pode engadir un punto de sincronización nesta liña."
 
 #. IDS_FILE_TO_ITSELF
-#: Merge.rc:5177
+#: Merge.rc:5176
 msgid "Same file is opened in both panes."
 msgstr "O mesmo ficheiro está aberto en ambos paneis."
 
 #. IDS_FILESSAME
-#: Merge.rc:5178
+#: Merge.rc:5177
 msgid "Selected files are identical."
 msgstr "Os ficheiros escollidos son idénticos."
 
 #. IDS_FILESSAME_CURCFG
-#: Merge.rc:5179
+#: Merge.rc:5178
 msgid "Selected files are identical (with current settings).\r\nChecking binary identity..."
 msgstr ""
 
 #. IDS_FILESSAME_BINERROR
-#: Merge.rc:5180
+#: Merge.rc:5179
 msgid "Selected files are identical (with current settings).\r\nBut binary comparison failed."
 msgstr ""
 
 #. IDS_FILESSAME_BINSAME
-#: Merge.rc:5181
+#: Merge.rc:5180
 msgid "Selected files are identical (binary match)."
 msgstr ""
 
 #. IDS_FILESSAME_BINDIFF
-#: Merge.rc:5182
+#: Merge.rc:5181
 msgid "Selected files are identical (with current settings).\r\nBut differ at the binary level."
 msgstr ""
 
 #. IDS_FILEERROR
-#: Merge.rc:5183
+#: Merge.rc:5182
 msgid "An error occurred while comparing files."
 msgstr "Producíuse un erro durante a comparación dos ficheiros."
 
 #. IDS_TEMP_FILEERROR
-#: Merge.rc:5184
+#: Merge.rc:5183
 msgid "Could not create temporary files. Check your temporary path settings."
 msgstr "Non se puideron crear os ficheiros temporais. Comprobe a ruta para arquivos temporais."
 
 #. IDS_SUGGEST_IGNOREEOL
-#: Merge.rc:5185
+#: Merge.rc:5184
 msgid "Files use different EOL.\n\nTreat all EOL as equivalent?\n\nSet 'Ignore EOL differences (Windows/Unix/Mac)' in Compare section of Options."
 msgstr ""
 "Estes ficheiros empregan tipos diferentes de saltos de liña.\n"
@@ -7237,17 +7232,17 @@ msgstr ""
 "Nota: si quere tratar todos os tipos de salto como equivalentes, marque a opción 'Ignorar diferenzas nos saltos de liña (Windows/Unix/Mac)' na pestana Comparar do diálogo de opcións (dispoñible en Editar/Configuración)."
 
 #. IDS_INVALID_DIRECTORY
-#: Merge.rc:5186
+#: Merge.rc:5185
 msgid "Selected folder is invalid."
 msgstr "A carpeta seleccionada non é válida."
 
 #. IDS_CANNOT_OPEN_BINARYFILE
-#: Merge.rc:5187
+#: Merge.rc:5186
 msgid "Cannot open a binary file in Editor."
 msgstr "Non se pode abrir un ficheiro binario no editor."
 
 #. IDS_CREATE_PAIR_FOLDER
-#: Merge.rc:5188
+#: Merge.rc:5187
 #, c-format
 msgid "Create matching folder:\n%1\non the other side and open?"
 msgstr ""
@@ -7258,41 +7253,41 @@ msgstr ""
 "coa anterior e abrir ámbalas dúas?"
 
 #. IDS_CONFIRM_COPY_ALL_DIFFS
-#: Merge.rc:5189
+#: Merge.rc:5188
 msgid "Copy all differences to other file?"
 msgstr "Seguro que quere copiar todas as diferenzas ao outro ficheiro?"
 
 #. IDS_MOVE_TO_NEXTFILE
-#: Merge.rc:5194
+#: Merge.rc:5193
 msgid "Move to next file?"
 msgstr "Quere ir ao seguinte ficheiro?"
 
 #. IDS_MOVE_TO_PREVFILE
-#: Merge.rc:5195
+#: Merge.rc:5194
 msgid "Move to previous file?"
 msgstr "Quere volver ao anterior ficheiro?"
 
 #. IDS_MOVE_TO_NEXTPAGE
-#: Merge.rc:5196
+#: Merge.rc:5195
 msgid "Move to next page?"
 msgstr "Quere ir á seguinte páxina?"
 
 #. IDS_MOVE_TO_PREVPAGE
-#: Merge.rc:5197
+#: Merge.rc:5196
 msgid "Move to previous page?"
 msgstr "Quere volver á páxina anterior?"
 
 #. IDS_MOVE_TO_FIRSTFILE
-#: Merge.rc:5198
+#: Merge.rc:5197
 msgid "Move to first file?"
 msgstr "Quere ir ao primeiro ficheiro?"
 
 #. IDS_MOVE_TO_LASTFILE
-#: Merge.rc:5199
+#: Merge.rc:5198
 msgid "Move to last file?"
 msgstr "Quere ir ao derradeiro ficheiro?"
 
-#: Merge.rc:5206
+#: Merge.rc:5205
 #, c-format
 msgid "Different codepages: left (cp%d), right (cp%d).\nDisplay in codepage (better display) or default Windows codepage (safer merging)?\n(Recommended: default Windows codepage)"
 msgstr ""
@@ -7300,51 +7295,51 @@ msgstr ""
 "Mostrar cada ficheiro coa súa codificación proporcionará unha mellor visualización, pero mesturar/copiar sería perigoso.\n"
 "Prefire tratar ambos os dous ficheiros como se tivesen a codificación predeterminada de Windows (recomendado)?"
 
-#: Merge.rc:5208
+#: Merge.rc:5207
 msgid "Information lost due to encoding errors: both files"
 msgstr "Perdeuse información debido a erros de codificación: en ambos ficheiros"
 
-#: Merge.rc:5210
+#: Merge.rc:5209
 msgid "Information lost due to encoding errors: first file"
 msgstr "Perdeuse información debido a erros de codificación: no primeiro ficheiro"
 
-#: Merge.rc:5212
+#: Merge.rc:5211
 msgid "Information lost due to encoding errors: second file"
 msgstr "Perdeuse información debido a erros de codificación: no segundo ficheiro"
 
-#: Merge.rc:5214
+#: Merge.rc:5213
 msgid "Information lost due to encoding errors: third file"
 msgstr "Perdeuse información debido a erros de codificación: no terceiro ficheiro"
 
 #. IDS_LINEDIFF_NODIFF
-#: Merge.rc:5220
+#: Merge.rc:5219
 msgid "No difference"
 msgstr "Non hai diferenza"
 
 #. IDS_LINEDIFF_NODIFF_CAPTION
-#: Merge.rc:5221
+#: Merge.rc:5220
 msgid "Line difference"
 msgstr "Diferenza de liña"
 
 #. IDS_NUM_REPLACED
-#: Merge.rc:5227
+#: Merge.rc:5226
 #, c-format
 msgid "Replaced %1 string(s)."
 msgstr "Substituídas %1 cadea(s)."
 
 #. IDS_EDIT_TEXT_NOT_FOUND
-#: Merge.rc:5228
+#: Merge.rc:5227
 #, c-format
 msgid "Cannot find string \"%s\"."
 msgstr "Non se pode atopar a cadea \"%s\"."
 
 #. IDS_MERGE_MODE
-#: Merge.rc:5234
+#: Merge.rc:5233
 msgid "Entering Merge Mode. Press F9 to turn off."
 msgstr "Vai entrar en modo mestura. Se quere desactivalo prema a tecla F9."
 
 #. IDS_AUTO_MERGE
-#: Merge.rc:5240
+#: Merge.rc:5239
 #, c-format
 msgid ""
 "Automatic merges: %1\n"
@@ -7354,89 +7349,89 @@ msgstr ""
 "Número de conflitos sen resolver: %2"
 
 #. IDS_CODEPAGE_MERGED
-#: Merge.rc:5241
+#: Merge.rc:5240
 msgid "Codepage change merged."
 msgstr "Mesturouse o cambio de codificación."
 
 #. IDS_CODEPAGE_CONFLICT
-#: Merge.rc:5242
+#: Merge.rc:5241
 msgid "Codepage changes are conflicting."
 msgstr "Os cambios de codificación son conflitivos."
 
 #. IDS_EOL_MERGED
-#: Merge.rc:5243
+#: Merge.rc:5242
 msgid "EOL change merged."
 msgstr "Mesturouse o cambio de EOL."
 
 #. IDS_EOL_CONFLICT
-#: Merge.rc:5244
+#: Merge.rc:5243
 msgid "EOL changes are conflicting."
 msgstr "Os cambios de EOL son conflitivos."
 
 #. IDS_LOCBAR_CAPTION
-#: Merge.rc:5250
+#: Merge.rc:5249
 msgid "Location Pane"
 msgstr "Panel de situación"
 
 #. IDS_DIFFBAR_CAPTION
-#: Merge.rc:5251
+#: Merge.rc:5250
 msgid "Diff Pane"
 msgstr "Panel de diferenzas"
 
 #. IDS_DIFF_SUCCEEDED
-#: Merge.rc:5258
+#: Merge.rc:5257
 msgid "Patch file written."
 msgstr "Escribíuse correctamente o ficheiro de parche."
 
 #. IDS_DIFF_FILEOVERWRITE
-#: Merge.rc:5259
+#: Merge.rc:5258
 msgid "Patch file already exists. Overwrite?"
 msgstr "O ficheiro de parche xa existe. Quere sobrescribilo?"
 
 #. IDS_DIFF_SELECTEDFILES
-#: Merge.rc:5260
+#: Merge.rc:5259
 #, c-format
 msgid "[%1 files selected]"
 msgstr "[%1 ficheiros seleccionados]"
 
 #. IDS_DIFF_NORMAL
-#: Merge.rc:5261
+#: Merge.rc:5260
 msgid "Normal"
 msgstr "Normal"
 
 #. IDS_DIFF_CONTEXT
-#: Merge.rc:5262
+#: Merge.rc:5261
 msgid "Context"
 msgstr "Contexto"
 
 #. IDS_DIFF_UNIFIED
-#: Merge.rc:5263
+#: Merge.rc:5262
 msgid "Unified"
 msgstr "Unificado"
 
 #. IDS_FILEWRITE_ERROR
-#: Merge.rc:5265
+#: Merge.rc:5264
 #, c-format
 msgid "Could not write to file %1."
 msgstr "Non se puido escribir no ficheiro %1."
 
 #. IDS_PATH_NOT_ABSOLUTE
-#: Merge.rc:5266
+#: Merge.rc:5265
 #, c-format
 msgid "Output path is not absolute: %1"
 msgstr "A ruta de saída especificada non é absoluta: %1"
 
 #. IDS_MUST_SPECIFY_OUTPUT
-#: Merge.rc:5267
+#: Merge.rc:5266
 msgid "Specify an output file."
 msgstr "Especifique un ficheiro de saída."
 
-#: Merge.rc:5269
+#: Merge.rc:5268
 msgid "Cannot create patch from binary files."
 msgstr "Non se pode crear un ficheiro de parche desde ficheiros binarios."
 
 #. IDS_SAVEFILES_FORPATCH
-#: Merge.rc:5270
+#: Merge.rc:5269
 msgid ""
 "Save all files first.\n"
 "\n"
@@ -7447,22 +7442,22 @@ msgstr ""
 "Para crear un parche é necesario que non haxa cambios sin gardar."
 
 #. IDS_FOLDER_NOTEXIST
-#: Merge.rc:5271
+#: Merge.rc:5270
 msgid "Folder does not exist."
 msgstr "A carpeta non existe."
 
 #. IDS_ARCHIVE_SUCCEEDED
-#: Merge.rc:5277
+#: Merge.rc:5276
 msgid "Archive file written."
 msgstr ""
 
 #. IDS_ARCHIVE_SAVEFILES
-#: Merge.rc:5278
+#: Merge.rc:5277
 msgid "Save all files first.\n\nCreating an archive requires no unsaved changes."
 msgstr ""
 
 #. IDS_NO_ZIP_SUPPORT
-#: Merge.rc:5283
+#: Merge.rc:5282
 msgid ""
 "Archive support not enabled.\n"
 "7-Zip and/or Merge7z*.dll not found.\n"
@@ -7473,37 +7468,37 @@ msgstr ""
 "Consulte o manual para ter máis información sobre o soporte de arquivos e como habilitalo."
 
 #. IDS_OPT_EXPORT_CAPTION
-#: Merge.rc:5284
+#: Merge.rc:5283
 msgid "Select file for export"
 msgstr "Seleccione un ficheiro para exportar"
 
 #. IDS_OPT_IMPORT_CAPTION
-#: Merge.rc:5285
+#: Merge.rc:5284
 msgid "Select file for import"
 msgstr "Seleccione un ficheiro para importar"
 
 #. IDS_OPT_IMPORT_DONE
-#: Merge.rc:5286
+#: Merge.rc:5285
 msgid "Options imported from file."
 msgstr "Opcións importadas desde o ficheiro."
 
 #. IDS_OPT_EXPORT_DONE
-#: Merge.rc:5287
+#: Merge.rc:5286
 msgid "Options exported to file."
 msgstr "Opcións exportadas ao ficheiro."
 
 #. IDS_OPT_IMPORT_ERR
-#: Merge.rc:5288
+#: Merge.rc:5287
 msgid "Failed to import options from file."
 msgstr "Erro ao importar opcións do arquivo."
 
 #. IDS_OPT_EXPORT_ERR
-#: Merge.rc:5289
+#: Merge.rc:5288
 msgid "Failed to write options to file."
 msgstr "Erro ao escribir as opcións ao ficheiro."
 
 #. IDS_CLOSEALL_WINDOWS
-#: Merge.rc:5290
+#: Merge.rc:5289
 msgid ""
 "Close multiple compare windows?\n"
 "\n"
@@ -7514,34 +7509,34 @@ msgstr ""
 "Quere continuar?"
 
 #. IDS_EOL_BIN
-#: Merge.rc:5300
+#: Merge.rc:5299
 msgctxt "EOL Type"
 msgid "Binary"
 msgstr "Binario"
 
 #. IDS_MARKER_COLOR_FMT
-#: Merge.rc:5305
+#: Merge.rc:5304
 #, c-format
 msgid "Marker Color %d"
 msgstr "Cor de marcador %d"
 
 #. IDS_MARKER_NEW_PATTERN
-#: Merge.rc:5306
+#: Merge.rc:5305
 msgid "New Pattern"
 msgstr "Novo padrón"
 
 #. IDS_PLUGINSLIST_TYPE
-#: Merge.rc:5312
+#: Merge.rc:5311
 msgid "Type"
 msgstr "Tipo"
 
 #. IDS_PLUGINS_TYPE_EDITSCRIPT
-#: Merge.rc:5316
+#: Merge.rc:5315
 msgid "Editor script"
 msgstr "Editor de script"
 
 #. ID_SELECTLINEDIFF
-#: Merge.rc:5322
+#: Merge.rc:5321
 msgid ""
 "\n"
 "Difference in Current Line (F4)"
@@ -7550,7 +7545,7 @@ msgstr ""
 "Diferenza na liña actual (F4)"
 
 #. ID_OPTIONS
-#: Merge.rc:5323
+#: Merge.rc:5322
 msgid ""
 "\n"
 "Options"
@@ -7559,7 +7554,7 @@ msgstr ""
 "Configuración"
 
 #. ID_REFRESH
-#: Merge.rc:5324
+#: Merge.rc:5323
 msgid ""
 "\n"
 "Refresh (F5)"
@@ -7568,7 +7563,7 @@ msgstr ""
 "Actualizar (F5)"
 
 #. ID_PREVDIFF
-#: Merge.rc:5330
+#: Merge.rc:5329
 msgid ""
 "\n"
 "Previous Difference (Alt+Up)"
@@ -7577,7 +7572,7 @@ msgstr ""
 "Diferenza anterior (Alt+Arriba)"
 
 #. ID_NEXTDIFF
-#: Merge.rc:5331
+#: Merge.rc:5330
 msgid ""
 "\n"
 "Next Difference (Alt+Down)"
@@ -7586,7 +7581,7 @@ msgstr ""
 "Diferenza seguinte (Alt+Abaixo)"
 
 #. ID_PREVCONFLICT
-#: Merge.rc:5332
+#: Merge.rc:5331
 msgid ""
 "\n"
 "Previous Conflict (Alt+Shift+Up)"
@@ -7595,7 +7590,7 @@ msgstr ""
 "Conflito anterior (Alt+Maiús+Arriba)"
 
 #. ID_NEXTCONFLICT
-#: Merge.rc:5333
+#: Merge.rc:5332
 msgid ""
 "\n"
 "Next Conflict (Alt+Shift+Down)"
@@ -7604,7 +7599,7 @@ msgstr ""
 "Conflito seguinte (Alt+Maiús+Abaixo)"
 
 #. ID_FIRSTDIFF
-#: Merge.rc:5338
+#: Merge.rc:5337
 msgid ""
 "\n"
 "First Difference (Alt+Home)"
@@ -7613,7 +7608,7 @@ msgstr ""
 "Primeira diferenza (Alt+Inicio)"
 
 #. ID_CURDIFF
-#: Merge.rc:5339
+#: Merge.rc:5338
 msgid ""
 "\n"
 "Current Difference (Alt+Enter)"
@@ -7622,7 +7617,7 @@ msgstr ""
 "Diferenza actual (Alt+Enter)"
 
 #. ID_LASTDIFF
-#: Merge.rc:5340
+#: Merge.rc:5339
 msgid ""
 "\n"
 "Last Difference (Alt+End)"
@@ -7631,7 +7626,7 @@ msgstr ""
 "Derradeira diferenza (Alt+Fin)"
 
 #. ID_L2R
-#: Merge.rc:5341
+#: Merge.rc:5340
 msgid ""
 "\n"
 "Copy to Right (Alt+Right)"
@@ -7640,7 +7635,7 @@ msgstr ""
 "Copiar ao dereito (Alt+Dereita)"
 
 #. ID_R2L
-#: Merge.rc:5342
+#: Merge.rc:5341
 msgid ""
 "\n"
 "Copy to Left (Alt+Left)"
@@ -7649,7 +7644,7 @@ msgstr ""
 "Copiar ao esquerdo (Alt+Esquerda)"
 
 #. ID_L2RNEXT
-#: Merge.rc:5343
+#: Merge.rc:5342
 msgid ""
 "\n"
 "Copy to Right and Advance (Ctrl+Alt+Right)"
@@ -7658,7 +7653,7 @@ msgstr ""
 "Copiar ao dereito e avanzar (Ctrl+Alt+Dereita)"
 
 #. ID_R2LNEXT
-#: Merge.rc:5344
+#: Merge.rc:5343
 msgid ""
 "\n"
 "Copy to Left and Advance (Ctrl+Alt+Left)"
@@ -7667,7 +7662,7 @@ msgstr ""
 "Copiar ao esquerdo e avanzar (Ctrl+Alt+Esquerda)"
 
 #. ID_ALL_RIGHT
-#: Merge.rc:5345
+#: Merge.rc:5344
 msgid ""
 "\n"
 "Copy All to Right"
@@ -7676,7 +7671,7 @@ msgstr ""
 "Copiar todo ao dereito"
 
 #. ID_ALL_LEFT
-#: Merge.rc:5346
+#: Merge.rc:5345
 msgid ""
 "\n"
 "Copy All to Left"
@@ -7685,7 +7680,7 @@ msgstr ""
 "Copiar todo ao esquerdo"
 
 #. ID_AUTO_MERGE
-#: Merge.rc:5347
+#: Merge.rc:5346
 msgid ""
 "\n"
 "Auto Merge (Ctrl+Alt+M)"
@@ -7694,7 +7689,7 @@ msgstr ""
 "Automesturar (Ctrl+Alt+M)"
 
 #. ID_FIRSTFILE
-#: Merge.rc:5348
+#: Merge.rc:5347
 msgid ""
 "\n"
 "First File"
@@ -7703,7 +7698,7 @@ msgstr ""
 "Primeiro ficheiro"
 
 #. ID_NEXTFILE
-#: Merge.rc:5349
+#: Merge.rc:5348
 msgid ""
 "\n"
 "Next File (Ctrl+F8)"
@@ -7712,7 +7707,7 @@ msgstr ""
 "Seguinte ficheiro (Ctrl+F8)"
 
 #. ID_LASTFILE
-#: Merge.rc:5350
+#: Merge.rc:5349
 msgid ""
 "\n"
 "Last File"
@@ -7721,7 +7716,7 @@ msgstr ""
 "Derradeiro ficheiro"
 
 #. ID_PREVFILE
-#: Merge.rc:5351
+#: Merge.rc:5350
 msgid ""
 "\n"
 "Previous File (Ctrl+F7)"
@@ -7730,141 +7725,141 @@ msgstr ""
 "Ficheiro anterior (Ctrl+F7)"
 
 #. IDS_UNPACK_AUTO
-#: Merge.rc:5358
+#: Merge.rc:5357
 msgid "Adapted unpacker applied to both files (one needs extension)."
 msgstr "O desempaquetador escollido aplícase a ambos ficheiros (só un ficheiro precisa a extensión)."
 
 #. IDS_NO_PREDIFFER
-#: Merge.rc:5359
+#: Merge.rc:5358
 msgid "No Prediffer (Normal)"
 msgstr "Sen precomparación (normal)"
 
 #. IDS_SUGGESTED_PLUGINS
-#: Merge.rc:5360
+#: Merge.rc:5359
 msgid "Suggested Plugins"
 msgstr "Complementos recomendados"
 
 #. IDS_NOT_SUGGESTED_PLUGINS
-#: Merge.rc:5361
+#: Merge.rc:5360
 msgid "All Plugins"
 msgstr "Todos os complementos"
 
 #. IDS_PRIVATEBUILD_FMT
-#: Merge.rc:5367
+#: Merge.rc:5366
 #, c-format
 msgid "Private Build: %1"
 msgstr "Compilación privada: %1"
 
 #. IDS_ALLRIGHTS_RESERVED
-#: Merge.rc:5368
+#: Merge.rc:5367
 msgid " - All rights reserved."
 msgstr ""
 
 #. IDS_TITLE_PLUGINS_SETTINGS
-#: Merge.rc:5374
+#: Merge.rc:5373
 msgid "Plugin Settings"
 msgstr "Configuración de complementos"
 
 #. IDS_NO_SCT_SCRIPTS
-#: Merge.rc:5376
+#: Merge.rc:5375
 msgid "WSH not found - .sct scripts disabled"
 msgstr "WSH non atopado - scripts .sct desactivados"
 
 #. IDS_LOCBAR_GOTOLINE_FMT
-#: Merge.rc:5384
+#: Merge.rc:5383
 #, c-format
 msgid "G&o to Line %1"
 msgstr "I&r á liña %1"
 
 #. IDS_GOTO_MOVED_LINE
-#: Merge.rc:5390
+#: Merge.rc:5389
 msgid "Go to Moved Line\tCtrl+Shift+G"
 msgstr "Ir á liña movida\tCtrl+Maiús+G"
 
 #. IDS_AUTOCOMPLETE_DISABLED
-#: Merge.rc:5396
+#: Merge.rc:5395
 msgctxt "Options dialog|General|Open dialog Auto completion"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_AUTOCOMPLETE_FILE_SYS
-#: Merge.rc:5397
+#: Merge.rc:5396
 msgid "From file system"
 msgstr "Do sistema de arquivos"
 
 #. IDS_AUTOCOMPLETE_MRU
-#: Merge.rc:5398
+#: Merge.rc:5397
 msgid "From Most Recently Used list"
 msgstr "Da listaxe dos máis usados"
 
 #. IDS_COLORSCHEME_PLAIN
-#: Merge.rc:5404
+#: Merge.rc:5403
 msgid "No Highlighting"
 msgstr "Sen resaltar"
 
 #. IDS_COLORSCHEME_PO
-#: Merge.rc:5439
+#: Merge.rc:5438
 msgid "Portable Object"
 msgstr "Obxecto portable"
 
 #. IDS_COLORSCHEME_RSRC
-#: Merge.rc:5444
+#: Merge.rc:5443
 msgid "Resources"
 msgstr "Recursos"
 
 #. IDS_COLORSCHEME_SH
-#: Merge.rc:5448
+#: Merge.rc:5447
 msgid "Shell"
 msgstr "Intérprete de comandos"
 
 #. IDS_CLOSE_LEFT_TABS
-#: Merge.rc:5469
+#: Merge.rc:5468
 msgid "Close &Left Tabs"
 msgstr "Pechar pestanas da &esquerda"
 
 #. IDS_CLOSE_RIGHT_TABS
-#: Merge.rc:5470
+#: Merge.rc:5469
 msgid "Close R&ight Tabs"
 msgstr "Pechar pestanas da dere&ita"
 
 #. IDS_CLOSE_OTHER_TABS
-#: Merge.rc:5471
+#: Merge.rc:5470
 msgid "Close &Other Tabs"
 msgstr "Pechar &outras pestanas"
 
 #. IDS_TABBAR_AUTO_MAXWIDTH
-#: Merge.rc:5472
+#: Merge.rc:5471
 msgid "Enable &Auto Max Width"
 msgstr "Activar &anchura máxima automática"
 
 #. IDS_WEBPAGE_MENU
-#: Merge.rc:5482
+#: Merge.rc:5481
 msgid "We&bpage"
 msgstr "Páxina We&b"
 
 #. IDS_VIEW_WRAP_TEXT
-#: Merge.rc:5487
+#: Merge.rc:5486
 msgid "W&rap Text"
 msgstr "Axusta&r texto"
 
 #. IDS_NOTINSTALLED
-#: Merge.rc:5492
+#: Merge.rc:5491
 msgid "%1 is not installed."
 msgstr "Non está instalado %1."
 
 #. IDS_CREATE_FOLDER
-#: Merge.rc:5497
+#: Merge.rc:5496
 #, c-format
 msgid "%1 does not exist. Create it?"
 msgstr "%1 non existe. Quere crealo?"
 
 #. IDS_CREATE_FOLDER_ERROR
-#: Merge.rc:5498
+#: Merge.rc:5497
 msgid "Failed to create folder."
 msgstr "Erro ao crear a carpeta."
 
 #. IDC_EXT_EDITOR_PATH
-#: Merge.rc:5503
+#: Merge.rc:5502
 msgid ""
 "Parameters:\n"
 "$file: Current file path\n"
@@ -7875,491 +7870,491 @@ msgstr ""
 "$linenum: número de liña da posición actual do cursor"
 
 #. IDS_DIFF_ALGORITHM_DEFAULT
-#: Merge.rc:5508
+#: Merge.rc:5507
 msgid "default"
 msgstr "predeterminado"
 
 #. IDS_DIFF_ALGORITHM_MINIMAL
-#: Merge.rc:5509
+#: Merge.rc:5508
 msgid "minimal"
 msgstr "mínimo"
 
 #. IDS_DIFF_ALGORITHM_PATIENCE
-#: Merge.rc:5510
+#: Merge.rc:5509
 msgid "patience"
 msgstr "solitario"
 
 #. IDS_DIFF_ALGORITHM_HISTOGRAM
-#: Merge.rc:5511
+#: Merge.rc:5510
 msgid "histogram"
 msgstr "histograma"
 
 #. IDS_DIFF_ALGORITHM_NONE
-#: Merge.rc:5512
+#: Merge.rc:5511
 msgid "none"
 msgstr "ningún"
 
 #. IDS_RENDERING_MODE_GDI
-#: Merge.rc:5517
+#: Merge.rc:5516
 msgid "GDI"
 msgstr "GDI"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_DEFAULT
-#: Merge.rc:5518
+#: Merge.rc:5517
 msgid "DirectWrite Default"
 msgstr "DirectWrite predeterminado"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_ALIASED
-#: Merge.rc:5519
+#: Merge.rc:5518
 msgid "DirectWrite Aliased"
 msgstr "Alias de DirectWrite"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_GDI_CLASSIC
-#: Merge.rc:5520
+#: Merge.rc:5519
 msgid "DirectWrite GDI Classic"
 msgstr "DirectWrite GDI clásico"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_GDI_NATURAL
-#: Merge.rc:5521
+#: Merge.rc:5520
 msgid "DirectWrite GDI Natural"
 msgstr "DirectWrite GDI natural"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_NATURAL
-#: Merge.rc:5522
+#: Merge.rc:5521
 msgid "DirectWrite Natural"
 msgstr "DirectWrite natural"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_NATURAL_SYMMETRIC
-#: Merge.rc:5523
+#: Merge.rc:5522
 msgid "DirectWrite Natural Symmetric"
 msgstr "DirectWrite natural simétrico"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_DISABLED
-#: Merge.rc:5528
+#: Merge.rc:5527
 msgctxt "Options dialog|General|Close windows with Esc"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_1
-#: Merge.rc:5529
+#: Merge.rc:5528
 msgid "MDI child window or main window"
 msgstr "Ventá MDI secundaria ou ventá principal"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_2
-#: Merge.rc:5530
+#: Merge.rc:5529
 msgid "MDI child window only"
 msgstr "Só ventá secundaria MDI"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_3
-#: Merge.rc:5531
+#: Merge.rc:5530
 msgid "Close main window if only one MDI child window"
 msgstr "Pechar a ventá principal se só hai unha ventá MDI secundaria"
 
 #. IDS_DIFF_GROUP
-#: Merge.rc:5536
+#: Merge.rc:5535
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Diff"
 msgstr "Diferenza"
 
 #. IDS_DIFF_HIGHLIGHT
-#: Merge.rc:5537
+#: Merge.rc:5536
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Highlight"
 msgstr "Resaltado"
 
 #. IDS_DIFF_BLINK
-#: Merge.rc:5538
+#: Merge.rc:5537
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Blink"
 msgstr "Escintilar"
 
 #. IDS_DIFF_BLOCKSIZE
-#: Merge.rc:5539
+#: Merge.rc:5538
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Block Size"
 msgstr "Tamaño do bloque"
 
 #. IDS_DIFF_BLOCKALPHA
-#: Merge.rc:5540
+#: Merge.rc:5539
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Block Alpha"
 msgstr "Bloque Alfa"
 
 #. IDS_DIFF_CDTHRESHOLD
-#: Merge.rc:5541
+#: Merge.rc:5540
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "CD Threshold"
 msgstr "Limiar de DC"
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION
-#: Merge.rc:5542
+#: Merge.rc:5541
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Ins/Del Detection"
 msgstr "Detectar Ins/Borrar"
 
 #. IDS_OVERLAY_MODE_NONE
-#: Merge.rc:5543 Merge.rc:5548
+#: Merge.rc:5542 Merge.rc:5547
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "None"
 msgstr "Ningún"
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION_VERTICAL
-#: Merge.rc:5544
+#: Merge.rc:5543
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Vertical"
 msgstr "Vertical"
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION_HORIZONTAL
-#: Merge.rc:5545
+#: Merge.rc:5544
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Horizontal"
 msgstr "Horizontal"
 
 #. IDS_OVERLAY_GROUP
-#: Merge.rc:5546
+#: Merge.rc:5545
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Overlay"
 msgstr "Superpoñer"
 
 #. IDS_OVERLAY_ALPHA
-#: Merge.rc:5547
+#: Merge.rc:5546
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha"
 msgstr "Alpha"
 
 #. IDS_OVERLAY_MODE_XOR
-#: Merge.rc:5549
+#: Merge.rc:5548
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "XOR"
 msgstr "XOR"
 
 #. IDS_OVERLAY_MODE_ALPHA
-#: Merge.rc:5550
+#: Merge.rc:5549
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha Blend"
 msgstr "Mestura Alpha"
 
 #. IDS_OVERLAY_MODE_ALPHA_ANIMATION
-#: Merge.rc:5551
+#: Merge.rc:5550
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha Animation"
 msgstr "Animación Alpha"
 
 #. IDS_ZOOM
-#: Merge.rc:5552
+#: Merge.rc:5551
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Zoom"
 msgstr "Zoom"
 
 #. IDS_PAGE
-#: Merge.rc:5553
+#: Merge.rc:5552
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Page:"
 msgstr "Páxina:"
 
 #. IDS_IMGCMP_STATUS_PT_RGBA_FMT
-#: Merge.rc:5554
+#: Merge.rc:5553
 #, c-format
 msgid "Pt: (%d, %d)  RGBA: (%d, %d, %d, %d)  "
 msgstr "Pto: (%d, %d)  RGBA: (%d, %d, %d, %d)  "
 
 #. IDS_IMGCMP_STATUS_DIST1_FMT
-#: Merge.rc:5555
+#: Merge.rc:5554
 #, c-format
 msgid "Dist: %g  "
 msgstr "Dist: %g  "
 
 #. IDS_IMGCMP_STATUS_DIST2_FMT
-#: Merge.rc:5556
+#: Merge.rc:5555
 #, c-format
 msgid "Dist: %g, %g  "
 msgstr "Dist: %g, %g "
 
 #. IDS_IMGCMP_STATUS_PAGE_ZOOM_SIZE_BPP_FMT
-#: Merge.rc:5557
+#: Merge.rc:5556
 #, c-format
 msgid "Page: %d/%d  Zoom: %d%%  %dx%dpx  %dbpp  "
 msgstr "Páxina: %d/%d  Zoom: %d%%  %dx%dpx  %dbpp  "
 
 #. IDS_IMGCMP_STATUS_RC_FMT
-#: Merge.rc:5558
+#: Merge.rc:5557
 #, c-format
 msgid "Rc: (%d, %d)  "
 msgstr "Rc: (%d, %d)  "
 
 #. IDS_IMGCMP_STATUS_FLIPPED_FMT
-#: Merge.rc:5559
+#: Merge.rc:5558
 #, c-format
 msgid "Flipped: %s  "
 msgstr "Volteada: %s "
 
 #. IDS_IMGCMP_STATUS_ROTATED_FMT
-#: Merge.rc:5560
+#: Merge.rc:5559
 #, c-format
 msgid "Rotated: %d  "
 msgstr "Rotada: %d "
 
 #. IDS_IMGCMP_REPORT_ALLPAGES
-#: Merge.rc:5561
+#: Merge.rc:5560
 msgid "All pages"
 msgstr "Todas as páxinas"
 
 #. IDS_IGNSUB_STR1
-#: Merge.rc:5566
+#: Merge.rc:5565
 msgid "<Edit here>"
 msgstr "<Editar aquí>"
 
 #. IDS_IGNSUB_STR2
-#: Merge.rc:5567
+#: Merge.rc:5566
 msgid "No differences found to select"
 msgstr "Non se atoparon deferenzas para seleccionar"
 
 #. IDS_IGNSUB_STR3
-#: Merge.rc:5568
+#: Merge.rc:5567
 msgid "No differences found to add as substitution filter"
 msgstr "Non se atoparon diferenzas para añadir como filtro de substitución"
 
 #. IDS_IGNSUB_STR4
-#: Merge.rc:5569
+#: Merge.rc:5568
 msgid "The pair is already in the Substitution Filters list"
 msgstr "Esta parella xa está presente na lista de Filtros de substitución"
 
 #. IDS_IGNSUB_STR5
-#: Merge.rc:5570
+#: Merge.rc:5569
 msgid "Add this change to Substitution Filters?"
 msgstr "Añadir este cambio aos Filtros de substitución?"
 
 #. IDS_OCRRESULT_TEXTONLY
-#: Merge.rc:5575
+#: Merge.rc:5574
 msgid "Text only"
 msgstr "Só texto"
 
 #. IDS_OCRRESULT_POS_LINE
-#: Merge.rc:5576
+#: Merge.rc:5575
 msgid "Line-by-line position and text"
 msgstr "Posición e texto liña por liña"
 
 #. IDS_OCRRESULT_POS_WORD
-#: Merge.rc:5577
+#: Merge.rc:5576
 msgid "Word-by-word position and text"
 msgstr "Posición e texto palabra por palabra"
 
 #. IDS_USERDATAFOLDER_APPDATA
-#: Merge.rc:5582
+#: Merge.rc:5581
 msgid "AppData (Roaming) folder"
 msgstr ""
 
 #. IDS_USERDATAFOLDER_INSTALL
-#: Merge.rc:5583
+#: Merge.rc:5582
 msgid "Install folder"
 msgstr "Carpeta de instalación"
 
 #. IDS_USERDATAFOLDER_DOCUMENTS
-#: Merge.rc:5584
+#: Merge.rc:5583
 msgid "Documents folder"
 msgstr ""
 
 #. IDS_SINGLEINSTANCE_DISABLED
-#: Merge.rc:5589
+#: Merge.rc:5588
 msgctxt "Options dialog|General|Single instance mode"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_SINGLEINSTANCE_STR1
-#: Merge.rc:5590
+#: Merge.rc:5589
 msgid "Allow only one instance to run"
 msgstr "Permitir executar só unha instancia"
 
 #. IDS_CLIPBOARD_HISTORY
-#: Merge.rc:5591
+#: Merge.rc:5590
 msgid "Clipboard &History"
 msgstr ""
 
 #. IDS_SINGLEINSTANCE_STR2
-#: Merge.rc:5592
+#: Merge.rc:5591
 msgid "Allow only one instance; wait for termination"
 msgstr "Permitir só a execución dunha instancia e esperar hasta que remate"
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_DISABLED
-#: Merge.rc:5597
+#: Merge.rc:5596
 msgctxt "Options dialog|General|Auto-reload modified files"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_STR1
-#: Merge.rc:5598
+#: Merge.rc:5597
 msgid "Only on window activated"
 msgstr "Só coa ventá activada"
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_STR2
-#: Merge.rc:5599
+#: Merge.rc:5598
 msgid "Immediately"
 msgstr "Inmediatamente"
 
 #. IDS_PLUGIN_ALL
-#: Merge.rc:5604
+#: Merge.rc:5603
 msgid "Al&l"
 msgstr "&Todo"
 
 #. IDS_PLUGIN_OTHERS
-#: Merge.rc:5605
+#: Merge.rc:5604
 msgid "&Others"
 msgstr "&Outros"
 
-#: Merge.rc:5607
+#: Merge.rc:5606
 #, c-format
 msgid "Missing plugin name in pipeline: %1"
 msgstr "Falta o nome do complemento na canalización de complementos %1"
 
-#: Merge.rc:5609
+#: Merge.rc:5608
 #, c-format
 msgid "Missing quote in plugin pipeline: %1"
 msgstr "Faltan comiñas na canalización de complementos %1"
 
 #. IDS_PLUGIN_NAME_ALREADY_EXISTS
-#: Merge.rc:5610
+#: Merge.rc:5609
 #, c-format
 msgid "Plugin name '%1' already exists."
 msgstr ""
 
 #. IDS_PLUGIN_TITLE1
-#: Merge.rc:5611
+#: Merge.rc:5610
 msgid "Specify plugin arguments"
 msgstr "Especificar os argumentos do complemento"
 
-#: Merge.rc:5613
+#: Merge.rc:5612
 #, c-format
 msgid "Plugin not found or invalid: %1"
 msgstr "Complemento non atopado ou non válido: %1"
 
 #. IDS_PLUGIN_NOT_UNPACK
-#: Merge.rc:5614
+#: Merge.rc:5613
 #, c-format
 msgid "'%1' is not an unpacker plugin"
 msgstr "'%1' non é un complemento desempaquetador"
 
 #. IDS_PLUGIN_NOT_PREDIFF
-#: Merge.rc:5615
+#: Merge.rc:5614
 #, c-format
 msgid "'%1' is not a prediffer plugin"
 msgstr "'%1' non é un complemento de precomparación"
 
-#: Merge.rc:5617
+#: Merge.rc:5616
 #, c-format
 msgid "Error prediffing '%1' with '%2'. Prediffing disabled."
 msgstr "Producíuse un erro ao precomparar o ficheiro '%1' co complemento '%2'. Xa non se vai facer ningunha outra precomparación."
 
 #. IDS_PLUGIN_CIRCULAR_REFERENCE
-#: Merge.rc:5618
+#: Merge.rc:5617
 #, c-format
 msgid "Circular reference in plugin pipeline: %1"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE1
-#: Merge.rc:5619
+#: Merge.rc:5618
 msgid "URL Handler"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE2
-#: Merge.rc:5620
+#: Merge.rc:5619
 msgid "File Unpacker"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE3
-#: Merge.rc:5621
+#: Merge.rc:5620
 msgid "File or Folder Unpacker"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE5
-#: Merge.rc:5623
+#: Merge.rc:5622
 msgid "Alias for Unpacker"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE6
-#: Merge.rc:5624
+#: Merge.rc:5623
 msgid "Alias for Prediffer"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE7
-#: Merge.rc:5625
+#: Merge.rc:5624
 msgid "Alias for Editor script"
 msgstr ""
 
 #. IDS_PLUGIN_ALIAS_DESC
-#: Merge.rc:5626
+#: Merge.rc:5625
 #, c-format
 msgid "Alias for plugin pipeline '%1'"
 msgstr ""
 
 #. IDS_PLUGIN_NEW_DESC
-#: Merge.rc:5627
+#: Merge.rc:5626
 msgid "New plugin description"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_ALL
-#: Merge.rc:5628
+#: Merge.rc:5627
 msgid "All"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_1ST
-#: Merge.rc:5629
+#: Merge.rc:5628
 msgid "1st"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_2ND
-#: Merge.rc:5630
+#: Merge.rc:5629
 msgid "2nd"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_3RD
-#: Merge.rc:5631
+#: Merge.rc:5630
 msgid "3rd"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_1ST_2ND
-#: Merge.rc:5632
+#: Merge.rc:5631
 msgid "1st and 2nd"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_1ST_3RD
-#: Merge.rc:5633
+#: Merge.rc:5632
 msgid "1st and 3rd"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_2ND_3RD
-#: Merge.rc:5634
+#: Merge.rc:5633
 msgid "2nd and 3rd"
 msgstr ""
 
 #. IDS_PLUGIN_CTRL_CLICK
-#: Merge.rc:5635
+#: Merge.rc:5634
 msgid "(Ctrl+Click to add to pipeline)"
 msgstr ""
 
 #. IDS_FILTER_APPLIED
-#: Merge.rc:5640
+#: Merge.rc:5639
 msgid "Filter applied"
 msgstr "Filtro aplicado"
 
 #. IDS_FILTERMENU_COMPARE
-#: Merge.rc:5645
+#: Merge.rc:5644
 #, c-format
 msgid "Compare %1"
 msgstr ""
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN2
-#: Merge.rc:5647
+#: Merge.rc:5646
 msgid "&Filter by This Column..."
 msgstr ""
 
 #. IDS_CLIPBOARDHISTORY_TIME
-#: Merge.rc:5652
+#: Merge.rc:5651
 #, c-format
 msgid "Clipboard at %s"
 msgstr "Portapapeis en %s"
 
 #. IDS_CLIPBOARDHISTORY_DISABLED
-#: Merge.rc:5653
+#: Merge.rc:5652
 msgid ""
 "Clipboard history disabled.\r\n"
 "Enable: Windows logo key + V, then Turn on."
@@ -8367,420 +8362,420 @@ msgstr ""
 "O historial do portapapeis está desactivado.\r\n"
 "Para habilitar o historial do portapapeis, prema na tecla do logo de Windows + V e logo no botón Activar."
 
-#: Merge.rc:5655
+#: Merge.rc:5654
 msgid "This system does not support clipboard history."
 msgstr "Este sistema non soporta o historial do portapapeis."
 
-#: Merge.rc:5657
+#: Merge.rc:5656
 msgid "32-bit WinMerge does not support Clipboard Compare"
 msgstr "A versión de 32 bit de WinMerge non soporta a comparación de portapapeis"
 
 #. IDS_WEBVIEW2_RUNTIME_NOT_INSTALLED
-#: Merge.rc:5662
+#: Merge.rc:5661
 msgid "WebView2 runtime not installed. Download it?"
 msgstr "O runtime WebView2 non está instalado. Quere descargalo?"
 
 #. IDS_JUMPLIST_NEW_TEXT_COMPARE
-#: Merge.rc:5667
+#: Merge.rc:5666
 msgid "New Text Compare"
 msgstr "Nova comparación de texto"
 
 #. IDS_JUMPLIST_NEW_TABLE_COMPARE
-#: Merge.rc:5668
+#: Merge.rc:5667
 msgid "New Table Compare"
 msgstr "Nova comparación de táboa"
 
 #. IDS_JUMPLIST_NEW_BINARY_COMPARE
-#: Merge.rc:5669
+#: Merge.rc:5668
 msgid "New Binary Compare"
 msgstr "Nova comparación binaria"
 
 #. IDS_JUMPLIST_NEW_IMAGE_COMPARE
-#: Merge.rc:5670
+#: Merge.rc:5669
 msgid "New Image Compare"
 msgstr "Nova comparación de imaxe"
 
 #. IDS_JUMPLIST_NEW_WEBPAGE_COMPARE
-#: Merge.rc:5671
+#: Merge.rc:5670
 msgid "New Webpage Compare"
 msgstr "Nova comparación de páxina web"
 
 #. IDS_JUMPLIST_NEW_FOLDER_COMPARE
-#: Merge.rc:5672
+#: Merge.rc:5671
 msgid "New Folder Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_CLIPBOARD_COMPARE
-#: Merge.rc:5673
+#: Merge.rc:5672
 msgid "Clipboard Compare"
 msgstr "Comparar de portapapeis"
 
 #. IDS_PREVIEWBAR_PRINT
-#: Merge.rc:5678
+#: Merge.rc:5677
 msgid "&Print..."
 msgstr "Im&primir..."
 
 #. IDS_PREVIEWBAR_PREVPAGE
-#: Merge.rc:5680
+#: Merge.rc:5679
 msgid "Pre&v Page"
 msgstr "Páxina an&terior"
 
 #. IDS_PREVIEWBAR_TWOPAGE
-#: Merge.rc:5681
+#: Merge.rc:5680
 msgid "&Two Page"
 msgstr "&Dúas páxinas"
 
 #. IDS_PREVIEWBAR_ONEPAGE
-#: Merge.rc:5682
+#: Merge.rc:5681
 msgid "&One Page"
 msgstr "Un&ha páxina"
 
 #. IDS_PREVIEWBAR_ZOOMIN
-#: Merge.rc:5683
+#: Merge.rc:5682
 msgid "Zoom &In"
 msgstr "Aumentar &zoom"
 
 #. IDS_PREVIEWBAR_ZOOMOUT
-#: Merge.rc:5684
+#: Merge.rc:5683
 msgid "Zoom &Out"
 msgstr "Reducir z&oom"
 
 #. IDS_WEBPAGE_COMPARING
-#: Merge.rc:5690
+#: Merge.rc:5689
 msgid "Comparing..."
 msgstr ""
 
 #. IDS_WEBPAGE_ZOOM
-#: Merge.rc:5691
+#: Merge.rc:5690
 msgid "Zoom:"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_DIFFHUNK
-#: Merge.rc:5696
+#: Merge.rc:5695
 msgid "Diff hunk"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_INLINE
-#: Merge.rc:5697
+#: Merge.rc:5696
 msgid "Inline diff"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_LINE
-#: Merge.rc:5698
+#: Merge.rc:5697
 msgid "Line"
 msgstr ""
 
-#: Merge.rc:5699
+#: Merge.rc:5698
 msgid "Character"
 msgstr ""
 
 #. ID_MICE_PREVDIFF
-#: Merge.rc:5704
+#: Merge.rc:5703
 msgid "\nPrevious Difference (Alt+Up)\n(Right Button+Wheel Up)\n(Alt+Wheel Up)"
 msgstr ""
 
 #. ID_MICE_NEXTDIFF
-#: Merge.rc:5705
+#: Merge.rc:5704
 msgid "\nNext Difference (Alt+Down)\n(Right Button+Wheel Down)\n(Alt+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_L2R
-#: Merge.rc:5706
+#: Merge.rc:5705
 msgid "\nCopy to Right (Alt+Right)\n(Right Button+Wheel Right)\n(Alt+Wheel Right)\n(Alt+Shift+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_R2L
-#: Merge.rc:5707
+#: Merge.rc:5706
 msgid "\nCopy to Left (Alt+Left)\n(Right Button+Wheel Left)\n(Alt+Wheel Left)\n(Alt+Shift+Wheel Up)"
 msgstr ""
 
 #. ID_MICE_L2RNEXT
-#: Merge.rc:5708
+#: Merge.rc:5707
 msgid "\nCopy to Right and Advance (Ctrl+Alt+Right)\n(Ctrl+Alt+Wheel Right)\n(Ctrl+Alt+Shift+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_R2LNEXT
-#: Merge.rc:5709
+#: Merge.rc:5708
 msgid "\nCopy to Left and Advance (Ctrl+Alt+Left)\n(Ctrl+Alt+Wheel Left)\n(Ctrl+Alt+Shift+Wheel Up)"
 msgstr ""
 
 #. IDS_LOG_COMPARING_2
-#: Merge.rc:5719
+#: Merge.rc:5718
 #, c-format
 msgid "Comparing %1 with %2"
 msgstr ""
 
 #. IDS_LOG_COMPARING_3
-#: Merge.rc:5720
+#: Merge.rc:5719
 #, c-format
 msgid "Comparing %1 with %2 and %3"
 msgstr ""
 
 #. IDS_LOG_COMPARE_COMPLETED
-#: Merge.rc:5721
+#: Merge.rc:5720
 msgid "Comparison completed"
 msgstr ""
 
 #. IDS_LOG_COMPARE_ERROR_2
-#: Merge.rc:5722
+#: Merge.rc:5721
 #, c-format
 msgid "Failed to compare %1 with %2: "
 msgstr ""
 
 #. IDS_LOG_COMPARE_ERROR_3
-#: Merge.rc:5723
+#: Merge.rc:5722
 #, c-format
 msgid "Failed to compare %1 with %2 and %3: "
 msgstr ""
 
 #. IDS_LOG_FILE_SAVED
-#: Merge.rc:5724
+#: Merge.rc:5723
 msgid "File saved"
 msgstr ""
 
 #. IDS_LOG_COPYING_FILES
-#: Merge.rc:5725
+#: Merge.rc:5724
 msgid "Copying files..."
 msgstr ""
 
 #. IDS_LOG_MOVING_FILES
-#: Merge.rc:5726
+#: Merge.rc:5725
 msgid "Moving files..."
 msgstr ""
 
 #. IDS_LOG_DELETING_FILES
-#: Merge.rc:5727
+#: Merge.rc:5726
 msgid "Deleting files..."
 msgstr ""
 
 #. IDS_LOG_RECYCLEBIN
-#: Merge.rc:5728
+#: Merge.rc:5727
 msgid "Recycle Bin"
 msgstr ""
 
 #. IDS_LOG_PERMANENTLY_DELETED
-#: Merge.rc:5729
+#: Merge.rc:5728
 msgid "Permanently deleted"
 msgstr ""
 
 #. IDS_LOG_FILEOPERATION_COMPLETED
-#: Merge.rc:5730
+#: Merge.rc:5729
 msgid "File operation completed successfully"
 msgstr ""
 
 #. IDS_LOG_FILEOPERATION_CANCELED
-#: Merge.rc:5731
+#: Merge.rc:5730
 msgid "File operation canceled"
 msgstr ""
 
 #. IDS_FILTER_ERROR_NO_ERROR
-#: Merge.rc:5736
+#: Merge.rc:5735
 msgid "No error"
 msgstr ""
 
 #. IDS_FILTER_ERROR_EMPTY_EXPRESSION
-#: Merge.rc:5737
+#: Merge.rc:5736
 msgid "Filter expression is empty"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNKNOWN_CHAR
-#: Merge.rc:5738
+#: Merge.rc:5737
 msgid "Unknown character in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNTERMINATED_STRING
-#: Merge.rc:5739
+#: Merge.rc:5738
 msgid "Unterminated string literal"
 msgstr ""
 
 #. IDS_FILTER_ERROR_SYNTAX_ERROR
-#: Merge.rc:5740
+#: Merge.rc:5739
 msgid "Syntax error in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_PARSE_FAILURE
-#: Merge.rc:5741
+#: Merge.rc:5740
 msgid "Failed to parse filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_LITERAL
-#: Merge.rc:5742
+#: Merge.rc:5741
 msgid "Invalid literal value"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_REGULAR_EXPRESSION
-#: Merge.rc:5743
+#: Merge.rc:5742
 msgid "Invalid regular expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNDEFINED_IDENTIFIER
-#: Merge.rc:5744
+#: Merge.rc:5743
 msgid "Undefined identifier"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_ARGUMENT_COUNT
-#: Merge.rc:5745
+#: Merge.rc:5744
 msgid "Invalid number of arguments"
 msgstr ""
 
 #. IDS_FILTER_ERROR_FILTER_NAME_NOT_FOUND
-#: Merge.rc:5746
+#: Merge.rc:5745
 msgid "Filter name not found"
 msgstr ""
 
 #. IDS_FILTER_ERROR_DIVIDE_BY_ZERO
-#: Merge.rc:5747
+#: Merge.rc:5746
 msgid "Division by zero in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNKNOWN_ERROR
-#: Merge.rc:5748
+#: Merge.rc:5747
 msgid "Unknown error"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_PROPERTY_NAME
-#: Merge.rc:5749
+#: Merge.rc:5748
 msgid "Invalid property name"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_DIRECTIVE
-#: Merge.rc:5750
+#: Merge.rc:5749
 msgid "Invalid directive"
 msgstr ""
 
 #. IDS_FILTER_OP_EQUALS
-#: Merge.rc:5755
+#: Merge.rc:5754
 msgid "Equals"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_EQUALS
-#: Merge.rc:5756
+#: Merge.rc:5755
 msgid "Does not equal"
 msgstr ""
 
 #. IDS_FILTER_OP_LESS_THAN
-#: Merge.rc:5757
+#: Merge.rc:5756
 msgid "Less than"
 msgstr ""
 
 #. IDS_FILTER_OP_LESS_EQUAL
-#: Merge.rc:5758
+#: Merge.rc:5757
 msgid "Less than or equal to"
 msgstr ""
 
 #. IDS_FILTER_OP_GREATER_EQUAL
-#: Merge.rc:5759
+#: Merge.rc:5758
 msgid "Greater than or equal to"
 msgstr ""
 
 #. IDS_FILTER_OP_GREATER_THAN
-#: Merge.rc:5760
+#: Merge.rc:5759
 msgid "Greater than"
 msgstr ""
 
 #. IDS_FILTER_OP_BETWEEN
-#: Merge.rc:5761
+#: Merge.rc:5760
 msgid "Between"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_BETWEEN
-#: Merge.rc:5762
+#: Merge.rc:5761
 msgid "Not Between"
 msgstr ""
 
 #. IDS_FILTER_OP_CONTAINS
-#: Merge.rc:5763
+#: Merge.rc:5762
 msgid "Contains"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_CONTAINS
-#: Merge.rc:5764
+#: Merge.rc:5763
 msgid "Not Contains"
 msgstr ""
 
 #. IDS_FILTER_OP_RECONTAINS
-#: Merge.rc:5765
+#: Merge.rc:5764
 msgid "Contains (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_RECONTAINS
-#: Merge.rc:5766
+#: Merge.rc:5765
 msgid "Not Contains (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_LIKE
-#: Merge.rc:5767
+#: Merge.rc:5766
 msgid "Match (wildcard)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_LIKE
-#: Merge.rc:5768
+#: Merge.rc:5767
 msgid "Not match (wildcard)"
 msgstr ""
 
 #. IDS_FILTER_OP_MATCHES
-#: Merge.rc:5769
+#: Merge.rc:5768
 msgid "Match (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_MATCHES
-#: Merge.rc:5770
+#: Merge.rc:5769
 msgid "Not match (regex)"
 msgstr ""
 
 #. IDS_COLORMODE_LIGHT
-#: Merge.rc:5775
+#: Merge.rc:5774
 msgid "Light"
 msgstr ""
 
 #. IDS_COLORMODE_DARK
-#: Merge.rc:5776
+#: Merge.rc:5775
 msgid "Dark"
 msgstr ""
 
 #. IDS_COLORMODE_FOLLOWSYSTEM
-#: Merge.rc:5777
+#: Merge.rc:5776
 msgid "Follow system"
 msgstr ""
 
 #. IDS_EXAMPLE
-#: Merge.rc:5782
+#: Merge.rc:5781
 #, c-format
 msgid "e.g. %1"
 msgstr ""
 
 #. IDS_DETECTED_PREVIOUS_CRASH
-#: Merge.rc:5787
+#: Merge.rc:5786
 msgid "WinMerge detected a previous crash. Please report this if possible."
 msgstr ""
 
 #. IDS_REGEX_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5792
+#: Merge.rc:5791
 msgid "# Regex replacement list\r\n# Format: regex<TAB>replacement\r\n# Backreferences like $1, $2 are supported\r\n\r\n(\\d{4})-(\\d{2})-(\\d{2})\t$1_$2_$3\r\n"
 msgstr ""
 
 #. IDS_STRING_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5793
+#: Merge.rc:5792
 msgid "# Replacement list\r\n# Format: search<TAB>replacement\r\n# Lines starting with # are ignored\r\n\r\nfrom1\tto1\r\nfrom2\tto2\r\n"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_ONLY
-#: Merge.rc:5798
+#: Merge.rc:5797
 msgid "Built-in only"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_FIRST
-#: Merge.rc:5799
+#: Merge.rc:5798
 msgid "Built-in first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_FIRST
-#: Merge.rc:5800
+#: Merge.rc:5799
 msgid "Tree-sitter first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_ONLY
-#: Merge.rc:5801
+#: Merge.rc:5800
 msgid "Tree-sitter only"
 msgstr ""
 

--- a/Translations/WinMerge/German.po
+++ b/Translations/WinMerge/German.po
@@ -26,7 +26,7 @@ msgstr ""
 "X-Poedit-Basepath: ../../Src\n"
 
 #. LANGUAGE, SUBLANGUAGE
-#: Merge.rc:26 Merge.rc:59 Merge.rc:5818
+#: Merge.rc:26 Merge.rc:59 Merge.rc:5817
 #, c-format
 msgid "LANG_ENGLISH, SUBLANG_ENGLISH_US"
 msgstr "LANG_GERMAN, SUBLANG_GERMAN"
@@ -176,7 +176,7 @@ msgstr "&Skripte"
 #. IDS_NO_EDIT_SCRIPTS
 #: Merge.rc:127 Merge.rc:352 Merge.rc:463 Merge.rc:673 Merge.rc:678
 #: Merge.rc:887 Merge.rc:899 Merge.rc:906 Merge.rc:963 Merge.rc:1210
-#: Merge.rc:5375
+#: Merge.rc:5374
 #, c-format
 msgid "< Empty >"
 msgstr "< Leer >"
@@ -243,7 +243,7 @@ msgid "Auto-Fit All Columns"
 msgstr "Alle Spalten automatisch anpassen"
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN
-#: Merge.rc:153 Merge.rc:5646
+#: Merge.rc:153 Merge.rc:5645
 msgid "&Filter by This Column"
 msgstr "Nach dieser Spalte &filtern"
 
@@ -309,7 +309,7 @@ msgid "&Previous Page"
 msgstr "&Vorherige Seite"
 
 #. IDS_PREVIEWBAR_NEXTPAGE
-#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5679
+#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5678
 #, c-format
 msgid "&Next Page"
 msgstr "&Nächste Seite"
@@ -577,7 +577,7 @@ msgstr "&Binär"
 #. IDS_IMAGE_MENU
 #: Merge.rc:329 Merge.rc:338 Merge.rc:432 Merge.rc:441 Merge.rc:609
 #: Merge.rc:618 Merge.rc:670 Merge.rc:960 Merge.rc:1187 Merge.rc:1200
-#: Merge.rc:5477
+#: Merge.rc:5476
 #, c-format
 msgid "&Image"
 msgstr "Bil&d"
@@ -715,7 +715,7 @@ msgid "&Huge"
 msgstr "&Riesig"
 
 #. IDS_VIEW_MENU_BAR
-#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5714
+#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5713
 msgid "Men&u Bar"
 msgstr "Men&üleiste"
 
@@ -1478,7 +1478,7 @@ msgid "Lo&cation Pane"
 msgstr "&Positionsleiste"
 
 #. IDS_OUTPUTBAR_CAPTION
-#: Merge.rc:782 Merge.rc:5252
+#: Merge.rc:782 Merge.rc:5251
 msgid "Output Pane"
 msgstr "Ausgabeleiste"
 
@@ -1774,55 +1774,55 @@ msgid "Co&mpare As"
 msgstr "Vergleichen al&s"
 
 #. IDS_COPY_LEFT_TO_MIDDLE2
-#: Merge.rc:968 Merge.rc:980 Merge.rc:4852
+#: Merge.rc:968 Merge.rc:980 Merge.rc:4851
 #, c-format
 msgid "Left to Middle (%1 of %2)"
 msgstr "Links nach Mitte (%1 von %2)"
 
 #. IDS_COPY_LEFT_TO_RIGHT2
-#: Merge.rc:969 Merge.rc:981 Merge.rc:4851
+#: Merge.rc:969 Merge.rc:981 Merge.rc:4850
 #, c-format
 msgid "Left to Right (%1 of %2)"
 msgstr "Links nach rechts (%1 von %2)"
 
 #. IDS_MOVE_LEFT_TO2
-#: Merge.rc:970 Merge.rc:982 Merge.rc:1045 Merge.rc:4863 Merge.rc:4892
+#: Merge.rc:970 Merge.rc:982 Merge.rc:1045 Merge.rc:4862 Merge.rc:4891
 #, c-format
 msgid "Left to... (%1 of %2)"
 msgstr "Links nach... (%1 von %2)"
 
 #. IDS_COPY_MIDDLE_TO_LEFT2
-#: Merge.rc:971 Merge.rc:983 Merge.rc:4849
+#: Merge.rc:971 Merge.rc:983 Merge.rc:4848
 #, c-format
 msgid "Middle to Left (%1 of %2)"
 msgstr "Mitte nach links (%1 von %2)"
 
 #. IDS_COPY_MIDDLE_TO_RIGHT2
-#: Merge.rc:972 Merge.rc:984 Merge.rc:4850
+#: Merge.rc:972 Merge.rc:984 Merge.rc:4849
 #, c-format
 msgid "Middle to Right (%1 of %2)"
 msgstr "Mitte nach rechts (%1 von %2)"
 
 #. IDS_MOVE_MIDDLE_TO2
-#: Merge.rc:973 Merge.rc:985 Merge.rc:1046 Merge.rc:4864 Merge.rc:4893
+#: Merge.rc:973 Merge.rc:985 Merge.rc:1046 Merge.rc:4863 Merge.rc:4892
 #, c-format
 msgid "Middle to... (%1 of %2)"
 msgstr "Mitte nach... (%1 von %2)"
 
 #. IDS_COPY_RIGHT_TO_MIDDLE2
-#: Merge.rc:974 Merge.rc:986 Merge.rc:4848
+#: Merge.rc:974 Merge.rc:986 Merge.rc:4847
 #, c-format
 msgid "Right to Middle (%1 of %2)"
 msgstr "Rechts nach Mitte (%1 von %2)"
 
 #. IDS_COPY_RIGHT_TO_LEFT2
-#: Merge.rc:975 Merge.rc:987 Merge.rc:4847
+#: Merge.rc:975 Merge.rc:987 Merge.rc:4846
 #, c-format
 msgid "Right to Left (%1 of %2)"
 msgstr "Rechts nach links (%1 von %2)"
 
 #. IDS_MOVE_RIGHT_TO2
-#: Merge.rc:976 Merge.rc:988 Merge.rc:1047 Merge.rc:4865 Merge.rc:4894
+#: Merge.rc:976 Merge.rc:988 Merge.rc:1047 Merge.rc:4864 Merge.rc:4893
 #, c-format
 msgid "Right to... (%1 of %2)"
 msgstr "Rechts nach... (%1 von %2)"
@@ -1888,31 +1888,31 @@ msgid "Cop&y Paths"
 msgstr "&Pfade kopieren"
 
 #. IDS_DEL_LEFT_FMT2
-#: Merge.rc:1026 Merge.rc:1035 Merge.rc:4880
+#: Merge.rc:1026 Merge.rc:1035 Merge.rc:4879
 #, c-format
 msgid "Left (%1 of %2)"
 msgstr "Links (%1 von %2)"
 
 #. IDS_DEL_MIDDLE_FMT2
-#: Merge.rc:1027 Merge.rc:1036 Merge.rc:4881
+#: Merge.rc:1027 Merge.rc:1036 Merge.rc:4880
 #, c-format
 msgid "Middle (%1 of %2)"
 msgstr "Mitte (%1 von %2)"
 
 #. IDS_DEL_RIGHT_FMT2
-#: Merge.rc:1028 Merge.rc:1037 Merge.rc:4882
+#: Merge.rc:1028 Merge.rc:1037 Merge.rc:4881
 #, c-format
 msgid "Right (%1 of %2)"
 msgstr "Rechts (%1 von %2)"
 
 #. IDS_DEL_BOTH_FMT2
-#: Merge.rc:1029 Merge.rc:1038 Merge.rc:4883
+#: Merge.rc:1029 Merge.rc:1038 Merge.rc:4882
 #, c-format
 msgid "Both (%1 of %2)"
 msgstr "Beide (%1 von %2)"
 
 #. IDS_DEL_ALL_FMT2
-#: Merge.rc:1030 Merge.rc:1039 Merge.rc:4888
+#: Merge.rc:1030 Merge.rc:1039 Merge.rc:4887
 #, c-format
 msgid "All (%1 of %2)"
 msgstr "Alle (%1 von %2)"
@@ -1941,19 +1941,19 @@ msgid "&Zip"
 msgstr "P&acken"
 
 #. IDS_COPY_BOTH_TO2
-#: Merge.rc:1048 Merge.rc:4866
+#: Merge.rc:1048 Merge.rc:4865
 #, c-format
 msgid "Both to... (%1 of %2)"
 msgstr "Beide nach... (%1 von %2)"
 
 #. IDS_COPY_ALL_TO2
-#: Merge.rc:1049 Merge.rc:4867
+#: Merge.rc:1049 Merge.rc:4866
 #, c-format
 msgid "All to... (%1 of %2)"
 msgstr "Alle nach... (%1 von %2)"
 
 #. IDS_COPY_DIFFERENCES_TO2
-#: Merge.rc:1050 Merge.rc:4868
+#: Merge.rc:1050 Merge.rc:4867
 #, c-format
 msgid "Differences to... (%1 of %2)"
 msgstr "Unterschiede nach... (%1 von %2)"
@@ -2026,13 +2026,13 @@ msgstr "Entpackereinstellungen"
 
 #. IDS_USERCHOICE_NONE
 #: Merge.rc:1088 Merge.rc:1094 Merge.rc:1836 Merge.rc:1840 Merge.rc:2031
-#: Merge.rc:2035 Merge.rc:5377
+#: Merge.rc:2035 Merge.rc:5376
 #, c-format
 msgid "<None>"
 msgstr "<Keine>"
 
 #. IDS_USERCHOICE_AUTOMATIC
-#: Merge.rc:1089 Merge.rc:1095 Merge.rc:5378
+#: Merge.rc:1089 Merge.rc:1095 Merge.rc:5377
 #, c-format
 msgid "<Automatic>"
 msgstr "<Automatisch>"
@@ -2985,13 +2985,13 @@ msgid "Text files only"
 msgstr "Nur Textdateien"
 
 #. IDS_EOL_NONE
-#: Merge.rc:1667 Merge.rc:1918 Merge.rc:5304
+#: Merge.rc:1667 Merge.rc:1918 Merge.rc:5303
 #, c-format
 msgid "None"
 msgstr "Keines"
 
 #. IDS_EOL_MIXED
-#: Merge.rc:1668 Merge.rc:5299
+#: Merge.rc:1668 Merge.rc:5298
 #, c-format
 msgid "Mixed"
 msgstr "Gemixt"
@@ -3265,14 +3265,14 @@ msgstr "Zeilen&status"
 
 #. IDS_DIFFERENT
 #: Merge.rc:1904 Merge.rc:1988 Merge.rc:2866 Merge.rc:3036 Merge.rc:3077
-#: Merge.rc:5058
+#: Merge.rc:5057
 #, c-format
 msgid "Different"
 msgstr "Unterschiedlich"
 
 #. IDS_IDENTICAL
 #: Merge.rc:1905 Merge.rc:1989 Merge.rc:2865 Merge.rc:3055 Merge.rc:3116
-#: Merge.rc:5048
+#: Merge.rc:5047
 #, c-format
 msgid "Identical"
 msgstr "Identisch"
@@ -3293,7 +3293,7 @@ msgid "Missing"
 msgstr "Fehlt"
 
 #. IDS_MOVED
-#: Merge.rc:1910 Merge.rc:5076
+#: Merge.rc:1910 Merge.rc:5075
 msgid "Moved"
 msgstr "Verschoben"
 
@@ -4125,7 +4125,7 @@ msgid "&Use custom system colors"
 msgstr "&Benutzerdefinierte Systemfarben verwenden"
 
 #. IDS_PRPCAT_SYSTEM
-#: Merge.rc:2565 Merge.rc:4559 Merge.rc:4560 Merge.rc:5007
+#: Merge.rc:2565 Merge.rc:4559 Merge.rc:4560 Merge.rc:5006
 #, c-format
 msgid "System"
 msgstr "System"
@@ -4578,7 +4578,7 @@ msgid "Items compared:"
 msgstr "Objekte verglichen:"
 
 #. IDS_PREVIEWBAR_CLOSE
-#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5685
+#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5684
 #, c-format
 msgid "&Close"
 msgstr "&Schließen"
@@ -5271,7 +5271,7 @@ msgid "A&ppend timestamp"
 msgstr "&Zeitstempel anhängen"
 
 #. IDS_CONFIRM_COPY_CAPTION
-#: Merge.rc:3214 Merge.rc:4915
+#: Merge.rc:3214 Merge.rc:4914
 #, c-format
 msgid "Confirm Copy"
 msgstr "Kopieren bestätigen"
@@ -5532,7 +5532,7 @@ msgid "&Character Set..."
 msgstr "&Zeichensatz..."
 
 #. IDS_PRPCAT_IMAGE
-#: Merge.rc:3351 Merge.rc:4574 Merge.rc:5015
+#: Merge.rc:3351 Merge.rc:4574 Merge.rc:5014
 msgid "Image"
 msgstr "Bild"
 
@@ -5968,7 +5968,7 @@ msgid "Project"
 msgstr "Projekt"
 
 #. IDS_COLHDR_NSDIFFS
-#: Merge.rc:4566 Merge.rc:4990
+#: Merge.rc:4566 Merge.rc:4989
 #, c-format
 msgid "Differences"
 msgstr "Unterschiede"
@@ -6128,13 +6128,13 @@ msgid "File Type"
 msgstr "Dateityp"
 
 #. IDS_COLHDR_EXTENSION
-#: Merge.rc:4653 Merge.rc:4947
+#: Merge.rc:4653 Merge.rc:4946
 #, c-format
 msgid "Extension"
 msgstr "Erweiterung"
 
 #. IDS_PRPCAT_MESSAGE
-#: Merge.rc:4659 Merge.rc:5019
+#: Merge.rc:4659 Merge.rc:5018
 msgid "Message"
 msgstr "Meldung"
 
@@ -6174,7 +6174,7 @@ msgid "Hidden Items"
 msgstr "Ausgeblendete Objekte"
 
 #. IDS_PLUGINSLIST_NAME
-#: Merge.rc:4680 Merge.rc:5311
+#: Merge.rc:4680 Merge.rc:5310
 #, c-format
 msgid "Name"
 msgstr "Name"
@@ -6198,7 +6198,7 @@ msgid "[F] "
 msgstr "[F] "
 
 #. IDS_PLUGINSLIST_DESC
-#: Merge.rc:4684 Merge.rc:5313
+#: Merge.rc:4684 Merge.rc:5312
 #, c-format
 msgid "Description"
 msgstr "Beschreibung"
@@ -6381,171 +6381,165 @@ msgstr "Zeile: %s  Spalte: %d/%d  Zeichen: %d/%d"
 msgid "  Sel: %d | %d"
 msgstr "  Auswahl: %d | %d"
 
-#. IDS_MERGEMODE_MERGING
-#: Merge.rc:4734
-#, c-format
-msgid "Merge"
-msgstr "Merge"
-
 #. IDS_DIFF_NUMBER_STATUS_FMT
-#: Merge.rc:4735
+#: Merge.rc:4734
 #, c-format
 msgid "Difference %1 of %2"
 msgstr "Unterschied %1 von %2"
 
 #. IDS_NO_DIFF_SEL_FMT
-#: Merge.rc:4736
+#: Merge.rc:4735
 #, c-format
 msgid "%1 Differences Found"
 msgstr "%1 Unterschiede gefunden"
 
 #. IDS_1_DIFF_FOUND
-#: Merge.rc:4737
+#: Merge.rc:4736
 #, c-format
 msgid "1 Difference Found"
 msgstr "1 Unterschied gefunden"
 
 #. IDS_NO_ERR_SEL_FMT
-#: Merge.rc:4738
+#: Merge.rc:4737
 #, c-format
 msgid "%1 Errors Found"
 msgstr "%1 Fehler gefunden"
 
 #. IDS_1_ERR_FOUND
-#: Merge.rc:4739
+#: Merge.rc:4738
 msgid "1 Error Found"
 msgstr "1 Fehler gefunden"
 
 #. IDS_STATUSBAR_READONLY, Abbreviation from "Read Only"
-#: Merge.rc:4740
+#: Merge.rc:4739
 #, c-format
 msgid "RO"
 msgstr "RO"
 
 #. IDS_DIRVIEW_STATUS_FMT_FOCUS
-#: Merge.rc:4746
+#: Merge.rc:4745
 #, c-format
 msgid "Item %1 of %2"
 msgstr "Objekt %1 von %2"
 
 #. IDS_DIRVIEW_STATUS_FMT_NOFOCUS
-#: Merge.rc:4747
+#: Merge.rc:4746
 #, c-format
 msgid "Items: %1"
 msgstr "Objekte: %1"
 
 #. IDS_DIRVIEW_STATUS_COMPARING
-#: Merge.rc:4748
+#: Merge.rc:4747
 #, c-format
 msgid "Comparing items..."
 msgstr "Objekte vergleichen..."
 
 #. IDS_ITEMS_PER_SEC
-#: Merge.rc:4749
+#: Merge.rc:4748
 #, c-format
 msgid "%.1f[items/sec]"
 msgstr "%.1f[Objekte/s]"
 
 #. IDS_ERROR_INCOMPARABLE
-#: Merge.rc:4755
+#: Merge.rc:4754
 msgid "Select two existing folders/files to compare."
 msgstr "Wählen Sie zwei Dateien oder Ordner zum Vergleichen aus."
 
 #. IDS_DIRSEL_TAG
-#: Merge.rc:4756
+#: Merge.rc:4755
 #, c-format
 msgid "Folder Selection"
 msgstr "Ordnerauswahl"
 
 #. IDS_OPEN_FILESDIRS
-#: Merge.rc:4757
+#: Merge.rc:4756
 #, c-format
 msgid "Select two (or three) folders/files to compare."
 msgstr "Wählen Sie zwei (oder drei) Dateien oder Ordner zum Vergleichen aus."
 
 #. IDS_OPEN_LEFTINVALID
-#: Merge.rc:4758
+#: Merge.rc:4757
 #, c-format
 msgid "Left (1st) path is invalid!"
 msgstr "Linker (1.) Pfad ist ungültig!"
 
 #. IDS_OPEN_MIDDLEINVALID
-#: Merge.rc:4759
+#: Merge.rc:4758
 #, c-format
 msgid "Middle (2nd) path is invalid!"
 msgstr "Mittlerer (2.) Pfad ist ungültig!"
 
 #. IDS_OPEN_RIGHTINVALID2
-#: Merge.rc:4760
+#: Merge.rc:4759
 #, c-format
 msgid "Right (2nd) path is invalid!"
 msgstr "Rechter (2.) Pfad ist ungültig!"
 
 #. IDS_OPEN_RIGHTINVALID3
-#: Merge.rc:4761
+#: Merge.rc:4760
 #, c-format
 msgid "Right (3rd) path is invalid!"
 msgstr "Rechter (3.) Pfad ist ungültig!"
 
 #. IDS_OPEN_BOTHINVALID
-#: Merge.rc:4762
+#: Merge.rc:4761
 #, c-format
 msgid "Both paths are invalid!"
 msgstr "Beide Pfade sind ungültig!"
 
-#: Merge.rc:4764
+#: Merge.rc:4763
 #, c-format
 msgid "Left (1st) and Middle (2nd) paths are invalid!"
 msgstr "Linker (1.) und mittlerer (2.) Pfad sind ungültig!"
 
 #. IDS_OPEN_LEFTRIGHTINVALID
-#: Merge.rc:4765
+#: Merge.rc:4764
 #, c-format
 msgid "Left (1st) and Right (3rd) paths are invalid!"
 msgstr "Linker (1.) und rechter (3.) Pfad sind ungültig!"
 
-#: Merge.rc:4767
+#: Merge.rc:4766
 #, c-format
 msgid "Middle (2nd) and Right (3rd) paths are invalid!"
 msgstr "Mittlerer (2.) und rechter (3.) Pfad sind ungültig!"
 
 #. IDS_OPEN_ALLINVALID
-#: Merge.rc:4768
+#: Merge.rc:4767
 #, c-format
 msgid "All paths are invalid!"
 msgstr "Alle Pfade sind ungültig!"
 
 #. IDS_OPEN_UNPACKERDISABLED
-#: Merge.rc:4769
+#: Merge.rc:4768
 msgid "Only enabled for file comparisons"
 msgstr "Nur für Dateivergleiche aktiviert"
 
 #. IDS_OPEN_MISMATCH
-#: Merge.rc:4770
+#: Merge.rc:4769
 #, c-format
 msgid "Cannot compare file and folder!"
 msgstr "Datei und Ordner können nicht verglichen werden!"
 
 #. IDS_ERROR_FILE_NOT_FOUND
-#: Merge.rc:4776
+#: Merge.rc:4775
 #, c-format
 msgid "File not found: %1"
 msgstr "Datei nicht gefunden: %1"
 
 #. IDS_ERROR_FOLDER_NOT_FOUND
-#: Merge.rc:4777
+#: Merge.rc:4776
 #, c-format
 msgid "Folder not found: %1"
 msgstr "Ordner nicht gefunden: %1"
 
 #. IDS_ERROR_FILE_NOT_UNPACKED
-#: Merge.rc:4778
+#: Merge.rc:4777
 #, c-format
 msgid "File not unpacked: %1"
 msgstr "Datei nicht entpackt: %1"
 
 #. IDS_ERROR_FILEOPEN
-#: Merge.rc:4779
+#: Merge.rc:4778
 #, c-format
 msgid ""
 "Cannot open file\n"
@@ -6559,13 +6553,13 @@ msgstr ""
 "%2"
 
 #. IDS_ERROR_CONF_RESOLVE
-#: Merge.rc:4780
+#: Merge.rc:4779
 #, c-format
 msgid "Failed to parse conflict file."
 msgstr "Fehler beim Analysieren der Konfliktdatei."
 
 #. IDS_NOT_CONFLICT_FILE
-#: Merge.rc:4781
+#: Merge.rc:4780
 #, c-format
 msgid ""
 "The file\n"
@@ -6577,7 +6571,7 @@ msgstr ""
 "ist keine Konfliktdatei."
 
 #. IDS_COMPARE_LARGE_FILES
-#: Merge.rc:4782
+#: Merge.rc:4781
 msgid ""
 "Comparing large files requires significant memory.\n"
 "Show only comparison results (not file contents)?"
@@ -6586,30 +6580,30 @@ msgstr ""
 "Nur Vergleichsergebnisse anzeigen (nicht den Dateiinhalt)?"
 
 #. IDS_SAVE_AS_TITLE
-#: Merge.rc:4788
+#: Merge.rc:4787
 #, c-format
 msgid "Save As"
 msgstr "Speichern unter"
 
 #. IDS_SAVE_FMT
-#: Merge.rc:4789
+#: Merge.rc:4788
 #, c-format
 msgid "Save changes to %1?"
 msgstr "Änderungen in %1 speichern?"
 
 #. IDS_SAVEREADONLY_FMT
-#: Merge.rc:4790
+#: Merge.rc:4789
 #, c-format
 msgid "%1 is read-only. Override? Or 'No' to save as new filename?"
 msgstr "%1 ist als schreibgeschützt markiert. Möchten Sie die schreibgeschützte Datei überschreiben? (Nicht unter neuem Dateinamen speichern.)"
 
 #. IDS_ERROR_BACKUP
-#: Merge.rc:4791
+#: Merge.rc:4790
 #, c-format
 msgid "Error backing up file"
 msgstr "Fehler beim Erstellen einer Sicherheitskopie"
 
-#: Merge.rc:4793
+#: Merge.rc:4792
 #, c-format
 msgid ""
 "Unable to backup original file:\n"
@@ -6623,7 +6617,7 @@ msgstr ""
 "Dennoch fortfahren?"
 
 #. IDS_FILESAVE_FAILED
-#: Merge.rc:4794
+#: Merge.rc:4793
 #, c-format
 msgid ""
 "Saving file failed.\n"
@@ -6639,7 +6633,7 @@ msgstr ""
 "\t- einen anderen Dateinamen verwenden? ('OK' betätigen)\n"
 "\t- die aktuelle Operation abbrechen? ('Abbrechen' betätigen)"
 
-#: Merge.rc:4796
+#: Merge.rc:4795
 #, c-format
 msgid ""
 "Plugin '%2' cannot pack changes to left file into '%1'.\n"
@@ -6652,7 +6646,7 @@ msgstr ""
 "\n"
 "Möchten Sie die entpackte Version in einer anderen Datei speichern?"
 
-#: Merge.rc:4798
+#: Merge.rc:4797
 #, c-format
 msgid ""
 "Plugin '%2' cannot pack changes to middle file into '%1'.\n"
@@ -6665,7 +6659,7 @@ msgstr ""
 "\n"
 "Möchten Sie die entpackte Version in einer anderen Datei speichern?"
 
-#: Merge.rc:4800
+#: Merge.rc:4799
 #, c-format
 msgid ""
 "Plugin '%2' cannot pack changes to right file into '%1'.\n"
@@ -6679,7 +6673,7 @@ msgstr ""
 "Möchten Sie die entpackte Version in einer anderen Datei speichern?"
 
 #. IDS_FILECHANGED_ONDISK
-#: Merge.rc:4801
+#: Merge.rc:4800
 #, c-format
 msgid ""
 "Another application updated\n"
@@ -6695,7 +6689,7 @@ msgstr ""
 "Geänderte Datei überschreiben?"
 
 #. IDS_SAVEREADONLY_MULTI
-#: Merge.rc:4802
+#: Merge.rc:4801
 #, c-format
 msgid ""
 "%1\n"
@@ -6705,7 +6699,7 @@ msgstr ""
 "ist als schreibgeschützt markiert. Möchten Sie das schreibgeschützte Objekt überschreiben?"
 
 #. IDS_FILECHANGED_RESCAN
-#: Merge.rc:4803
+#: Merge.rc:4802
 #, c-format
 msgid ""
 "Another application updated\n"
@@ -6721,25 +6715,25 @@ msgstr ""
 "Möchten Sie die Datei neu laden?"
 
 #. IDS_SAVE_LEFT_AS
-#: Merge.rc:4804
+#: Merge.rc:4803
 #, c-format
 msgid "Save Left File As"
 msgstr "Linke Datei speichern unter"
 
 #. IDS_SAVE_MIDDLE_AS
-#: Merge.rc:4805
+#: Merge.rc:4804
 #, c-format
 msgid "Save Middle File As"
 msgstr "Mittlere Datei speichern unter"
 
 #. IDS_SAVE_RIGHT_AS
-#: Merge.rc:4806
+#: Merge.rc:4805
 #, c-format
 msgid "Save Right File As"
 msgstr "Rechte Datei speichern unter"
 
 #. IDS_FILE_DISAPPEARED
-#: Merge.rc:4811
+#: Merge.rc:4810
 #, c-format
 msgid ""
 "File\n"
@@ -6751,7 +6745,7 @@ msgstr ""
 "ist verloren gegangen. Bitte speichern Sie eine Kopie der Datei, um fortzufahren."
 
 #. IDS_VIEWS_OUTOFSYNC
-#: Merge.rc:4817
+#: Merge.rc:4816
 #, c-format
 msgid ""
 "Cannot merge unsynched documents.\n"
@@ -6763,124 +6757,124 @@ msgstr ""
 "Aktualisieren Sie die Dokumente, bevor Sie fortfahren."
 
 #. IDS_BREAK_ON_WHITESPACE
-#: Merge.rc:4822
+#: Merge.rc:4821
 msgid "Break at whitespace"
 msgstr "An Leerzeichen unterbrechen"
 
 #. IDS_BREAK_ON_PUNCTUATION
-#: Merge.rc:4823
+#: Merge.rc:4822
 msgid "Break at whitespace or punctuation"
 msgstr "An Leerzeichen oder Interpunktion unterbrechen"
 
 #. IDS_L2M
-#: Merge.rc:4829
+#: Merge.rc:4828
 msgid "Copy to &Middle\tAlt+Right"
 msgstr "Zur &Mitte kopieren\tAlt+Rechts"
 
 #. IDS_R2M
-#: Merge.rc:4830
+#: Merge.rc:4829
 msgid "Copy to &Middle\tAlt+Left"
 msgstr "Zur &Mitte kopieren\tAlt+Links"
 
 #. IDS_COPY_FROM_MIDDLE_R
-#: Merge.rc:4831
+#: Merge.rc:4830
 msgid "Copy from Middle\tAlt+Shift+Right"
 msgstr "Von der Mitte kopieren\tAlt+Umschalt+Rechts"
 
 #. IDS_COPY_FROM_MIDDLE_L
-#: Merge.rc:4832
+#: Merge.rc:4831
 msgid "Copy from Middle\tAlt+Shift+Left"
 msgstr "Von der Mitte kopieren\tAlt+Umschalt+Links"
 
 #. IDS_L2MNEXT
-#: Merge.rc:4833
+#: Merge.rc:4832
 msgid "Copy to Middle and Advance\tCtrl+Alt+Right"
 msgstr "Zur Mitte kopieren und fortschreiten\tStrg+Alt+Rechts"
 
 #. IDS_R2MNEXT
-#: Merge.rc:4834
+#: Merge.rc:4833
 msgid "Copy to Middle and Advance\tCtrl+Alt+Left"
 msgstr "Zur Mitte kopieren und fortschreiten\tStrg+Alt+Links"
 
 #. IDS_ALL_MIDDLE
-#: Merge.rc:4835
+#: Merge.rc:4834
 msgid "Copy All to Middle"
 msgstr "Alles in die Mitte kopieren"
 
 #. IDS_COPY_RIGHT_TO_LEFT
-#: Merge.rc:4841
+#: Merge.rc:4840
 #, c-format
 msgid "Right to Left (%1)"
 msgstr "Rechts nach links (%1)"
 
 #. IDS_COPY_RIGHT_TO_MIDDLE
-#: Merge.rc:4842
+#: Merge.rc:4841
 #, c-format
 msgid "Right to Middle (%1)"
 msgstr "Rechts nach Mitte (%1)"
 
 #. IDS_COPY_MIDDLE_TO_LEFT
-#: Merge.rc:4843
+#: Merge.rc:4842
 #, c-format
 msgid "Middle to Left (%1)"
 msgstr "Mitte nach links (%1)"
 
 #. IDS_COPY_MIDDLE_TO_RIGHT
-#: Merge.rc:4844
+#: Merge.rc:4843
 #, c-format
 msgid "Middle to Right (%1)"
 msgstr "Mitte nach rechts (%1)"
 
 #. IDS_COPY_LEFT_TO_RIGHT
-#: Merge.rc:4845
+#: Merge.rc:4844
 #, c-format
 msgid "Left to Right (%1)"
 msgstr "Links nach rechts (%1)"
 
 #. IDS_COPY_LEFT_TO_MIDDLE
-#: Merge.rc:4846
+#: Merge.rc:4845
 #, c-format
 msgid "Left to Middle (%1)"
 msgstr "Links nach Mitte (%1)"
 
 #. IDS_MOVE_LEFT_TO
-#: Merge.rc:4857 Merge.rc:4889
+#: Merge.rc:4856 Merge.rc:4888
 #, c-format
 msgid "Left to... (%1)"
 msgstr "Links nach... (%1)"
 
 #. IDS_MOVE_MIDDLE_TO
-#: Merge.rc:4858 Merge.rc:4890
+#: Merge.rc:4857 Merge.rc:4889
 #, c-format
 msgid "Middle to... (%1)"
 msgstr "Mitte nach... (%1)"
 
 #. IDS_MOVE_RIGHT_TO
-#: Merge.rc:4859 Merge.rc:4891
+#: Merge.rc:4858 Merge.rc:4890
 #, c-format
 msgid "Right to... (%1)"
 msgstr "Rechts nach... (%1)"
 
 #. IDS_COPY_BOTH_TO
-#: Merge.rc:4860
+#: Merge.rc:4859
 #, c-format
 msgid "Both to... (%1)"
 msgstr "Beide nach... (%1)"
 
 #. IDS_COPY_ALL_TO
-#: Merge.rc:4861
+#: Merge.rc:4860
 #, c-format
 msgid "All to... (%1)"
 msgstr "Alle nach... (%1)"
 
 #. IDS_COPY_DIFFERENCES_TO
-#: Merge.rc:4862
+#: Merge.rc:4861
 #, c-format
 msgid "Differences to... (%1)"
 msgstr "Unterschiede nach... (%1)"
 
 #. IDS_ONLYDIFFITEMS_CONFIRM
-#: Merge.rc:4869
+#: Merge.rc:4868
 msgid ""
 "Some selected items are identical or skipped.\n"
 "Process only items with differences?"
@@ -6889,67 +6883,67 @@ msgstr ""
 "Nur Elemente mit Unterschieden verarbeiten?"
 
 #. IDS_DEL_LEFT_FMT
-#: Merge.rc:4875
+#: Merge.rc:4874
 #, c-format
 msgid "Left (%1)"
 msgstr "Links (%1)"
 
 #. IDS_DEL_MIDDLE_FMT
-#: Merge.rc:4876
+#: Merge.rc:4875
 #, c-format
 msgid "Middle (%1)"
 msgstr "Mitte (%1)"
 
 #. IDS_DEL_RIGHT_FMT
-#: Merge.rc:4877
+#: Merge.rc:4876
 #, c-format
 msgid "Right (%1)"
 msgstr "Rechts (%1)"
 
 #. IDS_DEL_BOTH_FMT
-#: Merge.rc:4878
+#: Merge.rc:4877
 #, c-format
 msgid "Both (%1)"
 msgstr "Beide (%1)"
 
 #. IDS_DEL_ALL_FMT
-#: Merge.rc:4879
+#: Merge.rc:4878
 #, c-format
 msgid "All (%1)"
 msgstr "Alle (%1)"
 
 #. IDS_SELECT_DEST_LEFT
-#: Merge.rc:4895
+#: Merge.rc:4894
 #, c-format
 msgid "Left Side - Select Destination Folder:"
 msgstr "Linke Seite - Zielordner auswählen:"
 
 #. IDS_SELECT_DEST_MIDDLE
-#: Merge.rc:4896
+#: Merge.rc:4895
 #, c-format
 msgid "Middle Side - Select Destination Folder:"
 msgstr "Mitte - Zielordner auswählen:"
 
 #. IDS_SELECT_DEST_RIGHT
-#: Merge.rc:4897
+#: Merge.rc:4896
 #, c-format
 msgid "Right Side - Select Destination Folder:"
 msgstr "Rechte Seite - Zielordner auswählen:"
 
 #. IDS_FILES_AFFECTED_FMT
-#: Merge.rc:4898
+#: Merge.rc:4897
 #, c-format
 msgid "(%1 Files Affected)"
 msgstr "(%1 Dateien betroffen)"
 
 #. IDS_FILES_AFFECTED_FMT2
-#: Merge.rc:4899
+#: Merge.rc:4898
 #, c-format
 msgid "(%1 of %2 Files Affected)"
 msgstr "(%1 von %2 Dateien betroffen)"
 
 #. IDS_CONFIRM_DELETE_SINGLE
-#: Merge.rc:4905
+#: Merge.rc:4904
 #, c-format
 msgid ""
 "Are you sure you want to delete\n"
@@ -6962,18 +6956,18 @@ msgstr ""
 "löschen?"
 
 #. IDS_CONFIRM_SINGLE_COPY
-#: Merge.rc:4906
+#: Merge.rc:4905
 msgid "Are you sure you want to copy?"
 msgstr "Wollen Sie wirklich kopieren?"
 
 #. IDS_CONFIRM_MULTIPLE_COPY
-#: Merge.rc:4907
+#: Merge.rc:4906
 #, c-format
 msgid "Are you sure you want to copy %d items?"
 msgstr "Wollen Sie wirklich %d Objekte kopieren?"
 
 #. IDS_DIRCMP_NOTSYNC
-#: Merge.rc:4908
+#: Merge.rc:4907
 #, c-format
 msgid ""
 "Operation aborted!\n"
@@ -6993,28 +6987,28 @@ msgstr ""
 "Bitte aktualisieren Sie den Vergleich."
 
 #. IDS_CONFIRM_SINGLE_MOVE
-#: Merge.rc:4913
+#: Merge.rc:4912
 msgid "Are you sure you want to move?"
 msgstr "Wollen Sie wirklich verschieben?"
 
 #. IDS_CONFIRM_MULTIPLE_MOVE
-#: Merge.rc:4914
+#: Merge.rc:4913
 #, c-format
 msgid "Are you sure you want to move %d items?"
 msgstr "Wollen Sie wirklich %d Objekte verschieben?"
 
 #. IDS_CONFIRM_MOVE_CAPTION
-#: Merge.rc:4916
+#: Merge.rc:4915
 #, c-format
 msgid "Confirm Move"
 msgstr "Verschieben bestätigen"
 
-#: Merge.rc:4918
+#: Merge.rc:4917
 #, c-format
 msgid "Close the folder comparison window?"
 msgstr "Sie schließen gerade das Fenster, in dem Ordner verglichen werden. Möchten Sie das Fenster wirklich schließen?"
 
-#: Merge.rc:4920
+#: Merge.rc:4919
 msgid "Close the folder comparison window, which took a long time?"
 msgstr ""
 "Sie sind im Begriff ein Vergleichsfenster zu schließen, das mit einem erheblichen Zeitaufwand erstellt wurde.\n"
@@ -7022,23 +7016,23 @@ msgstr ""
 "Möchten Sie wirklich fortfahren?"
 
 #. IDS_ERROR_INVALID_DIR_FILE_NAME
-#: Merge.rc:4921
+#: Merge.rc:4920
 msgid "The file or folder name is invalid."
 msgstr "Der Datei- oder Ordnername ist ungültig."
 
 #. IDS_ERROR_EXECUTE_FILE
-#: Merge.rc:4927
+#: Merge.rc:4926
 #, c-format
 msgid "Failed to execute external editor: %1"
 msgstr "Konnte externen Editor nicht ausführen: %1"
 
 #. IDS_UNKNOWN_ARCHIVE_FORMAT
-#: Merge.rc:4933
+#: Merge.rc:4932
 #, c-format
 msgid "Unknown archive format"
 msgstr "Unbekanntes Archivformat"
 
-#: Merge.rc:4935
+#: Merge.rc:4934
 msgid ""
 "Failed to extract archive.\n"
 "Compare as text file?"
@@ -7047,560 +7041,560 @@ msgstr ""
 "Möchten Sie die Archivdateien als Textdateien vergleichen?"
 
 #. IDS_COLHDR_FILENAME
-#: Merge.rc:4941
+#: Merge.rc:4940
 #, c-format
 msgid "Filename"
 msgstr "Dateiname"
 
 #. IDS_COLHDR_DIR
-#: Merge.rc:4942
+#: Merge.rc:4941
 msgctxt "DirView|ColumnHeader"
 msgid "Folder"
 msgstr "Ordner"
 
 #. IDS_COLHDR_RESULT
-#: Merge.rc:4943
+#: Merge.rc:4942
 #, c-format
 msgid "Comparison Result"
 msgstr "Vergleichsergebnis"
 
 #. IDS_COLHDR_LTIMEM
-#: Merge.rc:4944
+#: Merge.rc:4943
 #, c-format
 msgid "Left Date"
 msgstr "Linkes Datum"
 
 #. IDS_COLHDR_RTIMEM
-#: Merge.rc:4945
+#: Merge.rc:4944
 #, c-format
 msgid "Right Date"
 msgstr "Rechtes Datum"
 
 #. IDS_COLHDR_MTIMEM
-#: Merge.rc:4946
+#: Merge.rc:4945
 #, c-format
 msgid "Middle Date"
 msgstr "Mittleres Datum"
 
 #. IDS_COLHDR_LSIZE
-#: Merge.rc:4948
+#: Merge.rc:4947
 #, c-format
 msgid "Left Size"
 msgstr "Linke Größe"
 
 #. IDS_COLHDR_RSIZE
-#: Merge.rc:4949
+#: Merge.rc:4948
 #, c-format
 msgid "Right Size"
 msgstr "Rechte Größe"
 
 #. IDS_COLHDR_MSIZE
-#: Merge.rc:4954
+#: Merge.rc:4953
 #, c-format
 msgid "Middle Size"
 msgstr "Mittlere Größe"
 
 #. IDS_COLHDR_RSIZE_SHORT
-#: Merge.rc:4955
+#: Merge.rc:4954
 #, c-format
 msgid "Right Size (Short)"
 msgstr "Rechte Größe (kurz)"
 
 #. IDS_COLHDR_LSIZE_SHORT
-#: Merge.rc:4956
+#: Merge.rc:4955
 #, c-format
 msgid "Left Size (Short)"
 msgstr "Linke Größe (kurz)"
 
 #. IDS_COLHDR_MSIZE_SHORT
-#: Merge.rc:4957
+#: Merge.rc:4956
 #, c-format
 msgid "Middle Size (Short)"
 msgstr "Mittlere Größe (kurz)"
 
 #. IDS_COLHDR_LTIMEC
-#: Merge.rc:4963
+#: Merge.rc:4962
 #, c-format
 msgid "Left Creation Time"
 msgstr "Linkes Erstellungsdatum"
 
 #. IDS_COLHDR_RTIMEC
-#: Merge.rc:4964
+#: Merge.rc:4963
 #, c-format
 msgid "Right Creation Time"
 msgstr "Rechtes Erstellungsdatum"
 
 #. IDS_COLHDR_MTIMEC
-#: Merge.rc:4965
+#: Merge.rc:4964
 #, c-format
 msgid "Middle Creation Time"
 msgstr "Mittleres Erstellungsdatum"
 
 #. IDS_COLHDR_NEWER
-#: Merge.rc:4966
+#: Merge.rc:4965
 #, c-format
 msgid "Newer File"
 msgstr "Neuere Datei"
 
 #. IDS_COLHDR_LVERSION
-#: Merge.rc:4967
+#: Merge.rc:4966
 #, c-format
 msgid "Left File Version"
 msgstr "Linke Dateiversion"
 
 #. IDS_COLHDR_RVERSION
-#: Merge.rc:4968
+#: Merge.rc:4967
 #, c-format
 msgid "Right File Version"
 msgstr "Rechte Dateiversion"
 
 #. IDS_COLHDR_MVERSION
-#: Merge.rc:4969
+#: Merge.rc:4968
 #, c-format
 msgid "Middle File Version"
 msgstr "Mittlere Dateiversion"
 
 #. IDS_COLHDR_RESULT_ABBR
-#: Merge.rc:4970
+#: Merge.rc:4969
 #, c-format
 msgid "Short Result"
 msgstr "Kurzes Ergebnis"
 
 #. IDS_COLHDR_LATTRIBUTES
-#: Merge.rc:4971
+#: Merge.rc:4970
 #, c-format
 msgid "Left Attributes"
 msgstr "Linke Attribute"
 
 #. IDS_COLHDR_RATTRIBUTES
-#: Merge.rc:4972
+#: Merge.rc:4971
 #, c-format
 msgid "Right Attributes"
 msgstr "Rechte Attribute"
 
 #. IDS_COLHDR_MATTRIBUTES
-#: Merge.rc:4973
+#: Merge.rc:4972
 #, c-format
 msgid "Middle Attributes"
 msgstr "Mittlere Attribute"
 
 #. IDS_COLHDR_LEOL_TYPE
-#: Merge.rc:4978
+#: Merge.rc:4977
 #, c-format
 msgid "Left EOL"
 msgstr "Linkes Zeilenende"
 
 #. IDS_COLHDR_MEOL_TYPE
-#: Merge.rc:4979
+#: Merge.rc:4978
 #, c-format
 msgid "Middle EOL"
 msgstr "Mittleres Zeilenende"
 
 #. IDS_COLHDR_REOL_TYPE
-#: Merge.rc:4980
+#: Merge.rc:4979
 #, c-format
 msgid "Right EOL"
 msgstr "Rechtes Zeilenende"
 
 #. IDS_COLHDR_LENCODING
-#: Merge.rc:4986
+#: Merge.rc:4985
 #, c-format
 msgid "Left Encoding"
 msgstr "Linke Codierung"
 
 #. IDS_COLHDR_RENCODING
-#: Merge.rc:4987
+#: Merge.rc:4986
 #, c-format
 msgid "Right Encoding"
 msgstr "Rechte Codierung"
 
 #. IDS_COLHDR_MENCODING
-#: Merge.rc:4988
+#: Merge.rc:4987
 #, c-format
 msgid "Middle Encoding"
 msgstr "Mittlere Codierung"
 
 #. IDS_COLHDR_NIDIFFS
-#: Merge.rc:4989
+#: Merge.rc:4988
 msgid "Ignored Diff"
 msgstr "Ignorierter Unterschied"
 
 #. IDS_COLHDR_BINARY
-#: Merge.rc:4991
+#: Merge.rc:4990
 msgctxt "DirView|ColumnHeader"
 msgid "Binary"
 msgstr "Binär"
 
 #. IDS_PLUGINS_TYPE_UNPACKER
-#: Merge.rc:4992 Merge.rc:5314
+#: Merge.rc:4991 Merge.rc:5313
 #, c-format
 msgid "Unpacker"
 msgstr "Entpacker"
 
 #. IDS_PLUGIN_TYPE4
-#: Merge.rc:4993 Merge.rc:5315 Merge.rc:5622
+#: Merge.rc:4992 Merge.rc:5314 Merge.rc:5621
 #, c-format
 msgid "Prediffer"
 msgstr "Prediffer"
 
 #. IDS_COLHDR_LEFT
-#: Merge.rc:4994
+#: Merge.rc:4993
 msgid "Left"
 msgstr "Links"
 
 #. IDS_COLHDR_MIDDLE
-#: Merge.rc:4995
+#: Merge.rc:4994
 msgid "Middle"
 msgstr "Mitte"
 
 #. IDS_COLHDR_RIGHT
-#: Merge.rc:4996
+#: Merge.rc:4995
 msgid "Right"
 msgstr "Rechts"
 
 #. IDS_COLHDR_DIFF
-#: Merge.rc:4997
+#: Merge.rc:4996
 msgid "Diff"
 msgstr "Unterschied"
 
 #. IDS_COLHDR_LEFT_DUPLICATE
-#: Merge.rc:4998
+#: Merge.rc:4997
 msgid "Left Duplicate Count"
 msgstr "Linke Duplikatanzahl"
 
 #. IDS_COLHDR_RIGHT_DUPLICATE
-#: Merge.rc:4999
+#: Merge.rc:4998
 msgid "Right Duplicate Count"
 msgstr "Mittlere Duplikatanzahl"
 
 #. IDS_COLHDR_MIDDLE_DUPLICATE
-#: Merge.rc:5000
+#: Merge.rc:4999
 msgid "Middle Duplicate Count"
 msgstr "Rechte Duplikatanzahl"
 
 #. IDS_COLHDR_MOVE
-#: Merge.rc:5001
+#: Merge.rc:5000
 msgid "Move"
 msgstr "Verschieben"
 
 #. IDS_PRPCAT_AUDIO
-#: Merge.rc:5008
+#: Merge.rc:5007
 msgid "Audio"
 msgstr "Audio"
 
 #. IDS_PRPCAT_CALENDAR
-#: Merge.rc:5009
+#: Merge.rc:5008
 msgid "Calendar"
 msgstr "Kalender"
 
 #. IDS_PRPCAT_COMMUNICATION
-#: Merge.rc:5010
+#: Merge.rc:5009
 msgid "Communication"
 msgstr "Kommunikation"
 
 #. IDS_PRPCAT_CONTACT
-#: Merge.rc:5011
+#: Merge.rc:5010
 msgid "Contact"
 msgstr "Kontakt"
 
 #. IDS_PRPCAT_DEVICES
-#: Merge.rc:5012
+#: Merge.rc:5011
 msgid "Devices"
 msgstr "Geräte"
 
 #. IDS_PRPCAT_DOCUMENT
-#: Merge.rc:5013
+#: Merge.rc:5012
 msgid "Document"
 msgstr "Dokument"
 
 #. IDS_PRPCAT_HOME
-#: Merge.rc:5014
+#: Merge.rc:5013
 msgid "Home"
 msgstr "Home"
 
 #. IDS_PRPCAT_JOURNAL
-#: Merge.rc:5016
+#: Merge.rc:5015
 msgid "Journal"
 msgstr "Journal"
 
 #. IDS_PRPCAT_LINK
-#: Merge.rc:5017
+#: Merge.rc:5016
 msgid "Link"
 msgstr "Link"
 
 #. IDS_PRPCAT_MEDIA
-#: Merge.rc:5018
+#: Merge.rc:5017
 msgid "Media"
 msgstr "Medium"
 
 #. IDS_PRPCAT_MUSIC
-#: Merge.rc:5020
+#: Merge.rc:5019
 msgid "Music"
 msgstr "Musik"
 
 #. IDS_PRPCAT_NOTE
-#: Merge.rc:5021
+#: Merge.rc:5020
 msgid "Note"
 msgstr "Notiz"
 
 #. IDS_PRPCAT_PHOTO
-#: Merge.rc:5022
+#: Merge.rc:5021
 msgid "Photo"
 msgstr "Foto"
 
 #. IDS_PRPCAT_RECORDEDTV
-#: Merge.rc:5023
+#: Merge.rc:5022
 msgid "RecordedTV"
 msgstr "Aufgezeichnetes TV"
 
 #. IDS_PRPCAT_SEARCH
-#: Merge.rc:5024
+#: Merge.rc:5023
 msgid "Search"
 msgstr "Suche"
 
 #. IDS_PRPCAT_SECURITY
-#: Merge.rc:5025
+#: Merge.rc:5024
 msgid "Security"
 msgstr "Sicherheit"
 
 #. IDS_PRPCAT_SOFTWARE
-#: Merge.rc:5026
+#: Merge.rc:5025
 msgid "Software"
 msgstr "Software"
 
 #. IDS_PRPCAT_TASK
-#: Merge.rc:5027
+#: Merge.rc:5026
 msgid "Task"
 msgstr "Aufgabe"
 
 #. IDS_PRPCAT_VIDEO
-#: Merge.rc:5028
+#: Merge.rc:5027
 msgid "Video"
 msgstr "Video"
 
 #. IDS_PRPCAT_HASH
-#: Merge.rc:5029
+#: Merge.rc:5028
 msgid "Hash"
 msgstr "Hash"
 
 #. IDS_CANT_COMPARE_FILES
-#: Merge.rc:5035
+#: Merge.rc:5034
 #, c-format
 msgid "Unable to compare files"
 msgstr "Dateien können nicht verglichen werden"
 
 #. IDS_ABORTED_ITEM
-#: Merge.rc:5036
+#: Merge.rc:5035
 #, c-format
 msgid "Item aborted"
 msgstr "Objekt abgebrochen"
 
 #. IDS_FILE_SKIPPED
-#: Merge.rc:5037
+#: Merge.rc:5036
 #, c-format
 msgid "File skipped"
 msgstr "Datei übersprungen"
 
 #. IDS_DIR_SKIPPED
-#: Merge.rc:5038
+#: Merge.rc:5037
 #, c-format
 msgid "Folder skipped"
 msgstr "Ordner übersprungen"
 
 #. IDS_LEFT_ONLY_IN_FMT
-#: Merge.rc:5039
+#: Merge.rc:5038
 #, c-format
 msgid "Left only: %1"
 msgstr "Nur links: %1"
 
 #. IDS_MIDDLE_ONLY_IN_FMT
-#: Merge.rc:5040
+#: Merge.rc:5039
 #, c-format
 msgid "Middle only: %1"
 msgstr "Nur Mitte: %1"
 
 #. IDS_RIGHT_ONLY_IN_FMT
-#: Merge.rc:5041
+#: Merge.rc:5040
 #, c-format
 msgid "Right only: %1"
 msgstr "Nur rechts: %1"
 
 #. IDS_DOES_NOT_EXIST_IN_FMT
-#: Merge.rc:5042
+#: Merge.rc:5041
 #, c-format
 msgid "Does not exist in %1"
 msgstr "Existiert nicht in %1"
 
 #. IDS_BIN_FILES_SAME
-#: Merge.rc:5043
+#: Merge.rc:5042
 #, c-format
 msgid "Binary files are identical"
 msgstr "Binärdateien sind identisch"
 
 #. IDS_BIN_FILES_DIFF
-#: Merge.rc:5049
+#: Merge.rc:5048
 #, c-format
 msgid "Binary files are different"
 msgstr "Binärdateien sind unterschiedlich"
 
 #. IDS_FILES_ARE_DIFFERENT
-#: Merge.rc:5050
+#: Merge.rc:5049
 #, c-format
 msgid "Files are different"
 msgstr "Dateien sind unterschiedlich"
 
 #. IDS_FOLDERS_ARE_DIFFERENT
-#: Merge.rc:5051
+#: Merge.rc:5050
 #, c-format
 msgid "Folders are different"
 msgstr "Ordner sind unterschiedlich"
 
 #. IDS_LEFTONLY
-#: Merge.rc:5052
+#: Merge.rc:5051
 #, c-format
 msgid "Left Only"
 msgstr "Nur links"
 
 #. IDS_RIGHTONLY
-#: Merge.rc:5053
+#: Merge.rc:5052
 #, c-format
 msgid "Right Only"
 msgstr "Nur rechts"
 
 #. IDS_MIDDLEONLY
-#: Merge.rc:5054
+#: Merge.rc:5053
 #, c-format
 msgid "Middle Only"
 msgstr "Nur Mitte"
 
 #. IDS_NOITEMLEFT
-#: Merge.rc:5055
+#: Merge.rc:5054
 #, c-format
 msgid "No item in left"
 msgstr "Keine linken Objekte"
 
 #. IDS_NOITEMRIGHT
-#: Merge.rc:5056
+#: Merge.rc:5055
 #, c-format
 msgid "No item in right"
 msgstr "Keine rechten Objekte"
 
 #. IDS_NOITEMMIDDLE
-#: Merge.rc:5057
+#: Merge.rc:5056
 #, c-format
 msgid "No item in middle"
 msgstr "Keine mittleren Objekte"
 
 #. IDS_CMPRES_ERROR
-#: Merge.rc:5059
+#: Merge.rc:5058
 #, c-format
 msgid "Error"
 msgstr "Fehler"
 
 #. IDS_TEXT_FILES_SAME
-#: Merge.rc:5060
+#: Merge.rc:5059
 #, c-format
 msgid "Text files are identical"
 msgstr "Textdateien sind identisch"
 
 #. IDS_LEFTONLY_DIFF
-#: Merge.rc:5061
+#: Merge.rc:5060
 msgid " (Middle and right are identical)"
 msgstr " (Mitte und Rechts sind identisch)"
 
 #. IDS_MIDDLEONLY_DIFF
-#: Merge.rc:5062
+#: Merge.rc:5061
 msgid " (Left and right are identical)"
 msgstr " (Links und Rechts sind identisch)"
 
 #. IDS_RIGHTONLY_DIFF
-#: Merge.rc:5063
+#: Merge.rc:5062
 msgid " (Left and middle are identical)"
 msgstr " (Links und Mitte sind identisch)"
 
 #. IDS_PATH_MISMATCH
-#: Merge.rc:5064
+#: Merge.rc:5063
 msgid " (paths differ)"
 msgstr " (Pfade unterscheiden sich)"
 
 #. IDS_TEXT_FILES_DIFF
-#: Merge.rc:5065
+#: Merge.rc:5064
 #, c-format
 msgid "Text files are different"
 msgstr "Textdateien sind unterschiedlich"
 
 #. IDS_IMAGE_FILES_SAME
-#: Merge.rc:5066
+#: Merge.rc:5065
 msgid "Image files are identical"
 msgstr "Bilddateien sind identisch"
 
 #. IDS_IMAGE_FILES_DIFF
-#: Merge.rc:5067
+#: Merge.rc:5066
 msgid "Image files are different"
 msgstr "Bilddateien sind unterschiedlich"
 
 #. IDS_EXPR_DIFF
-#: Merge.rc:5068
+#: Merge.rc:5067
 #, c-format
 msgid "Files are different (expr: %1)"
 msgstr "Dateien sind unterschiedlich (Ausdruck: %1)"
 
 #. IDS_HASH_GROUP
-#: Merge.rc:5069
+#: Merge.rc:5068
 #, c-format
 msgid "Group%d"
 msgstr "Gruppe%d"
 
 #. IDS_RENAME_MOVE_DETECTION_DISALBED
-#: Merge.rc:5070
+#: Merge.rc:5069
 msgctxt "Options dialog|Compare|Folder|Detect renames and moves"
 msgid "Disabled"
 msgstr "Deaktiviert"
 
 #. IDS_RENAME_MOVE_DETECTION_RENAME
-#: Merge.rc:5071
+#: Merge.rc:5070
 msgid "Detect renames"
 msgstr "Umbenennungen erkennen"
 
 #. IDS_RENAME_MOVE_DETECTION_RENAME_MOVE
-#: Merge.rc:5072
+#: Merge.rc:5071
 msgid "Detect renames and moves"
 msgstr "Umbenennungen und Verschiebungen erkennen"
 
 #. IDS_RENAME_MOVE_MERGE_MODE_RENAME
-#: Merge.rc:5073
+#: Merge.rc:5072
 msgid "Merge renames"
 msgstr "Umbenennungen zusammenführen"
 
 #. IDS_RENAME_MOVE_MERGE_MODE_RENAME_MOVE
-#: Merge.rc:5074
+#: Merge.rc:5073
 msgid "Merge renames and moves"
 msgstr "Umbenennungen und Verschiebungen zusammenführen"
 
 #. IDS_RENAMED
-#: Merge.rc:5075
+#: Merge.rc:5074
 msgid "Renamed"
 msgstr "Umbenannt"
 
 #. IDS_RENAMED_MOVED
-#: Merge.rc:5077
+#: Merge.rc:5076
 msgid "Renamed/Moved"
 msgstr "Umbenannt/Verschoben"
 
 #. IDS_RENAMED_MOVED_ITEMS
-#: Merge.rc:5078
+#: Merge.rc:5077
 #, c-format
 msgid "(%1 items)"
 msgstr "(%1 Elemente)"
 
 #. IDS_RENAMED_MOVED_RESULT
-#: Merge.rc:5079
+#: Merge.rc:5078
 #, c-format
 msgid "%1 (set %2): "
 msgstr "%1 (Gruppe %2): "
 
 #. IDS_SWITCH_FLAT_MODE
-#: Merge.rc:5080
+#: Merge.rc:5079
 msgid ""
 "Some moved items have been merged.\n"
 "In Tree Mode, these items may appear in positions that do not reflect the actual folder structure, which can be confusing.\n"
@@ -7611,268 +7605,268 @@ msgstr ""
 "In den Flachmodus wechseln?"
 
 #. IDS_ELAPSED_TIME
-#: Merge.rc:5086
+#: Merge.rc:5085
 #, c-format
 msgid "Elapsed time: %ld ms"
 msgstr "Ausführungszeit: %ld ms"
 
 #. IDS_STATUS_SELITEM1
-#: Merge.rc:5087
+#: Merge.rc:5086
 #, c-format
 msgid "1 item selected"
 msgstr "1 Objekt ausgewählt"
 
 #. IDS_STATUS_SELITEMS
-#: Merge.rc:5088
+#: Merge.rc:5087
 #, c-format
 msgid "%1 items selected"
 msgstr "%1 Objekte ausgewählt"
 
 #. IDS_COLDESC_FILENAME
-#: Merge.rc:5094
+#: Merge.rc:5093
 #, c-format
 msgid "Filename or folder name."
 msgstr "Datei- oder Ordnername."
 
 #. IDS_COLDESC_DIR
-#: Merge.rc:5095
+#: Merge.rc:5094
 #, c-format
 msgid "Subfolder name when subfolders are included."
 msgstr "Unterordnername, wenn Unterordner vorhanden sind."
 
 #. IDS_COLDESC_RESULT
-#: Merge.rc:5096
+#: Merge.rc:5095
 #, c-format
 msgid "Comparison result, long form."
 msgstr "Vergleichsergebnis, langes Format."
 
 #. IDS_COLDESC_LTIMEM
-#: Merge.rc:5101
+#: Merge.rc:5100
 #, c-format
 msgid "Left side modification date."
 msgstr "Linkes Änderungsdatum."
 
 #. IDS_COLDESC_RTIMEM
-#: Merge.rc:5102
+#: Merge.rc:5101
 #, c-format
 msgid "Right side modification date."
 msgstr "Rechtes Änderungsdatum."
 
 #. IDS_COLDESC_MTIMEM
-#: Merge.rc:5103
+#: Merge.rc:5102
 #, c-format
 msgid "Middle side modification date."
 msgstr "Mittleres Änderungsdatum."
 
 #. IDS_COLDESC_EXTENSION
-#: Merge.rc:5104
+#: Merge.rc:5103
 #, c-format
 msgid "File's extension."
 msgstr "Dateierweiterung."
 
 #. IDS_COLDESC_LSIZE
-#: Merge.rc:5105
+#: Merge.rc:5104
 #, c-format
 msgid "Left file size in bytes."
 msgstr "Linke Dateigröße in Byte."
 
 #. IDS_COLDESC_RSIZE
-#: Merge.rc:5106
+#: Merge.rc:5105
 #, c-format
 msgid "Right file size in bytes."
 msgstr "Rechte Dateigröße in Byte."
 
 #. IDS_COLDESC_MSIZE
-#: Merge.rc:5107
+#: Merge.rc:5106
 #, c-format
 msgid "Middle file size in bytes."
 msgstr "Mittlere Dateigröße in Byte."
 
 #. IDS_COLDESC_LSIZE_SHORT
-#: Merge.rc:5108
+#: Merge.rc:5107
 #, c-format
 msgid "Left file size abbreviated."
 msgstr "Linke Dateigröße gekürzt."
 
 #. IDS_COLDESC_RSIZE_SHORT
-#: Merge.rc:5109
+#: Merge.rc:5108
 #, c-format
 msgid "Right file size abbreviated."
 msgstr "Rechte Dateigröße gekürzt."
 
 #. IDS_COLDESC_MSIZE_SHORT
-#: Merge.rc:5110
+#: Merge.rc:5109
 #, c-format
 msgid "Middle file size abbreviated."
 msgstr "Mittlere Dateigröße gekürzt."
 
 #. IDS_COLDESC_LTIMEC
-#: Merge.rc:5116
+#: Merge.rc:5115
 #, c-format
 msgid "Left side creation time."
 msgstr "Linkes Erstellungsdatum."
 
 #. IDS_COLDESC_RTIMEC
-#: Merge.rc:5117
+#: Merge.rc:5116
 #, c-format
 msgid "Right side creation time."
 msgstr "Rechtes Erstellungsdatum."
 
 #. IDS_COLDESC_MTIMEC
-#: Merge.rc:5118
+#: Merge.rc:5117
 #, c-format
 msgid "Middle side creation time."
 msgstr "Mittleres Erstellungsdatum."
 
 #. IDS_COLDESC_NEWER
-#: Merge.rc:5119
+#: Merge.rc:5118
 #, c-format
 msgid "Tells which side has newer modification date."
 msgstr "Zeigt, welche Seite ein neueres Änderungsdatum hat."
 
 #. IDS_COLDESC_LVERSION
-#: Merge.rc:5120
+#: Merge.rc:5119
 msgid "Left side file version, only for some file types."
 msgstr "Linke Dateiversion, nur für einige Dateitypen."
 
 #. IDS_COLDESC_RVERSION
-#: Merge.rc:5121
+#: Merge.rc:5120
 msgid "Right side file version, only for some file types."
 msgstr "Rechte Dateiversion, nur für einige Dateitypen."
 
 #. IDS_COLDESC_MVERSION
-#: Merge.rc:5126
+#: Merge.rc:5125
 msgid "Middle side file version, only for some file types."
 msgstr "Mittlere Dateiversion, nur für einige Dateitypen."
 
 #. IDS_COLDESC_RESULT_ABBR
-#: Merge.rc:5127
+#: Merge.rc:5126
 #, c-format
 msgid "Short comparison result."
 msgstr "Vergleichsergebnis, kurzes Format."
 
 #. IDS_COLDESC_LATTRIBUTES
-#: Merge.rc:5128
+#: Merge.rc:5127
 #, c-format
 msgid "Left side attributes."
 msgstr "Linke Attribute."
 
 #. IDS_COLDESC_RATTRIBUTES
-#: Merge.rc:5129
+#: Merge.rc:5128
 #, c-format
 msgid "Right side attributes."
 msgstr "Rechte Attribute."
 
 #. IDS_COLDESC_MATTRIBUTES
-#: Merge.rc:5130
+#: Merge.rc:5129
 #, c-format
 msgid "Middle side attributes."
 msgstr "Mittlere Attribute."
 
 #. IDS_COLDESC_LEOL_TYPE
-#: Merge.rc:5131
+#: Merge.rc:5130
 msgid "Left side file EOL type."
 msgstr "Linker Zeilenende-Typ."
 
 #. IDS_COLDESC_REOL_TYPE
-#: Merge.rc:5132
+#: Merge.rc:5131
 msgid "Right side file EOL type."
 msgstr "Rechter Zeilenende-Typ."
 
 #. IDS_COLDESC_MEOL_TYPE
-#: Merge.rc:5133
+#: Merge.rc:5132
 msgid "Middle side file EOL type."
 msgstr "Mittlerer Zeilenende-Typ."
 
 #. IDS_COLDESC_LENCODING
-#: Merge.rc:5139
+#: Merge.rc:5138
 #, c-format
 msgid "Left side encoding."
 msgstr "Linke Zeichensatzcodierung."
 
 #. IDS_COLDESC_RENCODING
-#: Merge.rc:5140
+#: Merge.rc:5139
 #, c-format
 msgid "Right side encoding."
 msgstr "Rechte Zeichensatzcodierung."
 
 #. IDS_COLDESC_MENCODING
-#: Merge.rc:5141
+#: Merge.rc:5140
 #, c-format
 msgid "Middle side encoding."
 msgstr "Mittlere Zeichensatzcodierung."
 
 #. IDS_COLDESC_NIDIFFS
-#: Merge.rc:5142
+#: Merge.rc:5141
 #, c-format
 msgid "Number of ignored differences in file. Ignored and cannot be merged."
 msgstr "Anzahl der ignorierten Unterschiede in der Datei. Diese Unterschiede werden von WinMerge ignoriert und können nicht gemischt werden."
 
 #. IDS_COLDESC_NSDIFFS
-#: Merge.rc:5143
+#: Merge.rc:5142
 #, c-format
 msgid "Number of differences in file (excluding ignored)."
 msgstr "Anzahl der Unterschiede in der Datei. Die Zahl enthält nicht die ignorierten Unterschiede."
 
 #. IDS_COLDESC_BINARY
-#: Merge.rc:5144
+#: Merge.rc:5143
 #, c-format
 msgid "Shows an asterisk (*) if the file is binary."
 msgstr "Zeigt ein Asterisk (*), wenn die Datei binär ist."
 
 #. IDS_COLDESC_UNPACKER
-#: Merge.rc:5145
+#: Merge.rc:5144
 msgid "Unpacker plugin name or pipeline."
 msgstr "Name des Entpacker-Plugins oder der Pipeline."
 
 #. IDS_COLDESC_PREDIFFER
-#: Merge.rc:5146
+#: Merge.rc:5145
 msgid "Prediffer plugin name or pipeline."
 msgstr "Name des Prediffer-Plugins oder der Pipeline."
 
 #. IDS_DIRECTORY_REPORT_TITLE
-#: Merge.rc:5152
+#: Merge.rc:5151
 #, c-format
 msgid "Compare %1 with %2"
 msgstr "%1 mit %2 vergleichen"
 
 #. IDS_DIRECTORY_REPORT_TITLE3
-#: Merge.rc:5153
+#: Merge.rc:5152
 #, c-format
 msgid "Compare %1 with %2 and %3"
 msgstr "%1 mit %2 und %3 vergleichen"
 
 #. IDS_REPORT_COMMALIST
-#: Merge.rc:5154
+#: Merge.rc:5153
 #, c-format
 msgid "Comma-separated list"
 msgstr "Komma-getrennte Liste"
 
 #. IDS_REPORT_TABLIST
-#: Merge.rc:5155
+#: Merge.rc:5154
 #, c-format
 msgid "Tab-separated list"
 msgstr "Tab-getrennte Liste"
 
 #. IDS_REPORT_SIMPLEHTML
-#: Merge.rc:5156
+#: Merge.rc:5155
 #, c-format
 msgid "Simple HTML"
 msgstr "Einfaches HTML"
 
 #. IDS_REPORT_SIMPLEXML
-#: Merge.rc:5157
+#: Merge.rc:5156
 #, c-format
 msgid "Simple XML"
 msgstr "Einfaches XML"
 
-#: Merge.rc:5159
+#: Merge.rc:5158
 #, c-format
 msgid "Report file already exists. Overwrite?"
 msgstr "Der Bericht existiert bereits. Überschreiben?"
 
 #. IDS_REPORT_ERROR
-#: Merge.rc:5164
+#: Merge.rc:5163
 #, c-format
 msgid ""
 "Error creating the report:\n"
@@ -7882,30 +7876,30 @@ msgstr ""
 "%1"
 
 #. IDS_REPORT_SUCCESS
-#: Merge.rc:5165
+#: Merge.rc:5164
 #, c-format
 msgid "Report created successfully."
 msgstr "Der Bericht wurde erfolgreich geschrieben."
 
 #. IDS_SYNCPOINT_LASTBLOCK
-#: Merge.rc:5171
+#: Merge.rc:5170
 msgid "Cannot add a synchronization point at this line."
 msgstr "In dieser Zeile kann kein Synchronisationspunkt hinzugefügt werden."
 
 #. IDS_FILE_TO_ITSELF
-#: Merge.rc:5177
+#: Merge.rc:5176
 #, c-format
 msgid "Same file is opened in both panes."
 msgstr "In beiden Bereichen ist die gleiche Datei geöffnet."
 
 #. IDS_FILESSAME
-#: Merge.rc:5178
+#: Merge.rc:5177
 #, c-format
 msgid "Selected files are identical."
 msgstr "Die ausgewählten Dateien sind identisch."
 
 #. IDS_FILESSAME_CURCFG
-#: Merge.rc:5179
+#: Merge.rc:5178
 msgid ""
 "Selected files are identical (with current settings).\r\n"
 "Checking binary identity..."
@@ -7914,7 +7908,7 @@ msgstr ""
 "Die binäre Übereinstimmung wird geprüft..."
 
 #. IDS_FILESSAME_BINERROR
-#: Merge.rc:5180
+#: Merge.rc:5179
 msgid ""
 "Selected files are identical (with current settings).\r\n"
 "But binary comparison failed."
@@ -7923,12 +7917,12 @@ msgstr ""
 "Binärvergleich fehlgeschlagen."
 
 #. IDS_FILESSAME_BINSAME
-#: Merge.rc:5181
+#: Merge.rc:5180
 msgid "Selected files are identical (binary match)."
 msgstr "Die ausgewählten Dateien sind identisch (binäre Übereinstimmung)."
 
 #. IDS_FILESSAME_BINDIFF
-#: Merge.rc:5182
+#: Merge.rc:5181
 msgid ""
 "Selected files are identical (with current settings).\r\n"
 "But differ at the binary level."
@@ -7937,19 +7931,19 @@ msgstr ""
 "Unterscheiden sich jedoch auf binärer Ebene."
 
 #. IDS_FILEERROR
-#: Merge.rc:5183
+#: Merge.rc:5182
 #, c-format
 msgid "An error occurred while comparing files."
 msgstr "Beim Vergleichen der Dateien ist ein Fehler aufgetreten."
 
 #. IDS_TEMP_FILEERROR
-#: Merge.rc:5184
+#: Merge.rc:5183
 #, c-format
 msgid "Could not create temporary files. Check your temporary path settings."
 msgstr "Temporäre Dateien konnten nicht erzeugt werden. Überprüfen Sie Ihre Einstellungen für temporäre Dateien."
 
 #. IDS_SUGGEST_IGNOREEOL
-#: Merge.rc:5185
+#: Merge.rc:5184
 msgid ""
 "Files use different EOL.\n"
 "\n"
@@ -7964,19 +7958,19 @@ msgstr ""
 "Hinweis: Wenn Sie immer alle Zeilenumbruchformate als gleichwertig behandeln wollen, aktivieren Sie die Option 'Zeilenumbruchunterschiede (Windows/Unix/Mac) ignorieren' unter Einstellungen/Vergleichen/Allgemein."
 
 #. IDS_INVALID_DIRECTORY
-#: Merge.rc:5186
+#: Merge.rc:5185
 #, c-format
 msgid "Selected folder is invalid."
 msgstr "Der ausgewählte Ordner ist ungültig."
 
 #. IDS_CANNOT_OPEN_BINARYFILE
-#: Merge.rc:5187
+#: Merge.rc:5186
 #, c-format
 msgid "Cannot open a binary file in Editor."
 msgstr "Kann keine Binärdatei im Editor öffnen."
 
 #. IDS_CREATE_PAIR_FOLDER
-#: Merge.rc:5188
+#: Merge.rc:5187
 #, c-format
 msgid ""
 "Create matching folder:\n"
@@ -7990,45 +7984,45 @@ msgstr ""
 "auf der anderen Seite erzeugen und die Ordner öffnen?"
 
 #. IDS_CONFIRM_COPY_ALL_DIFFS
-#: Merge.rc:5189
+#: Merge.rc:5188
 msgid "Copy all differences to other file?"
 msgstr "Wollen Sie wirklich alle Unterschiede in die andere Datei kopieren?"
 
 #. IDS_MOVE_TO_NEXTFILE
-#: Merge.rc:5194
+#: Merge.rc:5193
 #, c-format
 msgid "Move to next file?"
 msgstr "Möchten Sie zur nächsten Datei wechseln?"
 
 #. IDS_MOVE_TO_PREVFILE
-#: Merge.rc:5195
+#: Merge.rc:5194
 #, c-format
 msgid "Move to previous file?"
 msgstr "Möchten Sie zur vorherigen Datei wechseln?"
 
 #. IDS_MOVE_TO_NEXTPAGE
-#: Merge.rc:5196
+#: Merge.rc:5195
 #, c-format
 msgid "Move to next page?"
 msgstr "Möchten Sie zur nächsten Seite wechseln?"
 
 #. IDS_MOVE_TO_PREVPAGE
-#: Merge.rc:5197
+#: Merge.rc:5196
 #, c-format
 msgid "Move to previous page?"
 msgstr "Möchten Sie zur vorherigen Seite wechseln?"
 
 #. IDS_MOVE_TO_FIRSTFILE
-#: Merge.rc:5198
+#: Merge.rc:5197
 msgid "Move to first file?"
 msgstr "Möchten Sie zur ersten Datei wechseln?"
 
 #. IDS_MOVE_TO_LASTFILE
-#: Merge.rc:5199
+#: Merge.rc:5198
 msgid "Move to last file?"
 msgstr "Möchten Sie zur letzten Datei wechseln?"
 
-#: Merge.rc:5206
+#: Merge.rc:5205
 #, c-format
 msgid ""
 "Different codepages: left (cp%d), right (cp%d).\n"
@@ -8039,57 +8033,57 @@ msgstr ""
 "Die Anzeige jeder Datei in ihrer Codeseite verbessert die Anzeige, das Zusammenführen/Kopieren ist jedoch gefährlich.\n"
 "Möchten Sie beide Dateien mit der Standard-Windows-Codeseite behandeln (empfohlen)?"
 
-#: Merge.rc:5208
+#: Merge.rc:5207
 #, c-format
 msgid "Information lost due to encoding errors: both files"
 msgstr "Informationsverlust wegen Codierungsfehlern: Beide Dateien"
 
-#: Merge.rc:5210
+#: Merge.rc:5209
 #, c-format
 msgid "Information lost due to encoding errors: first file"
 msgstr "Informationsverlust wegen Codierungsfehlern: Erste Datei"
 
-#: Merge.rc:5212
+#: Merge.rc:5211
 #, c-format
 msgid "Information lost due to encoding errors: second file"
 msgstr "Informationsverlust wegen Codierungsfehlern: Zweite Datei"
 
-#: Merge.rc:5214
+#: Merge.rc:5213
 #, c-format
 msgid "Information lost due to encoding errors: third file"
 msgstr "Informationsverlust wegen Codierungsfehlern: Dritte Datei"
 
 #. IDS_LINEDIFF_NODIFF
-#: Merge.rc:5220
+#: Merge.rc:5219
 #, c-format
 msgid "No difference"
 msgstr "Kein Unterschied"
 
 #. IDS_LINEDIFF_NODIFF_CAPTION
-#: Merge.rc:5221
+#: Merge.rc:5220
 #, c-format
 msgid "Line difference"
 msgstr "Zeilenunterschied"
 
 #. IDS_NUM_REPLACED
-#: Merge.rc:5227
+#: Merge.rc:5226
 #, c-format
 msgid "Replaced %1 string(s)."
 msgstr "%1 Vorkommen ersetzt."
 
 #. IDS_EDIT_TEXT_NOT_FOUND
-#: Merge.rc:5228
+#: Merge.rc:5227
 #, c-format
 msgid "Cannot find string \"%s\"."
 msgstr "Kann \"%s\" nicht finden."
 
 #. IDS_MERGE_MODE
-#: Merge.rc:5234
+#: Merge.rc:5233
 msgid "Entering Merge Mode. Press F9 to turn off."
 msgstr "Sie wechseln jetzt in den Merge-Modus. Wenn Sie den Merge-Modus deaktivieren möchten, betätigen Sie die Taste F9."
 
 #. IDS_AUTO_MERGE
-#: Merge.rc:5240
+#: Merge.rc:5239
 #, c-format
 msgid ""
 "Automatic merges: %1\n"
@@ -8099,97 +8093,97 @@ msgstr ""
 "Anzahl der ungelösten Konflikte: %2"
 
 #. IDS_CODEPAGE_MERGED
-#: Merge.rc:5241
+#: Merge.rc:5240
 msgid "Codepage change merged."
 msgstr "Die Änderung der Codeseite wurde zusammengeführt."
 
 #. IDS_CODEPAGE_CONFLICT
-#: Merge.rc:5242
+#: Merge.rc:5241
 msgid "Codepage changes are conflicting."
 msgstr "Die Änderungen der Codeseite sind widersprüchlich."
 
 #. IDS_EOL_MERGED
-#: Merge.rc:5243
+#: Merge.rc:5242
 msgid "EOL change merged."
 msgstr "Die Änderung des Zeilenendes wurde zusammengeführt."
 
 #. IDS_EOL_CONFLICT
-#: Merge.rc:5244
+#: Merge.rc:5243
 msgid "EOL changes are conflicting."
 msgstr "Die Änderungen des Zeilenendes sind widersprüchlich."
 
 #. IDS_LOCBAR_CAPTION
-#: Merge.rc:5250
+#: Merge.rc:5249
 #, c-format
 msgid "Location Pane"
 msgstr "Positionsleiste"
 
 #. IDS_DIFFBAR_CAPTION
-#: Merge.rc:5251
+#: Merge.rc:5250
 #, c-format
 msgid "Diff Pane"
 msgstr "Unterschiedsleiste"
 
 #. IDS_DIFF_SUCCEEDED
-#: Merge.rc:5258
+#: Merge.rc:5257
 #, c-format
 msgid "Patch file written."
 msgstr "Die Patchdatei wurde erfolgreich geschrieben."
 
 #. IDS_DIFF_FILEOVERWRITE
-#: Merge.rc:5259
+#: Merge.rc:5258
 #, c-format
 msgid "Patch file already exists. Overwrite?"
 msgstr "Die Patchdatei existiert bereits. Überschreiben?"
 
 #. IDS_DIFF_SELECTEDFILES
-#: Merge.rc:5260
+#: Merge.rc:5259
 #, c-format
 msgid "[%1 files selected]"
 msgstr "[%1 Dateien ausgewählt]"
 
 #. IDS_DIFF_NORMAL
-#: Merge.rc:5261
+#: Merge.rc:5260
 #, c-format
 msgid "Normal"
 msgstr "Normal"
 
 #. IDS_DIFF_CONTEXT
-#: Merge.rc:5262
+#: Merge.rc:5261
 #, c-format
 msgid "Context"
 msgstr "Kontext"
 
 #. IDS_DIFF_UNIFIED
-#: Merge.rc:5263
+#: Merge.rc:5262
 #, c-format
 msgid "Unified"
 msgstr "Einheitlich"
 
 #. IDS_FILEWRITE_ERROR
-#: Merge.rc:5265
+#: Merge.rc:5264
 #, c-format
 msgid "Could not write to file %1."
 msgstr "Konnte nicht in die Datei %1 schreiben."
 
 #. IDS_PATH_NOT_ABSOLUTE
-#: Merge.rc:5266
+#: Merge.rc:5265
 #, c-format
 msgid "Output path is not absolute: %1"
 msgstr "Der angegebene Ausgabepfad ist kein absoluter Pfad: %1"
 
 #. IDS_MUST_SPECIFY_OUTPUT
-#: Merge.rc:5267
+#: Merge.rc:5266
 msgid "Specify an output file."
 msgstr "Geben Sie eine Ausgabedatei an."
 
-#: Merge.rc:5269
+#: Merge.rc:5268
 #, c-format
 msgid "Cannot create patch from binary files."
 msgstr "Kann keine Patchdatei von Binärdateien erzeugen."
 
 #. IDS_SAVEFILES_FORPATCH
-#: Merge.rc:5270
+#: Merge.rc:5269
 #, c-format
 msgid ""
 "Save all files first.\n"
@@ -8201,18 +8195,18 @@ msgstr ""
 "Das Erzeugen eines Patches erfordert, dass keine ungespeicherten Änderungen in den Dateien existieren."
 
 #. IDS_FOLDER_NOTEXIST
-#: Merge.rc:5271
+#: Merge.rc:5270
 #, c-format
 msgid "Folder does not exist."
 msgstr "Der Ordner existiert nicht."
 
 #. IDS_ARCHIVE_SUCCEEDED
-#: Merge.rc:5277
+#: Merge.rc:5276
 msgid "Archive file written."
 msgstr "Archivdatei wurde erstellt."
 
 #. IDS_ARCHIVE_SAVEFILES
-#: Merge.rc:5278
+#: Merge.rc:5277
 msgid ""
 "Save all files first.\n"
 "\n"
@@ -8223,7 +8217,7 @@ msgstr ""
 "Vor dem Erstellen eines Archivs müssen alle Änderungen gespeichert werden."
 
 #. IDS_NO_ZIP_SUPPORT
-#: Merge.rc:5283
+#: Merge.rc:5282
 msgid ""
 "Archive support not enabled.\n"
 "7-Zip and/or Merge7z*.dll not found.\n"
@@ -8234,43 +8228,43 @@ msgstr ""
 "Entnehmen Sie dem Handbuch mehr Informationen über die Archivunterstützung und wie sie aktiviert wird."
 
 #. IDS_OPT_EXPORT_CAPTION
-#: Merge.rc:5284
+#: Merge.rc:5283
 #, c-format
 msgid "Select file for export"
 msgstr "Datei zum Exportieren auswählen"
 
 #. IDS_OPT_IMPORT_CAPTION
-#: Merge.rc:5285
+#: Merge.rc:5284
 #, c-format
 msgid "Select file for import"
 msgstr "Datei zum Importieren auswählen"
 
 #. IDS_OPT_IMPORT_DONE
-#: Merge.rc:5286
+#: Merge.rc:5285
 #, c-format
 msgid "Options imported from file."
 msgstr "Einstellungen aus der Datei importiert."
 
 #. IDS_OPT_EXPORT_DONE
-#: Merge.rc:5287
+#: Merge.rc:5286
 #, c-format
 msgid "Options exported to file."
 msgstr "Einstellungen in die Datei exportiert."
 
 #. IDS_OPT_IMPORT_ERR
-#: Merge.rc:5288
+#: Merge.rc:5287
 #, c-format
 msgid "Failed to import options from file."
 msgstr "Konnte die Einstellungen nicht aus der Datei importieren."
 
 #. IDS_OPT_EXPORT_ERR
-#: Merge.rc:5289
+#: Merge.rc:5288
 #, c-format
 msgid "Failed to write options to file."
 msgstr "Konnte die Einstellungen nicht in die Datei exportieren."
 
 #. IDS_CLOSEALL_WINDOWS
-#: Merge.rc:5290
+#: Merge.rc:5289
 #, c-format
 msgid ""
 "Close multiple compare windows?\n"
@@ -8282,36 +8276,36 @@ msgstr ""
 "Möchten Sie wirklich fortfahren?"
 
 #. IDS_EOL_BIN
-#: Merge.rc:5300
+#: Merge.rc:5299
 msgctxt "EOL Type"
 msgid "Binary"
 msgstr "Binär"
 
 #. IDS_MARKER_COLOR_FMT
-#: Merge.rc:5305
+#: Merge.rc:5304
 #, c-format
 msgid "Marker Color %d"
 msgstr "Markierungsfarbe %d"
 
 #. IDS_MARKER_NEW_PATTERN
-#: Merge.rc:5306
+#: Merge.rc:5305
 msgid "New Pattern"
 msgstr "Neues Muster"
 
 #. IDS_PLUGINSLIST_TYPE
-#: Merge.rc:5312
+#: Merge.rc:5311
 #, c-format
 msgid "Type"
 msgstr "Typ"
 
 #. IDS_PLUGINS_TYPE_EDITSCRIPT
-#: Merge.rc:5316
+#: Merge.rc:5315
 #, c-format
 msgid "Editor script"
 msgstr "Editor-Skript"
 
 #. ID_SELECTLINEDIFF
-#: Merge.rc:5322
+#: Merge.rc:5321
 #, c-format
 msgid ""
 "\n"
@@ -8321,7 +8315,7 @@ msgstr ""
 "Zeilenunterschied markieren (F4)"
 
 #. ID_OPTIONS
-#: Merge.rc:5323
+#: Merge.rc:5322
 #, c-format
 msgid ""
 "\n"
@@ -8331,7 +8325,7 @@ msgstr ""
 "Einstellungen"
 
 #. ID_REFRESH
-#: Merge.rc:5324
+#: Merge.rc:5323
 #, c-format
 msgid ""
 "\n"
@@ -8341,7 +8335,7 @@ msgstr ""
 "Aktualisieren (F5)"
 
 #. ID_PREVDIFF
-#: Merge.rc:5330
+#: Merge.rc:5329
 #, c-format
 msgid ""
 "\n"
@@ -8351,7 +8345,7 @@ msgstr ""
 "Vorheriger Unterschied (Alt+Hoch)"
 
 #. ID_NEXTDIFF
-#: Merge.rc:5331
+#: Merge.rc:5330
 #, c-format
 msgid ""
 "\n"
@@ -8361,7 +8355,7 @@ msgstr ""
 "Nächster Unterschied (Alt+Runter)"
 
 #. ID_PREVCONFLICT
-#: Merge.rc:5332
+#: Merge.rc:5331
 #, c-format
 msgid ""
 "\n"
@@ -8371,7 +8365,7 @@ msgstr ""
 "Vorheriger Konflikt (Alt+Umschalt+Hoch)"
 
 #. ID_NEXTCONFLICT
-#: Merge.rc:5333
+#: Merge.rc:5332
 #, c-format
 msgid ""
 "\n"
@@ -8381,7 +8375,7 @@ msgstr ""
 "Nächster Konflikt (Alt+Umschalt+Runter)"
 
 #. ID_FIRSTDIFF
-#: Merge.rc:5338
+#: Merge.rc:5337
 #, c-format
 msgid ""
 "\n"
@@ -8391,7 +8385,7 @@ msgstr ""
 "Erster Unterschied (Alt+Pos 1)"
 
 #. ID_CURDIFF
-#: Merge.rc:5339
+#: Merge.rc:5338
 #, c-format
 msgid ""
 "\n"
@@ -8401,7 +8395,7 @@ msgstr ""
 "Aktueller Unterschied (Alt+Enter)"
 
 #. ID_LASTDIFF
-#: Merge.rc:5340
+#: Merge.rc:5339
 #, c-format
 msgid ""
 "\n"
@@ -8411,7 +8405,7 @@ msgstr ""
 "Letzter Unterschied (Alt+Ende)"
 
 #. ID_L2R
-#: Merge.rc:5341
+#: Merge.rc:5340
 msgid ""
 "\n"
 "Copy to Right (Alt+Right)"
@@ -8420,7 +8414,7 @@ msgstr ""
 "Nach rechts kopieren (Alt+Rechts)"
 
 #. ID_R2L
-#: Merge.rc:5342
+#: Merge.rc:5341
 msgid ""
 "\n"
 "Copy to Left (Alt+Left)"
@@ -8429,7 +8423,7 @@ msgstr ""
 "Nach links kopieren (Alt+Links)"
 
 #. ID_L2RNEXT
-#: Merge.rc:5343
+#: Merge.rc:5342
 msgid ""
 "\n"
 "Copy to Right and Advance (Ctrl+Alt+Right)"
@@ -8438,7 +8432,7 @@ msgstr ""
 "Nach rechts kopieren und fortschreiten (Strg+Alt+Rechts)"
 
 #. ID_R2LNEXT
-#: Merge.rc:5344
+#: Merge.rc:5343
 msgid ""
 "\n"
 "Copy to Left and Advance (Ctrl+Alt+Left)"
@@ -8447,7 +8441,7 @@ msgstr ""
 "Nach links kopieren und fortschreiten (Strg+Alt+Links)"
 
 #. ID_ALL_RIGHT
-#: Merge.rc:5345
+#: Merge.rc:5344
 msgid ""
 "\n"
 "Copy All to Right"
@@ -8456,7 +8450,7 @@ msgstr ""
 "Alles nach rechts kopieren"
 
 #. ID_ALL_LEFT
-#: Merge.rc:5346
+#: Merge.rc:5345
 msgid ""
 "\n"
 "Copy All to Left"
@@ -8465,7 +8459,7 @@ msgstr ""
 "Alles nach links kopieren"
 
 #. ID_AUTO_MERGE
-#: Merge.rc:5347
+#: Merge.rc:5346
 #, c-format
 msgid ""
 "\n"
@@ -8475,7 +8469,7 @@ msgstr ""
 "Automatisch mischen (Strg+Alt+M)"
 
 #. ID_FIRSTFILE
-#: Merge.rc:5348
+#: Merge.rc:5347
 msgid ""
 "\n"
 "First File"
@@ -8484,7 +8478,7 @@ msgstr ""
 "Erste Datei"
 
 #. ID_NEXTFILE
-#: Merge.rc:5349
+#: Merge.rc:5348
 msgid ""
 "\n"
 "Next File (Ctrl+F8)"
@@ -8493,7 +8487,7 @@ msgstr ""
 "Nächste Datei (Strg+F8)"
 
 #. ID_LASTFILE
-#: Merge.rc:5350
+#: Merge.rc:5349
 msgid ""
 "\n"
 "Last File"
@@ -8502,7 +8496,7 @@ msgstr ""
 "Letzte Datei"
 
 #. ID_PREVFILE
-#: Merge.rc:5351
+#: Merge.rc:5350
 msgid ""
 "\n"
 "Previous File (Ctrl+F7)"
@@ -8511,156 +8505,156 @@ msgstr ""
 "Vorherige Datei (Strg+F7)"
 
 #. IDS_UNPACK_AUTO
-#: Merge.rc:5358
+#: Merge.rc:5357
 msgid "Adapted unpacker applied to both files (one needs extension)."
 msgstr "Der passende Entpacker wird auf beide Dateien angewendet. Nur eine Datei benötigt die Erweiterung."
 
 #. IDS_NO_PREDIFFER
-#: Merge.rc:5359
+#: Merge.rc:5358
 #, c-format
 msgid "No Prediffer (Normal)"
 msgstr "Kein Prediffer (normal)"
 
 #. IDS_SUGGESTED_PLUGINS
-#: Merge.rc:5360
+#: Merge.rc:5359
 #, c-format
 msgid "Suggested Plugins"
 msgstr "Vorgeschlagene Plugins"
 
 #. IDS_NOT_SUGGESTED_PLUGINS
-#: Merge.rc:5361
+#: Merge.rc:5360
 msgid "All Plugins"
 msgstr "Alle Plugins"
 
 #. IDS_PRIVATEBUILD_FMT
-#: Merge.rc:5367
+#: Merge.rc:5366
 #, c-format
 msgid "Private Build: %1"
 msgstr "Private Build: %1"
 
 #. IDS_ALLRIGHTS_RESERVED
-#: Merge.rc:5368
+#: Merge.rc:5367
 msgid " - All rights reserved."
 msgstr " - Alle Rechte vorbehalten."
 
 #. IDS_TITLE_PLUGINS_SETTINGS
-#: Merge.rc:5374
+#: Merge.rc:5373
 #, c-format
 msgid "Plugin Settings"
 msgstr "Plugin-Einstellungen"
 
 #. IDS_NO_SCT_SCRIPTS
-#: Merge.rc:5376
+#: Merge.rc:5375
 #, c-format
 msgid "WSH not found - .sct scripts disabled"
 msgstr "WSH nicht gefunden - SCT-Skripte deaktiviert"
 
 #. IDS_LOCBAR_GOTOLINE_FMT
-#: Merge.rc:5384
+#: Merge.rc:5383
 #, c-format
 msgid "G&o to Line %1"
 msgstr "Gehe zu &Zeile %1"
 
 #. IDS_GOTO_MOVED_LINE
-#: Merge.rc:5390
+#: Merge.rc:5389
 msgid "Go to Moved Line\tCtrl+Shift+G"
 msgstr "Zur &verschobenen Zeile gehen\tStrg+Umschalt+G"
 
 #. IDS_AUTOCOMPLETE_DISABLED
-#: Merge.rc:5396
+#: Merge.rc:5395
 msgctxt "Options dialog|General|Open dialog Auto completion"
 msgid "Disabled"
 msgstr "Deaktiviert"
 
 #. IDS_AUTOCOMPLETE_FILE_SYS
-#: Merge.rc:5397
+#: Merge.rc:5396
 #, c-format
 msgid "From file system"
 msgstr "Vom Dateisystem"
 
 #. IDS_AUTOCOMPLETE_MRU
-#: Merge.rc:5398
+#: Merge.rc:5397
 #, c-format
 msgid "From Most Recently Used list"
 msgstr "Von MRU-Liste"
 
 #. IDS_COLORSCHEME_PLAIN
-#: Merge.rc:5404
+#: Merge.rc:5403
 #, c-format
 msgid "No Highlighting"
 msgstr "Keine Hervorhebung"
 
 #. IDS_COLORSCHEME_PO
-#: Merge.rc:5439
+#: Merge.rc:5438
 #, c-format
 msgid "Portable Object"
 msgstr "Portable Object"
 
 #. IDS_COLORSCHEME_RSRC
-#: Merge.rc:5444
+#: Merge.rc:5443
 #, c-format
 msgid "Resources"
 msgstr "Ressourcen"
 
 #. IDS_COLORSCHEME_SH
-#: Merge.rc:5448
+#: Merge.rc:5447
 #, c-format
 msgid "Shell"
 msgstr "Shell"
 
 #. IDS_CLOSE_LEFT_TABS
-#: Merge.rc:5469
+#: Merge.rc:5468
 #, c-format
 msgid "Close &Left Tabs"
 msgstr "Tabs &links vom aktuellen Tab schließen"
 
 #. IDS_CLOSE_RIGHT_TABS
-#: Merge.rc:5470
+#: Merge.rc:5469
 #, c-format
 msgid "Close R&ight Tabs"
 msgstr "Tabs &rechts vom aktuellen Tab schließen"
 
 #. IDS_CLOSE_OTHER_TABS
-#: Merge.rc:5471
+#: Merge.rc:5470
 #, c-format
 msgid "Close &Other Tabs"
 msgstr "&Alle anderen Tabs schließen"
 
 #. IDS_TABBAR_AUTO_MAXWIDTH
-#: Merge.rc:5472
+#: Merge.rc:5471
 #, c-format
 msgid "Enable &Auto Max Width"
 msgstr "Automatisch maximale Breite aktivieren"
 
 #. IDS_WEBPAGE_MENU
-#: Merge.rc:5482
+#: Merge.rc:5481
 msgid "We&bpage"
 msgstr "We&bseite"
 
 #. IDS_VIEW_WRAP_TEXT
-#: Merge.rc:5487
+#: Merge.rc:5486
 msgid "W&rap Text"
 msgstr "Text umbrechen"
 
 #. IDS_NOTINSTALLED
-#: Merge.rc:5492
+#: Merge.rc:5491
 msgid "%1 is not installed."
 msgstr "%1 ist nicht installiert."
 
 #. IDS_CREATE_FOLDER
-#: Merge.rc:5497
+#: Merge.rc:5496
 #, c-format
 msgid "%1 does not exist. Create it?"
 msgstr "%1 existiert nicht. Möchten Sie sie anlegen?"
 
 #. IDS_CREATE_FOLDER_ERROR
-#: Merge.rc:5498
+#: Merge.rc:5497
 #, c-format
 msgid "Failed to create folder."
 msgstr "Ordner erstellen ist fehlgeschlagen."
 
 #. IDC_EXT_EDITOR_PATH
-#: Merge.rc:5503
+#: Merge.rc:5502
 #, c-format
 msgid ""
 "Parameters:\n"
@@ -8672,492 +8666,492 @@ msgstr ""
 "$linenum: Zeilennummer der aktuellen Cursorposition"
 
 #. IDS_DIFF_ALGORITHM_DEFAULT
-#: Merge.rc:5508
+#: Merge.rc:5507
 msgid "default"
 msgstr "Standard"
 
 #. IDS_DIFF_ALGORITHM_MINIMAL
-#: Merge.rc:5509
+#: Merge.rc:5508
 msgid "minimal"
 msgstr "Minimal"
 
 #. IDS_DIFF_ALGORITHM_PATIENCE
-#: Merge.rc:5510
+#: Merge.rc:5509
 msgid "patience"
 msgstr "Patience"
 
 #. IDS_DIFF_ALGORITHM_HISTOGRAM
-#: Merge.rc:5511
+#: Merge.rc:5510
 msgid "histogram"
 msgstr "Histogramm"
 
 #. IDS_DIFF_ALGORITHM_NONE
-#: Merge.rc:5512
+#: Merge.rc:5511
 msgid "none"
 msgstr "keine"
 
 #. IDS_RENDERING_MODE_GDI
-#: Merge.rc:5517
+#: Merge.rc:5516
 msgid "GDI"
 msgstr "GDI"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_DEFAULT
-#: Merge.rc:5518
+#: Merge.rc:5517
 msgid "DirectWrite Default"
 msgstr "DirectWrite Standard"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_ALIASED
-#: Merge.rc:5519
+#: Merge.rc:5518
 msgid "DirectWrite Aliased"
 msgstr "DirectWrite Aliasing"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_GDI_CLASSIC
-#: Merge.rc:5520
+#: Merge.rc:5519
 msgid "DirectWrite GDI Classic"
 msgstr "DirectWrite GDI klassisch"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_GDI_NATURAL
-#: Merge.rc:5521
+#: Merge.rc:5520
 msgid "DirectWrite GDI Natural"
 msgstr "DirectWrite GDI natürlich"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_NATURAL
-#: Merge.rc:5522
+#: Merge.rc:5521
 msgid "DirectWrite Natural"
 msgstr "DirectWrite natürlich"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_NATURAL_SYMMETRIC
-#: Merge.rc:5523
+#: Merge.rc:5522
 msgid "DirectWrite Natural Symmetric"
 msgstr "DirectWrite natürlich symmetrisch"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_DISABLED
-#: Merge.rc:5528
+#: Merge.rc:5527
 msgctxt "Options dialog|General|Close windows with Esc"
 msgid "Disabled"
 msgstr "Deaktiviert"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_1
-#: Merge.rc:5529
+#: Merge.rc:5528
 msgid "MDI child window or main window"
 msgstr "MDI-Unter- oder MDI-Hauptfenster"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_2
-#: Merge.rc:5530
+#: Merge.rc:5529
 msgid "MDI child window only"
 msgstr "Nur MDI-Unterfenster"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_3
-#: Merge.rc:5531
+#: Merge.rc:5530
 msgid "Close main window if only one MDI child window"
 msgstr "Hauptfenster schließen, wenn nur ein MDI-Unterfenster existiert"
 
 #. IDS_DIFF_GROUP
-#: Merge.rc:5536
+#: Merge.rc:5535
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Diff"
 msgstr "Unterschiede"
 
 #. IDS_DIFF_HIGHLIGHT
-#: Merge.rc:5537
+#: Merge.rc:5536
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Highlight"
 msgstr "Markieren"
 
 #. IDS_DIFF_BLINK
-#: Merge.rc:5538
+#: Merge.rc:5537
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Blink"
 msgstr "Blinken"
 
 #. IDS_DIFF_BLOCKSIZE
-#: Merge.rc:5539
+#: Merge.rc:5538
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Block Size"
 msgstr "Blockgröße"
 
 #. IDS_DIFF_BLOCKALPHA
-#: Merge.rc:5540
+#: Merge.rc:5539
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Block Alpha"
 msgstr "Block Alpha"
 
 #. IDS_DIFF_CDTHRESHOLD
-#: Merge.rc:5541
+#: Merge.rc:5540
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "CD Threshold"
 msgstr "CD Threshold"
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION
-#: Merge.rc:5542
+#: Merge.rc:5541
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Ins/Del Detection"
 msgstr "Einfg/Entf-Erkennung"
 
 #. IDS_OVERLAY_MODE_NONE
-#: Merge.rc:5543 Merge.rc:5548
+#: Merge.rc:5542 Merge.rc:5547
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "None"
 msgstr "Keine"
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION_VERTICAL
-#: Merge.rc:5544
+#: Merge.rc:5543
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Vertical"
 msgstr "Vertikal"
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION_HORIZONTAL
-#: Merge.rc:5545
+#: Merge.rc:5544
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Horizontal"
 msgstr "Horizontal"
 
 #. IDS_OVERLAY_GROUP
-#: Merge.rc:5546
+#: Merge.rc:5545
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Overlay"
 msgstr "Überlagerung"
 
 #. IDS_OVERLAY_ALPHA
-#: Merge.rc:5547
+#: Merge.rc:5546
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha"
 msgstr "Alpha"
 
 #. IDS_OVERLAY_MODE_XOR
-#: Merge.rc:5549
+#: Merge.rc:5548
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "XOR"
 msgstr "XOR"
 
 #. IDS_OVERLAY_MODE_ALPHA
-#: Merge.rc:5550
+#: Merge.rc:5549
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha Blend"
 msgstr "Alpha Blending"
 
 #. IDS_OVERLAY_MODE_ALPHA_ANIMATION
-#: Merge.rc:5551
+#: Merge.rc:5550
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha Animation"
 msgstr "Alpha Animation"
 
 #. IDS_ZOOM
-#: Merge.rc:5552
+#: Merge.rc:5551
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Zoom"
 msgstr "Zoom"
 
 #. IDS_PAGE
-#: Merge.rc:5553
+#: Merge.rc:5552
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Page:"
 msgstr "Seite:"
 
 #. IDS_IMGCMP_STATUS_PT_RGBA_FMT
-#: Merge.rc:5554
+#: Merge.rc:5553
 #, c-format
 msgid "Pt: (%d, %d)  RGBA: (%d, %d, %d, %d)  "
 msgstr "Pt.: (%d, %d)  RGBA: (%d, %d, %d, %d)  "
 
 #. IDS_IMGCMP_STATUS_DIST1_FMT
-#: Merge.rc:5555
+#: Merge.rc:5554
 #, c-format
 msgid "Dist: %g  "
 msgstr "Dist.: %g  "
 
 #. IDS_IMGCMP_STATUS_DIST2_FMT
-#: Merge.rc:5556
+#: Merge.rc:5555
 #, c-format
 msgid "Dist: %g, %g  "
 msgstr "Dist.: %g, %g  "
 
 #. IDS_IMGCMP_STATUS_PAGE_ZOOM_SIZE_BPP_FMT
-#: Merge.rc:5557
+#: Merge.rc:5556
 #, c-format
 msgid "Page: %d/%d  Zoom: %d%%  %dx%dpx  %dbpp  "
 msgstr "Seite: %d/%d  Zoom: %d%%  %dx%dpx  %dbpp  "
 
 #. IDS_IMGCMP_STATUS_RC_FMT
-#: Merge.rc:5558
+#: Merge.rc:5557
 #, c-format
 msgid "Rc: (%d, %d)  "
 msgstr "Re.: (%d, %d)  "
 
 #. IDS_IMGCMP_STATUS_FLIPPED_FMT
-#: Merge.rc:5559
+#: Merge.rc:5558
 #, c-format
 msgid "Flipped: %s  "
 msgstr "Umgedreht: %s  "
 
 #. IDS_IMGCMP_STATUS_ROTATED_FMT
-#: Merge.rc:5560
+#: Merge.rc:5559
 #, c-format
 msgid "Rotated: %d  "
 msgstr "Gedreht: %d  "
 
 #. IDS_IMGCMP_REPORT_ALLPAGES
-#: Merge.rc:5561
+#: Merge.rc:5560
 msgid "All pages"
 msgstr "Alle Seiten"
 
 #. IDS_IGNSUB_STR1
-#: Merge.rc:5566
+#: Merge.rc:5565
 msgid "<Edit here>"
 msgstr "<Hier bearbeiten>"
 
 #. IDS_IGNSUB_STR2
-#: Merge.rc:5567
+#: Merge.rc:5566
 msgid "No differences found to select"
 msgstr "Keine Unterschiede zur Auswahl gefunden"
 
 #. IDS_IGNSUB_STR3
-#: Merge.rc:5568
+#: Merge.rc:5567
 msgid "No differences found to add as substitution filter"
 msgstr "Keine Unterschiede zum Hinzufügen als Ersetzungsfilter gefunden"
 
 #. IDS_IGNSUB_STR4
-#: Merge.rc:5569
+#: Merge.rc:5568
 msgid "The pair is already in the Substitution Filters list"
 msgstr "Das Paar ist bereits in der Ersetzungsfilterliste vorhanden"
 
 #. IDS_IGNSUB_STR5
-#: Merge.rc:5570
+#: Merge.rc:5569
 msgid "Add this change to Substitution Filters?"
 msgstr "Diese Änderung zu den Ersetzungsfiltern hinzufügen?"
 
 #. IDS_OCRRESULT_TEXTONLY
-#: Merge.rc:5575
+#: Merge.rc:5574
 msgid "Text only"
 msgstr "Nur Text"
 
 #. IDS_OCRRESULT_POS_LINE
-#: Merge.rc:5576
+#: Merge.rc:5575
 msgid "Line-by-line position and text"
 msgstr "Position und Text zeilenweise"
 
 #. IDS_OCRRESULT_POS_WORD
-#: Merge.rc:5577
+#: Merge.rc:5576
 msgid "Word-by-word position and text"
 msgstr "Position und Text wortweise"
 
 #. IDS_USERDATAFOLDER_APPDATA
-#: Merge.rc:5582
+#: Merge.rc:5581
 msgid "AppData (Roaming) folder"
 msgstr "AppData-Ordner (Roaming)"
 
 #. IDS_USERDATAFOLDER_INSTALL
-#: Merge.rc:5583
+#: Merge.rc:5582
 msgid "Install folder"
 msgstr "Installationsordner"
 
 #. IDS_USERDATAFOLDER_DOCUMENTS
-#: Merge.rc:5584
+#: Merge.rc:5583
 msgid "Documents folder"
 msgstr "Dokumente-Ordner"
 
 #. IDS_SINGLEINSTANCE_DISABLED
-#: Merge.rc:5589
+#: Merge.rc:5588
 msgctxt "Options dialog|General|Single instance mode"
 msgid "Disabled"
 msgstr "Deaktiviert"
 
 #. IDS_SINGLEINSTANCE_STR1
-#: Merge.rc:5590
+#: Merge.rc:5589
 #, c-format
 msgid "Allow only one instance to run"
 msgstr "Nur eine Instanz zulassen"
 
 #. IDS_CLIPBOARD_HISTORY
-#: Merge.rc:5591
+#: Merge.rc:5590
 msgid "Clipboard &History"
 msgstr "Zwisc&henablageverlauf"
 
 #. IDS_SINGLEINSTANCE_STR2
-#: Merge.rc:5592
+#: Merge.rc:5591
 msgid "Allow only one instance; wait for termination"
 msgstr "Nur eine Instanz zulassen und warten, bis die Instanz beendet ist"
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_DISABLED
-#: Merge.rc:5597
+#: Merge.rc:5596
 msgctxt "Options dialog|General|Auto-reload modified files"
 msgid "Disabled"
 msgstr "Deaktiviert"
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_STR1
-#: Merge.rc:5598
+#: Merge.rc:5597
 msgid "Only on window activated"
 msgstr "Nur bei aktiviertem Fenster"
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_STR2
-#: Merge.rc:5599
+#: Merge.rc:5598
 msgid "Immediately"
 msgstr "Sofort, wenn eine externe Anwendung die angezeigte Datei ändert"
 
 #. IDS_PLUGIN_ALL
-#: Merge.rc:5604
+#: Merge.rc:5603
 msgid "Al&l"
 msgstr "A&lle"
 
 #. IDS_PLUGIN_OTHERS
-#: Merge.rc:5605
+#: Merge.rc:5604
 msgid "&Others"
 msgstr "Andere"
 
-#: Merge.rc:5607
+#: Merge.rc:5606
 #, c-format
 msgid "Missing plugin name in pipeline: %1"
 msgstr "Fehlender Plugin-Name in der Plugin-Pipeline: %1"
 
-#: Merge.rc:5609
+#: Merge.rc:5608
 #, c-format
 msgid "Missing quote in plugin pipeline: %1"
 msgstr "Fehlendes Anführungszeichen in der Plugin-Pipeline: %1"
 
 #. IDS_PLUGIN_NAME_ALREADY_EXISTS
-#: Merge.rc:5610
+#: Merge.rc:5609
 #, c-format
 msgid "Plugin name '%1' already exists."
 msgstr "Der Plug-in Name '%1' existiert bereits."
 
 #. IDS_PLUGIN_TITLE1
-#: Merge.rc:5611
+#: Merge.rc:5610
 msgid "Specify plugin arguments"
 msgstr "Plugin-Argumente angeben"
 
-#: Merge.rc:5613
+#: Merge.rc:5612
 #, c-format
 msgid "Plugin not found or invalid: %1"
 msgstr "Plugin nicht gefunden oder ungültig: %1"
 
 #. IDS_PLUGIN_NOT_UNPACK
-#: Merge.rc:5614
+#: Merge.rc:5613
 #, c-format
 msgid "'%1' is not an unpacker plugin"
 msgstr "'%1' ist kein Entpacker-Plugin"
 
 #. IDS_PLUGIN_NOT_PREDIFF
-#: Merge.rc:5615
+#: Merge.rc:5614
 #, c-format
 msgid "'%1' is not a prediffer plugin"
 msgstr "'%1' ist kein Prediffer-Plugin"
 
-#: Merge.rc:5617
+#: Merge.rc:5616
 #, c-format
 msgid "Error prediffing '%1' with '%2'. Prediffing disabled."
 msgstr "Beim Prediffing der Datei '%1' mit dem Plugin '%2' ist ein Fehler aufgetreten. Das Prediffing wird nicht mehr angewendet."
 
 #. IDS_PLUGIN_CIRCULAR_REFERENCE
-#: Merge.rc:5618
+#: Merge.rc:5617
 #, c-format
 msgid "Circular reference in plugin pipeline: %1"
 msgstr "Zirkuläre Referenz in der Plugin-Pipeline: %1"
 
 #. IDS_PLUGIN_TYPE1
-#: Merge.rc:5619
+#: Merge.rc:5618
 msgid "URL Handler"
 msgstr "URL-Handler"
 
 #. IDS_PLUGIN_TYPE2
-#: Merge.rc:5620
+#: Merge.rc:5619
 msgid "File Unpacker"
 msgstr "Datei Entpacker"
 
 #. IDS_PLUGIN_TYPE3
-#: Merge.rc:5621
+#: Merge.rc:5620
 msgid "File or Folder Unpacker"
 msgstr "Datei oder Ordner Entpacker"
 
 #. IDS_PLUGIN_TYPE5
-#: Merge.rc:5623
+#: Merge.rc:5622
 msgid "Alias for Unpacker"
 msgstr "Alias für den Entpacker"
 
 #. IDS_PLUGIN_TYPE6
-#: Merge.rc:5624
+#: Merge.rc:5623
 msgid "Alias for Prediffer"
 msgstr "Alias für Prediffer"
 
 #. IDS_PLUGIN_TYPE7
-#: Merge.rc:5625
+#: Merge.rc:5624
 msgid "Alias for Editor script"
 msgstr "Alias für Editor-Skript"
 
 #. IDS_PLUGIN_ALIAS_DESC
-#: Merge.rc:5626
+#: Merge.rc:5625
 #, c-format
 msgid "Alias for plugin pipeline '%1'"
 msgstr "Alias für Plugin Pipeline '%1'"
 
 #. IDS_PLUGIN_NEW_DESC
-#: Merge.rc:5627
+#: Merge.rc:5626
 msgid "New plugin description"
 msgstr "Neue Plug-in Beschreibung"
 
 #. IDS_PLUGIN_TARGETS_ALL
-#: Merge.rc:5628
+#: Merge.rc:5627
 msgid "All"
 msgstr "Alle"
 
 #. IDS_PLUGIN_TARGETS_1ST
-#: Merge.rc:5629
+#: Merge.rc:5628
 msgid "1st"
 msgstr "1."
 
 #. IDS_PLUGIN_TARGETS_2ND
-#: Merge.rc:5630
+#: Merge.rc:5629
 msgid "2nd"
 msgstr "2."
 
 #. IDS_PLUGIN_TARGETS_3RD
-#: Merge.rc:5631
+#: Merge.rc:5630
 msgid "3rd"
 msgstr "3."
 
 #. IDS_PLUGIN_TARGETS_1ST_2ND
-#: Merge.rc:5632
+#: Merge.rc:5631
 msgid "1st and 2nd"
 msgstr "1. und 2."
 
 #. IDS_PLUGIN_TARGETS_1ST_3RD
-#: Merge.rc:5633
+#: Merge.rc:5632
 msgid "1st and 3rd"
 msgstr "1. und 3."
 
 #. IDS_PLUGIN_TARGETS_2ND_3RD
-#: Merge.rc:5634
+#: Merge.rc:5633
 msgid "2nd and 3rd"
 msgstr "2. und 3."
 
 #. IDS_PLUGIN_CTRL_CLICK
-#: Merge.rc:5635
+#: Merge.rc:5634
 msgid "(Ctrl+Click to add to pipeline)"
 msgstr "(Strg+Klick, um zur Pipeline hinzuzufügen)"
 
 #. IDS_FILTER_APPLIED
-#: Merge.rc:5640
+#: Merge.rc:5639
 msgid "Filter applied"
 msgstr "Angewandter Filter"
 
 #. IDS_FILTERMENU_COMPARE
-#: Merge.rc:5645
+#: Merge.rc:5644
 #, c-format
 msgid "Compare %1"
 msgstr "Vergleiche %1"
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN2
-#: Merge.rc:5647
+#: Merge.rc:5646
 msgid "&Filter by This Column..."
 msgstr "Nach dieser Spalte &filtern..."
 
 #. IDS_CLIPBOARDHISTORY_TIME
-#: Merge.rc:5652
+#: Merge.rc:5651
 #, c-format
 msgid "Clipboard at %s"
 msgstr "Zwischenablage am %s"
 
 #. IDS_CLIPBOARDHISTORY_DISABLED
-#: Merge.rc:5653
+#: Merge.rc:5652
 msgid ""
 "Clipboard history disabled.\r\n"
 "Enable: Windows logo key + V, then Turn on."
@@ -9165,115 +9159,115 @@ msgstr ""
 "Der Zwischenablageverlauf ist deaktiviert.\r\n"
 "Um den Zwischenablageverlauf zu aktivieren, betätigen Sie 'Windows+V' und klicken dann auf die Schaltfläche 'Einschalten'."
 
-#: Merge.rc:5655
+#: Merge.rc:5654
 msgid "This system does not support clipboard history."
 msgstr "Dieses System unterstützt keinen Zwischenablageverlauf."
 
-#: Merge.rc:5657
+#: Merge.rc:5656
 msgid "32-bit WinMerge does not support Clipboard Compare"
 msgstr "Die 32-Bit-Version von WinMerge unterstützt den Zwischenablagevergleich nicht"
 
 #. IDS_WEBVIEW2_RUNTIME_NOT_INSTALLED
-#: Merge.rc:5662
+#: Merge.rc:5661
 msgid "WebView2 runtime not installed. Download it?"
 msgstr "WebView2-Laufzeitumgebung ist nicht installiert. Möchten Sie sie herunterladen?"
 
 #. IDS_JUMPLIST_NEW_TEXT_COMPARE
-#: Merge.rc:5667
+#: Merge.rc:5666
 msgid "New Text Compare"
 msgstr "Neuer Textvergleich"
 
 #. IDS_JUMPLIST_NEW_TABLE_COMPARE
-#: Merge.rc:5668
+#: Merge.rc:5667
 msgid "New Table Compare"
 msgstr "Neuer Tabellenvergleich"
 
 #. IDS_JUMPLIST_NEW_BINARY_COMPARE
-#: Merge.rc:5669
+#: Merge.rc:5668
 msgid "New Binary Compare"
 msgstr "Neuer Binärvergleich"
 
 #. IDS_JUMPLIST_NEW_IMAGE_COMPARE
-#: Merge.rc:5670
+#: Merge.rc:5669
 msgid "New Image Compare"
 msgstr "Neuer Bildvergleich"
 
 #. IDS_JUMPLIST_NEW_WEBPAGE_COMPARE
-#: Merge.rc:5671
+#: Merge.rc:5670
 msgid "New Webpage Compare"
 msgstr "Neuer Webseitenvergleich"
 
 #. IDS_JUMPLIST_NEW_FOLDER_COMPARE
-#: Merge.rc:5672
+#: Merge.rc:5671
 msgid "New Folder Compare"
 msgstr "Neuer Ordnervergleich"
 
 #. IDS_JUMPLIST_CLIPBOARD_COMPARE
-#: Merge.rc:5673
+#: Merge.rc:5672
 msgid "Clipboard Compare"
 msgstr "Zwischenablage vergleichen"
 
 #. IDS_PREVIEWBAR_PRINT
-#: Merge.rc:5678
+#: Merge.rc:5677
 msgid "&Print..."
 msgstr "&Drucken"
 
 #. IDS_PREVIEWBAR_PREVPAGE
-#: Merge.rc:5680
+#: Merge.rc:5679
 msgid "Pre&v Page"
 msgstr "&Vorige Seite"
 
 #. IDS_PREVIEWBAR_TWOPAGE
-#: Merge.rc:5681
+#: Merge.rc:5680
 msgid "&Two Page"
 msgstr "&Zwei Seiten"
 
 #. IDS_PREVIEWBAR_ONEPAGE
-#: Merge.rc:5682
+#: Merge.rc:5681
 msgid "&One Page"
 msgstr "&Eine Seite"
 
 #. IDS_PREVIEWBAR_ZOOMIN
-#: Merge.rc:5683
+#: Merge.rc:5682
 msgid "Zoom &In"
 msgstr "Here&inzoomen"
 
 #. IDS_PREVIEWBAR_ZOOMOUT
-#: Merge.rc:5684
+#: Merge.rc:5683
 msgid "Zoom &Out"
 msgstr "Hera&uszoomen"
 
 #. IDS_WEBPAGE_COMPARING
-#: Merge.rc:5690
+#: Merge.rc:5689
 msgid "Comparing..."
 msgstr "Vergleichen..."
 
 #. IDS_WEBPAGE_ZOOM
-#: Merge.rc:5691
+#: Merge.rc:5690
 msgid "Zoom:"
 msgstr "Zoom:"
 
 #. IDS_COPY_GRANULARITY_DIFFHUNK
-#: Merge.rc:5696
+#: Merge.rc:5695
 msgid "Diff hunk"
 msgstr "Diff-Hunk"
 
 #. IDS_COPY_GRANULARITY_INLINE
-#: Merge.rc:5697
+#: Merge.rc:5696
 msgid "Inline diff"
 msgstr "Zeilenuntersciede"
 
 #. IDS_COPY_GRANULARITY_LINE
-#: Merge.rc:5698
+#: Merge.rc:5697
 msgid "Line"
 msgstr "Zeile"
 
-#: Merge.rc:5699
+#: Merge.rc:5698
 msgid "Character"
 msgstr "Zeichen"
 
 #. ID_MICE_PREVDIFF
-#: Merge.rc:5704
+#: Merge.rc:5703
 msgid ""
 "\n"
 "Previous Difference (Alt+Up)\n"
@@ -9286,7 +9280,7 @@ msgstr ""
 "(Alt+Mausrad Hoch)"
 
 #. ID_MICE_NEXTDIFF
-#: Merge.rc:5705
+#: Merge.rc:5704
 msgid ""
 "\n"
 "Next Difference (Alt+Down)\n"
@@ -9299,7 +9293,7 @@ msgstr ""
 "(Alt+Mausrad Runter)"
 
 #. ID_MICE_L2R
-#: Merge.rc:5706
+#: Merge.rc:5705
 msgid ""
 "\n"
 "Copy to Right (Alt+Right)\n"
@@ -9314,7 +9308,7 @@ msgstr ""
 "(Alt+Umschalt+Mausrad Runter)"
 
 #. ID_MICE_R2L
-#: Merge.rc:5707
+#: Merge.rc:5706
 msgid ""
 "\n"
 "Copy to Left (Alt+Left)\n"
@@ -9329,7 +9323,7 @@ msgstr ""
 "(Alt+Umschalt+Mausrad Hoch)"
 
 #. ID_MICE_L2RNEXT
-#: Merge.rc:5708
+#: Merge.rc:5707
 msgid ""
 "\n"
 "Copy to Right and Advance (Ctrl+Alt+Right)\n"
@@ -9342,7 +9336,7 @@ msgstr ""
 "(Strg+Alt+Umschalt+Mausrad Runter)"
 
 #. ID_MICE_R2LNEXT
-#: Merge.rc:5709
+#: Merge.rc:5708
 msgid ""
 "\n"
 "Copy to Left and Advance (Ctrl+Alt+Left)\n"
@@ -9355,257 +9349,257 @@ msgstr ""
 "(Strg+Alt+Umschalt+Mausrad Hoch)"
 
 #. IDS_LOG_COMPARING_2
-#: Merge.rc:5719
+#: Merge.rc:5718
 #, c-format
 msgid "Comparing %1 with %2"
 msgstr "Vergleich von %1 mit %2"
 
 #. IDS_LOG_COMPARING_3
-#: Merge.rc:5720
+#: Merge.rc:5719
 #, c-format
 msgid "Comparing %1 with %2 and %3"
 msgstr "Vergleich von %1 mit %2 und %3"
 
 #. IDS_LOG_COMPARE_COMPLETED
-#: Merge.rc:5721
+#: Merge.rc:5720
 msgid "Comparison completed"
 msgstr "Vergleich abgeschlossen"
 
 #. IDS_LOG_COMPARE_ERROR_2
-#: Merge.rc:5722
+#: Merge.rc:5721
 #, c-format
 msgid "Failed to compare %1 with %2: "
 msgstr "Der Vergleich von %1 mit %2 ist fehlgeschlagen:"
 
 #. IDS_LOG_COMPARE_ERROR_3
-#: Merge.rc:5723
+#: Merge.rc:5722
 #, c-format
 msgid "Failed to compare %1 with %2 and %3: "
 msgstr "Der Vergleich von %1 mit %2 und %3 ist fehlgeschlagen:"
 
 #. IDS_LOG_FILE_SAVED
-#: Merge.rc:5724
+#: Merge.rc:5723
 msgid "File saved"
 msgstr "Datei gespeichert"
 
 #. IDS_LOG_COPYING_FILES
-#: Merge.rc:5725
+#: Merge.rc:5724
 msgid "Copying files..."
 msgstr "Dateien werden kopiert..."
 
 #. IDS_LOG_MOVING_FILES
-#: Merge.rc:5726
+#: Merge.rc:5725
 msgid "Moving files..."
 msgstr "Dateien werden verschoben ..."
 
 #. IDS_LOG_DELETING_FILES
-#: Merge.rc:5727
+#: Merge.rc:5726
 msgid "Deleting files..."
 msgstr "Dateien werden gelöscht..."
 
 #. IDS_LOG_RECYCLEBIN
-#: Merge.rc:5728
+#: Merge.rc:5727
 msgid "Recycle Bin"
 msgstr "Papierkorb"
 
 #. IDS_LOG_PERMANENTLY_DELETED
-#: Merge.rc:5729
+#: Merge.rc:5728
 msgid "Permanently deleted"
 msgstr "Dauerhaft gelöscht"
 
 #. IDS_LOG_FILEOPERATION_COMPLETED
-#: Merge.rc:5730
+#: Merge.rc:5729
 msgid "File operation completed successfully"
 msgstr "Dateioperation erfolgreich abgeschlossen"
 
 #. IDS_LOG_FILEOPERATION_CANCELED
-#: Merge.rc:5731
+#: Merge.rc:5730
 msgid "File operation canceled"
 msgstr "Dateioperation abgebrochen"
 
 #. IDS_FILTER_ERROR_NO_ERROR
-#: Merge.rc:5736
+#: Merge.rc:5735
 msgid "No error"
 msgstr "Kein Fehler"
 
 #. IDS_FILTER_ERROR_EMPTY_EXPRESSION
-#: Merge.rc:5737
+#: Merge.rc:5736
 msgid "Filter expression is empty"
 msgstr "Filterausdruck ist leer"
 
 #. IDS_FILTER_ERROR_UNKNOWN_CHAR
-#: Merge.rc:5738
+#: Merge.rc:5737
 msgid "Unknown character in filter expression"
 msgstr "Unbekanntes Zeichen im Filterausdruck"
 
 #. IDS_FILTER_ERROR_UNTERMINATED_STRING
-#: Merge.rc:5739
+#: Merge.rc:5738
 msgid "Unterminated string literal"
 msgstr "Zeichenfolgenliteral ohne Ende"
 
 #. IDS_FILTER_ERROR_SYNTAX_ERROR
-#: Merge.rc:5740
+#: Merge.rc:5739
 msgid "Syntax error in filter expression"
 msgstr "Syntaxfehler im Filterausdruck"
 
 #. IDS_FILTER_ERROR_PARSE_FAILURE
-#: Merge.rc:5741
+#: Merge.rc:5740
 msgid "Failed to parse filter expression"
 msgstr "Filterausdruck konnte nicht geparst werden"
 
 #. IDS_FILTER_ERROR_INVALID_LITERAL
-#: Merge.rc:5742
+#: Merge.rc:5741
 msgid "Invalid literal value"
 msgstr "Ungültiger literaler Wert"
 
 #. IDS_FILTER_ERROR_INVALID_REGULAR_EXPRESSION
-#: Merge.rc:5743
+#: Merge.rc:5742
 msgid "Invalid regular expression"
 msgstr "Ungültiger regulärer Ausdruck"
 
 #. IDS_FILTER_ERROR_UNDEFINED_IDENTIFIER
-#: Merge.rc:5744
+#: Merge.rc:5743
 msgid "Undefined identifier"
 msgstr "Undefinierter Bezeichner"
 
 #. IDS_FILTER_ERROR_INVALID_ARGUMENT_COUNT
-#: Merge.rc:5745
+#: Merge.rc:5744
 msgid "Invalid number of arguments"
 msgstr "Ungültige Anzahl von Argumenten"
 
 #. IDS_FILTER_ERROR_FILTER_NAME_NOT_FOUND
-#: Merge.rc:5746
+#: Merge.rc:5745
 msgid "Filter name not found"
 msgstr "Filtername nicht gefunden"
 
 #. IDS_FILTER_ERROR_DIVIDE_BY_ZERO
-#: Merge.rc:5747
+#: Merge.rc:5746
 msgid "Division by zero in filter expression"
 msgstr "Division durch Null im Filterausdruck"
 
 #. IDS_FILTER_ERROR_UNKNOWN_ERROR
-#: Merge.rc:5748
+#: Merge.rc:5747
 msgid "Unknown error"
 msgstr "Unbekannter Fehler"
 
 #. IDS_FILTER_ERROR_INVALID_PROPERTY_NAME
-#: Merge.rc:5749
+#: Merge.rc:5748
 msgid "Invalid property name"
 msgstr "Ungültiger Eigenschaftsname"
 
 #. IDS_FILTER_ERROR_INVALID_DIRECTIVE
-#: Merge.rc:5750
+#: Merge.rc:5749
 msgid "Invalid directive"
 msgstr "Ungültige Anweisung"
 
 #. IDS_FILTER_OP_EQUALS
-#: Merge.rc:5755
+#: Merge.rc:5754
 msgid "Equals"
 msgstr "Ist gleich"
 
 #. IDS_FILTER_OP_NOT_EQUALS
-#: Merge.rc:5756
+#: Merge.rc:5755
 msgid "Does not equal"
 msgstr "Ist nicht gleich"
 
 #. IDS_FILTER_OP_LESS_THAN
-#: Merge.rc:5757
+#: Merge.rc:5756
 msgid "Less than"
 msgstr "Weniger als"
 
 #. IDS_FILTER_OP_LESS_EQUAL
-#: Merge.rc:5758
+#: Merge.rc:5757
 msgid "Less than or equal to"
 msgstr "Kleiner oder gleich"
 
 #. IDS_FILTER_OP_GREATER_EQUAL
-#: Merge.rc:5759
+#: Merge.rc:5758
 msgid "Greater than or equal to"
 msgstr "Größer oder gleich"
 
 #. IDS_FILTER_OP_GREATER_THAN
-#: Merge.rc:5760
+#: Merge.rc:5759
 msgid "Greater than"
 msgstr "Größer als"
 
 #. IDS_FILTER_OP_BETWEEN
-#: Merge.rc:5761
+#: Merge.rc:5760
 msgid "Between"
 msgstr "Zwischen"
 
 #. IDS_FILTER_OP_NOT_BETWEEN
-#: Merge.rc:5762
+#: Merge.rc:5761
 msgid "Not Between"
 msgstr "Nicht zwischen"
 
 #. IDS_FILTER_OP_CONTAINS
-#: Merge.rc:5763
+#: Merge.rc:5762
 msgid "Contains"
 msgstr "Enthält"
 
 #. IDS_FILTER_OP_NOT_CONTAINS
-#: Merge.rc:5764
+#: Merge.rc:5763
 msgid "Not Contains"
 msgstr "Enthält nicht"
 
 #. IDS_FILTER_OP_RECONTAINS
-#: Merge.rc:5765
+#: Merge.rc:5764
 msgid "Contains (regex)"
 msgstr "Enthält (Regex)"
 
 #. IDS_FILTER_OP_NOT_RECONTAINS
-#: Merge.rc:5766
+#: Merge.rc:5765
 msgid "Not Contains (regex)"
 msgstr "Enthält nicht (Regex)"
 
 #. IDS_FILTER_OP_LIKE
-#: Merge.rc:5767
+#: Merge.rc:5766
 msgid "Match (wildcard)"
 msgstr "Entspricht (Platzhalter)"
 
 #. IDS_FILTER_OP_NOT_LIKE
-#: Merge.rc:5768
+#: Merge.rc:5767
 msgid "Not match (wildcard)"
 msgstr "Entspricht nicht (Platzhalter)"
 
 #. IDS_FILTER_OP_MATCHES
-#: Merge.rc:5769
+#: Merge.rc:5768
 msgid "Match (regex)"
 msgstr "Entspricht (Regex)"
 
 #. IDS_FILTER_OP_NOT_MATCHES
-#: Merge.rc:5770
+#: Merge.rc:5769
 msgid "Not match (regex)"
 msgstr "Entspricht nicht (Regex)"
 
 #. IDS_COLORMODE_LIGHT
-#: Merge.rc:5775
+#: Merge.rc:5774
 msgid "Light"
 msgstr "Hell"
 
 #. IDS_COLORMODE_DARK
-#: Merge.rc:5776
+#: Merge.rc:5775
 msgid "Dark"
 msgstr "Dunkel"
 
 #. IDS_COLORMODE_FOLLOWSYSTEM
-#: Merge.rc:5777
+#: Merge.rc:5776
 msgid "Follow system"
 msgstr "Systemeinstellung verwenden"
 
 #. IDS_EXAMPLE
-#: Merge.rc:5782
+#: Merge.rc:5781
 #, c-format
 msgid "e.g. %1"
 msgstr "z. B. %1"
 
 #. IDS_DETECTED_PREVIOUS_CRASH
-#: Merge.rc:5787
+#: Merge.rc:5786
 msgid "WinMerge detected a previous crash. Please report this if possible."
 msgstr "WinMerge hat einen vorherigen Absturz festgestellt. Bitte melden Sie ihn, wenn möglich."
 
 #. IDS_REGEX_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5792
+#: Merge.rc:5791
 msgid ""
 "# Regex replacement list\r\n"
 "# Format: regex<TAB>replacement\r\n"
@@ -9620,7 +9614,7 @@ msgstr ""
 "(\\d{4})-(\\d{2})-(\\d{2})\t$1_$2_$3\r\n"
 
 #. IDS_STRING_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5793
+#: Merge.rc:5792
 msgid ""
 "# Replacement list\r\n"
 "# Format: search<TAB>replacement\r\n"
@@ -9637,22 +9631,22 @@ msgstr ""
 "von2\tzu2\r\n"
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_ONLY
-#: Merge.rc:5798
+#: Merge.rc:5797
 msgid "Built-in only"
 msgstr "Nur integrierte"
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_FIRST
-#: Merge.rc:5799
+#: Merge.rc:5798
 msgid "Built-in first"
 msgstr "Integrierte zuerst"
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_FIRST
-#: Merge.rc:5800
+#: Merge.rc:5799
 msgid "Tree-sitter first"
 msgstr "Tree-sitter zuerst"
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_ONLY
-#: Merge.rc:5801
+#: Merge.rc:5800
 msgid "Tree-sitter only"
 msgstr "Nur Tree-sitter"
 

--- a/Translations/WinMerge/Greek.po
+++ b/Translations/WinMerge/Greek.po
@@ -20,7 +20,7 @@ msgstr ""
 "X-Poedit-Basepath: ../../Src/\n"
 
 #. LANGUAGE, SUBLANGUAGE
-#: Merge.rc:26 Merge.rc:59 Merge.rc:5818
+#: Merge.rc:26 Merge.rc:59 Merge.rc:5817
 #, c-format
 msgid "LANG_ENGLISH, SUBLANG_ENGLISH_US"
 msgstr "LANG_GREEK, SUBLANG_DEFAULT"
@@ -170,7 +170,7 @@ msgstr "Μακ&ροεντολές"
 #. IDS_NO_EDIT_SCRIPTS
 #: Merge.rc:127 Merge.rc:352 Merge.rc:463 Merge.rc:673 Merge.rc:678
 #: Merge.rc:887 Merge.rc:899 Merge.rc:906 Merge.rc:963 Merge.rc:1210
-#: Merge.rc:5375
+#: Merge.rc:5374
 #, c-format
 msgid "< Empty >"
 msgstr "< Άδειο >"
@@ -237,7 +237,7 @@ msgid "Auto-Fit All Columns"
 msgstr ""
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN
-#: Merge.rc:153 Merge.rc:5646
+#: Merge.rc:153 Merge.rc:5645
 msgid "&Filter by This Column"
 msgstr ""
 
@@ -303,7 +303,7 @@ msgid "&Previous Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_NEXTPAGE
-#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5679
+#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5678
 #, c-format
 msgid "&Next Page"
 msgstr ""
@@ -571,7 +571,7 @@ msgstr ""
 #. IDS_IMAGE_MENU
 #: Merge.rc:329 Merge.rc:338 Merge.rc:432 Merge.rc:441 Merge.rc:609
 #: Merge.rc:618 Merge.rc:670 Merge.rc:960 Merge.rc:1187 Merge.rc:1200
-#: Merge.rc:5477
+#: Merge.rc:5476
 #, c-format
 msgid "&Image"
 msgstr ""
@@ -709,7 +709,7 @@ msgid "&Huge"
 msgstr ""
 
 #. IDS_VIEW_MENU_BAR
-#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5714
+#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5713
 msgid "Men&u Bar"
 msgstr ""
 
@@ -1472,7 +1472,7 @@ msgid "Lo&cation Pane"
 msgstr "Πεδίο &Εντοπισμού"
 
 #. IDS_OUTPUTBAR_CAPTION
-#: Merge.rc:782 Merge.rc:5252
+#: Merge.rc:782 Merge.rc:5251
 msgid "Output Pane"
 msgstr ""
 
@@ -1768,55 +1768,55 @@ msgid "Co&mpare As"
 msgstr ""
 
 #. IDS_COPY_LEFT_TO_MIDDLE2
-#: Merge.rc:968 Merge.rc:980 Merge.rc:4852
+#: Merge.rc:968 Merge.rc:980 Merge.rc:4851
 #, c-format
 msgid "Left to Middle (%1 of %2)"
 msgstr ""
 
 #. IDS_COPY_LEFT_TO_RIGHT2
-#: Merge.rc:969 Merge.rc:981 Merge.rc:4851
+#: Merge.rc:969 Merge.rc:981 Merge.rc:4850
 #, c-format
 msgid "Left to Right (%1 of %2)"
 msgstr "Αριστερό στο Δεξιό (%1 από %2)"
 
 #. IDS_MOVE_LEFT_TO2
-#: Merge.rc:970 Merge.rc:982 Merge.rc:1045 Merge.rc:4863 Merge.rc:4892
+#: Merge.rc:970 Merge.rc:982 Merge.rc:1045 Merge.rc:4862 Merge.rc:4891
 #, c-format
 msgid "Left to... (%1 of %2)"
 msgstr "Αριστερό στο... (%1 από %2)"
 
 #. IDS_COPY_MIDDLE_TO_LEFT2
-#: Merge.rc:971 Merge.rc:983 Merge.rc:4849
+#: Merge.rc:971 Merge.rc:983 Merge.rc:4848
 #, c-format
 msgid "Middle to Left (%1 of %2)"
 msgstr ""
 
 #. IDS_COPY_MIDDLE_TO_RIGHT2
-#: Merge.rc:972 Merge.rc:984 Merge.rc:4850
+#: Merge.rc:972 Merge.rc:984 Merge.rc:4849
 #, c-format
 msgid "Middle to Right (%1 of %2)"
 msgstr ""
 
 #. IDS_MOVE_MIDDLE_TO2
-#: Merge.rc:973 Merge.rc:985 Merge.rc:1046 Merge.rc:4864 Merge.rc:4893
+#: Merge.rc:973 Merge.rc:985 Merge.rc:1046 Merge.rc:4863 Merge.rc:4892
 #, c-format
 msgid "Middle to... (%1 of %2)"
 msgstr ""
 
 #. IDS_COPY_RIGHT_TO_MIDDLE2
-#: Merge.rc:974 Merge.rc:986 Merge.rc:4848
+#: Merge.rc:974 Merge.rc:986 Merge.rc:4847
 #, c-format
 msgid "Right to Middle (%1 of %2)"
 msgstr ""
 
 #. IDS_COPY_RIGHT_TO_LEFT2
-#: Merge.rc:975 Merge.rc:987 Merge.rc:4847
+#: Merge.rc:975 Merge.rc:987 Merge.rc:4846
 #, c-format
 msgid "Right to Left (%1 of %2)"
 msgstr "Δεξιό στο Αριστερό (%1 από %2)"
 
 #. IDS_MOVE_RIGHT_TO2
-#: Merge.rc:976 Merge.rc:988 Merge.rc:1047 Merge.rc:4865 Merge.rc:4894
+#: Merge.rc:976 Merge.rc:988 Merge.rc:1047 Merge.rc:4864 Merge.rc:4893
 #, c-format
 msgid "Right to... (%1 of %2)"
 msgstr "Δεξιό στο... (%1 από %2)"
@@ -1882,31 +1882,31 @@ msgid "Cop&y Paths"
 msgstr "Αντιγραφή Δια&δρομών"
 
 #. IDS_DEL_LEFT_FMT2
-#: Merge.rc:1026 Merge.rc:1035 Merge.rc:4880
+#: Merge.rc:1026 Merge.rc:1035 Merge.rc:4879
 #, c-format
 msgid "Left (%1 of %2)"
 msgstr "Αριστερό (%1 από %2)"
 
 #. IDS_DEL_MIDDLE_FMT2
-#: Merge.rc:1027 Merge.rc:1036 Merge.rc:4881
+#: Merge.rc:1027 Merge.rc:1036 Merge.rc:4880
 #, c-format
 msgid "Middle (%1 of %2)"
 msgstr ""
 
 #. IDS_DEL_RIGHT_FMT2
-#: Merge.rc:1028 Merge.rc:1037 Merge.rc:4882
+#: Merge.rc:1028 Merge.rc:1037 Merge.rc:4881
 #, c-format
 msgid "Right (%1 of %2)"
 msgstr "Δεξιό (%1 από %2)"
 
 #. IDS_DEL_BOTH_FMT2
-#: Merge.rc:1029 Merge.rc:1038 Merge.rc:4883
+#: Merge.rc:1029 Merge.rc:1038 Merge.rc:4882
 #, c-format
 msgid "Both (%1 of %2)"
 msgstr "Αμφότερα (%1από %2)"
 
 #. IDS_DEL_ALL_FMT2
-#: Merge.rc:1030 Merge.rc:1039 Merge.rc:4888
+#: Merge.rc:1030 Merge.rc:1039 Merge.rc:4887
 #, c-format
 msgid "All (%1 of %2)"
 msgstr ""
@@ -1935,19 +1935,19 @@ msgid "&Zip"
 msgstr ""
 
 #. IDS_COPY_BOTH_TO2
-#: Merge.rc:1048 Merge.rc:4866
+#: Merge.rc:1048 Merge.rc:4865
 #, c-format
 msgid "Both to... (%1 of %2)"
 msgstr ""
 
 #. IDS_COPY_ALL_TO2
-#: Merge.rc:1049 Merge.rc:4867
+#: Merge.rc:1049 Merge.rc:4866
 #, c-format
 msgid "All to... (%1 of %2)"
 msgstr ""
 
 #. IDS_COPY_DIFFERENCES_TO2
-#: Merge.rc:1050 Merge.rc:4868
+#: Merge.rc:1050 Merge.rc:4867
 #, c-format
 msgid "Differences to... (%1 of %2)"
 msgstr ""
@@ -2020,13 +2020,13 @@ msgstr ""
 
 #. IDS_USERCHOICE_NONE
 #: Merge.rc:1088 Merge.rc:1094 Merge.rc:1836 Merge.rc:1840 Merge.rc:2031
-#: Merge.rc:2035 Merge.rc:5377
+#: Merge.rc:2035 Merge.rc:5376
 #, c-format
 msgid "<None>"
 msgstr "<Ουδέν>"
 
 #. IDS_USERCHOICE_AUTOMATIC
-#: Merge.rc:1089 Merge.rc:1095 Merge.rc:5378
+#: Merge.rc:1089 Merge.rc:1095 Merge.rc:5377
 #, c-format
 msgid "<Automatic>"
 msgstr "<Αυτόματο>"
@@ -2978,13 +2978,13 @@ msgid "Text files only"
 msgstr ""
 
 #. IDS_EOL_NONE
-#: Merge.rc:1667 Merge.rc:1918 Merge.rc:5304
+#: Merge.rc:1667 Merge.rc:1918 Merge.rc:5303
 #, c-format
 msgid "None"
 msgstr "Χωρίς"
 
 #. IDS_EOL_MIXED
-#: Merge.rc:1668 Merge.rc:5299
+#: Merge.rc:1668 Merge.rc:5298
 #, c-format
 msgid "Mixed"
 msgstr "Μικτό"
@@ -3258,14 +3258,14 @@ msgstr ""
 
 #. IDS_DIFFERENT
 #: Merge.rc:1904 Merge.rc:1988 Merge.rc:2866 Merge.rc:3036 Merge.rc:3077
-#: Merge.rc:5058
+#: Merge.rc:5057
 #, c-format
 msgid "Different"
 msgstr "Διαφορετικά"
 
 #. IDS_IDENTICAL
 #: Merge.rc:1905 Merge.rc:1989 Merge.rc:2865 Merge.rc:3055 Merge.rc:3116
-#: Merge.rc:5048
+#: Merge.rc:5047
 #, c-format
 msgid "Identical"
 msgstr "Πανομοιότυπα"
@@ -3286,7 +3286,7 @@ msgid "Missing"
 msgstr ""
 
 #. IDS_MOVED
-#: Merge.rc:1910 Merge.rc:5076
+#: Merge.rc:1910 Merge.rc:5075
 msgid "Moved"
 msgstr ""
 
@@ -4114,7 +4114,7 @@ msgid "&Use custom system colors"
 msgstr ""
 
 #. IDS_PRPCAT_SYSTEM
-#: Merge.rc:2565 Merge.rc:4559 Merge.rc:4560 Merge.rc:5007
+#: Merge.rc:2565 Merge.rc:4559 Merge.rc:4560 Merge.rc:5006
 #, c-format
 msgid "System"
 msgstr "Σύστημα"
@@ -4565,7 +4565,7 @@ msgid "Items compared:"
 msgstr "Συγκριθέντα αντικείμενα:"
 
 #. IDS_PREVIEWBAR_CLOSE
-#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5685
+#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5684
 #, c-format
 msgid "&Close"
 msgstr "Κ&λείσιμο"
@@ -5250,7 +5250,7 @@ msgid "A&ppend timestamp"
 msgstr "Προσθήκη &ημερομηνίας κ΄ ώρας"
 
 #. IDS_CONFIRM_COPY_CAPTION
-#: Merge.rc:3214 Merge.rc:4915
+#: Merge.rc:3214 Merge.rc:4914
 #, c-format
 msgid "Confirm Copy"
 msgstr "Επιβεβαίωση Αντιγραφής"
@@ -5511,7 +5511,7 @@ msgid "&Character Set..."
 msgstr ""
 
 #. IDS_PRPCAT_IMAGE
-#: Merge.rc:3351 Merge.rc:4574 Merge.rc:5015
+#: Merge.rc:3351 Merge.rc:4574 Merge.rc:5014
 msgid "Image"
 msgstr ""
 
@@ -5915,7 +5915,7 @@ msgid "Project"
 msgstr ""
 
 #. IDS_COLHDR_NSDIFFS
-#: Merge.rc:4566 Merge.rc:4990
+#: Merge.rc:4566 Merge.rc:4989
 #, c-format
 msgid "Differences"
 msgstr "Διαφορές"
@@ -6075,13 +6075,13 @@ msgid "File Type"
 msgstr ""
 
 #. IDS_COLHDR_EXTENSION
-#: Merge.rc:4653 Merge.rc:4947
+#: Merge.rc:4653 Merge.rc:4946
 #, c-format
 msgid "Extension"
 msgstr "Επέκταση"
 
 #. IDS_PRPCAT_MESSAGE
-#: Merge.rc:4659 Merge.rc:5019
+#: Merge.rc:4659 Merge.rc:5018
 msgid "Message"
 msgstr ""
 
@@ -6121,7 +6121,7 @@ msgid "Hidden Items"
 msgstr ""
 
 #. IDS_PLUGINSLIST_NAME
-#: Merge.rc:4680 Merge.rc:5311
+#: Merge.rc:4680 Merge.rc:5310
 #, c-format
 msgid "Name"
 msgstr "Όνομα"
@@ -6145,7 +6145,7 @@ msgid "[F] "
 msgstr ""
 
 #. IDS_PLUGINSLIST_DESC
-#: Merge.rc:4684 Merge.rc:5313
+#: Merge.rc:4684 Merge.rc:5312
 #, c-format
 msgid "Description"
 msgstr "Περιγραφή"
@@ -6314,171 +6314,165 @@ msgstr ""
 msgid "  Sel: %d | %d"
 msgstr ""
 
-#. IDS_MERGEMODE_MERGING
-#: Merge.rc:4734
-#, c-format
-msgid "Merge"
-msgstr "Συγχώνευση"
-
 #. IDS_DIFF_NUMBER_STATUS_FMT
-#: Merge.rc:4735
+#: Merge.rc:4734
 #, c-format
 msgid "Difference %1 of %2"
 msgstr "Διαφορά %1 από %2"
 
 #. IDS_NO_DIFF_SEL_FMT
-#: Merge.rc:4736
+#: Merge.rc:4735
 #, c-format
 msgid "%1 Differences Found"
 msgstr "%1 Διαφορές βρέθηκαν"
 
 #. IDS_1_DIFF_FOUND
-#: Merge.rc:4737
+#: Merge.rc:4736
 #, c-format
 msgid "1 Difference Found"
 msgstr "1 Διαφορά βρέθηκε"
 
 #. IDS_NO_ERR_SEL_FMT
-#: Merge.rc:4738
+#: Merge.rc:4737
 #, c-format
 msgid "%1 Errors Found"
 msgstr ""
 
 #. IDS_1_ERR_FOUND
-#: Merge.rc:4739
+#: Merge.rc:4738
 msgid "1 Error Found"
 msgstr ""
 
 #. IDS_STATUSBAR_READONLY, Abbreviation from "Read Only"
-#: Merge.rc:4740
+#: Merge.rc:4739
 #, c-format
 msgid "RO"
 msgstr "ΜγΑ"
 
 #. IDS_DIRVIEW_STATUS_FMT_FOCUS
-#: Merge.rc:4746
+#: Merge.rc:4745
 #, c-format
 msgid "Item %1 of %2"
 msgstr "Αντικείμενο %1 από %2"
 
 #. IDS_DIRVIEW_STATUS_FMT_NOFOCUS
-#: Merge.rc:4747
+#: Merge.rc:4746
 #, c-format
 msgid "Items: %1"
 msgstr "Αντικείμενα: %1"
 
 #. IDS_DIRVIEW_STATUS_COMPARING
-#: Merge.rc:4748
+#: Merge.rc:4747
 #, c-format
 msgid "Comparing items..."
 msgstr "Σύγκριση αντικειμένων..."
 
 #. IDS_ITEMS_PER_SEC
-#: Merge.rc:4749
+#: Merge.rc:4748
 #, c-format
 msgid "%.1f[items/sec]"
 msgstr ""
 
 #. IDS_ERROR_INCOMPARABLE
-#: Merge.rc:4755
+#: Merge.rc:4754
 msgid "Select two existing folders/files to compare."
 msgstr "Επιλέξατε δύο υπάρχοντες φακέλους ή αρχεία προς σύγκριση."
 
 #. IDS_DIRSEL_TAG
-#: Merge.rc:4756
+#: Merge.rc:4755
 #, c-format
 msgid "Folder Selection"
 msgstr "Επιλογή Φακέλων"
 
 #. IDS_OPEN_FILESDIRS
-#: Merge.rc:4757
+#: Merge.rc:4756
 #, c-format
 msgid "Select two (or three) folders/files to compare."
 msgstr ""
 
 #. IDS_OPEN_LEFTINVALID
-#: Merge.rc:4758
+#: Merge.rc:4757
 #, c-format
 msgid "Left (1st) path is invalid!"
 msgstr ""
 
 #. IDS_OPEN_MIDDLEINVALID
-#: Merge.rc:4759
+#: Merge.rc:4758
 #, c-format
 msgid "Middle (2nd) path is invalid!"
 msgstr ""
 
 #. IDS_OPEN_RIGHTINVALID2
-#: Merge.rc:4760
+#: Merge.rc:4759
 #, c-format
 msgid "Right (2nd) path is invalid!"
 msgstr ""
 
 #. IDS_OPEN_RIGHTINVALID3
-#: Merge.rc:4761
+#: Merge.rc:4760
 #, c-format
 msgid "Right (3rd) path is invalid!"
 msgstr ""
 
 #. IDS_OPEN_BOTHINVALID
-#: Merge.rc:4762
+#: Merge.rc:4761
 #, c-format
 msgid "Both paths are invalid!"
 msgstr "Σφάλμα σε αμφότερες τις διαδρομές!"
 
-#: Merge.rc:4764
+#: Merge.rc:4763
 #, c-format
 msgid "Left (1st) and Middle (2nd) paths are invalid!"
 msgstr ""
 
 #. IDS_OPEN_LEFTRIGHTINVALID
-#: Merge.rc:4765
+#: Merge.rc:4764
 #, c-format
 msgid "Left (1st) and Right (3rd) paths are invalid!"
 msgstr ""
 
-#: Merge.rc:4767
+#: Merge.rc:4766
 #, c-format
 msgid "Middle (2nd) and Right (3rd) paths are invalid!"
 msgstr ""
 
 #. IDS_OPEN_ALLINVALID
-#: Merge.rc:4768
+#: Merge.rc:4767
 #, c-format
 msgid "All paths are invalid!"
 msgstr ""
 
 #. IDS_OPEN_UNPACKERDISABLED
-#: Merge.rc:4769
+#: Merge.rc:4768
 msgid "Only enabled for file comparisons"
 msgstr ""
 
 #. IDS_OPEN_MISMATCH
-#: Merge.rc:4770
+#: Merge.rc:4769
 #, c-format
 msgid "Cannot compare file and folder!"
 msgstr "Η σύγκριση αρχείου και φακέλου δεν είναι δυνατή!"
 
 #. IDS_ERROR_FILE_NOT_FOUND
-#: Merge.rc:4776
+#: Merge.rc:4775
 #, c-format
 msgid "File not found: %1"
 msgstr "Το αρχείο δε βρέθηκε: %1"
 
 #. IDS_ERROR_FOLDER_NOT_FOUND
-#: Merge.rc:4777
+#: Merge.rc:4776
 #, c-format
 msgid "Folder not found: %1"
 msgstr ""
 
 #. IDS_ERROR_FILE_NOT_UNPACKED
-#: Merge.rc:4778
+#: Merge.rc:4777
 #, c-format
 msgid "File not unpacked: %1"
 msgstr "Το αρχείο δεν αποσυμπιέσθηκε: %1"
 
 #. IDS_ERROR_FILEOPEN
-#: Merge.rc:4779
+#: Merge.rc:4778
 #, c-format
 msgid ""
 "Cannot open file\n"
@@ -6492,13 +6486,13 @@ msgstr ""
 "%2"
 
 #. IDS_ERROR_CONF_RESOLVE
-#: Merge.rc:4780
+#: Merge.rc:4779
 #, c-format
 msgid "Failed to parse conflict file."
 msgstr "Αποτυχία αναλύσεως αρχείου διενέξεων."
 
 #. IDS_NOT_CONFLICT_FILE
-#: Merge.rc:4781
+#: Merge.rc:4780
 #, c-format
 msgid "The file\n%1\nis not a conflict file."
 msgstr ""
@@ -6507,35 +6501,35 @@ msgstr ""
 "δεν είναι αρχείο διενέξεων."
 
 #. IDS_COMPARE_LARGE_FILES
-#: Merge.rc:4782
+#: Merge.rc:4781
 msgid "Comparing large files requires significant memory.\nShow only comparison results (not file contents)?"
 msgstr ""
 
 #. IDS_SAVE_AS_TITLE
-#: Merge.rc:4788
+#: Merge.rc:4787
 #, c-format
 msgid "Save As"
 msgstr "Αποθήκευση Ως"
 
 #. IDS_SAVE_FMT
-#: Merge.rc:4789
+#: Merge.rc:4788
 #, c-format
 msgid "Save changes to %1?"
 msgstr "Αποθήκευση μεταβολών στο %1;"
 
 #. IDS_SAVEREADONLY_FMT
-#: Merge.rc:4790
+#: Merge.rc:4789
 #, c-format
 msgid "%1 is read-only. Override? Or 'No' to save as new filename?"
 msgstr "Το %1 έχει την ιδιότητα \"Μόνο για Ανάγνωση\". Θα θέλατε να αντικαταστήσετε το αρχείο; (Όχι για αποθήκευση ως διαφορετικό αρχείο.)"
 
 #. IDS_ERROR_BACKUP
-#: Merge.rc:4791
+#: Merge.rc:4790
 #, c-format
 msgid "Error backing up file"
 msgstr "Αποτυχία δημιουργίας εφεδρικού αρχείου"
 
-#: Merge.rc:4793
+#: Merge.rc:4792
 #, c-format
 msgid ""
 "Unable to backup original file:\n"
@@ -6549,7 +6543,7 @@ msgstr ""
 "Συνέχεια ως έχει;"
 
 #. IDS_FILESAVE_FAILED
-#: Merge.rc:4794
+#: Merge.rc:4793
 #, c-format
 msgid "Saving file failed.\n%1\n%2\n\t- Use different filename (OK)\n\t- Abort (Cancel)?"
 msgstr ""
@@ -6560,7 +6554,7 @@ msgstr ""
 "\t- χρησιμοποιήσετε ένα διαφορετικό όνομα (Πιέστε ΟΚ)\n"
 "\t- ματαιώσετε την τρέχουσα ενέργεια (Πιέστε Άκυρο);"
 
-#: Merge.rc:4796
+#: Merge.rc:4795
 #, c-format
 msgid "Plugin '%2' cannot pack changes to left file into '%1'.\n\nOriginal unchanged. Save unpacked version?"
 msgstr ""
@@ -6570,12 +6564,12 @@ msgstr ""
 "\n"
 "Επιθυμείτε να αποθηκεύσετε το αποσυμπιεσμένο αρχείο ως διαφορετικό αρχείο;"
 
-#: Merge.rc:4798
+#: Merge.rc:4797
 #, c-format
 msgid "Plugin '%2' cannot pack changes to middle file into '%1'.\n\nOriginal unchanged. Save unpacked version?"
 msgstr ""
 
-#: Merge.rc:4800
+#: Merge.rc:4799
 #, c-format
 msgid "Plugin '%2' cannot pack changes to right file into '%1'.\n\nOriginal unchanged. Save unpacked version?"
 msgstr ""
@@ -6586,7 +6580,7 @@ msgstr ""
 "Επιθυμείτε να αποθηκεύσετε το αποσυμπιεσμένο αρχείο ως διαφορετικό αρχείο;"
 
 #. IDS_FILECHANGED_ONDISK
-#: Merge.rc:4801
+#: Merge.rc:4800
 #, c-format
 msgid ""
 "Another application updated\n"
@@ -6602,7 +6596,7 @@ msgstr ""
 "Αντικατάσταση μεταβληθέντος αρχείου?"
 
 #. IDS_SAVEREADONLY_MULTI
-#: Merge.rc:4802
+#: Merge.rc:4801
 #, c-format
 msgid ""
 "%1\n"
@@ -6612,37 +6606,37 @@ msgstr ""
 "έχει την ιδιότητα \"Μόνο για Ανάγνωση\". Επιθυμείτε να αντικαταστήσετε το αρχείο;"
 
 #. IDS_FILECHANGED_RESCAN
-#: Merge.rc:4803
+#: Merge.rc:4802
 #, c-format
 msgid "Another application updated\n%1\nsince last scan.\n\nReload?"
 msgstr ""
 
 #. IDS_SAVE_LEFT_AS
-#: Merge.rc:4804
+#: Merge.rc:4803
 #, c-format
 msgid "Save Left File As"
 msgstr "Αποθήκευση Αριστερού Αρχείου Ως"
 
 #. IDS_SAVE_MIDDLE_AS
-#: Merge.rc:4805
+#: Merge.rc:4804
 #, c-format
 msgid "Save Middle File As"
 msgstr ""
 
 #. IDS_SAVE_RIGHT_AS
-#: Merge.rc:4806
+#: Merge.rc:4805
 #, c-format
 msgid "Save Right File As"
 msgstr "Αποθήκευση Δεξιού Αρχείου Ως"
 
 #. IDS_FILE_DISAPPEARED
-#: Merge.rc:4811
+#: Merge.rc:4810
 #, c-format
 msgid "File\n%1\nnot found. Save a copy to continue."
 msgstr ""
 
 #. IDS_VIEWS_OUTOFSYNC
-#: Merge.rc:4817
+#: Merge.rc:4816
 #, c-format
 msgid ""
 "Cannot merge unsynched documents.\n"
@@ -6654,189 +6648,189 @@ msgstr ""
 "Ανανεώστε τα αρχεία πριν συνεχίσετε."
 
 #. IDS_BREAK_ON_WHITESPACE
-#: Merge.rc:4822
+#: Merge.rc:4821
 msgid "Break at whitespace"
 msgstr "Στάση στα κενά"
 
 #. IDS_BREAK_ON_PUNCTUATION
-#: Merge.rc:4823
+#: Merge.rc:4822
 msgid "Break at whitespace or punctuation"
 msgstr "Στάση στα κενά ή στα σημεία στίξεως"
 
 #. IDS_L2M
-#: Merge.rc:4829
+#: Merge.rc:4828
 msgid "Copy to &Middle\tAlt+Right"
 msgstr ""
 
 #. IDS_R2M
-#: Merge.rc:4830
+#: Merge.rc:4829
 msgid "Copy to &Middle\tAlt+Left"
 msgstr ""
 
 #. IDS_COPY_FROM_MIDDLE_R
-#: Merge.rc:4831
+#: Merge.rc:4830
 msgid "Copy from Middle\tAlt+Shift+Right"
 msgstr ""
 
 #. IDS_COPY_FROM_MIDDLE_L
-#: Merge.rc:4832
+#: Merge.rc:4831
 msgid "Copy from Middle\tAlt+Shift+Left"
 msgstr ""
 
 #. IDS_L2MNEXT
-#: Merge.rc:4833
+#: Merge.rc:4832
 msgid "Copy to Middle and Advance\tCtrl+Alt+Right"
 msgstr ""
 
 #. IDS_R2MNEXT
-#: Merge.rc:4834
+#: Merge.rc:4833
 msgid "Copy to Middle and Advance\tCtrl+Alt+Left"
 msgstr ""
 
 #. IDS_ALL_MIDDLE
-#: Merge.rc:4835
+#: Merge.rc:4834
 msgid "Copy All to Middle"
 msgstr ""
 
 #. IDS_COPY_RIGHT_TO_LEFT
-#: Merge.rc:4841
+#: Merge.rc:4840
 #, c-format
 msgid "Right to Left (%1)"
 msgstr "Δεξιό στο Αριστερό (%1)"
 
 #. IDS_COPY_RIGHT_TO_MIDDLE
-#: Merge.rc:4842
+#: Merge.rc:4841
 #, c-format
 msgid "Right to Middle (%1)"
 msgstr ""
 
 #. IDS_COPY_MIDDLE_TO_LEFT
-#: Merge.rc:4843
+#: Merge.rc:4842
 #, c-format
 msgid "Middle to Left (%1)"
 msgstr ""
 
 #. IDS_COPY_MIDDLE_TO_RIGHT
-#: Merge.rc:4844
+#: Merge.rc:4843
 #, c-format
 msgid "Middle to Right (%1)"
 msgstr ""
 
 #. IDS_COPY_LEFT_TO_RIGHT
-#: Merge.rc:4845
+#: Merge.rc:4844
 #, c-format
 msgid "Left to Right (%1)"
 msgstr "Αριστερό στο Δεξιό (%1)"
 
 #. IDS_COPY_LEFT_TO_MIDDLE
-#: Merge.rc:4846
+#: Merge.rc:4845
 #, c-format
 msgid "Left to Middle (%1)"
 msgstr ""
 
 #. IDS_MOVE_LEFT_TO
-#: Merge.rc:4857 Merge.rc:4889
+#: Merge.rc:4856 Merge.rc:4888
 #, c-format
 msgid "Left to... (%1)"
 msgstr "Αριστερό στο... (%1)"
 
 #. IDS_MOVE_MIDDLE_TO
-#: Merge.rc:4858 Merge.rc:4890
+#: Merge.rc:4857 Merge.rc:4889
 #, c-format
 msgid "Middle to... (%1)"
 msgstr ""
 
 #. IDS_MOVE_RIGHT_TO
-#: Merge.rc:4859 Merge.rc:4891
+#: Merge.rc:4858 Merge.rc:4890
 #, c-format
 msgid "Right to... (%1)"
 msgstr "Δεξιό στο... (%1)"
 
 #. IDS_COPY_BOTH_TO
-#: Merge.rc:4860
+#: Merge.rc:4859
 #, c-format
 msgid "Both to... (%1)"
 msgstr ""
 
 #. IDS_COPY_ALL_TO
-#: Merge.rc:4861
+#: Merge.rc:4860
 #, c-format
 msgid "All to... (%1)"
 msgstr ""
 
 #. IDS_COPY_DIFFERENCES_TO
-#: Merge.rc:4862
+#: Merge.rc:4861
 #, c-format
 msgid "Differences to... (%1)"
 msgstr ""
 
 #. IDS_ONLYDIFFITEMS_CONFIRM
-#: Merge.rc:4869
+#: Merge.rc:4868
 msgid "Some selected items are identical or skipped.\nProcess only items with differences?"
 msgstr ""
 
 #. IDS_DEL_LEFT_FMT
-#: Merge.rc:4875
+#: Merge.rc:4874
 #, c-format
 msgid "Left (%1)"
 msgstr "Αριστερό (%1)"
 
 #. IDS_DEL_MIDDLE_FMT
-#: Merge.rc:4876
+#: Merge.rc:4875
 #, c-format
 msgid "Middle (%1)"
 msgstr ""
 
 #. IDS_DEL_RIGHT_FMT
-#: Merge.rc:4877
+#: Merge.rc:4876
 #, c-format
 msgid "Right (%1)"
 msgstr "Δεξιό (%1)"
 
 #. IDS_DEL_BOTH_FMT
-#: Merge.rc:4878
+#: Merge.rc:4877
 #, c-format
 msgid "Both (%1)"
 msgstr "Αμφότερα (%1)"
 
 #. IDS_DEL_ALL_FMT
-#: Merge.rc:4879
+#: Merge.rc:4878
 #, c-format
 msgid "All (%1)"
 msgstr ""
 
 #. IDS_SELECT_DEST_LEFT
-#: Merge.rc:4895
+#: Merge.rc:4894
 #, c-format
 msgid "Left Side - Select Destination Folder:"
 msgstr "Αριστερή πλευρά - επιλογή φακέλου προορισμού:"
 
 #. IDS_SELECT_DEST_MIDDLE
-#: Merge.rc:4896
+#: Merge.rc:4895
 #, c-format
 msgid "Middle Side - Select Destination Folder:"
 msgstr ""
 
 #. IDS_SELECT_DEST_RIGHT
-#: Merge.rc:4897
+#: Merge.rc:4896
 #, c-format
 msgid "Right Side - Select Destination Folder:"
 msgstr "Δεξιά πλευρά - επιλογή φακέλου προορισμού:"
 
 #. IDS_FILES_AFFECTED_FMT
-#: Merge.rc:4898
+#: Merge.rc:4897
 #, c-format
 msgid "(%1 Files Affected)"
 msgstr "(%1 Αρχεία Μεταβλήθηκαν)"
 
 #. IDS_FILES_AFFECTED_FMT2
-#: Merge.rc:4899
+#: Merge.rc:4898
 #, c-format
 msgid "(%1 of %2 Files Affected)"
 msgstr "(%1 από %2 Αρχεία Μεταβλήθηκαν)"
 
 #. IDS_CONFIRM_DELETE_SINGLE
-#: Merge.rc:4905
+#: Merge.rc:4904
 #, c-format
 msgid ""
 "Are you sure you want to delete\n"
@@ -6848,18 +6842,18 @@ msgstr ""
 "%1 ;"
 
 #. IDS_CONFIRM_SINGLE_COPY
-#: Merge.rc:4906
+#: Merge.rc:4905
 msgid "Are you sure you want to copy?"
 msgstr "Είσθε βέβαιοι ότι επιθυμείτε να αντιγράψετε?"
 
 #. IDS_CONFIRM_MULTIPLE_COPY
-#: Merge.rc:4907
+#: Merge.rc:4906
 #, c-format
 msgid "Are you sure you want to copy %d items?"
 msgstr "Είσθε βέβαιοι ότι επιθυμείτε να αντιγράψετε %d αντικείμενα?"
 
 #. IDS_DIRCMP_NOTSYNC
-#: Merge.rc:4908
+#: Merge.rc:4907
 #, c-format
 msgid ""
 "Operation aborted!\n"
@@ -6879,873 +6873,873 @@ msgstr ""
 "Παρακαλώ ανανεώστε τη σύγκριση."
 
 #. IDS_CONFIRM_SINGLE_MOVE
-#: Merge.rc:4913
+#: Merge.rc:4912
 msgid "Are you sure you want to move?"
 msgstr "Είσθε βέβαιος ότι επιθυμείτε να μετακινήσετε?"
 
 #. IDS_CONFIRM_MULTIPLE_MOVE
-#: Merge.rc:4914
+#: Merge.rc:4913
 #, c-format
 msgid "Are you sure you want to move %d items?"
 msgstr "Είσθε βέβαιος ότι επιθυμείτε να μετακινήσετε %d αντικείμενα?"
 
 #. IDS_CONFIRM_MOVE_CAPTION
-#: Merge.rc:4916
+#: Merge.rc:4915
 #, c-format
 msgid "Confirm Move"
 msgstr "Επιβεβαιώσατε Μετακίνηση"
 
-#: Merge.rc:4918
+#: Merge.rc:4917
 #, c-format
 msgid "Close the folder comparison window?"
 msgstr ""
 
-#: Merge.rc:4920
+#: Merge.rc:4919
 msgid "Close the folder comparison window, which took a long time?"
 msgstr ""
 
 #. IDS_ERROR_INVALID_DIR_FILE_NAME
-#: Merge.rc:4921
+#: Merge.rc:4920
 msgid "The file or folder name is invalid."
 msgstr ""
 
 #. IDS_ERROR_EXECUTE_FILE
-#: Merge.rc:4927
+#: Merge.rc:4926
 #, c-format
 msgid "Failed to execute external editor: %1"
 msgstr "Αποτυχία κατά το άνοιγμα άλλης εφαρμογής: %1"
 
 #. IDS_UNKNOWN_ARCHIVE_FORMAT
-#: Merge.rc:4933
+#: Merge.rc:4932
 #, c-format
 msgid "Unknown archive format"
 msgstr "Άγνωστη μορφή συμπιεσμένου αρχείου"
 
-#: Merge.rc:4935
+#: Merge.rc:4934
 msgid "Failed to extract archive.\nCompare as text file?"
 msgstr ""
 
 #. IDS_COLHDR_FILENAME
-#: Merge.rc:4941
+#: Merge.rc:4940
 #, c-format
 msgid "Filename"
 msgstr "Όνομα Αρχείου"
 
 #. IDS_COLHDR_DIR
-#: Merge.rc:4942
+#: Merge.rc:4941
 msgctxt "DirView|ColumnHeader"
 msgid "Folder"
 msgstr "Φάκελος"
 
 #. IDS_COLHDR_RESULT
-#: Merge.rc:4943
+#: Merge.rc:4942
 #, c-format
 msgid "Comparison Result"
 msgstr "Αποτέλεσμα Συγκρίσεως"
 
 #. IDS_COLHDR_LTIMEM
-#: Merge.rc:4944
+#: Merge.rc:4943
 #, c-format
 msgid "Left Date"
 msgstr "Ημερομηνία Αριστερού"
 
 #. IDS_COLHDR_RTIMEM
-#: Merge.rc:4945
+#: Merge.rc:4944
 #, c-format
 msgid "Right Date"
 msgstr "Ημερομηνία Δεξιού"
 
 #. IDS_COLHDR_MTIMEM
-#: Merge.rc:4946
+#: Merge.rc:4945
 #, c-format
 msgid "Middle Date"
 msgstr ""
 
 #. IDS_COLHDR_LSIZE
-#: Merge.rc:4948
+#: Merge.rc:4947
 #, c-format
 msgid "Left Size"
 msgstr "Μέγεθος Αριστερού"
 
 #. IDS_COLHDR_RSIZE
-#: Merge.rc:4949
+#: Merge.rc:4948
 #, c-format
 msgid "Right Size"
 msgstr "Μέγεθος Δεξιού"
 
 #. IDS_COLHDR_MSIZE
-#: Merge.rc:4954
+#: Merge.rc:4953
 #, c-format
 msgid "Middle Size"
 msgstr ""
 
 #. IDS_COLHDR_RSIZE_SHORT
-#: Merge.rc:4955
+#: Merge.rc:4954
 #, c-format
 msgid "Right Size (Short)"
 msgstr "Μέγεθος Δεξιού (Σύντομο)"
 
 #. IDS_COLHDR_LSIZE_SHORT
-#: Merge.rc:4956
+#: Merge.rc:4955
 #, c-format
 msgid "Left Size (Short)"
 msgstr "Μέγεθος Αριστερού (Σύντομο)"
 
 #. IDS_COLHDR_MSIZE_SHORT
-#: Merge.rc:4957
+#: Merge.rc:4956
 #, c-format
 msgid "Middle Size (Short)"
 msgstr ""
 
 #. IDS_COLHDR_LTIMEC
-#: Merge.rc:4963
+#: Merge.rc:4962
 #, c-format
 msgid "Left Creation Time"
 msgstr "Χρόνος Δημιουργίας Αριστερού"
 
 #. IDS_COLHDR_RTIMEC
-#: Merge.rc:4964
+#: Merge.rc:4963
 #, c-format
 msgid "Right Creation Time"
 msgstr "Χρόνος Δημιουργίας Δεξιού"
 
 #. IDS_COLHDR_MTIMEC
-#: Merge.rc:4965
+#: Merge.rc:4964
 #, c-format
 msgid "Middle Creation Time"
 msgstr ""
 
 #. IDS_COLHDR_NEWER
-#: Merge.rc:4966
+#: Merge.rc:4965
 #, c-format
 msgid "Newer File"
 msgstr "Νεώτερο Αρχείο"
 
 #. IDS_COLHDR_LVERSION
-#: Merge.rc:4967
+#: Merge.rc:4966
 #, c-format
 msgid "Left File Version"
 msgstr "Έκδοση Αριστερού Αρχείου"
 
 #. IDS_COLHDR_RVERSION
-#: Merge.rc:4968
+#: Merge.rc:4967
 #, c-format
 msgid "Right File Version"
 msgstr "Έκδοση Δεξιού Αρχείου"
 
 #. IDS_COLHDR_MVERSION
-#: Merge.rc:4969
+#: Merge.rc:4968
 #, c-format
 msgid "Middle File Version"
 msgstr ""
 
 #. IDS_COLHDR_RESULT_ABBR
-#: Merge.rc:4970
+#: Merge.rc:4969
 #, c-format
 msgid "Short Result"
 msgstr "Σύντομο Αποτέλεσμα"
 
 #. IDS_COLHDR_LATTRIBUTES
-#: Merge.rc:4971
+#: Merge.rc:4970
 #, c-format
 msgid "Left Attributes"
 msgstr "Ιδιότητες Αριστερού"
 
 #. IDS_COLHDR_RATTRIBUTES
-#: Merge.rc:4972
+#: Merge.rc:4971
 #, c-format
 msgid "Right Attributes"
 msgstr "Ιδιότητες Δεξιού"
 
 #. IDS_COLHDR_MATTRIBUTES
-#: Merge.rc:4973
+#: Merge.rc:4972
 #, c-format
 msgid "Middle Attributes"
 msgstr ""
 
 #. IDS_COLHDR_LEOL_TYPE
-#: Merge.rc:4978
+#: Merge.rc:4977
 #, c-format
 msgid "Left EOL"
 msgstr "Χαρακτήρας Τερματισμού Αριστερού"
 
 #. IDS_COLHDR_MEOL_TYPE
-#: Merge.rc:4979
+#: Merge.rc:4978
 #, c-format
 msgid "Middle EOL"
 msgstr ""
 
 #. IDS_COLHDR_REOL_TYPE
-#: Merge.rc:4980
+#: Merge.rc:4979
 #, c-format
 msgid "Right EOL"
 msgstr "Χαρακτήρας Τερματισμού Δεξιού"
 
 #. IDS_COLHDR_LENCODING
-#: Merge.rc:4986
+#: Merge.rc:4985
 #, c-format
 msgid "Left Encoding"
 msgstr "Κωδικοσελίδα Αριστερού"
 
 #. IDS_COLHDR_RENCODING
-#: Merge.rc:4987
+#: Merge.rc:4986
 #, c-format
 msgid "Right Encoding"
 msgstr "Κωδικοσελίδα Δεξιού"
 
 #. IDS_COLHDR_MENCODING
-#: Merge.rc:4988
+#: Merge.rc:4987
 #, c-format
 msgid "Middle Encoding"
 msgstr ""
 
 #. IDS_COLHDR_NIDIFFS
-#: Merge.rc:4989
+#: Merge.rc:4988
 msgid "Ignored Diff"
 msgstr "Αγνοηθείσα Διαφορά"
 
 #. IDS_COLHDR_BINARY
-#: Merge.rc:4991
+#: Merge.rc:4990
 msgctxt "DirView|ColumnHeader"
 msgid "Binary"
 msgstr "Δυαδικό"
 
 #. IDS_PLUGINS_TYPE_UNPACKER
-#: Merge.rc:4992 Merge.rc:5314
+#: Merge.rc:4991 Merge.rc:5313
 #, c-format
 msgid "Unpacker"
 msgstr "Αποσυμπιεστικό"
 
 #. IDS_PLUGIN_TYPE4
-#: Merge.rc:4993 Merge.rc:5315 Merge.rc:5622
+#: Merge.rc:4992 Merge.rc:5314 Merge.rc:5621
 #, c-format
 msgid "Prediffer"
 msgstr "Προεπεξεργαστής Διαφορών"
 
 #. IDS_COLHDR_LEFT
-#: Merge.rc:4994
+#: Merge.rc:4993
 msgid "Left"
 msgstr ""
 
 #. IDS_COLHDR_MIDDLE
-#: Merge.rc:4995
+#: Merge.rc:4994
 msgid "Middle"
 msgstr ""
 
 #. IDS_COLHDR_RIGHT
-#: Merge.rc:4996
+#: Merge.rc:4995
 msgid "Right"
 msgstr ""
 
 #. IDS_COLHDR_DIFF
-#: Merge.rc:4997
+#: Merge.rc:4996
 msgid "Diff"
 msgstr ""
 
 #. IDS_COLHDR_LEFT_DUPLICATE
-#: Merge.rc:4998
+#: Merge.rc:4997
 msgid "Left Duplicate Count"
 msgstr ""
 
 #. IDS_COLHDR_RIGHT_DUPLICATE
-#: Merge.rc:4999
+#: Merge.rc:4998
 msgid "Right Duplicate Count"
 msgstr ""
 
 #. IDS_COLHDR_MIDDLE_DUPLICATE
-#: Merge.rc:5000
+#: Merge.rc:4999
 msgid "Middle Duplicate Count"
 msgstr ""
 
 #. IDS_COLHDR_MOVE
-#: Merge.rc:5001
+#: Merge.rc:5000
 msgid "Move"
 msgstr ""
 
 #. IDS_PRPCAT_AUDIO
-#: Merge.rc:5008
+#: Merge.rc:5007
 msgid "Audio"
 msgstr ""
 
 #. IDS_PRPCAT_CALENDAR
-#: Merge.rc:5009
+#: Merge.rc:5008
 msgid "Calendar"
 msgstr ""
 
 #. IDS_PRPCAT_COMMUNICATION
-#: Merge.rc:5010
+#: Merge.rc:5009
 msgid "Communication"
 msgstr ""
 
 #. IDS_PRPCAT_CONTACT
-#: Merge.rc:5011
+#: Merge.rc:5010
 msgid "Contact"
 msgstr ""
 
 #. IDS_PRPCAT_DEVICES
-#: Merge.rc:5012
+#: Merge.rc:5011
 msgid "Devices"
 msgstr ""
 
 #. IDS_PRPCAT_DOCUMENT
-#: Merge.rc:5013
+#: Merge.rc:5012
 msgid "Document"
 msgstr ""
 
 #. IDS_PRPCAT_HOME
-#: Merge.rc:5014
+#: Merge.rc:5013
 msgid "Home"
 msgstr ""
 
 #. IDS_PRPCAT_JOURNAL
-#: Merge.rc:5016
+#: Merge.rc:5015
 msgid "Journal"
 msgstr ""
 
 #. IDS_PRPCAT_LINK
-#: Merge.rc:5017
+#: Merge.rc:5016
 msgid "Link"
 msgstr ""
 
 #. IDS_PRPCAT_MEDIA
-#: Merge.rc:5018
+#: Merge.rc:5017
 msgid "Media"
 msgstr ""
 
 #. IDS_PRPCAT_MUSIC
-#: Merge.rc:5020
+#: Merge.rc:5019
 msgid "Music"
 msgstr ""
 
 #. IDS_PRPCAT_NOTE
-#: Merge.rc:5021
+#: Merge.rc:5020
 msgid "Note"
 msgstr ""
 
 #. IDS_PRPCAT_PHOTO
-#: Merge.rc:5022
+#: Merge.rc:5021
 msgid "Photo"
 msgstr ""
 
 #. IDS_PRPCAT_RECORDEDTV
-#: Merge.rc:5023
+#: Merge.rc:5022
 msgid "RecordedTV"
 msgstr ""
 
 #. IDS_PRPCAT_SEARCH
-#: Merge.rc:5024
+#: Merge.rc:5023
 msgid "Search"
 msgstr ""
 
 #. IDS_PRPCAT_SECURITY
-#: Merge.rc:5025
+#: Merge.rc:5024
 msgid "Security"
 msgstr ""
 
 #. IDS_PRPCAT_SOFTWARE
-#: Merge.rc:5026
+#: Merge.rc:5025
 msgid "Software"
 msgstr ""
 
 #. IDS_PRPCAT_TASK
-#: Merge.rc:5027
+#: Merge.rc:5026
 msgid "Task"
 msgstr ""
 
 #. IDS_PRPCAT_VIDEO
-#: Merge.rc:5028
+#: Merge.rc:5027
 msgid "Video"
 msgstr ""
 
 #. IDS_PRPCAT_HASH
-#: Merge.rc:5029
+#: Merge.rc:5028
 msgid "Hash"
 msgstr ""
 
 #. IDS_CANT_COMPARE_FILES
-#: Merge.rc:5035
+#: Merge.rc:5034
 #, c-format
 msgid "Unable to compare files"
 msgstr "Η σύγκριση των αρχείων είναι αδύνατη"
 
 #. IDS_ABORTED_ITEM
-#: Merge.rc:5036
+#: Merge.rc:5035
 #, c-format
 msgid "Item aborted"
 msgstr "Το αντικείμενο ματαιώθηκε"
 
 #. IDS_FILE_SKIPPED
-#: Merge.rc:5037
+#: Merge.rc:5036
 #, c-format
 msgid "File skipped"
 msgstr "Το αρχείο παρελείφθη"
 
 #. IDS_DIR_SKIPPED
-#: Merge.rc:5038
+#: Merge.rc:5037
 #, c-format
 msgid "Folder skipped"
 msgstr "Ο φάκελος παρελείφθη"
 
 #. IDS_LEFT_ONLY_IN_FMT
-#: Merge.rc:5039
+#: Merge.rc:5038
 #, c-format
 msgid "Left only: %1"
 msgstr "Αριστερά μόνο: %1"
 
 #. IDS_MIDDLE_ONLY_IN_FMT
-#: Merge.rc:5040
+#: Merge.rc:5039
 #, c-format
 msgid "Middle only: %1"
 msgstr ""
 
 #. IDS_RIGHT_ONLY_IN_FMT
-#: Merge.rc:5041
+#: Merge.rc:5040
 #, c-format
 msgid "Right only: %1"
 msgstr "Δεξιά μόνο: %1"
 
 #. IDS_DOES_NOT_EXIST_IN_FMT
-#: Merge.rc:5042
+#: Merge.rc:5041
 #, c-format
 msgid "Does not exist in %1"
 msgstr ""
 
 #. IDS_BIN_FILES_SAME
-#: Merge.rc:5043
+#: Merge.rc:5042
 #, c-format
 msgid "Binary files are identical"
 msgstr "Τα δυαδικά αρχεία είναι πανομοιότυπα"
 
 #. IDS_BIN_FILES_DIFF
-#: Merge.rc:5049
+#: Merge.rc:5048
 #, c-format
 msgid "Binary files are different"
 msgstr "Τα δυαδικά αρχεία είναι διαφορετικά"
 
 #. IDS_FILES_ARE_DIFFERENT
-#: Merge.rc:5050
+#: Merge.rc:5049
 #, c-format
 msgid "Files are different"
 msgstr "Τα αρχεία είναι διαφορετικά"
 
 #. IDS_FOLDERS_ARE_DIFFERENT
-#: Merge.rc:5051
+#: Merge.rc:5050
 #, c-format
 msgid "Folders are different"
 msgstr ""
 
 #. IDS_LEFTONLY
-#: Merge.rc:5052
+#: Merge.rc:5051
 #, c-format
 msgid "Left Only"
 msgstr "Αριστερά μόνο"
 
 #. IDS_RIGHTONLY
-#: Merge.rc:5053
+#: Merge.rc:5052
 #, c-format
 msgid "Right Only"
 msgstr "Δεξιά μόνο"
 
 #. IDS_MIDDLEONLY
-#: Merge.rc:5054
+#: Merge.rc:5053
 #, c-format
 msgid "Middle Only"
 msgstr ""
 
 #. IDS_NOITEMLEFT
-#: Merge.rc:5055
+#: Merge.rc:5054
 #, c-format
 msgid "No item in left"
 msgstr ""
 
 #. IDS_NOITEMRIGHT
-#: Merge.rc:5056
+#: Merge.rc:5055
 #, c-format
 msgid "No item in right"
 msgstr ""
 
 #. IDS_NOITEMMIDDLE
-#: Merge.rc:5057
+#: Merge.rc:5056
 #, c-format
 msgid "No item in middle"
 msgstr ""
 
 #. IDS_CMPRES_ERROR
-#: Merge.rc:5059
+#: Merge.rc:5058
 #, c-format
 msgid "Error"
 msgstr "Σφάλμα"
 
 #. IDS_TEXT_FILES_SAME
-#: Merge.rc:5060
+#: Merge.rc:5059
 #, c-format
 msgid "Text files are identical"
 msgstr ""
 
 #. IDS_LEFTONLY_DIFF
-#: Merge.rc:5061
+#: Merge.rc:5060
 msgid " (Middle and right are identical)"
 msgstr ""
 
 #. IDS_MIDDLEONLY_DIFF
-#: Merge.rc:5062
+#: Merge.rc:5061
 msgid " (Left and right are identical)"
 msgstr ""
 
 #. IDS_RIGHTONLY_DIFF
-#: Merge.rc:5063
+#: Merge.rc:5062
 msgid " (Left and middle are identical)"
 msgstr ""
 
 #. IDS_PATH_MISMATCH
-#: Merge.rc:5064
+#: Merge.rc:5063
 msgid " (paths differ)"
 msgstr ""
 
 #. IDS_TEXT_FILES_DIFF
-#: Merge.rc:5065
+#: Merge.rc:5064
 #, c-format
 msgid "Text files are different"
 msgstr ""
 
 #. IDS_IMAGE_FILES_SAME
-#: Merge.rc:5066
+#: Merge.rc:5065
 msgid "Image files are identical"
 msgstr ""
 
 #. IDS_IMAGE_FILES_DIFF
-#: Merge.rc:5067
+#: Merge.rc:5066
 msgid "Image files are different"
 msgstr ""
 
 #. IDS_EXPR_DIFF
-#: Merge.rc:5068
+#: Merge.rc:5067
 #, c-format
 msgid "Files are different (expr: %1)"
 msgstr ""
 
 #. IDS_HASH_GROUP
-#: Merge.rc:5069
+#: Merge.rc:5068
 #, c-format
 msgid "Group%d"
 msgstr ""
 
 #. IDS_RENAME_MOVE_DETECTION_DISALBED
-#: Merge.rc:5070
+#: Merge.rc:5069
 msgctxt "Options dialog|Compare|Folder|Detect renames and moves"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_RENAME_MOVE_DETECTION_RENAME
-#: Merge.rc:5071
+#: Merge.rc:5070
 msgid "Detect renames"
 msgstr ""
 
 #. IDS_RENAME_MOVE_DETECTION_RENAME_MOVE
-#: Merge.rc:5072
+#: Merge.rc:5071
 msgid "Detect renames and moves"
 msgstr ""
 
 #. IDS_RENAME_MOVE_MERGE_MODE_RENAME
-#: Merge.rc:5073
+#: Merge.rc:5072
 msgid "Merge renames"
 msgstr ""
 
 #. IDS_RENAME_MOVE_MERGE_MODE_RENAME_MOVE
-#: Merge.rc:5074
+#: Merge.rc:5073
 msgid "Merge renames and moves"
 msgstr ""
 
 #. IDS_RENAMED
-#: Merge.rc:5075
+#: Merge.rc:5074
 msgid "Renamed"
 msgstr ""
 
 #. IDS_RENAMED_MOVED
-#: Merge.rc:5077
+#: Merge.rc:5076
 msgid "Renamed/Moved"
 msgstr ""
 
 #. IDS_RENAMED_MOVED_ITEMS
-#: Merge.rc:5078
+#: Merge.rc:5077
 #, c-format
 msgid "(%1 items)"
 msgstr ""
 
 #. IDS_RENAMED_MOVED_RESULT
-#: Merge.rc:5079
+#: Merge.rc:5078
 #, c-format
 msgid "%1 (set %2): "
 msgstr ""
 
 #. IDS_SWITCH_FLAT_MODE
-#: Merge.rc:5080
+#: Merge.rc:5079
 msgid "Some moved items have been merged.\nIn Tree Mode, these items may appear in positions that do not reflect the actual folder structure, which can be confusing.\nSwitch to Flat Mode?"
 msgstr ""
 
 #. IDS_ELAPSED_TIME
-#: Merge.rc:5086
+#: Merge.rc:5085
 #, c-format
 msgid "Elapsed time: %ld ms"
 msgstr "Παρελθών χρόνος: %ld ms"
 
 #. IDS_STATUS_SELITEM1
-#: Merge.rc:5087
+#: Merge.rc:5086
 #, c-format
 msgid "1 item selected"
 msgstr "1 αντικείμενο επιλεγμένο"
 
 #. IDS_STATUS_SELITEMS
-#: Merge.rc:5088
+#: Merge.rc:5087
 #, c-format
 msgid "%1 items selected"
 msgstr "%1 αντικείμενα επιλεγμένα"
 
 #. IDS_COLDESC_FILENAME
-#: Merge.rc:5094
+#: Merge.rc:5093
 #, c-format
 msgid "Filename or folder name."
 msgstr "Όνομα αρχείου ή όνομα φακέλου."
 
 #. IDS_COLDESC_DIR
-#: Merge.rc:5095
+#: Merge.rc:5094
 #, c-format
 msgid "Subfolder name when subfolders are included."
 msgstr "Όνομα υποφακέλου όταν οι υποφάκελοι περιλαμβάνονται."
 
 #. IDS_COLDESC_RESULT
-#: Merge.rc:5096
+#: Merge.rc:5095
 #, c-format
 msgid "Comparison result, long form."
 msgstr "Αποτέλεσμα συγκρίσεως, πλήρης ανάπτυξη"
 
 #. IDS_COLDESC_LTIMEM
-#: Merge.rc:5101
+#: Merge.rc:5100
 #, c-format
 msgid "Left side modification date."
 msgstr "Ημερομηνία τροποποιήσεως αριστερής πλευράς."
 
 #. IDS_COLDESC_RTIMEM
-#: Merge.rc:5102
+#: Merge.rc:5101
 #, c-format
 msgid "Right side modification date."
 msgstr "Ημερομηνία τροποποιήσεως δεξιάς πλευράς."
 
 #. IDS_COLDESC_MTIMEM
-#: Merge.rc:5103
+#: Merge.rc:5102
 #, c-format
 msgid "Middle side modification date."
 msgstr ""
 
 #. IDS_COLDESC_EXTENSION
-#: Merge.rc:5104
+#: Merge.rc:5103
 #, c-format
 msgid "File's extension."
 msgstr "Επέκταση αρχείου."
 
 #. IDS_COLDESC_LSIZE
-#: Merge.rc:5105
+#: Merge.rc:5104
 #, c-format
 msgid "Left file size in bytes."
 msgstr "Μέγεθος αριστερού αρχείου σε byte."
 
 #. IDS_COLDESC_RSIZE
-#: Merge.rc:5106
+#: Merge.rc:5105
 #, c-format
 msgid "Right file size in bytes."
 msgstr "Μέγεθος δεξιού αρχείου σε byte."
 
 #. IDS_COLDESC_MSIZE
-#: Merge.rc:5107
+#: Merge.rc:5106
 #, c-format
 msgid "Middle file size in bytes."
 msgstr ""
 
 #. IDS_COLDESC_LSIZE_SHORT
-#: Merge.rc:5108
+#: Merge.rc:5107
 #, c-format
 msgid "Left file size abbreviated."
 msgstr "Μέγεθος αριστερού αρχείου συντομευμένο."
 
 #. IDS_COLDESC_RSIZE_SHORT
-#: Merge.rc:5109
+#: Merge.rc:5108
 #, c-format
 msgid "Right file size abbreviated."
 msgstr "Μέγεθος δεξιού αρχείου συντομευμένο."
 
 #. IDS_COLDESC_MSIZE_SHORT
-#: Merge.rc:5110
+#: Merge.rc:5109
 #, c-format
 msgid "Middle file size abbreviated."
 msgstr ""
 
 #. IDS_COLDESC_LTIMEC
-#: Merge.rc:5116
+#: Merge.rc:5115
 #, c-format
 msgid "Left side creation time."
 msgstr "Χρόνος δημιουργίας αριστερής πλευράς."
 
 #. IDS_COLDESC_RTIMEC
-#: Merge.rc:5117
+#: Merge.rc:5116
 #, c-format
 msgid "Right side creation time."
 msgstr "Χρόνος δημιουργίας δεξιάς πλευράς."
 
 #. IDS_COLDESC_MTIMEC
-#: Merge.rc:5118
+#: Merge.rc:5117
 #, c-format
 msgid "Middle side creation time."
 msgstr ""
 
 #. IDS_COLDESC_NEWER
-#: Merge.rc:5119
+#: Merge.rc:5118
 #, c-format
 msgid "Tells which side has newer modification date."
 msgstr "Πληροφορεί ποια πλευρά έχει την πλέον πρόσφατη ημερομηνία τροποποιήσεως."
 
 #. IDS_COLDESC_LVERSION
-#: Merge.rc:5120
+#: Merge.rc:5119
 msgid "Left side file version, only for some file types."
 msgstr "Έκδοση αρχείου αριστερής πλευράς, μόνο για ορισμένους τύπους αρχείων."
 
 #. IDS_COLDESC_RVERSION
-#: Merge.rc:5121
+#: Merge.rc:5120
 msgid "Right side file version, only for some file types."
 msgstr "Έκδοση αρχείου δεξιάς πλευράς, μόνο για ορισμένους τύπους αρχείων."
 
 #. IDS_COLDESC_MVERSION
-#: Merge.rc:5126
+#: Merge.rc:5125
 msgid "Middle side file version, only for some file types."
 msgstr ""
 
 #. IDS_COLDESC_RESULT_ABBR
-#: Merge.rc:5127
+#: Merge.rc:5126
 #, c-format
 msgid "Short comparison result."
 msgstr "Βραχύ αποτέλεσμα συγκρίσεως."
 
 #. IDS_COLDESC_LATTRIBUTES
-#: Merge.rc:5128
+#: Merge.rc:5127
 #, c-format
 msgid "Left side attributes."
 msgstr "Ιδιότητες αριστερής πλευράς."
 
 #. IDS_COLDESC_RATTRIBUTES
-#: Merge.rc:5129
+#: Merge.rc:5128
 #, c-format
 msgid "Right side attributes."
 msgstr "Ιδιότητες δεξιάς πλευράς."
 
 #. IDS_COLDESC_MATTRIBUTES
-#: Merge.rc:5130
+#: Merge.rc:5129
 #, c-format
 msgid "Middle side attributes."
 msgstr ""
 
 #. IDS_COLDESC_LEOL_TYPE
-#: Merge.rc:5131
+#: Merge.rc:5130
 msgid "Left side file EOL type."
 msgstr "Τύπος χαρακτήρα τερματισμού αριστερής πλευράς."
 
 #. IDS_COLDESC_REOL_TYPE
-#: Merge.rc:5132
+#: Merge.rc:5131
 msgid "Right side file EOL type."
 msgstr "Τύπος χαρακτήρα τερματισμού δεξιάς πλευράς."
 
 #. IDS_COLDESC_MEOL_TYPE
-#: Merge.rc:5133
+#: Merge.rc:5132
 msgid "Middle side file EOL type."
 msgstr ""
 
 #. IDS_COLDESC_LENCODING
-#: Merge.rc:5139
+#: Merge.rc:5138
 #, c-format
 msgid "Left side encoding."
 msgstr "Κωδικοσελίδα αριστερής πλευράς."
 
 #. IDS_COLDESC_RENCODING
-#: Merge.rc:5140
+#: Merge.rc:5139
 #, c-format
 msgid "Right side encoding."
 msgstr "Κωδικοσελίδα δεξιάς πλευράς."
 
 #. IDS_COLDESC_MENCODING
-#: Merge.rc:5141
+#: Merge.rc:5140
 #, c-format
 msgid "Middle side encoding."
 msgstr ""
 
 #. IDS_COLDESC_NIDIFFS
-#: Merge.rc:5142
+#: Merge.rc:5141
 #, c-format
 msgid "Number of ignored differences in file. Ignored and cannot be merged."
 msgstr "Αριθμός αγνοηθεισών διαφορών στο αρχείο. Αυτές οι διαφορές αγνοούνται από το WinMerge και δεν είναι δυνατόν να συγχωνευθούν."
 
 #. IDS_COLDESC_NSDIFFS
-#: Merge.rc:5143
+#: Merge.rc:5142
 #, c-format
 msgid "Number of differences in file (excluding ignored)."
 msgstr "Αριθμός διαφορών στο αρχείο. Αυτός ο αριθμός δεν περιλαμβάνει αγνοηθείσες διαφορές."
 
 #. IDS_COLDESC_BINARY
-#: Merge.rc:5144
+#: Merge.rc:5143
 #, c-format
 msgid "Shows an asterisk (*) if the file is binary."
 msgstr "Εμφανίζει έναν αστερίσκο (*) εάν το αρχείο είναι δυαδικό."
 
 #. IDS_COLDESC_UNPACKER
-#: Merge.rc:5145
+#: Merge.rc:5144
 msgid "Unpacker plugin name or pipeline."
 msgstr ""
 
 #. IDS_COLDESC_PREDIFFER
-#: Merge.rc:5146
+#: Merge.rc:5145
 msgid "Prediffer plugin name or pipeline."
 msgstr ""
 
 #. IDS_DIRECTORY_REPORT_TITLE
-#: Merge.rc:5152
+#: Merge.rc:5151
 #, c-format
 msgid "Compare %1 with %2"
 msgstr "Σύγκριση %1 με %2"
 
 #. IDS_DIRECTORY_REPORT_TITLE3
-#: Merge.rc:5153
+#: Merge.rc:5152
 #, c-format
 msgid "Compare %1 with %2 and %3"
 msgstr ""
 
 #. IDS_REPORT_COMMALIST
-#: Merge.rc:5154
+#: Merge.rc:5153
 #, c-format
 msgid "Comma-separated list"
 msgstr "Κατάλογος με κόμμα ως χαρακτήρα διαχωρισμού"
 
 #. IDS_REPORT_TABLIST
-#: Merge.rc:5155
+#: Merge.rc:5154
 #, c-format
 msgid "Tab-separated list"
 msgstr "Κατάλογος με στηλοθέτη ως χαρακτήρα διαχωρισμού"
 
 #. IDS_REPORT_SIMPLEHTML
-#: Merge.rc:5156
+#: Merge.rc:5155
 #, c-format
 msgid "Simple HTML"
 msgstr "Απλό HTML"
 
 #. IDS_REPORT_SIMPLEXML
-#: Merge.rc:5157
+#: Merge.rc:5156
 #, c-format
 msgid "Simple XML"
 msgstr "Απλό XML"
 
-#: Merge.rc:5159
+#: Merge.rc:5158
 #, c-format
 msgid "Report file already exists. Overwrite?"
 msgstr "Το αρχείο αναφοράς αποτελεσμάτων υπάρχει ήδη. Επιθυμείτε να αντικαταστήσετε το υπάρχον αρχείο;"
 
 #. IDS_REPORT_ERROR
-#: Merge.rc:5164
+#: Merge.rc:5163
 #, c-format
 msgid ""
 "Error creating the report:\n"
@@ -7755,62 +7749,62 @@ msgstr ""
 "%1"
 
 #. IDS_REPORT_SUCCESS
-#: Merge.rc:5165
+#: Merge.rc:5164
 #, c-format
 msgid "Report created successfully."
 msgstr "Η αναφορά αποτελεσμάτων δημιουργήθηκε επιτυχώς."
 
 #. IDS_SYNCPOINT_LASTBLOCK
-#: Merge.rc:5171
+#: Merge.rc:5170
 msgid "Cannot add a synchronization point at this line."
 msgstr ""
 
 #. IDS_FILE_TO_ITSELF
-#: Merge.rc:5177
+#: Merge.rc:5176
 #, c-format
 msgid "Same file is opened in both panes."
 msgstr "Το ίδιο αρχείο ανοίχθηκε σε αμφότερα τα πεδία."
 
 #. IDS_FILESSAME
-#: Merge.rc:5178
+#: Merge.rc:5177
 #, c-format
 msgid "Selected files are identical."
 msgstr "Τα επιλεγμένα αρχεία είναι πανομοιότυπα."
 
 #. IDS_FILESSAME_CURCFG
-#: Merge.rc:5179
+#: Merge.rc:5178
 msgid "Selected files are identical (with current settings).\r\nChecking binary identity..."
 msgstr ""
 
 #. IDS_FILESSAME_BINERROR
-#: Merge.rc:5180
+#: Merge.rc:5179
 msgid "Selected files are identical (with current settings).\r\nBut binary comparison failed."
 msgstr ""
 
 #. IDS_FILESSAME_BINSAME
-#: Merge.rc:5181
+#: Merge.rc:5180
 msgid "Selected files are identical (binary match)."
 msgstr ""
 
 #. IDS_FILESSAME_BINDIFF
-#: Merge.rc:5182
+#: Merge.rc:5181
 msgid "Selected files are identical (with current settings).\r\nBut differ at the binary level."
 msgstr ""
 
 #. IDS_FILEERROR
-#: Merge.rc:5183
+#: Merge.rc:5182
 #, c-format
 msgid "An error occurred while comparing files."
 msgstr "Παρουσιάσθηκε κάποιο σφάλμα κατά τη σύγκριση των αρχείων."
 
 #. IDS_TEMP_FILEERROR
-#: Merge.rc:5184
+#: Merge.rc:5183
 #, c-format
 msgid "Could not create temporary files. Check your temporary path settings."
 msgstr "Η δημιουργία προσωρινών αρχείων δεν ήταν δυνατή. Ελέγξτε τις ρυθμίσεις σας τις σχετικές με την προσωρινή διαδρομή."
 
 #. IDS_SUGGEST_IGNOREEOL
-#: Merge.rc:5185
+#: Merge.rc:5184
 msgid "Files use different EOL.\n\nTreat all EOL as equivalent?\n\nSet 'Ignore EOL differences (Windows/Unix/Mac)' in Compare section of Options."
 msgstr ""
 "Αυτά τα αρχεία χρησιμοποιούν διαφορετικό χαρακτήρα τερματισμού.\n"
@@ -7820,19 +7814,19 @@ msgstr ""
 "Σημείωση: Εάν επιθυμείτε οι χαρακτήρες τερματισμού να θεωρούνται πάντοτε ισοδύναμοι, ενεργοποιείστε την επιλογή \"Διαφορές χαρακτήρων τερματισμού (Win/Unix/Mac) να αγνοούνται...\" στην καρτέλα Σύγκριση του διαλόγου επιλογών (εμφανίζεται με την επιλογή Επεξεργασία/Επιλογές)."
 
 #. IDS_INVALID_DIRECTORY
-#: Merge.rc:5186
+#: Merge.rc:5185
 #, c-format
 msgid "Selected folder is invalid."
 msgstr "Ο επιλεγμένος φάκελος δεν είναι έγκυρος."
 
 #. IDS_CANNOT_OPEN_BINARYFILE
-#: Merge.rc:5187
+#: Merge.rc:5186
 #, c-format
 msgid "Cannot open a binary file in Editor."
 msgstr "Το άνοιγμα δυαδικού αρχείου στο πεδίο επεξεργασίας δεν είναι δυνατόν."
 
 #. IDS_CREATE_PAIR_FOLDER
-#: Merge.rc:5188
+#: Merge.rc:5187
 #, c-format
 msgid "Create matching folder:\n%1\non the other side and open?"
 msgstr ""
@@ -7843,45 +7837,45 @@ msgstr ""
 "στην άλλη πλευρά και να ανοίξετε αυτούς τους φακέλους;"
 
 #. IDS_CONFIRM_COPY_ALL_DIFFS
-#: Merge.rc:5189
+#: Merge.rc:5188
 msgid "Copy all differences to other file?"
 msgstr ""
 
 #. IDS_MOVE_TO_NEXTFILE
-#: Merge.rc:5194
+#: Merge.rc:5193
 #, c-format
 msgid "Move to next file?"
 msgstr ""
 
 #. IDS_MOVE_TO_PREVFILE
-#: Merge.rc:5195
+#: Merge.rc:5194
 #, c-format
 msgid "Move to previous file?"
 msgstr ""
 
 #. IDS_MOVE_TO_NEXTPAGE
-#: Merge.rc:5196
+#: Merge.rc:5195
 #, c-format
 msgid "Move to next page?"
 msgstr ""
 
 #. IDS_MOVE_TO_PREVPAGE
-#: Merge.rc:5197
+#: Merge.rc:5196
 #, c-format
 msgid "Move to previous page?"
 msgstr ""
 
 #. IDS_MOVE_TO_FIRSTFILE
-#: Merge.rc:5198
+#: Merge.rc:5197
 msgid "Move to first file?"
 msgstr ""
 
 #. IDS_MOVE_TO_LASTFILE
-#: Merge.rc:5199
+#: Merge.rc:5198
 msgid "Move to last file?"
 msgstr ""
 
-#: Merge.rc:5206
+#: Merge.rc:5205
 #, c-format
 msgid "Different codepages: left (cp%d), right (cp%d).\nDisplay in codepage (better display) or default Windows codepage (safer merging)?\n(Recommended: default Windows codepage)"
 msgstr ""
@@ -7889,153 +7883,153 @@ msgstr ""
 "Η εμφάνιση κάθε φακέλου με τη δική του κωδικοσελίδα θα έχει εμφανισιακά καλύτερα αποτελέσματα αλλά η συγχώνευση/αντιγραφή θα είναι επικίνδυνη.\n"
 "Επιθυμείτε να θεωρηθεί ότι αμφότερα τα αρχεία χρησιμοποιούν την προκαθορισμένη κωδικοσελίδα του windows (συνιστάται);"
 
-#: Merge.rc:5208
+#: Merge.rc:5207
 #, c-format
 msgid "Information lost due to encoding errors: both files"
 msgstr "Απώλεια πληροφοριών λόγω σφαλμάτος κωδικοσελίδας: αμφότερα τα αρχεία"
 
-#: Merge.rc:5210
+#: Merge.rc:5209
 #, c-format
 msgid "Information lost due to encoding errors: first file"
 msgstr ""
 
-#: Merge.rc:5212
+#: Merge.rc:5211
 #, c-format
 msgid "Information lost due to encoding errors: second file"
 msgstr ""
 
-#: Merge.rc:5214
+#: Merge.rc:5213
 #, c-format
 msgid "Information lost due to encoding errors: third file"
 msgstr ""
 
 #. IDS_LINEDIFF_NODIFF
-#: Merge.rc:5220
+#: Merge.rc:5219
 #, c-format
 msgid "No difference"
 msgstr "Χωρίς διαφορά"
 
 #. IDS_LINEDIFF_NODIFF_CAPTION
-#: Merge.rc:5221
+#: Merge.rc:5220
 #, c-format
 msgid "Line difference"
 msgstr "Διαφορά γραμμής"
 
 #. IDS_NUM_REPLACED
-#: Merge.rc:5227
+#: Merge.rc:5226
 #, c-format
 msgid "Replaced %1 string(s)."
 msgstr "Αντικαταστάθηκαν %1 ακολουθίες χαρακτήρων."
 
 #. IDS_EDIT_TEXT_NOT_FOUND
-#: Merge.rc:5228
+#: Merge.rc:5227
 #, c-format
 msgid "Cannot find string \"%s\"."
 msgstr "Η ακολουθία χαρακτήρων \"%s\"
 
 #. IDS_MERGE_MODE
-#: Merge.rc:5234
+#: Merge.rc:5233
 msgid "Entering Merge Mode. Press F9 to turn off."
 msgstr ""
 
 #. IDS_AUTO_MERGE
-#: Merge.rc:5240
+#: Merge.rc:5239
 #, c-format
 msgid "Automatic merges: %1\nUnresolved conflicts: %2"
 msgstr ""
 
 #. IDS_CODEPAGE_MERGED
-#: Merge.rc:5241
+#: Merge.rc:5240
 msgid "Codepage change merged."
 msgstr ""
 
 #. IDS_CODEPAGE_CONFLICT
-#: Merge.rc:5242
+#: Merge.rc:5241
 msgid "Codepage changes are conflicting."
 msgstr ""
 
 #. IDS_EOL_MERGED
-#: Merge.rc:5243
+#: Merge.rc:5242
 msgid "EOL change merged."
 msgstr ""
 
 #. IDS_EOL_CONFLICT
-#: Merge.rc:5244
+#: Merge.rc:5243
 msgid "EOL changes are conflicting."
 msgstr ""
 
 #. IDS_LOCBAR_CAPTION
-#: Merge.rc:5250
+#: Merge.rc:5249
 #, c-format
 msgid "Location Pane"
 msgstr "Πεδίο Εντοπισμού"
 
 #. IDS_DIFFBAR_CAPTION
-#: Merge.rc:5251
+#: Merge.rc:5250
 #, c-format
 msgid "Diff Pane"
 msgstr "Πεδίο Διαφορών"
 
 #. IDS_DIFF_SUCCEEDED
-#: Merge.rc:5258
+#: Merge.rc:5257
 #, c-format
 msgid "Patch file written."
 msgstr "Η εγγραφή του αρχείου patch ολοκληρώθηκε επιτυχώς."
 
 #. IDS_DIFF_FILEOVERWRITE
-#: Merge.rc:5259
+#: Merge.rc:5258
 #, c-format
 msgid "Patch file already exists. Overwrite?"
 msgstr "Το αρχείο patch υπάρχει ήδη. Επιθυμείτε να το αντικαταστήσετε;"
 
 #. IDS_DIFF_SELECTEDFILES
-#: Merge.rc:5260
+#: Merge.rc:5259
 #, c-format
 msgid "[%1 files selected]"
 msgstr "[%1 επιλεγμένα αρχεία]"
 
 #. IDS_DIFF_NORMAL
-#: Merge.rc:5261
+#: Merge.rc:5260
 #, c-format
 msgid "Normal"
 msgstr "Κανονικό"
 
 #. IDS_DIFF_CONTEXT
-#: Merge.rc:5262
+#: Merge.rc:5261
 #, c-format
 msgid "Context"
 msgstr "Με περιβάλλον κείμενο"
 
 #. IDS_DIFF_UNIFIED
-#: Merge.rc:5263
+#: Merge.rc:5262
 #, c-format
 msgid "Unified"
 msgstr "Ενοποιημένο"
 
 #. IDS_FILEWRITE_ERROR
-#: Merge.rc:5265
+#: Merge.rc:5264
 #, c-format
 msgid "Could not write to file %1."
 msgstr "Η εγγραφή στο αρχείο %1 δεν ήταν δυνατή."
 
 #. IDS_PATH_NOT_ABSOLUTE
-#: Merge.rc:5266
+#: Merge.rc:5265
 #, c-format
 msgid "Output path is not absolute: %1"
 msgstr "Η ορισθείσα διαδρομή εξόδου δεν είναι απόλυτη διαδρομή: %1"
 
 #. IDS_MUST_SPECIFY_OUTPUT
-#: Merge.rc:5267
+#: Merge.rc:5266
 msgid "Specify an output file."
 msgstr "Ορίσατε ένα αρχείο εξόδου."
 
-#: Merge.rc:5269
+#: Merge.rc:5268
 #, c-format
 msgid "Cannot create patch from binary files."
 msgstr "Η δημιουργία αρχείου patch από δυαδικά αρχεία δεν είναι δυνατή."
 
 #. IDS_SAVEFILES_FORPATCH
-#: Merge.rc:5270
+#: Merge.rc:5269
 #, c-format
 msgid ""
 "Save all files first.\n"
@@ -8047,23 +8041,23 @@ msgstr ""
 "Η δημιουργία patch απαιτεί να μην υπάρχουν σε αρχεία αλλαγές οι οποίες δεν έχουν αποθηκευθεί."
 
 #. IDS_FOLDER_NOTEXIST
-#: Merge.rc:5271
+#: Merge.rc:5270
 #, c-format
 msgid "Folder does not exist."
 msgstr "Ο φάκελος δεν υπάρχει."
 
 #. IDS_ARCHIVE_SUCCEEDED
-#: Merge.rc:5277
+#: Merge.rc:5276
 msgid "Archive file written."
 msgstr ""
 
 #. IDS_ARCHIVE_SAVEFILES
-#: Merge.rc:5278
+#: Merge.rc:5277
 msgid "Save all files first.\n\nCreating an archive requires no unsaved changes."
 msgstr ""
 
 #. IDS_NO_ZIP_SUPPORT
-#: Merge.rc:5283
+#: Merge.rc:5282
 msgid "Archive support not enabled.\n7-Zip and/or Merge7z*.dll not found.\nSee manual for archive support."
 msgstr ""
 "Η υποστήριξη συμπιεσμένων αρχείων δεν είναι ενεργοποιημένη.\n"
@@ -8071,43 +8065,43 @@ msgstr ""
 "Δείτε στο εγχειρίδιο για περισσότερες πληροφορίες σχετικά με την υποστήριξη συμπιεσμένων αρχείων και με τον τρόπο ενεργοποιήσεως αυτής."
 
 #. IDS_OPT_EXPORT_CAPTION
-#: Merge.rc:5284
+#: Merge.rc:5283
 #, c-format
 msgid "Select file for export"
 msgstr "Επιλέξατε αρχείο προς εξαγωγή"
 
 #. IDS_OPT_IMPORT_CAPTION
-#: Merge.rc:5285
+#: Merge.rc:5284
 #, c-format
 msgid "Select file for import"
 msgstr "Επιλέξατε αρχείο προς εισαγωγή"
 
 #. IDS_OPT_IMPORT_DONE
-#: Merge.rc:5286
+#: Merge.rc:5285
 #, c-format
 msgid "Options imported from file."
 msgstr "Οι ρυθμίσεις εισήχθησαν από το αρχείο."
 
 #. IDS_OPT_EXPORT_DONE
-#: Merge.rc:5287
+#: Merge.rc:5286
 #, c-format
 msgid "Options exported to file."
 msgstr "Οι ρυθμίσεις εξήχθησαν στο αρχείο."
 
 #. IDS_OPT_IMPORT_ERR
-#: Merge.rc:5288
+#: Merge.rc:5287
 #, c-format
 msgid "Failed to import options from file."
 msgstr "Αποτυχία εισαγωγής ρυθμίσεων από το αρχείο."
 
 #. IDS_OPT_EXPORT_ERR
-#: Merge.rc:5289
+#: Merge.rc:5288
 #, c-format
 msgid "Failed to write options to file."
 msgstr "Αποτυχία εγγραφής ρυθμίσεων στο αρχείο."
 
 #. IDS_CLOSEALL_WINDOWS
-#: Merge.rc:5290
+#: Merge.rc:5289
 #, c-format
 msgid ""
 "Close multiple compare windows?\n"
@@ -8119,1209 +8113,1209 @@ msgstr ""
 "Επιθυμείτε να συνεχίσετε;"
 
 #. IDS_EOL_BIN
-#: Merge.rc:5300
+#: Merge.rc:5299
 msgctxt "EOL Type"
 msgid "Binary"
 msgstr "Δυαδικό"
 
 #. IDS_MARKER_COLOR_FMT
-#: Merge.rc:5305
+#: Merge.rc:5304
 #, c-format
 msgid "Marker Color %d"
 msgstr ""
 
 #. IDS_MARKER_NEW_PATTERN
-#: Merge.rc:5306
+#: Merge.rc:5305
 msgid "New Pattern"
 msgstr ""
 
 #. IDS_PLUGINSLIST_TYPE
-#: Merge.rc:5312
+#: Merge.rc:5311
 #, c-format
 msgid "Type"
 msgstr "Τύπος"
 
 #. IDS_PLUGINS_TYPE_EDITSCRIPT
-#: Merge.rc:5316
+#: Merge.rc:5315
 #, c-format
 msgid "Editor script"
 msgstr "Μακροεντολές Επεξεργαστή Κειμένου"
 
 #. ID_SELECTLINEDIFF
-#: Merge.rc:5322
+#: Merge.rc:5321
 #, c-format
 msgid "\nDifference in Current Line (F4)"
 msgstr ""
 
 #. ID_OPTIONS
-#: Merge.rc:5323
+#: Merge.rc:5322
 #, c-format
 msgid "\nOptions"
 msgstr ""
 
 #. ID_REFRESH
-#: Merge.rc:5324
+#: Merge.rc:5323
 #, c-format
 msgid "\nRefresh (F5)"
 msgstr ""
 
 #. ID_PREVDIFF
-#: Merge.rc:5330
+#: Merge.rc:5329
 #, c-format
 msgid "\nPrevious Difference (Alt+Up)"
 msgstr ""
 
 #. ID_NEXTDIFF
-#: Merge.rc:5331
+#: Merge.rc:5330
 #, c-format
 msgid "\nNext Difference (Alt+Down)"
 msgstr ""
 
 #. ID_PREVCONFLICT
-#: Merge.rc:5332
+#: Merge.rc:5331
 #, c-format
 msgid "\nPrevious Conflict (Alt+Shift+Up)"
 msgstr ""
 
 #. ID_NEXTCONFLICT
-#: Merge.rc:5333
+#: Merge.rc:5332
 #, c-format
 msgid "\nNext Conflict (Alt+Shift+Down)"
 msgstr ""
 
 #. ID_FIRSTDIFF
-#: Merge.rc:5338
+#: Merge.rc:5337
 #, c-format
 msgid "\nFirst Difference (Alt+Home)"
 msgstr ""
 
 #. ID_CURDIFF
-#: Merge.rc:5339
+#: Merge.rc:5338
 #, c-format
 msgid "\nCurrent Difference (Alt+Enter)"
 msgstr ""
 
 #. ID_LASTDIFF
-#: Merge.rc:5340
+#: Merge.rc:5339
 #, c-format
 msgid "\nLast Difference (Alt+End)"
 msgstr ""
 
 #. ID_L2R
-#: Merge.rc:5341
+#: Merge.rc:5340
 msgid "\nCopy to Right (Alt+Right)"
 msgstr ""
 
 #. ID_R2L
-#: Merge.rc:5342
+#: Merge.rc:5341
 msgid "\nCopy to Left (Alt+Left)"
 msgstr ""
 
 #. ID_L2RNEXT
-#: Merge.rc:5343
+#: Merge.rc:5342
 msgid "\nCopy to Right and Advance (Ctrl+Alt+Right)"
 msgstr ""
 
 #. ID_R2LNEXT
-#: Merge.rc:5344
+#: Merge.rc:5343
 msgid "\nCopy to Left and Advance (Ctrl+Alt+Left)"
 msgstr ""
 
 #. ID_ALL_RIGHT
-#: Merge.rc:5345
+#: Merge.rc:5344
 msgid "\nCopy All to Right"
 msgstr "\nΑντιγραφή όλων Δεξιά"
 
 #. ID_ALL_LEFT
-#: Merge.rc:5346
+#: Merge.rc:5345
 msgid "\nCopy All to Left"
 msgstr "\nΑντιγραφή όλων Αριστερά"
 
 #. ID_AUTO_MERGE
-#: Merge.rc:5347
+#: Merge.rc:5346
 #, c-format
 msgid "\nAuto Merge (Ctrl+Alt+M)"
 msgstr ""
 
 #. ID_FIRSTFILE
-#: Merge.rc:5348
+#: Merge.rc:5347
 msgid "\nFirst File"
 msgstr ""
 
 #. ID_NEXTFILE
-#: Merge.rc:5349
+#: Merge.rc:5348
 msgid "\nNext File (Ctrl+F8)"
 msgstr ""
 
 #. ID_LASTFILE
-#: Merge.rc:5350
+#: Merge.rc:5349
 msgid "\nLast File"
 msgstr ""
 
 #. ID_PREVFILE
-#: Merge.rc:5351
+#: Merge.rc:5350
 msgid "\nPrevious File (Ctrl+F7)"
 msgstr ""
 
 #. IDS_UNPACK_AUTO
-#: Merge.rc:5358
+#: Merge.rc:5357
 msgid "Adapted unpacker applied to both files (one needs extension)."
 msgstr "Το συνεργαζόμενο αποσυμπιεστικό ενεργεί σε αμφότερα τα αρχεία (μόνο ένα αρχείο χρειάζεται να έχει την επέκταση)."
 
 #. IDS_NO_PREDIFFER
-#: Merge.rc:5359
+#: Merge.rc:5358
 #, c-format
 msgid "No Prediffer (Normal)"
 msgstr "Χωρίς προεπεξεργασία διαφορών (Κανονική Λειτουργία)"
 
 #. IDS_SUGGESTED_PLUGINS
-#: Merge.rc:5360
+#: Merge.rc:5359
 #, c-format
 msgid "Suggested Plugins"
 msgstr "Προτεινόμενα Αρθρώματα"
 
 #. IDS_NOT_SUGGESTED_PLUGINS
-#: Merge.rc:5361
+#: Merge.rc:5360
 msgid "All Plugins"
 msgstr ""
 
 #. IDS_PRIVATEBUILD_FMT
-#: Merge.rc:5367
+#: Merge.rc:5366
 #, c-format
 msgid "Private Build: %1"
 msgstr "Ιδιωτική Μεταγλώττιση: %1"
 
 #. IDS_ALLRIGHTS_RESERVED
-#: Merge.rc:5368
+#: Merge.rc:5367
 msgid " - All rights reserved."
 msgstr ""
 
 #. IDS_TITLE_PLUGINS_SETTINGS
-#: Merge.rc:5374
+#: Merge.rc:5373
 #, c-format
 msgid "Plugin Settings"
 msgstr "Ρυθμίσεις Αρθρωμάτων"
 
 #. IDS_NO_SCT_SCRIPTS
-#: Merge.rc:5376
+#: Merge.rc:5375
 #, c-format
 msgid "WSH not found - .sct scripts disabled"
 msgstr "Το Περιβάλλον Διερμηνείας Windows (WSH) δε βρέθηκε - η χρήση αρχείων δέσμης ενεργειών .sct είναι απενεργοποιημένη"
 
 #. IDS_LOCBAR_GOTOLINE_FMT
-#: Merge.rc:5384
+#: Merge.rc:5383
 #, c-format
 msgid "G&o to Line %1"
 msgstr "Μετά&βαση στη Γραμμή %1"
 
 #. IDS_GOTO_MOVED_LINE
-#: Merge.rc:5390
+#: Merge.rc:5389
 msgid "Go to Moved Line\tCtrl+Shift+G"
 msgstr ""
 
 #. IDS_AUTOCOMPLETE_DISABLED
-#: Merge.rc:5396
+#: Merge.rc:5395
 msgctxt "Options dialog|General|Open dialog Auto completion"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_AUTOCOMPLETE_FILE_SYS
-#: Merge.rc:5397
+#: Merge.rc:5396
 #, c-format
 msgid "From file system"
 msgstr "Από Αρχειοσύστημα"
 
 #. IDS_AUTOCOMPLETE_MRU
-#: Merge.rc:5398
+#: Merge.rc:5397
 #, c-format
 msgid "From Most Recently Used list"
 msgstr "Από Κατάλογο προσφάτως χρησιμοποιηθέντων"
 
 #. IDS_COLORSCHEME_PLAIN
-#: Merge.rc:5404
+#: Merge.rc:5403
 #, c-format
 msgid "No Highlighting"
 msgstr "Χωρίς Χρωματισμό Κώδικα"
 
 #. IDS_COLORSCHEME_PO
-#: Merge.rc:5439
+#: Merge.rc:5438
 #, c-format
 msgid "Portable Object"
 msgstr ""
 
 #. IDS_COLORSCHEME_RSRC
-#: Merge.rc:5444
+#: Merge.rc:5443
 #, c-format
 msgid "Resources"
 msgstr ""
 
 #. IDS_COLORSCHEME_SH
-#: Merge.rc:5448
+#: Merge.rc:5447
 #, c-format
 msgid "Shell"
 msgstr ""
 
 #. IDS_CLOSE_LEFT_TABS
-#: Merge.rc:5469
+#: Merge.rc:5468
 #, c-format
 msgid "Close &Left Tabs"
 msgstr ""
 
 #. IDS_CLOSE_RIGHT_TABS
-#: Merge.rc:5470
+#: Merge.rc:5469
 #, c-format
 msgid "Close R&ight Tabs"
 msgstr ""
 
 #. IDS_CLOSE_OTHER_TABS
-#: Merge.rc:5471
+#: Merge.rc:5470
 #, c-format
 msgid "Close &Other Tabs"
 msgstr ""
 
 #. IDS_TABBAR_AUTO_MAXWIDTH
-#: Merge.rc:5472
+#: Merge.rc:5471
 #, c-format
 msgid "Enable &Auto Max Width"
 msgstr ""
 
 #. IDS_WEBPAGE_MENU
-#: Merge.rc:5482
+#: Merge.rc:5481
 msgid "We&bpage"
 msgstr ""
 
 #. IDS_VIEW_WRAP_TEXT
-#: Merge.rc:5487
+#: Merge.rc:5486
 msgid "W&rap Text"
 msgstr ""
 
 #. IDS_NOTINSTALLED
-#: Merge.rc:5492
+#: Merge.rc:5491
 msgid "%1 is not installed."
 msgstr ""
 
 #. IDS_CREATE_FOLDER
-#: Merge.rc:5497
+#: Merge.rc:5496
 #, c-format
 msgid "%1 does not exist. Create it?"
 msgstr ""
 
 #. IDS_CREATE_FOLDER_ERROR
-#: Merge.rc:5498
+#: Merge.rc:5497
 #, c-format
 msgid "Failed to create folder."
 msgstr ""
 
 #. IDC_EXT_EDITOR_PATH
-#: Merge.rc:5503
+#: Merge.rc:5502
 #, c-format
 msgid "Parameters:\n$file: Current file path\n$linenum: Current cursor line number"
 msgstr ""
 
 #. IDS_DIFF_ALGORITHM_DEFAULT
-#: Merge.rc:5508
+#: Merge.rc:5507
 msgid "default"
 msgstr ""
 
 #. IDS_DIFF_ALGORITHM_MINIMAL
-#: Merge.rc:5509
+#: Merge.rc:5508
 msgid "minimal"
 msgstr ""
 
 #. IDS_DIFF_ALGORITHM_PATIENCE
-#: Merge.rc:5510
+#: Merge.rc:5509
 msgid "patience"
 msgstr ""
 
 #. IDS_DIFF_ALGORITHM_HISTOGRAM
-#: Merge.rc:5511
+#: Merge.rc:5510
 msgid "histogram"
 msgstr ""
 
 #. IDS_DIFF_ALGORITHM_NONE
-#: Merge.rc:5512
+#: Merge.rc:5511
 msgid "none"
 msgstr ""
 
 #. IDS_RENDERING_MODE_GDI
-#: Merge.rc:5517
+#: Merge.rc:5516
 msgid "GDI"
 msgstr ""
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_DEFAULT
-#: Merge.rc:5518
+#: Merge.rc:5517
 msgid "DirectWrite Default"
 msgstr ""
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_ALIASED
-#: Merge.rc:5519
+#: Merge.rc:5518
 msgid "DirectWrite Aliased"
 msgstr ""
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_GDI_CLASSIC
-#: Merge.rc:5520
+#: Merge.rc:5519
 msgid "DirectWrite GDI Classic"
 msgstr ""
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_GDI_NATURAL
-#: Merge.rc:5521
+#: Merge.rc:5520
 msgid "DirectWrite GDI Natural"
 msgstr ""
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_NATURAL
-#: Merge.rc:5522
+#: Merge.rc:5521
 msgid "DirectWrite Natural"
 msgstr ""
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_NATURAL_SYMMETRIC
-#: Merge.rc:5523
+#: Merge.rc:5522
 msgid "DirectWrite Natural Symmetric"
 msgstr ""
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_DISABLED
-#: Merge.rc:5528
+#: Merge.rc:5527
 msgctxt "Options dialog|General|Close windows with Esc"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_1
-#: Merge.rc:5529
+#: Merge.rc:5528
 msgid "MDI child window or main window"
 msgstr ""
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_2
-#: Merge.rc:5530
+#: Merge.rc:5529
 msgid "MDI child window only"
 msgstr ""
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_3
-#: Merge.rc:5531
+#: Merge.rc:5530
 msgid "Close main window if only one MDI child window"
 msgstr ""
 
 #. IDS_DIFF_GROUP
-#: Merge.rc:5536
+#: Merge.rc:5535
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Diff"
 msgstr ""
 
 #. IDS_DIFF_HIGHLIGHT
-#: Merge.rc:5537
+#: Merge.rc:5536
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Highlight"
 msgstr ""
 
 #. IDS_DIFF_BLINK
-#: Merge.rc:5538
+#: Merge.rc:5537
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Blink"
 msgstr ""
 
 #. IDS_DIFF_BLOCKSIZE
-#: Merge.rc:5539
+#: Merge.rc:5538
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Block Size"
 msgstr ""
 
 #. IDS_DIFF_BLOCKALPHA
-#: Merge.rc:5540
+#: Merge.rc:5539
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Block Alpha"
 msgstr ""
 
 #. IDS_DIFF_CDTHRESHOLD
-#: Merge.rc:5541
+#: Merge.rc:5540
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "CD Threshold"
 msgstr ""
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION
-#: Merge.rc:5542
+#: Merge.rc:5541
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Ins/Del Detection"
 msgstr ""
 
 #. IDS_OVERLAY_MODE_NONE
-#: Merge.rc:5543 Merge.rc:5548
+#: Merge.rc:5542 Merge.rc:5547
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "None"
 msgstr ""
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION_VERTICAL
-#: Merge.rc:5544
+#: Merge.rc:5543
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Vertical"
 msgstr ""
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION_HORIZONTAL
-#: Merge.rc:5545
+#: Merge.rc:5544
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Horizontal"
 msgstr ""
 
 #. IDS_OVERLAY_GROUP
-#: Merge.rc:5546
+#: Merge.rc:5545
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Overlay"
 msgstr ""
 
 #. IDS_OVERLAY_ALPHA
-#: Merge.rc:5547
+#: Merge.rc:5546
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha"
 msgstr ""
 
 #. IDS_OVERLAY_MODE_XOR
-#: Merge.rc:5549
+#: Merge.rc:5548
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "XOR"
 msgstr ""
 
 #. IDS_OVERLAY_MODE_ALPHA
-#: Merge.rc:5550
+#: Merge.rc:5549
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha Blend"
 msgstr ""
 
 #. IDS_OVERLAY_MODE_ALPHA_ANIMATION
-#: Merge.rc:5551
+#: Merge.rc:5550
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha Animation"
 msgstr ""
 
 #. IDS_ZOOM
-#: Merge.rc:5552
+#: Merge.rc:5551
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Zoom"
 msgstr ""
 
 #. IDS_PAGE
-#: Merge.rc:5553
+#: Merge.rc:5552
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Page:"
 msgstr ""
 
 #. IDS_IMGCMP_STATUS_PT_RGBA_FMT
-#: Merge.rc:5554
+#: Merge.rc:5553
 #, c-format
 msgid "Pt: (%d, %d)  RGBA: (%d, %d, %d, %d)  "
 msgstr ""
 
 #. IDS_IMGCMP_STATUS_DIST1_FMT
-#: Merge.rc:5555
+#: Merge.rc:5554
 #, c-format
 msgid "Dist: %g  "
 msgstr ""
 
 #. IDS_IMGCMP_STATUS_DIST2_FMT
-#: Merge.rc:5556
+#: Merge.rc:5555
 #, c-format
 msgid "Dist: %g, %g  "
 msgstr ""
 
 #. IDS_IMGCMP_STATUS_PAGE_ZOOM_SIZE_BPP_FMT
-#: Merge.rc:5557
+#: Merge.rc:5556
 #, c-format
 msgid "Page: %d/%d  Zoom: %d%%  %dx%dpx  %dbpp  "
 msgstr ""
 
 #. IDS_IMGCMP_STATUS_RC_FMT
-#: Merge.rc:5558
+#: Merge.rc:5557
 #, c-format
 msgid "Rc: (%d, %d)  "
 msgstr ""
 
 #. IDS_IMGCMP_STATUS_FLIPPED_FMT
-#: Merge.rc:5559
+#: Merge.rc:5558
 #, c-format
 msgid "Flipped: %s  "
 msgstr ""
 
 #. IDS_IMGCMP_STATUS_ROTATED_FMT
-#: Merge.rc:5560
+#: Merge.rc:5559
 #, c-format
 msgid "Rotated: %d  "
 msgstr ""
 
 #. IDS_IMGCMP_REPORT_ALLPAGES
-#: Merge.rc:5561
+#: Merge.rc:5560
 msgid "All pages"
 msgstr ""
 
 #. IDS_IGNSUB_STR1
-#: Merge.rc:5566
+#: Merge.rc:5565
 msgid "<Edit here>"
 msgstr ""
 
 #. IDS_IGNSUB_STR2
-#: Merge.rc:5567
+#: Merge.rc:5566
 msgid "No differences found to select"
 msgstr ""
 
 #. IDS_IGNSUB_STR3
-#: Merge.rc:5568
+#: Merge.rc:5567
 msgid "No differences found to add as substitution filter"
 msgstr ""
 
 #. IDS_IGNSUB_STR4
-#: Merge.rc:5569
+#: Merge.rc:5568
 msgid "The pair is already in the Substitution Filters list"
 msgstr ""
 
 #. IDS_IGNSUB_STR5
-#: Merge.rc:5570
+#: Merge.rc:5569
 msgid "Add this change to Substitution Filters?"
 msgstr ""
 
 #. IDS_OCRRESULT_TEXTONLY
-#: Merge.rc:5575
+#: Merge.rc:5574
 msgid "Text only"
 msgstr ""
 
 #. IDS_OCRRESULT_POS_LINE
-#: Merge.rc:5576
+#: Merge.rc:5575
 msgid "Line-by-line position and text"
 msgstr ""
 
 #. IDS_OCRRESULT_POS_WORD
-#: Merge.rc:5577
+#: Merge.rc:5576
 msgid "Word-by-word position and text"
 msgstr ""
 
 #. IDS_USERDATAFOLDER_APPDATA
-#: Merge.rc:5582
+#: Merge.rc:5581
 msgid "AppData (Roaming) folder"
 msgstr ""
 
 #. IDS_USERDATAFOLDER_INSTALL
-#: Merge.rc:5583
+#: Merge.rc:5582
 msgid "Install folder"
 msgstr ""
 
 #. IDS_USERDATAFOLDER_DOCUMENTS
-#: Merge.rc:5584
+#: Merge.rc:5583
 msgid "Documents folder"
 msgstr ""
 
 #. IDS_SINGLEINSTANCE_DISABLED
-#: Merge.rc:5589
+#: Merge.rc:5588
 msgctxt "Options dialog|General|Single instance mode"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_SINGLEINSTANCE_STR1
-#: Merge.rc:5590
+#: Merge.rc:5589
 #, c-format
 msgid "Allow only one instance to run"
 msgstr "Επιτρέπεται μόνο μία υπόσταση του WinMerge ανοικτή"
 
 #. IDS_CLIPBOARD_HISTORY
-#: Merge.rc:5591
+#: Merge.rc:5590
 msgid "Clipboard &History"
 msgstr ""
 
 #. IDS_SINGLEINSTANCE_STR2
-#: Merge.rc:5592
+#: Merge.rc:5591
 msgid "Allow only one instance; wait for termination"
 msgstr ""
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_DISABLED
-#: Merge.rc:5597
+#: Merge.rc:5596
 msgctxt "Options dialog|General|Auto-reload modified files"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_STR1
-#: Merge.rc:5598
+#: Merge.rc:5597
 msgid "Only on window activated"
 msgstr ""
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_STR2
-#: Merge.rc:5599
+#: Merge.rc:5598
 msgid "Immediately"
 msgstr ""
 
 #. IDS_PLUGIN_ALL
-#: Merge.rc:5604
+#: Merge.rc:5603
 msgid "Al&l"
 msgstr ""
 
 #. IDS_PLUGIN_OTHERS
-#: Merge.rc:5605
+#: Merge.rc:5604
 msgid "&Others"
 msgstr ""
 
-#: Merge.rc:5607
+#: Merge.rc:5606
 #, c-format
 msgid "Missing plugin name in pipeline: %1"
 msgstr ""
 
-#: Merge.rc:5609
+#: Merge.rc:5608
 #, c-format
 msgid "Missing quote in plugin pipeline: %1"
 msgstr ""
 
 #. IDS_PLUGIN_NAME_ALREADY_EXISTS
-#: Merge.rc:5610
+#: Merge.rc:5609
 #, c-format
 msgid "Plugin name '%1' already exists."
 msgstr ""
 
 #. IDS_PLUGIN_TITLE1
-#: Merge.rc:5611
+#: Merge.rc:5610
 msgid "Specify plugin arguments"
 msgstr ""
 
-#: Merge.rc:5613
+#: Merge.rc:5612
 #, c-format
 msgid "Plugin not found or invalid: %1"
 msgstr ""
 
 #. IDS_PLUGIN_NOT_UNPACK
-#: Merge.rc:5614
+#: Merge.rc:5613
 #, c-format
 msgid "'%1' is not an unpacker plugin"
 msgstr ""
 
 #. IDS_PLUGIN_NOT_PREDIFF
-#: Merge.rc:5615
+#: Merge.rc:5614
 #, c-format
 msgid "'%1' is not a prediffer plugin"
 msgstr ""
 
-#: Merge.rc:5617
+#: Merge.rc:5616
 #, c-format
 msgid "Error prediffing '%1' with '%2'. Prediffing disabled."
 msgstr ""
 
 #. IDS_PLUGIN_CIRCULAR_REFERENCE
-#: Merge.rc:5618
+#: Merge.rc:5617
 #, c-format
 msgid "Circular reference in plugin pipeline: %1"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE1
-#: Merge.rc:5619
+#: Merge.rc:5618
 msgid "URL Handler"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE2
-#: Merge.rc:5620
+#: Merge.rc:5619
 msgid "File Unpacker"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE3
-#: Merge.rc:5621
+#: Merge.rc:5620
 msgid "File or Folder Unpacker"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE5
-#: Merge.rc:5623
+#: Merge.rc:5622
 msgid "Alias for Unpacker"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE6
-#: Merge.rc:5624
+#: Merge.rc:5623
 msgid "Alias for Prediffer"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE7
-#: Merge.rc:5625
+#: Merge.rc:5624
 msgid "Alias for Editor script"
 msgstr ""
 
 #. IDS_PLUGIN_ALIAS_DESC
-#: Merge.rc:5626
+#: Merge.rc:5625
 #, c-format
 msgid "Alias for plugin pipeline '%1'"
 msgstr ""
 
 #. IDS_PLUGIN_NEW_DESC
-#: Merge.rc:5627
+#: Merge.rc:5626
 msgid "New plugin description"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_ALL
-#: Merge.rc:5628
+#: Merge.rc:5627
 msgid "All"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_1ST
-#: Merge.rc:5629
+#: Merge.rc:5628
 msgid "1st"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_2ND
-#: Merge.rc:5630
+#: Merge.rc:5629
 msgid "2nd"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_3RD
-#: Merge.rc:5631
+#: Merge.rc:5630
 msgid "3rd"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_1ST_2ND
-#: Merge.rc:5632
+#: Merge.rc:5631
 msgid "1st and 2nd"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_1ST_3RD
-#: Merge.rc:5633
+#: Merge.rc:5632
 msgid "1st and 3rd"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_2ND_3RD
-#: Merge.rc:5634
+#: Merge.rc:5633
 msgid "2nd and 3rd"
 msgstr ""
 
 #. IDS_PLUGIN_CTRL_CLICK
-#: Merge.rc:5635
+#: Merge.rc:5634
 msgid "(Ctrl+Click to add to pipeline)"
 msgstr ""
 
 #. IDS_FILTER_APPLIED
-#: Merge.rc:5640
+#: Merge.rc:5639
 msgid "Filter applied"
 msgstr ""
 
 #. IDS_FILTERMENU_COMPARE
-#: Merge.rc:5645
+#: Merge.rc:5644
 #, c-format
 msgid "Compare %1"
 msgstr ""
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN2
-#: Merge.rc:5647
+#: Merge.rc:5646
 msgid "&Filter by This Column..."
 msgstr ""
 
 #. IDS_CLIPBOARDHISTORY_TIME
-#: Merge.rc:5652
+#: Merge.rc:5651
 #, c-format
 msgid "Clipboard at %s"
 msgstr ""
 
 #. IDS_CLIPBOARDHISTORY_DISABLED
-#: Merge.rc:5653
+#: Merge.rc:5652
 msgid "Clipboard history disabled.\r\nEnable: Windows logo key + V, then Turn on."
 msgstr ""
 
-#: Merge.rc:5655
+#: Merge.rc:5654
 msgid "This system does not support clipboard history."
 msgstr ""
 
-#: Merge.rc:5657
+#: Merge.rc:5656
 msgid "32-bit WinMerge does not support Clipboard Compare"
 msgstr ""
 
 #. IDS_WEBVIEW2_RUNTIME_NOT_INSTALLED
-#: Merge.rc:5662
+#: Merge.rc:5661
 msgid "WebView2 runtime not installed. Download it?"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_TEXT_COMPARE
-#: Merge.rc:5667
+#: Merge.rc:5666
 msgid "New Text Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_TABLE_COMPARE
-#: Merge.rc:5668
+#: Merge.rc:5667
 msgid "New Table Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_BINARY_COMPARE
-#: Merge.rc:5669
+#: Merge.rc:5668
 msgid "New Binary Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_IMAGE_COMPARE
-#: Merge.rc:5670
+#: Merge.rc:5669
 msgid "New Image Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_WEBPAGE_COMPARE
-#: Merge.rc:5671
+#: Merge.rc:5670
 msgid "New Webpage Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_FOLDER_COMPARE
-#: Merge.rc:5672
+#: Merge.rc:5671
 msgid "New Folder Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_CLIPBOARD_COMPARE
-#: Merge.rc:5673
+#: Merge.rc:5672
 msgid "Clipboard Compare"
 msgstr ""
 
 #. IDS_PREVIEWBAR_PRINT
-#: Merge.rc:5678
+#: Merge.rc:5677
 msgid "&Print..."
 msgstr ""
 
 #. IDS_PREVIEWBAR_PREVPAGE
-#: Merge.rc:5680
+#: Merge.rc:5679
 msgid "Pre&v Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_TWOPAGE
-#: Merge.rc:5681
+#: Merge.rc:5680
 msgid "&Two Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_ONEPAGE
-#: Merge.rc:5682
+#: Merge.rc:5681
 msgid "&One Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_ZOOMIN
-#: Merge.rc:5683
+#: Merge.rc:5682
 msgid "Zoom &In"
 msgstr ""
 
 #. IDS_PREVIEWBAR_ZOOMOUT
-#: Merge.rc:5684
+#: Merge.rc:5683
 msgid "Zoom &Out"
 msgstr ""
 
 #. IDS_WEBPAGE_COMPARING
-#: Merge.rc:5690
+#: Merge.rc:5689
 msgid "Comparing..."
 msgstr ""
 
 #. IDS_WEBPAGE_ZOOM
-#: Merge.rc:5691
+#: Merge.rc:5690
 msgid "Zoom:"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_DIFFHUNK
-#: Merge.rc:5696
+#: Merge.rc:5695
 msgid "Diff hunk"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_INLINE
-#: Merge.rc:5697
+#: Merge.rc:5696
 msgid "Inline diff"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_LINE
-#: Merge.rc:5698
+#: Merge.rc:5697
 msgid "Line"
 msgstr ""
 
-#: Merge.rc:5699
+#: Merge.rc:5698
 msgid "Character"
 msgstr ""
 
 #. ID_MICE_PREVDIFF
-#: Merge.rc:5704
+#: Merge.rc:5703
 msgid "\nPrevious Difference (Alt+Up)\n(Right Button+Wheel Up)\n(Alt+Wheel Up)"
 msgstr ""
 
 #. ID_MICE_NEXTDIFF
-#: Merge.rc:5705
+#: Merge.rc:5704
 msgid "\nNext Difference (Alt+Down)\n(Right Button+Wheel Down)\n(Alt+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_L2R
-#: Merge.rc:5706
+#: Merge.rc:5705
 msgid "\nCopy to Right (Alt+Right)\n(Right Button+Wheel Right)\n(Alt+Wheel Right)\n(Alt+Shift+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_R2L
-#: Merge.rc:5707
+#: Merge.rc:5706
 msgid "\nCopy to Left (Alt+Left)\n(Right Button+Wheel Left)\n(Alt+Wheel Left)\n(Alt+Shift+Wheel Up)"
 msgstr ""
 
 #. ID_MICE_L2RNEXT
-#: Merge.rc:5708
+#: Merge.rc:5707
 msgid "\nCopy to Right and Advance (Ctrl+Alt+Right)\n(Ctrl+Alt+Wheel Right)\n(Ctrl+Alt+Shift+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_R2LNEXT
-#: Merge.rc:5709
+#: Merge.rc:5708
 msgid "\nCopy to Left and Advance (Ctrl+Alt+Left)\n(Ctrl+Alt+Wheel Left)\n(Ctrl+Alt+Shift+Wheel Up)"
 msgstr ""
 
 #. IDS_LOG_COMPARING_2
-#: Merge.rc:5719
+#: Merge.rc:5718
 #, c-format
 msgid "Comparing %1 with %2"
 msgstr ""
 
 #. IDS_LOG_COMPARING_3
-#: Merge.rc:5720
+#: Merge.rc:5719
 #, c-format
 msgid "Comparing %1 with %2 and %3"
 msgstr ""
 
 #. IDS_LOG_COMPARE_COMPLETED
-#: Merge.rc:5721
+#: Merge.rc:5720
 msgid "Comparison completed"
 msgstr ""
 
 #. IDS_LOG_COMPARE_ERROR_2
-#: Merge.rc:5722
+#: Merge.rc:5721
 #, c-format
 msgid "Failed to compare %1 with %2: "
 msgstr ""
 
 #. IDS_LOG_COMPARE_ERROR_3
-#: Merge.rc:5723
+#: Merge.rc:5722
 #, c-format
 msgid "Failed to compare %1 with %2 and %3: "
 msgstr ""
 
 #. IDS_LOG_FILE_SAVED
-#: Merge.rc:5724
+#: Merge.rc:5723
 msgid "File saved"
 msgstr ""
 
 #. IDS_LOG_COPYING_FILES
-#: Merge.rc:5725
+#: Merge.rc:5724
 msgid "Copying files..."
 msgstr ""
 
 #. IDS_LOG_MOVING_FILES
-#: Merge.rc:5726
+#: Merge.rc:5725
 msgid "Moving files..."
 msgstr ""
 
 #. IDS_LOG_DELETING_FILES
-#: Merge.rc:5727
+#: Merge.rc:5726
 msgid "Deleting files..."
 msgstr ""
 
 #. IDS_LOG_RECYCLEBIN
-#: Merge.rc:5728
+#: Merge.rc:5727
 msgid "Recycle Bin"
 msgstr ""
 
 #. IDS_LOG_PERMANENTLY_DELETED
-#: Merge.rc:5729
+#: Merge.rc:5728
 msgid "Permanently deleted"
 msgstr ""
 
 #. IDS_LOG_FILEOPERATION_COMPLETED
-#: Merge.rc:5730
+#: Merge.rc:5729
 msgid "File operation completed successfully"
 msgstr ""
 
 #. IDS_LOG_FILEOPERATION_CANCELED
-#: Merge.rc:5731
+#: Merge.rc:5730
 msgid "File operation canceled"
 msgstr ""
 
 #. IDS_FILTER_ERROR_NO_ERROR
-#: Merge.rc:5736
+#: Merge.rc:5735
 msgid "No error"
 msgstr ""
 
 #. IDS_FILTER_ERROR_EMPTY_EXPRESSION
-#: Merge.rc:5737
+#: Merge.rc:5736
 msgid "Filter expression is empty"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNKNOWN_CHAR
-#: Merge.rc:5738
+#: Merge.rc:5737
 msgid "Unknown character in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNTERMINATED_STRING
-#: Merge.rc:5739
+#: Merge.rc:5738
 msgid "Unterminated string literal"
 msgstr ""
 
 #. IDS_FILTER_ERROR_SYNTAX_ERROR
-#: Merge.rc:5740
+#: Merge.rc:5739
 msgid "Syntax error in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_PARSE_FAILURE
-#: Merge.rc:5741
+#: Merge.rc:5740
 msgid "Failed to parse filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_LITERAL
-#: Merge.rc:5742
+#: Merge.rc:5741
 msgid "Invalid literal value"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_REGULAR_EXPRESSION
-#: Merge.rc:5743
+#: Merge.rc:5742
 msgid "Invalid regular expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNDEFINED_IDENTIFIER
-#: Merge.rc:5744
+#: Merge.rc:5743
 msgid "Undefined identifier"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_ARGUMENT_COUNT
-#: Merge.rc:5745
+#: Merge.rc:5744
 msgid "Invalid number of arguments"
 msgstr ""
 
 #. IDS_FILTER_ERROR_FILTER_NAME_NOT_FOUND
-#: Merge.rc:5746
+#: Merge.rc:5745
 msgid "Filter name not found"
 msgstr ""
 
 #. IDS_FILTER_ERROR_DIVIDE_BY_ZERO
-#: Merge.rc:5747
+#: Merge.rc:5746
 msgid "Division by zero in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNKNOWN_ERROR
-#: Merge.rc:5748
+#: Merge.rc:5747
 msgid "Unknown error"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_PROPERTY_NAME
-#: Merge.rc:5749
+#: Merge.rc:5748
 msgid "Invalid property name"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_DIRECTIVE
-#: Merge.rc:5750
+#: Merge.rc:5749
 msgid "Invalid directive"
 msgstr ""
 
 #. IDS_FILTER_OP_EQUALS
-#: Merge.rc:5755
+#: Merge.rc:5754
 msgid "Equals"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_EQUALS
-#: Merge.rc:5756
+#: Merge.rc:5755
 msgid "Does not equal"
 msgstr ""
 
 #. IDS_FILTER_OP_LESS_THAN
-#: Merge.rc:5757
+#: Merge.rc:5756
 msgid "Less than"
 msgstr ""
 
 #. IDS_FILTER_OP_LESS_EQUAL
-#: Merge.rc:5758
+#: Merge.rc:5757
 msgid "Less than or equal to"
 msgstr ""
 
 #. IDS_FILTER_OP_GREATER_EQUAL
-#: Merge.rc:5759
+#: Merge.rc:5758
 msgid "Greater than or equal to"
 msgstr ""
 
 #. IDS_FILTER_OP_GREATER_THAN
-#: Merge.rc:5760
+#: Merge.rc:5759
 msgid "Greater than"
 msgstr ""
 
 #. IDS_FILTER_OP_BETWEEN
-#: Merge.rc:5761
+#: Merge.rc:5760
 msgid "Between"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_BETWEEN
-#: Merge.rc:5762
+#: Merge.rc:5761
 msgid "Not Between"
 msgstr ""
 
 #. IDS_FILTER_OP_CONTAINS
-#: Merge.rc:5763
+#: Merge.rc:5762
 msgid "Contains"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_CONTAINS
-#: Merge.rc:5764
+#: Merge.rc:5763
 msgid "Not Contains"
 msgstr ""
 
 #. IDS_FILTER_OP_RECONTAINS
-#: Merge.rc:5765
+#: Merge.rc:5764
 msgid "Contains (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_RECONTAINS
-#: Merge.rc:5766
+#: Merge.rc:5765
 msgid "Not Contains (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_LIKE
-#: Merge.rc:5767
+#: Merge.rc:5766
 msgid "Match (wildcard)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_LIKE
-#: Merge.rc:5768
+#: Merge.rc:5767
 msgid "Not match (wildcard)"
 msgstr ""
 
 #. IDS_FILTER_OP_MATCHES
-#: Merge.rc:5769
+#: Merge.rc:5768
 msgid "Match (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_MATCHES
-#: Merge.rc:5770
+#: Merge.rc:5769
 msgid "Not match (regex)"
 msgstr ""
 
 #. IDS_COLORMODE_LIGHT
-#: Merge.rc:5775
+#: Merge.rc:5774
 msgid "Light"
 msgstr ""
 
 #. IDS_COLORMODE_DARK
-#: Merge.rc:5776
+#: Merge.rc:5775
 msgid "Dark"
 msgstr ""
 
 #. IDS_COLORMODE_FOLLOWSYSTEM
-#: Merge.rc:5777
+#: Merge.rc:5776
 msgid "Follow system"
 msgstr ""
 
 #. IDS_EXAMPLE
-#: Merge.rc:5782
+#: Merge.rc:5781
 #, c-format
 msgid "e.g. %1"
 msgstr ""
 
 #. IDS_DETECTED_PREVIOUS_CRASH
-#: Merge.rc:5787
+#: Merge.rc:5786
 msgid "WinMerge detected a previous crash. Please report this if possible."
 msgstr ""
 
 #. IDS_REGEX_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5792
+#: Merge.rc:5791
 msgid "# Regex replacement list\r\n# Format: regex<TAB>replacement\r\n# Backreferences like $1, $2 are supported\r\n\r\n(\\d{4})-(\\d{2})-(\\d{2})\t$1_$2_$3\r\n"
 msgstr ""
 
 #. IDS_STRING_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5793
+#: Merge.rc:5792
 msgid "# Replacement list\r\n# Format: search<TAB>replacement\r\n# Lines starting with # are ignored\r\n\r\nfrom1\tto1\r\nfrom2\tto2\r\n"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_ONLY
-#: Merge.rc:5798
+#: Merge.rc:5797
 msgid "Built-in only"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_FIRST
-#: Merge.rc:5799
+#: Merge.rc:5798
 msgid "Built-in first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_FIRST
-#: Merge.rc:5800
+#: Merge.rc:5799
 msgid "Tree-sitter first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_ONLY
-#: Merge.rc:5801
+#: Merge.rc:5800
 msgid "Tree-sitter only"
 msgstr ""
 

--- a/Translations/WinMerge/Hebrew.po
+++ b/Translations/WinMerge/Hebrew.po
@@ -21,7 +21,7 @@ msgstr ""
 "X-Generator: Poedit 3.5\n"
 
 #. LANGUAGE, SUBLANGUAGE
-#: Merge.rc:26 Merge.rc:59 Merge.rc:5818
+#: Merge.rc:26 Merge.rc:59 Merge.rc:5817
 msgid "LANG_ENGLISH, SUBLANG_ENGLISH_US"
 msgstr "LANG_HEBREW, SUBLANG_HEBREW_ISRAEL"
 
@@ -163,7 +163,7 @@ msgstr "סקריפטים"
 #. IDS_NO_EDIT_SCRIPTS
 #: Merge.rc:127 Merge.rc:352 Merge.rc:463 Merge.rc:673 Merge.rc:678
 #: Merge.rc:887 Merge.rc:899 Merge.rc:906 Merge.rc:963 Merge.rc:1210
-#: Merge.rc:5375
+#: Merge.rc:5374
 msgid "< Empty >"
 msgstr "< ריק >"
 
@@ -228,7 +228,7 @@ msgid "Auto-Fit All Columns"
 msgstr "התאם אוטומטית את כל העמודות"
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN
-#: Merge.rc:153 Merge.rc:5646
+#: Merge.rc:153 Merge.rc:5645
 msgid "&Filter by This Column"
 msgstr ""
 
@@ -289,7 +289,7 @@ msgid "&Previous Page"
 msgstr "עמוד קודם"
 
 #. IDS_PREVIEWBAR_NEXTPAGE
-#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5679
+#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5678
 msgid "&Next Page"
 msgstr "עמוד הבא"
 
@@ -540,7 +540,7 @@ msgstr "בינארי"
 #. IDS_IMAGE_MENU
 #: Merge.rc:329 Merge.rc:338 Merge.rc:432 Merge.rc:441 Merge.rc:609
 #: Merge.rc:618 Merge.rc:670 Merge.rc:960 Merge.rc:1187 Merge.rc:1200
-#: Merge.rc:5477
+#: Merge.rc:5476
 msgid "&Image"
 msgstr "תמונה"
 
@@ -662,7 +662,7 @@ msgid "&Huge"
 msgstr "ענק"
 
 #. IDS_VIEW_MENU_BAR
-#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5714
+#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5713
 msgid "Men&u Bar"
 msgstr "סרגל תפריטים"
 
@@ -1317,7 +1317,7 @@ msgid "Lo&cation Pane"
 msgstr "חלונית מיקום"
 
 #. IDS_OUTPUTBAR_CAPTION
-#: Merge.rc:782 Merge.rc:5252
+#: Merge.rc:782 Merge.rc:5251
 msgid "Output Pane"
 msgstr ""
 
@@ -1580,55 +1580,55 @@ msgid "Co&mpare As"
 msgstr ""
 
 #. IDS_COPY_LEFT_TO_MIDDLE2
-#: Merge.rc:968 Merge.rc:980 Merge.rc:4852
+#: Merge.rc:968 Merge.rc:980 Merge.rc:4851
 #, c-format
 msgid "Left to Middle (%1 of %2)"
 msgstr ""
 
 #. IDS_COPY_LEFT_TO_RIGHT2
-#: Merge.rc:969 Merge.rc:981 Merge.rc:4851
+#: Merge.rc:969 Merge.rc:981 Merge.rc:4850
 #, c-format
 msgid "Left to Right (%1 of %2)"
 msgstr ""
 
 #. IDS_MOVE_LEFT_TO2
-#: Merge.rc:970 Merge.rc:982 Merge.rc:1045 Merge.rc:4863 Merge.rc:4892
+#: Merge.rc:970 Merge.rc:982 Merge.rc:1045 Merge.rc:4862 Merge.rc:4891
 #, c-format
 msgid "Left to... (%1 of %2)"
 msgstr ""
 
 #. IDS_COPY_MIDDLE_TO_LEFT2
-#: Merge.rc:971 Merge.rc:983 Merge.rc:4849
+#: Merge.rc:971 Merge.rc:983 Merge.rc:4848
 #, c-format
 msgid "Middle to Left (%1 of %2)"
 msgstr ""
 
 #. IDS_COPY_MIDDLE_TO_RIGHT2
-#: Merge.rc:972 Merge.rc:984 Merge.rc:4850
+#: Merge.rc:972 Merge.rc:984 Merge.rc:4849
 #, c-format
 msgid "Middle to Right (%1 of %2)"
 msgstr ""
 
 #. IDS_MOVE_MIDDLE_TO2
-#: Merge.rc:973 Merge.rc:985 Merge.rc:1046 Merge.rc:4864 Merge.rc:4893
+#: Merge.rc:973 Merge.rc:985 Merge.rc:1046 Merge.rc:4863 Merge.rc:4892
 #, c-format
 msgid "Middle to... (%1 of %2)"
 msgstr ""
 
 #. IDS_COPY_RIGHT_TO_MIDDLE2
-#: Merge.rc:974 Merge.rc:986 Merge.rc:4848
+#: Merge.rc:974 Merge.rc:986 Merge.rc:4847
 #, c-format
 msgid "Right to Middle (%1 of %2)"
 msgstr ""
 
 #. IDS_COPY_RIGHT_TO_LEFT2
-#: Merge.rc:975 Merge.rc:987 Merge.rc:4847
+#: Merge.rc:975 Merge.rc:987 Merge.rc:4846
 #, c-format
 msgid "Right to Left (%1 of %2)"
 msgstr ""
 
 #. IDS_MOVE_RIGHT_TO2
-#: Merge.rc:976 Merge.rc:988 Merge.rc:1047 Merge.rc:4865 Merge.rc:4894
+#: Merge.rc:976 Merge.rc:988 Merge.rc:1047 Merge.rc:4864 Merge.rc:4893
 #, c-format
 msgid "Right to... (%1 of %2)"
 msgstr ""
@@ -1684,31 +1684,31 @@ msgid "Cop&y Paths"
 msgstr "העתק נתיבי קבצים"
 
 #. IDS_DEL_LEFT_FMT2
-#: Merge.rc:1026 Merge.rc:1035 Merge.rc:4880
+#: Merge.rc:1026 Merge.rc:1035 Merge.rc:4879
 #, c-format
 msgid "Left (%1 of %2)"
 msgstr ""
 
 #. IDS_DEL_MIDDLE_FMT2
-#: Merge.rc:1027 Merge.rc:1036 Merge.rc:4881
+#: Merge.rc:1027 Merge.rc:1036 Merge.rc:4880
 #, c-format
 msgid "Middle (%1 of %2)"
 msgstr ""
 
 #. IDS_DEL_RIGHT_FMT2
-#: Merge.rc:1028 Merge.rc:1037 Merge.rc:4882
+#: Merge.rc:1028 Merge.rc:1037 Merge.rc:4881
 #, c-format
 msgid "Right (%1 of %2)"
 msgstr ""
 
 #. IDS_DEL_BOTH_FMT2
-#: Merge.rc:1029 Merge.rc:1038 Merge.rc:4883
+#: Merge.rc:1029 Merge.rc:1038 Merge.rc:4882
 #, c-format
 msgid "Both (%1 of %2)"
 msgstr ""
 
 #. IDS_DEL_ALL_FMT2
-#: Merge.rc:1030 Merge.rc:1039 Merge.rc:4888
+#: Merge.rc:1030 Merge.rc:1039 Merge.rc:4887
 #, c-format
 msgid "All (%1 of %2)"
 msgstr ""
@@ -1734,19 +1734,19 @@ msgid "&Zip"
 msgstr "כיווץ"
 
 #. IDS_COPY_BOTH_TO2
-#: Merge.rc:1048 Merge.rc:4866
+#: Merge.rc:1048 Merge.rc:4865
 #, c-format
 msgid "Both to... (%1 of %2)"
 msgstr "שניהם אל... (%1 מתוך %2)"
 
 #. IDS_COPY_ALL_TO2
-#: Merge.rc:1049 Merge.rc:4867
+#: Merge.rc:1049 Merge.rc:4866
 #, c-format
 msgid "All to... (%1 of %2)"
 msgstr "הכל אל... (%1 מתוך %2)"
 
 #. IDS_COPY_DIFFERENCES_TO2
-#: Merge.rc:1050 Merge.rc:4868
+#: Merge.rc:1050 Merge.rc:4867
 #, c-format
 msgid "Differences to... (%1 of %2)"
 msgstr "הבדלים אל... (%1 מתוך %2)"
@@ -1813,12 +1813,12 @@ msgstr "הגדרות מפענח"
 
 #. IDS_USERCHOICE_NONE
 #: Merge.rc:1088 Merge.rc:1094 Merge.rc:1836 Merge.rc:1840 Merge.rc:2031
-#: Merge.rc:2035 Merge.rc:5377
+#: Merge.rc:2035 Merge.rc:5376
 msgid "<None>"
 msgstr "<ללא>"
 
 #. IDS_USERCHOICE_AUTOMATIC
-#: Merge.rc:1089 Merge.rc:1095 Merge.rc:5378
+#: Merge.rc:1089 Merge.rc:1095 Merge.rc:5377
 msgid "<Automatic>"
 msgstr "<אוטומטי>"
 
@@ -2748,12 +2748,12 @@ msgid "Text files only"
 msgstr ""
 
 #. IDS_EOL_NONE
-#: Merge.rc:1667 Merge.rc:1918 Merge.rc:5304
+#: Merge.rc:1667 Merge.rc:1918 Merge.rc:5303
 msgid "None"
 msgstr "ללא"
 
 #. IDS_EOL_MIXED
-#: Merge.rc:1668 Merge.rc:5299
+#: Merge.rc:1668 Merge.rc:5298
 msgid "Mixed"
 msgstr "מעורב"
 
@@ -3025,13 +3025,13 @@ msgstr ""
 
 #. IDS_DIFFERENT
 #: Merge.rc:1904 Merge.rc:1988 Merge.rc:2866 Merge.rc:3036 Merge.rc:3077
-#: Merge.rc:5058
+#: Merge.rc:5057
 msgid "Different"
 msgstr "שונה"
 
 #. IDS_IDENTICAL
 #: Merge.rc:1905 Merge.rc:1989 Merge.rc:2865 Merge.rc:3055 Merge.rc:3116
-#: Merge.rc:5048
+#: Merge.rc:5047
 msgid "Identical"
 msgstr "זהה"
 
@@ -3051,7 +3051,7 @@ msgid "Missing"
 msgstr ""
 
 #. IDS_MOVED
-#: Merge.rc:1910 Merge.rc:5076
+#: Merge.rc:1910 Merge.rc:5075
 msgid "Moved"
 msgstr ""
 
@@ -3787,7 +3787,7 @@ msgid "&Use custom system colors"
 msgstr "השתמש בצבעי מערכת מותאמים אישית (ייתכן שחלק מרכיבי הממשק לא יחולו)"
 
 #. IDS_PRPCAT_SYSTEM
-#: Merge.rc:2565 Merge.rc:4559 Merge.rc:4560 Merge.rc:5007
+#: Merge.rc:2565 Merge.rc:4559 Merge.rc:4560 Merge.rc:5006
 msgid "System"
 msgstr "מערכת"
 
@@ -4187,7 +4187,7 @@ msgid "Items compared:"
 msgstr "פריטים שהושוו:"
 
 #. IDS_PREVIEWBAR_CLOSE
-#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5685
+#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5684
 msgid "&Close"
 msgstr "סגור"
 
@@ -4810,7 +4810,7 @@ msgid "A&ppend timestamp"
 msgstr "הוסף חותמת זמן"
 
 #. IDS_CONFIRM_COPY_CAPTION
-#: Merge.rc:3214 Merge.rc:4915
+#: Merge.rc:3214 Merge.rc:4914
 msgid "Confirm Copy"
 msgstr "אישור העתקה"
 
@@ -5047,7 +5047,7 @@ msgid "&Character Set..."
 msgstr "ערכת תווים..."
 
 #. IDS_PRPCAT_IMAGE
-#: Merge.rc:3351 Merge.rc:4574 Merge.rc:5015
+#: Merge.rc:3351 Merge.rc:4574 Merge.rc:5014
 msgid "Image"
 msgstr "תמונה"
 
@@ -5428,7 +5428,7 @@ msgid "Project"
 msgstr "פרויקט"
 
 #. IDS_COLHDR_NSDIFFS
-#: Merge.rc:4566 Merge.rc:4990
+#: Merge.rc:4566 Merge.rc:4989
 msgid "Differences"
 msgstr "הבדלים"
 
@@ -5573,12 +5573,12 @@ msgid "File Type"
 msgstr "סוג קובץ"
 
 #. IDS_COLHDR_EXTENSION
-#: Merge.rc:4653 Merge.rc:4947
+#: Merge.rc:4653 Merge.rc:4946
 msgid "Extension"
 msgstr "סיומת"
 
 #. IDS_PRPCAT_MESSAGE
-#: Merge.rc:4659 Merge.rc:5019
+#: Merge.rc:4659 Merge.rc:5018
 msgid "Message"
 msgstr "הודעה"
 
@@ -5618,7 +5618,7 @@ msgid "Hidden Items"
 msgstr "פריטים מוסתרים"
 
 #. IDS_PLUGINSLIST_NAME
-#: Merge.rc:4680 Merge.rc:5311
+#: Merge.rc:4680 Merge.rc:5310
 msgid "Name"
 msgstr "שם"
 
@@ -5638,7 +5638,7 @@ msgid "[F] "
 msgstr "[F] "
 
 #. IDS_PLUGINSLIST_DESC
-#: Merge.rc:4684 Merge.rc:5313
+#: Merge.rc:4684 Merge.rc:5312
 msgid "Description"
 msgstr "תיאור"
 
@@ -5794,155 +5794,150 @@ msgstr ""
 msgid "  Sel: %d | %d"
 msgstr ""
 
-#. IDS_MERGEMODE_MERGING
-#: Merge.rc:4734
-msgid "Merge"
-msgstr "מזג"
-
 #. IDS_DIFF_NUMBER_STATUS_FMT
-#: Merge.rc:4735
+#: Merge.rc:4734
 #, c-format
 msgid "Difference %1 of %2"
 msgstr ""
 
 #. IDS_NO_DIFF_SEL_FMT
-#: Merge.rc:4736
+#: Merge.rc:4735
 #, c-format
 msgid "%1 Differences Found"
 msgstr ""
 
 #. IDS_1_DIFF_FOUND
-#: Merge.rc:4737
+#: Merge.rc:4736
 msgid "1 Difference Found"
 msgstr "נמצא הבדל אחד"
 
 #. IDS_NO_ERR_SEL_FMT
-#: Merge.rc:4738
+#: Merge.rc:4737
 #, c-format
 msgid "%1 Errors Found"
 msgstr ""
 
 #. IDS_1_ERR_FOUND
-#: Merge.rc:4739
+#: Merge.rc:4738
 msgid "1 Error Found"
 msgstr ""
 
 #. IDS_STATUSBAR_READONLY, Abbreviation from "Read Only"
-#: Merge.rc:4740
+#: Merge.rc:4739
 msgid "RO"
 msgstr "לקריאה בלבד"
 
 #. IDS_DIRVIEW_STATUS_FMT_FOCUS
-#: Merge.rc:4746
+#: Merge.rc:4745
 #, c-format
 msgid "Item %1 of %2"
 msgstr "פריט %1 מתוך %2"
 
 #. IDS_DIRVIEW_STATUS_FMT_NOFOCUS
-#: Merge.rc:4747
+#: Merge.rc:4746
 #, c-format
 msgid "Items: %1"
 msgstr "פריטים: %1"
 
 #. IDS_DIRVIEW_STATUS_COMPARING
-#: Merge.rc:4748
+#: Merge.rc:4747
 msgid "Comparing items..."
 msgstr "משווה פריטים..."
 
 #. IDS_ITEMS_PER_SEC
-#: Merge.rc:4749
+#: Merge.rc:4748
 #, c-format
 msgid "%.1f[items/sec]"
 msgstr "%.1f[פריטים/שנייה]"
 
 #. IDS_ERROR_INCOMPARABLE
-#: Merge.rc:4755
+#: Merge.rc:4754
 msgid "Select two existing folders/files to compare."
 msgstr "בחר שתי תיקיות או קבצים קיימים להשוואה."
 
 #. IDS_DIRSEL_TAG
-#: Merge.rc:4756
+#: Merge.rc:4755
 msgid "Folder Selection"
 msgstr "בחירת תיקיה"
 
 #. IDS_OPEN_FILESDIRS
-#: Merge.rc:4757
+#: Merge.rc:4756
 msgid "Select two (or three) folders/files to compare."
 msgstr "בחר שתי (או שלוש) תיקיות או שניים (או שלושה) קבצים להשוואה."
 
 #. IDS_OPEN_LEFTINVALID
-#: Merge.rc:4758
+#: Merge.rc:4757
 msgid "Left (1st) path is invalid!"
 msgstr "הנתיב השמאלי (1) אינו חוקי!"
 
 #. IDS_OPEN_MIDDLEINVALID
-#: Merge.rc:4759
+#: Merge.rc:4758
 msgid "Middle (2nd) path is invalid!"
 msgstr "הנתיב האמצעי (2) אינו חוקי!"
 
 #. IDS_OPEN_RIGHTINVALID2
-#: Merge.rc:4760
+#: Merge.rc:4759
 msgid "Right (2nd) path is invalid!"
 msgstr "הנתיב הימני (2) אינו חוקי!"
 
 #. IDS_OPEN_RIGHTINVALID3
-#: Merge.rc:4761
+#: Merge.rc:4760
 msgid "Right (3rd) path is invalid!"
 msgstr "הנתיב הימני (3) אינו חוקי!"
 
 #. IDS_OPEN_BOTHINVALID
-#: Merge.rc:4762
+#: Merge.rc:4761
 msgid "Both paths are invalid!"
 msgstr "שני הנתיבים אינם חוקיים!"
 
-#: Merge.rc:4764
+#: Merge.rc:4763
 msgid "Left (1st) and Middle (2nd) paths are invalid!"
 msgstr "הנתיבים השמאלי (1) והאמצעי (2) אינם חוקיים!"
 
 #. IDS_OPEN_LEFTRIGHTINVALID
-#: Merge.rc:4765
+#: Merge.rc:4764
 msgid "Left (1st) and Right (3rd) paths are invalid!"
 msgstr "הנתיבים השמאלי (1) והימני (3) אינם חוקיים!"
 
-#: Merge.rc:4767
+#: Merge.rc:4766
 msgid "Middle (2nd) and Right (3rd) paths are invalid!"
 msgstr "הנתיבים האמצעי (2) והימני (3) אינם חוקיים!"
 
 #. IDS_OPEN_ALLINVALID
-#: Merge.rc:4768
+#: Merge.rc:4767
 msgid "All paths are invalid!"
 msgstr "כל הנתיבים אינם חוקיים!"
 
 #. IDS_OPEN_UNPACKERDISABLED
-#: Merge.rc:4769
+#: Merge.rc:4768
 msgid "Only enabled for file comparisons"
 msgstr "מאופשר רק להשוואת קבצים"
 
 #. IDS_OPEN_MISMATCH
-#: Merge.rc:4770
+#: Merge.rc:4769
 msgid "Cannot compare file and folder!"
 msgstr "לא ניתן להשוות בין קובץ לתיקיה!"
 
 #. IDS_ERROR_FILE_NOT_FOUND
-#: Merge.rc:4776
+#: Merge.rc:4775
 #, c-format
 msgid "File not found: %1"
 msgstr "קובץ לא נמצא: %1"
 
 #. IDS_ERROR_FOLDER_NOT_FOUND
-#: Merge.rc:4777
+#: Merge.rc:4776
 #, c-format
 msgid "Folder not found: %1"
 msgstr ""
 
 #. IDS_ERROR_FILE_NOT_UNPACKED
-#: Merge.rc:4778
+#: Merge.rc:4777
 #, c-format
 msgid "File not unpacked: %1"
 msgstr "הקובץ לא נפרס: %1"
 
 #. IDS_ERROR_FILEOPEN
-#: Merge.rc:4779
+#: Merge.rc:4778
 #, c-format
 msgid ""
 "Cannot open file\n"
@@ -5956,12 +5951,12 @@ msgstr ""
 "%2"
 
 #. IDS_ERROR_CONF_RESOLVE
-#: Merge.rc:4780
+#: Merge.rc:4779
 msgid "Failed to parse conflict file."
 msgstr "כשל בניתוח קובץ הסתירה."
 
 #. IDS_NOT_CONFLICT_FILE
-#: Merge.rc:4781
+#: Merge.rc:4780
 #, c-format
 msgid "The file\n%1\nis not a conflict file."
 msgstr ""
@@ -5970,7 +5965,7 @@ msgstr ""
 "אינו קובץ סתירה."
 
 #. IDS_COMPARE_LARGE_FILES
-#: Merge.rc:4782
+#: Merge.rc:4781
 msgid "Comparing large files requires significant memory.\nShow only comparison results (not file contents)?"
 msgstr ""
 "אתה עומד להשוות קבצים גדולים מאוד.\n"
@@ -5979,28 +5974,28 @@ msgstr ""
 "\n"
 
 #. IDS_SAVE_AS_TITLE
-#: Merge.rc:4788
+#: Merge.rc:4787
 msgid "Save As"
 msgstr "שמור בשם"
 
 #. IDS_SAVE_FMT
-#: Merge.rc:4789
+#: Merge.rc:4788
 #, c-format
 msgid "Save changes to %1?"
 msgstr "לשמור שינויים ב-%1?"
 
 #. IDS_SAVEREADONLY_FMT
-#: Merge.rc:4790
+#: Merge.rc:4789
 #, c-format
 msgid "%1 is read-only. Override? Or 'No' to save as new filename?"
 msgstr "%1 מסומן כקובץ לקריאה בלבד. האם ברצונך לדרוס את הקובץ? (בחר לא כדי לשמור בשם אחר.)"
 
 #. IDS_ERROR_BACKUP
-#: Merge.rc:4791
+#: Merge.rc:4790
 msgid "Error backing up file"
 msgstr "שגיאה בגיבוי הקובץ"
 
-#: Merge.rc:4793
+#: Merge.rc:4792
 #, c-format
 msgid ""
 "Unable to backup original file:\n"
@@ -6014,7 +6009,7 @@ msgstr ""
 "להמשיך בכל זאת?"
 
 #. IDS_FILESAVE_FAILED
-#: Merge.rc:4794
+#: Merge.rc:4793
 #, c-format
 msgid "Saving file failed.\n%1\n%2\n\t- Use different filename (OK)\n\t- Abort (Cancel)?"
 msgstr ""
@@ -6025,1052 +6020,1052 @@ msgstr ""
 "\t- להשתמש בשם קובץ אחר (לחץ על אישור)\n"
 "\t- לבטל את הפעולה (לחץ על ביטול)?"
 
-#: Merge.rc:4796
+#: Merge.rc:4795
 #, c-format
 msgid "Plugin '%2' cannot pack changes to left file into '%1'.\n\nOriginal unchanged. Save unpacked version?"
 msgstr ""
 
-#: Merge.rc:4798
+#: Merge.rc:4797
 #, c-format
 msgid "Plugin '%2' cannot pack changes to middle file into '%1'.\n\nOriginal unchanged. Save unpacked version?"
 msgstr ""
 
-#: Merge.rc:4800
+#: Merge.rc:4799
 #, c-format
 msgid "Plugin '%2' cannot pack changes to right file into '%1'.\n\nOriginal unchanged. Save unpacked version?"
 msgstr ""
 
 #. IDS_FILECHANGED_ONDISK
-#: Merge.rc:4801
+#: Merge.rc:4800
 #, c-format
 msgid "Another application updated\n%1\nsince WinMerge loaded it.\n\nOverwrite?"
 msgstr ""
 
 #. IDS_SAVEREADONLY_MULTI
-#: Merge.rc:4802
+#: Merge.rc:4801
 #, c-format
 msgid "%1\nis read-only. Override?"
 msgstr ""
 
 #. IDS_FILECHANGED_RESCAN
-#: Merge.rc:4803
+#: Merge.rc:4802
 #, c-format
 msgid "Another application updated\n%1\nsince last scan.\n\nReload?"
 msgstr ""
 
 #. IDS_SAVE_LEFT_AS
-#: Merge.rc:4804
+#: Merge.rc:4803
 msgid "Save Left File As"
 msgstr "שמור קובץ שמאל בשם"
 
 #. IDS_SAVE_MIDDLE_AS
-#: Merge.rc:4805
+#: Merge.rc:4804
 msgid "Save Middle File As"
 msgstr "שמור קובץ אמצע בשם"
 
 #. IDS_SAVE_RIGHT_AS
-#: Merge.rc:4806
+#: Merge.rc:4805
 msgid "Save Right File As"
 msgstr "שמור קובץ ימין בשם"
 
 #. IDS_FILE_DISAPPEARED
-#: Merge.rc:4811
+#: Merge.rc:4810
 #, c-format
 msgid "File\n%1\nnot found. Save a copy to continue."
 msgstr ""
 
 #. IDS_VIEWS_OUTOFSYNC
-#: Merge.rc:4817
+#: Merge.rc:4816
 msgid "Cannot merge unsynched documents.\n\nRefresh before continuing."
 msgstr ""
 
 #. IDS_BREAK_ON_WHITESPACE
-#: Merge.rc:4822
+#: Merge.rc:4821
 msgid "Break at whitespace"
 msgstr "פיצול ברווחים"
 
 #. IDS_BREAK_ON_PUNCTUATION
-#: Merge.rc:4823
+#: Merge.rc:4822
 msgid "Break at whitespace or punctuation"
 msgstr "פיצול ברווחים או סימני פיסוק"
 
 #. IDS_L2M
-#: Merge.rc:4829
+#: Merge.rc:4828
 msgid "Copy to &Middle\tAlt+Right"
 msgstr "העתק לאמצע\tAlt+Right"
 
 #. IDS_R2M
-#: Merge.rc:4830
+#: Merge.rc:4829
 msgid "Copy to &Middle\tAlt+Left"
 msgstr "העתק לאמצע\tAlt+Left"
 
 #. IDS_COPY_FROM_MIDDLE_R
-#: Merge.rc:4831
+#: Merge.rc:4830
 msgid "Copy from Middle\tAlt+Shift+Right"
 msgstr "העתק מהאמצע\tAlt+Shift+Right"
 
 #. IDS_COPY_FROM_MIDDLE_L
-#: Merge.rc:4832
+#: Merge.rc:4831
 msgid "Copy from Middle\tAlt+Shift+Left"
 msgstr "העתק מהאמצע\tAlt+Shift+Left"
 
 #. IDS_L2MNEXT
-#: Merge.rc:4833
+#: Merge.rc:4832
 msgid "Copy to Middle and Advance\tCtrl+Alt+Right"
 msgstr "העתק לאמצע והתקדם\tCtrl+Alt+Right"
 
 #. IDS_R2MNEXT
-#: Merge.rc:4834
+#: Merge.rc:4833
 msgid "Copy to Middle and Advance\tCtrl+Alt+Left"
 msgstr "העתק לאמצע והתקדם\tCtrl+Alt+Left"
 
 #. IDS_ALL_MIDDLE
-#: Merge.rc:4835
+#: Merge.rc:4834
 msgid "Copy All to Middle"
 msgstr "העתק הכל לאמצע"
 
 #. IDS_COPY_RIGHT_TO_LEFT
-#: Merge.rc:4841
+#: Merge.rc:4840
 #, c-format
 msgid "Right to Left (%1)"
 msgstr ""
 
 #. IDS_COPY_RIGHT_TO_MIDDLE
-#: Merge.rc:4842
+#: Merge.rc:4841
 #, c-format
 msgid "Right to Middle (%1)"
 msgstr ""
 
 #. IDS_COPY_MIDDLE_TO_LEFT
-#: Merge.rc:4843
+#: Merge.rc:4842
 #, c-format
 msgid "Middle to Left (%1)"
 msgstr ""
 
 #. IDS_COPY_MIDDLE_TO_RIGHT
-#: Merge.rc:4844
+#: Merge.rc:4843
 #, c-format
 msgid "Middle to Right (%1)"
 msgstr ""
 
 #. IDS_COPY_LEFT_TO_RIGHT
-#: Merge.rc:4845
+#: Merge.rc:4844
 #, c-format
 msgid "Left to Right (%1)"
 msgstr ""
 
 #. IDS_COPY_LEFT_TO_MIDDLE
-#: Merge.rc:4846
+#: Merge.rc:4845
 #, c-format
 msgid "Left to Middle (%1)"
 msgstr ""
 
 #. IDS_MOVE_LEFT_TO
-#: Merge.rc:4857 Merge.rc:4889
+#: Merge.rc:4856 Merge.rc:4888
 #, c-format
 msgid "Left to... (%1)"
 msgstr ""
 
 #. IDS_MOVE_MIDDLE_TO
-#: Merge.rc:4858 Merge.rc:4890
+#: Merge.rc:4857 Merge.rc:4889
 #, c-format
 msgid "Middle to... (%1)"
 msgstr ""
 
 #. IDS_MOVE_RIGHT_TO
-#: Merge.rc:4859 Merge.rc:4891
+#: Merge.rc:4858 Merge.rc:4890
 #, c-format
 msgid "Right to... (%1)"
 msgstr ""
 
 #. IDS_COPY_BOTH_TO
-#: Merge.rc:4860
+#: Merge.rc:4859
 #, c-format
 msgid "Both to... (%1)"
 msgstr ""
 
 #. IDS_COPY_ALL_TO
-#: Merge.rc:4861
+#: Merge.rc:4860
 #, c-format
 msgid "All to... (%1)"
 msgstr ""
 
 #. IDS_COPY_DIFFERENCES_TO
-#: Merge.rc:4862
+#: Merge.rc:4861
 #, c-format
 msgid "Differences to... (%1)"
 msgstr ""
 
 #. IDS_ONLYDIFFITEMS_CONFIRM
-#: Merge.rc:4869
+#: Merge.rc:4868
 msgid "Some selected items are identical or skipped.\nProcess only items with differences?"
 msgstr ""
 
 #. IDS_DEL_LEFT_FMT
-#: Merge.rc:4875
+#: Merge.rc:4874
 #, c-format
 msgid "Left (%1)"
 msgstr ""
 
 #. IDS_DEL_MIDDLE_FMT
-#: Merge.rc:4876
+#: Merge.rc:4875
 #, c-format
 msgid "Middle (%1)"
 msgstr ""
 
 #. IDS_DEL_RIGHT_FMT
-#: Merge.rc:4877
+#: Merge.rc:4876
 #, c-format
 msgid "Right (%1)"
 msgstr ""
 
 #. IDS_DEL_BOTH_FMT
-#: Merge.rc:4878
+#: Merge.rc:4877
 #, c-format
 msgid "Both (%1)"
 msgstr ""
 
 #. IDS_DEL_ALL_FMT
-#: Merge.rc:4879
+#: Merge.rc:4878
 #, c-format
 msgid "All (%1)"
 msgstr ""
 
 #. IDS_SELECT_DEST_LEFT
-#: Merge.rc:4895
+#: Merge.rc:4894
 msgid "Left Side - Select Destination Folder:"
 msgstr ""
 
 #. IDS_SELECT_DEST_MIDDLE
-#: Merge.rc:4896
+#: Merge.rc:4895
 msgid "Middle Side - Select Destination Folder:"
 msgstr ""
 
 #. IDS_SELECT_DEST_RIGHT
-#: Merge.rc:4897
+#: Merge.rc:4896
 msgid "Right Side - Select Destination Folder:"
 msgstr ""
 
 #. IDS_FILES_AFFECTED_FMT
-#: Merge.rc:4898
+#: Merge.rc:4897
 #, c-format
 msgid "(%1 Files Affected)"
 msgstr ""
 
 #. IDS_FILES_AFFECTED_FMT2
-#: Merge.rc:4899
+#: Merge.rc:4898
 #, c-format
 msgid "(%1 of %2 Files Affected)"
 msgstr ""
 
 #. IDS_CONFIRM_DELETE_SINGLE
-#: Merge.rc:4905
+#: Merge.rc:4904
 #, c-format
 msgid "Are you sure you want to delete\n\n%1 ?"
 msgstr ""
 
 #. IDS_CONFIRM_SINGLE_COPY
-#: Merge.rc:4906
+#: Merge.rc:4905
 msgid "Are you sure you want to copy?"
 msgstr "האם אתה בטוח שברצונך להעתיק?"
 
 #. IDS_CONFIRM_MULTIPLE_COPY
-#: Merge.rc:4907
+#: Merge.rc:4906
 #, c-format
 msgid "Are you sure you want to copy %d items?"
 msgstr "האם אתה בטוח שברצונך להעתיק %d פריטים?"
 
 #. IDS_DIRCMP_NOTSYNC
-#: Merge.rc:4908
+#: Merge.rc:4907
 #, c-format
 msgid "Operation aborted!\n\nFolder contents changed, path\n%1\nnot found.\n\nRefresh the compare."
 msgstr ""
 
 #. IDS_CONFIRM_SINGLE_MOVE
-#: Merge.rc:4913
+#: Merge.rc:4912
 msgid "Are you sure you want to move?"
 msgstr ""
 
 #. IDS_CONFIRM_MULTIPLE_MOVE
-#: Merge.rc:4914
+#: Merge.rc:4913
 #, c-format
 msgid "Are you sure you want to move %d items?"
 msgstr ""
 
 #. IDS_CONFIRM_MOVE_CAPTION
-#: Merge.rc:4916
+#: Merge.rc:4915
 msgid "Confirm Move"
 msgstr "אישור העברה"
 
-#: Merge.rc:4918
+#: Merge.rc:4917
 msgid "Close the folder comparison window?"
 msgstr ""
 
-#: Merge.rc:4920
+#: Merge.rc:4919
 msgid "Close the folder comparison window, which took a long time?"
 msgstr ""
 
 #. IDS_ERROR_INVALID_DIR_FILE_NAME
-#: Merge.rc:4921
+#: Merge.rc:4920
 msgid "The file or folder name is invalid."
 msgstr "שם הקובץ או התיקיה אינו חוקי."
 
 #. IDS_ERROR_EXECUTE_FILE
-#: Merge.rc:4927
+#: Merge.rc:4926
 #, c-format
 msgid "Failed to execute external editor: %1"
 msgstr ""
 
 #. IDS_UNKNOWN_ARCHIVE_FORMAT
-#: Merge.rc:4933
+#: Merge.rc:4932
 msgid "Unknown archive format"
 msgstr "פורמט ארכיון לא ידוע"
 
-#: Merge.rc:4935
+#: Merge.rc:4934
 msgid "Failed to extract archive.\nCompare as text file?"
 msgstr ""
 
 #. IDS_COLHDR_FILENAME
-#: Merge.rc:4941
+#: Merge.rc:4940
 msgid "Filename"
 msgstr "שם קובץ"
 
 #. IDS_COLHDR_DIR
-#: Merge.rc:4942
+#: Merge.rc:4941
 msgctxt "DirView|ColumnHeader"
 msgid "Folder"
 msgstr "תיקיה"
 
 #. IDS_COLHDR_RESULT
-#: Merge.rc:4943
+#: Merge.rc:4942
 msgid "Comparison Result"
 msgstr "תוצאת השוואה"
 
 #. IDS_COLHDR_LTIMEM
-#: Merge.rc:4944
+#: Merge.rc:4943
 msgid "Left Date"
 msgstr "תאריך שמאל"
 
 #. IDS_COLHDR_RTIMEM
-#: Merge.rc:4945
+#: Merge.rc:4944
 msgid "Right Date"
 msgstr "תאריך ימין"
 
 #. IDS_COLHDR_MTIMEM
-#: Merge.rc:4946
+#: Merge.rc:4945
 msgid "Middle Date"
 msgstr "תאריך אמצע"
 
 #. IDS_COLHDR_LSIZE
-#: Merge.rc:4948
+#: Merge.rc:4947
 msgid "Left Size"
 msgstr "גודל שמאל"
 
 #. IDS_COLHDR_RSIZE
-#: Merge.rc:4949
+#: Merge.rc:4948
 msgid "Right Size"
 msgstr "גודל ימין"
 
 #. IDS_COLHDR_MSIZE
-#: Merge.rc:4954
+#: Merge.rc:4953
 msgid "Middle Size"
 msgstr "גודל אמצע"
 
 #. IDS_COLHDR_RSIZE_SHORT
-#: Merge.rc:4955
+#: Merge.rc:4954
 msgid "Right Size (Short)"
 msgstr "גודל ימין (מקוצר)"
 
 #. IDS_COLHDR_LSIZE_SHORT
-#: Merge.rc:4956
+#: Merge.rc:4955
 msgid "Left Size (Short)"
 msgstr "גודל שמאל (מקוצר)"
 
 #. IDS_COLHDR_MSIZE_SHORT
-#: Merge.rc:4957
+#: Merge.rc:4956
 msgid "Middle Size (Short)"
 msgstr "גודל אמצע (מקוצר)"
 
 #. IDS_COLHDR_LTIMEC
-#: Merge.rc:4963
+#: Merge.rc:4962
 msgid "Left Creation Time"
 msgstr "זמן יצירה שמאל"
 
 #. IDS_COLHDR_RTIMEC
-#: Merge.rc:4964
+#: Merge.rc:4963
 msgid "Right Creation Time"
 msgstr "זמן יצירה ימין"
 
 #. IDS_COLHDR_MTIMEC
-#: Merge.rc:4965
+#: Merge.rc:4964
 msgid "Middle Creation Time"
 msgstr "זמן יצירה אמצע"
 
 #. IDS_COLHDR_NEWER
-#: Merge.rc:4966
+#: Merge.rc:4965
 msgid "Newer File"
 msgstr "קובץ חדש יותר"
 
 #. IDS_COLHDR_LVERSION
-#: Merge.rc:4967
+#: Merge.rc:4966
 msgid "Left File Version"
 msgstr "גרסת קובץ שמאל"
 
 #. IDS_COLHDR_RVERSION
-#: Merge.rc:4968
+#: Merge.rc:4967
 msgid "Right File Version"
 msgstr "גרסת קובץ ימין"
 
 #. IDS_COLHDR_MVERSION
-#: Merge.rc:4969
+#: Merge.rc:4968
 msgid "Middle File Version"
 msgstr "גרסת קובץ אמצע"
 
 #. IDS_COLHDR_RESULT_ABBR
-#: Merge.rc:4970
+#: Merge.rc:4969
 msgid "Short Result"
 msgstr "תוצאה מקוצרת"
 
 #. IDS_COLHDR_LATTRIBUTES
-#: Merge.rc:4971
+#: Merge.rc:4970
 msgid "Left Attributes"
 msgstr "מאפייני שמאל"
 
 #. IDS_COLHDR_RATTRIBUTES
-#: Merge.rc:4972
+#: Merge.rc:4971
 msgid "Right Attributes"
 msgstr "מאפייני ימין"
 
 #. IDS_COLHDR_MATTRIBUTES
-#: Merge.rc:4973
+#: Merge.rc:4972
 msgid "Middle Attributes"
 msgstr "מאפייני אמצע"
 
 #. IDS_COLHDR_LEOL_TYPE
-#: Merge.rc:4978
+#: Merge.rc:4977
 msgid "Left EOL"
 msgstr "סוף שורה שמאל"
 
 #. IDS_COLHDR_MEOL_TYPE
-#: Merge.rc:4979
+#: Merge.rc:4978
 msgid "Middle EOL"
 msgstr "סוף שורה אמצע"
 
 #. IDS_COLHDR_REOL_TYPE
-#: Merge.rc:4980
+#: Merge.rc:4979
 msgid "Right EOL"
 msgstr "סוף שורה ימין"
 
 #. IDS_COLHDR_LENCODING
-#: Merge.rc:4986
+#: Merge.rc:4985
 msgid "Left Encoding"
 msgstr "קידוד שמאל"
 
 #. IDS_COLHDR_RENCODING
-#: Merge.rc:4987
+#: Merge.rc:4986
 msgid "Right Encoding"
 msgstr "קידוד ימין"
 
 #. IDS_COLHDR_MENCODING
-#: Merge.rc:4988
+#: Merge.rc:4987
 msgid "Middle Encoding"
 msgstr "קידוד אמצע"
 
 #. IDS_COLHDR_NIDIFFS
-#: Merge.rc:4989
+#: Merge.rc:4988
 msgid "Ignored Diff"
 msgstr "הבדל שהתעלמו ממנו"
 
 #. IDS_COLHDR_BINARY
-#: Merge.rc:4991
+#: Merge.rc:4990
 msgctxt "DirView|ColumnHeader"
 msgid "Binary"
 msgstr "בינארי"
 
 #. IDS_PLUGINS_TYPE_UNPACKER
-#: Merge.rc:4992 Merge.rc:5314
+#: Merge.rc:4991 Merge.rc:5313
 msgid "Unpacker"
 msgstr "מחלץ"
 
 #. IDS_PLUGIN_TYPE4
-#: Merge.rc:4993 Merge.rc:5315 Merge.rc:5622
+#: Merge.rc:4992 Merge.rc:5314 Merge.rc:5621
 msgid "Prediffer"
 msgstr "השוואה מוקדמת"
 
 #. IDS_COLHDR_LEFT
-#: Merge.rc:4994
+#: Merge.rc:4993
 msgid "Left"
 msgstr "שמאל"
 
 #. IDS_COLHDR_MIDDLE
-#: Merge.rc:4995
+#: Merge.rc:4994
 msgid "Middle"
 msgstr "אמצע"
 
 #. IDS_COLHDR_RIGHT
-#: Merge.rc:4996
+#: Merge.rc:4995
 msgid "Right"
 msgstr "ימין"
 
 #. IDS_COLHDR_DIFF
-#: Merge.rc:4997
+#: Merge.rc:4996
 msgid "Diff"
 msgstr "הבדל"
 
 #. IDS_COLHDR_LEFT_DUPLICATE
-#: Merge.rc:4998
+#: Merge.rc:4997
 msgid "Left Duplicate Count"
 msgstr "מספר כפילויות שמאל"
 
 #. IDS_COLHDR_RIGHT_DUPLICATE
-#: Merge.rc:4999
+#: Merge.rc:4998
 msgid "Right Duplicate Count"
 msgstr "מספר כפילויות ימין"
 
 #. IDS_COLHDR_MIDDLE_DUPLICATE
-#: Merge.rc:5000
+#: Merge.rc:4999
 msgid "Middle Duplicate Count"
 msgstr "מספר כפילויות אמצע"
 
 #. IDS_COLHDR_MOVE
-#: Merge.rc:5001
+#: Merge.rc:5000
 msgid "Move"
 msgstr "העבר"
 
 #. IDS_PRPCAT_AUDIO
-#: Merge.rc:5008
+#: Merge.rc:5007
 msgid "Audio"
 msgstr "שמע"
 
 #. IDS_PRPCAT_CALENDAR
-#: Merge.rc:5009
+#: Merge.rc:5008
 msgid "Calendar"
 msgstr "לוח שנה"
 
 #. IDS_PRPCAT_COMMUNICATION
-#: Merge.rc:5010
+#: Merge.rc:5009
 msgid "Communication"
 msgstr "תקשורת"
 
 #. IDS_PRPCAT_CONTACT
-#: Merge.rc:5011
+#: Merge.rc:5010
 msgid "Contact"
 msgstr "איש קשר"
 
 #. IDS_PRPCAT_DEVICES
-#: Merge.rc:5012
+#: Merge.rc:5011
 msgid "Devices"
 msgstr "התקנים"
 
 #. IDS_PRPCAT_DOCUMENT
-#: Merge.rc:5013
+#: Merge.rc:5012
 msgid "Document"
 msgstr "מסמך"
 
 #. IDS_PRPCAT_HOME
-#: Merge.rc:5014
+#: Merge.rc:5013
 msgid "Home"
 msgstr "בית"
 
 #. IDS_PRPCAT_JOURNAL
-#: Merge.rc:5016
+#: Merge.rc:5015
 msgid "Journal"
 msgstr "יומן"
 
 #. IDS_PRPCAT_LINK
-#: Merge.rc:5017
+#: Merge.rc:5016
 msgid "Link"
 msgstr "קישור"
 
 #. IDS_PRPCAT_MEDIA
-#: Merge.rc:5018
+#: Merge.rc:5017
 msgid "Media"
 msgstr "מדיה"
 
 #. IDS_PRPCAT_MUSIC
-#: Merge.rc:5020
+#: Merge.rc:5019
 msgid "Music"
 msgstr "מוזיקה"
 
 #. IDS_PRPCAT_NOTE
-#: Merge.rc:5021
+#: Merge.rc:5020
 msgid "Note"
 msgstr "פתק"
 
 #. IDS_PRPCAT_PHOTO
-#: Merge.rc:5022
+#: Merge.rc:5021
 msgid "Photo"
 msgstr "תמונה"
 
 #. IDS_PRPCAT_RECORDEDTV
-#: Merge.rc:5023
+#: Merge.rc:5022
 msgid "RecordedTV"
 msgstr "טלוויזיה מוקלטת"
 
 #. IDS_PRPCAT_SEARCH
-#: Merge.rc:5024
+#: Merge.rc:5023
 msgid "Search"
 msgstr "חיפוש"
 
 #. IDS_PRPCAT_SECURITY
-#: Merge.rc:5025
+#: Merge.rc:5024
 msgid "Security"
 msgstr "אבטחה"
 
 #. IDS_PRPCAT_SOFTWARE
-#: Merge.rc:5026
+#: Merge.rc:5025
 msgid "Software"
 msgstr "תוכנה"
 
 #. IDS_PRPCAT_TASK
-#: Merge.rc:5027
+#: Merge.rc:5026
 msgid "Task"
 msgstr "משימה"
 
 #. IDS_PRPCAT_VIDEO
-#: Merge.rc:5028
+#: Merge.rc:5027
 msgid "Video"
 msgstr "וידאו"
 
 #. IDS_PRPCAT_HASH
-#: Merge.rc:5029
+#: Merge.rc:5028
 msgid "Hash"
 msgstr "גיבוב"
 
 #. IDS_CANT_COMPARE_FILES
-#: Merge.rc:5035
+#: Merge.rc:5034
 msgid "Unable to compare files"
 msgstr "לא ניתן להשוות קבצים"
 
 #. IDS_ABORTED_ITEM
-#: Merge.rc:5036
+#: Merge.rc:5035
 msgid "Item aborted"
 msgstr "הפריט בוטל"
 
 #. IDS_FILE_SKIPPED
-#: Merge.rc:5037
+#: Merge.rc:5036
 msgid "File skipped"
 msgstr "הקובץ דולג"
 
 #. IDS_DIR_SKIPPED
-#: Merge.rc:5038
+#: Merge.rc:5037
 msgid "Folder skipped"
 msgstr "התיקיה דולגה"
 
 #. IDS_LEFT_ONLY_IN_FMT
-#: Merge.rc:5039
+#: Merge.rc:5038
 #, c-format
 msgid "Left only: %1"
 msgstr "רק בשמאל: %1"
 
 #. IDS_MIDDLE_ONLY_IN_FMT
-#: Merge.rc:5040
+#: Merge.rc:5039
 #, c-format
 msgid "Middle only: %1"
 msgstr "רק באמצע: %1"
 
 #. IDS_RIGHT_ONLY_IN_FMT
-#: Merge.rc:5041
+#: Merge.rc:5040
 #, c-format
 msgid "Right only: %1"
 msgstr "רק בימין: %1"
 
 #. IDS_DOES_NOT_EXIST_IN_FMT
-#: Merge.rc:5042
+#: Merge.rc:5041
 #, c-format
 msgid "Does not exist in %1"
 msgstr "לא קיים ב-%1"
 
 #. IDS_BIN_FILES_SAME
-#: Merge.rc:5043
+#: Merge.rc:5042
 msgid "Binary files are identical"
 msgstr "קבצים בינאריים זהים"
 
 #. IDS_BIN_FILES_DIFF
-#: Merge.rc:5049
+#: Merge.rc:5048
 msgid "Binary files are different"
 msgstr "קבצים בינאריים שונים"
 
 #. IDS_FILES_ARE_DIFFERENT
-#: Merge.rc:5050
+#: Merge.rc:5049
 msgid "Files are different"
 msgstr "קבצים שונים"
 
 #. IDS_FOLDERS_ARE_DIFFERENT
-#: Merge.rc:5051
+#: Merge.rc:5050
 msgid "Folders are different"
 msgstr "תיקיות שונות"
 
 #. IDS_LEFTONLY
-#: Merge.rc:5052
+#: Merge.rc:5051
 msgid "Left Only"
 msgstr "רק בשמאל"
 
 #. IDS_RIGHTONLY
-#: Merge.rc:5053
+#: Merge.rc:5052
 msgid "Right Only"
 msgstr "רק בימין"
 
 #. IDS_MIDDLEONLY
-#: Merge.rc:5054
+#: Merge.rc:5053
 msgid "Middle Only"
 msgstr "רק באמצע"
 
 #. IDS_NOITEMLEFT
-#: Merge.rc:5055
+#: Merge.rc:5054
 msgid "No item in left"
 msgstr "אין פריט בשמאל"
 
 #. IDS_NOITEMRIGHT
-#: Merge.rc:5056
+#: Merge.rc:5055
 msgid "No item in right"
 msgstr "אין פריט בימין"
 
 #. IDS_NOITEMMIDDLE
-#: Merge.rc:5057
+#: Merge.rc:5056
 msgid "No item in middle"
 msgstr "אין פריט באמצע"
 
 #. IDS_CMPRES_ERROR
-#: Merge.rc:5059
+#: Merge.rc:5058
 msgid "Error"
 msgstr "שגיאה"
 
 #. IDS_TEXT_FILES_SAME
-#: Merge.rc:5060
+#: Merge.rc:5059
 msgid "Text files are identical"
 msgstr "קבצי טקסט זהים"
 
 #. IDS_LEFTONLY_DIFF
-#: Merge.rc:5061
+#: Merge.rc:5060
 msgid " (Middle and right are identical)"
 msgstr ""
 
 #. IDS_MIDDLEONLY_DIFF
-#: Merge.rc:5062
+#: Merge.rc:5061
 msgid " (Left and right are identical)"
 msgstr ""
 
 #. IDS_RIGHTONLY_DIFF
-#: Merge.rc:5063
+#: Merge.rc:5062
 msgid " (Left and middle are identical)"
 msgstr ""
 
 #. IDS_PATH_MISMATCH
-#: Merge.rc:5064
+#: Merge.rc:5063
 msgid " (paths differ)"
 msgstr ""
 
 #. IDS_TEXT_FILES_DIFF
-#: Merge.rc:5065
+#: Merge.rc:5064
 msgid "Text files are different"
 msgstr "קבצי טקסט שונים"
 
 #. IDS_IMAGE_FILES_SAME
-#: Merge.rc:5066
+#: Merge.rc:5065
 msgid "Image files are identical"
 msgstr "קבצי תמונה זהים"
 
 #. IDS_IMAGE_FILES_DIFF
-#: Merge.rc:5067
+#: Merge.rc:5066
 msgid "Image files are different"
 msgstr "קבצי תמונה שונים"
 
 #. IDS_EXPR_DIFF
-#: Merge.rc:5068
+#: Merge.rc:5067
 #, c-format
 msgid "Files are different (expr: %1)"
 msgstr ""
 
 #. IDS_HASH_GROUP
-#: Merge.rc:5069
+#: Merge.rc:5068
 #, c-format
 msgid "Group%d"
 msgstr "קבוצה %d"
 
 #. IDS_RENAME_MOVE_DETECTION_DISALBED
-#: Merge.rc:5070
+#: Merge.rc:5069
 msgctxt "Options dialog|Compare|Folder|Detect renames and moves"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_RENAME_MOVE_DETECTION_RENAME
-#: Merge.rc:5071
+#: Merge.rc:5070
 msgid "Detect renames"
 msgstr ""
 
 #. IDS_RENAME_MOVE_DETECTION_RENAME_MOVE
-#: Merge.rc:5072
+#: Merge.rc:5071
 msgid "Detect renames and moves"
 msgstr ""
 
 #. IDS_RENAME_MOVE_MERGE_MODE_RENAME
-#: Merge.rc:5073
+#: Merge.rc:5072
 msgid "Merge renames"
 msgstr ""
 
 #. IDS_RENAME_MOVE_MERGE_MODE_RENAME_MOVE
-#: Merge.rc:5074
+#: Merge.rc:5073
 msgid "Merge renames and moves"
 msgstr ""
 
 #. IDS_RENAMED
-#: Merge.rc:5075
+#: Merge.rc:5074
 msgid "Renamed"
 msgstr ""
 
 #. IDS_RENAMED_MOVED
-#: Merge.rc:5077
+#: Merge.rc:5076
 msgid "Renamed/Moved"
 msgstr ""
 
 #. IDS_RENAMED_MOVED_ITEMS
-#: Merge.rc:5078
+#: Merge.rc:5077
 #, c-format
 msgid "(%1 items)"
 msgstr ""
 
 #. IDS_RENAMED_MOVED_RESULT
-#: Merge.rc:5079
+#: Merge.rc:5078
 #, c-format
 msgid "%1 (set %2): "
 msgstr ""
 
 #. IDS_SWITCH_FLAT_MODE
-#: Merge.rc:5080
+#: Merge.rc:5079
 msgid "Some moved items have been merged.\nIn Tree Mode, these items may appear in positions that do not reflect the actual folder structure, which can be confusing.\nSwitch to Flat Mode?"
 msgstr ""
 
 #. IDS_ELAPSED_TIME
-#: Merge.rc:5086
+#: Merge.rc:5085
 #, c-format
 msgid "Elapsed time: %ld ms"
 msgstr "זמן שחלף: %ld מילישניות"
 
 #. IDS_STATUS_SELITEM1
-#: Merge.rc:5087
+#: Merge.rc:5086
 msgid "1 item selected"
 msgstr "פריט אחד נבחר"
 
 #. IDS_STATUS_SELITEMS
-#: Merge.rc:5088
+#: Merge.rc:5087
 #, c-format
 msgid "%1 items selected"
 msgstr "%1 פריטים נבחרו"
 
 #. IDS_COLDESC_FILENAME
-#: Merge.rc:5094
+#: Merge.rc:5093
 msgid "Filename or folder name."
 msgstr "שם קובץ או תיקיה."
 
 #. IDS_COLDESC_DIR
-#: Merge.rc:5095
+#: Merge.rc:5094
 msgid "Subfolder name when subfolders are included."
 msgstr "שם תיקיית משנה כאשר תיקיות משנה כלולות."
 
 #. IDS_COLDESC_RESULT
-#: Merge.rc:5096
+#: Merge.rc:5095
 msgid "Comparison result, long form."
 msgstr "תוצאת השוואה, תצורה מלאה."
 
 #. IDS_COLDESC_LTIMEM
-#: Merge.rc:5101
+#: Merge.rc:5100
 msgid "Left side modification date."
 msgstr "תאריך שינוי צד שמאל."
 
 #. IDS_COLDESC_RTIMEM
-#: Merge.rc:5102
+#: Merge.rc:5101
 msgid "Right side modification date."
 msgstr "תאריך שינוי צד ימין."
 
 #. IDS_COLDESC_MTIMEM
-#: Merge.rc:5103
+#: Merge.rc:5102
 msgid "Middle side modification date."
 msgstr "תאריך שינוי צד אמצע."
 
 #. IDS_COLDESC_EXTENSION
-#: Merge.rc:5104
+#: Merge.rc:5103
 msgid "File's extension."
 msgstr "סיומת קובץ."
 
 #. IDS_COLDESC_LSIZE
-#: Merge.rc:5105
+#: Merge.rc:5104
 msgid "Left file size in bytes."
 msgstr "גודל קובץ שמאל בבייטים."
 
 #. IDS_COLDESC_RSIZE
-#: Merge.rc:5106
+#: Merge.rc:5105
 msgid "Right file size in bytes."
 msgstr "גודל קובץ ימין בבייטים."
 
 #. IDS_COLDESC_MSIZE
-#: Merge.rc:5107
+#: Merge.rc:5106
 msgid "Middle file size in bytes."
 msgstr "גודל קובץ אמצע בבייטים."
 
 #. IDS_COLDESC_LSIZE_SHORT
-#: Merge.rc:5108
+#: Merge.rc:5107
 msgid "Left file size abbreviated."
 msgstr "גודל קובץ שמאל (מקוצר)."
 
 #. IDS_COLDESC_RSIZE_SHORT
-#: Merge.rc:5109
+#: Merge.rc:5108
 msgid "Right file size abbreviated."
 msgstr "גודל קובץ ימין (מקוצר)."
 
 #. IDS_COLDESC_MSIZE_SHORT
-#: Merge.rc:5110
+#: Merge.rc:5109
 msgid "Middle file size abbreviated."
 msgstr "גודל קובץ אמצע (מקוצר)."
 
 #. IDS_COLDESC_LTIMEC
-#: Merge.rc:5116
+#: Merge.rc:5115
 msgid "Left side creation time."
 msgstr "זמן יצירה צד שמאל."
 
 #. IDS_COLDESC_RTIMEC
-#: Merge.rc:5117
+#: Merge.rc:5116
 msgid "Right side creation time."
 msgstr "זמן יצירה צד ימין."
 
 #. IDS_COLDESC_MTIMEC
-#: Merge.rc:5118
+#: Merge.rc:5117
 msgid "Middle side creation time."
 msgstr "זמן יצירה צד אמצע."
 
 #. IDS_COLDESC_NEWER
-#: Merge.rc:5119
+#: Merge.rc:5118
 msgid "Tells which side has newer modification date."
 msgstr "מציין איזה צד בעל תאריך שינוי חדש יותר."
 
 #. IDS_COLDESC_LVERSION
-#: Merge.rc:5120
+#: Merge.rc:5119
 msgid "Left side file version, only for some file types."
 msgstr ""
 
 #. IDS_COLDESC_RVERSION
-#: Merge.rc:5121
+#: Merge.rc:5120
 msgid "Right side file version, only for some file types."
 msgstr ""
 
 #. IDS_COLDESC_MVERSION
-#: Merge.rc:5126
+#: Merge.rc:5125
 msgid "Middle side file version, only for some file types."
 msgstr ""
 
 #. IDS_COLDESC_RESULT_ABBR
-#: Merge.rc:5127
+#: Merge.rc:5126
 msgid "Short comparison result."
 msgstr "תוצאת השוואה מקוצרת."
 
 #. IDS_COLDESC_LATTRIBUTES
-#: Merge.rc:5128
+#: Merge.rc:5127
 msgid "Left side attributes."
 msgstr "מאפייני צד שמאל."
 
 #. IDS_COLDESC_RATTRIBUTES
-#: Merge.rc:5129
+#: Merge.rc:5128
 msgid "Right side attributes."
 msgstr "מאפייני צד ימין."
 
 #. IDS_COLDESC_MATTRIBUTES
-#: Merge.rc:5130
+#: Merge.rc:5129
 msgid "Middle side attributes."
 msgstr "מאפייני צד אמצע."
 
 #. IDS_COLDESC_LEOL_TYPE
-#: Merge.rc:5131
+#: Merge.rc:5130
 msgid "Left side file EOL type."
 msgstr "סוג סוף שורה של קובץ בצד שמאל."
 
 #. IDS_COLDESC_REOL_TYPE
-#: Merge.rc:5132
+#: Merge.rc:5131
 msgid "Right side file EOL type."
 msgstr "סוג סוף שורה של קובץ בצד ימין."
 
 #. IDS_COLDESC_MEOL_TYPE
-#: Merge.rc:5133
+#: Merge.rc:5132
 msgid "Middle side file EOL type."
 msgstr "סוג סוף שורה של קובץ בצד אמצע."
 
 #. IDS_COLDESC_LENCODING
-#: Merge.rc:5139
+#: Merge.rc:5138
 msgid "Left side encoding."
 msgstr "קידוד צד שמאל."
 
 #. IDS_COLDESC_RENCODING
-#: Merge.rc:5140
+#: Merge.rc:5139
 msgid "Right side encoding."
 msgstr "קידוד צד ימין."
 
 #. IDS_COLDESC_MENCODING
-#: Merge.rc:5141
+#: Merge.rc:5140
 msgid "Middle side encoding."
 msgstr "קידוד צד אמצע."
 
 #. IDS_COLDESC_NIDIFFS
-#: Merge.rc:5142
+#: Merge.rc:5141
 msgid "Number of ignored differences in file. Ignored and cannot be merged."
 msgstr "מספר ההבדלים שהתעלמו מהם בקובץ. הבדלים אלו מתעלמים על ידי WinMerge ולא ניתן למזג אותם."
 
 #. IDS_COLDESC_NSDIFFS
-#: Merge.rc:5143
+#: Merge.rc:5142
 msgid "Number of differences in file (excluding ignored)."
 msgstr "מספר ההבדלים בקובץ. מספר זה אינו כולל הבדלים שהתעלמו מהם."
 
 #. IDS_COLDESC_BINARY
-#: Merge.rc:5144
+#: Merge.rc:5143
 msgid "Shows an asterisk (*) if the file is binary."
 msgstr "מציג כוכבית (*) אם הקובץ בינארי."
 
 #. IDS_COLDESC_UNPACKER
-#: Merge.rc:5145
+#: Merge.rc:5144
 msgid "Unpacker plugin name or pipeline."
 msgstr "שם תוסף מחלץ או צינור עיבוד."
 
 #. IDS_COLDESC_PREDIFFER
-#: Merge.rc:5146
+#: Merge.rc:5145
 msgid "Prediffer plugin name or pipeline."
 msgstr "שם תוסף השוואה מוקדמת או צינור עיבוד."
 
 #. IDS_DIRECTORY_REPORT_TITLE
-#: Merge.rc:5152
+#: Merge.rc:5151
 #, c-format
 msgid "Compare %1 with %2"
 msgstr "השווה %1 עם %2"
 
 #. IDS_DIRECTORY_REPORT_TITLE3
-#: Merge.rc:5153
+#: Merge.rc:5152
 #, c-format
 msgid "Compare %1 with %2 and %3"
 msgstr "השווה %1 עם %2 ו-%3"
 
 #. IDS_REPORT_COMMALIST
-#: Merge.rc:5154
+#: Merge.rc:5153
 msgid "Comma-separated list"
 msgstr "רשימה מופרדת בפסיקים"
 
 #. IDS_REPORT_TABLIST
-#: Merge.rc:5155
+#: Merge.rc:5154
 msgid "Tab-separated list"
 msgstr "רשימה מופרדת בטאבים"
 
 #. IDS_REPORT_SIMPLEHTML
-#: Merge.rc:5156
+#: Merge.rc:5155
 msgid "Simple HTML"
 msgstr "HTML פשוט"
 
 #. IDS_REPORT_SIMPLEXML
-#: Merge.rc:5157
+#: Merge.rc:5156
 msgid "Simple XML"
 msgstr "XML פשוט"
 
-#: Merge.rc:5159
+#: Merge.rc:5158
 msgid "Report file already exists. Overwrite?"
 msgstr "קובץ הדוח כבר קיים. האם ברצונך להחליף את הקובץ הקיים?"
 
 #. IDS_REPORT_ERROR
-#: Merge.rc:5164
+#: Merge.rc:5163
 #, c-format
 msgid ""
 "Error creating the report:\n"
@@ -7080,249 +7075,249 @@ msgstr ""
 "%1"
 
 #. IDS_REPORT_SUCCESS
-#: Merge.rc:5165
+#: Merge.rc:5164
 msgid "Report created successfully."
 msgstr "הדוח נוצר בהצלחה."
 
 #. IDS_SYNCPOINT_LASTBLOCK
-#: Merge.rc:5171
+#: Merge.rc:5170
 msgid "Cannot add a synchronization point at this line."
 msgstr "לא ניתן להוסיף נקודת סנכרון בשורה זו."
 
 #. IDS_FILE_TO_ITSELF
-#: Merge.rc:5177
+#: Merge.rc:5176
 msgid "Same file is opened in both panes."
 msgstr "אותו קובץ פתוח בשתי החלוניות."
 
 #. IDS_FILESSAME
-#: Merge.rc:5178
+#: Merge.rc:5177
 msgid "Selected files are identical."
 msgstr "הקבצים שנבחרו זהים."
 
 #. IDS_FILESSAME_CURCFG
-#: Merge.rc:5179
+#: Merge.rc:5178
 msgid "Selected files are identical (with current settings).\r\nChecking binary identity..."
 msgstr ""
 
 #. IDS_FILESSAME_BINERROR
-#: Merge.rc:5180
+#: Merge.rc:5179
 msgid "Selected files are identical (with current settings).\r\nBut binary comparison failed."
 msgstr ""
 
 #. IDS_FILESSAME_BINSAME
-#: Merge.rc:5181
+#: Merge.rc:5180
 msgid "Selected files are identical (binary match)."
 msgstr ""
 
 #. IDS_FILESSAME_BINDIFF
-#: Merge.rc:5182
+#: Merge.rc:5181
 msgid "Selected files are identical (with current settings).\r\nBut differ at the binary level."
 msgstr ""
 
 #. IDS_FILEERROR
-#: Merge.rc:5183
+#: Merge.rc:5182
 msgid "An error occurred while comparing files."
 msgstr "אירעה שגיאה בעת השוואת הקבצים."
 
 #. IDS_TEMP_FILEERROR
-#: Merge.rc:5184
+#: Merge.rc:5183
 msgid "Could not create temporary files. Check your temporary path settings."
 msgstr "לא ניתן ליצור קבצים זמניים. בדוק את הגדרות נתיב הקבצים הזמניים שלך."
 
 #. IDS_SUGGEST_IGNOREEOL
-#: Merge.rc:5185
+#: Merge.rc:5184
 msgid "Files use different EOL.\n\nTreat all EOL as equivalent?\n\nSet 'Ignore EOL differences (Windows/Unix/Mac)' in Compare section of Options."
 msgstr ""
 
 #. IDS_INVALID_DIRECTORY
-#: Merge.rc:5186
+#: Merge.rc:5185
 msgid "Selected folder is invalid."
 msgstr "התיקיה שנבחרה אינה חוקית."
 
 #. IDS_CANNOT_OPEN_BINARYFILE
-#: Merge.rc:5187
+#: Merge.rc:5186
 msgid "Cannot open a binary file in Editor."
 msgstr "לא ניתן לפתוח קובץ בינארי בעורך."
 
 #. IDS_CREATE_PAIR_FOLDER
-#: Merge.rc:5188
+#: Merge.rc:5187
 #, c-format
 msgid "Create matching folder:\n%1\non the other side and open?"
 msgstr ""
 
 #. IDS_CONFIRM_COPY_ALL_DIFFS
-#: Merge.rc:5189
+#: Merge.rc:5188
 msgid "Copy all differences to other file?"
 msgstr "האם אתה בטוח שברצונך להעתיק את כל ההבדלים לקובץ השני?"
 
 #. IDS_MOVE_TO_NEXTFILE
-#: Merge.rc:5194
+#: Merge.rc:5193
 msgid "Move to next file?"
 msgstr "האם לעבור לקובץ הבא?"
 
 #. IDS_MOVE_TO_PREVFILE
-#: Merge.rc:5195
+#: Merge.rc:5194
 msgid "Move to previous file?"
 msgstr "האם לעבור לקובץ הקודם?"
 
 #. IDS_MOVE_TO_NEXTPAGE
-#: Merge.rc:5196
+#: Merge.rc:5195
 msgid "Move to next page?"
 msgstr "האם לעבור לעמוד הבא?"
 
 #. IDS_MOVE_TO_PREVPAGE
-#: Merge.rc:5197
+#: Merge.rc:5196
 msgid "Move to previous page?"
 msgstr "האם לעבור לעמוד הקודם?"
 
 #. IDS_MOVE_TO_FIRSTFILE
-#: Merge.rc:5198
+#: Merge.rc:5197
 msgid "Move to first file?"
 msgstr "האם לעבור לקובץ הראשון?"
 
 #. IDS_MOVE_TO_LASTFILE
-#: Merge.rc:5199
+#: Merge.rc:5198
 msgid "Move to last file?"
 msgstr "האם לעבור לקובץ האחרון?"
 
-#: Merge.rc:5206
+#: Merge.rc:5205
 #, c-format
 msgid "Different codepages: left (cp%d), right (cp%d).\nDisplay in codepage (better display) or default Windows codepage (safer merging)?\n(Recommended: default Windows codepage)"
 msgstr ""
 
-#: Merge.rc:5208
+#: Merge.rc:5207
 msgid "Information lost due to encoding errors: both files"
 msgstr ""
 
-#: Merge.rc:5210
+#: Merge.rc:5209
 msgid "Information lost due to encoding errors: first file"
 msgstr ""
 
-#: Merge.rc:5212
+#: Merge.rc:5211
 msgid "Information lost due to encoding errors: second file"
 msgstr ""
 
-#: Merge.rc:5214
+#: Merge.rc:5213
 msgid "Information lost due to encoding errors: third file"
 msgstr ""
 
 #. IDS_LINEDIFF_NODIFF
-#: Merge.rc:5220
+#: Merge.rc:5219
 msgid "No difference"
 msgstr "אין הבדל"
 
 #. IDS_LINEDIFF_NODIFF_CAPTION
-#: Merge.rc:5221
+#: Merge.rc:5220
 msgid "Line difference"
 msgstr "הבדל בשורה"
 
 #. IDS_NUM_REPLACED
-#: Merge.rc:5227
+#: Merge.rc:5226
 #, c-format
 msgid "Replaced %1 string(s)."
 msgstr "הוחלפו %1 מחרוזות."
 
 #. IDS_EDIT_TEXT_NOT_FOUND
-#: Merge.rc:5228
+#: Merge.rc:5227
 #, c-format
 msgid "Cannot find string \"%s\"."
 msgstr "לא ניתן למצוא את המחרוזת \"%s\"."
 
 #. IDS_MERGE_MODE
-#: Merge.rc:5234
+#: Merge.rc:5233
 msgid "Entering Merge Mode. Press F9 to turn off."
 msgstr "אתה נכנס כעת למצב מיזוג. כדי לכבות את מצב המיזוג, לחץ על מקש F9."
 
 #. IDS_AUTO_MERGE
-#: Merge.rc:5240
+#: Merge.rc:5239
 #, c-format
 msgid "Automatic merges: %1\nUnresolved conflicts: %2"
 msgstr ""
 
 #. IDS_CODEPAGE_MERGED
-#: Merge.rc:5241
+#: Merge.rc:5240
 msgid "Codepage change merged."
 msgstr "השינוי בקידוד הדף מוזג."
 
 #. IDS_CODEPAGE_CONFLICT
-#: Merge.rc:5242
+#: Merge.rc:5241
 msgid "Codepage changes are conflicting."
 msgstr "השינויים בקידוד הדף מתנגשים."
 
 #. IDS_EOL_MERGED
-#: Merge.rc:5243
+#: Merge.rc:5242
 msgid "EOL change merged."
 msgstr "השינוי בסוג סוף השורה מוזג."
 
 #. IDS_EOL_CONFLICT
-#: Merge.rc:5244
+#: Merge.rc:5243
 msgid "EOL changes are conflicting."
 msgstr "השינויים בסוג סוף השורה מתנגשים."
 
 #. IDS_LOCBAR_CAPTION
-#: Merge.rc:5250
+#: Merge.rc:5249
 msgid "Location Pane"
 msgstr "חלונית מיקום"
 
 #. IDS_DIFFBAR_CAPTION
-#: Merge.rc:5251
+#: Merge.rc:5250
 msgid "Diff Pane"
 msgstr "חלונית השוואה"
 
 #. IDS_DIFF_SUCCEEDED
-#: Merge.rc:5258
+#: Merge.rc:5257
 msgid "Patch file written."
 msgstr "קובץ התיקון נכתב בהצלחה."
 
 #. IDS_DIFF_FILEOVERWRITE
-#: Merge.rc:5259
+#: Merge.rc:5258
 msgid "Patch file already exists. Overwrite?"
 msgstr "קובץ התיקון כבר קיים. האם להחליף אותו?"
 
 #. IDS_DIFF_SELECTEDFILES
-#: Merge.rc:5260
+#: Merge.rc:5259
 #, c-format
 msgid "[%1 files selected]"
 msgstr ""
 
 #. IDS_DIFF_NORMAL
-#: Merge.rc:5261
+#: Merge.rc:5260
 msgid "Normal"
 msgstr "רגיל"
 
 #. IDS_DIFF_CONTEXT
-#: Merge.rc:5262
+#: Merge.rc:5261
 msgid "Context"
 msgstr "הקשר"
 
 #. IDS_DIFF_UNIFIED
-#: Merge.rc:5263
+#: Merge.rc:5262
 msgid "Unified"
 msgstr "מאוחד"
 
 #. IDS_FILEWRITE_ERROR
-#: Merge.rc:5265
+#: Merge.rc:5264
 #, c-format
 msgid "Could not write to file %1."
 msgstr "לא ניתן לכתוב לקובץ %1."
 
 #. IDS_PATH_NOT_ABSOLUTE
-#: Merge.rc:5266
+#: Merge.rc:5265
 #, c-format
 msgid "Output path is not absolute: %1"
 msgstr "נתיב הפלט שצוין אינו נתיב מוחלט: %1"
 
 #. IDS_MUST_SPECIFY_OUTPUT
-#: Merge.rc:5267
+#: Merge.rc:5266
 msgid "Specify an output file."
 msgstr "ציין קובץ פלט."
 
-#: Merge.rc:5269
+#: Merge.rc:5268
 msgid "Cannot create patch from binary files."
 msgstr "לא ניתן ליצור קובץ תיקון מקבצים בינאריים."
 
 #. IDS_SAVEFILES_FORPATCH
-#: Merge.rc:5270
+#: Merge.rc:5269
 msgid ""
 "Save all files first.\n"
 "\n"
@@ -7333,22 +7328,22 @@ msgstr ""
 "יצירת קובץ תיקון מחייבת שלא יהיו שינויים שלא נשמרו בקבצים."
 
 #. IDS_FOLDER_NOTEXIST
-#: Merge.rc:5271
+#: Merge.rc:5270
 msgid "Folder does not exist."
 msgstr "התיקיה אינה קיימת."
 
 #. IDS_ARCHIVE_SUCCEEDED
-#: Merge.rc:5277
+#: Merge.rc:5276
 msgid "Archive file written."
 msgstr ""
 
 #. IDS_ARCHIVE_SAVEFILES
-#: Merge.rc:5278
+#: Merge.rc:5277
 msgid "Save all files first.\n\nCreating an archive requires no unsaved changes."
 msgstr ""
 
 #. IDS_NO_ZIP_SUPPORT
-#: Merge.rc:5283
+#: Merge.rc:5282
 msgid ""
 "Archive support not enabled.\n"
 "7-Zip and/or Merge7z*.dll not found.\n"
@@ -7359,37 +7354,37 @@ msgstr ""
 "ראה את המדריך למידע נוסף על תמיכת ארכיונים וכיצד להפעיל אותה."
 
 #. IDS_OPT_EXPORT_CAPTION
-#: Merge.rc:5284
+#: Merge.rc:5283
 msgid "Select file for export"
 msgstr "בחר קובץ לייצוא"
 
 #. IDS_OPT_IMPORT_CAPTION
-#: Merge.rc:5285
+#: Merge.rc:5284
 msgid "Select file for import"
 msgstr "בחר קובץ לייבוא"
 
 #. IDS_OPT_IMPORT_DONE
-#: Merge.rc:5286
+#: Merge.rc:5285
 msgid "Options imported from file."
 msgstr "אפשרויות יובאו מהקובץ."
 
 #. IDS_OPT_EXPORT_DONE
-#: Merge.rc:5287
+#: Merge.rc:5286
 msgid "Options exported to file."
 msgstr "אפשרויות יוצאו לקובץ."
 
 #. IDS_OPT_IMPORT_ERR
-#: Merge.rc:5288
+#: Merge.rc:5287
 msgid "Failed to import options from file."
 msgstr "ייבוא האפשרויות מהקובץ נכשל."
 
 #. IDS_OPT_EXPORT_ERR
-#: Merge.rc:5289
+#: Merge.rc:5288
 msgid "Failed to write options to file."
 msgstr "כתיבת האפשרויות לקובץ נכשלה."
 
 #. IDS_CLOSEALL_WINDOWS
-#: Merge.rc:5290
+#: Merge.rc:5289
 msgid ""
 "Close multiple compare windows?\n"
 "\n"
@@ -7400,34 +7395,34 @@ msgstr ""
 "האם להמשיך?"
 
 #. IDS_EOL_BIN
-#: Merge.rc:5300
+#: Merge.rc:5299
 msgctxt "EOL Type"
 msgid "Binary"
 msgstr "בינארי"
 
 #. IDS_MARKER_COLOR_FMT
-#: Merge.rc:5305
+#: Merge.rc:5304
 #, c-format
 msgid "Marker Color %d"
 msgstr "צבע סימון %d"
 
 #. IDS_MARKER_NEW_PATTERN
-#: Merge.rc:5306
+#: Merge.rc:5305
 msgid "New Pattern"
 msgstr "תבנית חדשה"
 
 #. IDS_PLUGINSLIST_TYPE
-#: Merge.rc:5312
+#: Merge.rc:5311
 msgid "Type"
 msgstr "סוג"
 
 #. IDS_PLUGINS_TYPE_EDITSCRIPT
-#: Merge.rc:5316
+#: Merge.rc:5315
 msgid "Editor script"
 msgstr "סקריפט עורך"
 
 #. ID_SELECTLINEDIFF
-#: Merge.rc:5322
+#: Merge.rc:5321
 msgid ""
 "\n"
 "Difference in Current Line (F4)"
@@ -7436,7 +7431,7 @@ msgstr ""
 "הבדל בשורה הנוכחית (F4)"
 
 #. ID_OPTIONS
-#: Merge.rc:5323
+#: Merge.rc:5322
 msgid ""
 "\n"
 "Options"
@@ -7445,7 +7440,7 @@ msgstr ""
 "אפשרויות"
 
 #. ID_REFRESH
-#: Merge.rc:5324
+#: Merge.rc:5323
 msgid ""
 "\n"
 "Refresh (F5)"
@@ -7454,7 +7449,7 @@ msgstr ""
 "רענן (F5)"
 
 #. ID_PREVDIFF
-#: Merge.rc:5330
+#: Merge.rc:5329
 msgid ""
 "\n"
 "Previous Difference (Alt+Up)"
@@ -7463,7 +7458,7 @@ msgstr ""
 "הבדל קודם (Alt+Up)"
 
 #. ID_NEXTDIFF
-#: Merge.rc:5331
+#: Merge.rc:5330
 msgid ""
 "\n"
 "Next Difference (Alt+Down)"
@@ -7472,7 +7467,7 @@ msgstr ""
 "הבדל הבא (Alt+Down)"
 
 #. ID_PREVCONFLICT
-#: Merge.rc:5332
+#: Merge.rc:5331
 msgid ""
 "\n"
 "Previous Conflict (Alt+Shift+Up)"
@@ -7481,7 +7476,7 @@ msgstr ""
 "סתירה קודמת (Alt+Shift+Up)"
 
 #. ID_NEXTCONFLICT
-#: Merge.rc:5333
+#: Merge.rc:5332
 msgid ""
 "\n"
 "Next Conflict (Alt+Shift+Down)"
@@ -7490,7 +7485,7 @@ msgstr ""
 "סתירה הבאה (Alt+Shift+Down)"
 
 #. ID_FIRSTDIFF
-#: Merge.rc:5338
+#: Merge.rc:5337
 msgid ""
 "\n"
 "First Difference (Alt+Home)"
@@ -7499,7 +7494,7 @@ msgstr ""
 "הבדל ראשון (Alt+Home)"
 
 #. ID_CURDIFF
-#: Merge.rc:5339
+#: Merge.rc:5338
 msgid ""
 "\n"
 "Current Difference (Alt+Enter)"
@@ -7508,7 +7503,7 @@ msgstr ""
 "הבדל נוכחי (Alt+Enter)"
 
 #. ID_LASTDIFF
-#: Merge.rc:5340
+#: Merge.rc:5339
 msgid ""
 "\n"
 "Last Difference (Alt+End)"
@@ -7517,7 +7512,7 @@ msgstr ""
 "הבדל אחרון (Alt+End)"
 
 #. ID_L2R
-#: Merge.rc:5341
+#: Merge.rc:5340
 msgid ""
 "\n"
 "Copy to Right (Alt+Right)"
@@ -7526,7 +7521,7 @@ msgstr ""
 "העתק לימין (Alt+Right)"
 
 #. ID_R2L
-#: Merge.rc:5342
+#: Merge.rc:5341
 msgid ""
 "\n"
 "Copy to Left (Alt+Left)"
@@ -7535,7 +7530,7 @@ msgstr ""
 "העתק לשמאל (Alt+Left)"
 
 #. ID_L2RNEXT
-#: Merge.rc:5343
+#: Merge.rc:5342
 msgid ""
 "\n"
 "Copy to Right and Advance (Ctrl+Alt+Right)"
@@ -7544,7 +7539,7 @@ msgstr ""
 "העתק לימין והתקדם (Ctrl+Alt+Right)"
 
 #. ID_R2LNEXT
-#: Merge.rc:5344
+#: Merge.rc:5343
 msgid ""
 "\n"
 "Copy to Left and Advance (Ctrl+Alt+Left)"
@@ -7553,7 +7548,7 @@ msgstr ""
 "העתק לשמאל והתקדם (Ctrl+Alt+Left)"
 
 #. ID_ALL_RIGHT
-#: Merge.rc:5345
+#: Merge.rc:5344
 msgid ""
 "\n"
 "Copy All to Right"
@@ -7562,7 +7557,7 @@ msgstr ""
 "העתק הכל לימין"
 
 #. ID_ALL_LEFT
-#: Merge.rc:5346
+#: Merge.rc:5345
 msgid ""
 "\n"
 "Copy All to Left"
@@ -7571,7 +7566,7 @@ msgstr ""
 "העתק הכל לשמאל"
 
 #. ID_AUTO_MERGE
-#: Merge.rc:5347
+#: Merge.rc:5346
 msgid ""
 "\n"
 "Auto Merge (Ctrl+Alt+M)"
@@ -7580,651 +7575,651 @@ msgstr ""
 "מיזוג אוטומטי (Ctrl+Alt+M)"
 
 #. ID_FIRSTFILE
-#: Merge.rc:5348
+#: Merge.rc:5347
 msgid "\nFirst File"
 msgstr ""
 
 #. ID_NEXTFILE
-#: Merge.rc:5349
+#: Merge.rc:5348
 msgid "\nNext File (Ctrl+F8)"
 msgstr ""
 
 #. ID_LASTFILE
-#: Merge.rc:5350
+#: Merge.rc:5349
 msgid "\nLast File"
 msgstr ""
 
 #. ID_PREVFILE
-#: Merge.rc:5351
+#: Merge.rc:5350
 msgid "\nPrevious File (Ctrl+F7)"
 msgstr ""
 
 #. IDS_UNPACK_AUTO
-#: Merge.rc:5358
+#: Merge.rc:5357
 msgid "Adapted unpacker applied to both files (one needs extension)."
 msgstr ""
 
 #. IDS_NO_PREDIFFER
-#: Merge.rc:5359
+#: Merge.rc:5358
 msgid "No Prediffer (Normal)"
 msgstr "ללא השוואה מוקדמת (רגיל)"
 
 #. IDS_SUGGESTED_PLUGINS
-#: Merge.rc:5360
+#: Merge.rc:5359
 msgid "Suggested Plugins"
 msgstr "תוספים מוצעים"
 
 #. IDS_NOT_SUGGESTED_PLUGINS
-#: Merge.rc:5361
+#: Merge.rc:5360
 msgid "All Plugins"
 msgstr "כל התוספים"
 
 #. IDS_PRIVATEBUILD_FMT
-#: Merge.rc:5367
+#: Merge.rc:5366
 #, c-format
 msgid "Private Build: %1"
 msgstr "בנייה פרטית: %1"
 
 #. IDS_ALLRIGHTS_RESERVED
-#: Merge.rc:5368
+#: Merge.rc:5367
 msgid " - All rights reserved."
 msgstr ""
 
 #. IDS_TITLE_PLUGINS_SETTINGS
-#: Merge.rc:5374
+#: Merge.rc:5373
 msgid "Plugin Settings"
 msgstr "הגדרות תוסף"
 
 #. IDS_NO_SCT_SCRIPTS
-#: Merge.rc:5376
+#: Merge.rc:5375
 msgid "WSH not found - .sct scripts disabled"
 msgstr "WSH לא נמצא - סקריפטים מסוג .sct הושבתו"
 
 #. IDS_LOCBAR_GOTOLINE_FMT
-#: Merge.rc:5384
+#: Merge.rc:5383
 #, c-format
 msgid "G&o to Line %1"
 msgstr "עבור לשורה %1"
 
 #. IDS_GOTO_MOVED_LINE
-#: Merge.rc:5390
+#: Merge.rc:5389
 msgid "Go to Moved Line\tCtrl+Shift+G"
 msgstr "עבור לשורה שהוזזה\tCtrl+Shift+G"
 
 #. IDS_AUTOCOMPLETE_DISABLED
-#: Merge.rc:5396
+#: Merge.rc:5395
 msgctxt "Options dialog|General|Open dialog Auto completion"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_AUTOCOMPLETE_FILE_SYS
-#: Merge.rc:5397
+#: Merge.rc:5396
 msgid "From file system"
 msgstr "ממערכת הקבצים"
 
 #. IDS_AUTOCOMPLETE_MRU
-#: Merge.rc:5398
+#: Merge.rc:5397
 msgid "From Most Recently Used list"
 msgstr "מרשימת הקבצים שנעשה בהם שימוש לאחרונה"
 
 #. IDS_COLORSCHEME_PLAIN
-#: Merge.rc:5404
+#: Merge.rc:5403
 msgid "No Highlighting"
 msgstr "ללא הדגשה"
 
 #. IDS_COLORSCHEME_PO
-#: Merge.rc:5439
+#: Merge.rc:5438
 msgid "Portable Object"
 msgstr "אובייקט נייד"
 
 #. IDS_COLORSCHEME_RSRC
-#: Merge.rc:5444
+#: Merge.rc:5443
 msgid "Resources"
 msgstr "משאבים"
 
 #. IDS_COLORSCHEME_SH
-#: Merge.rc:5448
+#: Merge.rc:5447
 msgid "Shell"
 msgstr "מעטפת"
 
 #. IDS_CLOSE_LEFT_TABS
-#: Merge.rc:5469
+#: Merge.rc:5468
 msgid "Close &Left Tabs"
 msgstr "סגור כרטיסיות שמאל"
 
 #. IDS_CLOSE_RIGHT_TABS
-#: Merge.rc:5470
+#: Merge.rc:5469
 msgid "Close R&ight Tabs"
 msgstr "סגור כרטיסיות ימין"
 
 #. IDS_CLOSE_OTHER_TABS
-#: Merge.rc:5471
+#: Merge.rc:5470
 msgid "Close &Other Tabs"
 msgstr "סגור כרטיסיות אחרות"
 
 #. IDS_TABBAR_AUTO_MAXWIDTH
-#: Merge.rc:5472
+#: Merge.rc:5471
 msgid "Enable &Auto Max Width"
 msgstr "אפשר רוחב מקסימלי אוטומטי"
 
 #. IDS_WEBPAGE_MENU
-#: Merge.rc:5482
+#: Merge.rc:5481
 msgid "We&bpage"
 msgstr "דף אינטרנט"
 
 #. IDS_VIEW_WRAP_TEXT
-#: Merge.rc:5487
+#: Merge.rc:5486
 msgid "W&rap Text"
 msgstr "גלישת טקסט"
 
 #. IDS_NOTINSTALLED
-#: Merge.rc:5492
+#: Merge.rc:5491
 #, c-format
 msgid "%1 is not installed."
 msgstr "%1 אינו מותקן."
 
 #. IDS_CREATE_FOLDER
-#: Merge.rc:5497
+#: Merge.rc:5496
 #, c-format
 msgid "%1 does not exist. Create it?"
 msgstr "%1 אינו קיים. האם ליצור אותו?"
 
 #. IDS_CREATE_FOLDER_ERROR
-#: Merge.rc:5498
+#: Merge.rc:5497
 msgid "Failed to create folder."
 msgstr "יצירת התיקיה נכשלה."
 
 #. IDC_EXT_EDITOR_PATH
-#: Merge.rc:5503
+#: Merge.rc:5502
 msgid "Parameters:\n$file: Current file path\n$linenum: Current cursor line number"
 msgstr ""
 
 #. IDS_DIFF_ALGORITHM_DEFAULT
-#: Merge.rc:5508
+#: Merge.rc:5507
 msgid "default"
 msgstr "ברירת מחדל"
 
 #. IDS_DIFF_ALGORITHM_MINIMAL
-#: Merge.rc:5509
+#: Merge.rc:5508
 msgid "minimal"
 msgstr "מינימלי"
 
 #. IDS_DIFF_ALGORITHM_PATIENCE
-#: Merge.rc:5510
+#: Merge.rc:5509
 msgid "patience"
 msgstr "סבלנות"
 
 #. IDS_DIFF_ALGORITHM_HISTOGRAM
-#: Merge.rc:5511
+#: Merge.rc:5510
 msgid "histogram"
 msgstr "היסטוגרמה"
 
 #. IDS_DIFF_ALGORITHM_NONE
-#: Merge.rc:5512
+#: Merge.rc:5511
 msgid "none"
 msgstr "ללא"
 
 #. IDS_RENDERING_MODE_GDI
-#: Merge.rc:5517
+#: Merge.rc:5516
 msgid "GDI"
 msgstr "GDI"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_DEFAULT
-#: Merge.rc:5518
+#: Merge.rc:5517
 msgid "DirectWrite Default"
 msgstr "ברירת מחדל של DirectWrite"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_ALIASED
-#: Merge.rc:5519
+#: Merge.rc:5518
 msgid "DirectWrite Aliased"
 msgstr "DirectWrite עם החלקה"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_GDI_CLASSIC
-#: Merge.rc:5520
+#: Merge.rc:5519
 msgid "DirectWrite GDI Classic"
 msgstr "DirectWrite GDI קלאסי"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_GDI_NATURAL
-#: Merge.rc:5521
+#: Merge.rc:5520
 msgid "DirectWrite GDI Natural"
 msgstr "DirectWrite GDI טבעי"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_NATURAL
-#: Merge.rc:5522
+#: Merge.rc:5521
 msgid "DirectWrite Natural"
 msgstr "DirectWrite טבעי"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_NATURAL_SYMMETRIC
-#: Merge.rc:5523
+#: Merge.rc:5522
 msgid "DirectWrite Natural Symmetric"
 msgstr "DirectWrite טבעי סימטרי"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_DISABLED
-#: Merge.rc:5528
+#: Merge.rc:5527
 msgctxt "Options dialog|General|Close windows with Esc"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_1
-#: Merge.rc:5529
+#: Merge.rc:5528
 msgid "MDI child window or main window"
 msgstr "חלון בן MDI או חלון ראשי"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_2
-#: Merge.rc:5530
+#: Merge.rc:5529
 msgid "MDI child window only"
 msgstr "רק חלון בן MDI"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_3
-#: Merge.rc:5531
+#: Merge.rc:5530
 msgid "Close main window if only one MDI child window"
 msgstr "סגור את החלון הראשי אם יש רק חלון בן MDI אחד"
 
 #. IDS_DIFF_GROUP
-#: Merge.rc:5536
+#: Merge.rc:5535
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Diff"
 msgstr "הבדל"
 
 #. IDS_DIFF_HIGHLIGHT
-#: Merge.rc:5537
+#: Merge.rc:5536
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Highlight"
 msgstr "הדגשה"
 
 #. IDS_DIFF_BLINK
-#: Merge.rc:5538
+#: Merge.rc:5537
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Blink"
 msgstr "הבהוב"
 
 #. IDS_DIFF_BLOCKSIZE
-#: Merge.rc:5539
+#: Merge.rc:5538
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Block Size"
 msgstr "גודל בלוק"
 
 #. IDS_DIFF_BLOCKALPHA
-#: Merge.rc:5540
+#: Merge.rc:5539
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Block Alpha"
 msgstr "אלפא של בלוק"
 
 #. IDS_DIFF_CDTHRESHOLD
-#: Merge.rc:5541
+#: Merge.rc:5540
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "CD Threshold"
 msgstr "סף CD"
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION
-#: Merge.rc:5542
+#: Merge.rc:5541
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Ins/Del Detection"
 msgstr "זיהוי הוספה/מחיקה"
 
 #. IDS_OVERLAY_MODE_NONE
-#: Merge.rc:5543 Merge.rc:5548
+#: Merge.rc:5542 Merge.rc:5547
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "None"
 msgstr "ללא"
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION_VERTICAL
-#: Merge.rc:5544
+#: Merge.rc:5543
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Vertical"
 msgstr "אנכי"
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION_HORIZONTAL
-#: Merge.rc:5545
+#: Merge.rc:5544
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Horizontal"
 msgstr "אופקי"
 
 #. IDS_OVERLAY_GROUP
-#: Merge.rc:5546
+#: Merge.rc:5545
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Overlay"
 msgstr "חפיפה"
 
 #. IDS_OVERLAY_ALPHA
-#: Merge.rc:5547
+#: Merge.rc:5546
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha"
 msgstr "אלפא"
 
 #. IDS_OVERLAY_MODE_XOR
-#: Merge.rc:5549
+#: Merge.rc:5548
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "XOR"
 msgstr "XOR"
 
 #. IDS_OVERLAY_MODE_ALPHA
-#: Merge.rc:5550
+#: Merge.rc:5549
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha Blend"
 msgstr "שילוב אלפא"
 
 #. IDS_OVERLAY_MODE_ALPHA_ANIMATION
-#: Merge.rc:5551
+#: Merge.rc:5550
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha Animation"
 msgstr "אנימציית אלפא"
 
 #. IDS_ZOOM
-#: Merge.rc:5552
+#: Merge.rc:5551
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Zoom"
 msgstr "התקרבות"
 
 #. IDS_PAGE
-#: Merge.rc:5553
+#: Merge.rc:5552
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Page:"
 msgstr "עמוד:"
 
 #. IDS_IMGCMP_STATUS_PT_RGBA_FMT
-#: Merge.rc:5554
+#: Merge.rc:5553
 #, c-format
 msgid "Pt: (%d, %d)  RGBA: (%d, %d, %d, %d)  "
 msgstr "נקודה: (%d, %d)  RGBA: (%d, %d, %d, %d)  "
 
 #. IDS_IMGCMP_STATUS_DIST1_FMT
-#: Merge.rc:5555
+#: Merge.rc:5554
 #, c-format
 msgid "Dist: %g  "
 msgstr "מרחק: %g  "
 
 #. IDS_IMGCMP_STATUS_DIST2_FMT
-#: Merge.rc:5556
+#: Merge.rc:5555
 #, c-format
 msgid "Dist: %g, %g  "
 msgstr "מרחק: %g, %g  "
 
 #. IDS_IMGCMP_STATUS_PAGE_ZOOM_SIZE_BPP_FMT
-#: Merge.rc:5557
+#: Merge.rc:5556
 #, c-format
 msgid "Page: %d/%d  Zoom: %d%%  %dx%dpx  %dbpp  "
 msgstr "עמוד: %d/%d  התקרבות: %d%%  %dx%dpx  %dbpp  "
 
 #. IDS_IMGCMP_STATUS_RC_FMT
-#: Merge.rc:5558
+#: Merge.rc:5557
 #, c-format
 msgid "Rc: (%d, %d)  "
 msgstr "Rc: (%d, %d)  "
 
 #. IDS_IMGCMP_STATUS_FLIPPED_FMT
-#: Merge.rc:5559
+#: Merge.rc:5558
 #, c-format
 msgid "Flipped: %s  "
 msgstr "הפוך: %s  "
 
 #. IDS_IMGCMP_STATUS_ROTATED_FMT
-#: Merge.rc:5560
+#: Merge.rc:5559
 #, c-format
 msgid "Rotated: %d  "
 msgstr "מסובב: %d  "
 
 #. IDS_IMGCMP_REPORT_ALLPAGES
-#: Merge.rc:5561
+#: Merge.rc:5560
 msgid "All pages"
 msgstr "כל העמודים"
 
 #. IDS_IGNSUB_STR1
-#: Merge.rc:5566
+#: Merge.rc:5565
 msgid "<Edit here>"
 msgstr "<ערוך כאן>"
 
 #. IDS_IGNSUB_STR2
-#: Merge.rc:5567
+#: Merge.rc:5566
 msgid "No differences found to select"
 msgstr "לא נמצאו הבדלים לבחירה"
 
 #. IDS_IGNSUB_STR3
-#: Merge.rc:5568
+#: Merge.rc:5567
 msgid "No differences found to add as substitution filter"
 msgstr "לא נמצאו הבדלים להוספה כמסנן החלפה"
 
 #. IDS_IGNSUB_STR4
-#: Merge.rc:5569
+#: Merge.rc:5568
 msgid "The pair is already in the Substitution Filters list"
 msgstr "הזוג כבר קיים ברשימת מסנני ההחלפה"
 
 #. IDS_IGNSUB_STR5
-#: Merge.rc:5570
+#: Merge.rc:5569
 msgid "Add this change to Substitution Filters?"
 msgstr "להוסיף שינוי זה למסנני ההחלפה?"
 
 #. IDS_OCRRESULT_TEXTONLY
-#: Merge.rc:5575
+#: Merge.rc:5574
 msgid "Text only"
 msgstr "טקסט בלבד"
 
 #. IDS_OCRRESULT_POS_LINE
-#: Merge.rc:5576
+#: Merge.rc:5575
 msgid "Line-by-line position and text"
 msgstr "מיקום וטקסט שורה-אחר-שורה"
 
 #. IDS_OCRRESULT_POS_WORD
-#: Merge.rc:5577
+#: Merge.rc:5576
 msgid "Word-by-word position and text"
 msgstr "מיקום וטקסט מילה-אחר-מילה"
 
 #. IDS_USERDATAFOLDER_APPDATA
-#: Merge.rc:5582
+#: Merge.rc:5581
 msgid "AppData (Roaming) folder"
 msgstr ""
 
 #. IDS_USERDATAFOLDER_INSTALL
-#: Merge.rc:5583
+#: Merge.rc:5582
 msgid "Install folder"
 msgstr "תיקיית התקנה"
 
 #. IDS_USERDATAFOLDER_DOCUMENTS
-#: Merge.rc:5584
+#: Merge.rc:5583
 msgid "Documents folder"
 msgstr ""
 
 #. IDS_SINGLEINSTANCE_DISABLED
-#: Merge.rc:5589
+#: Merge.rc:5588
 msgctxt "Options dialog|General|Single instance mode"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_SINGLEINSTANCE_STR1
-#: Merge.rc:5590
+#: Merge.rc:5589
 msgid "Allow only one instance to run"
 msgstr "אפשר להריץ מופע אחד בלבד"
 
 #. IDS_CLIPBOARD_HISTORY
-#: Merge.rc:5591
+#: Merge.rc:5590
 msgid "Clipboard &History"
 msgstr ""
 
 #. IDS_SINGLEINSTANCE_STR2
-#: Merge.rc:5592
+#: Merge.rc:5591
 msgid "Allow only one instance; wait for termination"
 msgstr "אפשר להריץ מופע אחד בלבד והמתן לסיומו"
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_DISABLED
-#: Merge.rc:5597
+#: Merge.rc:5596
 msgctxt "Options dialog|General|Auto-reload modified files"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_STR1
-#: Merge.rc:5598
+#: Merge.rc:5597
 msgid "Only on window activated"
 msgstr "רק כאשר חלון מופעל"
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_STR2
-#: Merge.rc:5599
+#: Merge.rc:5598
 msgid "Immediately"
 msgstr "מיידית"
 
 #. IDS_PLUGIN_ALL
-#: Merge.rc:5604
+#: Merge.rc:5603
 msgid "Al&l"
 msgstr "הכ&ל"
 
 #. IDS_PLUGIN_OTHERS
-#: Merge.rc:5605
+#: Merge.rc:5604
 msgid "&Others"
 msgstr "&אחרים"
 
-#: Merge.rc:5607
+#: Merge.rc:5606
 #, c-format
 msgid "Missing plugin name in pipeline: %1"
 msgstr "שם התוסף חסר בצינור התוספים: %1"
 
-#: Merge.rc:5609
+#: Merge.rc:5608
 #, c-format
 msgid "Missing quote in plugin pipeline: %1"
 msgstr "מרכאות חסרות בצינור התוספים: %1"
 
 #. IDS_PLUGIN_NAME_ALREADY_EXISTS
-#: Merge.rc:5610
+#: Merge.rc:5609
 #, c-format
 msgid "Plugin name '%1' already exists."
 msgstr "שם התוסף '%1' כבר קיים."
 
 #. IDS_PLUGIN_TITLE1
-#: Merge.rc:5611
+#: Merge.rc:5610
 msgid "Specify plugin arguments"
 msgstr "ציין פרמטרים לתוסף"
 
-#: Merge.rc:5613
+#: Merge.rc:5612
 #, c-format
 msgid "Plugin not found or invalid: %1"
 msgstr "התוסף לא נמצא או לא תקין: %1"
 
 #. IDS_PLUGIN_NOT_UNPACK
-#: Merge.rc:5614
+#: Merge.rc:5613
 #, c-format
 msgid "'%1' is not an unpacker plugin"
 msgstr "'%1' אינו תוסף מחלץ"
 
 #. IDS_PLUGIN_NOT_PREDIFF
-#: Merge.rc:5615
+#: Merge.rc:5614
 #, c-format
 msgid "'%1' is not a prediffer plugin"
 msgstr "'%1' אינו תוסף השוואה מוקדמת"
 
-#: Merge.rc:5617
+#: Merge.rc:5616
 #, c-format
 msgid "Error prediffing '%1' with '%2'. Prediffing disabled."
 msgstr "אירעה שגיאה בעת השוואה מוקדמת של הקובץ '%1' עם התוסף '%2'. ההשוואה המוקדמת לא תיושם עוד."
 
 #. IDS_PLUGIN_CIRCULAR_REFERENCE
-#: Merge.rc:5618
+#: Merge.rc:5617
 #, c-format
 msgid "Circular reference in plugin pipeline: %1"
 msgstr "ייחוס מעגלי בצינור התוספים: %1"
 
 #. IDS_PLUGIN_TYPE1
-#: Merge.rc:5619
+#: Merge.rc:5618
 msgid "URL Handler"
 msgstr "מטפל בכתובות URL"
 
 #. IDS_PLUGIN_TYPE2
-#: Merge.rc:5620
+#: Merge.rc:5619
 msgid "File Unpacker"
 msgstr "מחלץ קבצים"
 
 #. IDS_PLUGIN_TYPE3
-#: Merge.rc:5621
+#: Merge.rc:5620
 msgid "File or Folder Unpacker"
 msgstr "מחלץ קובץ או תיקיה"
 
 #. IDS_PLUGIN_TYPE5
-#: Merge.rc:5623
+#: Merge.rc:5622
 msgid "Alias for Unpacker"
 msgstr "כינוי למחלץ"
 
 #. IDS_PLUGIN_TYPE6
-#: Merge.rc:5624
+#: Merge.rc:5623
 msgid "Alias for Prediffer"
 msgstr "כינוי לתוסף השוואה מוקדמת"
 
 #. IDS_PLUGIN_TYPE7
-#: Merge.rc:5625
+#: Merge.rc:5624
 msgid "Alias for Editor script"
 msgstr "כינוי לסקריפט עורך"
 
 #. IDS_PLUGIN_ALIAS_DESC
-#: Merge.rc:5626
+#: Merge.rc:5625
 #, c-format
 msgid "Alias for plugin pipeline '%1'"
 msgstr "כינוי לצינור תוספים '%1'"
 
 #. IDS_PLUGIN_NEW_DESC
-#: Merge.rc:5627
+#: Merge.rc:5626
 msgid "New plugin description"
 msgstr "תיאור תוסף חדש"
 
 #. IDS_PLUGIN_TARGETS_ALL
-#: Merge.rc:5628
+#: Merge.rc:5627
 msgid "All"
 msgstr "הכל"
 
 #. IDS_PLUGIN_TARGETS_1ST
-#: Merge.rc:5629
+#: Merge.rc:5628
 msgid "1st"
 msgstr "ראשון"
 
 #. IDS_PLUGIN_TARGETS_2ND
-#: Merge.rc:5630
+#: Merge.rc:5629
 msgid "2nd"
 msgstr "שני"
 
 #. IDS_PLUGIN_TARGETS_3RD
-#: Merge.rc:5631
+#: Merge.rc:5630
 msgid "3rd"
 msgstr "שלישי"
 
 #. IDS_PLUGIN_TARGETS_1ST_2ND
-#: Merge.rc:5632
+#: Merge.rc:5631
 msgid "1st and 2nd"
 msgstr "ראשון ושני"
 
 #. IDS_PLUGIN_TARGETS_1ST_3RD
-#: Merge.rc:5633
+#: Merge.rc:5632
 msgid "1st and 3rd"
 msgstr "ראשון ושלישי"
 
 #. IDS_PLUGIN_TARGETS_2ND_3RD
-#: Merge.rc:5634
+#: Merge.rc:5633
 msgid "2nd and 3rd"
 msgstr "שני ושלישי"
 
 #. IDS_PLUGIN_CTRL_CLICK
-#: Merge.rc:5635
+#: Merge.rc:5634
 msgid "(Ctrl+Click to add to pipeline)"
 msgstr ""
 
 #. IDS_FILTER_APPLIED
-#: Merge.rc:5640
+#: Merge.rc:5639
 msgid "Filter applied"
 msgstr "המסנן הופעל"
 
 #. IDS_FILTERMENU_COMPARE
-#: Merge.rc:5645
+#: Merge.rc:5644
 #, c-format
 msgid "Compare %1"
 msgstr ""
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN2
-#: Merge.rc:5647
+#: Merge.rc:5646
 msgid "&Filter by This Column..."
 msgstr ""
 
 #. IDS_CLIPBOARDHISTORY_TIME
-#: Merge.rc:5652
+#: Merge.rc:5651
 #, c-format
 msgid "Clipboard at %s"
 msgstr "לוח גזירים ב-%s"
 
 #. IDS_CLIPBOARDHISTORY_DISABLED
-#: Merge.rc:5653
+#: Merge.rc:5652
 msgid ""
 "Clipboard history disabled.\r\n"
 "Enable: Windows logo key + V, then Turn on."
@@ -8232,115 +8227,115 @@ msgstr ""
 "היסטוריית לוח גזירים מושבתת.\r\n"
 "כדי להפעיל אותה, לחץ על מקש Windows + V ולאחר מכן לחץ על כפתור 'הפעל'."
 
-#: Merge.rc:5655
+#: Merge.rc:5654
 msgid "This system does not support clipboard history."
 msgstr "מערכת זו אינה תומכת בהיסטוריית לוח גזירים."
 
-#: Merge.rc:5657
+#: Merge.rc:5656
 msgid "32-bit WinMerge does not support Clipboard Compare"
 msgstr "גרסת 32 ביט של WinMerge אינה תומכת בהשוואת לוח גזירים"
 
 #. IDS_WEBVIEW2_RUNTIME_NOT_INSTALLED
-#: Merge.rc:5662
+#: Merge.rc:5661
 msgid "WebView2 runtime not installed. Download it?"
 msgstr "WebView2 Runtime אינו מותקן. האם ברצונך להוריד אותו?"
 
 #. IDS_JUMPLIST_NEW_TEXT_COMPARE
-#: Merge.rc:5667
+#: Merge.rc:5666
 msgid "New Text Compare"
 msgstr "השוואת טקסט חדשה"
 
 #. IDS_JUMPLIST_NEW_TABLE_COMPARE
-#: Merge.rc:5668
+#: Merge.rc:5667
 msgid "New Table Compare"
 msgstr "השוואת טבלה חדשה"
 
 #. IDS_JUMPLIST_NEW_BINARY_COMPARE
-#: Merge.rc:5669
+#: Merge.rc:5668
 msgid "New Binary Compare"
 msgstr "השוואה בינארית חדשה"
 
 #. IDS_JUMPLIST_NEW_IMAGE_COMPARE
-#: Merge.rc:5670
+#: Merge.rc:5669
 msgid "New Image Compare"
 msgstr "השוואת תמונה חדשה"
 
 #. IDS_JUMPLIST_NEW_WEBPAGE_COMPARE
-#: Merge.rc:5671
+#: Merge.rc:5670
 msgid "New Webpage Compare"
 msgstr "השוואת דף אינטרנט חדשה"
 
 #. IDS_JUMPLIST_NEW_FOLDER_COMPARE
-#: Merge.rc:5672
+#: Merge.rc:5671
 msgid "New Folder Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_CLIPBOARD_COMPARE
-#: Merge.rc:5673
+#: Merge.rc:5672
 msgid "Clipboard Compare"
 msgstr "השוואת לוח גזירים"
 
 #. IDS_PREVIEWBAR_PRINT
-#: Merge.rc:5678
+#: Merge.rc:5677
 msgid "&Print..."
 msgstr "&הדפס..."
 
 #. IDS_PREVIEWBAR_PREVPAGE
-#: Merge.rc:5680
+#: Merge.rc:5679
 msgid "Pre&v Page"
 msgstr "עמוד קו&דם"
 
 #. IDS_PREVIEWBAR_TWOPAGE
-#: Merge.rc:5681
+#: Merge.rc:5680
 msgid "&Two Page"
 msgstr "&שני עמודים"
 
 #. IDS_PREVIEWBAR_ONEPAGE
-#: Merge.rc:5682
+#: Merge.rc:5681
 msgid "&One Page"
 msgstr "&עמוד אחד"
 
 #. IDS_PREVIEWBAR_ZOOMIN
-#: Merge.rc:5683
+#: Merge.rc:5682
 msgid "Zoom &In"
 msgstr "התקרבות &פנימה"
 
 #. IDS_PREVIEWBAR_ZOOMOUT
-#: Merge.rc:5684
+#: Merge.rc:5683
 msgid "Zoom &Out"
 msgstr "התרחקות &החוצה"
 
 #. IDS_WEBPAGE_COMPARING
-#: Merge.rc:5690
+#: Merge.rc:5689
 msgid "Comparing..."
 msgstr "משווה..."
 
 #. IDS_WEBPAGE_ZOOM
-#: Merge.rc:5691
+#: Merge.rc:5690
 msgid "Zoom:"
 msgstr "התקרבות:"
 
 #. IDS_COPY_GRANULARITY_DIFFHUNK
-#: Merge.rc:5696
+#: Merge.rc:5695
 msgid "Diff hunk"
 msgstr "גוש הבדלים"
 
 #. IDS_COPY_GRANULARITY_INLINE
-#: Merge.rc:5697
+#: Merge.rc:5696
 msgid "Inline diff"
 msgstr "הבדלים פנימיים"
 
 #. IDS_COPY_GRANULARITY_LINE
-#: Merge.rc:5698
+#: Merge.rc:5697
 msgid "Line"
 msgstr "שורה"
 
-#: Merge.rc:5699
+#: Merge.rc:5698
 msgid "Character"
 msgstr "תו"
 
 #. ID_MICE_PREVDIFF
-#: Merge.rc:5704
+#: Merge.rc:5703
 msgid ""
 "\n"
 "Previous Difference (Alt+Up)\n"
@@ -8353,7 +8348,7 @@ msgstr ""
 "(Alt+גלגלת למעלה)"
 
 #. ID_MICE_NEXTDIFF
-#: Merge.rc:5705
+#: Merge.rc:5704
 msgid ""
 "\n"
 "Next Difference (Alt+Down)\n"
@@ -8366,7 +8361,7 @@ msgstr ""
 "(Alt+גלגלת למטה)"
 
 #. ID_MICE_L2R
-#: Merge.rc:5706
+#: Merge.rc:5705
 msgid ""
 "\n"
 "Copy to Right (Alt+Right)\n"
@@ -8381,7 +8376,7 @@ msgstr ""
 "(Alt+Shift+גלגלת למטה)"
 
 #. ID_MICE_R2L
-#: Merge.rc:5707
+#: Merge.rc:5706
 msgid ""
 "\n"
 "Copy to Left (Alt+Left)\n"
@@ -8396,7 +8391,7 @@ msgstr ""
 "(Alt+Shift+גלגלת למעלה)"
 
 #. ID_MICE_L2RNEXT
-#: Merge.rc:5708
+#: Merge.rc:5707
 msgid ""
 "\n"
 "Copy to Right and Advance (Ctrl+Alt+Right)\n"
@@ -8409,7 +8404,7 @@ msgstr ""
 "(Ctrl+Alt+Shift+גלגלת למטה)"
 
 #. ID_MICE_R2LNEXT
-#: Merge.rc:5709
+#: Merge.rc:5708
 msgid ""
 "\n"
 "Copy to Left and Advance (Ctrl+Alt+Left)\n"
@@ -8422,282 +8417,282 @@ msgstr ""
 "(Ctrl+Alt+Shift+גלגלת למעלה)"
 
 #. IDS_LOG_COMPARING_2
-#: Merge.rc:5719
+#: Merge.rc:5718
 #, c-format
 msgid "Comparing %1 with %2"
 msgstr ""
 
 #. IDS_LOG_COMPARING_3
-#: Merge.rc:5720
+#: Merge.rc:5719
 #, c-format
 msgid "Comparing %1 with %2 and %3"
 msgstr ""
 
 #. IDS_LOG_COMPARE_COMPLETED
-#: Merge.rc:5721
+#: Merge.rc:5720
 msgid "Comparison completed"
 msgstr ""
 
 #. IDS_LOG_COMPARE_ERROR_2
-#: Merge.rc:5722
+#: Merge.rc:5721
 #, c-format
 msgid "Failed to compare %1 with %2: "
 msgstr ""
 
 #. IDS_LOG_COMPARE_ERROR_3
-#: Merge.rc:5723
+#: Merge.rc:5722
 #, c-format
 msgid "Failed to compare %1 with %2 and %3: "
 msgstr ""
 
 #. IDS_LOG_FILE_SAVED
-#: Merge.rc:5724
+#: Merge.rc:5723
 msgid "File saved"
 msgstr ""
 
 #. IDS_LOG_COPYING_FILES
-#: Merge.rc:5725
+#: Merge.rc:5724
 msgid "Copying files..."
 msgstr ""
 
 #. IDS_LOG_MOVING_FILES
-#: Merge.rc:5726
+#: Merge.rc:5725
 msgid "Moving files..."
 msgstr ""
 
 #. IDS_LOG_DELETING_FILES
-#: Merge.rc:5727
+#: Merge.rc:5726
 msgid "Deleting files..."
 msgstr ""
 
 #. IDS_LOG_RECYCLEBIN
-#: Merge.rc:5728
+#: Merge.rc:5727
 msgid "Recycle Bin"
 msgstr ""
 
 #. IDS_LOG_PERMANENTLY_DELETED
-#: Merge.rc:5729
+#: Merge.rc:5728
 msgid "Permanently deleted"
 msgstr ""
 
 #. IDS_LOG_FILEOPERATION_COMPLETED
-#: Merge.rc:5730
+#: Merge.rc:5729
 msgid "File operation completed successfully"
 msgstr ""
 
 #. IDS_LOG_FILEOPERATION_CANCELED
-#: Merge.rc:5731
+#: Merge.rc:5730
 msgid "File operation canceled"
 msgstr ""
 
 #. IDS_FILTER_ERROR_NO_ERROR
-#: Merge.rc:5736
+#: Merge.rc:5735
 msgid "No error"
 msgstr ""
 
 #. IDS_FILTER_ERROR_EMPTY_EXPRESSION
-#: Merge.rc:5737
+#: Merge.rc:5736
 msgid "Filter expression is empty"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNKNOWN_CHAR
-#: Merge.rc:5738
+#: Merge.rc:5737
 msgid "Unknown character in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNTERMINATED_STRING
-#: Merge.rc:5739
+#: Merge.rc:5738
 msgid "Unterminated string literal"
 msgstr ""
 
 #. IDS_FILTER_ERROR_SYNTAX_ERROR
-#: Merge.rc:5740
+#: Merge.rc:5739
 msgid "Syntax error in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_PARSE_FAILURE
-#: Merge.rc:5741
+#: Merge.rc:5740
 msgid "Failed to parse filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_LITERAL
-#: Merge.rc:5742
+#: Merge.rc:5741
 msgid "Invalid literal value"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_REGULAR_EXPRESSION
-#: Merge.rc:5743
+#: Merge.rc:5742
 msgid "Invalid regular expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNDEFINED_IDENTIFIER
-#: Merge.rc:5744
+#: Merge.rc:5743
 msgid "Undefined identifier"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_ARGUMENT_COUNT
-#: Merge.rc:5745
+#: Merge.rc:5744
 msgid "Invalid number of arguments"
 msgstr ""
 
 #. IDS_FILTER_ERROR_FILTER_NAME_NOT_FOUND
-#: Merge.rc:5746
+#: Merge.rc:5745
 msgid "Filter name not found"
 msgstr ""
 
 #. IDS_FILTER_ERROR_DIVIDE_BY_ZERO
-#: Merge.rc:5747
+#: Merge.rc:5746
 msgid "Division by zero in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNKNOWN_ERROR
-#: Merge.rc:5748
+#: Merge.rc:5747
 msgid "Unknown error"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_PROPERTY_NAME
-#: Merge.rc:5749
+#: Merge.rc:5748
 msgid "Invalid property name"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_DIRECTIVE
-#: Merge.rc:5750
+#: Merge.rc:5749
 msgid "Invalid directive"
 msgstr ""
 
 #. IDS_FILTER_OP_EQUALS
-#: Merge.rc:5755
+#: Merge.rc:5754
 msgid "Equals"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_EQUALS
-#: Merge.rc:5756
+#: Merge.rc:5755
 msgid "Does not equal"
 msgstr ""
 
 #. IDS_FILTER_OP_LESS_THAN
-#: Merge.rc:5757
+#: Merge.rc:5756
 msgid "Less than"
 msgstr ""
 
 #. IDS_FILTER_OP_LESS_EQUAL
-#: Merge.rc:5758
+#: Merge.rc:5757
 msgid "Less than or equal to"
 msgstr ""
 
 #. IDS_FILTER_OP_GREATER_EQUAL
-#: Merge.rc:5759
+#: Merge.rc:5758
 msgid "Greater than or equal to"
 msgstr ""
 
 #. IDS_FILTER_OP_GREATER_THAN
-#: Merge.rc:5760
+#: Merge.rc:5759
 msgid "Greater than"
 msgstr ""
 
 #. IDS_FILTER_OP_BETWEEN
-#: Merge.rc:5761
+#: Merge.rc:5760
 msgid "Between"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_BETWEEN
-#: Merge.rc:5762
+#: Merge.rc:5761
 msgid "Not Between"
 msgstr ""
 
 #. IDS_FILTER_OP_CONTAINS
-#: Merge.rc:5763
+#: Merge.rc:5762
 msgid "Contains"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_CONTAINS
-#: Merge.rc:5764
+#: Merge.rc:5763
 msgid "Not Contains"
 msgstr ""
 
 #. IDS_FILTER_OP_RECONTAINS
-#: Merge.rc:5765
+#: Merge.rc:5764
 msgid "Contains (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_RECONTAINS
-#: Merge.rc:5766
+#: Merge.rc:5765
 msgid "Not Contains (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_LIKE
-#: Merge.rc:5767
+#: Merge.rc:5766
 msgid "Match (wildcard)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_LIKE
-#: Merge.rc:5768
+#: Merge.rc:5767
 msgid "Not match (wildcard)"
 msgstr ""
 
 #. IDS_FILTER_OP_MATCHES
-#: Merge.rc:5769
+#: Merge.rc:5768
 msgid "Match (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_MATCHES
-#: Merge.rc:5770
+#: Merge.rc:5769
 msgid "Not match (regex)"
 msgstr ""
 
 #. IDS_COLORMODE_LIGHT
-#: Merge.rc:5775
+#: Merge.rc:5774
 msgid "Light"
 msgstr ""
 
 #. IDS_COLORMODE_DARK
-#: Merge.rc:5776
+#: Merge.rc:5775
 msgid "Dark"
 msgstr ""
 
 #. IDS_COLORMODE_FOLLOWSYSTEM
-#: Merge.rc:5777
+#: Merge.rc:5776
 msgid "Follow system"
 msgstr ""
 
 #. IDS_EXAMPLE
-#: Merge.rc:5782
+#: Merge.rc:5781
 #, c-format
 msgid "e.g. %1"
 msgstr ""
 
 #. IDS_DETECTED_PREVIOUS_CRASH
-#: Merge.rc:5787
+#: Merge.rc:5786
 msgid "WinMerge detected a previous crash. Please report this if possible."
 msgstr ""
 
 #. IDS_REGEX_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5792
+#: Merge.rc:5791
 msgid "# Regex replacement list\r\n# Format: regex<TAB>replacement\r\n# Backreferences like $1, $2 are supported\r\n\r\n(\\d{4})-(\\d{2})-(\\d{2})\t$1_$2_$3\r\n"
 msgstr ""
 
 #. IDS_STRING_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5793
+#: Merge.rc:5792
 msgid "# Replacement list\r\n# Format: search<TAB>replacement\r\n# Lines starting with # are ignored\r\n\r\nfrom1\tto1\r\nfrom2\tto2\r\n"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_ONLY
-#: Merge.rc:5798
+#: Merge.rc:5797
 msgid "Built-in only"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_FIRST
-#: Merge.rc:5799
+#: Merge.rc:5798
 msgid "Built-in first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_FIRST
-#: Merge.rc:5800
+#: Merge.rc:5799
 msgid "Tree-sitter first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_ONLY
-#: Merge.rc:5801
+#: Merge.rc:5800
 msgid "Tree-sitter only"
 msgstr ""
 

--- a/Translations/WinMerge/Hungarian.po
+++ b/Translations/WinMerge/Hungarian.po
@@ -23,7 +23,7 @@ msgstr ""
 "X-Generator: Poedit 2.4.2\n"
 
 #. LANGUAGE, SUBLANGUAGE
-#: Merge.rc:26 Merge.rc:59 Merge.rc:5818
+#: Merge.rc:26 Merge.rc:59 Merge.rc:5817
 #, c-format
 msgid "LANG_ENGLISH, SUBLANG_ENGLISH_US"
 msgstr "LANG_HUNGARIAN, SUBLANG_DEFAULT"
@@ -173,7 +173,7 @@ msgstr "&Szkriptek"
 #. IDS_NO_EDIT_SCRIPTS
 #: Merge.rc:127 Merge.rc:352 Merge.rc:463 Merge.rc:673 Merge.rc:678
 #: Merge.rc:887 Merge.rc:899 Merge.rc:906 Merge.rc:963 Merge.rc:1210
-#: Merge.rc:5375
+#: Merge.rc:5374
 #, c-format
 msgid "< Empty >"
 msgstr "< Üres >"
@@ -240,7 +240,7 @@ msgid "Auto-Fit All Columns"
 msgstr "Minden oszlop automatikus illeszkedése"
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN
-#: Merge.rc:153 Merge.rc:5646
+#: Merge.rc:153 Merge.rc:5645
 msgid "&Filter by This Column"
 msgstr "&Szűrés ezen oszlop alapján"
 
@@ -306,7 +306,7 @@ msgid "&Previous Page"
 msgstr "Előző oldal"
 
 #. IDS_PREVIEWBAR_NEXTPAGE
-#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5679
+#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5678
 #, c-format
 msgid "&Next Page"
 msgstr "Következő oldal"
@@ -574,7 +574,7 @@ msgstr "Bináris"
 #. IDS_IMAGE_MENU
 #: Merge.rc:329 Merge.rc:338 Merge.rc:432 Merge.rc:441 Merge.rc:609
 #: Merge.rc:618 Merge.rc:670 Merge.rc:960 Merge.rc:1187 Merge.rc:1200
-#: Merge.rc:5477
+#: Merge.rc:5476
 #, c-format
 msgid "&Image"
 msgstr "Kép"
@@ -712,7 +712,7 @@ msgid "&Huge"
 msgstr "Hatalmas"
 
 #. IDS_VIEW_MENU_BAR
-#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5714
+#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5713
 msgid "Men&u Bar"
 msgstr "Menü sáv"
 
@@ -1475,7 +1475,7 @@ msgid "Lo&cation Pane"
 msgstr "Eltérések helye"
 
 #. IDS_OUTPUTBAR_CAPTION
-#: Merge.rc:782 Merge.rc:5252
+#: Merge.rc:782 Merge.rc:5251
 msgid "Output Pane"
 msgstr "Kimenet panel"
 
@@ -1771,55 +1771,55 @@ msgid "Co&mpare As"
 msgstr "Összehasonlítás mint"
 
 #. IDS_COPY_LEFT_TO_MIDDLE2
-#: Merge.rc:968 Merge.rc:980 Merge.rc:4852
+#: Merge.rc:968 Merge.rc:980 Merge.rc:4851
 #, c-format
 msgid "Left to Middle (%1 of %2)"
 msgstr "Bal a középsővel (%1 / %2)"
 
 #. IDS_COPY_LEFT_TO_RIGHT2
-#: Merge.rc:969 Merge.rc:981 Merge.rc:4851
+#: Merge.rc:969 Merge.rc:981 Merge.rc:4850
 #, c-format
 msgid "Left to Right (%1 of %2)"
 msgstr "Bal a jobbal (%1 / %2)"
 
 #. IDS_MOVE_LEFT_TO2
-#: Merge.rc:970 Merge.rc:982 Merge.rc:1045 Merge.rc:4863 Merge.rc:4892
+#: Merge.rc:970 Merge.rc:982 Merge.rc:1045 Merge.rc:4862 Merge.rc:4891
 #, c-format
 msgid "Left to... (%1 of %2)"
 msgstr "Bal a... (%1 / %2)"
 
 #. IDS_COPY_MIDDLE_TO_LEFT2
-#: Merge.rc:971 Merge.rc:983 Merge.rc:4849
+#: Merge.rc:971 Merge.rc:983 Merge.rc:4848
 #, c-format
 msgid "Middle to Left (%1 of %2)"
 msgstr "Középső a ballal (%1 / %2)"
 
 #. IDS_COPY_MIDDLE_TO_RIGHT2
-#: Merge.rc:972 Merge.rc:984 Merge.rc:4850
+#: Merge.rc:972 Merge.rc:984 Merge.rc:4849
 #, c-format
 msgid "Middle to Right (%1 of %2)"
 msgstr "Középső a jobbal (%1 / %2)"
 
 #. IDS_MOVE_MIDDLE_TO2
-#: Merge.rc:973 Merge.rc:985 Merge.rc:1046 Merge.rc:4864 Merge.rc:4893
+#: Merge.rc:973 Merge.rc:985 Merge.rc:1046 Merge.rc:4863 Merge.rc:4892
 #, c-format
 msgid "Middle to... (%1 of %2)"
 msgstr "A középső a... (%1 / %2)"
 
 #. IDS_COPY_RIGHT_TO_MIDDLE2
-#: Merge.rc:974 Merge.rc:986 Merge.rc:4848
+#: Merge.rc:974 Merge.rc:986 Merge.rc:4847
 #, c-format
 msgid "Right to Middle (%1 of %2)"
 msgstr "Jobb a középsővel (%1 / %2)"
 
 #. IDS_COPY_RIGHT_TO_LEFT2
-#: Merge.rc:975 Merge.rc:987 Merge.rc:4847
+#: Merge.rc:975 Merge.rc:987 Merge.rc:4846
 #, c-format
 msgid "Right to Left (%1 of %2)"
 msgstr "Jobb a ballal (%1 / %2)"
 
 #. IDS_MOVE_RIGHT_TO2
-#: Merge.rc:976 Merge.rc:988 Merge.rc:1047 Merge.rc:4865 Merge.rc:4894
+#: Merge.rc:976 Merge.rc:988 Merge.rc:1047 Merge.rc:4864 Merge.rc:4893
 #, c-format
 msgid "Right to... (%1 of %2)"
 msgstr "Jobb a... (%1 of %2)"
@@ -1885,31 +1885,31 @@ msgid "Cop&y Paths"
 msgstr "Elérési utak másolása"
 
 #. IDS_DEL_LEFT_FMT2
-#: Merge.rc:1026 Merge.rc:1035 Merge.rc:4880
+#: Merge.rc:1026 Merge.rc:1035 Merge.rc:4879
 #, c-format
 msgid "Left (%1 of %2)"
 msgstr "Bal (%1 / %2)"
 
 #. IDS_DEL_MIDDLE_FMT2
-#: Merge.rc:1027 Merge.rc:1036 Merge.rc:4881
+#: Merge.rc:1027 Merge.rc:1036 Merge.rc:4880
 #, c-format
 msgid "Middle (%1 of %2)"
 msgstr "Középső (%1 / %2)"
 
 #. IDS_DEL_RIGHT_FMT2
-#: Merge.rc:1028 Merge.rc:1037 Merge.rc:4882
+#: Merge.rc:1028 Merge.rc:1037 Merge.rc:4881
 #, c-format
 msgid "Right (%1 of %2)"
 msgstr "Jobb (%1 / %2)"
 
 #. IDS_DEL_BOTH_FMT2
-#: Merge.rc:1029 Merge.rc:1038 Merge.rc:4883
+#: Merge.rc:1029 Merge.rc:1038 Merge.rc:4882
 #, c-format
 msgid "Both (%1 of %2)"
 msgstr "Mindkettő (%1 ennyiből: %2)"
 
 #. IDS_DEL_ALL_FMT2
-#: Merge.rc:1030 Merge.rc:1039 Merge.rc:4888
+#: Merge.rc:1030 Merge.rc:1039 Merge.rc:4887
 #, c-format
 msgid "All (%1 of %2)"
 msgstr "Mind (%1 / %2)"
@@ -1938,19 +1938,19 @@ msgid "&Zip"
 msgstr "&Zip"
 
 #. IDS_COPY_BOTH_TO2
-#: Merge.rc:1048 Merge.rc:4866
+#: Merge.rc:1048 Merge.rc:4865
 #, c-format
 msgid "Both to... (%1 of %2)"
 msgstr "Mindkettő a... (%1 / %2)"
 
 #. IDS_COPY_ALL_TO2
-#: Merge.rc:1049 Merge.rc:4867
+#: Merge.rc:1049 Merge.rc:4866
 #, c-format
 msgid "All to... (%1 of %2)"
 msgstr "Mind a... (%1 / %2)"
 
 #. IDS_COPY_DIFFERENCES_TO2
-#: Merge.rc:1050 Merge.rc:4868
+#: Merge.rc:1050 Merge.rc:4867
 #, c-format
 msgid "Differences to... (%1 of %2)"
 msgstr "Különbség ezzel... (%1 / %2)"
@@ -2023,13 +2023,13 @@ msgstr "Kicsomagoló beállításai"
 
 #. IDS_USERCHOICE_NONE
 #: Merge.rc:1088 Merge.rc:1094 Merge.rc:1836 Merge.rc:1840 Merge.rc:2031
-#: Merge.rc:2035 Merge.rc:5377
+#: Merge.rc:2035 Merge.rc:5376
 #, c-format
 msgid "<None>"
 msgstr "<Nincs>"
 
 #. IDS_USERCHOICE_AUTOMATIC
-#: Merge.rc:1089 Merge.rc:1095 Merge.rc:5378
+#: Merge.rc:1089 Merge.rc:1095 Merge.rc:5377
 #, c-format
 msgid "<Automatic>"
 msgstr "<Automatikus>"
@@ -2981,13 +2981,13 @@ msgid "Text files only"
 msgstr "Csak szöveges fájlok"
 
 #. IDS_EOL_NONE
-#: Merge.rc:1667 Merge.rc:1918 Merge.rc:5304
+#: Merge.rc:1667 Merge.rc:1918 Merge.rc:5303
 #, c-format
 msgid "None"
 msgstr "Nincs"
 
 #. IDS_EOL_MIXED
-#: Merge.rc:1668 Merge.rc:5299
+#: Merge.rc:1668 Merge.rc:5298
 #, c-format
 msgid "Mixed"
 msgstr "Vegyes"
@@ -3261,14 +3261,14 @@ msgstr "Sor &állapota"
 
 #. IDS_DIFFERENT
 #: Merge.rc:1904 Merge.rc:1988 Merge.rc:2866 Merge.rc:3036 Merge.rc:3077
-#: Merge.rc:5058
+#: Merge.rc:5057
 #, c-format
 msgid "Different"
 msgstr "Különböző"
 
 #. IDS_IDENTICAL
 #: Merge.rc:1905 Merge.rc:1989 Merge.rc:2865 Merge.rc:3055 Merge.rc:3116
-#: Merge.rc:5048
+#: Merge.rc:5047
 #, c-format
 msgid "Identical"
 msgstr "Egyező"
@@ -3289,7 +3289,7 @@ msgid "Missing"
 msgstr "Hiányzó"
 
 #. IDS_MOVED
-#: Merge.rc:1910 Merge.rc:5076
+#: Merge.rc:1910 Merge.rc:5075
 msgid "Moved"
 msgstr "Áthelyezve"
 
@@ -4117,7 +4117,7 @@ msgid "&Use custom system colors"
 msgstr "&Egyéni rendszerszínek használata (egyes UI elemek nem alkalmazhatók)"
 
 #. IDS_PRPCAT_SYSTEM
-#: Merge.rc:2565 Merge.rc:4559 Merge.rc:4560 Merge.rc:5007
+#: Merge.rc:2565 Merge.rc:4559 Merge.rc:4560 Merge.rc:5006
 #, c-format
 msgid "System"
 msgstr "Rendszer"
@@ -4568,7 +4568,7 @@ msgid "Items compared:"
 msgstr "Összehasonlított elemek:"
 
 #. IDS_PREVIEWBAR_CLOSE
-#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5685
+#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5684
 #, c-format
 msgid "&Close"
 msgstr "&Bezárás"
@@ -5261,7 +5261,7 @@ msgid "A&ppend timestamp"
 msgstr "Időpecsét hozzáfűzése"
 
 #. IDS_CONFIRM_COPY_CAPTION
-#: Merge.rc:3214 Merge.rc:4915
+#: Merge.rc:3214 Merge.rc:4914
 #, c-format
 msgid "Confirm Copy"
 msgstr "Másolás megerősítése"
@@ -5522,7 +5522,7 @@ msgid "&Character Set..."
 msgstr "Karakterkészlet..."
 
 #. IDS_PRPCAT_IMAGE
-#: Merge.rc:3351 Merge.rc:4574 Merge.rc:5015
+#: Merge.rc:3351 Merge.rc:4574 Merge.rc:5014
 msgid "Image"
 msgstr "Kép"
 
@@ -5946,7 +5946,7 @@ msgid "Project"
 msgstr "Projekt"
 
 #. IDS_COLHDR_NSDIFFS
-#: Merge.rc:4566 Merge.rc:4990
+#: Merge.rc:4566 Merge.rc:4989
 #, c-format
 msgid "Differences"
 msgstr "Eltérések"
@@ -6102,13 +6102,13 @@ msgid "File Type"
 msgstr "Fájltípus"
 
 #. IDS_COLHDR_EXTENSION
-#: Merge.rc:4653 Merge.rc:4947
+#: Merge.rc:4653 Merge.rc:4946
 #, c-format
 msgid "Extension"
 msgstr "Kiterjesztés"
 
 #. IDS_PRPCAT_MESSAGE
-#: Merge.rc:4659 Merge.rc:5019
+#: Merge.rc:4659 Merge.rc:5018
 msgid "Message"
 msgstr "Üzenet"
 
@@ -6148,7 +6148,7 @@ msgid "Hidden Items"
 msgstr "Rejtett elemek"
 
 #. IDS_PLUGINSLIST_NAME
-#: Merge.rc:4680 Merge.rc:5311
+#: Merge.rc:4680 Merge.rc:5310
 #, c-format
 msgid "Name"
 msgstr "Név"
@@ -6172,7 +6172,7 @@ msgid "[F] "
 msgstr "[F] "
 
 #. IDS_PLUGINSLIST_DESC
-#: Merge.rc:4684 Merge.rc:5313
+#: Merge.rc:4684 Merge.rc:5312
 #, c-format
 msgid "Description"
 msgstr "Leírás"
@@ -6347,171 +6347,165 @@ msgstr "Sor: %s  Oszlop: %d/%d  Karakter: %d/%d"
 msgid "  Sel: %d | %d"
 msgstr "  Kiv.: %d | %d"
 
-#. IDS_MERGEMODE_MERGING
-#: Merge.rc:4734
-#, c-format
-msgid "Merge"
-msgstr "Egyesítés"
-
 #. IDS_DIFF_NUMBER_STATUS_FMT
-#: Merge.rc:4735
+#: Merge.rc:4734
 #, c-format
 msgid "Difference %1 of %2"
 msgstr "Különbség: %1 / %2"
 
 #. IDS_NO_DIFF_SEL_FMT
-#: Merge.rc:4736
+#: Merge.rc:4735
 #, c-format
 msgid "%1 Differences Found"
 msgstr "%1 különbség található"
 
 #. IDS_1_DIFF_FOUND
-#: Merge.rc:4737
+#: Merge.rc:4736
 #, c-format
 msgid "1 Difference Found"
 msgstr "1 különbség található"
 
 #. IDS_NO_ERR_SEL_FMT
-#: Merge.rc:4738
+#: Merge.rc:4737
 #, c-format
 msgid "%1 Errors Found"
 msgstr "%1 hiba található"
 
 #. IDS_1_ERR_FOUND
-#: Merge.rc:4739
+#: Merge.rc:4738
 msgid "1 Error Found"
 msgstr "1 hiba található"
 
 #. IDS_STATUSBAR_READONLY, Abbreviation from "Read Only"
-#: Merge.rc:4740
+#: Merge.rc:4739
 #, c-format
 msgid "RO"
 msgstr "RO"
 
 #. IDS_DIRVIEW_STATUS_FMT_FOCUS
-#: Merge.rc:4746
+#: Merge.rc:4745
 #, c-format
 msgid "Item %1 of %2"
 msgstr "elem: %1 / %2"
 
 #. IDS_DIRVIEW_STATUS_FMT_NOFOCUS
-#: Merge.rc:4747
+#: Merge.rc:4746
 #, c-format
 msgid "Items: %1"
 msgstr "%1 elem"
 
 #. IDS_DIRVIEW_STATUS_COMPARING
-#: Merge.rc:4748
+#: Merge.rc:4747
 #, c-format
 msgid "Comparing items..."
 msgstr "Elemek összehasonlítása..."
 
 #. IDS_ITEMS_PER_SEC
-#: Merge.rc:4749
+#: Merge.rc:4748
 #, c-format
 msgid "%.1f[items/sec]"
 msgstr "%.1f[elem/smp]"
 
 #. IDS_ERROR_INCOMPARABLE
-#: Merge.rc:4755
+#: Merge.rc:4754
 msgid "Select two existing folders/files to compare."
 msgstr "Válassz ki két összehasonlítandó fájlt vagy könyvtárat."
 
 #. IDS_DIRSEL_TAG
-#: Merge.rc:4756
+#: Merge.rc:4755
 #, c-format
 msgid "Folder Selection"
 msgstr "Könytár kiválasztás"
 
 #. IDS_OPEN_FILESDIRS
-#: Merge.rc:4757
+#: Merge.rc:4756
 #, c-format
 msgid "Select two (or three) folders/files to compare."
 msgstr "Válassz 2 (vagy 3) fájlt (vagy mappát) az összehasonlításhoz."
 
 #. IDS_OPEN_LEFTINVALID
-#: Merge.rc:4758
+#: Merge.rc:4757
 #, c-format
 msgid "Left (1st) path is invalid!"
 msgstr "A bal (1.) elérési út érvénytelen!"
 
 #. IDS_OPEN_MIDDLEINVALID
-#: Merge.rc:4759
+#: Merge.rc:4758
 #, c-format
 msgid "Middle (2nd) path is invalid!"
 msgstr "A középső (2.) elérési út érvénytelen!"
 
 #. IDS_OPEN_RIGHTINVALID2
-#: Merge.rc:4760
+#: Merge.rc:4759
 #, c-format
 msgid "Right (2nd) path is invalid!"
 msgstr "A jobb (2.) elérési út érvénytelen!"
 
 #. IDS_OPEN_RIGHTINVALID3
-#: Merge.rc:4761
+#: Merge.rc:4760
 #, c-format
 msgid "Right (3rd) path is invalid!"
 msgstr "A jobb (3.) elérési út érvénytelen!"
 
 #. IDS_OPEN_BOTHINVALID
-#: Merge.rc:4762
+#: Merge.rc:4761
 #, c-format
 msgid "Both paths are invalid!"
 msgstr "Mindkét elérési út érvénytelen!"
 
-#: Merge.rc:4764
+#: Merge.rc:4763
 #, c-format
 msgid "Left (1st) and Middle (2nd) paths are invalid!"
 msgstr "A bal (1.) és a középső(2.) elérési út érvénytelen!"
 
 #. IDS_OPEN_LEFTRIGHTINVALID
-#: Merge.rc:4765
+#: Merge.rc:4764
 #, c-format
 msgid "Left (1st) and Right (3rd) paths are invalid!"
 msgstr "A bal (1.) és a jobb(3.) elérési út érvénytelen!"
 
-#: Merge.rc:4767
+#: Merge.rc:4766
 #, c-format
 msgid "Middle (2nd) and Right (3rd) paths are invalid!"
 msgstr "A középső(2.) és a jobb(3.) elérési út érvénytelen!"
 
 #. IDS_OPEN_ALLINVALID
-#: Merge.rc:4768
+#: Merge.rc:4767
 #, c-format
 msgid "All paths are invalid!"
 msgstr "Mindegyik elérési út érvénytelen!"
 
 #. IDS_OPEN_UNPACKERDISABLED
-#: Merge.rc:4769
+#: Merge.rc:4768
 msgid "Only enabled for file comparisons"
 msgstr "Csak fájlok összahasonlításánál elérhető"
 
 #. IDS_OPEN_MISMATCH
-#: Merge.rc:4770
+#: Merge.rc:4769
 #, c-format
 msgid "Cannot compare file and folder!"
 msgstr "Nem lehet fájlt könyvtárral összehasonlítani!"
 
 #. IDS_ERROR_FILE_NOT_FOUND
-#: Merge.rc:4776
+#: Merge.rc:4775
 #, c-format
 msgid "File not found: %1"
 msgstr "Ez a fájl nem található: %1"
 
 #. IDS_ERROR_FOLDER_NOT_FOUND
-#: Merge.rc:4777
+#: Merge.rc:4776
 #, c-format
 msgid "Folder not found: %1"
 msgstr "%1 mappa nem található"
 
 #. IDS_ERROR_FILE_NOT_UNPACKED
-#: Merge.rc:4778
+#: Merge.rc:4777
 #, c-format
 msgid "File not unpacked: %1"
 msgstr "Ez a fájl nincs kicsomagolva: %1"
 
 #. IDS_ERROR_FILEOPEN
-#: Merge.rc:4779
+#: Merge.rc:4778
 #, c-format
 msgid ""
 "Cannot open file\n"
@@ -6525,48 +6519,48 @@ msgstr ""
 "%2"
 
 #. IDS_ERROR_CONF_RESOLVE
-#: Merge.rc:4780
+#: Merge.rc:4779
 #, c-format
 msgid "Failed to parse conflict file."
 msgstr "Hiba a konfliktusfájl elemzésekor."
 
 #. IDS_NOT_CONFLICT_FILE
-#: Merge.rc:4781
+#: Merge.rc:4780
 #, c-format
 msgid "The file\n%1\nis not a conflict file."
 msgstr "A fájl\n%1\nnem egy konfliktus fájl."
 
 #. IDS_COMPARE_LARGE_FILES
-#: Merge.rc:4782
+#: Merge.rc:4781
 msgid "Comparing large files requires significant memory.\nShow only comparison results (not file contents)?"
 msgstr "Nagy fájlok összehasonlítása sok memóriát igényel.\nCsak az összehasonlítás eredményét szeretnéd megjeleníteni, (a fájlok tartalmát nem)?\n"
 "\n"
 
 #. IDS_SAVE_AS_TITLE
-#: Merge.rc:4788
+#: Merge.rc:4787
 #, c-format
 msgid "Save As"
 msgstr "Mentés másként"
 
 #. IDS_SAVE_FMT
-#: Merge.rc:4789
+#: Merge.rc:4788
 #, c-format
 msgid "Save changes to %1?"
 msgstr "Mentsem a változtatásokat %1 néven?"
 
 #. IDS_SAVEREADONLY_FMT
-#: Merge.rc:4790
+#: Merge.rc:4789
 #, c-format
 msgid "%1 is read-only. Override? Or 'No' to save as new filename?"
 msgstr "%1 csak olvasható. Szeretnéd felülírni a csak olvasható fájlt? (Kattints a Nem gombra a fájl új néven való mentéséhez.)"
 
 #. IDS_ERROR_BACKUP
-#: Merge.rc:4791
+#: Merge.rc:4790
 #, c-format
 msgid "Error backing up file"
 msgstr "Hiba a fájl biztonsági másolatának készítésekor"
 
-#: Merge.rc:4793
+#: Merge.rc:4792
 #, c-format
 msgid ""
 "Unable to backup original file:\n"
@@ -6580,7 +6574,7 @@ msgstr ""
 "Folytatod mindenképp?"
 
 #. IDS_FILESAVE_FAILED
-#: Merge.rc:4794
+#: Merge.rc:4793
 #, c-format
 msgid "Saving file failed.\n%1\n%2\n\t- Use different filename (OK)\n\t- Abort (Cancel)?"
 msgstr ""
@@ -6591,12 +6585,12 @@ msgstr ""
 "\t- másik fájlnév választása (OK)\n"
 "\t- a jelenlegi folyamat megszakítása (Mégsem)?"
 
-#: Merge.rc:4796
+#: Merge.rc:4795
 #, c-format
 msgid "Plugin '%2' cannot pack changes to left file into '%1'.\n\nOriginal unchanged. Save unpacked version?"
 msgstr "A(z) %2 bővítmény nem tudja becsomagolni a bal fájlban végzett módosításokat itt: %1.\n\nAz eredeti fájl nem változott. Elmented a be nem csomagolt verziót?"
 
-#: Merge.rc:4798
+#: Merge.rc:4797
 #, c-format
 msgid "Plugin '%2' cannot pack changes to middle file into '%1'.\n\nOriginal unchanged. Save unpacked version?"
 msgstr ""
@@ -6606,7 +6600,7 @@ msgstr ""
 "\n"
 "Elmented a be nem csomagolt verziót egy másik fájlba?"
 
-#: Merge.rc:4800
+#: Merge.rc:4799
 #, c-format
 msgid "Plugin '%2' cannot pack changes to right file into '%1'.\n\nOriginal unchanged. Save unpacked version?"
 msgstr ""
@@ -6617,7 +6611,7 @@ msgstr ""
 "Elmented a be nem csomagolt verziót egy másik fájlba?"
 
 #. IDS_FILECHANGED_ONDISK
-#: Merge.rc:4801
+#: Merge.rc:4800
 #, c-format
 msgid ""
 "Another application updated\n"
@@ -6633,7 +6627,7 @@ msgstr ""
 "Felülírjuk a megváltoztatott fájlt?"
 
 #. IDS_SAVEREADONLY_MULTI
-#: Merge.rc:4802
+#: Merge.rc:4801
 #, c-format
 msgid ""
 "%1\n"
@@ -6643,7 +6637,7 @@ msgstr ""
 "csak olvasható. Szeretnéd ezt megváltoztatni?"
 
 #. IDS_FILECHANGED_RESCAN
-#: Merge.rc:4803
+#: Merge.rc:4802
 #, c-format
 msgid "Another application updated\n%1\nsince last scan.\n\nReload?"
 msgstr ""
@@ -6654,25 +6648,25 @@ msgstr ""
 "Szeretnéd újra betölteni a fájlt?"
 
 #. IDS_SAVE_LEFT_AS
-#: Merge.rc:4804
+#: Merge.rc:4803
 #, c-format
 msgid "Save Left File As"
 msgstr "Bal oldali fájl mentése mint"
 
 #. IDS_SAVE_MIDDLE_AS
-#: Merge.rc:4805
+#: Merge.rc:4804
 #, c-format
 msgid "Save Middle File As"
 msgstr "Középső fájl mentése mint"
 
 #. IDS_SAVE_RIGHT_AS
-#: Merge.rc:4806
+#: Merge.rc:4805
 #, c-format
 msgid "Save Right File As"
 msgstr "Jobb oldali fájl mentése mint"
 
 #. IDS_FILE_DISAPPEARED
-#: Merge.rc:4811
+#: Merge.rc:4810
 #, c-format
 msgid ""
 "File\n"
@@ -6684,7 +6678,7 @@ msgstr ""
 "eltűnt. A folytatáshoz mentsd el a fájlt."
 
 #. IDS_VIEWS_OUTOFSYNC
-#: Merge.rc:4817
+#: Merge.rc:4816
 #, c-format
 msgid ""
 "Cannot merge unsynched documents.\n"
@@ -6696,189 +6690,189 @@ msgstr ""
 "Frissítsd a dokumentumokat, mielőtt folytatnád."
 
 #. IDS_BREAK_ON_WHITESPACE
-#: Merge.rc:4822
+#: Merge.rc:4821
 msgid "Break at whitespace"
 msgstr "Megállás szóközöknél"
 
 #. IDS_BREAK_ON_PUNCTUATION
-#: Merge.rc:4823
+#: Merge.rc:4822
 msgid "Break at whitespace or punctuation"
 msgstr "Megállás szóközöknél vagy írásjeleknél"
 
 #. IDS_L2M
-#: Merge.rc:4829
+#: Merge.rc:4828
 msgid "Copy to &Middle\tAlt+Right"
 msgstr "Másolás a középsőbe\tAlt+Right"
 
 #. IDS_R2M
-#: Merge.rc:4830
+#: Merge.rc:4829
 msgid "Copy to &Middle\tAlt+Left"
 msgstr "Másolás a középsőbe\tAlt+Left"
 
 #. IDS_COPY_FROM_MIDDLE_R
-#: Merge.rc:4831
+#: Merge.rc:4830
 msgid "Copy from Middle\tAlt+Shift+Right"
 msgstr "Másolás a középsőből\tAlt+Shift+Right"
 
 #. IDS_COPY_FROM_MIDDLE_L
-#: Merge.rc:4832
+#: Merge.rc:4831
 msgid "Copy from Middle\tAlt+Shift+Left"
 msgstr "Másolás a középsőből\Alt+Shift+Left"
 
 #. IDS_L2MNEXT
-#: Merge.rc:4833
+#: Merge.rc:4832
 msgid "Copy to Middle and Advance\tCtrl+Alt+Right"
 msgstr "Másolás a középsőbe, majd tovább\tCtrl+Alt+Right"
 
 #. IDS_R2MNEXT
-#: Merge.rc:4834
+#: Merge.rc:4833
 msgid "Copy to Middle and Advance\tCtrl+Alt+Left"
 msgstr "Másolás a középsőbe, majd tovább\tCtrl+Alt+Left"
 
 #. IDS_ALL_MIDDLE
-#: Merge.rc:4835
+#: Merge.rc:4834
 msgid "Copy All to Middle"
 msgstr "Az összes másolása a középsőbe"
 
 #. IDS_COPY_RIGHT_TO_LEFT
-#: Merge.rc:4841
+#: Merge.rc:4840
 #, c-format
 msgid "Right to Left (%1)"
 msgstr "Jobbról a balba (%1)"
 
 #. IDS_COPY_RIGHT_TO_MIDDLE
-#: Merge.rc:4842
+#: Merge.rc:4841
 #, c-format
 msgid "Right to Middle (%1)"
 msgstr "Jobbról a középsőbe (%1)"
 
 #. IDS_COPY_MIDDLE_TO_LEFT
-#: Merge.rc:4843
+#: Merge.rc:4842
 #, c-format
 msgid "Middle to Left (%1)"
 msgstr "Középső a balba (%1)"
 
 #. IDS_COPY_MIDDLE_TO_RIGHT
-#: Merge.rc:4844
+#: Merge.rc:4843
 #, c-format
 msgid "Middle to Right (%1)"
 msgstr "Középső a jobba (%1)"
 
 #. IDS_COPY_LEFT_TO_RIGHT
-#: Merge.rc:4845
+#: Merge.rc:4844
 #, c-format
 msgid "Left to Right (%1)"
 msgstr "Bal a jobba (%1)"
 
 #. IDS_COPY_LEFT_TO_MIDDLE
-#: Merge.rc:4846
+#: Merge.rc:4845
 #, c-format
 msgid "Left to Middle (%1)"
 msgstr "Bal a középsőbe(%1)"
 
 #. IDS_MOVE_LEFT_TO
-#: Merge.rc:4857 Merge.rc:4889
+#: Merge.rc:4856 Merge.rc:4888
 #, c-format
 msgid "Left to... (%1)"
 msgstr "Balból a... (%1)"
 
 #. IDS_MOVE_MIDDLE_TO
-#: Merge.rc:4858 Merge.rc:4890
+#: Merge.rc:4857 Merge.rc:4889
 #, c-format
 msgid "Middle to... (%1)"
 msgstr "A középsőből a...(%1)"
 
 #. IDS_MOVE_RIGHT_TO
-#: Merge.rc:4859 Merge.rc:4891
+#: Merge.rc:4858 Merge.rc:4890
 #, c-format
 msgid "Right to... (%1)"
 msgstr "Jobból a... (%1)"
 
 #. IDS_COPY_BOTH_TO
-#: Merge.rc:4860
+#: Merge.rc:4859
 #, c-format
 msgid "Both to... (%1)"
 msgstr "Mindkettőből a...(%1)"
 
 #. IDS_COPY_ALL_TO
-#: Merge.rc:4861
+#: Merge.rc:4860
 #, c-format
 msgid "All to... (%1)"
 msgstr "Az összesből a...(%1)"
 
 #. IDS_COPY_DIFFERENCES_TO
-#: Merge.rc:4862
+#: Merge.rc:4861
 #, c-format
 msgid "Differences to... (%1)"
 msgstr "Különbségek ehhez...(%1)"
 
 #. IDS_ONLYDIFFITEMS_CONFIRM
-#: Merge.rc:4869
+#: Merge.rc:4868
 msgid "Some selected items are identical or skipped.\nProcess only items with differences?"
 msgstr "Néhány kiválasztott elem azonos vagy kimaradt.\nCsak az eltéréseket tartalmazó elemek feldolgozása?"
 
 #. IDS_DEL_LEFT_FMT
-#: Merge.rc:4875
+#: Merge.rc:4874
 #, c-format
 msgid "Left (%1)"
 msgstr "Bal (%1)"
 
 #. IDS_DEL_MIDDLE_FMT
-#: Merge.rc:4876
+#: Merge.rc:4875
 #, c-format
 msgid "Middle (%1)"
 msgstr "Középső (%1)"
 
 #. IDS_DEL_RIGHT_FMT
-#: Merge.rc:4877
+#: Merge.rc:4876
 #, c-format
 msgid "Right (%1)"
 msgstr "Jobb (%1)"
 
 #. IDS_DEL_BOTH_FMT
-#: Merge.rc:4878
+#: Merge.rc:4877
 #, c-format
 msgid "Both (%1)"
 msgstr "Mindkettő (%1)"
 
 #. IDS_DEL_ALL_FMT
-#: Merge.rc:4879
+#: Merge.rc:4878
 #, c-format
 msgid "All (%1)"
 msgstr "Összes (%1)"
 
 #. IDS_SELECT_DEST_LEFT
-#: Merge.rc:4895
+#: Merge.rc:4894
 #, c-format
 msgid "Left Side - Select Destination Folder:"
 msgstr "Bal oldal - célmappa választása:"
 
 #. IDS_SELECT_DEST_MIDDLE
-#: Merge.rc:4896
+#: Merge.rc:4895
 #, c-format
 msgid "Middle Side - Select Destination Folder:"
 msgstr "Középső oldal - célmappa választása:"
 
 #. IDS_SELECT_DEST_RIGHT
-#: Merge.rc:4897
+#: Merge.rc:4896
 #, c-format
 msgid "Right Side - Select Destination Folder:"
 msgstr "Jobb oldal - célmappa választása:"
 
 #. IDS_FILES_AFFECTED_FMT
-#: Merge.rc:4898
+#: Merge.rc:4897
 #, c-format
 msgid "(%1 Files Affected)"
 msgstr "(%1 fájl érintve)"
 
 #. IDS_FILES_AFFECTED_FMT2
-#: Merge.rc:4899
+#: Merge.rc:4898
 #, c-format
 msgid "(%1 of %2 Files Affected)"
 msgstr "(%1 / %2 fájl érintve)"
 
 #. IDS_CONFIRM_DELETE_SINGLE
-#: Merge.rc:4905
+#: Merge.rc:4904
 #, c-format
 msgid ""
 "Are you sure you want to delete\n"
@@ -6890,18 +6884,18 @@ msgstr ""
 "%1 ?"
 
 #. IDS_CONFIRM_SINGLE_COPY
-#: Merge.rc:4906
+#: Merge.rc:4905
 msgid "Are you sure you want to copy?"
 msgstr "Biztosan másolod?"
 
 #. IDS_CONFIRM_MULTIPLE_COPY
-#: Merge.rc:4907
+#: Merge.rc:4906
 #, c-format
 msgid "Are you sure you want to copy %d items?"
 msgstr "Biztosan másolsz %d elemet?"
 
 #. IDS_DIRCMP_NOTSYNC
-#: Merge.rc:4908
+#: Merge.rc:4907
 #, c-format
 msgid ""
 "Operation aborted!\n"
@@ -6921,873 +6915,873 @@ msgstr ""
 "Frissítsd az összehasonlítást."
 
 #. IDS_CONFIRM_SINGLE_MOVE
-#: Merge.rc:4913
+#: Merge.rc:4912
 msgid "Are you sure you want to move?"
 msgstr "Biztosan áthelyezed?"
 
 #. IDS_CONFIRM_MULTIPLE_MOVE
-#: Merge.rc:4914
+#: Merge.rc:4913
 #, c-format
 msgid "Are you sure you want to move %d items?"
 msgstr "Biztosan áthelyezel %d elemet?"
 
 #. IDS_CONFIRM_MOVE_CAPTION
-#: Merge.rc:4916
+#: Merge.rc:4915
 #, c-format
 msgid "Confirm Move"
 msgstr "Áthelyezés megerősítése"
 
-#: Merge.rc:4918
+#: Merge.rc:4917
 #, c-format
 msgid "Close the folder comparison window?"
 msgstr "Bezárni készülsz a mappákat összehasonlító ablakot. Biztosan bezárod az ablakot?"
 
-#: Merge.rc:4920
+#: Merge.rc:4919
 msgid "Close the folder comparison window, which took a long time?"
 msgstr "Bezárni készülsz a mappa összehasonlító ablakot, ami meglehetősen sok időt vett igénybe. Biztosan bezárod az ablakot?"
 
 #. IDS_ERROR_INVALID_DIR_FILE_NAME
-#: Merge.rc:4921
+#: Merge.rc:4920
 msgid "The file or folder name is invalid."
 msgstr "A fájl- vagy a mappanév érvénytelen"
 
 #. IDS_ERROR_EXECUTE_FILE
-#: Merge.rc:4927
+#: Merge.rc:4926
 #, c-format
 msgid "Failed to execute external editor: %1"
 msgstr "Nem sikerült elindítani a külső szerkesztőt: %1"
 
 #. IDS_UNKNOWN_ARCHIVE_FORMAT
-#: Merge.rc:4933
+#: Merge.rc:4932
 #, c-format
 msgid "Unknown archive format"
 msgstr "Ismeretlen archívum formátum"
 
-#: Merge.rc:4935
+#: Merge.rc:4934
 msgid "Failed to extract archive.\nCompare as text file?"
 msgstr "Nem sikerült kibontani az archív fájlokat.\nSzeretnéd összehasonlítani az archív fájlokat szöveges fájlokként?"
 
 #. IDS_COLHDR_FILENAME
-#: Merge.rc:4941
+#: Merge.rc:4940
 #, c-format
 msgid "Filename"
 msgstr "Fájlnév"
 
 #. IDS_COLHDR_DIR
-#: Merge.rc:4942
+#: Merge.rc:4941
 msgctxt "DirView|ColumnHeader"
 msgid "Folder"
 msgstr "Mappa"
 
 #. IDS_COLHDR_RESULT
-#: Merge.rc:4943
+#: Merge.rc:4942
 #, c-format
 msgid "Comparison Result"
 msgstr "Összehasonlítási eredmények"
 
 #. IDS_COLHDR_LTIMEM
-#: Merge.rc:4944
+#: Merge.rc:4943
 #, c-format
 msgid "Left Date"
 msgstr "Bal dátuma"
 
 #. IDS_COLHDR_RTIMEM
-#: Merge.rc:4945
+#: Merge.rc:4944
 #, c-format
 msgid "Right Date"
 msgstr "Jobb dátuma"
 
 #. IDS_COLHDR_MTIMEM
-#: Merge.rc:4946
+#: Merge.rc:4945
 #, c-format
 msgid "Middle Date"
 msgstr "Középső dátuma"
 
 #. IDS_COLHDR_LSIZE
-#: Merge.rc:4948
+#: Merge.rc:4947
 #, c-format
 msgid "Left Size"
 msgstr "Bal mérete"
 
 #. IDS_COLHDR_RSIZE
-#: Merge.rc:4949
+#: Merge.rc:4948
 #, c-format
 msgid "Right Size"
 msgstr "Jobb mérete"
 
 #. IDS_COLHDR_MSIZE
-#: Merge.rc:4954
+#: Merge.rc:4953
 #, c-format
 msgid "Middle Size"
 msgstr "Középső mérete"
 
 #. IDS_COLHDR_RSIZE_SHORT
-#: Merge.rc:4955
+#: Merge.rc:4954
 #, c-format
 msgid "Right Size (Short)"
 msgstr "Jobb mérete (rövid)"
 
 #. IDS_COLHDR_LSIZE_SHORT
-#: Merge.rc:4956
+#: Merge.rc:4955
 #, c-format
 msgid "Left Size (Short)"
 msgstr "Bal mérete (rövid)"
 
 #. IDS_COLHDR_MSIZE_SHORT
-#: Merge.rc:4957
+#: Merge.rc:4956
 #, c-format
 msgid "Middle Size (Short)"
 msgstr "Középső mérete (rövid)"
 
 #. IDS_COLHDR_LTIMEC
-#: Merge.rc:4963
+#: Merge.rc:4962
 #, c-format
 msgid "Left Creation Time"
 msgstr "Bal létrehozási ideje"
 
 #. IDS_COLHDR_RTIMEC
-#: Merge.rc:4964
+#: Merge.rc:4963
 #, c-format
 msgid "Right Creation Time"
 msgstr "Jobb létrehozási ideje"
 
 #. IDS_COLHDR_MTIMEC
-#: Merge.rc:4965
+#: Merge.rc:4964
 #, c-format
 msgid "Middle Creation Time"
 msgstr "Középső létrehozási ideje"
 
 #. IDS_COLHDR_NEWER
-#: Merge.rc:4966
+#: Merge.rc:4965
 #, c-format
 msgid "Newer File"
 msgstr "Újabb fájl"
 
 #. IDS_COLHDR_LVERSION
-#: Merge.rc:4967
+#: Merge.rc:4966
 #, c-format
 msgid "Left File Version"
 msgstr "Bal fájlverziója"
 
 #. IDS_COLHDR_RVERSION
-#: Merge.rc:4968
+#: Merge.rc:4967
 #, c-format
 msgid "Right File Version"
 msgstr "Jobb fájlverziója"
 
 #. IDS_COLHDR_MVERSION
-#: Merge.rc:4969
+#: Merge.rc:4968
 #, c-format
 msgid "Middle File Version"
 msgstr "Középső fájlverziója"
 
 #. IDS_COLHDR_RESULT_ABBR
-#: Merge.rc:4970
+#: Merge.rc:4969
 #, c-format
 msgid "Short Result"
 msgstr "Rövid eredmények"
 
 #. IDS_COLHDR_LATTRIBUTES
-#: Merge.rc:4971
+#: Merge.rc:4970
 #, c-format
 msgid "Left Attributes"
 msgstr "Bal attribútumai"
 
 #. IDS_COLHDR_RATTRIBUTES
-#: Merge.rc:4972
+#: Merge.rc:4971
 #, c-format
 msgid "Right Attributes"
 msgstr "Jobb attribútumai"
 
 #. IDS_COLHDR_MATTRIBUTES
-#: Merge.rc:4973
+#: Merge.rc:4972
 #, c-format
 msgid "Middle Attributes"
 msgstr "Középső attribúumai"
 
 #. IDS_COLHDR_LEOL_TYPE
-#: Merge.rc:4978
+#: Merge.rc:4977
 #, c-format
 msgid "Left EOL"
 msgstr "Bal sorugrásai"
 
 #. IDS_COLHDR_MEOL_TYPE
-#: Merge.rc:4979
+#: Merge.rc:4978
 #, c-format
 msgid "Middle EOL"
 msgstr "Középső sorugrásai"
 
 #. IDS_COLHDR_REOL_TYPE
-#: Merge.rc:4980
+#: Merge.rc:4979
 #, c-format
 msgid "Right EOL"
 msgstr "Jobb sorugrásai"
 
 #. IDS_COLHDR_LENCODING
-#: Merge.rc:4986
+#: Merge.rc:4985
 #, c-format
 msgid "Left Encoding"
 msgstr "Bal kódolása"
 
 #. IDS_COLHDR_RENCODING
-#: Merge.rc:4987
+#: Merge.rc:4986
 #, c-format
 msgid "Right Encoding"
 msgstr "Jobb kódolása"
 
 #. IDS_COLHDR_MENCODING
-#: Merge.rc:4988
+#: Merge.rc:4987
 #, c-format
 msgid "Middle Encoding"
 msgstr "Középső kódolása"
 
 #. IDS_COLHDR_NIDIFFS
-#: Merge.rc:4989
+#: Merge.rc:4988
 msgid "Ignored Diff"
 msgstr "Eltérések mellőzése"
 
 #. IDS_COLHDR_BINARY
-#: Merge.rc:4991
+#: Merge.rc:4990
 msgctxt "DirView|ColumnHeader"
 msgid "Binary"
 msgstr "Bináris"
 
 #. IDS_PLUGINS_TYPE_UNPACKER
-#: Merge.rc:4992 Merge.rc:5314
+#: Merge.rc:4991 Merge.rc:5313
 #, c-format
 msgid "Unpacker"
 msgstr "Kitömörítő"
 
 #. IDS_PLUGIN_TYPE4
-#: Merge.rc:4993 Merge.rc:5315 Merge.rc:5622
+#: Merge.rc:4992 Merge.rc:5314 Merge.rc:5621
 #, c-format
 msgid "Prediffer"
 msgstr "Elővizsgáló"
 
 #. IDS_COLHDR_LEFT
-#: Merge.rc:4994
+#: Merge.rc:4993
 msgid "Left"
 msgstr "Bal"
 
 #. IDS_COLHDR_MIDDLE
-#: Merge.rc:4995
+#: Merge.rc:4994
 msgid "Middle"
 msgstr "Középső"
 
 #. IDS_COLHDR_RIGHT
-#: Merge.rc:4996
+#: Merge.rc:4995
 msgid "Right"
 msgstr "Jobb"
 
 #. IDS_COLHDR_DIFF
-#: Merge.rc:4997
+#: Merge.rc:4996
 msgid "Diff"
 msgstr "Különbség"
 
 #. IDS_COLHDR_LEFT_DUPLICATE
-#: Merge.rc:4998
+#: Merge.rc:4997
 msgid "Left Duplicate Count"
 msgstr "Bal duplikátum számláló"
 
 #. IDS_COLHDR_RIGHT_DUPLICATE
-#: Merge.rc:4999
+#: Merge.rc:4998
 msgid "Right Duplicate Count"
 msgstr "Jöbb duplikátum számláló"
 
 #. IDS_COLHDR_MIDDLE_DUPLICATE
-#: Merge.rc:5000
+#: Merge.rc:4999
 msgid "Middle Duplicate Count"
 msgstr "Középső duplikátum számláló"
 
 #. IDS_COLHDR_MOVE
-#: Merge.rc:5001
+#: Merge.rc:5000
 msgid "Move"
 msgstr "Áthelyezés"
 
 #. IDS_PRPCAT_AUDIO
-#: Merge.rc:5008
+#: Merge.rc:5007
 msgid "Audio"
 msgstr "Hang"
 
 #. IDS_PRPCAT_CALENDAR
-#: Merge.rc:5009
+#: Merge.rc:5008
 msgid "Calendar"
 msgstr "Naptár"
 
 #. IDS_PRPCAT_COMMUNICATION
-#: Merge.rc:5010
+#: Merge.rc:5009
 msgid "Communication"
 msgstr "Kommunikáció"
 
 #. IDS_PRPCAT_CONTACT
-#: Merge.rc:5011
+#: Merge.rc:5010
 msgid "Contact"
 msgstr "Névjegy"
 
 #. IDS_PRPCAT_DEVICES
-#: Merge.rc:5012
+#: Merge.rc:5011
 msgid "Devices"
 msgstr "Eszközök"
 
 #. IDS_PRPCAT_DOCUMENT
-#: Merge.rc:5013
+#: Merge.rc:5012
 msgid "Document"
 msgstr "Dokumentum"
 
 #. IDS_PRPCAT_HOME
-#: Merge.rc:5014
+#: Merge.rc:5013
 msgid "Home"
 msgstr "Otthon"
 
 #. IDS_PRPCAT_JOURNAL
-#: Merge.rc:5016
+#: Merge.rc:5015
 msgid "Journal"
 msgstr "Napló"
 
 #. IDS_PRPCAT_LINK
-#: Merge.rc:5017
+#: Merge.rc:5016
 msgid "Link"
 msgstr "Hivatkozás"
 
 #. IDS_PRPCAT_MEDIA
-#: Merge.rc:5018
+#: Merge.rc:5017
 msgid "Media"
 msgstr "Média"
 
 #. IDS_PRPCAT_MUSIC
-#: Merge.rc:5020
+#: Merge.rc:5019
 msgid "Music"
 msgstr "Zene"
 
 #. IDS_PRPCAT_NOTE
-#: Merge.rc:5021
+#: Merge.rc:5020
 msgid "Note"
 msgstr "Megjegyzés"
 
 #. IDS_PRPCAT_PHOTO
-#: Merge.rc:5022
+#: Merge.rc:5021
 msgid "Photo"
 msgstr "Fénykép"
 
 #. IDS_PRPCAT_RECORDEDTV
-#: Merge.rc:5023
+#: Merge.rc:5022
 msgid "RecordedTV"
 msgstr "TV felvétel"
 
 #. IDS_PRPCAT_SEARCH
-#: Merge.rc:5024
+#: Merge.rc:5023
 msgid "Search"
 msgstr "Keresés"
 
 #. IDS_PRPCAT_SECURITY
-#: Merge.rc:5025
+#: Merge.rc:5024
 msgid "Security"
 msgstr "Biztonság"
 
 #. IDS_PRPCAT_SOFTWARE
-#: Merge.rc:5026
+#: Merge.rc:5025
 msgid "Software"
 msgstr "Szoftver"
 
 #. IDS_PRPCAT_TASK
-#: Merge.rc:5027
+#: Merge.rc:5026
 msgid "Task"
 msgstr "Feladat"
 
 #. IDS_PRPCAT_VIDEO
-#: Merge.rc:5028
+#: Merge.rc:5027
 msgid "Video"
 msgstr "Videó"
 
 #. IDS_PRPCAT_HASH
-#: Merge.rc:5029
+#: Merge.rc:5028
 msgid "Hash"
 msgstr "Hash"
 
 #. IDS_CANT_COMPARE_FILES
-#: Merge.rc:5035
+#: Merge.rc:5034
 #, c-format
 msgid "Unable to compare files"
 msgstr "Nem lehet összehasonlítani a fájlokat"
 
 #. IDS_ABORTED_ITEM
-#: Merge.rc:5036
+#: Merge.rc:5035
 #, c-format
 msgid "Item aborted"
 msgstr "Elem leállítva"
 
 #. IDS_FILE_SKIPPED
-#: Merge.rc:5037
+#: Merge.rc:5036
 #, c-format
 msgid "File skipped"
 msgstr "A fájl kihagyva"
 
 #. IDS_DIR_SKIPPED
-#: Merge.rc:5038
+#: Merge.rc:5037
 #, c-format
 msgid "Folder skipped"
 msgstr "A könyvtár kihagyva"
 
 #. IDS_LEFT_ONLY_IN_FMT
-#: Merge.rc:5039
+#: Merge.rc:5038
 #, c-format
 msgid "Left only: %1"
 msgstr "Csak bal: %1"
 
 #. IDS_MIDDLE_ONLY_IN_FMT
-#: Merge.rc:5040
+#: Merge.rc:5039
 #, c-format
 msgid "Middle only: %1"
 msgstr "Csak középső: %1"
 
 #. IDS_RIGHT_ONLY_IN_FMT
-#: Merge.rc:5041
+#: Merge.rc:5040
 #, c-format
 msgid "Right only: %1"
 msgstr "Csak jobb: %1"
 
 #. IDS_DOES_NOT_EXIST_IN_FMT
-#: Merge.rc:5042
+#: Merge.rc:5041
 #, c-format
 msgid "Does not exist in %1"
 msgstr "Nincs benne ebben: %1"
 
 #. IDS_BIN_FILES_SAME
-#: Merge.rc:5043
+#: Merge.rc:5042
 #, c-format
 msgid "Binary files are identical"
 msgstr "A bináris fájlok megegyezőek"
 
 #. IDS_BIN_FILES_DIFF
-#: Merge.rc:5049
+#: Merge.rc:5048
 #, c-format
 msgid "Binary files are different"
 msgstr "A bináris fájlok különbözőek"
 
 #. IDS_FILES_ARE_DIFFERENT
-#: Merge.rc:5050
+#: Merge.rc:5049
 #, c-format
 msgid "Files are different"
 msgstr "A fájlok különbözőek"
 
 #. IDS_FOLDERS_ARE_DIFFERENT
-#: Merge.rc:5051
+#: Merge.rc:5050
 #, c-format
 msgid "Folders are different"
 msgstr "A könyvtárak különböznek"
 
 #. IDS_LEFTONLY
-#: Merge.rc:5052
+#: Merge.rc:5051
 #, c-format
 msgid "Left Only"
 msgstr "Csak a bal"
 
 #. IDS_RIGHTONLY
-#: Merge.rc:5053
+#: Merge.rc:5052
 #, c-format
 msgid "Right Only"
 msgstr "Csak a jobb"
 
 #. IDS_MIDDLEONLY
-#: Merge.rc:5054
+#: Merge.rc:5053
 #, c-format
 msgid "Middle Only"
 msgstr "Csak a középső"
 
 #. IDS_NOITEMLEFT
-#: Merge.rc:5055
+#: Merge.rc:5054
 #, c-format
 msgid "No item in left"
 msgstr "Nincs elem a balban"
 
 #. IDS_NOITEMRIGHT
-#: Merge.rc:5056
+#: Merge.rc:5055
 #, c-format
 msgid "No item in right"
 msgstr "Nincs elem a jobban"
 
 #. IDS_NOITEMMIDDLE
-#: Merge.rc:5057
+#: Merge.rc:5056
 #, c-format
 msgid "No item in middle"
 msgstr "Nincs elem a középsőben"
 
 #. IDS_CMPRES_ERROR
-#: Merge.rc:5059
+#: Merge.rc:5058
 #, c-format
 msgid "Error"
 msgstr "Hiba"
 
 #. IDS_TEXT_FILES_SAME
-#: Merge.rc:5060
+#: Merge.rc:5059
 #, c-format
 msgid "Text files are identical"
 msgstr "A szövegfájlok megegyeznek"
 
 #. IDS_LEFTONLY_DIFF
-#: Merge.rc:5061
+#: Merge.rc:5060
 msgid " (Middle and right are identical)"
 msgstr " (Középső és jobb egyforma)"
 
 #. IDS_MIDDLEONLY_DIFF
-#: Merge.rc:5062
+#: Merge.rc:5061
 msgid " (Left and right are identical)"
 msgstr " (Bal és jobb egyforma)"
 
 #. IDS_RIGHTONLY_DIFF
-#: Merge.rc:5063
+#: Merge.rc:5062
 msgid " (Left and middle are identical)"
 msgstr " (Bal és középső egyforma)"
 
 #. IDS_PATH_MISMATCH
-#: Merge.rc:5064
+#: Merge.rc:5063
 msgid " (paths differ)"
 msgstr " (utak különbözősége)"
 
 #. IDS_TEXT_FILES_DIFF
-#: Merge.rc:5065
+#: Merge.rc:5064
 #, c-format
 msgid "Text files are different"
 msgstr "A szövegfájlok különböznek"
 
 #. IDS_IMAGE_FILES_SAME
-#: Merge.rc:5066
+#: Merge.rc:5065
 msgid "Image files are identical"
 msgstr "A képfájlok egyformák"
 
 #. IDS_IMAGE_FILES_DIFF
-#: Merge.rc:5067
+#: Merge.rc:5066
 msgid "Image files are different"
 msgstr "A képfájlok különböznek"
 
 #. IDS_EXPR_DIFF
-#: Merge.rc:5068
+#: Merge.rc:5067
 #, c-format
 msgid "Files are different (expr: %1)"
 msgstr "A fájlok eltérőek (kifejezés: %1)"
 
 #. IDS_HASH_GROUP
-#: Merge.rc:5069
+#: Merge.rc:5068
 #, c-format
 msgid "Group%d"
 msgstr "Csoport%d"
 
 #. IDS_RENAME_MOVE_DETECTION_DISALBED
-#: Merge.rc:5070
+#: Merge.rc:5069
 msgctxt "Options dialog|Compare|Folder|Detect renames and moves"
 msgid "Disabled"
 msgstr "Letiltva"
 
 #. IDS_RENAME_MOVE_DETECTION_RENAME
-#: Merge.rc:5071
+#: Merge.rc:5070
 msgid "Detect renames"
 msgstr "Átnevezések észlelése"
 
 #. IDS_RENAME_MOVE_DETECTION_RENAME_MOVE
-#: Merge.rc:5072
+#: Merge.rc:5071
 msgid "Detect renames and moves"
 msgstr "Átnevezések és áthelyezések észlelése"
 
 #. IDS_RENAME_MOVE_MERGE_MODE_RENAME
-#: Merge.rc:5073
+#: Merge.rc:5072
 msgid "Merge renames"
 msgstr "Átnevezések egyesítése"
 
 #. IDS_RENAME_MOVE_MERGE_MODE_RENAME_MOVE
-#: Merge.rc:5074
+#: Merge.rc:5073
 msgid "Merge renames and moves"
 msgstr "Átnevezések és áthelyezések egyesítése"
 
 #. IDS_RENAMED
-#: Merge.rc:5075
+#: Merge.rc:5074
 msgid "Renamed"
 msgstr "Átnevezve"
 
 #. IDS_RENAMED_MOVED
-#: Merge.rc:5077
+#: Merge.rc:5076
 msgid "Renamed/Moved"
 msgstr "Átnevezve/Áthelyezve"
 
 #. IDS_RENAMED_MOVED_ITEMS
-#: Merge.rc:5078
+#: Merge.rc:5077
 #, c-format
 msgid "(%1 items)"
 msgstr "(%1 elem)"
 
 #. IDS_RENAMED_MOVED_RESULT
-#: Merge.rc:5079
+#: Merge.rc:5078
 #, c-format
 msgid "%1 (set %2): "
 msgstr "%1 (készlet %2)"
 
 #. IDS_SWITCH_FLAT_MODE
-#: Merge.rc:5080
+#: Merge.rc:5079
 msgid "Some moved items have been merged.\nIn Tree Mode, these items may appear in positions that do not reflect the actual folder structure, which can be confusing.\nSwitch to Flat Mode?"
 msgstr "Néhány áthelyezett elem egyesítésre került.\nFa nézetben ezek az elemek olyan pozíciókban jelenhetnek meg, amelyek nem tükrözik a tényleges mappastruktúrát, ami zavaró lehet.\nVáltás sík nézetre?"
 
 #. IDS_ELAPSED_TIME
-#: Merge.rc:5086
+#: Merge.rc:5085
 #, c-format
 msgid "Elapsed time: %ld ms"
 msgstr "Eltelt idő: %ld ms"
 
 #. IDS_STATUS_SELITEM1
-#: Merge.rc:5087
+#: Merge.rc:5086
 #, c-format
 msgid "1 item selected"
 msgstr "1 elem kiválasztva"
 
 #. IDS_STATUS_SELITEMS
-#: Merge.rc:5088
+#: Merge.rc:5087
 #, c-format
 msgid "%1 items selected"
 msgstr "%1 elem kiválasztva"
 
 #. IDS_COLDESC_FILENAME
-#: Merge.rc:5094
+#: Merge.rc:5093
 #, c-format
 msgid "Filename or folder name."
 msgstr "Fájlnév vagy könyvtárnév."
 
 #. IDS_COLDESC_DIR
-#: Merge.rc:5095
+#: Merge.rc:5094
 #, c-format
 msgid "Subfolder name when subfolders are included."
 msgstr "Alkönyvtár neve ha az alkönyvtárak is ki vannak választva."
 
 #. IDS_COLDESC_RESULT
-#: Merge.rc:5096
+#: Merge.rc:5095
 #, c-format
 msgid "Comparison result, long form."
 msgstr "Összehasonlítási eredmény bővebb formában."
 
 #. IDS_COLDESC_LTIMEM
-#: Merge.rc:5101
+#: Merge.rc:5100
 #, c-format
 msgid "Left side modification date."
 msgstr "Bal módosítási ideje."
 
 #. IDS_COLDESC_RTIMEM
-#: Merge.rc:5102
+#: Merge.rc:5101
 #, c-format
 msgid "Right side modification date."
 msgstr "Jobb módosítási ideje."
 
 #. IDS_COLDESC_MTIMEM
-#: Merge.rc:5103
+#: Merge.rc:5102
 #, c-format
 msgid "Middle side modification date."
 msgstr "Középső módosítási ideje."
 
 #. IDS_COLDESC_EXTENSION
-#: Merge.rc:5104
+#: Merge.rc:5103
 #, c-format
 msgid "File's extension."
 msgstr "Fájlok kiterjesztése."
 
 #. IDS_COLDESC_LSIZE
-#: Merge.rc:5105
+#: Merge.rc:5104
 #, c-format
 msgid "Left file size in bytes."
 msgstr "Bal fájlmérete bájtban."
 
 #. IDS_COLDESC_RSIZE
-#: Merge.rc:5106
+#: Merge.rc:5105
 #, c-format
 msgid "Right file size in bytes."
 msgstr "Jobb fájlmérete bájtban."
 
 #. IDS_COLDESC_MSIZE
-#: Merge.rc:5107
+#: Merge.rc:5106
 #, c-format
 msgid "Middle file size in bytes."
 msgstr "Középső fájlmérete bájtban."
 
 #. IDS_COLDESC_LSIZE_SHORT
-#: Merge.rc:5108
+#: Merge.rc:5107
 #, c-format
 msgid "Left file size abbreviated."
 msgstr "Bal fájlmérete rövidítve."
 
 #. IDS_COLDESC_RSIZE_SHORT
-#: Merge.rc:5109
+#: Merge.rc:5108
 #, c-format
 msgid "Right file size abbreviated."
 msgstr "Jobb fájlmérete rövidítve."
 
 #. IDS_COLDESC_MSIZE_SHORT
-#: Merge.rc:5110
+#: Merge.rc:5109
 #, c-format
 msgid "Middle file size abbreviated."
 msgstr "Középső fájlmérete rövidítve."
 
 #. IDS_COLDESC_LTIMEC
-#: Merge.rc:5116
+#: Merge.rc:5115
 #, c-format
 msgid "Left side creation time."
 msgstr "Bal létrehozási ideje."
 
 #. IDS_COLDESC_RTIMEC
-#: Merge.rc:5117
+#: Merge.rc:5116
 #, c-format
 msgid "Right side creation time."
 msgstr "Jobb létrehozási ideje."
 
 #. IDS_COLDESC_MTIMEC
-#: Merge.rc:5118
+#: Merge.rc:5117
 #, c-format
 msgid "Middle side creation time."
 msgstr "A középső létrehozásának ideje."
 
 #. IDS_COLDESC_NEWER
-#: Merge.rc:5119
+#: Merge.rc:5118
 #, c-format
 msgid "Tells which side has newer modification date."
 msgstr "Megmutatja, melyik oldalnak újabb a létrehozási dátuma."
 
 #. IDS_COLDESC_LVERSION
-#: Merge.rc:5120
+#: Merge.rc:5119
 msgid "Left side file version, only for some file types."
 msgstr "Bal fájlverziója, csak egyes fájltípusoknál."
 
 #. IDS_COLDESC_RVERSION
-#: Merge.rc:5121
+#: Merge.rc:5120
 msgid "Right side file version, only for some file types."
 msgstr "Jobb fájlverziója, csak egyes fájltípusoknál."
 
 #. IDS_COLDESC_MVERSION
-#: Merge.rc:5126
+#: Merge.rc:5125
 msgid "Middle side file version, only for some file types."
 msgstr "Középső fájlverziója, csak egyes fájltípusoknál."
 
 #. IDS_COLDESC_RESULT_ABBR
-#: Merge.rc:5127
+#: Merge.rc:5126
 #, c-format
 msgid "Short comparison result."
 msgstr "Rövid összehasonlítási eredmények."
 
 #. IDS_COLDESC_LATTRIBUTES
-#: Merge.rc:5128
+#: Merge.rc:5127
 #, c-format
 msgid "Left side attributes."
 msgstr "Bal attribútumai."
 
 #. IDS_COLDESC_RATTRIBUTES
-#: Merge.rc:5129
+#: Merge.rc:5128
 #, c-format
 msgid "Right side attributes."
 msgstr "Jobb attribútumai."
 
 #. IDS_COLDESC_MATTRIBUTES
-#: Merge.rc:5130
+#: Merge.rc:5129
 #, c-format
 msgid "Middle side attributes."
 msgstr "Középső attribútumai."
 
 #. IDS_COLDESC_LEOL_TYPE
-#: Merge.rc:5131
+#: Merge.rc:5130
 msgid "Left side file EOL type."
 msgstr "Bal oldali fájl sorvég típus."
 
 #. IDS_COLDESC_REOL_TYPE
-#: Merge.rc:5132
+#: Merge.rc:5131
 msgid "Right side file EOL type."
 msgstr "Jobb oldali fájl sorvég típus."
 
 #. IDS_COLDESC_MEOL_TYPE
-#: Merge.rc:5133
+#: Merge.rc:5132
 msgid "Middle side file EOL type."
 msgstr "Középső oldali fájl sorvég típus."
 
 #. IDS_COLDESC_LENCODING
-#: Merge.rc:5139
+#: Merge.rc:5138
 #, c-format
 msgid "Left side encoding."
 msgstr "Bal kódolása."
 
 #. IDS_COLDESC_RENCODING
-#: Merge.rc:5140
+#: Merge.rc:5139
 #, c-format
 msgid "Right side encoding."
 msgstr "Jobb kódolása."
 
 #. IDS_COLDESC_MENCODING
-#: Merge.rc:5141
+#: Merge.rc:5140
 #, c-format
 msgid "Middle side encoding."
 msgstr "Középső kódolása."
 
 #. IDS_COLDESC_NIDIFFS
-#: Merge.rc:5142
+#: Merge.rc:5141
 #, c-format
 msgid "Number of ignored differences in file. Ignored and cannot be merged."
 msgstr "Mellőzött különbségek száma a fájlban. Ezeket a különbségeket a WinMerge mellőzte és nem is egyesíthetőek."
 
 #. IDS_COLDESC_NSDIFFS
-#: Merge.rc:5143
+#: Merge.rc:5142
 #, c-format
 msgid "Number of differences in file (excluding ignored)."
 msgstr "Különbségek száma a fájlban. Ez a szám nem tartalmazza a mellőzött különbségeket."
 
 #. IDS_COLDESC_BINARY
-#: Merge.rc:5144
+#: Merge.rc:5143
 #, c-format
 msgid "Shows an asterisk (*) if the file is binary."
 msgstr "(*) látható, ha a fájl bináris."
 
 #. IDS_COLDESC_UNPACKER
-#: Merge.rc:5145
+#: Merge.rc:5144
 msgid "Unpacker plugin name or pipeline."
 msgstr "Kicsomagoló bővítmény név vagy pipeline"
 
 #. IDS_COLDESC_PREDIFFER
-#: Merge.rc:5146
+#: Merge.rc:5145
 msgid "Prediffer plugin name or pipeline."
 msgstr "Elővizsgáló bővítmény név vagy pipeline"
 
 #. IDS_DIRECTORY_REPORT_TITLE
-#: Merge.rc:5152
+#: Merge.rc:5151
 #, c-format
 msgid "Compare %1 with %2"
 msgstr "%1 összehasonlítása ezzel: %2"
 
 #. IDS_DIRECTORY_REPORT_TITLE3
-#: Merge.rc:5153
+#: Merge.rc:5152
 #, c-format
 msgid "Compare %1 with %2 and %3"
 msgstr "%1 összehasonlítása ezekkel: %2 és %3"
 
 #. IDS_REPORT_COMMALIST
-#: Merge.rc:5154
+#: Merge.rc:5153
 #, c-format
 msgid "Comma-separated list"
 msgstr "Vesszővel elválasztott lista"
 
 #. IDS_REPORT_TABLIST
-#: Merge.rc:5155
+#: Merge.rc:5154
 #, c-format
 msgid "Tab-separated list"
 msgstr "Tabulált lista"
 
 #. IDS_REPORT_SIMPLEHTML
-#: Merge.rc:5156
+#: Merge.rc:5155
 #, c-format
 msgid "Simple HTML"
 msgstr "Egyszerű HTML"
 
 #. IDS_REPORT_SIMPLEXML
-#: Merge.rc:5157
+#: Merge.rc:5156
 #, c-format
 msgid "Simple XML"
 msgstr "Egyszerű XML"
 
-#: Merge.rc:5159
+#: Merge.rc:5158
 #, c-format
 msgid "Report file already exists. Overwrite?"
 msgstr "A jelentés fájl már létezik. Szeretnéd felülírni a létező fájlt?"
 
 #. IDS_REPORT_ERROR
-#: Merge.rc:5164
+#: Merge.rc:5163
 #, c-format
 msgid ""
 "Error creating the report:\n"
@@ -7797,62 +7791,62 @@ msgstr ""
 "%1"
 
 #. IDS_REPORT_SUCCESS
-#: Merge.rc:5165
+#: Merge.rc:5164
 #, c-format
 msgid "Report created successfully."
 msgstr "A jelentés sikeresen elkészült."
 
 #. IDS_SYNCPOINT_LASTBLOCK
-#: Merge.rc:5171
+#: Merge.rc:5170
 msgid "Cannot add a synchronization point at this line."
 msgstr "Itt nem adható hozzá szinkronizálási pont ehhez a sorhoz."
 
 #. IDS_FILE_TO_ITSELF
-#: Merge.rc:5177
+#: Merge.rc:5176
 #, c-format
 msgid "Same file is opened in both panes."
 msgstr "Ugyanaz a fájl van megnyitva mindkét panelen."
 
 #. IDS_FILESSAME
-#: Merge.rc:5178
+#: Merge.rc:5177
 #, c-format
 msgid "Selected files are identical."
 msgstr "A kijelölt fájlok egyformák."
 
 #. IDS_FILESSAME_CURCFG
-#: Merge.rc:5179
+#: Merge.rc:5178
 msgid "Selected files are identical (with current settings).\r\nChecking binary identity..."
 msgstr "A kijelölt fájlok egyformák (a jelenlegi beállításokkal).\r\nBináris azonosság ellenőrzése..."
 
 #. IDS_FILESSAME_BINERROR
-#: Merge.rc:5180
+#: Merge.rc:5179
 msgid "Selected files are identical (with current settings).\r\nBut binary comparison failed."
 msgstr "A kijelölt fájlok egyformák (a jelenlegi beállításokkal).\r\nDe a bináris összehasonlítás sikertelen."
 
 #. IDS_FILESSAME_BINSAME
-#: Merge.rc:5181
+#: Merge.rc:5180
 msgid "Selected files are identical (binary match)."
 msgstr "A kijelölt fájlok egyformák (bináris egyezés)."
 
 #. IDS_FILESSAME_BINDIFF
-#: Merge.rc:5182
+#: Merge.rc:5181
 msgid "Selected files are identical (with current settings).\r\nBut differ at the binary level."
 msgstr "A kijelölt fájlok egyformák (a jelenlegi beállításokkal).\r\nDe bináris szinten különböznek."
 
 #. IDS_FILEERROR
-#: Merge.rc:5183
+#: Merge.rc:5182
 #, c-format
 msgid "An error occurred while comparing files."
 msgstr "Hiba történt a fájlok összehasonlításakor."
 
 #. IDS_TEMP_FILEERROR
-#: Merge.rc:5184
+#: Merge.rc:5183
 #, c-format
 msgid "Could not create temporary files. Check your temporary path settings."
 msgstr "Nem lehetett létrehozni az ideiglenes fájlokat. Ellenőrizd az ideiglenes könyvtár beállításait."
 
 #. IDS_SUGGEST_IGNOREEOL
-#: Merge.rc:5185
+#: Merge.rc:5184
 msgid "Files use different EOL.\n\nTreat all EOL as equivalent?\n\nSet 'Ignore EOL differences (Windows/Unix/Mac)' in Compare section of Options."
 msgstr ""
 "Ezek a fájlok eltérő sorvége-karaktereket tartalmaznak.\n"
@@ -7862,19 +7856,19 @@ msgstr ""
 "Megjegyzés: Amennyiben minden esetben ezt az opciót szeretnéd használni, kapcsold be a 'Sorvég különbségek mellőzése' opciót az Összehasonlítás menüpontban (a Szerkesztés/Beállítások menüpont alatt találod meg)."
 
 #. IDS_INVALID_DIRECTORY
-#: Merge.rc:5186
+#: Merge.rc:5185
 #, c-format
 msgid "Selected folder is invalid."
 msgstr "A kiválasztott mappa érvénytelen."
 
 #. IDS_CANNOT_OPEN_BINARYFILE
-#: Merge.rc:5187
+#: Merge.rc:5186
 #, c-format
 msgid "Cannot open a binary file in Editor."
 msgstr "A bináris fájl nem volt megnyitható a szerkesztővel."
 
 #. IDS_CREATE_PAIR_FOLDER
-#: Merge.rc:5188
+#: Merge.rc:5187
 #, c-format
 msgid "Create matching folder:\n%1\non the other side and open?"
 msgstr ""
@@ -7885,45 +7879,45 @@ msgstr ""
 "a másik oldalhoz és megnyitod ezeket a mappákat?"
 
 #. IDS_CONFIRM_COPY_ALL_DIFFS
-#: Merge.rc:5189
+#: Merge.rc:5188
 msgid "Copy all differences to other file?"
 msgstr "Biztos, hogy minden eltérést át akarsz másolni a másik fájlba?"
 
 #. IDS_MOVE_TO_NEXTFILE
-#: Merge.rc:5194
+#: Merge.rc:5193
 #, c-format
 msgid "Move to next file?"
 msgstr "Továbblépsz a következő fájlra?"
 
 #. IDS_MOVE_TO_PREVFILE
-#: Merge.rc:5195
+#: Merge.rc:5194
 #, c-format
 msgid "Move to previous file?"
 msgstr "Visszalépsz az előző fájlra?"
 
 #. IDS_MOVE_TO_NEXTPAGE
-#: Merge.rc:5196
+#: Merge.rc:5195
 #, c-format
 msgid "Move to next page?"
 msgstr "Továbblépsz a következő oldalra?"
 
 #. IDS_MOVE_TO_PREVPAGE
-#: Merge.rc:5197
+#: Merge.rc:5196
 #, c-format
 msgid "Move to previous page?"
 msgstr "Visszalépsz az előző oldalra?"
 
 #. IDS_MOVE_TO_FIRSTFILE
-#: Merge.rc:5198
+#: Merge.rc:5197
 msgid "Move to first file?"
 msgstr "Átlépés az első fájlhoz?"
 
 #. IDS_MOVE_TO_LASTFILE
-#: Merge.rc:5199
+#: Merge.rc:5198
 msgid "Move to last file?"
 msgstr "Átlépés az utolsó fájlhoz?"
 
-#: Merge.rc:5206
+#: Merge.rc:5205
 #, c-format
 msgid "Different codepages: left (cp%d), right (cp%d).\nDisplay in codepage (better display) or default Windows codepage (safer merging)?\n(Recommended: default Windows codepage)"
 msgstr ""
@@ -7931,57 +7925,57 @@ msgstr ""
 "A különböző kódlapokkal történő kijelzés könnyebben áttekinthető de az egyesítés/törlés kockázatos lehet.\n"
 "Szeretnéd mindkét fájlt az alapértelmezett Windows kódlapként kezelni (ajánlott)?"
 
-#: Merge.rc:5208
+#: Merge.rc:5207
 #, c-format
 msgid "Information lost due to encoding errors: both files"
 msgstr "Kódolási hibák miatt elveszett információk: mindkét fájl"
 
-#: Merge.rc:5210
+#: Merge.rc:5209
 #, c-format
 msgid "Information lost due to encoding errors: first file"
 msgstr "Kódolási hibák miatt elveszett információk: 1.fájl"
 
-#: Merge.rc:5212
+#: Merge.rc:5211
 #, c-format
 msgid "Information lost due to encoding errors: second file"
 msgstr "Kódolási hibák miatt elveszett információk: 2.fájl"
 
-#: Merge.rc:5214
+#: Merge.rc:5213
 #, c-format
 msgid "Information lost due to encoding errors: third file"
 msgstr "Kódolási hibák miatt elveszett információk: 3.fájl"
 
 #. IDS_LINEDIFF_NODIFF
-#: Merge.rc:5220
+#: Merge.rc:5219
 #, c-format
 msgid "No difference"
 msgstr "Nincs eltérés"
 
 #. IDS_LINEDIFF_NODIFF_CAPTION
-#: Merge.rc:5221
+#: Merge.rc:5220
 #, c-format
 msgid "Line difference"
 msgstr "Sor eltérés"
 
 #. IDS_NUM_REPLACED
-#: Merge.rc:5227
+#: Merge.rc:5226
 #, c-format
 msgid "Replaced %1 string(s)."
 msgstr "Cserélve lett %1 sztring."
 
 #. IDS_EDIT_TEXT_NOT_FOUND
-#: Merge.rc:5228
+#: Merge.rc:5227
 #, c-format
 msgid "Cannot find string \"%s\"."
 msgstr "Nem található ez a sztring: \"%s\"."
 
 #. IDS_MERGE_MODE
-#: Merge.rc:5234
+#: Merge.rc:5233
 msgid "Entering Merge Mode. Press F9 to turn off."
 msgstr "Most belépsz az egyesítési módba. Ha ki akarod kapcsolni, nyomd meg az F9-et."
 
 #. IDS_AUTO_MERGE
-#: Merge.rc:5240
+#: Merge.rc:5239
 #, c-format
 msgid ""
 "Automatic merges: %1\n"
@@ -7991,97 +7985,97 @@ msgstr ""
 "A megoldatlan konfliktusok száma: %2"
 
 #. IDS_CODEPAGE_MERGED
-#: Merge.rc:5241
+#: Merge.rc:5240
 msgid "Codepage change merged."
 msgstr "A kódlap változása egyesítésre került."
 
 #. IDS_CODEPAGE_CONFLICT
-#: Merge.rc:5242
+#: Merge.rc:5241
 msgid "Codepage changes are conflicting."
 msgstr "A kódlap változásai ellentmondásosak."
 
 #. IDS_EOL_MERGED
-#: Merge.rc:5243
+#: Merge.rc:5242
 msgid "EOL change merged."
 msgstr "A sorvég változás egyesítésre került."
 
 #. IDS_EOL_CONFLICT
-#: Merge.rc:5244
+#: Merge.rc:5243
 msgid "EOL changes are conflicting."
 msgstr "A sorvég változások ellentmondásosak."
 
 #. IDS_LOCBAR_CAPTION
-#: Merge.rc:5250
+#: Merge.rc:5249
 #, c-format
 msgid "Location Pane"
 msgstr "Eltérések helye"
 
 #. IDS_DIFFBAR_CAPTION
-#: Merge.rc:5251
+#: Merge.rc:5250
 #, c-format
 msgid "Diff Pane"
 msgstr "Eltérés panel"
 
 #. IDS_DIFF_SUCCEEDED
-#: Merge.rc:5258
+#: Merge.rc:5257
 #, c-format
 msgid "Patch file written."
 msgstr "A Patch fájl sikeresen elkészült."
 
 #. IDS_DIFF_FILEOVERWRITE
-#: Merge.rc:5259
+#: Merge.rc:5258
 #, c-format
 msgid "Patch file already exists. Overwrite?"
 msgstr "A patch fájl már létezik. Szeretnéd felülírni azt?"
 
 #. IDS_DIFF_SELECTEDFILES
-#: Merge.rc:5260
+#: Merge.rc:5259
 #, c-format
 msgid "[%1 files selected]"
 msgstr "[%1 kijelölt fájl]"
 
 #. IDS_DIFF_NORMAL
-#: Merge.rc:5261
+#: Merge.rc:5260
 #, c-format
 msgid "Normal"
 msgstr "Normál"
 
 #. IDS_DIFF_CONTEXT
-#: Merge.rc:5262
+#: Merge.rc:5261
 #, c-format
 msgid "Context"
 msgstr "Szövegkörnyezet"
 
 #. IDS_DIFF_UNIFIED
-#: Merge.rc:5263
+#: Merge.rc:5262
 #, c-format
 msgid "Unified"
 msgstr "Egységesített"
 
 #. IDS_FILEWRITE_ERROR
-#: Merge.rc:5265
+#: Merge.rc:5264
 #, c-format
 msgid "Could not write to file %1."
 msgstr "Nem lehetett ebbe a fájlba írni: %1."
 
 #. IDS_PATH_NOT_ABSOLUTE
-#: Merge.rc:5266
+#: Merge.rc:5265
 #, c-format
 msgid "Output path is not absolute: %1"
 msgstr "A megadott kimeneti útvonal nem abszolút elérési út: %1"
 
 #. IDS_MUST_SPECIFY_OUTPUT
-#: Merge.rc:5267
+#: Merge.rc:5266
 msgid "Specify an output file."
 msgstr "Adj meg egy kimeneti fájlt."
 
-#: Merge.rc:5269
+#: Merge.rc:5268
 #, c-format
 msgid "Cannot create patch from binary files."
 msgstr "Nem lehet patch fájlt létrehozni bináris fájlokból."
 
 #. IDS_SAVEFILES_FORPATCH
-#: Merge.rc:5270
+#: Merge.rc:5269
 #, c-format
 msgid ""
 "Save all files first.\n"
@@ -8093,23 +8087,23 @@ msgstr ""
 "A patch létrehozásához szükséges, hogy ne legyenek el nem mentett változtatások a fájlokban."
 
 #. IDS_FOLDER_NOTEXIST
-#: Merge.rc:5271
+#: Merge.rc:5270
 #, c-format
 msgid "Folder does not exist."
 msgstr "A mappa nem létezik."
 
 #. IDS_ARCHIVE_SUCCEEDED
-#: Merge.rc:5277
+#: Merge.rc:5276
 msgid "Archive file written."
 msgstr "Archív fájl kiírva."
 
 #. IDS_ARCHIVE_SAVEFILES
-#: Merge.rc:5278
+#: Merge.rc:5277
 msgid "Save all files first.\n\nCreating an archive requires no unsaved changes."
 msgstr "Először mentsd el az összes fájlt.\n\nArchívum létrehozásához nem lehetnek mentetlen módosítások."
 
 #. IDS_NO_ZIP_SUPPORT
-#: Merge.rc:5283
+#: Merge.rc:5282
 msgid ""
 "Archive support not enabled.\n"
 "7-Zip and/or Merge7z*.dll not found.\n"
@@ -8120,43 +8114,43 @@ msgstr ""
 "Olvasd el a kézikönyv archívum támogatásról szóló részét."
 
 #. IDS_OPT_EXPORT_CAPTION
-#: Merge.rc:5284
+#: Merge.rc:5283
 #, c-format
 msgid "Select file for export"
 msgstr "Fájl kiválasztása az exportáláshoz"
 
 #. IDS_OPT_IMPORT_CAPTION
-#: Merge.rc:5285
+#: Merge.rc:5284
 #, c-format
 msgid "Select file for import"
 msgstr "Fájl kiválasztása az importáláshoz"
 
 #. IDS_OPT_IMPORT_DONE
-#: Merge.rc:5286
+#: Merge.rc:5285
 #, c-format
 msgid "Options imported from file."
 msgstr "Beállítások importálva a fájlból."
 
 #. IDS_OPT_EXPORT_DONE
-#: Merge.rc:5287
+#: Merge.rc:5286
 #, c-format
 msgid "Options exported to file."
 msgstr "Beállítások exportálva a fájlba."
 
 #. IDS_OPT_IMPORT_ERR
-#: Merge.rc:5288
+#: Merge.rc:5287
 #, c-format
 msgid "Failed to import options from file."
 msgstr "Beállítások importálása a fájlból sikertelen."
 
 #. IDS_OPT_EXPORT_ERR
-#: Merge.rc:5289
+#: Merge.rc:5288
 #, c-format
 msgid "Failed to write options to file."
 msgstr "Beállítások exportálása a fájlba sikertelen."
 
 #. IDS_CLOSEALL_WINDOWS
-#: Merge.rc:5290
+#: Merge.rc:5289
 #, c-format
 msgid ""
 "Close multiple compare windows?\n"
@@ -8168,36 +8162,36 @@ msgstr ""
 "Biztosan folytatod?"
 
 #. IDS_EOL_BIN
-#: Merge.rc:5300
+#: Merge.rc:5299
 msgctxt "EOL Type"
 msgid "Binary"
 msgstr "Bináris"
 
 #. IDS_MARKER_COLOR_FMT
-#: Merge.rc:5305
+#: Merge.rc:5304
 #, c-format
 msgid "Marker Color %d"
 msgstr "Jelölőszín %d"
 
 #. IDS_MARKER_NEW_PATTERN
-#: Merge.rc:5306
+#: Merge.rc:5305
 msgid "New Pattern"
 msgstr "Új fajta"
 
 #. IDS_PLUGINSLIST_TYPE
-#: Merge.rc:5312
+#: Merge.rc:5311
 #, c-format
 msgid "Type"
 msgstr "Típus"
 
 #. IDS_PLUGINS_TYPE_EDITSCRIPT
-#: Merge.rc:5316
+#: Merge.rc:5315
 #, c-format
 msgid "Editor script"
 msgstr "Szkript szerkesztő"
 
 #. ID_SELECTLINEDIFF
-#: Merge.rc:5322
+#: Merge.rc:5321
 #, c-format
 msgid ""
 "\n"
@@ -8207,7 +8201,7 @@ msgstr ""
 "Az eltérés az aktuális sorban (F4)"
 
 #. ID_OPTIONS
-#: Merge.rc:5323
+#: Merge.rc:5322
 #, c-format
 msgid ""
 "\n"
@@ -8217,7 +8211,7 @@ msgstr ""
 "Lehetőségek"
 
 #. ID_REFRESH
-#: Merge.rc:5324
+#: Merge.rc:5323
 #, c-format
 msgid ""
 "\n"
@@ -8227,7 +8221,7 @@ msgstr ""
 "Frissítés (F5)"
 
 #. ID_PREVDIFF
-#: Merge.rc:5330
+#: Merge.rc:5329
 #, c-format
 msgid ""
 "\n"
@@ -8237,7 +8231,7 @@ msgstr ""
 "Előző különbség (Alt+Fel)"
 
 #. ID_NEXTDIFF
-#: Merge.rc:5331
+#: Merge.rc:5330
 #, c-format
 msgid ""
 "\n"
@@ -8247,7 +8241,7 @@ msgstr ""
 "Következő különbség (Alt+Le)"
 
 #. ID_PREVCONFLICT
-#: Merge.rc:5332
+#: Merge.rc:5331
 #, c-format
 msgid ""
 "\n"
@@ -8257,7 +8251,7 @@ msgstr ""
 "Előző konfliktus (Alt+Shift+Fel)"
 
 #. ID_NEXTCONFLICT
-#: Merge.rc:5333
+#: Merge.rc:5332
 #, c-format
 msgid ""
 "\n"
@@ -8267,7 +8261,7 @@ msgstr ""
 "Következő konfliktus (Alt+Shift+Le)"
 
 #. ID_FIRSTDIFF
-#: Merge.rc:5338
+#: Merge.rc:5337
 #, c-format
 msgid ""
 "\n"
@@ -8277,7 +8271,7 @@ msgstr ""
 "Első különbség (Alt+Home)"
 
 #. ID_CURDIFF
-#: Merge.rc:5339
+#: Merge.rc:5338
 #, c-format
 msgid ""
 "\n"
@@ -8287,7 +8281,7 @@ msgstr ""
 "Aktuális különbség (Alt+Enter)"
 
 #. ID_LASTDIFF
-#: Merge.rc:5340
+#: Merge.rc:5339
 #, c-format
 msgid ""
 "\n"
@@ -8297,37 +8291,37 @@ msgstr ""
 "Utolsó különbség (Alt+End)"
 
 #. ID_L2R
-#: Merge.rc:5341
+#: Merge.rc:5340
 msgid "\nCopy to Right (Alt+Right)"
 msgstr "\nMásolás jobbra (Alt+Jobbra)"
 
 #. ID_R2L
-#: Merge.rc:5342
+#: Merge.rc:5341
 msgid "\nCopy to Left (Alt+Left)"
 msgstr "\nMásolás balra (Alt+Balra)"
 
 #. ID_L2RNEXT
-#: Merge.rc:5343
+#: Merge.rc:5342
 msgid "\nCopy to Right and Advance (Ctrl+Alt+Right)"
 msgstr "\nMásolás jobbra, továbblépés (Ctrl+Alt+Jobbra)"
 
 #. ID_R2LNEXT
-#: Merge.rc:5344
+#: Merge.rc:5343
 msgid "\nCopy to Left and Advance (Ctrl+Alt+Left)"
 msgstr "\nMásolás balra, továbblépés (Ctrl+Alt+Balra)"
 
 #. ID_ALL_RIGHT
-#: Merge.rc:5345
+#: Merge.rc:5344
 msgid "\nCopy All to Right"
 msgstr "\nAz összes másolása jobbra"
 
 #. ID_ALL_LEFT
-#: Merge.rc:5346
+#: Merge.rc:5345
 msgid "\nCopy All to Left"
 msgstr "\nAz összes másolása balra"
 
 #. ID_AUTO_MERGE
-#: Merge.rc:5347
+#: Merge.rc:5346
 #, c-format
 msgid ""
 "\n"
@@ -8337,7 +8331,7 @@ msgstr ""
 "Automatikus egyesítés (Ctrl+Alt+M)"
 
 #. ID_FIRSTFILE
-#: Merge.rc:5348
+#: Merge.rc:5347
 msgid ""
 "\n"
 "First File"
@@ -8346,7 +8340,7 @@ msgstr ""
 "Első fájl"
 
 #. ID_NEXTFILE
-#: Merge.rc:5349
+#: Merge.rc:5348
 msgid ""
 "\n"
 "Next File (Ctrl+F8)"
@@ -8355,7 +8349,7 @@ msgstr ""
 "Következő fájl (Ctrl+F8)"
 
 #. ID_LASTFILE
-#: Merge.rc:5350
+#: Merge.rc:5349
 msgid ""
 "\n"
 "Last File"
@@ -8364,7 +8358,7 @@ msgstr ""
 "Utolsó fájl"
 
 #. ID_PREVFILE
-#: Merge.rc:5351
+#: Merge.rc:5350
 msgid ""
 "\n"
 "Previous File (Ctrl+F7)"
@@ -8373,156 +8367,156 @@ msgstr ""
 "Előző fájl (Ctrl+F7)"
 
 #. IDS_UNPACK_AUTO
-#: Merge.rc:5358
+#: Merge.rc:5357
 msgid "Adapted unpacker applied to both files (one needs extension)."
 msgstr "A választott kicsomagoló lesz használva mindkét fájlnál (az egyik fájlnak csak a kiterjesztése lényeges)."
 
 #. IDS_NO_PREDIFFER
-#: Merge.rc:5359
+#: Merge.rc:5358
 #, c-format
 msgid "No Prediffer (Normal)"
 msgstr "Nincs elővizsgálat (normál)"
 
 #. IDS_SUGGESTED_PLUGINS
-#: Merge.rc:5360
+#: Merge.rc:5359
 #, c-format
 msgid "Suggested Plugins"
 msgstr "Javasolt bővítmények"
 
 #. IDS_NOT_SUGGESTED_PLUGINS
-#: Merge.rc:5361
+#: Merge.rc:5360
 msgid "All Plugins"
 msgstr "Minden bővítmény"
 
 #. IDS_PRIVATEBUILD_FMT
-#: Merge.rc:5367
+#: Merge.rc:5366
 #, c-format
 msgid "Private Build: %1"
 msgstr "Saját verzió: %1"
 
 #. IDS_ALLRIGHTS_RESERVED
-#: Merge.rc:5368
+#: Merge.rc:5367
 msgid " - All rights reserved."
 msgstr "- Minden jog fenntartva."
 
 #. IDS_TITLE_PLUGINS_SETTINGS
-#: Merge.rc:5374
+#: Merge.rc:5373
 #, c-format
 msgid "Plugin Settings"
 msgstr "Bővítmény beállítások"
 
 #. IDS_NO_SCT_SCRIPTS
-#: Merge.rc:5376
+#: Merge.rc:5375
 #, c-format
 msgid "WSH not found - .sct scripts disabled"
 msgstr "A WSH nem található - Az .sct szkriptek le lesznek tiltva"
 
 #. IDS_LOCBAR_GOTOLINE_FMT
-#: Merge.rc:5384
+#: Merge.rc:5383
 #, c-format
 msgid "G&o to Line %1"
 msgstr "&Ugrás a(z) %1. sorra"
 
 #. IDS_GOTO_MOVED_LINE
-#: Merge.rc:5390
+#: Merge.rc:5389
 msgid "Go to Moved Line\tCtrl+Shift+G"
 msgstr "Ugrás az áthelyezett sorhoz\tCtrl+Shift+G"
 
 #. IDS_AUTOCOMPLETE_DISABLED
-#: Merge.rc:5396
+#: Merge.rc:5395
 msgctxt "Options dialog|General|Open dialog Auto completion"
 msgid "Disabled"
 msgstr "Letiltva"
 
 #. IDS_AUTOCOMPLETE_FILE_SYS
-#: Merge.rc:5397
+#: Merge.rc:5396
 #, c-format
 msgid "From file system"
 msgstr "A fájlrendszerből"
 
 #. IDS_AUTOCOMPLETE_MRU
-#: Merge.rc:5398
+#: Merge.rc:5397
 #, c-format
 msgid "From Most Recently Used list"
 msgstr "A legutóbb használtakból"
 
 #. IDS_COLORSCHEME_PLAIN
-#: Merge.rc:5404
+#: Merge.rc:5403
 #, c-format
 msgid "No Highlighting"
 msgstr "Nincs kiemelés"
 
 #. IDS_COLORSCHEME_PO
-#: Merge.rc:5439
+#: Merge.rc:5438
 #, c-format
 msgid "Portable Object"
 msgstr "Hordozható objektum"
 
 #. IDS_COLORSCHEME_RSRC
-#: Merge.rc:5444
+#: Merge.rc:5443
 #, c-format
 msgid "Resources"
 msgstr "Erőforrások"
 
 #. IDS_COLORSCHEME_SH
-#: Merge.rc:5448
+#: Merge.rc:5447
 #, c-format
 msgid "Shell"
 msgstr "Shell"
 
 #. IDS_CLOSE_LEFT_TABS
-#: Merge.rc:5469
+#: Merge.rc:5468
 #, c-format
 msgid "Close &Left Tabs"
 msgstr "Bal tabulátorok bezárása"
 
 #. IDS_CLOSE_RIGHT_TABS
-#: Merge.rc:5470
+#: Merge.rc:5469
 #, c-format
 msgid "Close R&ight Tabs"
 msgstr "Jobb tabulátorok bezárása"
 
 #. IDS_CLOSE_OTHER_TABS
-#: Merge.rc:5471
+#: Merge.rc:5470
 #, c-format
 msgid "Close &Other Tabs"
 msgstr "Többi tabulátor bezárása"
 
 #. IDS_TABBAR_AUTO_MAXWIDTH
-#: Merge.rc:5472
+#: Merge.rc:5471
 #, c-format
 msgid "Enable &Auto Max Width"
 msgstr "Auto oszlopszélesség be"
 
 #. IDS_WEBPAGE_MENU
-#: Merge.rc:5482
+#: Merge.rc:5481
 msgid "We&bpage"
 msgstr "Weboldal"
 
 #. IDS_VIEW_WRAP_TEXT
-#: Merge.rc:5487
+#: Merge.rc:5486
 msgid "W&rap Text"
 msgstr "Szöveg tördelése"
 
 #. IDS_NOTINSTALLED
-#: Merge.rc:5492
+#: Merge.rc:5491
 msgid "%1 is not installed."
 msgstr "Az %1 hexa szerkesztő nincs telepítve."
 
 #. IDS_CREATE_FOLDER
-#: Merge.rc:5497
+#: Merge.rc:5496
 #, c-format
 msgid "%1 does not exist. Create it?"
 msgstr "%1 nem létezik. Létrehozod?"
 
 #. IDS_CREATE_FOLDER_ERROR
-#: Merge.rc:5498
+#: Merge.rc:5497
 #, c-format
 msgid "Failed to create folder."
 msgstr "Nem sikerült a mappa létrehozása."
 
 #. IDC_EXT_EDITOR_PATH
-#: Merge.rc:5503
+#: Merge.rc:5502
 #, c-format
 msgid ""
 "Parameters:\n"
@@ -8534,908 +8528,908 @@ msgstr ""
 "$linenum: A kurzor aktuális pozíciója sorának száma"
 
 #. IDS_DIFF_ALGORITHM_DEFAULT
-#: Merge.rc:5508
+#: Merge.rc:5507
 msgid "default"
 msgstr "alapbeállítás"
 
 #. IDS_DIFF_ALGORITHM_MINIMAL
-#: Merge.rc:5509
+#: Merge.rc:5508
 msgid "minimal"
 msgstr "minimális"
 
 #. IDS_DIFF_ALGORITHM_PATIENCE
-#: Merge.rc:5510
+#: Merge.rc:5509
 msgid "patience"
 msgstr "kitartó"
 
 #. IDS_DIFF_ALGORITHM_HISTOGRAM
-#: Merge.rc:5511
+#: Merge.rc:5510
 msgid "histogram"
 msgstr "hisztogram"
 
 #. IDS_DIFF_ALGORITHM_NONE
-#: Merge.rc:5512
+#: Merge.rc:5511
 msgid "none"
 msgstr "nincs"
 
 #. IDS_RENDERING_MODE_GDI
-#: Merge.rc:5517
+#: Merge.rc:5516
 msgid "GDI"
 msgstr "GDI"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_DEFAULT
-#: Merge.rc:5518
+#: Merge.rc:5517
 msgid "DirectWrite Default"
 msgstr "DirectWrite Default"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_ALIASED
-#: Merge.rc:5519
+#: Merge.rc:5518
 msgid "DirectWrite Aliased"
 msgstr "DirectWrite Aliased"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_GDI_CLASSIC
-#: Merge.rc:5520
+#: Merge.rc:5519
 msgid "DirectWrite GDI Classic"
 msgstr "DirectWrite GDI Classic"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_GDI_NATURAL
-#: Merge.rc:5521
+#: Merge.rc:5520
 msgid "DirectWrite GDI Natural"
 msgstr "DirectWrite GDI Natural"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_NATURAL
-#: Merge.rc:5522
+#: Merge.rc:5521
 msgid "DirectWrite Natural"
 msgstr "DirectWrite Natural"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_NATURAL_SYMMETRIC
-#: Merge.rc:5523
+#: Merge.rc:5522
 msgid "DirectWrite Natural Symmetric"
 msgstr "DirectWrite Natural Symmetric"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_DISABLED
-#: Merge.rc:5528
+#: Merge.rc:5527
 msgctxt "Options dialog|General|Close windows with Esc"
 msgid "Disabled"
 msgstr "Letiltva"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_1
-#: Merge.rc:5529
+#: Merge.rc:5528
 msgid "MDI child window or main window"
 msgstr "MDI gyermekablak vagy főablak"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_2
-#: Merge.rc:5530
+#: Merge.rc:5529
 msgid "MDI child window only"
 msgstr "Csak MDI gyermekablak"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_3
-#: Merge.rc:5531
+#: Merge.rc:5530
 msgid "Close main window if only one MDI child window"
 msgstr "A főablak bezárása, ha csak 1 MDI gyermekablak van?"
 
 #. IDS_DIFF_GROUP
-#: Merge.rc:5536
+#: Merge.rc:5535
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Diff"
 msgstr "Különbség"
 
 #. IDS_DIFF_HIGHLIGHT
-#: Merge.rc:5537
+#: Merge.rc:5536
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Highlight"
 msgstr "Kiemelés"
 
 #. IDS_DIFF_BLINK
-#: Merge.rc:5538
+#: Merge.rc:5537
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Blink"
 msgstr "Villogás"
 
 #. IDS_DIFF_BLOCKSIZE
-#: Merge.rc:5539
+#: Merge.rc:5538
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Block Size"
 msgstr "Blokkméret"
 
 #. IDS_DIFF_BLOCKALPHA
-#: Merge.rc:5540
+#: Merge.rc:5539
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Block Alpha"
 msgstr "Alfa blokk"
 
 #. IDS_DIFF_CDTHRESHOLD
-#: Merge.rc:5541
+#: Merge.rc:5540
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "CD Threshold"
 msgstr "CD küszöbérték"
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION
-#: Merge.rc:5542
+#: Merge.rc:5541
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Ins/Del Detection"
 msgstr "Beszúrás/Törlés érzékelés"
 
 #. IDS_OVERLAY_MODE_NONE
-#: Merge.rc:5543 Merge.rc:5548
+#: Merge.rc:5542 Merge.rc:5547
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "None"
 msgstr "Nincs"
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION_VERTICAL
-#: Merge.rc:5544
+#: Merge.rc:5543
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Vertical"
 msgstr "Függőleges"
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION_HORIZONTAL
-#: Merge.rc:5545
+#: Merge.rc:5544
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Horizontal"
 msgstr "Vízszintes"
 
 #. IDS_OVERLAY_GROUP
-#: Merge.rc:5546
+#: Merge.rc:5545
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Overlay"
 msgstr "Átfedés"
 
 #. IDS_OVERLAY_ALPHA
-#: Merge.rc:5547
+#: Merge.rc:5546
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha"
 msgstr "Alfa"
 
 #. IDS_OVERLAY_MODE_XOR
-#: Merge.rc:5549
+#: Merge.rc:5548
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "XOR"
 msgstr "XOR"
 
 #. IDS_OVERLAY_MODE_ALPHA
-#: Merge.rc:5550
+#: Merge.rc:5549
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha Blend"
 msgstr "Átlátszóság"
 
 #. IDS_OVERLAY_MODE_ALPHA_ANIMATION
-#: Merge.rc:5551
+#: Merge.rc:5550
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha Animation"
 msgstr "Átlátszóság animáció"
 
 #. IDS_ZOOM
-#: Merge.rc:5552
+#: Merge.rc:5551
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Zoom"
 msgstr "Nagyítás"
 
 #. IDS_PAGE
-#: Merge.rc:5553
+#: Merge.rc:5552
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Page:"
 msgstr "Oldal:"
 
 #. IDS_IMGCMP_STATUS_PT_RGBA_FMT
-#: Merge.rc:5554
+#: Merge.rc:5553
 #, c-format
 msgid "Pt: (%d, %d)  RGBA: (%d, %d, %d, %d)  "
 msgstr "Pont: (%d, %d)  RGBA: (%d, %d, %d, %d)  "
 
 #. IDS_IMGCMP_STATUS_DIST1_FMT
-#: Merge.rc:5555
+#: Merge.rc:5554
 #, c-format
 msgid "Dist: %g  "
 msgstr "Táv: %g  "
 
 #. IDS_IMGCMP_STATUS_DIST2_FMT
-#: Merge.rc:5556
+#: Merge.rc:5555
 #, c-format
 msgid "Dist: %g, %g  "
 msgstr "Táv: %g, %g  "
 
 #. IDS_IMGCMP_STATUS_PAGE_ZOOM_SIZE_BPP_FMT
-#: Merge.rc:5557
+#: Merge.rc:5556
 #, c-format
 msgid "Page: %d/%d  Zoom: %d%%  %dx%dpx  %dbpp  "
 msgstr "Oldal: %d/%d  Nagyítás: %d%%  %dx%dképpont  %dbpp  "
 
 #. IDS_IMGCMP_STATUS_RC_FMT
-#: Merge.rc:5558
+#: Merge.rc:5557
 #, c-format
 msgid "Rc: (%d, %d)  "
 msgstr "Rc: (%d, %d)  "
 
 #. IDS_IMGCMP_STATUS_FLIPPED_FMT
-#: Merge.rc:5559
+#: Merge.rc:5558
 #, c-format
 msgid "Flipped: %s  "
 msgstr "Megfordítva: %s  "
 
 #. IDS_IMGCMP_STATUS_ROTATED_FMT
-#: Merge.rc:5560
+#: Merge.rc:5559
 #, c-format
 msgid "Rotated: %d  "
 msgstr "Elforgatva: %d  "
 
 #. IDS_IMGCMP_REPORT_ALLPAGES
-#: Merge.rc:5561
+#: Merge.rc:5560
 msgid "All pages"
 msgstr "Minden oldal"
 
 #. IDS_IGNSUB_STR1
-#: Merge.rc:5566
+#: Merge.rc:5565
 msgid "<Edit here>"
 msgstr "<Szerkesztés itt>"
 
 #. IDS_IGNSUB_STR2
-#: Merge.rc:5567
+#: Merge.rc:5566
 msgid "No differences found to select"
 msgstr "Nem található kijelölhető különbség"
 
 #. IDS_IGNSUB_STR3
-#: Merge.rc:5568
+#: Merge.rc:5567
 msgid "No differences found to add as substitution filter"
 msgstr "Nem található helyettesítő szűrőként megadható különbség"
 
 #. IDS_IGNSUB_STR4
-#: Merge.rc:5569
+#: Merge.rc:5568
 msgid "The pair is already in the Substitution Filters list"
 msgstr "Ez a páros már szerepel a helyettesítő szűrők listáján"
 
 #. IDS_IGNSUB_STR5
-#: Merge.rc:5570
+#: Merge.rc:5569
 msgid "Add this change to Substitution Filters?"
 msgstr "Hozzáadod ezt a változást a helyettesítési szűrőkhöz?"
 
 #. IDS_OCRRESULT_TEXTONLY
-#: Merge.rc:5575
+#: Merge.rc:5574
 msgid "Text only"
 msgstr "Csak szöveg"
 
 #. IDS_OCRRESULT_POS_LINE
-#: Merge.rc:5576
+#: Merge.rc:5575
 msgid "Line-by-line position and text"
 msgstr "Pozíció és szöveg sorról sorra"
 
 #. IDS_OCRRESULT_POS_WORD
-#: Merge.rc:5577
+#: Merge.rc:5576
 msgid "Word-by-word position and text"
 msgstr "Pozíció és szöveg szóról szóra"
 
 #. IDS_USERDATAFOLDER_APPDATA
-#: Merge.rc:5582
+#: Merge.rc:5581
 msgid "AppData (Roaming) folder"
 msgstr "AppData (Roaming) mappa"
 
 #. IDS_USERDATAFOLDER_INSTALL
-#: Merge.rc:5583
+#: Merge.rc:5582
 msgid "Install folder"
 msgstr "Telepítési mappa"
 
 #. IDS_USERDATAFOLDER_DOCUMENTS
-#: Merge.rc:5584
+#: Merge.rc:5583
 msgid "Documents folder"
 msgstr "Dokumentumok mappa"
 
 #. IDS_SINGLEINSTANCE_DISABLED
-#: Merge.rc:5589
+#: Merge.rc:5588
 msgctxt "Options dialog|General|Single instance mode"
 msgid "Disabled"
 msgstr "Letiltva"
 
 #. IDS_SINGLEINSTANCE_STR1
-#: Merge.rc:5590
+#: Merge.rc:5589
 msgid "Allow only one instance to run"
 msgstr "Csak egy példány futhat egyszerre"
 
 #. IDS_CLIPBOARD_HISTORY
-#: Merge.rc:5591
+#: Merge.rc:5590
 msgid "Clipboard &History"
 msgstr "Vágólap &előzmények"
 
 #. IDS_SINGLEINSTANCE_STR2
-#: Merge.rc:5592
+#: Merge.rc:5591
 msgid "Allow only one instance; wait for termination"
 msgstr "Csak egy példány futhat és megvárja, amíg a példány leáll"
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_DISABLED
-#: Merge.rc:5597
+#: Merge.rc:5596
 msgctxt "Options dialog|General|Auto-reload modified files"
 msgid "Disabled"
 msgstr "Letiltva"
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_STR1
-#: Merge.rc:5598
+#: Merge.rc:5597
 msgid "Only on window activated"
 msgstr "Csak ablakon aktivált"
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_STR2
-#: Merge.rc:5599
+#: Merge.rc:5598
 msgid "Immediately"
 msgstr "Azonnal"
 
 #. IDS_PLUGIN_ALL
-#: Merge.rc:5604
+#: Merge.rc:5603
 msgid "Al&l"
 msgstr "Összes"
 
 #. IDS_PLUGIN_OTHERS
-#: Merge.rc:5605
+#: Merge.rc:5604
 msgid "&Others"
 msgstr "Egyéb"
 
-#: Merge.rc:5607
+#: Merge.rc:5606
 #, c-format
 msgid "Missing plugin name in pipeline: %1"
 msgstr "Hiányzó bővítménynév a bővítmény pipeline-ban: %1"
 
-#: Merge.rc:5609
+#: Merge.rc:5608
 #, c-format
 msgid "Missing quote in plugin pipeline: %1"
 msgstr "Hiányzó idézőjel a bővítmény pipeline-ban: %1"
 
 #. IDS_PLUGIN_NAME_ALREADY_EXISTS
-#: Merge.rc:5610
+#: Merge.rc:5609
 #, c-format
 msgid "Plugin name '%1' already exists."
 msgstr "Ez a bővítménynév már létezik: '%1' "
 
 #. IDS_PLUGIN_TITLE1
-#: Merge.rc:5611
+#: Merge.rc:5610
 msgid "Specify plugin arguments"
 msgstr "Bővítmény argumentumok megadása"
 
-#: Merge.rc:5613
+#: Merge.rc:5612
 #, c-format
 msgid "Plugin not found or invalid: %1"
 msgstr "A bővítmény nem található vagy érvénytelen: %1"
 
 #. IDS_PLUGIN_NOT_UNPACK
-#: Merge.rc:5614
+#: Merge.rc:5613
 #, c-format
 msgid "'%1' is not an unpacker plugin"
 msgstr "A(z) '%1' nem kitömörítő bővítmény"
 
 #. IDS_PLUGIN_NOT_PREDIFF
-#: Merge.rc:5615
+#: Merge.rc:5614
 #, c-format
 msgid "'%1' is not a prediffer plugin"
 msgstr "A(z) '%1' nem elővizsgáló bővítmény""
 
-#: Merge.rc:5617
+#: Merge.rc:5616
 #, c-format
 msgid "Error prediffing '%1' with '%2'. Prediffing disabled."
 msgstr "Hiba történt a(z) „%1” fájl „%2” bővítménnyel történő elővizsgálatakor. Az elővizsgálat többé nem kerül alkalmazásra."
 
 #. IDS_PLUGIN_CIRCULAR_REFERENCE
-#: Merge.rc:5618
+#: Merge.rc:5617
 #, c-format
 msgid "Circular reference in plugin pipeline: %1"
 msgstr "Körkörös hivatkozás a beépülő bővítményben: %1"
 
 #. IDS_PLUGIN_TYPE1
-#: Merge.rc:5619
+#: Merge.rc:5618
 msgid "URL Handler"
 msgstr "URL Kezelő"
 
 #. IDS_PLUGIN_TYPE2
-#: Merge.rc:5620
+#: Merge.rc:5619
 msgid "File Unpacker"
 msgstr "Fájl kitömörítő"
 
 #. IDS_PLUGIN_TYPE3
-#: Merge.rc:5621
+#: Merge.rc:5620
 msgid "File or Folder Unpacker"
 msgstr "Fájl vagy mappa kitömörítő"
 
 #. IDS_PLUGIN_TYPE5
-#: Merge.rc:5623
+#: Merge.rc:5622
 msgid "Alias for Unpacker"
 msgstr "Kitömörítő alias"
 
 #. IDS_PLUGIN_TYPE6
-#: Merge.rc:5624
+#: Merge.rc:5623
 msgid "Alias for Prediffer"
 msgstr "Elővizsgáló alias"
 
 #. IDS_PLUGIN_TYPE7
-#: Merge.rc:5625
+#: Merge.rc:5624
 msgid "Alias for Editor script"
 msgstr "Szerkesztőszkript alias"
 
 #. IDS_PLUGIN_ALIAS_DESC
-#: Merge.rc:5626
+#: Merge.rc:5625
 #, c-format
 msgid "Alias for plugin pipeline '%1'"
 msgstr "'%1' bővítmény pipeline alias"
 
 #. IDS_PLUGIN_NEW_DESC
-#: Merge.rc:5627
+#: Merge.rc:5626
 msgid "New plugin description"
 msgstr "Új bővítmény leírás"
 
 #. IDS_PLUGIN_TARGETS_ALL
-#: Merge.rc:5628
+#: Merge.rc:5627
 msgid "All"
 msgstr "Összes"
 
 #. IDS_PLUGIN_TARGETS_1ST
-#: Merge.rc:5629
+#: Merge.rc:5628
 msgid "1st"
 msgstr "1."
 
 #. IDS_PLUGIN_TARGETS_2ND
-#: Merge.rc:5630
+#: Merge.rc:5629
 msgid "2nd"
 msgstr "2."
 
 #. IDS_PLUGIN_TARGETS_3RD
-#: Merge.rc:5631
+#: Merge.rc:5630
 msgid "3rd"
 msgstr "3."
 
 #. IDS_PLUGIN_TARGETS_1ST_2ND
-#: Merge.rc:5632
+#: Merge.rc:5631
 msgid "1st and 2nd"
 msgstr "1. és 2."
 
 #. IDS_PLUGIN_TARGETS_1ST_3RD
-#: Merge.rc:5633
+#: Merge.rc:5632
 msgid "1st and 3rd"
 msgstr "1. és 3."
 
 #. IDS_PLUGIN_TARGETS_2ND_3RD
-#: Merge.rc:5634
+#: Merge.rc:5633
 msgid "2nd and 3rd"
 msgstr "2. és 3."
 
 #. IDS_PLUGIN_CTRL_CLICK
-#: Merge.rc:5635
+#: Merge.rc:5634
 msgid "(Ctrl+Click to add to pipeline)"
 msgstr ""
 
 #. IDS_FILTER_APPLIED
-#: Merge.rc:5640
+#: Merge.rc:5639
 msgid "Filter applied"
 msgstr "Szűrő alkalmazva"
 
 #. IDS_FILTERMENU_COMPARE
-#: Merge.rc:5645
+#: Merge.rc:5644
 #, c-format
 msgid "Compare %1"
 msgstr "Összehasonlítás %1"
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN2
-#: Merge.rc:5647
+#: Merge.rc:5646
 msgid "&Filter by This Column..."
 msgstr "&Szűrés ezen oszlop alapján..."
 
 #. IDS_CLIPBOARDHISTORY_TIME
-#: Merge.rc:5652
+#: Merge.rc:5651
 #, c-format
 msgid "Clipboard at %s"
 msgstr "Vágólap itt: %s"
 
 #. IDS_CLIPBOARDHISTORY_DISABLED
-#: Merge.rc:5653
+#: Merge.rc:5652
 msgid "Clipboard history disabled.\r\nEnable: Windows logo key + V, then Turn on."
 msgstr "Vágólap előzmények letiltva.\r\nAz engedélyezéshez nyomd meg a Win+V gombokat, majd kattints a bekapcsolás gombra"
 
-#: Merge.rc:5655
+#: Merge.rc:5654
 msgid "This system does not support clipboard history."
 msgstr "Ez a rendszer nem támogatja a vágólap előzményeket"
 
-#: Merge.rc:5657
+#: Merge.rc:5656
 msgid "32-bit WinMerge does not support Clipboard Compare"
 msgstr "A WinMerge 32 bites verziója nem támogatja a vágólap összehasonlítást"
 
 #. IDS_WEBVIEW2_RUNTIME_NOT_INSTALLED
-#: Merge.rc:5662
+#: Merge.rc:5661
 msgid "WebView2 runtime not installed. Download it?"
 msgstr "A WebView2 runtime nincs telepítve. Le akarod tölteni?"
 
 #. IDS_JUMPLIST_NEW_TEXT_COMPARE
-#: Merge.rc:5667
+#: Merge.rc:5666
 msgid "New Text Compare"
 msgstr "Új szöveg összehasonlítás"
 
 #. IDS_JUMPLIST_NEW_TABLE_COMPARE
-#: Merge.rc:5668
+#: Merge.rc:5667
 msgid "New Table Compare"
 msgstr "Új táblázat összehasonlítás"
 
 #. IDS_JUMPLIST_NEW_BINARY_COMPARE
-#: Merge.rc:5669
+#: Merge.rc:5668
 msgid "New Binary Compare"
 msgstr "Új bináris összehasonlítás"
 
 #. IDS_JUMPLIST_NEW_IMAGE_COMPARE
-#: Merge.rc:5670
+#: Merge.rc:5669
 msgid "New Image Compare"
 msgstr "Új kép összehasonlítás"
 
 #. IDS_JUMPLIST_NEW_WEBPAGE_COMPARE
-#: Merge.rc:5671
+#: Merge.rc:5670
 msgid "New Webpage Compare"
 msgstr "Új weboldal összehasonlítás"
 
 #. IDS_JUMPLIST_NEW_FOLDER_COMPARE
-#: Merge.rc:5672
+#: Merge.rc:5671
 msgid "New Folder Compare"
 msgstr "Új mappa összehasonlítás"
 
 #. IDS_JUMPLIST_CLIPBOARD_COMPARE
-#: Merge.rc:5673
+#: Merge.rc:5672
 msgid "Clipboard Compare"
 msgstr "Vágólap összehasonlítás"
 
 #. IDS_PREVIEWBAR_PRINT
-#: Merge.rc:5678
+#: Merge.rc:5677
 msgid "&Print..."
 msgstr "&Nyomtatás..."
 
 #. IDS_PREVIEWBAR_PREVPAGE
-#: Merge.rc:5680
+#: Merge.rc:5679
 msgid "Pre&v Page"
 msgstr "Kö&vetkező oldal"
 
 #. IDS_PREVIEWBAR_TWOPAGE
-#: Merge.rc:5681
+#: Merge.rc:5680
 msgid "&Two Page"
 msgstr "&Két oldal"
 
 #. IDS_PREVIEWBAR_ONEPAGE
-#: Merge.rc:5682
+#: Merge.rc:5681
 msgid "&One Page"
 msgstr "&Egy oldal"
 
 #. IDS_PREVIEWBAR_ZOOMIN
-#: Merge.rc:5683
+#: Merge.rc:5682
 msgid "Zoom &In"
 msgstr "&Nagyítás"
 
 #. IDS_PREVIEWBAR_ZOOMOUT
-#: Merge.rc:5684
+#: Merge.rc:5683
 msgid "Zoom &Out"
 msgstr "K&icsinyítés"
 
 #. IDS_WEBPAGE_COMPARING
-#: Merge.rc:5690
+#: Merge.rc:5689
 msgid "Comparing..."
 msgstr "Összehasonlítás..."
 
 #. IDS_WEBPAGE_ZOOM
-#: Merge.rc:5691
+#: Merge.rc:5690
 msgid "Zoom:"
 msgstr "Nagyítás:"
 
 #. IDS_COPY_GRANULARITY_DIFFHUNK
-#: Merge.rc:5696
+#: Merge.rc:5695
 msgid "Diff hunk"
 msgstr "Különb.nagyság"
 
 #. IDS_COPY_GRANULARITY_INLINE
-#: Merge.rc:5697
+#: Merge.rc:5696
 msgid "Inline diff"
 msgstr "Soron belüli kül."
 
 #. IDS_COPY_GRANULARITY_LINE
-#: Merge.rc:5698
+#: Merge.rc:5697
 msgid "Line"
 msgstr "Sor"
 
-#: Merge.rc:5699
+#: Merge.rc:5698
 msgid "Character"
 msgstr "Karakter"
 
 #. ID_MICE_PREVDIFF
-#: Merge.rc:5704
+#: Merge.rc:5703
 msgid "\nPrevious Difference (Alt+Up)\n(Right Button+Wheel Up)\n(Alt+Wheel Up)"
 msgstr "\nElőző különbség (Alt+fel)\n(Jobb gomb+görgő fel)\n(Alt+görgő fel)"
 
 #. ID_MICE_NEXTDIFF
-#: Merge.rc:5705
+#: Merge.rc:5704
 msgid "\nNext Difference (Alt+Down)\n(Right Button+Wheel Down)\n(Alt+Wheel Down)"
 msgstr "\nKövetkező különbség (Alt+le)\n(Jobb gomb+görgő le)\n(Alt+görgő le)"
 
 #. ID_MICE_L2R
-#: Merge.rc:5706
+#: Merge.rc:5705
 msgid "\nCopy to Right (Alt+Right)\n(Right Button+Wheel Right)\n(Alt+Wheel Right)\n(Alt+Shift+Wheel Down)"
 msgstr "\nMásolás jobbra (Alt+jobbra)\n(Jobb gomb+görgő jobbra)\n(Alt+görgő jobbra)\n(Alt+Shift+görgő le)"
 
 #. ID_MICE_R2L
-#: Merge.rc:5707
+#: Merge.rc:5706
 msgid "\nCopy to Left (Alt+Left)\n(Right Button+Wheel Left)\n(Alt+Wheel Left)\n(Alt+Shift+Wheel Up)"
 msgstr "\nMásolás balra (Alt+balra)\n(Jobb gomb+görgő balra)\n(Alt+görgő balra)\n(Alt+Shift+görgő fel)"
 
 #. ID_MICE_L2RNEXT
-#: Merge.rc:5708
+#: Merge.rc:5707
 msgid "\nCopy to Right and Advance (Ctrl+Alt+Right)\n(Ctrl+Alt+Wheel Right)\n(Ctrl+Alt+Shift+Wheel Down)"
 msgstr "\nMásolás jobbra és előre (Ctrl+Alt+jobbra)\n(Ctrl+Alt+görgő jobbra)\n(Ctrl+Alt+Shift+görgő le)"
 
 #. ID_MICE_R2LNEXT
-#: Merge.rc:5709
+#: Merge.rc:5708
 msgid "\nCopy to Left and Advance (Ctrl+Alt+Left)\n(Ctrl+Alt+Wheel Left)\n(Ctrl+Alt+Shift+Wheel Up)"
 msgstr "\nMásolás balra és előre (Ctrl+Alt+balra)\n(Ctrl+Alt+görgő balra)\n(Ctrl+Alt+Shift+görgő fel)"
 
 #. IDS_LOG_COMPARING_2
-#: Merge.rc:5719
+#: Merge.rc:5718
 #, c-format
 msgid "Comparing %1 with %2"
 msgstr "%1 összehasonlítása ezzel: %2"
 
 #. IDS_LOG_COMPARING_3
-#: Merge.rc:5720
+#: Merge.rc:5719
 #, c-format
 msgid "Comparing %1 with %2 and %3"
 msgstr "%1 összehasonlítása ezekkel: %2 és %3"
 
 #. IDS_LOG_COMPARE_COMPLETED
-#: Merge.rc:5721
+#: Merge.rc:5720
 msgid "Comparison completed"
 msgstr "Összehasonlítás kész"
 
 #. IDS_LOG_COMPARE_ERROR_2
-#: Merge.rc:5722
+#: Merge.rc:5721
 #, c-format
 msgid "Failed to compare %1 with %2: "
 msgstr "Nem sikerült %1 összehasonlítása ezzel: %2"
 
 #. IDS_LOG_COMPARE_ERROR_3
-#: Merge.rc:5723
+#: Merge.rc:5722
 #, c-format
 msgid "Failed to compare %1 with %2 and %3: "
 msgstr "Nem sikerült %1 összehasonlítása ezekkel: %2 és %3"
 
 #. IDS_LOG_FILE_SAVED
-#: Merge.rc:5724
+#: Merge.rc:5723
 msgid "File saved"
 msgstr "Fájl mentve"
 
 #. IDS_LOG_COPYING_FILES
-#: Merge.rc:5725
+#: Merge.rc:5724
 msgid "Copying files..."
 msgstr "Fájlok másolása..."
 
 #. IDS_LOG_MOVING_FILES
-#: Merge.rc:5726
+#: Merge.rc:5725
 msgid "Moving files..."
 msgstr "Fájlok áthelyezése..."
 
 #. IDS_LOG_DELETING_FILES
-#: Merge.rc:5727
+#: Merge.rc:5726
 msgid "Deleting files..."
 msgstr "Fájlok törlése..."
 
 #. IDS_LOG_RECYCLEBIN
-#: Merge.rc:5728
+#: Merge.rc:5727
 msgid "Recycle Bin"
 msgstr "Lomtár"
 
 #. IDS_LOG_PERMANENTLY_DELETED
-#: Merge.rc:5729
+#: Merge.rc:5728
 msgid "Permanently deleted"
 msgstr "Véglegesen törölve"
 
 #. IDS_LOG_FILEOPERATION_COMPLETED
-#: Merge.rc:5730
+#: Merge.rc:5729
 msgid "File operation completed successfully"
 msgstr "A fájlművelet sikeresen befejeződött"
 
 #. IDS_LOG_FILEOPERATION_CANCELED
-#: Merge.rc:5731
+#: Merge.rc:5730
 msgid "File operation canceled"
 msgstr "A fájlművelet megszakítva"
 
 #. IDS_FILTER_ERROR_NO_ERROR
-#: Merge.rc:5736
+#: Merge.rc:5735
 msgid "No error"
 msgstr "Nincs hiba"
 
 #. IDS_FILTER_ERROR_EMPTY_EXPRESSION
-#: Merge.rc:5737
+#: Merge.rc:5736
 msgid "Filter expression is empty"
 msgstr "A szűrőkifejezés üres"
 
 #. IDS_FILTER_ERROR_UNKNOWN_CHAR
-#: Merge.rc:5738
+#: Merge.rc:5737
 msgid "Unknown character in filter expression"
 msgstr "Ismeretlen karakter a szűrőkifejezésben"
 
 #. IDS_FILTER_ERROR_UNTERMINATED_STRING
-#: Merge.rc:5739
+#: Merge.rc:5738
 msgid "Unterminated string literal"
 msgstr "Le nem zárt szting literális"
 
 #. IDS_FILTER_ERROR_SYNTAX_ERROR
-#: Merge.rc:5740
+#: Merge.rc:5739
 msgid "Syntax error in filter expression"
 msgstr "Szintaxishiba a szűrőkifejezésben"
 
 #. IDS_FILTER_ERROR_PARSE_FAILURE
-#: Merge.rc:5741
+#: Merge.rc:5740
 msgid "Failed to parse filter expression"
 msgstr "Nem sikerült elemezni a szűrőkifejezést"
 
 #. IDS_FILTER_ERROR_INVALID_LITERAL
-#: Merge.rc:5742
+#: Merge.rc:5741
 msgid "Invalid literal value"
 msgstr "Érvénytelen literális érték"
 
 #. IDS_FILTER_ERROR_INVALID_REGULAR_EXPRESSION
-#: Merge.rc:5743
+#: Merge.rc:5742
 msgid "Invalid regular expression"
 msgstr "Érvénytelen reguláris kifejezés"
 
 #. IDS_FILTER_ERROR_UNDEFINED_IDENTIFIER
-#: Merge.rc:5744
+#: Merge.rc:5743
 msgid "Undefined identifier"
 msgstr "Meghatározatlan azonosító"
 
 #. IDS_FILTER_ERROR_INVALID_ARGUMENT_COUNT
-#: Merge.rc:5745
+#: Merge.rc:5744
 msgid "Invalid number of arguments"
 msgstr "Érvénytelen számú argumentum"
 
 #. IDS_FILTER_ERROR_FILTER_NAME_NOT_FOUND
-#: Merge.rc:5746
+#: Merge.rc:5745
 msgid "Filter name not found"
 msgstr "A szűrő neve nem található"
 
 #. IDS_FILTER_ERROR_DIVIDE_BY_ZERO
-#: Merge.rc:5747
+#: Merge.rc:5746
 msgid "Division by zero in filter expression"
 msgstr "Nullával való osztás a szűrőkifejezésben"
 
 #. IDS_FILTER_ERROR_UNKNOWN_ERROR
-#: Merge.rc:5748
+#: Merge.rc:5747
 msgid "Unknown error"
 msgstr "Ismeretlen hiba"
 
 #. IDS_FILTER_ERROR_INVALID_PROPERTY_NAME
-#: Merge.rc:5749
+#: Merge.rc:5748
 msgid "Invalid property name"
 msgstr "Érvénytelen tulajdonságnév"
 
 #. IDS_FILTER_ERROR_INVALID_DIRECTIVE
-#: Merge.rc:5750
+#: Merge.rc:5749
 msgid "Invalid directive"
 msgstr "Érvénytelen utasítás"
 
 #. IDS_FILTER_OP_EQUALS
-#: Merge.rc:5755
+#: Merge.rc:5754
 msgid "Equals"
 msgstr "Egyenlők"
 
 #. IDS_FILTER_OP_NOT_EQUALS
-#: Merge.rc:5756
+#: Merge.rc:5755
 msgid "Does not equal"
 msgstr "Nem egyenlő"
 
 #. IDS_FILTER_OP_LESS_THAN
-#: Merge.rc:5757
+#: Merge.rc:5756
 msgid "Less than"
 msgstr "Kevesebb, mint"
 
 #. IDS_FILTER_OP_LESS_EQUAL
-#: Merge.rc:5758
+#: Merge.rc:5757
 msgid "Less than or equal to"
 msgstr "Kevesebb vagy egyenlő, mint"
 
 #. IDS_FILTER_OP_GREATER_EQUAL
-#: Merge.rc:5759
+#: Merge.rc:5758
 msgid "Greater than or equal to"
 msgstr "Nagyobb vagy egyenlő, mint"
 
 #. IDS_FILTER_OP_GREATER_THAN
-#: Merge.rc:5760
+#: Merge.rc:5759
 msgid "Greater than"
 msgstr "Nagyobb , mint"
 
 #. IDS_FILTER_OP_BETWEEN
-#: Merge.rc:5761
+#: Merge.rc:5760
 msgid "Between"
 msgstr "Ezek között"
 
 #. IDS_FILTER_OP_NOT_BETWEEN
-#: Merge.rc:5762
+#: Merge.rc:5761
 msgid "Not Between"
 msgstr "Nem ezek között"
 
 #. IDS_FILTER_OP_CONTAINS
-#: Merge.rc:5763
+#: Merge.rc:5762
 msgid "Contains"
 msgstr "Tartalmazza"
 
 #. IDS_FILTER_OP_NOT_CONTAINS
-#: Merge.rc:5764
+#: Merge.rc:5763
 msgid "Not Contains"
 msgstr "Nem tartalmazza"
 
 #. IDS_FILTER_OP_RECONTAINS
-#: Merge.rc:5765
+#: Merge.rc:5764
 msgid "Contains (regex)"
 msgstr "Tartalmazza (regex)"
 
 #. IDS_FILTER_OP_NOT_RECONTAINS
-#: Merge.rc:5766
+#: Merge.rc:5765
 msgid "Not Contains (regex)"
 msgstr "Nem tartalmazza (regex)"
 
 #. IDS_FILTER_OP_LIKE
-#: Merge.rc:5767
+#: Merge.rc:5766
 msgid "Match (wildcard)"
 msgstr "Egyezés (helyettesítő karakter)"
 
 #. IDS_FILTER_OP_NOT_LIKE
-#: Merge.rc:5768
+#: Merge.rc:5767
 msgid "Not match (wildcard)"
 msgstr "Nem egyezik (helyettesítő karakter)"
 
 #. IDS_FILTER_OP_MATCHES
-#: Merge.rc:5769
+#: Merge.rc:5768
 msgid "Match (regex)"
 msgstr "Egyezés (regex)"
 
 #. IDS_FILTER_OP_NOT_MATCHES
-#: Merge.rc:5770
+#: Merge.rc:5769
 msgid "Not match (regex)"
 msgstr "Nem egyezik (regex)"
 
 #. IDS_COLORMODE_LIGHT
-#: Merge.rc:5775
+#: Merge.rc:5774
 msgid "Light"
 msgstr "Világos"
 
 #. IDS_COLORMODE_DARK
-#: Merge.rc:5776
+#: Merge.rc:5775
 msgid "Dark"
 msgstr "Sötét"
 
 #. IDS_COLORMODE_FOLLOWSYSTEM
-#: Merge.rc:5777
+#: Merge.rc:5776
 msgid "Follow system"
 msgstr "Rendszert követi"
 
 #. IDS_EXAMPLE
-#: Merge.rc:5782
+#: Merge.rc:5781
 #, c-format
 msgid "e.g. %1"
 msgstr "pl %1"
 
 #. IDS_DETECTED_PREVIOUS_CRASH
-#: Merge.rc:5787
+#: Merge.rc:5786
 msgid "WinMerge detected a previous crash. Please report this if possible."
 msgstr "A WinMerge egy korábbi összeomlást észlelt. Kérjük, jelentse ezt, ha lehetséges."
 
 #. IDS_REGEX_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5792
+#: Merge.rc:5791
 msgid "# Regex replacement list\r\n# Format: regex<TAB>replacement\r\n# Backreferences like $1, $2 are supported\r\n\r\n(\\d{4})-(\\d{2})-(\\d{2})\t$1_$2_$3\r\n"
 msgstr "# Regex helyettesítési lista\r\n# Formátum: regex<TAB>csere\r\n# A $1 és $2-hez hasonló visszahivatkozások támogatottak\r\n\r\n(\\d{4})-(\\d{2})-(\\d{2})\t$1_$2_$3\r\n"
 
 #. IDS_STRING_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5793
+#: Merge.rc:5792
 msgid "# Replacement list\r\n# Format: search<TAB>replacement\r\n# Lines starting with # are ignored\r\n\r\nfrom1\tto1\r\nfrom2\tto2\r\n"
 msgstr "# Cserelista\r\n# Formátum: search<TAB>replacement\r\n# A # karakterrel kezdődő sorokat figyelmen kívül hagyja\r\n\r\n1-től 1-ig\r\n2-től 2-ig\r\n"
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_ONLY
-#: Merge.rc:5798
+#: Merge.rc:5797
 msgid "Built-in only"
 msgstr "Csak beépített"
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_FIRST
-#: Merge.rc:5799
+#: Merge.rc:5798
 msgid "Built-in first"
 msgstr "Beépített először"
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_FIRST
-#: Merge.rc:5800
+#: Merge.rc:5799
 msgid "Tree-sitter first"
 msgstr "Tree-sitter először"
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_ONLY
-#: Merge.rc:5801
+#: Merge.rc:5800
 msgid "Tree-sitter only"
 msgstr "Tree-sitter csak"
 

--- a/Translations/WinMerge/Italian.po
+++ b/Translations/WinMerge/Italian.po
@@ -24,7 +24,7 @@ msgstr ""
 "X-Poedit-SourceCharset: UTF-8\n"
 
 #. LANGUAGE, SUBLANGUAGE
-#: Merge.rc:26 Merge.rc:59 Merge.rc:5818
+#: Merge.rc:26 Merge.rc:59 Merge.rc:5817
 msgid "LANG_ENGLISH, SUBLANG_ENGLISH_US"
 msgstr "LANG_ITALIAN, SUBLANG_ITALIAN"
 
@@ -166,7 +166,7 @@ msgstr "&Script"
 #. IDS_NO_EDIT_SCRIPTS
 #: Merge.rc:127 Merge.rc:352 Merge.rc:463 Merge.rc:673 Merge.rc:678
 #: Merge.rc:887 Merge.rc:899 Merge.rc:906 Merge.rc:963 Merge.rc:1210
-#: Merge.rc:5375
+#: Merge.rc:5374
 msgid "< Empty >"
 msgstr "< Vuoto >"
 
@@ -231,7 +231,7 @@ msgid "Auto-Fit All Columns"
 msgstr "Adatta tutte le colonne"
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN
-#: Merge.rc:153 Merge.rc:5646
+#: Merge.rc:153 Merge.rc:5645
 msgid "&Filter by This Column"
 msgstr "&Filtra in base a questa colonna"
 
@@ -292,7 +292,7 @@ msgid "&Previous Page"
 msgstr "Pagina &precedente"
 
 #. IDS_PREVIEWBAR_NEXTPAGE
-#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5679
+#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5678
 msgid "&Next Page"
 msgstr "Pagina s&uccessiva"
 
@@ -543,7 +543,7 @@ msgstr "&Binario"
 #. IDS_IMAGE_MENU
 #: Merge.rc:329 Merge.rc:338 Merge.rc:432 Merge.rc:441 Merge.rc:609
 #: Merge.rc:618 Merge.rc:670 Merge.rc:960 Merge.rc:1187 Merge.rc:1200
-#: Merge.rc:5477
+#: Merge.rc:5476
 msgid "&Image"
 msgstr "&Immagine"
 
@@ -665,7 +665,7 @@ msgid "&Huge"
 msgstr "&Gigantesca"
 
 #. IDS_VIEW_MENU_BAR
-#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5714
+#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5713
 msgid "Men&u Bar"
 msgstr "Barra men&u"
 
@@ -1320,7 +1320,7 @@ msgid "Lo&cation Pane"
 msgstr "Pannello posi&zione"
 
 #. IDS_OUTPUTBAR_CAPTION
-#: Merge.rc:782 Merge.rc:5252
+#: Merge.rc:782 Merge.rc:5251
 msgid "Output Pane"
 msgstr "Pannello output"
 
@@ -1583,55 +1583,55 @@ msgid "Co&mpare As"
 msgstr "Con&fronta come"
 
 #. IDS_COPY_LEFT_TO_MIDDLE2
-#: Merge.rc:968 Merge.rc:980 Merge.rc:4852
+#: Merge.rc:968 Merge.rc:980 Merge.rc:4851
 #, c-format
 msgid "Left to Middle (%1 of %2)"
 msgstr "Da sinistra al centro (%1 di %2)"
 
 #. IDS_COPY_LEFT_TO_RIGHT2
-#: Merge.rc:969 Merge.rc:981 Merge.rc:4851
+#: Merge.rc:969 Merge.rc:981 Merge.rc:4850
 #, c-format
 msgid "Left to Right (%1 of %2)"
 msgstr "Da sinistra a destra (%1 di %2)"
 
 #. IDS_MOVE_LEFT_TO2
-#: Merge.rc:970 Merge.rc:982 Merge.rc:1045 Merge.rc:4863 Merge.rc:4892
+#: Merge.rc:970 Merge.rc:982 Merge.rc:1045 Merge.rc:4862 Merge.rc:4891
 #, c-format
 msgid "Left to... (%1 of %2)"
 msgstr "Da sinistra a... (%1 di %2)"
 
 #. IDS_COPY_MIDDLE_TO_LEFT2
-#: Merge.rc:971 Merge.rc:983 Merge.rc:4849
+#: Merge.rc:971 Merge.rc:983 Merge.rc:4848
 #, c-format
 msgid "Middle to Left (%1 of %2)"
 msgstr "Dal centro a sinistra (%1 di %2)"
 
 #. IDS_COPY_MIDDLE_TO_RIGHT2
-#: Merge.rc:972 Merge.rc:984 Merge.rc:4850
+#: Merge.rc:972 Merge.rc:984 Merge.rc:4849
 #, c-format
 msgid "Middle to Right (%1 of %2)"
 msgstr "Dal centro a destra (%1 di %2)"
 
 #. IDS_MOVE_MIDDLE_TO2
-#: Merge.rc:973 Merge.rc:985 Merge.rc:1046 Merge.rc:4864 Merge.rc:4893
+#: Merge.rc:973 Merge.rc:985 Merge.rc:1046 Merge.rc:4863 Merge.rc:4892
 #, c-format
 msgid "Middle to... (%1 of %2)"
 msgstr "Dal centro a... (%1 di %2)"
 
 #. IDS_COPY_RIGHT_TO_MIDDLE2
-#: Merge.rc:974 Merge.rc:986 Merge.rc:4848
+#: Merge.rc:974 Merge.rc:986 Merge.rc:4847
 #, c-format
 msgid "Right to Middle (%1 of %2)"
 msgstr "Da destra al centro (%1 di %2)"
 
 #. IDS_COPY_RIGHT_TO_LEFT2
-#: Merge.rc:975 Merge.rc:987 Merge.rc:4847
+#: Merge.rc:975 Merge.rc:987 Merge.rc:4846
 #, c-format
 msgid "Right to Left (%1 of %2)"
 msgstr "Da destra a sinistra (%1 di %2)"
 
 #. IDS_MOVE_RIGHT_TO2
-#: Merge.rc:976 Merge.rc:988 Merge.rc:1047 Merge.rc:4865 Merge.rc:4894
+#: Merge.rc:976 Merge.rc:988 Merge.rc:1047 Merge.rc:4864 Merge.rc:4893
 #, c-format
 msgid "Right to... (%1 of %2)"
 msgstr "Da destra a... (%1 di %2)"
@@ -1687,31 +1687,31 @@ msgid "Cop&y Paths"
 msgstr "Cop&ia percorsi"
 
 #. IDS_DEL_LEFT_FMT2
-#: Merge.rc:1026 Merge.rc:1035 Merge.rc:4880
+#: Merge.rc:1026 Merge.rc:1035 Merge.rc:4879
 #, c-format
 msgid "Left (%1 of %2)"
 msgstr "Sinistra (%1 di %2)"
 
 #. IDS_DEL_MIDDLE_FMT2
-#: Merge.rc:1027 Merge.rc:1036 Merge.rc:4881
+#: Merge.rc:1027 Merge.rc:1036 Merge.rc:4880
 #, c-format
 msgid "Middle (%1 of %2)"
 msgstr "Centro (%1 di %2)"
 
 #. IDS_DEL_RIGHT_FMT2
-#: Merge.rc:1028 Merge.rc:1037 Merge.rc:4882
+#: Merge.rc:1028 Merge.rc:1037 Merge.rc:4881
 #, c-format
 msgid "Right (%1 of %2)"
 msgstr "Destra (%1 di %2)"
 
 #. IDS_DEL_BOTH_FMT2
-#: Merge.rc:1029 Merge.rc:1038 Merge.rc:4883
+#: Merge.rc:1029 Merge.rc:1038 Merge.rc:4882
 #, c-format
 msgid "Both (%1 of %2)"
 msgstr "Entrambi (%1 di %2)"
 
 #. IDS_DEL_ALL_FMT2
-#: Merge.rc:1030 Merge.rc:1039 Merge.rc:4888
+#: Merge.rc:1030 Merge.rc:1039 Merge.rc:4887
 #, c-format
 msgid "All (%1 of %2)"
 msgstr "Tutti (%1 di %2)"
@@ -1737,19 +1737,19 @@ msgid "&Zip"
 msgstr "Crea &zip"
 
 #. IDS_COPY_BOTH_TO2
-#: Merge.rc:1048 Merge.rc:4866
+#: Merge.rc:1048 Merge.rc:4865
 #, c-format
 msgid "Both to... (%1 of %2)"
 msgstr "Entrambi a... (%1 di %2)"
 
 #. IDS_COPY_ALL_TO2
-#: Merge.rc:1049 Merge.rc:4867
+#: Merge.rc:1049 Merge.rc:4866
 #, c-format
 msgid "All to... (%1 of %2)"
 msgstr "Tutti a... (%1 di %2)"
 
 #. IDS_COPY_DIFFERENCES_TO2
-#: Merge.rc:1050 Merge.rc:4868
+#: Merge.rc:1050 Merge.rc:4867
 #, c-format
 msgid "Differences to... (%1 of %2)"
 msgstr "Differenza a... (%1 di %2)"
@@ -1816,12 +1816,12 @@ msgstr "Impostazioni decompressione"
 
 #. IDS_USERCHOICE_NONE
 #: Merge.rc:1088 Merge.rc:1094 Merge.rc:1836 Merge.rc:1840 Merge.rc:2031
-#: Merge.rc:2035 Merge.rc:5377
+#: Merge.rc:2035 Merge.rc:5376
 msgid "<None>"
 msgstr "<Nessuno>"
 
 #. IDS_USERCHOICE_AUTOMATIC
-#: Merge.rc:1089 Merge.rc:1095 Merge.rc:5378
+#: Merge.rc:1089 Merge.rc:1095 Merge.rc:5377
 msgid "<Automatic>"
 msgstr "<Automatico>"
 
@@ -2751,12 +2751,12 @@ msgid "Text files only"
 msgstr "Solo file testo"
 
 #. IDS_EOL_NONE
-#: Merge.rc:1667 Merge.rc:1918 Merge.rc:5304
+#: Merge.rc:1667 Merge.rc:1918 Merge.rc:5303
 msgid "None"
 msgstr "Nessuno"
 
 #. IDS_EOL_MIXED
-#: Merge.rc:1668 Merge.rc:5299
+#: Merge.rc:1668 Merge.rc:5298
 msgid "Mixed"
 msgstr "Mescolato"
 
@@ -3028,13 +3028,13 @@ msgstr "&Stato linea"
 
 #. IDS_DIFFERENT
 #: Merge.rc:1904 Merge.rc:1988 Merge.rc:2866 Merge.rc:3036 Merge.rc:3077
-#: Merge.rc:5058
+#: Merge.rc:5057
 msgid "Different"
 msgstr "Diversi"
 
 #. IDS_IDENTICAL
 #: Merge.rc:1905 Merge.rc:1989 Merge.rc:2865 Merge.rc:3055 Merge.rc:3116
-#: Merge.rc:5048
+#: Merge.rc:5047
 msgid "Identical"
 msgstr "Identici"
 
@@ -3054,7 +3054,7 @@ msgid "Missing"
 msgstr "Mancante"
 
 #. IDS_MOVED
-#: Merge.rc:1910 Merge.rc:5076
+#: Merge.rc:1910 Merge.rc:5075
 msgid "Moved"
 msgstr "Spostato"
 
@@ -3797,7 +3797,7 @@ msgid "&Use custom system colors"
 msgstr "&Usa colori sistema personalizzati"
 
 #. IDS_PRPCAT_SYSTEM
-#: Merge.rc:2565 Merge.rc:4559 Merge.rc:4560 Merge.rc:5007
+#: Merge.rc:2565 Merge.rc:4559 Merge.rc:4560 Merge.rc:5006
 msgid "System"
 msgstr "Sistema"
 
@@ -4201,7 +4201,7 @@ msgid "Items compared:"
 msgstr "Elementi confrontati:"
 
 #. IDS_PREVIEWBAR_CLOSE
-#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5685
+#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5684
 msgid "&Close"
 msgstr "&Chiudi"
 
@@ -4826,7 +4826,7 @@ msgid "A&ppend timestamp"
 msgstr "Aggiungi marca &temporale"
 
 #. IDS_CONFIRM_COPY_CAPTION
-#: Merge.rc:3214 Merge.rc:4915
+#: Merge.rc:3214 Merge.rc:4914
 msgid "Confirm Copy"
 msgstr "Conferma copia"
 
@@ -5063,7 +5063,7 @@ msgid "&Character Set..."
 msgstr "Set &caratteri..."
 
 #. IDS_PRPCAT_IMAGE
-#: Merge.rc:3351 Merge.rc:4574 Merge.rc:5015
+#: Merge.rc:3351 Merge.rc:4574 Merge.rc:5014
 msgid "Image"
 msgstr "Immagine"
 
@@ -5467,7 +5467,7 @@ msgid "Project"
 msgstr "Progetto"
 
 #. IDS_COLHDR_NSDIFFS
-#: Merge.rc:4566 Merge.rc:4990
+#: Merge.rc:4566 Merge.rc:4989
 msgid "Differences"
 msgstr "Differenze"
 
@@ -5616,12 +5616,12 @@ msgid "File Type"
 msgstr "Tipo file"
 
 #. IDS_COLHDR_EXTENSION
-#: Merge.rc:4653 Merge.rc:4947
+#: Merge.rc:4653 Merge.rc:4946
 msgid "Extension"
 msgstr "Estensione"
 
 #. IDS_PRPCAT_MESSAGE
-#: Merge.rc:4659 Merge.rc:5019
+#: Merge.rc:4659 Merge.rc:5018
 msgid "Message"
 msgstr "Messaggio"
 
@@ -5661,7 +5661,7 @@ msgid "Hidden Items"
 msgstr "Elementi nascosti"
 
 #. IDS_PLUGINSLIST_NAME
-#: Merge.rc:4680 Merge.rc:5311
+#: Merge.rc:4680 Merge.rc:5310
 msgid "Name"
 msgstr "Nome"
 
@@ -5681,7 +5681,7 @@ msgid "[F] "
 msgstr "[F] "
 
 #. IDS_PLUGINSLIST_DESC
-#: Merge.rc:4684 Merge.rc:5313
+#: Merge.rc:4684 Merge.rc:5312
 msgid "Description"
 msgstr "Descrizione"
 
@@ -5854,155 +5854,150 @@ msgstr "Ln: %s  Col: %d/%d  Car: %d/%d"
 msgid "  Sel: %d | %d"
 msgstr " Sel: %d | %d"
 
-#. IDS_MERGEMODE_MERGING
-#: Merge.rc:4734
-msgid "Merge"
-msgstr "Unione"
-
 #. IDS_DIFF_NUMBER_STATUS_FMT
-#: Merge.rc:4735
+#: Merge.rc:4734
 #, c-format
 msgid "Difference %1 of %2"
 msgstr "Differenza %1 di %2"
 
 #. IDS_NO_DIFF_SEL_FMT
-#: Merge.rc:4736
+#: Merge.rc:4735
 #, c-format
 msgid "%1 Differences Found"
 msgstr "%1 differenze trovate"
 
 #. IDS_1_DIFF_FOUND
-#: Merge.rc:4737
+#: Merge.rc:4736
 msgid "1 Difference Found"
 msgstr "1 differenza trovata"
 
 #. IDS_NO_ERR_SEL_FMT
-#: Merge.rc:4738
+#: Merge.rc:4737
 #, c-format
 msgid "%1 Errors Found"
 msgstr "Trovati %1 errori"
 
 #. IDS_1_ERR_FOUND
-#: Merge.rc:4739
+#: Merge.rc:4738
 msgid "1 Error Found"
 msgstr "Trovato 1 errore"
 
 #. IDS_STATUSBAR_READONLY, Abbreviation from "Read Only"
-#: Merge.rc:4740
+#: Merge.rc:4739
 msgid "RO"
 msgstr "SL"
 
 #. IDS_DIRVIEW_STATUS_FMT_FOCUS
-#: Merge.rc:4746
+#: Merge.rc:4745
 #, c-format
 msgid "Item %1 of %2"
 msgstr "Elemento %1 di %2"
 
 #. IDS_DIRVIEW_STATUS_FMT_NOFOCUS
-#: Merge.rc:4747
+#: Merge.rc:4746
 #, c-format
 msgid "Items: %1"
 msgstr "Elementi: %1"
 
 #. IDS_DIRVIEW_STATUS_COMPARING
-#: Merge.rc:4748
+#: Merge.rc:4747
 msgid "Comparing items..."
 msgstr "Confronto elementi..."
 
 #. IDS_ITEMS_PER_SEC
-#: Merge.rc:4749
+#: Merge.rc:4748
 #, c-format
 msgid "%.1f[items/sec]"
 msgstr "%.1f[elementi/sec]"
 
 #. IDS_ERROR_INCOMPARABLE
-#: Merge.rc:4755
+#: Merge.rc:4754
 msgid "Select two existing folders/files to compare."
 msgstr "Seleziona due cartelle o file esistenti da confrontare."
 
 #. IDS_DIRSEL_TAG
-#: Merge.rc:4756
+#: Merge.rc:4755
 msgid "Folder Selection"
 msgstr "Selezione cartella"
 
 #. IDS_OPEN_FILESDIRS
-#: Merge.rc:4757
+#: Merge.rc:4756
 msgid "Select two (or three) folders/files to compare."
 msgstr "Seleziona due (o tre) cartelle o due (o tre) file da confrontare."
 
 #. IDS_OPEN_LEFTINVALID
-#: Merge.rc:4758
+#: Merge.rc:4757
 msgid "Left (1st) path is invalid!"
 msgstr "Il percorso di sinistra (1°) non è valido!"
 
 #. IDS_OPEN_MIDDLEINVALID
-#: Merge.rc:4759
+#: Merge.rc:4758
 msgid "Middle (2nd) path is invalid!"
 msgstr "Il percorso centrale (2°) non è valido!"
 
 #. IDS_OPEN_RIGHTINVALID2
-#: Merge.rc:4760
+#: Merge.rc:4759
 msgid "Right (2nd) path is invalid!"
 msgstr "Il percorso di destra (2°) non è valido!"
 
 #. IDS_OPEN_RIGHTINVALID3
-#: Merge.rc:4761
+#: Merge.rc:4760
 msgid "Right (3rd) path is invalid!"
 msgstr "Il percorso di destra (3°) non è valido!"
 
 #. IDS_OPEN_BOTHINVALID
-#: Merge.rc:4762
+#: Merge.rc:4761
 msgid "Both paths are invalid!"
 msgstr "Entrambi i percorsi non sono validi!"
 
-#: Merge.rc:4764
+#: Merge.rc:4763
 msgid "Left (1st) and Middle (2nd) paths are invalid!"
 msgstr "I percorsi di sinistra (1°) e centrale (2°) non sono validi!"
 
 #. IDS_OPEN_LEFTRIGHTINVALID
-#: Merge.rc:4765
+#: Merge.rc:4764
 msgid "Left (1st) and Right (3rd) paths are invalid!"
 msgstr "I percorsi di sinistra (1°) e di destra (3°) non sono validi!"
 
-#: Merge.rc:4767
+#: Merge.rc:4766
 msgid "Middle (2nd) and Right (3rd) paths are invalid!"
 msgstr "I percorsi centrale (2°) e di destra (3°) non sono validi!"
 
 #. IDS_OPEN_ALLINVALID
-#: Merge.rc:4768
+#: Merge.rc:4767
 msgid "All paths are invalid!"
 msgstr "Tutti i percorsi non sono validi!"
 
 #. IDS_OPEN_UNPACKERDISABLED
-#: Merge.rc:4769
+#: Merge.rc:4768
 msgid "Only enabled for file comparisons"
 msgstr "Abilitato solo per il confronto tra file"
 
 #. IDS_OPEN_MISMATCH
-#: Merge.rc:4770
+#: Merge.rc:4769
 msgid "Cannot compare file and folder!"
 msgstr "Impossibile confrontare file e cartelle!"
 
 #. IDS_ERROR_FILE_NOT_FOUND
-#: Merge.rc:4776
+#: Merge.rc:4775
 #, c-format
 msgid "File not found: %1"
 msgstr "File non trovato: %1"
 
 #. IDS_ERROR_FOLDER_NOT_FOUND
-#: Merge.rc:4777
+#: Merge.rc:4776
 #, c-format
 msgid "Folder not found: %1"
 msgstr "Cartella non trovata"
 
 #. IDS_ERROR_FILE_NOT_UNPACKED
-#: Merge.rc:4778
+#: Merge.rc:4777
 #, c-format
 msgid "File not unpacked: %1"
 msgstr "File non decompresso: %1"
 
 #. IDS_ERROR_FILEOPEN
-#: Merge.rc:4779
+#: Merge.rc:4778
 #, c-format
 msgid ""
 "Cannot open file\n"
@@ -6016,12 +6011,12 @@ msgstr ""
 "%2"
 
 #. IDS_ERROR_CONF_RESOLVE
-#: Merge.rc:4780
+#: Merge.rc:4779
 msgid "Failed to parse conflict file."
 msgstr "Non è stato possibile analizzare il file del conflitto."
 
 #. IDS_NOT_CONFLICT_FILE
-#: Merge.rc:4781
+#: Merge.rc:4780
 #, c-format
 msgid ""
 "The file\n"
@@ -6033,7 +6028,7 @@ msgstr ""
 "non è un file del conflitto."
 
 #. IDS_COMPARE_LARGE_FILES
-#: Merge.rc:4782
+#: Merge.rc:4781
 msgid ""
 "Comparing large files requires significant memory.\n"
 "Show only comparison results (not file contents)?"
@@ -6044,29 +6039,29 @@ msgstr ""
 "file)?"
 
 #. IDS_SAVE_AS_TITLE
-#: Merge.rc:4788
+#: Merge.rc:4787
 msgid "Save As"
 msgstr "Salva con nome"
 
 #. IDS_SAVE_FMT
-#: Merge.rc:4789
+#: Merge.rc:4788
 #, c-format
 msgid "Save changes to %1?"
 msgstr "Vuoi salvare le modifiche in %1?"
 
 #. IDS_SAVEREADONLY_FMT
-#: Merge.rc:4790
+#: Merge.rc:4789
 #, c-format
 msgid "%1 is read-only. Override? Or 'No' to save as new filename?"
 msgstr ""
 "%1 è in sola lettura. Vuoi sovrascriverlo?"
 
 #. IDS_ERROR_BACKUP
-#: Merge.rc:4791
+#: Merge.rc:4790
 msgid "Error backing up file"
 msgstr "Errore durante il salvataggio di una copia di backup del file"
 
-#: Merge.rc:4793
+#: Merge.rc:4792
 #, c-format
 msgid ""
 "Unable to backup original file:\n"
@@ -6080,7 +6075,7 @@ msgstr ""
 "Vuoi continuare comunque?"
 
 #. IDS_FILESAVE_FAILED
-#: Merge.rc:4794
+#: Merge.rc:4793
 #, c-format
 msgid ""
 "Saving file failed.\n"
@@ -6096,7 +6091,7 @@ msgstr ""
 "\t- usare un nome diverso per il file (seleziona 'OK')\n"
 "\t- annullare l'operazione attuale (seleziona 'Annulla')?"
 
-#: Merge.rc:4796
+#: Merge.rc:4795
 #, c-format
 msgid ""
 "Plugin '%2' cannot pack changes to left file into '%1'.\n"
@@ -6110,7 +6105,7 @@ msgstr ""
 "\n"
 "Vuoi salvare la versione non compressa in un altro file?"
 
-#: Merge.rc:4798
+#: Merge.rc:4797
 #, c-format
 msgid ""
 "Plugin '%2' cannot pack changes to middle file into '%1'.\n"
@@ -6124,7 +6119,7 @@ msgstr ""
 "\n"
 "Vuoi salvare la versione decompressa in un altro file?"
 
-#: Merge.rc:4800
+#: Merge.rc:4799
 #, c-format
 msgid ""
 "Plugin '%2' cannot pack changes to right file into '%1'.\n"
@@ -6139,7 +6134,7 @@ msgstr ""
 "Vuoi salvare la versione non compressa in un altro file?"
 
 #. IDS_FILECHANGED_ONDISK
-#: Merge.rc:4801
+#: Merge.rc:4800
 #, c-format
 msgid ""
 "Another application updated\n"
@@ -6155,7 +6150,7 @@ msgstr ""
 "Vuoi sovrascrivere il file modificato?"
 
 #. IDS_SAVEREADONLY_MULTI
-#: Merge.rc:4802
+#: Merge.rc:4801
 #, c-format
 msgid ""
 "%1\n"
@@ -6165,7 +6160,7 @@ msgstr ""
 "è in sola lettura. Vuoi sovrascriverlo?"
 
 #. IDS_FILECHANGED_RESCAN
-#: Merge.rc:4803
+#: Merge.rc:4802
 #, c-format
 msgid ""
 "Another application updated\n"
@@ -6181,22 +6176,22 @@ msgstr ""
 "Vuoi ricaricare il file modificato?"
 
 #. IDS_SAVE_LEFT_AS
-#: Merge.rc:4804
+#: Merge.rc:4803
 msgid "Save Left File As"
 msgstr "Salva il file di sinistra con nome"
 
 #. IDS_SAVE_MIDDLE_AS
-#: Merge.rc:4805
+#: Merge.rc:4804
 msgid "Save Middle File As"
 msgstr "Salva il file centrale con nome"
 
 #. IDS_SAVE_RIGHT_AS
-#: Merge.rc:4806
+#: Merge.rc:4805
 msgid "Save Right File As"
 msgstr "Salva il file di destra con nome"
 
 #. IDS_FILE_DISAPPEARED
-#: Merge.rc:4811
+#: Merge.rc:4810
 #, c-format
 msgid ""
 "File\n"
@@ -6209,7 +6204,7 @@ msgstr ""
 "Per continuare salva una copia del file."
 
 #. IDS_VIEWS_OUTOFSYNC
-#: Merge.rc:4817
+#: Merge.rc:4816
 msgid ""
 "Cannot merge unsynched documents.\n"
 "\n"
@@ -6220,186 +6215,186 @@ msgstr ""
 "Aggiorna i documenti prima di continuare."
 
 #. IDS_BREAK_ON_WHITESPACE
-#: Merge.rc:4822
+#: Merge.rc:4821
 msgid "Break at whitespace"
 msgstr "Interrompi agli spazi"
 
 #. IDS_BREAK_ON_PUNCTUATION
-#: Merge.rc:4823
+#: Merge.rc:4822
 msgid "Break at whitespace or punctuation"
 msgstr "Interrompi agli spazi o alla punteggiatura"
 
 #. IDS_L2M
-#: Merge.rc:4829
+#: Merge.rc:4828
 msgid "Copy to &Middle\tAlt+Right"
 msgstr "Copia al &centro\tAlt+Destra"
 
 #. IDS_R2M
-#: Merge.rc:4830
+#: Merge.rc:4829
 msgid "Copy to &Middle\tAlt+Left"
 msgstr "Copia al &centro\tAlt+Sinistra"
 
 #. IDS_COPY_FROM_MIDDLE_R
-#: Merge.rc:4831
+#: Merge.rc:4830
 msgid "Copy from Middle\tAlt+Shift+Right"
 msgstr "Copia dal centro\tAlt+Maiusc+Destra"
 
 #. IDS_COPY_FROM_MIDDLE_L
-#: Merge.rc:4832
+#: Merge.rc:4831
 msgid "Copy from Middle\tAlt+Shift+Left"
 msgstr "Copia dal centro\tAlt+Maiusc+Sinistra"
 
 #. IDS_L2MNEXT
-#: Merge.rc:4833
+#: Merge.rc:4832
 msgid "Copy to Middle and Advance\tCtrl+Alt+Right"
 msgstr "Copia al centro e vai alla successiva\tCtrl+Alt+Destra"
 
 #. IDS_R2MNEXT
-#: Merge.rc:4834
+#: Merge.rc:4833
 msgid "Copy to Middle and Advance\tCtrl+Alt+Left"
 msgstr "Copia al centro e vai alla successiva\tCtrl+Alt+Sinistra"
 
 #. IDS_ALL_MIDDLE
-#: Merge.rc:4835
+#: Merge.rc:4834
 msgid "Copy All to Middle"
 msgstr "Copia tutto al centro"
 
 #. IDS_COPY_RIGHT_TO_LEFT
-#: Merge.rc:4841
+#: Merge.rc:4840
 #, c-format
 msgid "Right to Left (%1)"
 msgstr "Da destra a sinistra (%1)"
 
 #. IDS_COPY_RIGHT_TO_MIDDLE
-#: Merge.rc:4842
+#: Merge.rc:4841
 #, c-format
 msgid "Right to Middle (%1)"
 msgstr "Da destra al centro (%1)"
 
 #. IDS_COPY_MIDDLE_TO_LEFT
-#: Merge.rc:4843
+#: Merge.rc:4842
 #, c-format
 msgid "Middle to Left (%1)"
 msgstr "Dal centro a sinistra (%1)"
 
 #. IDS_COPY_MIDDLE_TO_RIGHT
-#: Merge.rc:4844
+#: Merge.rc:4843
 #, c-format
 msgid "Middle to Right (%1)"
 msgstr "Dal centro a destra (%1)"
 
 #. IDS_COPY_LEFT_TO_RIGHT
-#: Merge.rc:4845
+#: Merge.rc:4844
 #, c-format
 msgid "Left to Right (%1)"
 msgstr "Da sinistra a destra (%1)"
 
 #. IDS_COPY_LEFT_TO_MIDDLE
-#: Merge.rc:4846
+#: Merge.rc:4845
 #, c-format
 msgid "Left to Middle (%1)"
 msgstr "Da sinistra al centro (%1)"
 
 #. IDS_MOVE_LEFT_TO
-#: Merge.rc:4857 Merge.rc:4889
+#: Merge.rc:4856 Merge.rc:4888
 #, c-format
 msgid "Left to... (%1)"
 msgstr "Da sinistra a... (%1)"
 
 #. IDS_MOVE_MIDDLE_TO
-#: Merge.rc:4858 Merge.rc:4890
+#: Merge.rc:4857 Merge.rc:4889
 #, c-format
 msgid "Middle to... (%1)"
 msgstr "Dal centro a... (%1)"
 
 #. IDS_MOVE_RIGHT_TO
-#: Merge.rc:4859 Merge.rc:4891
+#: Merge.rc:4858 Merge.rc:4890
 #, c-format
 msgid "Right to... (%1)"
 msgstr "Da destra a... (%1)"
 
 #. IDS_COPY_BOTH_TO
-#: Merge.rc:4860
+#: Merge.rc:4859
 #, c-format
 msgid "Both to... (%1)"
 msgstr "Entrambi a... (%1)"
 
 #. IDS_COPY_ALL_TO
-#: Merge.rc:4861
+#: Merge.rc:4860
 #, c-format
 msgid "All to... (%1)"
 msgstr "Tutti a... (%1)"
 
 #. IDS_COPY_DIFFERENCES_TO
-#: Merge.rc:4862
+#: Merge.rc:4861
 #, c-format
 msgid "Differences to... (%1)"
 msgstr "Differenze a... (%1)"
 
 #. IDS_ONLYDIFFITEMS_CONFIRM
-#: Merge.rc:4869
+#: Merge.rc:4868
 msgid "Some selected items are identical or skipped.\nProcess only items with differences?"
 msgstr "Alcuni elementi selezionati sono identici o saltati.\nVuoi elaborare solo gli elementi con differenze?"
 
 #. IDS_DEL_LEFT_FMT
-#: Merge.rc:4875
+#: Merge.rc:4874
 #, c-format
 msgid "Left (%1)"
 msgstr "Sinistra (%1)"
 
 #. IDS_DEL_MIDDLE_FMT
-#: Merge.rc:4876
+#: Merge.rc:4875
 #, c-format
 msgid "Middle (%1)"
 msgstr "Centro (%1)"
 
 #. IDS_DEL_RIGHT_FMT
-#: Merge.rc:4877
+#: Merge.rc:4876
 #, c-format
 msgid "Right (%1)"
 msgstr "Destra (%1)"
 
 #. IDS_DEL_BOTH_FMT
-#: Merge.rc:4878
+#: Merge.rc:4877
 #, c-format
 msgid "Both (%1)"
 msgstr "Entrambi (%1)"
 
 #. IDS_DEL_ALL_FMT
-#: Merge.rc:4879
+#: Merge.rc:4878
 #, c-format
 msgid "All (%1)"
 msgstr "Tutti (%1)"
 
 #. IDS_SELECT_DEST_LEFT
-#: Merge.rc:4895
+#: Merge.rc:4894
 msgid "Left Side - Select Destination Folder:"
 msgstr "Lato sinistro - seleziona cartella di destinazione:"
 
 #. IDS_SELECT_DEST_MIDDLE
-#: Merge.rc:4896
+#: Merge.rc:4895
 msgid "Middle Side - Select Destination Folder:"
 msgstr "Lato centrale - seleziona cartella di destinazione:"
 
 #. IDS_SELECT_DEST_RIGHT
-#: Merge.rc:4897
+#: Merge.rc:4896
 msgid "Right Side - Select Destination Folder:"
 msgstr "Lato destro - seleziona cartella di destinazione:"
 
 #. IDS_FILES_AFFECTED_FMT
-#: Merge.rc:4898
+#: Merge.rc:4897
 #, c-format
 msgid "(%1 Files Affected)"
 msgstr "(%1 file interessati)"
 
 #. IDS_FILES_AFFECTED_FMT2
-#: Merge.rc:4899
+#: Merge.rc:4898
 #, c-format
 msgid "(%1 of %2 Files Affected)"
 msgstr "(%1 di %2 file interessati)"
 
 #. IDS_CONFIRM_DELETE_SINGLE
-#: Merge.rc:4905
+#: Merge.rc:4904
 #, c-format
 msgid ""
 "Are you sure you want to delete\n"
@@ -6411,18 +6406,18 @@ msgstr ""
 "%1 ?"
 
 #. IDS_CONFIRM_SINGLE_COPY
-#: Merge.rc:4906
+#: Merge.rc:4905
 msgid "Are you sure you want to copy?"
 msgstr "Sei sicuro di voler copiare?"
 
 #. IDS_CONFIRM_MULTIPLE_COPY
-#: Merge.rc:4907
+#: Merge.rc:4906
 #, c-format
 msgid "Are you sure you want to copy %d items?"
 msgstr "Sei sicuro di voler copiare %d elementi?"
 
 #. IDS_DIRCMP_NOTSYNC
-#: Merge.rc:4908
+#: Merge.rc:4907
 #, c-format
 msgid ""
 "Operation aborted!\n"
@@ -6442,50 +6437,50 @@ msgstr ""
 "Aggiorna il confronto."
 
 #. IDS_CONFIRM_SINGLE_MOVE
-#: Merge.rc:4913
+#: Merge.rc:4912
 msgid "Are you sure you want to move?"
 msgstr "Spostare?"
 
 #. IDS_CONFIRM_MULTIPLE_MOVE
-#: Merge.rc:4914
+#: Merge.rc:4913
 #, c-format
 msgid "Are you sure you want to move %d items?"
 msgstr "Sei sicuro di voler spostare %d elementi?"
 
 #. IDS_CONFIRM_MOVE_CAPTION
-#: Merge.rc:4916
+#: Merge.rc:4915
 msgid "Confirm Move"
 msgstr "Conferma spostamento"
 
-#: Merge.rc:4918
+#: Merge.rc:4917
 msgid "Close the folder comparison window?"
 msgstr ""
 "Si sta per chiudere la finestra che sta confrontando le cartelle.\n"
 "Vuoi chiudere la finestra?"
 
-#: Merge.rc:4920
+#: Merge.rc:4919
 msgid "Close the folder comparison window, which took a long time?"
 msgstr ""
 "Vuoi chiudere la finestra di confronto delle cartelle, che ha richiesto "
 "molto tempo?"
 
 #. IDS_ERROR_INVALID_DIR_FILE_NAME
-#: Merge.rc:4921
+#: Merge.rc:4920
 msgid "The file or folder name is invalid."
 msgstr "Il nome file o cartella non è valido."
 
 #. IDS_ERROR_EXECUTE_FILE
-#: Merge.rc:4927
+#: Merge.rc:4926
 #, c-format
 msgid "Failed to execute external editor: %1"
 msgstr "Impossibile avviare l'editor esterno: %1"
 
 #. IDS_UNKNOWN_ARCHIVE_FORMAT
-#: Merge.rc:4933
+#: Merge.rc:4932
 msgid "Unknown archive format"
 msgstr "Formato archivio sconosciuto"
 
-#: Merge.rc:4935
+#: Merge.rc:4934
 msgid ""
 "Failed to extract archive.\n"
 "Compare as text file?"
@@ -6494,752 +6489,752 @@ msgstr ""
 "Vuoi confrontare i file archivio come file testo?"
 
 #. IDS_COLHDR_FILENAME
-#: Merge.rc:4941
+#: Merge.rc:4940
 msgid "Filename"
 msgstr "Nome file"
 
 #. IDS_COLHDR_DIR
-#: Merge.rc:4942
+#: Merge.rc:4941
 msgctxt "DirView|ColumnHeader"
 msgid "Folder"
 msgstr "Cartella"
 
 #. IDS_COLHDR_RESULT
-#: Merge.rc:4943
+#: Merge.rc:4942
 msgid "Comparison Result"
 msgstr "Risultato confronto"
 
 #. IDS_COLHDR_LTIMEM
-#: Merge.rc:4944
+#: Merge.rc:4943
 msgid "Left Date"
 msgstr "Data di sinistra"
 
 #. IDS_COLHDR_RTIMEM
-#: Merge.rc:4945
+#: Merge.rc:4944
 msgid "Right Date"
 msgstr "Data di destra"
 
 #. IDS_COLHDR_MTIMEM
-#: Merge.rc:4946
+#: Merge.rc:4945
 msgid "Middle Date"
 msgstr "Data centrale"
 
 #. IDS_COLHDR_LSIZE
-#: Merge.rc:4948
+#: Merge.rc:4947
 msgid "Left Size"
 msgstr "Dimensioni di sinistra"
 
 #. IDS_COLHDR_RSIZE
-#: Merge.rc:4949
+#: Merge.rc:4948
 msgid "Right Size"
 msgstr "Dimensioni di destra"
 
 #. IDS_COLHDR_MSIZE
-#: Merge.rc:4954
+#: Merge.rc:4953
 msgid "Middle Size"
 msgstr "Dimensioni centrale"
 
 #. IDS_COLHDR_RSIZE_SHORT
-#: Merge.rc:4955
+#: Merge.rc:4954
 msgid "Right Size (Short)"
 msgstr "Dim. destra (breve)"
 
 #. IDS_COLHDR_LSIZE_SHORT
-#: Merge.rc:4956
+#: Merge.rc:4955
 msgid "Left Size (Short)"
 msgstr "Dim. sinistra (breve)"
 
 #. IDS_COLHDR_MSIZE_SHORT
-#: Merge.rc:4957
+#: Merge.rc:4956
 msgid "Middle Size (Short)"
 msgstr "Dim. centro (breve)"
 
 #. IDS_COLHDR_LTIMEC
-#: Merge.rc:4963
+#: Merge.rc:4962
 msgid "Left Creation Time"
 msgstr "Data creazione di sinistra"
 
 #. IDS_COLHDR_RTIMEC
-#: Merge.rc:4964
+#: Merge.rc:4963
 msgid "Right Creation Time"
 msgstr "Data creazione di destra"
 
 #. IDS_COLHDR_MTIMEC
-#: Merge.rc:4965
+#: Merge.rc:4964
 msgid "Middle Creation Time"
 msgstr "Data creazione centrale"
 
 #. IDS_COLHDR_NEWER
-#: Merge.rc:4966
+#: Merge.rc:4965
 msgid "Newer File"
 msgstr "File più recente"
 
 #. IDS_COLHDR_LVERSION
-#: Merge.rc:4967
+#: Merge.rc:4966
 msgid "Left File Version"
 msgstr "Versione file sinistra"
 
 #. IDS_COLHDR_RVERSION
-#: Merge.rc:4968
+#: Merge.rc:4967
 msgid "Right File Version"
 msgstr "Versione file destra"
 
 #. IDS_COLHDR_MVERSION
-#: Merge.rc:4969
+#: Merge.rc:4968
 msgid "Middle File Version"
 msgstr "Versione file centrale"
 
 #. IDS_COLHDR_RESULT_ABBR
-#: Merge.rc:4970
+#: Merge.rc:4969
 msgid "Short Result"
 msgstr "Risultato breve"
 
 #. IDS_COLHDR_LATTRIBUTES
-#: Merge.rc:4971
+#: Merge.rc:4970
 msgid "Left Attributes"
 msgstr "Attributi sinistra"
 
 #. IDS_COLHDR_RATTRIBUTES
-#: Merge.rc:4972
+#: Merge.rc:4971
 msgid "Right Attributes"
 msgstr "Attributi destra"
 
 #. IDS_COLHDR_MATTRIBUTES
-#: Merge.rc:4973
+#: Merge.rc:4972
 msgid "Middle Attributes"
 msgstr "Attributi centrale"
 
 #. IDS_COLHDR_LEOL_TYPE
-#: Merge.rc:4978
+#: Merge.rc:4977
 msgid "Left EOL"
 msgstr "EOL di sinistra"
 
 #. IDS_COLHDR_MEOL_TYPE
-#: Merge.rc:4979
+#: Merge.rc:4978
 msgid "Middle EOL"
 msgstr "EOL centrale"
 
 #. IDS_COLHDR_REOL_TYPE
-#: Merge.rc:4980
+#: Merge.rc:4979
 msgid "Right EOL"
 msgstr "EOL di destra"
 
 #. IDS_COLHDR_LENCODING
-#: Merge.rc:4986
+#: Merge.rc:4985
 msgid "Left Encoding"
 msgstr "Codifica di sinistra"
 
 #. IDS_COLHDR_RENCODING
-#: Merge.rc:4987
+#: Merge.rc:4986
 msgid "Right Encoding"
 msgstr "Codifica di destra"
 
 #. IDS_COLHDR_MENCODING
-#: Merge.rc:4988
+#: Merge.rc:4987
 msgid "Middle Encoding"
 msgstr "Codifica centrale"
 
 #. IDS_COLHDR_NIDIFFS
-#: Merge.rc:4989
+#: Merge.rc:4988
 msgid "Ignored Diff"
 msgstr "Diff ignorate"
 
 #. IDS_COLHDR_BINARY
-#: Merge.rc:4991
+#: Merge.rc:4990
 msgctxt "DirView|ColumnHeader"
 msgid "Binary"
 msgstr "Binario"
 
 #. IDS_PLUGINS_TYPE_UNPACKER
-#: Merge.rc:4992 Merge.rc:5314
+#: Merge.rc:4991 Merge.rc:5313
 msgid "Unpacker"
 msgstr "Decompressore"
 
 #. IDS_PLUGIN_TYPE4
-#: Merge.rc:4993 Merge.rc:5315 Merge.rc:5622
+#: Merge.rc:4992 Merge.rc:5314 Merge.rc:5621
 msgid "Prediffer"
 msgstr "Prediffer"
 
 #. IDS_COLHDR_LEFT
-#: Merge.rc:4994
+#: Merge.rc:4993
 msgid "Left"
 msgstr "Sinistra"
 
 #. IDS_COLHDR_MIDDLE
-#: Merge.rc:4995
+#: Merge.rc:4994
 msgid "Middle"
 msgstr "Centro"
 
 #. IDS_COLHDR_RIGHT
-#: Merge.rc:4996
+#: Merge.rc:4995
 msgid "Right"
 msgstr "Destra"
 
 #. IDS_COLHDR_DIFF
-#: Merge.rc:4997
+#: Merge.rc:4996
 msgid "Diff"
 msgstr "Diff"
 
 #. IDS_COLHDR_LEFT_DUPLICATE
-#: Merge.rc:4998
+#: Merge.rc:4997
 msgid "Left Duplicate Count"
 msgstr "Numero di duplicati a sinistra"
 
 #. IDS_COLHDR_RIGHT_DUPLICATE
-#: Merge.rc:4999
+#: Merge.rc:4998
 msgid "Right Duplicate Count"
 msgstr "Numero di duplicati a destra"
 
 #. IDS_COLHDR_MIDDLE_DUPLICATE
-#: Merge.rc:5000
+#: Merge.rc:4999
 msgid "Middle Duplicate Count"
 msgstr "Numero di duplicati al centro"
 
 #. IDS_COLHDR_MOVE
-#: Merge.rc:5001
+#: Merge.rc:5000
 msgid "Move"
 msgstr "Sposta"
 
 #. IDS_PRPCAT_AUDIO
-#: Merge.rc:5008
+#: Merge.rc:5007
 msgid "Audio"
 msgstr "Audio"
 
 #. IDS_PRPCAT_CALENDAR
-#: Merge.rc:5009
+#: Merge.rc:5008
 msgid "Calendar"
 msgstr "Calendario"
 
 #. IDS_PRPCAT_COMMUNICATION
-#: Merge.rc:5010
+#: Merge.rc:5009
 msgid "Communication"
 msgstr "Comunicazione"
 
 #. IDS_PRPCAT_CONTACT
-#: Merge.rc:5011
+#: Merge.rc:5010
 msgid "Contact"
 msgstr "Contatti"
 
 #. IDS_PRPCAT_DEVICES
-#: Merge.rc:5012
+#: Merge.rc:5011
 msgid "Devices"
 msgstr "Dispositivi"
 
 #. IDS_PRPCAT_DOCUMENT
-#: Merge.rc:5013
+#: Merge.rc:5012
 msgid "Document"
 msgstr "Documento"
 
 #. IDS_PRPCAT_HOME
-#: Merge.rc:5014
+#: Merge.rc:5013
 msgid "Home"
 msgstr "Home"
 
 #. IDS_PRPCAT_JOURNAL
-#: Merge.rc:5016
+#: Merge.rc:5015
 msgid "Journal"
 msgstr "Diario"
 
 #. IDS_PRPCAT_LINK
-#: Merge.rc:5017
+#: Merge.rc:5016
 msgid "Link"
 msgstr "Link"
 
 #. IDS_PRPCAT_MEDIA
-#: Merge.rc:5018
+#: Merge.rc:5017
 msgid "Media"
 msgstr "Media"
 
 #. IDS_PRPCAT_MUSIC
-#: Merge.rc:5020
+#: Merge.rc:5019
 msgid "Music"
 msgstr "Musica"
 
 #. IDS_PRPCAT_NOTE
-#: Merge.rc:5021
+#: Merge.rc:5020
 msgid "Note"
 msgstr "Note"
 
 #. IDS_PRPCAT_PHOTO
-#: Merge.rc:5022
+#: Merge.rc:5021
 msgid "Photo"
 msgstr "Foto"
 
 #. IDS_PRPCAT_RECORDEDTV
-#: Merge.rc:5023
+#: Merge.rc:5022
 msgid "RecordedTV"
 msgstr "RegistrazioniTV"
 
 #. IDS_PRPCAT_SEARCH
-#: Merge.rc:5024
+#: Merge.rc:5023
 msgid "Search"
 msgstr "Ricerca"
 
 #. IDS_PRPCAT_SECURITY
-#: Merge.rc:5025
+#: Merge.rc:5024
 msgid "Security"
 msgstr "Sicurezza"
 
 #. IDS_PRPCAT_SOFTWARE
-#: Merge.rc:5026
+#: Merge.rc:5025
 msgid "Software"
 msgstr "Software"
 
 #. IDS_PRPCAT_TASK
-#: Merge.rc:5027
+#: Merge.rc:5026
 msgid "Task"
 msgstr "Attività"
 
 #. IDS_PRPCAT_VIDEO
-#: Merge.rc:5028
+#: Merge.rc:5027
 msgid "Video"
 msgstr "Video"
 
 #. IDS_PRPCAT_HASH
-#: Merge.rc:5029
+#: Merge.rc:5028
 msgid "Hash"
 msgstr "Hash"
 
 #. IDS_CANT_COMPARE_FILES
-#: Merge.rc:5035
+#: Merge.rc:5034
 msgid "Unable to compare files"
 msgstr "Impossibile confrontare i file"
 
 #. IDS_ABORTED_ITEM
-#: Merge.rc:5036
+#: Merge.rc:5035
 msgid "Item aborted"
 msgstr "Elemento annullato"
 
 #. IDS_FILE_SKIPPED
-#: Merge.rc:5037
+#: Merge.rc:5036
 msgid "File skipped"
 msgstr "File saltato"
 
 #. IDS_DIR_SKIPPED
-#: Merge.rc:5038
+#: Merge.rc:5037
 msgid "Folder skipped"
 msgstr "Cartella saltata"
 
 #. IDS_LEFT_ONLY_IN_FMT
-#: Merge.rc:5039
+#: Merge.rc:5038
 #, c-format
 msgid "Left only: %1"
 msgstr "Solo sinistra: %1"
 
 #. IDS_MIDDLE_ONLY_IN_FMT
-#: Merge.rc:5040
+#: Merge.rc:5039
 #, c-format
 msgid "Middle only: %1"
 msgstr "Solo al centro: %1"
 
 #. IDS_RIGHT_ONLY_IN_FMT
-#: Merge.rc:5041
+#: Merge.rc:5040
 #, c-format
 msgid "Right only: %1"
 msgstr "Solo destra: %1"
 
 #. IDS_DOES_NOT_EXIST_IN_FMT
-#: Merge.rc:5042
+#: Merge.rc:5041
 #, c-format
 msgid "Does not exist in %1"
 msgstr "Non esiste in %1"
 
 #. IDS_BIN_FILES_SAME
-#: Merge.rc:5043
+#: Merge.rc:5042
 msgid "Binary files are identical"
 msgstr "I file binari sono identici"
 
 #. IDS_BIN_FILES_DIFF
-#: Merge.rc:5049
+#: Merge.rc:5048
 msgid "Binary files are different"
 msgstr "I file binari sono diversi"
 
 #. IDS_FILES_ARE_DIFFERENT
-#: Merge.rc:5050
+#: Merge.rc:5049
 msgid "Files are different"
 msgstr "I file sono diversi"
 
 #. IDS_FOLDERS_ARE_DIFFERENT
-#: Merge.rc:5051
+#: Merge.rc:5050
 msgid "Folders are different"
 msgstr "Le cartelle sono diverse"
 
 #. IDS_LEFTONLY
-#: Merge.rc:5052
+#: Merge.rc:5051
 msgid "Left Only"
 msgstr "Solo a sinistra"
 
 #. IDS_RIGHTONLY
-#: Merge.rc:5053
+#: Merge.rc:5052
 msgid "Right Only"
 msgstr "Solo a destra"
 
 #. IDS_MIDDLEONLY
-#: Merge.rc:5054
+#: Merge.rc:5053
 msgid "Middle Only"
 msgstr "Solo al centro"
 
 #. IDS_NOITEMLEFT
-#: Merge.rc:5055
+#: Merge.rc:5054
 msgid "No item in left"
 msgstr "Nessun elemento a sinistra"
 
 #. IDS_NOITEMRIGHT
-#: Merge.rc:5056
+#: Merge.rc:5055
 msgid "No item in right"
 msgstr "Nessun elemento a destra"
 
 #. IDS_NOITEMMIDDLE
-#: Merge.rc:5057
+#: Merge.rc:5056
 msgid "No item in middle"
 msgstr "Nessun elemento al centro"
 
 #. IDS_CMPRES_ERROR
-#: Merge.rc:5059
+#: Merge.rc:5058
 msgid "Error"
 msgstr "Errore"
 
 #. IDS_TEXT_FILES_SAME
-#: Merge.rc:5060
+#: Merge.rc:5059
 msgid "Text files are identical"
 msgstr "I file di testo sono identici"
 
 #. IDS_LEFTONLY_DIFF
-#: Merge.rc:5061
+#: Merge.rc:5060
 msgid " (Middle and right are identical)"
 msgstr " (centrale e destro sono identici)"
 
 #. IDS_MIDDLEONLY_DIFF
-#: Merge.rc:5062
+#: Merge.rc:5061
 msgid " (Left and right are identical)"
 msgstr " (sinistro e destro sono identici)"
 
 #. IDS_RIGHTONLY_DIFF
-#: Merge.rc:5063
+#: Merge.rc:5062
 msgid " (Left and middle are identical)"
 msgstr " (sinistro e centrale sono identici)"
 
 #. IDS_PATH_MISMATCH
-#: Merge.rc:5064
+#: Merge.rc:5063
 msgid " (paths differ)"
 msgstr " (percorso differente)"
 
 #. IDS_TEXT_FILES_DIFF
-#: Merge.rc:5065
+#: Merge.rc:5064
 msgid "Text files are different"
 msgstr "I file di testo sono diversi"
 
 #. IDS_IMAGE_FILES_SAME
-#: Merge.rc:5066
+#: Merge.rc:5065
 msgid "Image files are identical"
 msgstr "Le immagini sono identiche"
 
 #. IDS_IMAGE_FILES_DIFF
-#: Merge.rc:5067
+#: Merge.rc:5066
 msgid "Image files are different"
 msgstr "Le immagini sono diverse"
 
 #. IDS_EXPR_DIFF
-#: Merge.rc:5068
+#: Merge.rc:5067
 #, c-format
 msgid "Files are different (expr: %1)"
 msgstr "I file sono differenti (espr: %1)"
 
 #. IDS_HASH_GROUP
-#: Merge.rc:5069
+#: Merge.rc:5068
 #, c-format
 msgid "Group%d"
 msgstr "Gurppo%d"
 
 #. IDS_RENAME_MOVE_DETECTION_DISALBED
-#: Merge.rc:5070
+#: Merge.rc:5069
 msgctxt "Options dialog|Compare|Folder|Detect renames and moves"
 msgid "Disabled"
 msgstr "Disabilitato"
 
 #. IDS_RENAME_MOVE_DETECTION_RENAME
-#: Merge.rc:5071
+#: Merge.rc:5070
 msgid "Detect renames"
 msgstr "Rileva rinomine"
 
 #. IDS_RENAME_MOVE_DETECTION_RENAME_MOVE
-#: Merge.rc:5072
+#: Merge.rc:5071
 msgid "Detect renames and moves"
 msgstr "Rileva rinomine e spostamenti"
 
 #. IDS_RENAME_MOVE_MERGE_MODE_RENAME
-#: Merge.rc:5073
+#: Merge.rc:5072
 msgid "Merge renames"
 msgstr "Unisci rinomina"
 
 #. IDS_RENAME_MOVE_MERGE_MODE_RENAME_MOVE
-#: Merge.rc:5074
+#: Merge.rc:5073
 msgid "Merge renames and moves"
 msgstr "Unisci rinomina e sposta"
 
 #. IDS_RENAMED
-#: Merge.rc:5075
+#: Merge.rc:5074
 msgid "Renamed"
 msgstr "Rinominato"
 
 #. IDS_RENAMED_MOVED
-#: Merge.rc:5077
+#: Merge.rc:5076
 msgid "Renamed/Moved"
 msgstr "Rinominato/spostato"
 
 #. IDS_RENAMED_MOVED_ITEMS
-#: Merge.rc:5078
+#: Merge.rc:5077
 #, c-format
 msgid "(%1 items)"
 msgstr "(%1 elementi)"
 
 #. IDS_RENAMED_MOVED_RESULT
-#: Merge.rc:5079
+#: Merge.rc:5078
 #, c-format
 msgid "%1 (set %2): "
 msgstr "%1 (imposta %2): "
 
 #. IDS_SWITCH_FLAT_MODE
-#: Merge.rc:5080
+#: Merge.rc:5079
 msgid "Some moved items have been merged.\nIn Tree Mode, these items may appear in positions that do not reflect the actual folder structure, which can be confusing.\nSwitch to Flat Mode?"
 msgstr "Alcuni elementi spostati sono stati uniti.\nIn modalità struttura, questi elementi potrebbero essere visualizzati in posizioni che non riflettono la struttura effettiva delle cartelle, il che può creare confusione.\nVuoi passare alla modalità semplice?"
 
 #. IDS_ELAPSED_TIME
-#: Merge.rc:5086
+#: Merge.rc:5085
 #, c-format
 msgid "Elapsed time: %ld ms"
 msgstr "Tempo trascorso: %ld ms"
 
 #. IDS_STATUS_SELITEM1
-#: Merge.rc:5087
+#: Merge.rc:5086
 msgid "1 item selected"
 msgstr "1 elemento selezionato"
 
 #. IDS_STATUS_SELITEMS
-#: Merge.rc:5088
+#: Merge.rc:5087
 #, c-format
 msgid "%1 items selected"
 msgstr "%1 elementi selezionati"
 
 #. IDS_COLDESC_FILENAME
-#: Merge.rc:5094
+#: Merge.rc:5093
 msgid "Filename or folder name."
 msgstr "Nome file o cartella."
 
 #. IDS_COLDESC_DIR
-#: Merge.rc:5095
+#: Merge.rc:5094
 msgid "Subfolder name when subfolders are included."
 msgstr "Nome sotto-cartella quando le sotto-cartelle sono incluse."
 
 #. IDS_COLDESC_RESULT
-#: Merge.rc:5096
+#: Merge.rc:5095
 msgid "Comparison result, long form."
 msgstr "Risultato del confronto, forma completa."
 
 #. IDS_COLDESC_LTIMEM
-#: Merge.rc:5101
+#: Merge.rc:5100
 msgid "Left side modification date."
 msgstr "Data ultima modifica del lato sinistro."
 
 #. IDS_COLDESC_RTIMEM
-#: Merge.rc:5102
+#: Merge.rc:5101
 msgid "Right side modification date."
 msgstr "Data ultima modifica del lato destro."
 
 #. IDS_COLDESC_MTIMEM
-#: Merge.rc:5103
+#: Merge.rc:5102
 msgid "Middle side modification date."
 msgstr "Data ultima modifica del lato centrale."
 
 #. IDS_COLDESC_EXTENSION
-#: Merge.rc:5104
+#: Merge.rc:5103
 msgid "File's extension."
 msgstr "Estensione del file."
 
 #. IDS_COLDESC_LSIZE
-#: Merge.rc:5105
+#: Merge.rc:5104
 msgid "Left file size in bytes."
 msgstr "Dimensione di sinistra in byte."
 
 #. IDS_COLDESC_RSIZE
-#: Merge.rc:5106
+#: Merge.rc:5105
 msgid "Right file size in bytes."
 msgstr "Dimensione di destra in byte."
 
 #. IDS_COLDESC_MSIZE
-#: Merge.rc:5107
+#: Merge.rc:5106
 msgid "Middle file size in bytes."
 msgstr "Dimensione del centro in byte."
 
 #. IDS_COLDESC_LSIZE_SHORT
-#: Merge.rc:5108
+#: Merge.rc:5107
 msgid "Left file size abbreviated."
 msgstr "Dimensione di sinistra brevi."
 
 #. IDS_COLDESC_RSIZE_SHORT
-#: Merge.rc:5109
+#: Merge.rc:5108
 msgid "Right file size abbreviated."
 msgstr "Dimensione di destra brevi."
 
 #. IDS_COLDESC_MSIZE_SHORT
-#: Merge.rc:5110
+#: Merge.rc:5109
 msgid "Middle file size abbreviated."
 msgstr "Dimensione del centro brevi."
 
 #. IDS_COLDESC_LTIMEC
-#: Merge.rc:5116
+#: Merge.rc:5115
 msgid "Left side creation time."
 msgstr "Data di creazione di sinistra."
 
 #. IDS_COLDESC_RTIMEC
-#: Merge.rc:5117
+#: Merge.rc:5116
 msgid "Right side creation time."
 msgstr "Data di creazione di destra."
 
 #. IDS_COLDESC_MTIMEC
-#: Merge.rc:5118
+#: Merge.rc:5117
 msgid "Middle side creation time."
 msgstr "Data creazione lato sinistro centro."
 
 #. IDS_COLDESC_NEWER
-#: Merge.rc:5119
+#: Merge.rc:5118
 msgid "Tells which side has newer modification date."
 msgstr "Indica quale lato ha la data dell'ultima modifica più recente."
 
 #. IDS_COLDESC_LVERSION
-#: Merge.rc:5120
+#: Merge.rc:5119
 msgid "Left side file version, only for some file types."
 msgstr "Versione file lato sinistro, solo per alcuni tipi di file."
 
 #. IDS_COLDESC_RVERSION
-#: Merge.rc:5121
+#: Merge.rc:5120
 msgid "Right side file version, only for some file types."
 msgstr "Versione file lato destro, solo per alcuni tipi di file."
 
 #. IDS_COLDESC_MVERSION
-#: Merge.rc:5126
+#: Merge.rc:5125
 msgid "Middle side file version, only for some file types."
 msgstr "Versione file lato centrale, solo per alcuni tipi di file."
 
 #. IDS_COLDESC_RESULT_ABBR
-#: Merge.rc:5127
+#: Merge.rc:5126
 msgid "Short comparison result."
 msgstr "Risultato confronto in forma breve."
 
 #. IDS_COLDESC_LATTRIBUTES
-#: Merge.rc:5128
+#: Merge.rc:5127
 msgid "Left side attributes."
 msgstr "Attributi lato sinistro."
 
 #. IDS_COLDESC_RATTRIBUTES
-#: Merge.rc:5129
+#: Merge.rc:5128
 msgid "Right side attributes."
 msgstr "Attributi lato destro."
 
 #. IDS_COLDESC_MATTRIBUTES
-#: Merge.rc:5130
+#: Merge.rc:5129
 msgid "Middle side attributes."
 msgstr "Attributi lato centrale."
 
 #. IDS_COLDESC_LEOL_TYPE
-#: Merge.rc:5131
+#: Merge.rc:5130
 msgid "Left side file EOL type."
 msgstr "Tipo fine linea lato sinistro."
 
 #. IDS_COLDESC_REOL_TYPE
-#: Merge.rc:5132
+#: Merge.rc:5131
 msgid "Right side file EOL type."
 msgstr "Tipo fine linea lato destro."
 
 #. IDS_COLDESC_MEOL_TYPE
-#: Merge.rc:5133
+#: Merge.rc:5132
 msgid "Middle side file EOL type."
 msgstr "Tipo fine linea lato centrale."
 
 #. IDS_COLDESC_LENCODING
-#: Merge.rc:5139
+#: Merge.rc:5138
 msgid "Left side encoding."
 msgstr "Codifica zona sinistra."
 
 #. IDS_COLDESC_RENCODING
-#: Merge.rc:5140
+#: Merge.rc:5139
 msgid "Right side encoding."
 msgstr "Codifica lato destro."
 
 #. IDS_COLDESC_MENCODING
-#: Merge.rc:5141
+#: Merge.rc:5140
 msgid "Middle side encoding."
 msgstr "Codifica lato centrale."
 
 #. IDS_COLDESC_NIDIFFS
-#: Merge.rc:5142
+#: Merge.rc:5141
 msgid "Number of ignored differences in file. Ignored and cannot be merged."
 msgstr ""
 "Numero di differenze ignorate nel file.\n"
 "Queste differenze sono ignorate da WinMerge e non possono venire unite."
 
 #. IDS_COLDESC_NSDIFFS
-#: Merge.rc:5143
+#: Merge.rc:5142
 msgid "Number of differences in file (excluding ignored)."
 msgstr ""
 "Numero di differenze nel file.\n"
 "Questo numero non include le differenze ignorate."
 
 #. IDS_COLDESC_BINARY
-#: Merge.rc:5144
+#: Merge.rc:5143
 msgid "Shows an asterisk (*) if the file is binary."
 msgstr "Visualizza un asterisco (*) se il file è binario."
 
 #. IDS_COLDESC_UNPACKER
-#: Merge.rc:5145
+#: Merge.rc:5144
 msgid "Unpacker plugin name or pipeline."
 msgstr "Nome o pipeline plugin decompressione."
 
 #. IDS_COLDESC_PREDIFFER
-#: Merge.rc:5146
+#: Merge.rc:5145
 msgid "Prediffer plugin name or pipeline."
 msgstr "Nome plugin Prediffer o pipeline."
 
 #. IDS_DIRECTORY_REPORT_TITLE
-#: Merge.rc:5152
+#: Merge.rc:5151
 #, c-format
 msgid "Compare %1 with %2"
 msgstr "Confronta %1 con %2"
 
 #. IDS_DIRECTORY_REPORT_TITLE3
-#: Merge.rc:5153
+#: Merge.rc:5152
 #, c-format
 msgid "Compare %1 with %2 and %3"
 msgstr "Confronta %1 con %2 e %3"
 
 #. IDS_REPORT_COMMALIST
-#: Merge.rc:5154
+#: Merge.rc:5153
 msgid "Comma-separated list"
 msgstr "Elenco separato da virgole"
 
 #. IDS_REPORT_TABLIST
-#: Merge.rc:5155
+#: Merge.rc:5154
 msgid "Tab-separated list"
 msgstr "Elenco separato da tabulazioni"
 
 #. IDS_REPORT_SIMPLEHTML
-#: Merge.rc:5156
+#: Merge.rc:5155
 msgid "Simple HTML"
 msgstr "HTML semplice"
 
 #. IDS_REPORT_SIMPLEXML
-#: Merge.rc:5157
+#: Merge.rc:5156
 msgid "Simple XML"
 msgstr "XML semplice"
 
-#: Merge.rc:5159
+#: Merge.rc:5158
 msgid "Report file already exists. Overwrite?"
 msgstr ""
 "Il file del rapporto esiste già.\n"
 "Vuoi sovrascrivere il file esistente?"
 
 #. IDS_REPORT_ERROR
-#: Merge.rc:5164
+#: Merge.rc:5163
 #, c-format
 msgid ""
 "Error creating the report:\n"
@@ -7249,59 +7244,59 @@ msgstr ""
 "%1"
 
 #. IDS_REPORT_SUCCESS
-#: Merge.rc:5165
+#: Merge.rc:5164
 msgid "Report created successfully."
 msgstr "Creazione rapporto completata."
 
 #. IDS_SYNCPOINT_LASTBLOCK
-#: Merge.rc:5171
+#: Merge.rc:5170
 msgid "Cannot add a synchronization point at this line."
 msgstr "Impossibile aggiungere un punto di sincronizzazione su questa linea."
 
 #. IDS_FILE_TO_ITSELF
-#: Merge.rc:5177
+#: Merge.rc:5176
 msgid "Same file is opened in both panes."
 msgstr "Lo stesso file è aperto in entrambi i pannelli."
 
 #. IDS_FILESSAME
-#: Merge.rc:5178
+#: Merge.rc:5177
 msgid "Selected files are identical."
 msgstr "I file selezionati sono identici."
 
 #. IDS_FILESSAME_CURCFG
-#: Merge.rc:5179
+#: Merge.rc:5178
 msgid "Selected files are identical (with current settings).\r\nChecking binary identity..."
 msgstr "I file selezionati sono identici (con le impostazioni attuali).\r\nVerifica identità binaria..."
 
 #. IDS_FILESSAME_BINERROR
-#: Merge.rc:5180
+#: Merge.rc:5179
 msgid "Selected files are identical (with current settings).\r\nBut binary comparison failed."
 msgstr "I file selezionati sono identici (con le impostazioni attuali).\r\nMa il confronto binario non è riuscito."
 
 #. IDS_FILESSAME_BINSAME
-#: Merge.rc:5181
+#: Merge.rc:5180
 msgid "Selected files are identical (binary match)."
 msgstr "I file selezionati sono identici (corrispondenza binaria)."
 
 #. IDS_FILESSAME_BINDIFF
-#: Merge.rc:5182
+#: Merge.rc:5181
 msgid "Selected files are identical (with current settings).\r\nBut differ at the binary level."
 msgstr "I file selezionati sono identici (con le impostazioni attuali).\r\nMa differiscono a livello binario."
 
 #. IDS_FILEERROR
-#: Merge.rc:5183
+#: Merge.rc:5182
 msgid "An error occurred while comparing files."
 msgstr "Si è verificato un errore durante il confronto dei file."
 
 #. IDS_TEMP_FILEERROR
-#: Merge.rc:5184
+#: Merge.rc:5183
 msgid "Could not create temporary files. Check your temporary path settings."
 msgstr ""
 "Impossibile creare file temporanei.\n"
 "Controlla le impostazioni del percorso dei file temporanei."
 
 #. IDS_SUGGEST_IGNOREEOL
-#: Merge.rc:5185
+#: Merge.rc:5184
 msgid ""
 "Files use different EOL.\n"
 "\n"
@@ -7318,17 +7313,17 @@ msgstr ""
 "differenze fine riga (Windows/Unix/Mac)'."
 
 #. IDS_INVALID_DIRECTORY
-#: Merge.rc:5186
+#: Merge.rc:5185
 msgid "Selected folder is invalid."
 msgstr "La cartella selezionata non è valida."
 
 #. IDS_CANNOT_OPEN_BINARYFILE
-#: Merge.rc:5187
+#: Merge.rc:5186
 msgid "Cannot open a binary file in Editor."
 msgstr "Impossibile aprire un file binario nell'editor."
 
 #. IDS_CREATE_PAIR_FOLDER
-#: Merge.rc:5188
+#: Merge.rc:5187
 #, c-format
 msgid ""
 "Create matching folder:\n"
@@ -7342,41 +7337,41 @@ msgstr ""
 "dall'altro lato ed aprirle entrambe?"
 
 #. IDS_CONFIRM_COPY_ALL_DIFFS
-#: Merge.rc:5189
+#: Merge.rc:5188
 msgid "Copy all differences to other file?"
 msgstr "Sei sicuro di voler copiare tutte le differenze nell'altro file?"
 
 #. IDS_MOVE_TO_NEXTFILE
-#: Merge.rc:5194
+#: Merge.rc:5193
 msgid "Move to next file?"
 msgstr "Vuoi passare al file successivo?"
 
 #. IDS_MOVE_TO_PREVFILE
-#: Merge.rc:5195
+#: Merge.rc:5194
 msgid "Move to previous file?"
 msgstr "Vuoi passare al file precedente?"
 
 #. IDS_MOVE_TO_NEXTPAGE
-#: Merge.rc:5196
+#: Merge.rc:5195
 msgid "Move to next page?"
 msgstr "Vuoi passare alla pagina successiva?"
 
 #. IDS_MOVE_TO_PREVPAGE
-#: Merge.rc:5197
+#: Merge.rc:5196
 msgid "Move to previous page?"
 msgstr "Vuoi passare alla pagina precedente?"
 
 #. IDS_MOVE_TO_FIRSTFILE
-#: Merge.rc:5198
+#: Merge.rc:5197
 msgid "Move to first file?"
 msgstr "Vuoi passare al primo file?"
 
 #. IDS_MOVE_TO_LASTFILE
-#: Merge.rc:5199
+#: Merge.rc:5198
 msgid "Move to last file?"
 msgstr "Vuoi passare all'ultimo file?"
 
-#: Merge.rc:5206
+#: Merge.rc:5205
 #, c-format
 msgid ""
 "Different codepages: left (cp%d), right (cp%d).\n"
@@ -7390,53 +7385,53 @@ msgstr ""
 "Vuoi considerare entrambi i file come se avessero il codice pagina "
 "predefinito di Windows (raccomandato)?"
 
-#: Merge.rc:5208
+#: Merge.rc:5207
 msgid "Information lost due to encoding errors: both files"
 msgstr "Informazioni perse a causa di errori nella codifica: entrambi i file"
 
-#: Merge.rc:5210
+#: Merge.rc:5209
 msgid "Information lost due to encoding errors: first file"
 msgstr "Informazioni perse a causa di errori nella codifica: primo file"
 
-#: Merge.rc:5212
+#: Merge.rc:5211
 msgid "Information lost due to encoding errors: second file"
 msgstr "Informazioni perse a causa di errori nella codifica: secondo file"
 
-#: Merge.rc:5214
+#: Merge.rc:5213
 msgid "Information lost due to encoding errors: third file"
 msgstr "Informazioni perse a causa di errori nella codifica: terzo file"
 
 #. IDS_LINEDIFF_NODIFF
-#: Merge.rc:5220
+#: Merge.rc:5219
 msgid "No difference"
 msgstr "Nessuna differenza"
 
 #. IDS_LINEDIFF_NODIFF_CAPTION
-#: Merge.rc:5221
+#: Merge.rc:5220
 msgid "Line difference"
 msgstr "Differenza linea"
 
 #. IDS_NUM_REPLACED
-#: Merge.rc:5227
+#: Merge.rc:5226
 #, c-format
 msgid "Replaced %1 string(s)."
 msgstr "%1 stringhe sostituite."
 
 #. IDS_EDIT_TEXT_NOT_FOUND
-#: Merge.rc:5228
+#: Merge.rc:5227
 #, c-format
 msgid "Cannot find string \"%s\"."
 msgstr "Impossibile trovare la stringa “%s”."
 
 #. IDS_MERGE_MODE
-#: Merge.rc:5234
+#: Merge.rc:5233
 msgid "Entering Merge Mode. Press F9 to turn off."
 msgstr ""
 "Stai per entrare nella modalità Unione.\n"
 "Per disattivarla premi il tasto F9."
 
 #. IDS_AUTO_MERGE
-#: Merge.rc:5240
+#: Merge.rc:5239
 #, c-format
 msgid ""
 "Automatic merges: %1\n"
@@ -7446,91 +7441,91 @@ msgstr ""
 "Numero di conflitti non risolti: %2"
 
 #. IDS_CODEPAGE_MERGED
-#: Merge.rc:5241
+#: Merge.rc:5240
 msgid "Codepage change merged."
 msgstr "La modifica al codice di pagina è stata unita."
 
 #. IDS_CODEPAGE_CONFLICT
-#: Merge.rc:5242
+#: Merge.rc:5241
 msgid "Codepage changes are conflicting."
 msgstr "Le modifiche al codice di pagina sono in conflitto."
 
 #. IDS_EOL_MERGED
-#: Merge.rc:5243
+#: Merge.rc:5242
 msgid "EOL change merged."
 msgstr "La modifica ai caratteri di fine linea è stata unita."
 
 #. IDS_EOL_CONFLICT
-#: Merge.rc:5244
+#: Merge.rc:5243
 msgid "EOL changes are conflicting."
 msgstr "Le modifiche ai caratteri di fine linea sono in conflitto."
 
 #. IDS_LOCBAR_CAPTION
-#: Merge.rc:5250
+#: Merge.rc:5249
 msgid "Location Pane"
 msgstr "Pannello posizione"
 
 #. IDS_DIFFBAR_CAPTION
-#: Merge.rc:5251
+#: Merge.rc:5250
 msgid "Diff Pane"
 msgstr "Pannello differenze"
 
 #. IDS_DIFF_SUCCEEDED
-#: Merge.rc:5258
+#: Merge.rc:5257
 msgid "Patch file written."
 msgstr "Scrittura file patch completata."
 
 #. IDS_DIFF_FILEOVERWRITE
-#: Merge.rc:5259
+#: Merge.rc:5258
 msgid "Patch file already exists. Overwrite?"
 msgstr ""
 "Il file di patch esiste già.\n"
 "Vuoi sovrascriverlo?"
 
 #. IDS_DIFF_SELECTEDFILES
-#: Merge.rc:5260
+#: Merge.rc:5259
 #, c-format
 msgid "[%1 files selected]"
 msgstr "[%1 file selezionati]"
 
 #. IDS_DIFF_NORMAL
-#: Merge.rc:5261
+#: Merge.rc:5260
 msgid "Normal"
 msgstr "Normale"
 
 #. IDS_DIFF_CONTEXT
-#: Merge.rc:5262
+#: Merge.rc:5261
 msgid "Context"
 msgstr "Contesto"
 
 #. IDS_DIFF_UNIFIED
-#: Merge.rc:5263
+#: Merge.rc:5262
 msgid "Unified"
 msgstr "Unificato"
 
 #. IDS_FILEWRITE_ERROR
-#: Merge.rc:5265
+#: Merge.rc:5264
 #, c-format
 msgid "Could not write to file %1."
 msgstr "Impossibile scrivere nel file %1."
 
 #. IDS_PATH_NOT_ABSOLUTE
-#: Merge.rc:5266
+#: Merge.rc:5265
 #, c-format
 msgid "Output path is not absolute: %1"
 msgstr "Il percorso destinazione specificato non è assoluto: %1"
 
 #. IDS_MUST_SPECIFY_OUTPUT
-#: Merge.rc:5267
+#: Merge.rc:5266
 msgid "Specify an output file."
 msgstr "Specifica un file destinazione."
 
-#: Merge.rc:5269
+#: Merge.rc:5268
 msgid "Cannot create patch from binary files."
 msgstr "Impossibile creare un file di patch da file binari."
 
 #. IDS_SAVEFILES_FORPATCH
-#: Merge.rc:5270
+#: Merge.rc:5269
 msgid ""
 "Save all files first.\n"
 "\n"
@@ -7542,22 +7537,22 @@ msgstr ""
 "nei file."
 
 #. IDS_FOLDER_NOTEXIST
-#: Merge.rc:5271
+#: Merge.rc:5270
 msgid "Folder does not exist."
 msgstr "La cartella non esiste."
 
 #. IDS_ARCHIVE_SUCCEEDED
-#: Merge.rc:5277
+#: Merge.rc:5276
 msgid "Archive file written."
 msgstr "File archivio salvato."
 
 #. IDS_ARCHIVE_SAVEFILES
-#: Merge.rc:5278
+#: Merge.rc:5277
 msgid "Save all files first.\n\nCreating an archive requires no unsaved changes."
 msgstr "Prima salva tutti i file.\n\nLa creazione di un archivio richiede che le modifiche siano salvate."
 
 #. IDS_NO_ZIP_SUPPORT
-#: Merge.rc:5283
+#: Merge.rc:5282
 msgid ""
 "Archive support not enabled.\n"
 "7-Zip and/or Merge7z*.dll not found.\n"
@@ -7569,37 +7564,37 @@ msgstr ""
 "Consulta il manuale per ulteriori informazioni sugli archivi."
 
 #. IDS_OPT_EXPORT_CAPTION
-#: Merge.rc:5284
+#: Merge.rc:5283
 msgid "Select file for export"
 msgstr "Seleziona il file per l'esportazione"
 
 #. IDS_OPT_IMPORT_CAPTION
-#: Merge.rc:5285
+#: Merge.rc:5284
 msgid "Select file for import"
 msgstr "Seleziona il file per l'importazione"
 
 #. IDS_OPT_IMPORT_DONE
-#: Merge.rc:5286
+#: Merge.rc:5285
 msgid "Options imported from file."
 msgstr "Opzioni importate dal file."
 
 #. IDS_OPT_EXPORT_DONE
-#: Merge.rc:5287
+#: Merge.rc:5286
 msgid "Options exported to file."
 msgstr "Opzioni esportate nel file."
 
 #. IDS_OPT_IMPORT_ERR
-#: Merge.rc:5288
+#: Merge.rc:5287
 msgid "Failed to import options from file."
 msgstr "Impossibile importare le opzioni dal file."
 
 #. IDS_OPT_EXPORT_ERR
-#: Merge.rc:5289
+#: Merge.rc:5288
 msgid "Failed to write options to file."
 msgstr "Impossibile esportare le opzioni nel file."
 
 #. IDS_CLOSEALL_WINDOWS
-#: Merge.rc:5290
+#: Merge.rc:5289
 msgid ""
 "Close multiple compare windows?\n"
 "\n"
@@ -7610,34 +7605,34 @@ msgstr ""
 "Vuoi proseguire?"
 
 #. IDS_EOL_BIN
-#: Merge.rc:5300
+#: Merge.rc:5299
 msgctxt "EOL Type"
 msgid "Binary"
 msgstr "Binario"
 
 #. IDS_MARKER_COLOR_FMT
-#: Merge.rc:5305
+#: Merge.rc:5304
 #, c-format
 msgid "Marker Color %d"
 msgstr "Colore dell'evidenziatore %d"
 
 #. IDS_MARKER_NEW_PATTERN
-#: Merge.rc:5306
+#: Merge.rc:5305
 msgid "New Pattern"
 msgstr "Nuovo pattern"
 
 #. IDS_PLUGINSLIST_TYPE
-#: Merge.rc:5312
+#: Merge.rc:5311
 msgid "Type"
 msgstr "Tipo"
 
 #. IDS_PLUGINS_TYPE_EDITSCRIPT
-#: Merge.rc:5316
+#: Merge.rc:5315
 msgid "Editor script"
 msgstr "Editor script"
 
 #. ID_SELECTLINEDIFF
-#: Merge.rc:5322
+#: Merge.rc:5321
 msgid ""
 "\n"
 "Difference in Current Line (F4)"
@@ -7646,7 +7641,7 @@ msgstr ""
 "Differenza nella linea attuale (F4)"
 
 #. ID_OPTIONS
-#: Merge.rc:5323
+#: Merge.rc:5322
 msgid ""
 "\n"
 "Options"
@@ -7655,7 +7650,7 @@ msgstr ""
 "Opzioni"
 
 #. ID_REFRESH
-#: Merge.rc:5324
+#: Merge.rc:5323
 msgid ""
 "\n"
 "Refresh (F5)"
@@ -7664,7 +7659,7 @@ msgstr ""
 "Aggiorna (F5)"
 
 #. ID_PREVDIFF
-#: Merge.rc:5330
+#: Merge.rc:5329
 msgid ""
 "\n"
 "Previous Difference (Alt+Up)"
@@ -7673,7 +7668,7 @@ msgstr ""
 "Differenza precedente (Alt+Su)"
 
 #. ID_NEXTDIFF
-#: Merge.rc:5331
+#: Merge.rc:5330
 msgid ""
 "\n"
 "Next Difference (Alt+Down)"
@@ -7682,7 +7677,7 @@ msgstr ""
 "Differenza successiva (Alt+Giù)"
 
 #. ID_PREVCONFLICT
-#: Merge.rc:5332
+#: Merge.rc:5331
 msgid ""
 "\n"
 "Previous Conflict (Alt+Shift+Up)"
@@ -7691,7 +7686,7 @@ msgstr ""
 "Conflitto precedente (Alt+Maiusc+Su)"
 
 #. ID_NEXTCONFLICT
-#: Merge.rc:5333
+#: Merge.rc:5332
 msgid ""
 "\n"
 "Next Conflict (Alt+Shift+Down)"
@@ -7700,7 +7695,7 @@ msgstr ""
 "Conflitto successivo (Alt+Maiusc+Giù)"
 
 #. ID_FIRSTDIFF
-#: Merge.rc:5338
+#: Merge.rc:5337
 msgid ""
 "\n"
 "First Difference (Alt+Home)"
@@ -7709,7 +7704,7 @@ msgstr ""
 "Prima differenza (Alt+Inizio)"
 
 #. ID_CURDIFF
-#: Merge.rc:5339
+#: Merge.rc:5338
 msgid ""
 "\n"
 "Current Difference (Alt+Enter)"
@@ -7718,7 +7713,7 @@ msgstr ""
 "Differenza attuale (Alt+Invio)"
 
 #. ID_LASTDIFF
-#: Merge.rc:5340
+#: Merge.rc:5339
 msgid ""
 "\n"
 "Last Difference (Alt+End)"
@@ -7727,7 +7722,7 @@ msgstr ""
 "Ultima differenza (Alt+Fine)"
 
 #. ID_L2R
-#: Merge.rc:5341
+#: Merge.rc:5340
 msgid ""
 "\n"
 "Copy to Right (Alt+Right)"
@@ -7736,7 +7731,7 @@ msgstr ""
 "Copia a destra (Alt+Destra)"
 
 #. ID_R2L
-#: Merge.rc:5342
+#: Merge.rc:5341
 msgid ""
 "\n"
 "Copy to Left (Alt+Left)"
@@ -7745,7 +7740,7 @@ msgstr ""
 "Copia a sinistra (Alt+Sinistra)"
 
 #. ID_L2RNEXT
-#: Merge.rc:5343
+#: Merge.rc:5342
 msgid ""
 "\n"
 "Copy to Right and Advance (Ctrl+Alt+Right)"
@@ -7754,7 +7749,7 @@ msgstr ""
 "Copia a destra e avanza (Ctrl+Alt+Destra)"
 
 #. ID_R2LNEXT
-#: Merge.rc:5344
+#: Merge.rc:5343
 msgid ""
 "\n"
 "Copy to Left and Advance (Ctrl+Alt+Left)"
@@ -7763,7 +7758,7 @@ msgstr ""
 "Copia a sinistra e avanza (Ctrl+Alt+Sinistra)"
 
 #. ID_ALL_RIGHT
-#: Merge.rc:5345
+#: Merge.rc:5344
 msgid ""
 "\n"
 "Copy All to Right"
@@ -7772,7 +7767,7 @@ msgstr ""
 "Copia tutto a destra"
 
 #. ID_ALL_LEFT
-#: Merge.rc:5346
+#: Merge.rc:5345
 msgid ""
 "\n"
 "Copy All to Left"
@@ -7781,7 +7776,7 @@ msgstr ""
 "Copia tutto a sinistra"
 
 #. ID_AUTO_MERGE
-#: Merge.rc:5347
+#: Merge.rc:5346
 msgid ""
 "\n"
 "Auto Merge (Ctrl+Alt+M)"
@@ -7790,7 +7785,7 @@ msgstr ""
 "Unione automatica (Ctrl+Alt+M)"
 
 #. ID_FIRSTFILE
-#: Merge.rc:5348
+#: Merge.rc:5347
 msgid ""
 "\n"
 "First File"
@@ -7799,7 +7794,7 @@ msgstr ""
 "Primo file"
 
 #. ID_NEXTFILE
-#: Merge.rc:5349
+#: Merge.rc:5348
 msgid ""
 "\n"
 "Next File (Ctrl+F8)"
@@ -7808,7 +7803,7 @@ msgstr ""
 "File successivo (Ctrl+F8)"
 
 #. ID_LASTFILE
-#: Merge.rc:5350
+#: Merge.rc:5349
 msgid ""
 "\n"
 "Last File"
@@ -7817,7 +7812,7 @@ msgstr ""
 "Ultimo file"
 
 #. ID_PREVFILE
-#: Merge.rc:5351
+#: Merge.rc:5350
 msgid ""
 "\n"
 "Previous File (Ctrl+F7)"
@@ -7826,133 +7821,133 @@ msgstr ""
 "File precedente (Ctrl+F7)"
 
 #. IDS_UNPACK_AUTO
-#: Merge.rc:5358
+#: Merge.rc:5357
 msgid "Adapted unpacker applied to both files (one needs extension)."
 msgstr ""
 "Il decompressore è applicato a entrambi i file (è sufficiente che uno dei "
 "file abbia l'estensione)."
 
 #. IDS_NO_PREDIFFER
-#: Merge.rc:5359
+#: Merge.rc:5358
 msgid "No Prediffer (Normal)"
 msgstr "Nessun prediffer (normale)"
 
 #. IDS_SUGGESTED_PLUGINS
-#: Merge.rc:5360
+#: Merge.rc:5359
 msgid "Suggested Plugins"
 msgstr "Plugin consigliate"
 
 #. IDS_NOT_SUGGESTED_PLUGINS
-#: Merge.rc:5361
+#: Merge.rc:5360
 msgid "All Plugins"
 msgstr "Tutti i plugin"
 
 #. IDS_PRIVATEBUILD_FMT
-#: Merge.rc:5367
+#: Merge.rc:5366
 #, c-format
 msgid "Private Build: %1"
 msgstr "Build privata: %1"
 
 #. IDS_ALLRIGHTS_RESERVED
-#: Merge.rc:5368
+#: Merge.rc:5367
 msgid " - All rights reserved."
 msgstr " - Tutti diritti riservati."
 
 #. IDS_TITLE_PLUGINS_SETTINGS
-#: Merge.rc:5374
+#: Merge.rc:5373
 msgid "Plugin Settings"
 msgstr "Impostazioni plugin"
 
 #. IDS_NO_SCT_SCRIPTS
-#: Merge.rc:5376
+#: Merge.rc:5375
 msgid "WSH not found - .sct scripts disabled"
 msgstr "WSH non trovato - script .sct disattivati"
 
 #. IDS_LOCBAR_GOTOLINE_FMT
-#: Merge.rc:5384
+#: Merge.rc:5383
 #, c-format
 msgid "G&o to Line %1"
 msgstr "Vai alla &linea %1"
 
 #. IDS_GOTO_MOVED_LINE
-#: Merge.rc:5390
+#: Merge.rc:5389
 msgid "Go to Moved Line\tCtrl+Shift+G"
 msgstr "Vai alla riga spostata\tCtrl+Maiusc+G"
 
 #. IDS_AUTOCOMPLETE_DISABLED
-#: Merge.rc:5396
+#: Merge.rc:5395
 msgctxt "Options dialog|General|Open dialog Auto completion"
 msgid "Disabled"
 msgstr "Disabilitato"
 
 #. IDS_AUTOCOMPLETE_FILE_SYS
-#: Merge.rc:5397
+#: Merge.rc:5396
 msgid "From file system"
 msgstr "Dal file system"
 
 #. IDS_AUTOCOMPLETE_MRU
-#: Merge.rc:5398
+#: Merge.rc:5397
 msgid "From Most Recently Used list"
 msgstr "Dall'elenco dei file recenti"
 
 #. IDS_COLORSCHEME_PLAIN
-#: Merge.rc:5404
+#: Merge.rc:5403
 msgid "No Highlighting"
 msgstr "Nessuna evidenziazione"
 
 #. IDS_COLORSCHEME_PO
-#: Merge.rc:5439
+#: Merge.rc:5438
 msgid "Portable Object"
 msgstr "Oggetto portatile"
 
 #. IDS_COLORSCHEME_RSRC
-#: Merge.rc:5444
+#: Merge.rc:5443
 msgid "Resources"
 msgstr "Risorse"
 
 #. IDS_COLORSCHEME_SH
-#: Merge.rc:5448
+#: Merge.rc:5447
 msgid "Shell"
 msgstr "Shell"
 
 #. IDS_CLOSE_LEFT_TABS
-#: Merge.rc:5469
+#: Merge.rc:5468
 msgid "Close &Left Tabs"
 msgstr "Chiudi schede a &sinistra"
 
 #. IDS_CLOSE_RIGHT_TABS
-#: Merge.rc:5470
+#: Merge.rc:5469
 msgid "Close R&ight Tabs"
 msgstr "Chiudi schede a &destra"
 
 #. IDS_CLOSE_OTHER_TABS
-#: Merge.rc:5471
+#: Merge.rc:5470
 msgid "Close &Other Tabs"
 msgstr "Chiudi &altre schede"
 
 #. IDS_TABBAR_AUTO_MAXWIDTH
-#: Merge.rc:5472
+#: Merge.rc:5471
 msgid "Enable &Auto Max Width"
 msgstr "Abilita altezza massima &automatica"
 
 #. IDS_WEBPAGE_MENU
-#: Merge.rc:5482
+#: Merge.rc:5481
 msgid "We&bpage"
 msgstr "Pagina we&b"
 
 #. IDS_VIEW_WRAP_TEXT
-#: Merge.rc:5487
+#: Merge.rc:5486
 msgid "W&rap Text"
 msgstr "Testo con a &capo automatico"
 
 #. IDS_NOTINSTALLED
-#: Merge.rc:5492
+#: Merge.rc:5491
 #, c-format
 msgid "%1 is not installed."
 msgstr "%1 non è installato."
 
 #. IDS_CREATE_FOLDER
-#: Merge.rc:5497
+#: Merge.rc:5496
 #, c-format
 msgid "%1 does not exist. Create it?"
 msgstr ""
@@ -7960,12 +7955,12 @@ msgstr ""
 "Vuoi crearlo?"
 
 #. IDS_CREATE_FOLDER_ERROR
-#: Merge.rc:5498
+#: Merge.rc:5497
 msgid "Failed to create folder."
 msgstr "Non è stato possibile creare la cartella."
 
 #. IDC_EXT_EDITOR_PATH
-#: Merge.rc:5503
+#: Merge.rc:5502
 msgid ""
 "Parameters:\n"
 "$file: Current file path\n"
@@ -7976,493 +7971,493 @@ msgstr ""
 "$linenum: numero di linea alla posizione attuale del cursore"
 
 #. IDS_DIFF_ALGORITHM_DEFAULT
-#: Merge.rc:5508
+#: Merge.rc:5507
 msgid "default"
 msgstr "predefinito"
 
 #. IDS_DIFF_ALGORITHM_MINIMAL
-#: Merge.rc:5509
+#: Merge.rc:5508
 msgid "minimal"
 msgstr "minimo"
 
 #. IDS_DIFF_ALGORITHM_PATIENCE
-#: Merge.rc:5510
+#: Merge.rc:5509
 msgid "patience"
 msgstr "pazienza"
 
 #. IDS_DIFF_ALGORITHM_HISTOGRAM
-#: Merge.rc:5511
+#: Merge.rc:5510
 msgid "histogram"
 msgstr "istogramma"
 
 #. IDS_DIFF_ALGORITHM_NONE
-#: Merge.rc:5512
+#: Merge.rc:5511
 msgid "none"
 msgstr "nessuno"
 
 #. IDS_RENDERING_MODE_GDI
-#: Merge.rc:5517
+#: Merge.rc:5516
 msgid "GDI"
 msgstr "GDI"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_DEFAULT
-#: Merge.rc:5518
+#: Merge.rc:5517
 msgid "DirectWrite Default"
 msgstr "Predefinita DirectWrite"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_ALIASED
-#: Merge.rc:5519
+#: Merge.rc:5518
 msgid "DirectWrite Aliased"
 msgstr "Alias DirectWrite"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_GDI_CLASSIC
-#: Merge.rc:5520
+#: Merge.rc:5519
 msgid "DirectWrite GDI Classic"
 msgstr "GDI Classica DirectWrite"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_GDI_NATURAL
-#: Merge.rc:5521
+#: Merge.rc:5520
 msgid "DirectWrite GDI Natural"
 msgstr "GDI naturale DirectWrite"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_NATURAL
-#: Merge.rc:5522
+#: Merge.rc:5521
 msgid "DirectWrite Natural"
 msgstr "Naturale DirectWrite"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_NATURAL_SYMMETRIC
-#: Merge.rc:5523
+#: Merge.rc:5522
 msgid "DirectWrite Natural Symmetric"
 msgstr "Naturale simmetrica DirectWrite"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_DISABLED
-#: Merge.rc:5528
+#: Merge.rc:5527
 msgctxt "Options dialog|General|Close windows with Esc"
 msgid "Disabled"
 msgstr "Disabilitata"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_1
-#: Merge.rc:5529
+#: Merge.rc:5528
 msgid "MDI child window or main window"
 msgstr "Finestra secondaria MDI o finestra principale"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_2
-#: Merge.rc:5530
+#: Merge.rc:5529
 msgid "MDI child window only"
 msgstr "Solo finestra secondaria MDI"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_3
-#: Merge.rc:5531
+#: Merge.rc:5530
 msgid "Close main window if only one MDI child window"
 msgstr ""
 "Se è presente una sola finestra secondaria MDI chiudi la finestra principale"
 
 #. IDS_DIFF_GROUP
-#: Merge.rc:5536
+#: Merge.rc:5535
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Diff"
 msgstr "Differenze"
 
 #. IDS_DIFF_HIGHLIGHT
-#: Merge.rc:5537
+#: Merge.rc:5536
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Highlight"
 msgstr "Evidenzia"
 
 #. IDS_DIFF_BLINK
-#: Merge.rc:5538
+#: Merge.rc:5537
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Blink"
 msgstr "Lampeggia"
 
 #. IDS_DIFF_BLOCKSIZE
-#: Merge.rc:5539
+#: Merge.rc:5538
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Block Size"
 msgstr "Dimensione blocco"
 
 #. IDS_DIFF_BLOCKALPHA
-#: Merge.rc:5540
+#: Merge.rc:5539
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Block Alpha"
 msgstr "Blocca alfa"
 
 #. IDS_DIFF_CDTHRESHOLD
-#: Merge.rc:5541
+#: Merge.rc:5540
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "CD Threshold"
 msgstr "Soglia CD"
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION
-#: Merge.rc:5542
+#: Merge.rc:5541
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Ins/Del Detection"
 msgstr "Rilevamento Ins/Canc"
 
 #. IDS_OVERLAY_MODE_NONE
-#: Merge.rc:5543 Merge.rc:5548
+#: Merge.rc:5542 Merge.rc:5547
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "None"
 msgstr "Nessuno"
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION_VERTICAL
-#: Merge.rc:5544
+#: Merge.rc:5543
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Vertical"
 msgstr "Verticale"
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION_HORIZONTAL
-#: Merge.rc:5545
+#: Merge.rc:5544
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Horizontal"
 msgstr "Orizzontale"
 
 #. IDS_OVERLAY_GROUP
-#: Merge.rc:5546
+#: Merge.rc:5545
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Overlay"
 msgstr "Sovrapposizione"
 
 #. IDS_OVERLAY_ALPHA
-#: Merge.rc:5547
+#: Merge.rc:5546
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha"
 msgstr "Alfa"
 
 #. IDS_OVERLAY_MODE_XOR
-#: Merge.rc:5549
+#: Merge.rc:5548
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "XOR"
 msgstr "XOR"
 
 #. IDS_OVERLAY_MODE_ALPHA
-#: Merge.rc:5550
+#: Merge.rc:5549
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha Blend"
 msgstr "Miscela alfa"
 
 #. IDS_OVERLAY_MODE_ALPHA_ANIMATION
-#: Merge.rc:5551
+#: Merge.rc:5550
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha Animation"
 msgstr "Animazione alfa"
 
 #. IDS_ZOOM
-#: Merge.rc:5552
+#: Merge.rc:5551
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Zoom"
 msgstr "Zoom"
 
 #. IDS_PAGE
-#: Merge.rc:5553
+#: Merge.rc:5552
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Page:"
 msgstr "Pagina:"
 
 #. IDS_IMGCMP_STATUS_PT_RGBA_FMT
-#: Merge.rc:5554
+#: Merge.rc:5553
 #, c-format
 msgid "Pt: (%d, %d)  RGBA: (%d, %d, %d, %d)  "
 msgstr "Pt: (%d, %d)  RGBA: (%d, %d, %d, %d)  "
 
 #. IDS_IMGCMP_STATUS_DIST1_FMT
-#: Merge.rc:5555
+#: Merge.rc:5554
 #, c-format
 msgid "Dist: %g  "
 msgstr "Dist: %g  "
 
 #. IDS_IMGCMP_STATUS_DIST2_FMT
-#: Merge.rc:5556
+#: Merge.rc:5555
 #, c-format
 msgid "Dist: %g, %g  "
 msgstr "Dist: %g, %g  "
 
 #. IDS_IMGCMP_STATUS_PAGE_ZOOM_SIZE_BPP_FMT
-#: Merge.rc:5557
+#: Merge.rc:5556
 #, c-format
 msgid "Page: %d/%d  Zoom: %d%%  %dx%dpx  %dbpp  "
 msgstr "Pagina: %d/%d  Zoom: %d%%  %dx%dpx  %dbpp  "
 
 #. IDS_IMGCMP_STATUS_RC_FMT
-#: Merge.rc:5558
+#: Merge.rc:5557
 #, c-format
 msgid "Rc: (%d, %d)  "
 msgstr "Rc: (%d, %d)  "
 
 #. IDS_IMGCMP_STATUS_FLIPPED_FMT
-#: Merge.rc:5559
+#: Merge.rc:5558
 #, c-format
 msgid "Flipped: %s  "
 msgstr "Invertito: %s  "
 
 #. IDS_IMGCMP_STATUS_ROTATED_FMT
-#: Merge.rc:5560
+#: Merge.rc:5559
 #, c-format
 msgid "Rotated: %d  "
 msgstr "Ruotato: %d "
 
 #. IDS_IMGCMP_REPORT_ALLPAGES
-#: Merge.rc:5561
+#: Merge.rc:5560
 msgid "All pages"
 msgstr "Tutte le pagine"
 
 #. IDS_IGNSUB_STR1
-#: Merge.rc:5566
+#: Merge.rc:5565
 msgid "<Edit here>"
 msgstr "<Modifica>"
 
 #. IDS_IGNSUB_STR2
-#: Merge.rc:5567
+#: Merge.rc:5566
 msgid "No differences found to select"
 msgstr "Non è stata trovata nessuna differenza da selezionare"
 
 #. IDS_IGNSUB_STR3
-#: Merge.rc:5568
+#: Merge.rc:5567
 msgid "No differences found to add as substitution filter"
 msgstr "Nessuna differenza trovata da aggiungere come filtro sostituzione"
 
 #. IDS_IGNSUB_STR4
-#: Merge.rc:5569
+#: Merge.rc:5568
 msgid "The pair is already in the Substitution Filters list"
 msgstr "La coppia è già presente nell'elenco dei filtri sostituzione"
 
 #. IDS_IGNSUB_STR5
-#: Merge.rc:5570
+#: Merge.rc:5569
 msgid "Add this change to Substitution Filters?"
 msgstr "Vuoi aggiungere questa modifica ai filtri sostituzione?"
 
 #. IDS_OCRRESULT_TEXTONLY
-#: Merge.rc:5575
+#: Merge.rc:5574
 msgid "Text only"
 msgstr "Solo testo"
 
 #. IDS_OCRRESULT_POS_LINE
-#: Merge.rc:5576
+#: Merge.rc:5575
 msgid "Line-by-line position and text"
 msgstr "Posizione e testo riga per riga"
 
 #. IDS_OCRRESULT_POS_WORD
-#: Merge.rc:5577
+#: Merge.rc:5576
 msgid "Word-by-word position and text"
 msgstr "Posizione e testo parola per parola"
 
 #. IDS_USERDATAFOLDER_APPDATA
-#: Merge.rc:5582
+#: Merge.rc:5581
 msgid "AppData (Roaming) folder"
 msgstr "Cartella Appdata (Roaming)"
 
 #. IDS_USERDATAFOLDER_INSTALL
-#: Merge.rc:5583
+#: Merge.rc:5582
 msgid "Install folder"
 msgstr "Cartella installazione"
 
 #. IDS_USERDATAFOLDER_DOCUMENTS
-#: Merge.rc:5584
+#: Merge.rc:5583
 msgid "Documents folder"
 msgstr "Cartella Documenti"
 
 #. IDS_SINGLEINSTANCE_DISABLED
-#: Merge.rc:5589
+#: Merge.rc:5588
 msgctxt "Options dialog|General|Single instance mode"
 msgid "Disabled"
 msgstr "Disabilitata"
 
 #. IDS_SINGLEINSTANCE_STR1
-#: Merge.rc:5590
+#: Merge.rc:5589
 msgid "Allow only one instance to run"
 msgstr "Permetti l'esecuzione di un'unica istanza del programma"
 
 #. IDS_CLIPBOARD_HISTORY
-#: Merge.rc:5591
+#: Merge.rc:5590
 msgid "Clipboard &History"
 msgstr "&Cronologia aappunti"
 
 #. IDS_SINGLEINSTANCE_STR2
-#: Merge.rc:5592
+#: Merge.rc:5591
 msgid "Allow only one instance; wait for termination"
 msgstr ""
 "Permetti l'esecuzione di un'unica istanza del programma e attendi che termini"
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_DISABLED
-#: Merge.rc:5597
+#: Merge.rc:5596
 msgctxt "Options dialog|General|Auto-reload modified files"
 msgid "Disabled"
 msgstr "Disabilitato"
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_STR1
-#: Merge.rc:5598
+#: Merge.rc:5597
 msgid "Only on window activated"
 msgstr "Solo nella finestra attivata"
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_STR2
-#: Merge.rc:5599
+#: Merge.rc:5598
 msgid "Immediately"
 msgstr "Immediatamente"
 
 #. IDS_PLUGIN_ALL
-#: Merge.rc:5604
+#: Merge.rc:5603
 msgid "Al&l"
 msgstr "&Tutti"
 
 #. IDS_PLUGIN_OTHERS
-#: Merge.rc:5605
+#: Merge.rc:5604
 msgid "&Others"
 msgstr "&Altri"
 
-#: Merge.rc:5607
+#: Merge.rc:5606
 #, c-format
 msgid "Missing plugin name in pipeline: %1"
 msgstr "Nome plugin mancante nella pipeline plugin: %1"
 
-#: Merge.rc:5609
+#: Merge.rc:5608
 #, c-format
 msgid "Missing quote in plugin pipeline: %1"
 msgstr "Virgoletta mancante nella pipeline plugin: %1"
 
 #. IDS_PLUGIN_NAME_ALREADY_EXISTS
-#: Merge.rc:5610
+#: Merge.rc:5609
 #, c-format
 msgid "Plugin name '%1' already exists."
 msgstr "Il nome plugin '%1' esiste già."
 
 #. IDS_PLUGIN_TITLE1
-#: Merge.rc:5611
+#: Merge.rc:5610
 msgid "Specify plugin arguments"
 msgstr "Specifica gli argomenti del plugin"
 
-#: Merge.rc:5613
+#: Merge.rc:5612
 #, c-format
 msgid "Plugin not found or invalid: %1"
 msgstr "Plugin non trovato o non valido: %1"
 
 #. IDS_PLUGIN_NOT_UNPACK
-#: Merge.rc:5614
+#: Merge.rc:5613
 #, c-format
 msgid "'%1' is not an unpacker plugin"
 msgstr "'%1' non è un plugin di decompressione"
 
 #. IDS_PLUGIN_NOT_PREDIFF
-#: Merge.rc:5615
+#: Merge.rc:5614
 #, c-format
 msgid "'%1' is not a prediffer plugin"
 msgstr "'%1' non è un plugin pre-differente"
 
-#: Merge.rc:5617
+#: Merge.rc:5616
 #, c-format
 msgid "Error prediffing '%1' with '%2'. Prediffing disabled."
 msgstr "Errore pre-differenze \"%1\" con \"%2\". Pre-differenze disabilitate."
 
 #. IDS_PLUGIN_CIRCULAR_REFERENCE
-#: Merge.rc:5618
+#: Merge.rc:5617
 #, c-format
 msgid "Circular reference in plugin pipeline: %1"
 msgstr "Riferimento circolare pipeline plugin: %1"
 
 #. IDS_PLUGIN_TYPE1
-#: Merge.rc:5619
+#: Merge.rc:5618
 msgid "URL Handler"
 msgstr "Gestore URL"
 
 #. IDS_PLUGIN_TYPE2
-#: Merge.rc:5620
+#: Merge.rc:5619
 msgid "File Unpacker"
 msgstr "Decompressione file"
 
 #. IDS_PLUGIN_TYPE3
-#: Merge.rc:5621
+#: Merge.rc:5620
 msgid "File or Folder Unpacker"
 msgstr "Decompressione file/cartella"
 
 #. IDS_PLUGIN_TYPE5
-#: Merge.rc:5623
+#: Merge.rc:5622
 msgid "Alias for Unpacker"
 msgstr "Alias decompressione"
 
 #. IDS_PLUGIN_TYPE6
-#: Merge.rc:5624
+#: Merge.rc:5623
 msgid "Alias for Prediffer"
 msgstr "Alias pre-differenza"
 
 #. IDS_PLUGIN_TYPE7
-#: Merge.rc:5625
+#: Merge.rc:5624
 msgid "Alias for Editor script"
 msgstr "Alias per script editor"
 
 #. IDS_PLUGIN_ALIAS_DESC
-#: Merge.rc:5626
+#: Merge.rc:5625
 #, c-format
 msgid "Alias for plugin pipeline '%1'"
 msgstr "Alias pipeline plugin '%1'"
 
 #. IDS_PLUGIN_NEW_DESC
-#: Merge.rc:5627
+#: Merge.rc:5626
 msgid "New plugin description"
 msgstr "Nuova descrizione plugin"
 
 #. IDS_PLUGIN_TARGETS_ALL
-#: Merge.rc:5628
+#: Merge.rc:5627
 msgid "All"
 msgstr "Tutti"
 
 #. IDS_PLUGIN_TARGETS_1ST
-#: Merge.rc:5629
+#: Merge.rc:5628
 msgid "1st"
 msgstr "Primo"
 
 #. IDS_PLUGIN_TARGETS_2ND
-#: Merge.rc:5630
+#: Merge.rc:5629
 msgid "2nd"
 msgstr "Secondo"
 
 #. IDS_PLUGIN_TARGETS_3RD
-#: Merge.rc:5631
+#: Merge.rc:5630
 msgid "3rd"
 msgstr "terzo"
 
 #. IDS_PLUGIN_TARGETS_1ST_2ND
-#: Merge.rc:5632
+#: Merge.rc:5631
 msgid "1st and 2nd"
 msgstr "Primo e secondo"
 
 #. IDS_PLUGIN_TARGETS_1ST_3RD
-#: Merge.rc:5633
+#: Merge.rc:5632
 msgid "1st and 3rd"
 msgstr "Primo e terzo"
 
 #. IDS_PLUGIN_TARGETS_2ND_3RD
-#: Merge.rc:5634
+#: Merge.rc:5633
 msgid "2nd and 3rd"
 msgstr "Secondo e terzo"
 
 #. IDS_PLUGIN_CTRL_CLICK
-#: Merge.rc:5635
+#: Merge.rc:5634
 msgid "(Ctrl+Click to add to pipeline)"
 msgstr ""
 
 #. IDS_FILTER_APPLIED
-#: Merge.rc:5640
+#: Merge.rc:5639
 msgid "Filter applied"
 msgstr "Filtro applicato"
 
 #. IDS_FILTERMENU_COMPARE
-#: Merge.rc:5645
+#: Merge.rc:5644
 #, c-format
 msgid "Compare %1"
 msgstr "Confronta %1"
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN2
-#: Merge.rc:5647
+#: Merge.rc:5646
 msgid "&Filter by This Column..."
 msgstr "&Filtra in base a questa colonna..."
 
 #. IDS_CLIPBOARDHISTORY_TIME
-#: Merge.rc:5652
+#: Merge.rc:5651
 #, c-format
 msgid "Clipboard at %s"
 msgstr "Appunti in %s"
 
 #. IDS_CLIPBOARDHISTORY_DISABLED
-#: Merge.rc:5653
+#: Merge.rc:5652
 msgid ""
 "Clipboard history disabled.\r\n"
 "Enable: Windows logo key + V, then Turn on."
@@ -8471,118 +8466,118 @@ msgstr ""
 "Per abilitare la cronologia degli appunti, premi il tasto Logo Windows + V, "
 "quindi fai clic sul pulsante Attiva."
 
-#: Merge.rc:5655
+#: Merge.rc:5654
 msgid "This system does not support clipboard history."
 msgstr "Questo sistema non supporta la cronologia degli appunti."
 
-#: Merge.rc:5657
+#: Merge.rc:5656
 msgid "32-bit WinMerge does not support Clipboard Compare"
 msgstr ""
 "La versione di WinMerge a 32 bit non supporta il confronto degli appunti"
 
 #. IDS_WEBVIEW2_RUNTIME_NOT_INSTALLED
-#: Merge.rc:5662
+#: Merge.rc:5661
 msgid "WebView2 runtime not installed. Download it?"
 msgstr ""
 "Il runtime WebView2 non è installato.\n"
 "Vuoi scaricarlo?"
 
 #. IDS_JUMPLIST_NEW_TEXT_COMPARE
-#: Merge.rc:5667
+#: Merge.rc:5666
 msgid "New Text Compare"
 msgstr "Nuovo confronto testo"
 
 #. IDS_JUMPLIST_NEW_TABLE_COMPARE
-#: Merge.rc:5668
+#: Merge.rc:5667
 msgid "New Table Compare"
 msgstr "Nuova confronto tabella"
 
 #. IDS_JUMPLIST_NEW_BINARY_COMPARE
-#: Merge.rc:5669
+#: Merge.rc:5668
 msgid "New Binary Compare"
 msgstr "Nuovo confronto binario"
 
 #. IDS_JUMPLIST_NEW_IMAGE_COMPARE
-#: Merge.rc:5670
+#: Merge.rc:5669
 msgid "New Image Compare"
 msgstr "Nuovo confronto immagine"
 
 #. IDS_JUMPLIST_NEW_WEBPAGE_COMPARE
-#: Merge.rc:5671
+#: Merge.rc:5670
 msgid "New Webpage Compare"
 msgstr "Nuovo confronto pagina web"
 
 #. IDS_JUMPLIST_NEW_FOLDER_COMPARE
-#: Merge.rc:5672
+#: Merge.rc:5671
 msgid "New Folder Compare"
 msgstr "Nuovo confronto cartella"
 
 #. IDS_JUMPLIST_CLIPBOARD_COMPARE
-#: Merge.rc:5673
+#: Merge.rc:5672
 msgid "Clipboard Compare"
 msgstr "Confronto appunti"
 
 #. IDS_PREVIEWBAR_PRINT
-#: Merge.rc:5678
+#: Merge.rc:5677
 msgid "&Print..."
 msgstr "Stam&pa...."
 
 #. IDS_PREVIEWBAR_PREVPAGE
-#: Merge.rc:5680
+#: Merge.rc:5679
 msgid "Pre&v Page"
 msgstr "Pagina &prec"
 
 #. IDS_PREVIEWBAR_TWOPAGE
-#: Merge.rc:5681
+#: Merge.rc:5680
 msgid "&Two Page"
 msgstr "&Due pagine"
 
 #. IDS_PREVIEWBAR_ONEPAGE
-#: Merge.rc:5682
+#: Merge.rc:5681
 msgid "&One Page"
 msgstr "&Una pagina"
 
 #. IDS_PREVIEWBAR_ZOOMIN
-#: Merge.rc:5683
+#: Merge.rc:5682
 msgid "Zoom &In"
 msgstr "Zoom +"
 
 #. IDS_PREVIEWBAR_ZOOMOUT
-#: Merge.rc:5684
+#: Merge.rc:5683
 msgid "Zoom &Out"
 msgstr "Zoom &-"
 
 #. IDS_WEBPAGE_COMPARING
-#: Merge.rc:5690
+#: Merge.rc:5689
 msgid "Comparing..."
 msgstr "Confronto..."
 
 #. IDS_WEBPAGE_ZOOM
-#: Merge.rc:5691
+#: Merge.rc:5690
 msgid "Zoom:"
 msgstr "Zoom:"
 
 #. IDS_COPY_GRANULARITY_DIFFHUNK
-#: Merge.rc:5696
+#: Merge.rc:5695
 msgid "Diff hunk"
 msgstr "Segmento diff"
 
 #. IDS_COPY_GRANULARITY_INLINE
-#: Merge.rc:5697
+#: Merge.rc:5696
 msgid "Inline diff"
 msgstr "Diff. in linea"
 
 #. IDS_COPY_GRANULARITY_LINE
-#: Merge.rc:5698
+#: Merge.rc:5697
 msgid "Line"
 msgstr "Linea"
 
-#: Merge.rc:5699
+#: Merge.rc:5698
 msgid "Character"
 msgstr "Carattere"
 
 #. ID_MICE_PREVDIFF
-#: Merge.rc:5704
+#: Merge.rc:5703
 msgid ""
 "\n"
 "Previous Difference (Alt+Up)\n"
@@ -8595,7 +8590,7 @@ msgstr ""
 "(Alt+Rotellina Su)"
 
 #. ID_MICE_NEXTDIFF
-#: Merge.rc:5705
+#: Merge.rc:5704
 msgid ""
 "\n"
 "Next Difference (Alt+Down)\n"
@@ -8608,7 +8603,7 @@ msgstr ""
 "(Alt+Rotellina Giù)"
 
 #. ID_MICE_L2R
-#: Merge.rc:5706
+#: Merge.rc:5705
 msgid ""
 "\n"
 "Copy to Right (Alt+Right)\n"
@@ -8623,7 +8618,7 @@ msgstr ""
 "(Alt+Maiusc+Rotellina giù)"
 
 #. ID_MICE_R2L
-#: Merge.rc:5707
+#: Merge.rc:5706
 msgid ""
 "\n"
 "Copy to Left (Alt+Left)\n"
@@ -8638,7 +8633,7 @@ msgstr ""
 "(Alt+Maiusc+Rotellina su)"
 
 #. ID_MICE_L2RNEXT
-#: Merge.rc:5708
+#: Merge.rc:5707
 msgid ""
 "\n"
 "Copy to Right and Advance (Ctrl+Alt+Right)\n"
@@ -8651,7 +8646,7 @@ msgstr ""
 "(Ctrl+Alt+Maiusc+Rotella Giù)"
 
 #. ID_MICE_R2LNEXT
-#: Merge.rc:5709
+#: Merge.rc:5708
 msgid ""
 "\n"
 "Copy to Left and Advance (Ctrl+Alt+Left)\n"
@@ -8664,282 +8659,282 @@ msgstr ""
 "(Ctrl+Alt+Maiusc+Rotellina Su)"
 
 #. IDS_LOG_COMPARING_2
-#: Merge.rc:5719
+#: Merge.rc:5718
 #, c-format
 msgid "Comparing %1 with %2"
 msgstr "Confronto %1 con %2"
 
 #. IDS_LOG_COMPARING_3
-#: Merge.rc:5720
+#: Merge.rc:5719
 #, c-format
 msgid "Comparing %1 with %2 and %3"
 msgstr "Confronto %1 con %2 e %3"
 
 #. IDS_LOG_COMPARE_COMPLETED
-#: Merge.rc:5721
+#: Merge.rc:5720
 msgid "Comparison completed"
 msgstr "Confronto completato"
 
 #. IDS_LOG_COMPARE_ERROR_2
-#: Merge.rc:5722
+#: Merge.rc:5721
 #, c-format
 msgid "Failed to compare %1 with %2: "
 msgstr "Impossibile confrontare %1 con %2: "
 
 #. IDS_LOG_COMPARE_ERROR_3
-#: Merge.rc:5723
+#: Merge.rc:5722
 #, c-format
 msgid "Failed to compare %1 with %2 and %3: "
 msgstr "Impossibile confrontare %1 con %2 e %3: "
 
 #. IDS_LOG_FILE_SAVED
-#: Merge.rc:5724
+#: Merge.rc:5723
 msgid "File saved"
 msgstr "File salvato"
 
 #. IDS_LOG_COPYING_FILES
-#: Merge.rc:5725
+#: Merge.rc:5724
 msgid "Copying files..."
 msgstr "Copia file..."
 
 #. IDS_LOG_MOVING_FILES
-#: Merge.rc:5726
+#: Merge.rc:5725
 msgid "Moving files..."
 msgstr "Spostamento file..."
 
 #. IDS_LOG_DELETING_FILES
-#: Merge.rc:5727
+#: Merge.rc:5726
 msgid "Deleting files..."
 msgstr "Eliminazione file..."
 
 #. IDS_LOG_RECYCLEBIN
-#: Merge.rc:5728
+#: Merge.rc:5727
 msgid "Recycle Bin"
 msgstr "Cestino"
 
 #. IDS_LOG_PERMANENTLY_DELETED
-#: Merge.rc:5729
+#: Merge.rc:5728
 msgid "Permanently deleted"
 msgstr "Permanentemente eliminati"
 
 #. IDS_LOG_FILEOPERATION_COMPLETED
-#: Merge.rc:5730
+#: Merge.rc:5729
 msgid "File operation completed successfully"
 msgstr "Operazione file completata correttamente"
 
 #. IDS_LOG_FILEOPERATION_CANCELED
-#: Merge.rc:5731
+#: Merge.rc:5730
 msgid "File operation canceled"
 msgstr "Operazione file annullata"
 
 #. IDS_FILTER_ERROR_NO_ERROR
-#: Merge.rc:5736
+#: Merge.rc:5735
 msgid "No error"
 msgstr "Nessun errore"
 
 #. IDS_FILTER_ERROR_EMPTY_EXPRESSION
-#: Merge.rc:5737
+#: Merge.rc:5736
 msgid "Filter expression is empty"
 msgstr "L'espressione filtro è vuota"
 
 #. IDS_FILTER_ERROR_UNKNOWN_CHAR
-#: Merge.rc:5738
+#: Merge.rc:5737
 msgid "Unknown character in filter expression"
 msgstr "Carattere sconosciuto nell'espressione filtro"
 
 #. IDS_FILTER_ERROR_UNTERMINATED_STRING
-#: Merge.rc:5739
+#: Merge.rc:5738
 msgid "Unterminated string literal"
 msgstr "Stringa letterale non terminata"
 
 #. IDS_FILTER_ERROR_SYNTAX_ERROR
-#: Merge.rc:5740
+#: Merge.rc:5739
 msgid "Syntax error in filter expression"
 msgstr "Errore di sintassi nell'espressione filtro"
 
 #. IDS_FILTER_ERROR_PARSE_FAILURE
-#: Merge.rc:5741
+#: Merge.rc:5740
 msgid "Failed to parse filter expression"
 msgstr "Impossibile analizzare l'espressione filtro"
 
 #. IDS_FILTER_ERROR_INVALID_LITERAL
-#: Merge.rc:5742
+#: Merge.rc:5741
 msgid "Invalid literal value"
 msgstr "Valore letterale non valido"
 
 #. IDS_FILTER_ERROR_INVALID_REGULAR_EXPRESSION
-#: Merge.rc:5743
+#: Merge.rc:5742
 msgid "Invalid regular expression"
 msgstr "Espressione regolare non valida"
 
 #. IDS_FILTER_ERROR_UNDEFINED_IDENTIFIER
-#: Merge.rc:5744
+#: Merge.rc:5743
 msgid "Undefined identifier"
 msgstr "Identificatore non definito"
 
 #. IDS_FILTER_ERROR_INVALID_ARGUMENT_COUNT
-#: Merge.rc:5745
+#: Merge.rc:5744
 msgid "Invalid number of arguments"
 msgstr "Numero di argomenti non valido"
 
 #. IDS_FILTER_ERROR_FILTER_NAME_NOT_FOUND
-#: Merge.rc:5746
+#: Merge.rc:5745
 msgid "Filter name not found"
 msgstr "Nome filtro non trovato"
 
 #. IDS_FILTER_ERROR_DIVIDE_BY_ZERO
-#: Merge.rc:5747
+#: Merge.rc:5746
 msgid "Division by zero in filter expression"
 msgstr "Divisione per zero nell'espressione filtro"
 
 #. IDS_FILTER_ERROR_UNKNOWN_ERROR
-#: Merge.rc:5748
+#: Merge.rc:5747
 msgid "Unknown error"
 msgstr "Errore sconosciuto"
 
 #. IDS_FILTER_ERROR_INVALID_PROPERTY_NAME
-#: Merge.rc:5749
+#: Merge.rc:5748
 msgid "Invalid property name"
 msgstr "Nome proprietà non valido"
 
 #. IDS_FILTER_ERROR_INVALID_DIRECTIVE
-#: Merge.rc:5750
+#: Merge.rc:5749
 msgid "Invalid directive"
 msgstr "Direttiva non valida"
 
 #. IDS_FILTER_OP_EQUALS
-#: Merge.rc:5755
+#: Merge.rc:5754
 msgid "Equals"
 msgstr "Uguale"
 
 #. IDS_FILTER_OP_NOT_EQUALS
-#: Merge.rc:5756
+#: Merge.rc:5755
 msgid "Does not equal"
 msgstr "Non uguale"
 
 #. IDS_FILTER_OP_LESS_THAN
-#: Merge.rc:5757
+#: Merge.rc:5756
 msgid "Less than"
 msgstr "Inferiore a"
 
 #. IDS_FILTER_OP_LESS_EQUAL
-#: Merge.rc:5758
+#: Merge.rc:5757
 msgid "Less than or equal to"
 msgstr "Inferiore a o uguale a"
 
 #. IDS_FILTER_OP_GREATER_EQUAL
-#: Merge.rc:5759
+#: Merge.rc:5758
 msgid "Greater than or equal to"
 msgstr "Maggiore di o uguale a"
 
 #. IDS_FILTER_OP_GREATER_THAN
-#: Merge.rc:5760
+#: Merge.rc:5759
 msgid "Greater than"
 msgstr "Maggiore di"
 
 #. IDS_FILTER_OP_BETWEEN
-#: Merge.rc:5761
+#: Merge.rc:5760
 msgid "Between"
 msgstr "Tra"
 
 #. IDS_FILTER_OP_NOT_BETWEEN
-#: Merge.rc:5762
+#: Merge.rc:5761
 msgid "Not Between"
 msgstr "Non tra"
 
 #. IDS_FILTER_OP_CONTAINS
-#: Merge.rc:5763
+#: Merge.rc:5762
 msgid "Contains"
 msgstr "Contiene"
 
 #. IDS_FILTER_OP_NOT_CONTAINS
-#: Merge.rc:5764
+#: Merge.rc:5763
 msgid "Not Contains"
 msgstr "Non contiene"
 
 #. IDS_FILTER_OP_RECONTAINS
-#: Merge.rc:5765
+#: Merge.rc:5764
 msgid "Contains (regex)"
 msgstr "Contiene (regx)"
 
 #. IDS_FILTER_OP_NOT_RECONTAINS
-#: Merge.rc:5766
+#: Merge.rc:5765
 msgid "Not Contains (regex)"
 msgstr "Non contiene (regex)"
 
 #. IDS_FILTER_OP_LIKE
-#: Merge.rc:5767
+#: Merge.rc:5766
 msgid "Match (wildcard)"
 msgstr "Corrispondenza (carattere jolly)"
 
 #. IDS_FILTER_OP_NOT_LIKE
-#: Merge.rc:5768
+#: Merge.rc:5767
 msgid "Not match (wildcard)"
 msgstr "Non corrispondenza (carattere jolly)"
 
 #. IDS_FILTER_OP_MATCHES
-#: Merge.rc:5769
+#: Merge.rc:5768
 msgid "Match (regex)"
 msgstr "Corrispondenza (regex)"
 
 #. IDS_FILTER_OP_NOT_MATCHES
-#: Merge.rc:5770
+#: Merge.rc:5769
 msgid "Not match (regex)"
 msgstr "Non corrispondenza (regex)"
 
 #. IDS_COLORMODE_LIGHT
-#: Merge.rc:5775
+#: Merge.rc:5774
 msgid "Light"
 msgstr "Chiaro"
 
 #. IDS_COLORMODE_DARK
-#: Merge.rc:5776
+#: Merge.rc:5775
 msgid "Dark"
 msgstr "Scuro"
 
 #. IDS_COLORMODE_FOLLOWSYSTEM
-#: Merge.rc:5777
+#: Merge.rc:5776
 msgid "Follow system"
 msgstr "Sistema"
 
 #. IDS_EXAMPLE
-#: Merge.rc:5782
+#: Merge.rc:5781
 #, c-format
 msgid "e.g. %1"
 msgstr "es. %1"
 
 #. IDS_DETECTED_PREVIOUS_CRASH
-#: Merge.rc:5787
+#: Merge.rc:5786
 msgid "WinMerge detected a previous crash. Please report this if possible."
 msgstr "WinMerge ha rilevato un precedente arresto anomalo. Se possibile, segnalalo."
 
 #. IDS_REGEX_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5792
+#: Merge.rc:5791
 msgid "# Regex replacement list\r\n# Format: regex<TAB>replacement\r\n# Backreferences like $1, $2 are supported\r\n\r\n(\\d{4})-(\\d{2})-(\\d{2})\t$1_$2_$3\r\n"
 msgstr "# Elenco sostituzione Regex\r\n# Formato: regex<TAB>sostituzione\r\n# Sono supportati riferimenti all'indietro come $1, $2\r\n\r\n(\\d{4})-(\\d{2})-(\\d{2})\t$1_$2_$3\r\n"
 
 #. IDS_STRING_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5793
+#: Merge.rc:5792
 msgid "# Replacement list\r\n# Format: search<TAB>replacement\r\n# Lines starting with # are ignored\r\n\r\nfrom1\tto1\r\nfrom2\tto2\r\n"
 msgstr "# Elenco sostituzioni\r\n# Formato: ricerca<TAB>sostituzione\r\n# Le righe che iniziano con # verranno ignorate\r\n\r\nda1\ta1\r\nda2\ta2\r\n"
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_ONLY
-#: Merge.rc:5798
+#: Merge.rc:5797
 msgid "Built-in only"
 msgstr "Solo integrati"
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_FIRST
-#: Merge.rc:5799
+#: Merge.rc:5798
 msgid "Built-in first"
 msgstr "Prima integrati"
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_FIRST
-#: Merge.rc:5800
+#: Merge.rc:5799
 msgid "Tree-sitter first"
 msgstr "Prima tree-sitter"
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_ONLY
-#: Merge.rc:5801
+#: Merge.rc:5800
 msgid "Tree-sitter only"
 msgstr "Solo tree-sitter"
 

--- a/Translations/WinMerge/Japanese.po
+++ b/Translations/WinMerge/Japanese.po
@@ -22,7 +22,7 @@ msgstr ""
 "X-Generator: Poedit 3.9\n"
 
 #. LANGUAGE, SUBLANGUAGE
-#: Merge.rc:26 Merge.rc:59 Merge.rc:5818
+#: Merge.rc:26 Merge.rc:59 Merge.rc:5817
 msgid "LANG_ENGLISH, SUBLANG_ENGLISH_US"
 msgstr "LANG_JAPANESE, SUBLANG_DEFAULT"
 
@@ -164,7 +164,7 @@ msgstr "スクリプト(&S)"
 #. IDS_NO_EDIT_SCRIPTS
 #: Merge.rc:127 Merge.rc:352 Merge.rc:463 Merge.rc:673 Merge.rc:678
 #: Merge.rc:887 Merge.rc:899 Merge.rc:906 Merge.rc:963 Merge.rc:1210
-#: Merge.rc:5375
+#: Merge.rc:5374
 msgid "< Empty >"
 msgstr "< なし >"
 
@@ -229,7 +229,7 @@ msgid "Auto-Fit All Columns"
 msgstr "全列幅を自動調整する"
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN
-#: Merge.rc:153 Merge.rc:5646
+#: Merge.rc:153 Merge.rc:5645
 msgid "&Filter by This Column"
 msgstr "この列でフィルター(&F)"
 
@@ -290,7 +290,7 @@ msgid "&Previous Page"
 msgstr "前ページ(&P)"
 
 #. IDS_PREVIEWBAR_NEXTPAGE
-#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5679
+#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5678
 msgid "&Next Page"
 msgstr "次ページ(&N)"
 
@@ -541,7 +541,7 @@ msgstr "バイナリ(&B)"
 #. IDS_IMAGE_MENU
 #: Merge.rc:329 Merge.rc:338 Merge.rc:432 Merge.rc:441 Merge.rc:609
 #: Merge.rc:618 Merge.rc:670 Merge.rc:960 Merge.rc:1187 Merge.rc:1200
-#: Merge.rc:5477
+#: Merge.rc:5476
 msgid "&Image"
 msgstr "画像(&I)"
 
@@ -663,7 +663,7 @@ msgid "&Huge"
 msgstr "特大(&H)"
 
 #. IDS_VIEW_MENU_BAR
-#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5714
+#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5713
 msgid "Men&u Bar"
 msgstr "メニューバー(&U)"
 
@@ -1318,7 +1318,7 @@ msgid "Lo&cation Pane"
 msgstr "ロケーション ペイン(&C)"
 
 #. IDS_OUTPUTBAR_CAPTION
-#: Merge.rc:782 Merge.rc:5252
+#: Merge.rc:782 Merge.rc:5251
 msgid "Output Pane"
 msgstr "出力 ペイン"
 
@@ -1581,55 +1581,55 @@ msgid "Co&mpare As"
 msgstr "形式を指定して比較(&M)"
 
 #. IDS_COPY_LEFT_TO_MIDDLE2
-#: Merge.rc:968 Merge.rc:980 Merge.rc:4852
+#: Merge.rc:968 Merge.rc:980 Merge.rc:4851
 #, c-format
 msgid "Left to Middle (%1 of %2)"
 msgstr "左側から中央 (%1 / %2)"
 
 #. IDS_COPY_LEFT_TO_RIGHT2
-#: Merge.rc:969 Merge.rc:981 Merge.rc:4851
+#: Merge.rc:969 Merge.rc:981 Merge.rc:4850
 #, c-format
 msgid "Left to Right (%1 of %2)"
 msgstr "左側を右側に (%1 / %2)"
 
 #. IDS_MOVE_LEFT_TO2
-#: Merge.rc:970 Merge.rc:982 Merge.rc:1045 Merge.rc:4863 Merge.rc:4892
+#: Merge.rc:970 Merge.rc:982 Merge.rc:1045 Merge.rc:4862 Merge.rc:4891
 #, c-format
 msgid "Left to... (%1 of %2)"
 msgstr "左側を... (%1 / %2)"
 
 #. IDS_COPY_MIDDLE_TO_LEFT2
-#: Merge.rc:971 Merge.rc:983 Merge.rc:4849
+#: Merge.rc:971 Merge.rc:983 Merge.rc:4848
 #, c-format
 msgid "Middle to Left (%1 of %2)"
 msgstr "中央から左側 (%1 / %2)"
 
 #. IDS_COPY_MIDDLE_TO_RIGHT2
-#: Merge.rc:972 Merge.rc:984 Merge.rc:4850
+#: Merge.rc:972 Merge.rc:984 Merge.rc:4849
 #, c-format
 msgid "Middle to Right (%1 of %2)"
 msgstr "中央から右側 (%1 / %2)"
 
 #. IDS_MOVE_MIDDLE_TO2
-#: Merge.rc:973 Merge.rc:985 Merge.rc:1046 Merge.rc:4864 Merge.rc:4893
+#: Merge.rc:973 Merge.rc:985 Merge.rc:1046 Merge.rc:4863 Merge.rc:4892
 #, c-format
 msgid "Middle to... (%1 of %2)"
 msgstr "中央を... (%1 / %2)"
 
 #. IDS_COPY_RIGHT_TO_MIDDLE2
-#: Merge.rc:974 Merge.rc:986 Merge.rc:4848
+#: Merge.rc:974 Merge.rc:986 Merge.rc:4847
 #, c-format
 msgid "Right to Middle (%1 of %2)"
 msgstr "右側から中央 (%1 / %2)"
 
 #. IDS_COPY_RIGHT_TO_LEFT2
-#: Merge.rc:975 Merge.rc:987 Merge.rc:4847
+#: Merge.rc:975 Merge.rc:987 Merge.rc:4846
 #, c-format
 msgid "Right to Left (%1 of %2)"
 msgstr "右側を左側に (%1 / %2)"
 
 #. IDS_MOVE_RIGHT_TO2
-#: Merge.rc:976 Merge.rc:988 Merge.rc:1047 Merge.rc:4865 Merge.rc:4894
+#: Merge.rc:976 Merge.rc:988 Merge.rc:1047 Merge.rc:4864 Merge.rc:4893
 #, c-format
 msgid "Right to... (%1 of %2)"
 msgstr "右側を... (%1 / %2)"
@@ -1685,31 +1685,31 @@ msgid "Cop&y Paths"
 msgstr "パス名をコピー(&Y)"
 
 #. IDS_DEL_LEFT_FMT2
-#: Merge.rc:1026 Merge.rc:1035 Merge.rc:4880
+#: Merge.rc:1026 Merge.rc:1035 Merge.rc:4879
 #, c-format
 msgid "Left (%1 of %2)"
 msgstr "左側 (%1 / %2)"
 
 #. IDS_DEL_MIDDLE_FMT2
-#: Merge.rc:1027 Merge.rc:1036 Merge.rc:4881
+#: Merge.rc:1027 Merge.rc:1036 Merge.rc:4880
 #, c-format
 msgid "Middle (%1 of %2)"
 msgstr "中央 (%1 / %2)"
 
 #. IDS_DEL_RIGHT_FMT2
-#: Merge.rc:1028 Merge.rc:1037 Merge.rc:4882
+#: Merge.rc:1028 Merge.rc:1037 Merge.rc:4881
 #, c-format
 msgid "Right (%1 of %2)"
 msgstr "右側 (%1 / %2)"
 
 #. IDS_DEL_BOTH_FMT2
-#: Merge.rc:1029 Merge.rc:1038 Merge.rc:4883
+#: Merge.rc:1029 Merge.rc:1038 Merge.rc:4882
 #, c-format
 msgid "Both (%1 of %2)"
 msgstr "両側 (%1 / %2)"
 
 #. IDS_DEL_ALL_FMT2
-#: Merge.rc:1030 Merge.rc:1039 Merge.rc:4888
+#: Merge.rc:1030 Merge.rc:1039 Merge.rc:4887
 #, c-format
 msgid "All (%1 of %2)"
 msgstr "すべて (%1 / %2)"
@@ -1735,19 +1735,19 @@ msgid "&Zip"
 msgstr "圧縮(&Z)"
 
 #. IDS_COPY_BOTH_TO2
-#: Merge.rc:1048 Merge.rc:4866
+#: Merge.rc:1048 Merge.rc:4865
 #, c-format
 msgid "Both to... (%1 of %2)"
 msgstr "両側を... (%1 / %2)"
 
 #. IDS_COPY_ALL_TO2
-#: Merge.rc:1049 Merge.rc:4867
+#: Merge.rc:1049 Merge.rc:4866
 #, c-format
 msgid "All to... (%1 of %2)"
 msgstr "すべてを... (%1 / %2)"
 
 #. IDS_COPY_DIFFERENCES_TO2
-#: Merge.rc:1050 Merge.rc:4868
+#: Merge.rc:1050 Merge.rc:4867
 #, c-format
 msgid "Differences to... (%1 of %2)"
 msgstr "差異を... (%1 / %2)"
@@ -1814,12 +1814,12 @@ msgstr "展開プラグイン設定"
 
 #. IDS_USERCHOICE_NONE
 #: Merge.rc:1088 Merge.rc:1094 Merge.rc:1836 Merge.rc:1840 Merge.rc:2031
-#: Merge.rc:2035 Merge.rc:5377
+#: Merge.rc:2035 Merge.rc:5376
 msgid "<None>"
 msgstr "<なし>"
 
 #. IDS_USERCHOICE_AUTOMATIC
-#: Merge.rc:1089 Merge.rc:1095 Merge.rc:5378
+#: Merge.rc:1089 Merge.rc:1095 Merge.rc:5377
 msgid "<Automatic>"
 msgstr "<自動>"
 
@@ -2749,12 +2749,12 @@ msgid "Text files only"
 msgstr "テキストファイルのみ"
 
 #. IDS_EOL_NONE
-#: Merge.rc:1667 Merge.rc:1918 Merge.rc:5304
+#: Merge.rc:1667 Merge.rc:1918 Merge.rc:5303
 msgid "None"
 msgstr "なし"
 
 #. IDS_EOL_MIXED
-#: Merge.rc:1668 Merge.rc:5299
+#: Merge.rc:1668 Merge.rc:5298
 msgid "Mixed"
 msgstr "Mixed"
 
@@ -3026,13 +3026,13 @@ msgstr "行状態(&S)"
 
 #. IDS_DIFFERENT
 #: Merge.rc:1904 Merge.rc:1988 Merge.rc:2866 Merge.rc:3036 Merge.rc:3077
-#: Merge.rc:5058
+#: Merge.rc:5057
 msgid "Different"
 msgstr "差異あり"
 
 #. IDS_IDENTICAL
 #: Merge.rc:1905 Merge.rc:1989 Merge.rc:2865 Merge.rc:3055 Merge.rc:3116
-#: Merge.rc:5048
+#: Merge.rc:5047
 msgid "Identical"
 msgstr "同一"
 
@@ -3052,7 +3052,7 @@ msgid "Missing"
 msgstr "欠落している"
 
 #. IDS_MOVED
-#: Merge.rc:1910 Merge.rc:5076
+#: Merge.rc:1910 Merge.rc:5075
 msgid "Moved"
 msgstr "移動"
 
@@ -3792,7 +3792,7 @@ msgid "&Use custom system colors"
 msgstr "カスタムシステムカラーを使用する（一部のUI要素には適用されません）"
 
 #. IDS_PRPCAT_SYSTEM
-#: Merge.rc:2565 Merge.rc:4559 Merge.rc:4560 Merge.rc:5007
+#: Merge.rc:2565 Merge.rc:4559 Merge.rc:4560 Merge.rc:5006
 msgid "System"
 msgstr "システム"
 
@@ -4192,7 +4192,7 @@ msgid "Items compared:"
 msgstr "比較した項目:"
 
 #. IDS_PREVIEWBAR_CLOSE
-#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5685
+#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5684
 msgid "&Close"
 msgstr "閉じる(&C)"
 
@@ -4815,7 +4815,7 @@ msgid "A&ppend timestamp"
 msgstr "タイムスタンプを追加する(&P)"
 
 #. IDS_CONFIRM_COPY_CAPTION
-#: Merge.rc:3214 Merge.rc:4915
+#: Merge.rc:3214 Merge.rc:4914
 msgid "Confirm Copy"
 msgstr "コピーの確認"
 
@@ -5052,7 +5052,7 @@ msgid "&Character Set..."
 msgstr "文字セット(&C)..."
 
 #. IDS_PRPCAT_IMAGE
-#: Merge.rc:3351 Merge.rc:4574 Merge.rc:5015
+#: Merge.rc:3351 Merge.rc:4574 Merge.rc:5014
 msgid "Image"
 msgstr "画像"
 
@@ -5451,7 +5451,7 @@ msgid "Project"
 msgstr "プロジェクト"
 
 #. IDS_COLHDR_NSDIFFS
-#: Merge.rc:4566 Merge.rc:4990
+#: Merge.rc:4566 Merge.rc:4989
 msgid "Differences"
 msgstr "差異"
 
@@ -5596,12 +5596,12 @@ msgid "File Type"
 msgstr "ファイル タイプ"
 
 #. IDS_COLHDR_EXTENSION
-#: Merge.rc:4653 Merge.rc:4947
+#: Merge.rc:4653 Merge.rc:4946
 msgid "Extension"
 msgstr "拡張子"
 
 #. IDS_PRPCAT_MESSAGE
-#: Merge.rc:4659 Merge.rc:5019
+#: Merge.rc:4659 Merge.rc:5018
 msgid "Message"
 msgstr "メッセージ"
 
@@ -5641,7 +5641,7 @@ msgid "Hidden Items"
 msgstr "非表示の項目"
 
 #. IDS_PLUGINSLIST_NAME
-#: Merge.rc:4680 Merge.rc:5311
+#: Merge.rc:4680 Merge.rc:5310
 msgid "Name"
 msgstr "名前"
 
@@ -5661,7 +5661,7 @@ msgid "[F] "
 msgstr "[F] "
 
 #. IDS_PLUGINSLIST_DESC
-#: Merge.rc:4684 Merge.rc:5313
+#: Merge.rc:4684 Merge.rc:5312
 msgid "Description"
 msgstr "説明"
 
@@ -5827,155 +5827,150 @@ msgstr "行: %s  列: %d/%d  文字: %d/%d"
 msgid "  Sel: %d | %d"
 msgstr "  選択: %d | %d"
 
-#. IDS_MERGEMODE_MERGING
-#: Merge.rc:4734
-msgid "Merge"
-msgstr "マージ"
-
 #. IDS_DIFF_NUMBER_STATUS_FMT
-#: Merge.rc:4735
+#: Merge.rc:4734
 #, c-format
 msgid "Difference %1 of %2"
 msgstr "差異 %1 / %2"
 
 #. IDS_NO_DIFF_SEL_FMT
-#: Merge.rc:4736
+#: Merge.rc:4735
 #, c-format
 msgid "%1 Differences Found"
 msgstr "%1 件の差異が見つかりました"
 
 #. IDS_1_DIFF_FOUND
-#: Merge.rc:4737
+#: Merge.rc:4736
 msgid "1 Difference Found"
 msgstr "1 件の差異が見つかりました"
 
 #. IDS_NO_ERR_SEL_FMT
-#: Merge.rc:4738
+#: Merge.rc:4737
 #, c-format
 msgid "%1 Errors Found"
 msgstr "%1 件のエラーが発生しました"
 
 #. IDS_1_ERR_FOUND
-#: Merge.rc:4739
+#: Merge.rc:4738
 msgid "1 Error Found"
 msgstr "1 件のエラーが発生しました"
 
 #. IDS_STATUSBAR_READONLY, Abbreviation from "Read Only"
-#: Merge.rc:4740
+#: Merge.rc:4739
 msgid "RO"
 msgstr "RO"
 
 #. IDS_DIRVIEW_STATUS_FMT_FOCUS
-#: Merge.rc:4746
+#: Merge.rc:4745
 #, c-format
 msgid "Item %1 of %2"
 msgstr "項目 %1 / %2"
 
 #. IDS_DIRVIEW_STATUS_FMT_NOFOCUS
-#: Merge.rc:4747
+#: Merge.rc:4746
 #, c-format
 msgid "Items: %1"
 msgstr "項目: %1"
 
 #. IDS_DIRVIEW_STATUS_COMPARING
-#: Merge.rc:4748
+#: Merge.rc:4747
 msgid "Comparing items..."
 msgstr "項目を比較しています..."
 
 #. IDS_ITEMS_PER_SEC
-#: Merge.rc:4749
+#: Merge.rc:4748
 #, c-format
 msgid "%.1f[items/sec]"
 msgstr "%.1f[項目/秒]"
 
 #. IDS_ERROR_INCOMPARABLE
-#: Merge.rc:4755
+#: Merge.rc:4754
 msgid "Select two existing folders/files to compare."
 msgstr "存在するフォルダーまたはファイルを選択してください。"
 
 #. IDS_DIRSEL_TAG
-#: Merge.rc:4756
+#: Merge.rc:4755
 msgid "Folder Selection"
 msgstr "Folder Selection"
 
 #. IDS_OPEN_FILESDIRS
-#: Merge.rc:4757
+#: Merge.rc:4756
 msgid "Select two (or three) folders/files to compare."
 msgstr "比較するフォルダーまたはファイルを 2 つ (または 3 つ) 選択してください。"
 
 #. IDS_OPEN_LEFTINVALID
-#: Merge.rc:4758
+#: Merge.rc:4757
 msgid "Left (1st) path is invalid!"
 msgstr "左側 (1 番目) のパスが無効です!"
 
 #. IDS_OPEN_MIDDLEINVALID
-#: Merge.rc:4759
+#: Merge.rc:4758
 msgid "Middle (2nd) path is invalid!"
 msgstr "中央 (2 番目) のパスが無効です!"
 
 #. IDS_OPEN_RIGHTINVALID2
-#: Merge.rc:4760
+#: Merge.rc:4759
 msgid "Right (2nd) path is invalid!"
 msgstr "右側 (2 番目) のパスが無効です!"
 
 #. IDS_OPEN_RIGHTINVALID3
-#: Merge.rc:4761
+#: Merge.rc:4760
 msgid "Right (3rd) path is invalid!"
 msgstr "右側 (3 番目) のパスが無効です!"
 
 #. IDS_OPEN_BOTHINVALID
-#: Merge.rc:4762
+#: Merge.rc:4761
 msgid "Both paths are invalid!"
 msgstr "両側 (1 番目と 2 番目) のパスが無効です!"
 
-#: Merge.rc:4764
+#: Merge.rc:4763
 msgid "Left (1st) and Middle (2nd) paths are invalid!"
 msgstr "左側 (1 番目) と中央 (2 番目) のパスが無効です!"
 
 #. IDS_OPEN_LEFTRIGHTINVALID
-#: Merge.rc:4765
+#: Merge.rc:4764
 msgid "Left (1st) and Right (3rd) paths are invalid!"
 msgstr "左側 (1 番目) と右側 (3 番目) のパスが無効です!"
 
-#: Merge.rc:4767
+#: Merge.rc:4766
 msgid "Middle (2nd) and Right (3rd) paths are invalid!"
 msgstr "中央 (2 番目) と右側 (3 番目) のパスが無効です!"
 
 #. IDS_OPEN_ALLINVALID
-#: Merge.rc:4768
+#: Merge.rc:4767
 msgid "All paths are invalid!"
 msgstr "すべてのパスが無効です!"
 
 #. IDS_OPEN_UNPACKERDISABLED
-#: Merge.rc:4769
+#: Merge.rc:4768
 msgid "Only enabled for file comparisons"
 msgstr "ファイル比較のみ有効"
 
 #. IDS_OPEN_MISMATCH
-#: Merge.rc:4770
+#: Merge.rc:4769
 msgid "Cannot compare file and folder!"
 msgstr "ファイルとフォルダーは比較できません!"
 
 #. IDS_ERROR_FILE_NOT_FOUND
-#: Merge.rc:4776
+#: Merge.rc:4775
 #, c-format
 msgid "File not found: %1"
 msgstr "ファイルが見つかりません: %1"
 
 #. IDS_ERROR_FOLDER_NOT_FOUND
-#: Merge.rc:4777
+#: Merge.rc:4776
 #, c-format
 msgid "Folder not found: %1"
 msgstr "フォルダーが見つかりません: %1"
 
 #. IDS_ERROR_FILE_NOT_UNPACKED
-#: Merge.rc:4778
+#: Merge.rc:4777
 #, c-format
 msgid "File not unpacked: %1"
 msgstr "ファイルが展開されていません: %1"
 
 #. IDS_ERROR_FILEOPEN
-#: Merge.rc:4779
+#: Merge.rc:4778
 #, c-format
 msgid ""
 "Cannot open file\n"
@@ -5989,12 +5984,12 @@ msgstr ""
 "%2"
 
 #. IDS_ERROR_CONF_RESOLVE
-#: Merge.rc:4780
+#: Merge.rc:4779
 msgid "Failed to parse conflict file."
 msgstr "コンフリクト ファイルの解析に失敗しました。"
 
 #. IDS_NOT_CONFLICT_FILE
-#: Merge.rc:4781
+#: Merge.rc:4780
 #, c-format
 msgid ""
 "The file\n"
@@ -6006,7 +6001,7 @@ msgstr ""
 "はコンフリクト ファイルではありません。"
 
 #. IDS_COMPARE_LARGE_FILES
-#: Merge.rc:4782
+#: Merge.rc:4781
 msgid ""
 "Comparing large files requires significant memory.\n"
 "Show only comparison results (not file contents)?"
@@ -6016,12 +6011,12 @@ msgstr ""
 "内容の表示はせずに、比較結果のみ表示しますか?"
 
 #. IDS_SAVE_AS_TITLE
-#: Merge.rc:4788
+#: Merge.rc:4787
 msgid "Save As"
 msgstr "名前を付けて保存"
 
 #. IDS_SAVE_FMT
-#: Merge.rc:4789
+#: Merge.rc:4788
 #, c-format
 msgid "Save changes to %1?"
 msgstr ""
@@ -6029,17 +6024,17 @@ msgstr ""
 "変更を保存しますか?"
 
 #. IDS_SAVEREADONLY_FMT
-#: Merge.rc:4790
+#: Merge.rc:4789
 #, c-format
 msgid "%1 is read-only. Override? Or 'No' to save as new filename?"
 msgstr "%1 は読み取り専用ファイルです。読み取り専用ファイルを上書きしますか? (新しいファイル名では保存しません。)"
 
 #. IDS_ERROR_BACKUP
-#: Merge.rc:4791
+#: Merge.rc:4790
 msgid "Error backing up file"
 msgstr "ファイル バックアップ エラー"
 
-#: Merge.rc:4793
+#: Merge.rc:4792
 #, c-format
 msgid ""
 "Unable to backup original file:\n"
@@ -6053,7 +6048,7 @@ msgstr ""
 "無視して続けますか?"
 
 #. IDS_FILESAVE_FAILED
-#: Merge.rc:4794
+#: Merge.rc:4793
 #, c-format
 msgid ""
 "Saving file failed.\n"
@@ -6068,7 +6063,7 @@ msgstr ""
 "- 別名で保存する場合は [OK] を、\n"
 "- 中止する場合は [キャンセル] を押してください。"
 
-#: Merge.rc:4796
+#: Merge.rc:4795
 #, c-format
 msgid ""
 "Plugin '%2' cannot pack changes to left file into '%1'.\n"
@@ -6081,7 +6076,7 @@ msgstr ""
 "\n"
 "展開されたものを別ファイルに保存しますか?"
 
-#: Merge.rc:4798
+#: Merge.rc:4797
 #, c-format
 msgid ""
 "Plugin '%2' cannot pack changes to middle file into '%1'.\n"
@@ -6094,7 +6089,7 @@ msgstr ""
 "\n"
 "展開されたものを別ファイルに保存しますか?"
 
-#: Merge.rc:4800
+#: Merge.rc:4799
 #, c-format
 msgid ""
 "Plugin '%2' cannot pack changes to right file into '%1'.\n"
@@ -6108,7 +6103,7 @@ msgstr ""
 "展開されたものを別ファイルに保存しますか?"
 
 #. IDS_FILECHANGED_ONDISK
-#: Merge.rc:4801
+#: Merge.rc:4800
 #, c-format
 msgid ""
 "Another application updated\n"
@@ -6121,7 +6116,7 @@ msgstr ""
 "このファイルは WinMerge 以外のアプリケーションで修正されています。修正されたファイルに上書きしますか?"
 
 #. IDS_SAVEREADONLY_MULTI
-#: Merge.rc:4802
+#: Merge.rc:4801
 #, c-format
 msgid ""
 "%1\n"
@@ -6131,7 +6126,7 @@ msgstr ""
 "は、読み取り専用です。読み取り専用の項目を上書きしますか?"
 
 #. IDS_FILECHANGED_RESCAN
-#: Merge.rc:4803
+#: Merge.rc:4802
 #, c-format
 msgid ""
 "Another application updated\n"
@@ -6146,22 +6141,22 @@ msgstr ""
 "ファイルを開きなおしますか?"
 
 #. IDS_SAVE_LEFT_AS
-#: Merge.rc:4804
+#: Merge.rc:4803
 msgid "Save Left File As"
 msgstr "左側のファイルを名前を付けて保存"
 
 #. IDS_SAVE_MIDDLE_AS
-#: Merge.rc:4805
+#: Merge.rc:4804
 msgid "Save Middle File As"
 msgstr "中央のファイルを名前を付けて保存"
 
 #. IDS_SAVE_RIGHT_AS
-#: Merge.rc:4806
+#: Merge.rc:4805
 msgid "Save Right File As"
 msgstr "右側のファイルを名前を付けて保存"
 
 #. IDS_FILE_DISAPPEARED
-#: Merge.rc:4811
+#: Merge.rc:4810
 #, c-format
 msgid ""
 "File\n"
@@ -6173,7 +6168,7 @@ msgstr ""
 "は消滅しました。続行するためにファイルのコピーを保存してください。"
 
 #. IDS_VIEWS_OUTOFSYNC
-#: Merge.rc:4817
+#: Merge.rc:4816
 msgid ""
 "Cannot merge unsynched documents.\n"
 "\n"
@@ -6184,188 +6179,188 @@ msgstr ""
 "続行する前にドキュメントを F5 キーで最新にしてください。"
 
 #. IDS_BREAK_ON_WHITESPACE
-#: Merge.rc:4822
+#: Merge.rc:4821
 msgid "Break at whitespace"
 msgstr "空白で区切る"
 
 #. IDS_BREAK_ON_PUNCTUATION
-#: Merge.rc:4823
+#: Merge.rc:4822
 msgid "Break at whitespace or punctuation"
 msgstr "空白か句読点で区切る"
 
 #. IDS_L2M
-#: Merge.rc:4829
+#: Merge.rc:4828
 msgid "Copy to &Middle\tAlt+Right"
 msgstr "中央にコピー(&M)\tAlt+Right"
 
 #. IDS_R2M
-#: Merge.rc:4830
+#: Merge.rc:4829
 msgid "Copy to &Middle\tAlt+Left"
 msgstr "中央にコピー(&M)\tAlt+Left"
 
 #. IDS_COPY_FROM_MIDDLE_R
-#: Merge.rc:4831
+#: Merge.rc:4830
 msgid "Copy from Middle\tAlt+Shift+Right"
 msgstr "中央からコピー\tAlt+Shift+Right"
 
 #. IDS_COPY_FROM_MIDDLE_L
-#: Merge.rc:4832
+#: Merge.rc:4831
 msgid "Copy from Middle\tAlt+Shift+Left"
 msgstr "中央からコピー\tAlt+Shift+Left"
 
 #. IDS_L2MNEXT
-#: Merge.rc:4833
+#: Merge.rc:4832
 msgid "Copy to Middle and Advance\tCtrl+Alt+Right"
 msgstr "中央にコピーして次に進む\tCtrl+Alt+Right"
 
 #. IDS_R2MNEXT
-#: Merge.rc:4834
+#: Merge.rc:4833
 msgid "Copy to Middle and Advance\tCtrl+Alt+Left"
 msgstr "中央にコピーして次に進む\tCtrl+Alt+Left"
 
 #. IDS_ALL_MIDDLE
-#: Merge.rc:4835
+#: Merge.rc:4834
 msgid "Copy All to Middle"
 msgstr "すべてを中央にコピー"
 
 #. IDS_COPY_RIGHT_TO_LEFT
-#: Merge.rc:4841
+#: Merge.rc:4840
 #, c-format
 msgid "Right to Left (%1)"
 msgstr "右側から左側 (%1)"
 
 #. IDS_COPY_RIGHT_TO_MIDDLE
-#: Merge.rc:4842
+#: Merge.rc:4841
 #, c-format
 msgid "Right to Middle (%1)"
 msgstr "右側から中央 (%1)"
 
 #. IDS_COPY_MIDDLE_TO_LEFT
-#: Merge.rc:4843
+#: Merge.rc:4842
 #, c-format
 msgid "Middle to Left (%1)"
 msgstr "中央から左側 (%1)"
 
 #. IDS_COPY_MIDDLE_TO_RIGHT
-#: Merge.rc:4844
+#: Merge.rc:4843
 #, c-format
 msgid "Middle to Right (%1)"
 msgstr "中央から右側 (%1)"
 
 #. IDS_COPY_LEFT_TO_RIGHT
-#: Merge.rc:4845
+#: Merge.rc:4844
 #, c-format
 msgid "Left to Right (%1)"
 msgstr "左側から右側 (%1)"
 
 #. IDS_COPY_LEFT_TO_MIDDLE
-#: Merge.rc:4846
+#: Merge.rc:4845
 #, c-format
 msgid "Left to Middle (%1)"
 msgstr "左側から中央 (%1)"
 
 #. IDS_MOVE_LEFT_TO
-#: Merge.rc:4857 Merge.rc:4889
+#: Merge.rc:4856 Merge.rc:4888
 #, c-format
 msgid "Left to... (%1)"
 msgstr "左側を... (%1)"
 
 #. IDS_MOVE_MIDDLE_TO
-#: Merge.rc:4858 Merge.rc:4890
+#: Merge.rc:4857 Merge.rc:4889
 #, c-format
 msgid "Middle to... (%1)"
 msgstr "中央を... (%1)"
 
 #. IDS_MOVE_RIGHT_TO
-#: Merge.rc:4859 Merge.rc:4891
+#: Merge.rc:4858 Merge.rc:4890
 #, c-format
 msgid "Right to... (%1)"
 msgstr "右側を... (%1)"
 
 #. IDS_COPY_BOTH_TO
-#: Merge.rc:4860
+#: Merge.rc:4859
 #, c-format
 msgid "Both to... (%1)"
 msgstr "両側を... (%1)"
 
 #. IDS_COPY_ALL_TO
-#: Merge.rc:4861
+#: Merge.rc:4860
 #, c-format
 msgid "All to... (%1)"
 msgstr "すべてを... (%1)"
 
 #. IDS_COPY_DIFFERENCES_TO
-#: Merge.rc:4862
+#: Merge.rc:4861
 #, c-format
 msgid "Differences to... (%1)"
 msgstr "差異を... (%1)"
 
 #. IDS_ONLYDIFFITEMS_CONFIRM
-#: Merge.rc:4869
+#: Merge.rc:4868
 msgid "Some selected items are identical or skipped.\nProcess only items with differences?"
 msgstr ""
 "選択した項目の一部が同一かスキップされた項目です。\n"
 "差異のある項目だけを処理しますか？"
 
 #. IDS_DEL_LEFT_FMT
-#: Merge.rc:4875
+#: Merge.rc:4874
 #, c-format
 msgid "Left (%1)"
 msgstr "左側 (%1)"
 
 #. IDS_DEL_MIDDLE_FMT
-#: Merge.rc:4876
+#: Merge.rc:4875
 #, c-format
 msgid "Middle (%1)"
 msgstr "中央 (%1)"
 
 #. IDS_DEL_RIGHT_FMT
-#: Merge.rc:4877
+#: Merge.rc:4876
 #, c-format
 msgid "Right (%1)"
 msgstr "右側 (%1)"
 
 #. IDS_DEL_BOTH_FMT
-#: Merge.rc:4878
+#: Merge.rc:4877
 #, c-format
 msgid "Both (%1)"
 msgstr "両側 (%1)"
 
 #. IDS_DEL_ALL_FMT
-#: Merge.rc:4879
+#: Merge.rc:4878
 #, c-format
 msgid "All (%1)"
 msgstr "すべて (%1)"
 
 #. IDS_SELECT_DEST_LEFT
-#: Merge.rc:4895
+#: Merge.rc:4894
 msgid "Left Side - Select Destination Folder:"
 msgstr "左側 - コピー/移動先フォルダーの指定:"
 
 #. IDS_SELECT_DEST_MIDDLE
-#: Merge.rc:4896
+#: Merge.rc:4895
 msgid "Middle Side - Select Destination Folder:"
 msgstr "中央 - コピー/移動先フォルダーの指定:"
 
 #. IDS_SELECT_DEST_RIGHT
-#: Merge.rc:4897
+#: Merge.rc:4896
 msgid "Right Side - Select Destination Folder:"
 msgstr "右側 - コピー/移動先フォルダーの指定:"
 
 #. IDS_FILES_AFFECTED_FMT
-#: Merge.rc:4898
+#: Merge.rc:4897
 #, c-format
 msgid "(%1 Files Affected)"
 msgstr "(%1 個のファイルに作用)"
 
 #. IDS_FILES_AFFECTED_FMT2
-#: Merge.rc:4899
+#: Merge.rc:4898
 #, c-format
 msgid "(%1 of %2 Files Affected)"
 msgstr "(%1 / %2 個のファイルに作用)"
 
 #. IDS_CONFIRM_DELETE_SINGLE
-#: Merge.rc:4905
+#: Merge.rc:4904
 #, c-format
 msgid ""
 "Are you sure you want to delete\n"
@@ -6378,18 +6373,18 @@ msgstr ""
 "を削除しますか?"
 
 #. IDS_CONFIRM_SINGLE_COPY
-#: Merge.rc:4906
+#: Merge.rc:4905
 msgid "Are you sure you want to copy?"
 msgstr "本当にコピーしますか?"
 
 #. IDS_CONFIRM_MULTIPLE_COPY
-#: Merge.rc:4907
+#: Merge.rc:4906
 #, c-format
 msgid "Are you sure you want to copy %d items?"
 msgstr "本当に %d 項目をコピーしますか?"
 
 #. IDS_DIRCMP_NOTSYNC
-#: Merge.rc:4908
+#: Merge.rc:4907
 #, c-format
 msgid ""
 "Operation aborted!\n"
@@ -6409,46 +6404,46 @@ msgstr ""
 "再度比較してください。"
 
 #. IDS_CONFIRM_SINGLE_MOVE
-#: Merge.rc:4913
+#: Merge.rc:4912
 msgid "Are you sure you want to move?"
 msgstr "項目を移動しますか?"
 
 #. IDS_CONFIRM_MULTIPLE_MOVE
-#: Merge.rc:4914
+#: Merge.rc:4913
 #, c-format
 msgid "Are you sure you want to move %d items?"
 msgstr "%d 個の項目を移動しますか?"
 
 #. IDS_CONFIRM_MOVE_CAPTION
-#: Merge.rc:4916
+#: Merge.rc:4915
 msgid "Confirm Move"
 msgstr "移動の確認"
 
-#: Merge.rc:4918
+#: Merge.rc:4917
 msgid "Close the folder comparison window?"
 msgstr "フォルダー比較中のウィンドウを閉じようとしています。本当にウィンドウを閉じますか?"
 
-#: Merge.rc:4920
+#: Merge.rc:4919
 msgid "Close the folder comparison window, which took a long time?"
 msgstr "比較にかなりの時間を要したウィンドウを閉じようとしています。本当にウィンドウを閉じますか?"
 
 #. IDS_ERROR_INVALID_DIR_FILE_NAME
-#: Merge.rc:4921
+#: Merge.rc:4920
 msgid "The file or folder name is invalid."
 msgstr "ファイル名またはフォルダー名が無効です。"
 
 #. IDS_ERROR_EXECUTE_FILE
-#: Merge.rc:4927
+#: Merge.rc:4926
 #, c-format
 msgid "Failed to execute external editor: %1"
 msgstr "外部エディターの実行に失敗しました: %1"
 
 #. IDS_UNKNOWN_ARCHIVE_FORMAT
-#: Merge.rc:4933
+#: Merge.rc:4932
 msgid "Unknown archive format"
 msgstr "未知のアーカイブ形式です"
 
-#: Merge.rc:4935
+#: Merge.rc:4934
 msgid ""
 "Failed to extract archive.\n"
 "Compare as text file?"
@@ -6457,513 +6452,513 @@ msgstr ""
 "アーカイブファイルをテキストファイルとして比較しますか?"
 
 #. IDS_COLHDR_FILENAME
-#: Merge.rc:4941
+#: Merge.rc:4940
 msgid "Filename"
 msgstr "名前"
 
 #. IDS_COLHDR_DIR
-#: Merge.rc:4942
+#: Merge.rc:4941
 msgctxt "DirView|ColumnHeader"
 msgid "Folder"
 msgstr "フォルダー"
 
 #. IDS_COLHDR_RESULT
-#: Merge.rc:4943
+#: Merge.rc:4942
 msgid "Comparison Result"
 msgstr "比較結果"
 
 #. IDS_COLHDR_LTIMEM
-#: Merge.rc:4944
+#: Merge.rc:4943
 msgid "Left Date"
 msgstr "左更新日時"
 
 #. IDS_COLHDR_RTIMEM
-#: Merge.rc:4945
+#: Merge.rc:4944
 msgid "Right Date"
 msgstr "右更新日時"
 
 #. IDS_COLHDR_MTIMEM
-#: Merge.rc:4946
+#: Merge.rc:4945
 msgid "Middle Date"
 msgstr "中更新日時"
 
 #. IDS_COLHDR_LSIZE
-#: Merge.rc:4948
+#: Merge.rc:4947
 msgid "Left Size"
 msgstr "左サイズ"
 
 #. IDS_COLHDR_RSIZE
-#: Merge.rc:4949
+#: Merge.rc:4948
 msgid "Right Size"
 msgstr "右サイズ"
 
 #. IDS_COLHDR_MSIZE
-#: Merge.rc:4954
+#: Merge.rc:4953
 msgid "Middle Size"
 msgstr "中サイズ"
 
 #. IDS_COLHDR_RSIZE_SHORT
-#: Merge.rc:4955
+#: Merge.rc:4954
 msgid "Right Size (Short)"
 msgstr "右サイズ(短縮)"
 
 #. IDS_COLHDR_LSIZE_SHORT
-#: Merge.rc:4956
+#: Merge.rc:4955
 msgid "Left Size (Short)"
 msgstr "左サイズ(短縮)"
 
 #. IDS_COLHDR_MSIZE_SHORT
-#: Merge.rc:4957
+#: Merge.rc:4956
 msgid "Middle Size (Short)"
 msgstr "中サイズ(短縮)"
 
 #. IDS_COLHDR_LTIMEC
-#: Merge.rc:4963
+#: Merge.rc:4962
 msgid "Left Creation Time"
 msgstr "左作成日時"
 
 #. IDS_COLHDR_RTIMEC
-#: Merge.rc:4964
+#: Merge.rc:4963
 msgid "Right Creation Time"
 msgstr "右作成日時"
 
 #. IDS_COLHDR_MTIMEC
-#: Merge.rc:4965
+#: Merge.rc:4964
 msgid "Middle Creation Time"
 msgstr "中作成日時"
 
 #. IDS_COLHDR_NEWER
-#: Merge.rc:4966
+#: Merge.rc:4965
 msgid "Newer File"
 msgstr "日時比較"
 
 #. IDS_COLHDR_LVERSION
-#: Merge.rc:4967
+#: Merge.rc:4966
 msgid "Left File Version"
 msgstr "左バージョン"
 
 #. IDS_COLHDR_RVERSION
-#: Merge.rc:4968
+#: Merge.rc:4967
 msgid "Right File Version"
 msgstr "右バージョン"
 
 #. IDS_COLHDR_MVERSION
-#: Merge.rc:4969
+#: Merge.rc:4968
 msgid "Middle File Version"
 msgstr "中バージョン"
 
 #. IDS_COLHDR_RESULT_ABBR
-#: Merge.rc:4970
+#: Merge.rc:4969
 msgid "Short Result"
 msgstr "比較結果(簡易)"
 
 #. IDS_COLHDR_LATTRIBUTES
-#: Merge.rc:4971
+#: Merge.rc:4970
 msgid "Left Attributes"
 msgstr "左属性"
 
 #. IDS_COLHDR_RATTRIBUTES
-#: Merge.rc:4972
+#: Merge.rc:4971
 msgid "Right Attributes"
 msgstr "右属性"
 
 #. IDS_COLHDR_MATTRIBUTES
-#: Merge.rc:4973
+#: Merge.rc:4972
 msgid "Middle Attributes"
 msgstr "中属性"
 
 #. IDS_COLHDR_LEOL_TYPE
-#: Merge.rc:4978
+#: Merge.rc:4977
 msgid "Left EOL"
 msgstr "左EOL"
 
 #. IDS_COLHDR_MEOL_TYPE
-#: Merge.rc:4979
+#: Merge.rc:4978
 msgid "Middle EOL"
 msgstr "中EOL"
 
 #. IDS_COLHDR_REOL_TYPE
-#: Merge.rc:4980
+#: Merge.rc:4979
 msgid "Right EOL"
 msgstr "右EOL"
 
 #. IDS_COLHDR_LENCODING
-#: Merge.rc:4986
+#: Merge.rc:4985
 msgid "Left Encoding"
 msgstr "左文字コード"
 
 #. IDS_COLHDR_RENCODING
-#: Merge.rc:4987
+#: Merge.rc:4986
 msgid "Right Encoding"
 msgstr "右文字コード"
 
 #. IDS_COLHDR_MENCODING
-#: Merge.rc:4988
+#: Merge.rc:4987
 msgid "Middle Encoding"
 msgstr "中文字コード"
 
 #. IDS_COLHDR_NIDIFFS
-#: Merge.rc:4989
+#: Merge.rc:4988
 msgid "Ignored Diff"
 msgstr "無視した差異数"
 
 #. IDS_COLHDR_BINARY
-#: Merge.rc:4991
+#: Merge.rc:4990
 msgctxt "DirView|ColumnHeader"
 msgid "Binary"
 msgstr "バイナリ"
 
 #. IDS_PLUGINS_TYPE_UNPACKER
-#: Merge.rc:4992 Merge.rc:5314
+#: Merge.rc:4991 Merge.rc:5313
 msgid "Unpacker"
 msgstr "展開プラグイン"
 
 #. IDS_PLUGIN_TYPE4
-#: Merge.rc:4993 Merge.rc:5315 Merge.rc:5622
+#: Merge.rc:4992 Merge.rc:5314 Merge.rc:5621
 msgid "Prediffer"
 msgstr "比較前処理プラグイン"
 
 #. IDS_COLHDR_LEFT
-#: Merge.rc:4994
+#: Merge.rc:4993
 msgid "Left"
 msgstr "左側"
 
 #. IDS_COLHDR_MIDDLE
-#: Merge.rc:4995
+#: Merge.rc:4994
 msgid "Middle"
 msgstr "中央"
 
 #. IDS_COLHDR_RIGHT
-#: Merge.rc:4996
+#: Merge.rc:4995
 msgid "Right"
 msgstr "右側"
 
 #. IDS_COLHDR_DIFF
-#: Merge.rc:4997
+#: Merge.rc:4996
 msgid "Diff"
 msgstr "差異"
 
 #. IDS_COLHDR_LEFT_DUPLICATE
-#: Merge.rc:4998
+#: Merge.rc:4997
 msgid "Left Duplicate Count"
 msgstr "左側重複数"
 
 #. IDS_COLHDR_RIGHT_DUPLICATE
-#: Merge.rc:4999
+#: Merge.rc:4998
 msgid "Right Duplicate Count"
 msgstr "右側重複数"
 
 #. IDS_COLHDR_MIDDLE_DUPLICATE
-#: Merge.rc:5000
+#: Merge.rc:4999
 msgid "Middle Duplicate Count"
 msgstr "中央重複数"
 
 #. IDS_COLHDR_MOVE
-#: Merge.rc:5001
+#: Merge.rc:5000
 msgid "Move"
 msgstr "移動"
 
 #. IDS_PRPCAT_AUDIO
-#: Merge.rc:5008
+#: Merge.rc:5007
 msgid "Audio"
 msgstr "音声"
 
 #. IDS_PRPCAT_CALENDAR
-#: Merge.rc:5009
+#: Merge.rc:5008
 msgid "Calendar"
 msgstr "予定表"
 
 #. IDS_PRPCAT_COMMUNICATION
-#: Merge.rc:5010
+#: Merge.rc:5009
 msgid "Communication"
 msgstr "コミュニケーション"
 
 #. IDS_PRPCAT_CONTACT
-#: Merge.rc:5011
+#: Merge.rc:5010
 msgid "Contact"
 msgstr "連絡先"
 
 #. IDS_PRPCAT_DEVICES
-#: Merge.rc:5012
+#: Merge.rc:5011
 msgid "Devices"
 msgstr "デバイス"
 
 #. IDS_PRPCAT_DOCUMENT
-#: Merge.rc:5013
+#: Merge.rc:5012
 msgid "Document"
 msgstr "ドキュメント"
 
 #. IDS_PRPCAT_HOME
-#: Merge.rc:5014
+#: Merge.rc:5013
 msgid "Home"
 msgstr "ホーム"
 
 #. IDS_PRPCAT_JOURNAL
-#: Merge.rc:5016
+#: Merge.rc:5015
 msgid "Journal"
 msgstr "ジャーナル"
 
 #. IDS_PRPCAT_LINK
-#: Merge.rc:5017
+#: Merge.rc:5016
 msgid "Link"
 msgstr "リンク"
 
 #. IDS_PRPCAT_MEDIA
-#: Merge.rc:5018
+#: Merge.rc:5017
 msgid "Media"
 msgstr "メディア"
 
 #. IDS_PRPCAT_MUSIC
-#: Merge.rc:5020
+#: Merge.rc:5019
 msgid "Music"
 msgstr "音楽"
 
 #. IDS_PRPCAT_NOTE
-#: Merge.rc:5021
+#: Merge.rc:5020
 msgid "Note"
 msgstr "ノート"
 
 #. IDS_PRPCAT_PHOTO
-#: Merge.rc:5022
+#: Merge.rc:5021
 msgid "Photo"
 msgstr "写真"
 
 #. IDS_PRPCAT_RECORDEDTV
-#: Merge.rc:5023
+#: Merge.rc:5022
 msgid "RecordedTV"
 msgstr "TV録画"
 
 #. IDS_PRPCAT_SEARCH
-#: Merge.rc:5024
+#: Merge.rc:5023
 msgid "Search"
 msgstr "検索"
 
 #. IDS_PRPCAT_SECURITY
-#: Merge.rc:5025
+#: Merge.rc:5024
 msgid "Security"
 msgstr "セキュリティ"
 
 #. IDS_PRPCAT_SOFTWARE
-#: Merge.rc:5026
+#: Merge.rc:5025
 msgid "Software"
 msgstr "ソフトウェア"
 
 #. IDS_PRPCAT_TASK
-#: Merge.rc:5027
+#: Merge.rc:5026
 msgid "Task"
 msgstr "タスク"
 
 #. IDS_PRPCAT_VIDEO
-#: Merge.rc:5028
+#: Merge.rc:5027
 msgid "Video"
 msgstr "ビデオ"
 
 #. IDS_PRPCAT_HASH
-#: Merge.rc:5029
+#: Merge.rc:5028
 msgid "Hash"
 msgstr "ハッシュ"
 
 #. IDS_CANT_COMPARE_FILES
-#: Merge.rc:5035
+#: Merge.rc:5034
 msgid "Unable to compare files"
 msgstr "ファイルを比較できません"
 
 #. IDS_ABORTED_ITEM
-#: Merge.rc:5036
+#: Merge.rc:5035
 msgid "Item aborted"
 msgstr "中断された項目"
 
 #. IDS_FILE_SKIPPED
-#: Merge.rc:5037
+#: Merge.rc:5036
 msgid "File skipped"
 msgstr "スキップされたファイル"
 
 #. IDS_DIR_SKIPPED
-#: Merge.rc:5038
+#: Merge.rc:5037
 msgid "Folder skipped"
 msgstr "スキップされたフォルダー"
 
 #. IDS_LEFT_ONLY_IN_FMT
-#: Merge.rc:5039
+#: Merge.rc:5038
 #, c-format
 msgid "Left only: %1"
 msgstr "左側のみ: %1"
 
 #. IDS_MIDDLE_ONLY_IN_FMT
-#: Merge.rc:5040
+#: Merge.rc:5039
 #, c-format
 msgid "Middle only: %1"
 msgstr "中央のみ: %1"
 
 #. IDS_RIGHT_ONLY_IN_FMT
-#: Merge.rc:5041
+#: Merge.rc:5040
 #, c-format
 msgid "Right only: %1"
 msgstr "右側のみ: %1"
 
 #. IDS_DOES_NOT_EXIST_IN_FMT
-#: Merge.rc:5042
+#: Merge.rc:5041
 #, c-format
 msgid "Does not exist in %1"
 msgstr "%1 内のみ存在しません"
 
 #. IDS_BIN_FILES_SAME
-#: Merge.rc:5043
+#: Merge.rc:5042
 msgid "Binary files are identical"
 msgstr "バイナリ ファイルは同一です"
 
 #. IDS_BIN_FILES_DIFF
-#: Merge.rc:5049
+#: Merge.rc:5048
 msgid "Binary files are different"
 msgstr "バイナリ ファイルは異なっています"
 
 #. IDS_FILES_ARE_DIFFERENT
-#: Merge.rc:5050
+#: Merge.rc:5049
 msgid "Files are different"
 msgstr "ファイルは異なっています"
 
 #. IDS_FOLDERS_ARE_DIFFERENT
-#: Merge.rc:5051
+#: Merge.rc:5050
 msgid "Folders are different"
 msgstr "フォルダーは異なっています"
 
 #. IDS_LEFTONLY
-#: Merge.rc:5052
+#: Merge.rc:5051
 msgid "Left Only"
 msgstr "左側のみ"
 
 #. IDS_RIGHTONLY
-#: Merge.rc:5053
+#: Merge.rc:5052
 msgid "Right Only"
 msgstr "右側のみ"
 
 #. IDS_MIDDLEONLY
-#: Merge.rc:5054
+#: Merge.rc:5053
 msgid "Middle Only"
 msgstr "中央のみ"
 
 #. IDS_NOITEMLEFT
-#: Merge.rc:5055
+#: Merge.rc:5054
 msgid "No item in left"
 msgstr "左側にない"
 
 #. IDS_NOITEMRIGHT
-#: Merge.rc:5056
+#: Merge.rc:5055
 msgid "No item in right"
 msgstr "右側にない"
 
 #. IDS_NOITEMMIDDLE
-#: Merge.rc:5057
+#: Merge.rc:5056
 msgid "No item in middle"
 msgstr "中央にない"
 
 #. IDS_CMPRES_ERROR
-#: Merge.rc:5059
+#: Merge.rc:5058
 msgid "Error"
 msgstr "エラー"
 
 #. IDS_TEXT_FILES_SAME
-#: Merge.rc:5060
+#: Merge.rc:5059
 msgid "Text files are identical"
 msgstr "テキスト ファイルは同一です"
 
 #. IDS_LEFTONLY_DIFF
-#: Merge.rc:5061
+#: Merge.rc:5060
 msgid " (Middle and right are identical)"
 msgstr " (中央と右側は同一です)"
 
 #. IDS_MIDDLEONLY_DIFF
-#: Merge.rc:5062
+#: Merge.rc:5061
 msgid " (Left and right are identical)"
 msgstr " (左側と右側は同一です)"
 
 #. IDS_RIGHTONLY_DIFF
-#: Merge.rc:5063
+#: Merge.rc:5062
 msgid " (Left and middle are identical)"
 msgstr " (左側と中央は同一です)"
 
 #. IDS_PATH_MISMATCH
-#: Merge.rc:5064
+#: Merge.rc:5063
 msgid " (paths differ)"
 msgstr "(パス不一致)"
 
 #. IDS_TEXT_FILES_DIFF
-#: Merge.rc:5065
+#: Merge.rc:5064
 msgid "Text files are different"
 msgstr "テキスト ファイルは異なります"
 
 #. IDS_IMAGE_FILES_SAME
-#: Merge.rc:5066
+#: Merge.rc:5065
 msgid "Image files are identical"
 msgstr "画像ファイルは同一です"
 
 #. IDS_IMAGE_FILES_DIFF
-#: Merge.rc:5067
+#: Merge.rc:5066
 msgid "Image files are different"
 msgstr "画像ファイルは異なります"
 
 #. IDS_EXPR_DIFF
-#: Merge.rc:5068
+#: Merge.rc:5067
 #, c-format
 msgid "Files are different (expr: %1)"
 msgstr "ファイルは異なります (式: %1)"
 
 #. IDS_HASH_GROUP
-#: Merge.rc:5069
+#: Merge.rc:5068
 #, c-format
 msgid "Group%d"
 msgstr "グループ%d"
 
 #. IDS_RENAME_MOVE_DETECTION_DISALBED
-#: Merge.rc:5070
+#: Merge.rc:5069
 msgctxt "Options dialog|Compare|Folder|Detect renames and moves"
 msgid "Disabled"
 msgstr "無効"
 
 #. IDS_RENAME_MOVE_DETECTION_RENAME
-#: Merge.rc:5071
+#: Merge.rc:5070
 msgid "Detect renames"
 msgstr "名前変更を検出"
 
 #. IDS_RENAME_MOVE_DETECTION_RENAME_MOVE
-#: Merge.rc:5072
+#: Merge.rc:5071
 msgid "Detect renames and moves"
 msgstr "名前変更と移動を検出"
 
 #. IDS_RENAME_MOVE_MERGE_MODE_RENAME
-#: Merge.rc:5073
+#: Merge.rc:5072
 msgid "Merge renames"
 msgstr "名前変更項目をマージ"
 
 #. IDS_RENAME_MOVE_MERGE_MODE_RENAME_MOVE
-#: Merge.rc:5074
+#: Merge.rc:5073
 msgid "Merge renames and moves"
 msgstr "名前変更と移動項目をマージ"
 
 #. IDS_RENAMED
-#: Merge.rc:5075
+#: Merge.rc:5074
 msgid "Renamed"
 msgstr "名前変更"
 
 #. IDS_RENAMED_MOVED
-#: Merge.rc:5077
+#: Merge.rc:5076
 msgid "Renamed/Moved"
 msgstr "名前変更/移動"
 
 #. IDS_RENAMED_MOVED_ITEMS
-#: Merge.rc:5078
+#: Merge.rc:5077
 #, c-format
 msgid "(%1 items)"
 msgstr "(%1 項目)"
 
 #. IDS_RENAMED_MOVED_RESULT
-#: Merge.rc:5079
+#: Merge.rc:5078
 #, c-format
 msgid "%1 (set %2): "
 msgstr "%1 (グループ %2): "
 
 #. IDS_SWITCH_FLAT_MODE
-#: Merge.rc:5080
+#: Merge.rc:5079
 msgid ""
 "Some moved items have been merged.\n"
 "In Tree Mode, these items may appear in positions that do not reflect the actual folder structure, which can be confusing.\n"
@@ -6974,235 +6969,235 @@ msgstr ""
 "フラット表示に切り替えますか?"
 
 #. IDS_ELAPSED_TIME
-#: Merge.rc:5086
+#: Merge.rc:5085
 #, c-format
 msgid "Elapsed time: %ld ms"
 msgstr "経過時間: %ld ms"
 
 #. IDS_STATUS_SELITEM1
-#: Merge.rc:5087
+#: Merge.rc:5086
 msgid "1 item selected"
 msgstr "1 個の項目を選択"
 
 #. IDS_STATUS_SELITEMS
-#: Merge.rc:5088
+#: Merge.rc:5087
 #, c-format
 msgid "%1 items selected"
 msgstr "%1 個の項目を選択"
 
 #. IDS_COLDESC_FILENAME
-#: Merge.rc:5094
+#: Merge.rc:5093
 msgid "Filename or folder name."
 msgstr "ファイル名またはフォルダー名です。"
 
 #. IDS_COLDESC_DIR
-#: Merge.rc:5095
+#: Merge.rc:5094
 msgid "Subfolder name when subfolders are included."
 msgstr "サブフォルダー名です。[サブフォルダーを含める] が有効な場合に表示されます。"
 
 #. IDS_COLDESC_RESULT
-#: Merge.rc:5096
+#: Merge.rc:5095
 msgid "Comparison result, long form."
 msgstr "長い形式の比較結果を表示します。"
 
 #. IDS_COLDESC_LTIMEM
-#: Merge.rc:5101
+#: Merge.rc:5100
 msgid "Left side modification date."
 msgstr "左側の更新日時です。"
 
 #. IDS_COLDESC_RTIMEM
-#: Merge.rc:5102
+#: Merge.rc:5101
 msgid "Right side modification date."
 msgstr "右側の更新日時です。"
 
 #. IDS_COLDESC_MTIMEM
-#: Merge.rc:5103
+#: Merge.rc:5102
 msgid "Middle side modification date."
 msgstr "中央の更新日時です。"
 
 #. IDS_COLDESC_EXTENSION
-#: Merge.rc:5104
+#: Merge.rc:5103
 msgid "File's extension."
 msgstr "ファイルの拡張子です。"
 
 #. IDS_COLDESC_LSIZE
-#: Merge.rc:5105
+#: Merge.rc:5104
 msgid "Left file size in bytes."
 msgstr "左側ファイルのバイト数です。"
 
 #. IDS_COLDESC_RSIZE
-#: Merge.rc:5106
+#: Merge.rc:5105
 msgid "Right file size in bytes."
 msgstr "右側ファイルのバイト数です。"
 
 #. IDS_COLDESC_MSIZE
-#: Merge.rc:5107
+#: Merge.rc:5106
 msgid "Middle file size in bytes."
 msgstr "中央ファイルのバイト数です。"
 
 #. IDS_COLDESC_LSIZE_SHORT
-#: Merge.rc:5108
+#: Merge.rc:5107
 msgid "Left file size abbreviated."
 msgstr "左側ファイルのバイト数(短縮形)です。"
 
 #. IDS_COLDESC_RSIZE_SHORT
-#: Merge.rc:5109
+#: Merge.rc:5108
 msgid "Right file size abbreviated."
 msgstr "右側ファイルのバイト数(短縮形)です。"
 
 #. IDS_COLDESC_MSIZE_SHORT
-#: Merge.rc:5110
+#: Merge.rc:5109
 msgid "Middle file size abbreviated."
 msgstr "中央ファイルのバイト数(短縮形)です。"
 
 #. IDS_COLDESC_LTIMEC
-#: Merge.rc:5116
+#: Merge.rc:5115
 msgid "Left side creation time."
 msgstr "左側の作成日時です。"
 
 #. IDS_COLDESC_RTIMEC
-#: Merge.rc:5117
+#: Merge.rc:5116
 msgid "Right side creation time."
 msgstr "右側の作成日時です。"
 
 #. IDS_COLDESC_MTIMEC
-#: Merge.rc:5118
+#: Merge.rc:5117
 msgid "Middle side creation time."
 msgstr "中央の作成日時です。"
 
 #. IDS_COLDESC_NEWER
-#: Merge.rc:5119
+#: Merge.rc:5118
 msgid "Tells which side has newer modification date."
 msgstr "どちらが最新の更新日時かを表示します。"
 
 #. IDS_COLDESC_LVERSION
-#: Merge.rc:5120
+#: Merge.rc:5119
 msgid "Left side file version, only for some file types."
 msgstr "左側ファイルのバージョンです。一部のファイル形式に限り表示されます。"
 
 #. IDS_COLDESC_RVERSION
-#: Merge.rc:5121
+#: Merge.rc:5120
 msgid "Right side file version, only for some file types."
 msgstr "右側ファイルのバージョンです。一部のファイル形式に限り表示されます。"
 
 #. IDS_COLDESC_MVERSION
-#: Merge.rc:5126
+#: Merge.rc:5125
 msgid "Middle side file version, only for some file types."
 msgstr "中央ファイルのバージョンです。一部のファイル形式に限り表示されます。"
 
 #. IDS_COLDESC_RESULT_ABBR
-#: Merge.rc:5127
+#: Merge.rc:5126
 msgid "Short comparison result."
 msgstr "短い形式の比較結果を表示します。"
 
 #. IDS_COLDESC_LATTRIBUTES
-#: Merge.rc:5128
+#: Merge.rc:5127
 msgid "Left side attributes."
 msgstr "左側の属性です。"
 
 #. IDS_COLDESC_RATTRIBUTES
-#: Merge.rc:5129
+#: Merge.rc:5128
 msgid "Right side attributes."
 msgstr "右側の属性です。"
 
 #. IDS_COLDESC_MATTRIBUTES
-#: Merge.rc:5130
+#: Merge.rc:5129
 msgid "Middle side attributes."
 msgstr "中央の属性です。"
 
 #. IDS_COLDESC_LEOL_TYPE
-#: Merge.rc:5131
+#: Merge.rc:5130
 msgid "Left side file EOL type."
 msgstr "左側の EOL タイプです。"
 
 #. IDS_COLDESC_REOL_TYPE
-#: Merge.rc:5132
+#: Merge.rc:5131
 msgid "Right side file EOL type."
 msgstr "右側の EOL タイプです。"
 
 #. IDS_COLDESC_MEOL_TYPE
-#: Merge.rc:5133
+#: Merge.rc:5132
 msgid "Middle side file EOL type."
 msgstr "中央の EOL タイプです。"
 
 #. IDS_COLDESC_LENCODING
-#: Merge.rc:5139
+#: Merge.rc:5138
 msgid "Left side encoding."
 msgstr "左側の文字コードです。"
 
 #. IDS_COLDESC_RENCODING
-#: Merge.rc:5140
+#: Merge.rc:5139
 msgid "Right side encoding."
 msgstr "右側の文字コードです。"
 
 #. IDS_COLDESC_MENCODING
-#: Merge.rc:5141
+#: Merge.rc:5140
 msgid "Middle side encoding."
 msgstr "中央の文字コードです。"
 
 #. IDS_COLDESC_NIDIFFS
-#: Merge.rc:5142
+#: Merge.rc:5141
 msgid "Number of ignored differences in file. Ignored and cannot be merged."
 msgstr "ファイル内で無視した差異の数です。この差異は WinMerge によって無視され、マージされません。"
 
 #. IDS_COLDESC_NSDIFFS
-#: Merge.rc:5143
+#: Merge.rc:5142
 msgid "Number of differences in file (excluding ignored)."
 msgstr "ファイル内の差異の数です。この数値は無視した差異数を含みません。"
 
 #. IDS_COLDESC_BINARY
-#: Merge.rc:5144
+#: Merge.rc:5143
 msgid "Shows an asterisk (*) if the file is binary."
 msgstr "バイナリ ファイルの場合にアスタリスク (*) を表示します。"
 
 #. IDS_COLDESC_UNPACKER
-#: Merge.rc:5145
+#: Merge.rc:5144
 msgid "Unpacker plugin name or pipeline."
 msgstr "展開プラグイン名またはパイプラインを表示します。"
 
 #. IDS_COLDESC_PREDIFFER
-#: Merge.rc:5146
+#: Merge.rc:5145
 msgid "Prediffer plugin name or pipeline."
 msgstr "比較前処理プラグイン名またはパイプラインを表示します。"
 
 #. IDS_DIRECTORY_REPORT_TITLE
-#: Merge.rc:5152
+#: Merge.rc:5151
 #, c-format
 msgid "Compare %1 with %2"
 msgstr "%1 と %2 の比較"
 
 #. IDS_DIRECTORY_REPORT_TITLE3
-#: Merge.rc:5153
+#: Merge.rc:5152
 #, c-format
 msgid "Compare %1 with %2 and %3"
 msgstr "%1 と %2 および %3 の比較"
 
 #. IDS_REPORT_COMMALIST
-#: Merge.rc:5154
+#: Merge.rc:5153
 msgid "Comma-separated list"
 msgstr "CSV 形式"
 
 #. IDS_REPORT_TABLIST
-#: Merge.rc:5155
+#: Merge.rc:5154
 msgid "Tab-separated list"
 msgstr "TAB 区切り形式"
 
 #. IDS_REPORT_SIMPLEHTML
-#: Merge.rc:5156
+#: Merge.rc:5155
 msgid "Simple HTML"
 msgstr "シンプルな HTML 形式"
 
 #. IDS_REPORT_SIMPLEXML
-#: Merge.rc:5157
+#: Merge.rc:5156
 msgid "Simple XML"
 msgstr "シンプルな XML 形式"
 
-#: Merge.rc:5159
+#: Merge.rc:5158
 msgid "Report file already exists. Overwrite?"
 msgstr "レポート ファイルは既に存在しています。既存のファイルを上書きしますか?"
 
 #. IDS_REPORT_ERROR
-#: Merge.rc:5164
+#: Merge.rc:5163
 #, c-format
 msgid ""
 "Error creating the report:\n"
@@ -7212,27 +7207,27 @@ msgstr ""
 "%1"
 
 #. IDS_REPORT_SUCCESS
-#: Merge.rc:5165
+#: Merge.rc:5164
 msgid "Report created successfully."
 msgstr "レポートの生成に成功しました。"
 
 #. IDS_SYNCPOINT_LASTBLOCK
-#: Merge.rc:5171
+#: Merge.rc:5170
 msgid "Cannot add a synchronization point at this line."
 msgstr "この行には同期ポイントを追加できません。"
 
 #. IDS_FILE_TO_ITSELF
-#: Merge.rc:5177
+#: Merge.rc:5176
 msgid "Same file is opened in both panes."
 msgstr "同じファイルが両側のパネルで開かれています。"
 
 #. IDS_FILESSAME
-#: Merge.rc:5178
+#: Merge.rc:5177
 msgid "Selected files are identical."
 msgstr "選択されたファイルは同一です。"
 
 #. IDS_FILESSAME_CURCFG
-#: Merge.rc:5179
+#: Merge.rc:5178
 msgid ""
 "Selected files are identical (with current settings).\r\n"
 "Checking binary identity..."
@@ -7241,7 +7236,7 @@ msgstr ""
 "バイナリ一致を確認しています..."
 
 #. IDS_FILESSAME_BINERROR
-#: Merge.rc:5180
+#: Merge.rc:5179
 msgid ""
 "Selected files are identical (with current settings).\r\n"
 "But binary comparison failed."
@@ -7250,12 +7245,12 @@ msgstr ""
 "しかし、バイナリ比較でエラーが発生しました。"
 
 #. IDS_FILESSAME_BINSAME
-#: Merge.rc:5181
+#: Merge.rc:5180
 msgid "Selected files are identical (binary match)."
 msgstr "選択されたファイルは一致しています(バイナリ一致)。"
 
 #. IDS_FILESSAME_BINDIFF
-#: Merge.rc:5182
+#: Merge.rc:5181
 msgid ""
 "Selected files are identical (with current settings).\r\n"
 "But differ at the binary level."
@@ -7264,17 +7259,17 @@ msgstr ""
 "しかし、バイナリレベルでは異なります。"
 
 #. IDS_FILEERROR
-#: Merge.rc:5183
+#: Merge.rc:5182
 msgid "An error occurred while comparing files."
 msgstr "ファイルの比較時にエラーが発生しました。"
 
 #. IDS_TEMP_FILEERROR
-#: Merge.rc:5184
+#: Merge.rc:5183
 msgid "Could not create temporary files. Check your temporary path settings."
 msgstr "テンポラリ ファイルが作成できません。テンポラリ パス設定を確認してください。"
 
 #. IDS_SUGGEST_IGNOREEOL
-#: Merge.rc:5185
+#: Merge.rc:5184
 msgid ""
 "Files use different EOL.\n"
 "\n"
@@ -7291,17 +7286,17 @@ msgstr ""
 "有効にしてください。"
 
 #. IDS_INVALID_DIRECTORY
-#: Merge.rc:5186
+#: Merge.rc:5185
 msgid "Selected folder is invalid."
 msgstr "選択されたフォルダーは無効です。"
 
 #. IDS_CANNOT_OPEN_BINARYFILE
-#: Merge.rc:5187
+#: Merge.rc:5186
 msgid "Cannot open a binary file in Editor."
 msgstr "バイナリ ファイルをエディターで開くことはできません。"
 
 #. IDS_CREATE_PAIR_FOLDER
-#: Merge.rc:5188
+#: Merge.rc:5187
 #, c-format
 msgid ""
 "Create matching folder:\n"
@@ -7314,41 +7309,41 @@ msgstr ""
 "%1"
 
 #. IDS_CONFIRM_COPY_ALL_DIFFS
-#: Merge.rc:5189
+#: Merge.rc:5188
 msgid "Copy all differences to other file?"
 msgstr "本当にすべての差異を他のファイルにコピーしますか?"
 
 #. IDS_MOVE_TO_NEXTFILE
-#: Merge.rc:5194
+#: Merge.rc:5193
 msgid "Move to next file?"
 msgstr "次のファイルに移動しますか?"
 
 #. IDS_MOVE_TO_PREVFILE
-#: Merge.rc:5195
+#: Merge.rc:5194
 msgid "Move to previous file?"
 msgstr "前のファイルに移動しますか?"
 
 #. IDS_MOVE_TO_NEXTPAGE
-#: Merge.rc:5196
+#: Merge.rc:5195
 msgid "Move to next page?"
 msgstr "次のページに移動しますか?"
 
 #. IDS_MOVE_TO_PREVPAGE
-#: Merge.rc:5197
+#: Merge.rc:5196
 msgid "Move to previous page?"
 msgstr "前のページに移動しますか?"
 
 #. IDS_MOVE_TO_FIRSTFILE
-#: Merge.rc:5198
+#: Merge.rc:5197
 msgid "Move to first file?"
 msgstr "最初のファイルに移動しますか?"
 
 #. IDS_MOVE_TO_LASTFILE
-#: Merge.rc:5199
+#: Merge.rc:5198
 msgid "Move to last file?"
 msgstr "最後のファイルに移動しますか?"
 
-#: Merge.rc:5206
+#: Merge.rc:5205
 #, c-format
 msgid ""
 "Different codepages: left (cp%d), right (cp%d).\n"
@@ -7359,53 +7354,53 @@ msgstr ""
 "各々のファイルをそのコードページで表示すれば、正しく表示されますが、マージやコピーが危険になります。\n"
 "コードページをデフォルト コードページとして扱いますが、よろしいですか(推奨)?"
 
-#: Merge.rc:5208
+#: Merge.rc:5207
 msgid "Information lost due to encoding errors: both files"
 msgstr "エンコーディング エラーにより情報が失われています。(両側のファイル)"
 
-#: Merge.rc:5210
+#: Merge.rc:5209
 msgid "Information lost due to encoding errors: first file"
 msgstr "エンコーディング エラーにより情報が失われています。(1 番目のファイル)"
 
-#: Merge.rc:5212
+#: Merge.rc:5211
 msgid "Information lost due to encoding errors: second file"
 msgstr "エンコーディング エラーにより情報が失われています。(2 番目のファイル)"
 
-#: Merge.rc:5214
+#: Merge.rc:5213
 msgid "Information lost due to encoding errors: third file"
 msgstr "エンコーディング エラーにより情報が失われています。(3 番目のファイル)"
 
 #. IDS_LINEDIFF_NODIFF
-#: Merge.rc:5220
+#: Merge.rc:5219
 msgid "No difference"
 msgstr "差異はありません"
 
 #. IDS_LINEDIFF_NODIFF_CAPTION
-#: Merge.rc:5221
+#: Merge.rc:5220
 msgid "Line difference"
 msgstr "行内差異"
 
 #. IDS_NUM_REPLACED
-#: Merge.rc:5227
+#: Merge.rc:5226
 #, c-format
 msgid "Replaced %1 string(s)."
 msgstr "%1 個の文字列を置換しました。"
 
 #. IDS_EDIT_TEXT_NOT_FOUND
-#: Merge.rc:5228
+#: Merge.rc:5227
 #, c-format
 msgid "Cannot find string \"%s\"."
 msgstr "文字列 \"%s\" が見つかりません。"
 
 #. IDS_MERGE_MODE
-#: Merge.rc:5234
+#: Merge.rc:5233
 msgid "Entering Merge Mode. Press F9 to turn off."
 msgstr ""
 "マージモードに切り替えます。マージモードはカーソル キーのみでマージしたり、次や前の差異に移動できるモードです。\n"
 "マージモードをオフにしたい場合は、F9 キーを押してください。"
 
 #. IDS_AUTO_MERGE
-#: Merge.rc:5240
+#: Merge.rc:5239
 #, c-format
 msgid ""
 "Automatic merges: %1\n"
@@ -7415,89 +7410,89 @@ msgstr ""
 "解決されていないコンフリクトの数: %2"
 
 #. IDS_CODEPAGE_MERGED
-#: Merge.rc:5241
+#: Merge.rc:5240
 msgid "Codepage change merged."
 msgstr "コードページの変更がマージされました。"
 
 #. IDS_CODEPAGE_CONFLICT
-#: Merge.rc:5242
+#: Merge.rc:5241
 msgid "Codepage changes are conflicting."
 msgstr "コードページの変更がコンフリクトしています。"
 
 #. IDS_EOL_MERGED
-#: Merge.rc:5243
+#: Merge.rc:5242
 msgid "EOL change merged."
 msgstr "改行コードの変更がマージされました。"
 
 #. IDS_EOL_CONFLICT
-#: Merge.rc:5244
+#: Merge.rc:5243
 msgid "EOL changes are conflicting."
 msgstr "改行コードの変更がコンフリクトしています。"
 
 #. IDS_LOCBAR_CAPTION
-#: Merge.rc:5250
+#: Merge.rc:5249
 msgid "Location Pane"
 msgstr "ロケーション ペイン"
 
 #. IDS_DIFFBAR_CAPTION
-#: Merge.rc:5251
+#: Merge.rc:5250
 msgid "Diff Pane"
 msgstr "Diff ペイン"
 
 #. IDS_DIFF_SUCCEEDED
-#: Merge.rc:5258
+#: Merge.rc:5257
 msgid "Patch file written."
 msgstr "パッチ ファイルの書き込みに成功しました。"
 
 #. IDS_DIFF_FILEOVERWRITE
-#: Merge.rc:5259
+#: Merge.rc:5258
 msgid "Patch file already exists. Overwrite?"
 msgstr "出力結果ファイルは既に存在しています。上書きしますか?"
 
 #. IDS_DIFF_SELECTEDFILES
-#: Merge.rc:5260
+#: Merge.rc:5259
 #, c-format
 msgid "[%1 files selected]"
 msgstr "[%1 個のファイルが選択されています]"
 
 #. IDS_DIFF_NORMAL
-#: Merge.rc:5261
+#: Merge.rc:5260
 msgid "Normal"
 msgstr "ノーマル"
 
 #. IDS_DIFF_CONTEXT
-#: Merge.rc:5262
+#: Merge.rc:5261
 msgid "Context"
 msgstr "コンテキスト"
 
 #. IDS_DIFF_UNIFIED
-#: Merge.rc:5263
+#: Merge.rc:5262
 msgid "Unified"
 msgstr "ユニファイド"
 
 #. IDS_FILEWRITE_ERROR
-#: Merge.rc:5265
+#: Merge.rc:5264
 #, c-format
 msgid "Could not write to file %1."
 msgstr "ファイル %1 に書き込めません。"
 
 #. IDS_PATH_NOT_ABSOLUTE
-#: Merge.rc:5266
+#: Merge.rc:5265
 #, c-format
 msgid "Output path is not absolute: %1"
 msgstr "指定した出力パスは、絶対パスではありません: %1"
 
 #. IDS_MUST_SPECIFY_OUTPUT
-#: Merge.rc:5267
+#: Merge.rc:5266
 msgid "Specify an output file."
 msgstr "出力パスを指定してください。"
 
-#: Merge.rc:5269
+#: Merge.rc:5268
 msgid "Cannot create patch from binary files."
 msgstr "バイナリ ファイルからパッチ ファイルは生成できません。"
 
 #. IDS_SAVEFILES_FORPATCH
-#: Merge.rc:5270
+#: Merge.rc:5269
 msgid ""
 "Save all files first.\n"
 "\n"
@@ -7508,17 +7503,17 @@ msgstr ""
 "パッチの生成には、変更がすべて保存されている必要があります。"
 
 #. IDS_FOLDER_NOTEXIST
-#: Merge.rc:5271
+#: Merge.rc:5270
 msgid "Folder does not exist."
 msgstr "フォルダーは存在しません。"
 
 #. IDS_ARCHIVE_SUCCEEDED
-#: Merge.rc:5277
+#: Merge.rc:5276
 msgid "Archive file written."
 msgstr "アーカイブファイルが作成されました。"
 
 #. IDS_ARCHIVE_SAVEFILES
-#: Merge.rc:5278
+#: Merge.rc:5277
 msgid "Save all files first.\n\nCreating an archive requires no unsaved changes."
 msgstr ""
 "まず先にすべてのファイルを保存してください。\n"
@@ -7526,7 +7521,7 @@ msgstr ""
 "アーカイブの生成には、変更がすべて保存されている必要があります。"
 
 #. IDS_NO_ZIP_SUPPORT
-#: Merge.rc:5283
+#: Merge.rc:5282
 msgid ""
 "Archive support not enabled.\n"
 "7-Zip and/or Merge7z*.dll not found.\n"
@@ -7537,37 +7532,37 @@ msgstr ""
 "アーカイブ サポートを有効にする方法については、マニュアルを参照してください。"
 
 #. IDS_OPT_EXPORT_CAPTION
-#: Merge.rc:5284
+#: Merge.rc:5283
 msgid "Select file for export"
 msgstr "エクスポートするファイルを指定してください"
 
 #. IDS_OPT_IMPORT_CAPTION
-#: Merge.rc:5285
+#: Merge.rc:5284
 msgid "Select file for import"
 msgstr "インポートするファイルを選択してください"
 
 #. IDS_OPT_IMPORT_DONE
-#: Merge.rc:5286
+#: Merge.rc:5285
 msgid "Options imported from file."
 msgstr "設定情報をファイルからインポートしました。"
 
 #. IDS_OPT_EXPORT_DONE
-#: Merge.rc:5287
+#: Merge.rc:5286
 msgid "Options exported to file."
 msgstr "設定情報をファイルにエクスポートしました。"
 
 #. IDS_OPT_IMPORT_ERR
-#: Merge.rc:5288
+#: Merge.rc:5287
 msgid "Failed to import options from file."
 msgstr "ファイルから設定情報のインポートに失敗しました。"
 
 #. IDS_OPT_EXPORT_ERR
-#: Merge.rc:5289
+#: Merge.rc:5288
 msgid "Failed to write options to file."
 msgstr "ファイルへの設定情報の書き込みに失敗しました。"
 
 #. IDS_CLOSEALL_WINDOWS
-#: Merge.rc:5290
+#: Merge.rc:5289
 msgid ""
 "Close multiple compare windows?\n"
 "\n"
@@ -7578,34 +7573,34 @@ msgstr ""
 "続行しますか?"
 
 #. IDS_EOL_BIN
-#: Merge.rc:5300
+#: Merge.rc:5299
 msgctxt "EOL Type"
 msgid "Binary"
 msgstr "バイナリ"
 
 #. IDS_MARKER_COLOR_FMT
-#: Merge.rc:5305
+#: Merge.rc:5304
 #, c-format
 msgid "Marker Color %d"
 msgstr "マーカー色 %d"
 
 #. IDS_MARKER_NEW_PATTERN
-#: Merge.rc:5306
+#: Merge.rc:5305
 msgid "New Pattern"
 msgstr "新しいパターン"
 
 #. IDS_PLUGINSLIST_TYPE
-#: Merge.rc:5312
+#: Merge.rc:5311
 msgid "Type"
 msgstr "タイプ"
 
 #. IDS_PLUGINS_TYPE_EDITSCRIPT
-#: Merge.rc:5316
+#: Merge.rc:5315
 msgid "Editor script"
 msgstr "エディター スクリプト"
 
 #. ID_SELECTLINEDIFF
-#: Merge.rc:5322
+#: Merge.rc:5321
 msgid ""
 "\n"
 "Difference in Current Line (F4)"
@@ -7614,7 +7609,7 @@ msgstr ""
 "現在の行内差異 (F4)"
 
 #. ID_OPTIONS
-#: Merge.rc:5323
+#: Merge.rc:5322
 msgid ""
 "\n"
 "Options"
@@ -7623,7 +7618,7 @@ msgstr ""
 "設定"
 
 #. ID_REFRESH
-#: Merge.rc:5324
+#: Merge.rc:5323
 msgid ""
 "\n"
 "Refresh (F5)"
@@ -7632,7 +7627,7 @@ msgstr ""
 "表示更新 (F5)"
 
 #. ID_PREVDIFF
-#: Merge.rc:5330
+#: Merge.rc:5329
 msgid ""
 "\n"
 "Previous Difference (Alt+Up)"
@@ -7641,7 +7636,7 @@ msgstr ""
 "前の差異 (Alt+Up)"
 
 #. ID_NEXTDIFF
-#: Merge.rc:5331
+#: Merge.rc:5330
 msgid ""
 "\n"
 "Next Difference (Alt+Down)"
@@ -7650,7 +7645,7 @@ msgstr ""
 "次の差異 (Alt+Down)"
 
 #. ID_PREVCONFLICT
-#: Merge.rc:5332
+#: Merge.rc:5331
 msgid ""
 "\n"
 "Previous Conflict (Alt+Shift+Up)"
@@ -7659,7 +7654,7 @@ msgstr ""
 "前のコンフリクト (Alt+Shift+Up)"
 
 #. ID_NEXTCONFLICT
-#: Merge.rc:5333
+#: Merge.rc:5332
 msgid ""
 "\n"
 "Next Conflict (Alt+Shift+Down)"
@@ -7668,7 +7663,7 @@ msgstr ""
 "次のコンフリクト (Alt+Shift+Down)"
 
 #. ID_FIRSTDIFF
-#: Merge.rc:5338
+#: Merge.rc:5337
 msgid ""
 "\n"
 "First Difference (Alt+Home)"
@@ -7677,7 +7672,7 @@ msgstr ""
 "最初の差異 (Alt+Home)"
 
 #. ID_CURDIFF
-#: Merge.rc:5339
+#: Merge.rc:5338
 msgid ""
 "\n"
 "Current Difference (Alt+Enter)"
@@ -7686,7 +7681,7 @@ msgstr ""
 "現在の差異 (Alt+Enter)"
 
 #. ID_LASTDIFF
-#: Merge.rc:5340
+#: Merge.rc:5339
 msgid ""
 "\n"
 "Last Difference (Alt+End)"
@@ -7695,7 +7690,7 @@ msgstr ""
 "最後の差異 (Alt+End)"
 
 #. ID_L2R
-#: Merge.rc:5341
+#: Merge.rc:5340
 msgid ""
 "\n"
 "Copy to Right (Alt+Right)"
@@ -7704,7 +7699,7 @@ msgstr ""
 "右側へコピー (Alt+Right)"
 
 #. ID_R2L
-#: Merge.rc:5342
+#: Merge.rc:5341
 msgid ""
 "\n"
 "Copy to Left (Alt+Left)"
@@ -7713,7 +7708,7 @@ msgstr ""
 "左側へコピー (Alt+Left)"
 
 #. ID_L2RNEXT
-#: Merge.rc:5343
+#: Merge.rc:5342
 msgid ""
 "\n"
 "Copy to Right and Advance (Ctrl+Alt+Right)"
@@ -7722,7 +7717,7 @@ msgstr ""
 "右側へコピーし次へ (Ctrl+Alt+Right)"
 
 #. ID_R2LNEXT
-#: Merge.rc:5344
+#: Merge.rc:5343
 msgid ""
 "\n"
 "Copy to Left and Advance (Ctrl+Alt+Left)"
@@ -7731,7 +7726,7 @@ msgstr ""
 "左側へコピーし次へ (Ctrl+Alt+Left)"
 
 #. ID_ALL_RIGHT
-#: Merge.rc:5345
+#: Merge.rc:5344
 msgid ""
 "\n"
 "Copy All to Right"
@@ -7740,7 +7735,7 @@ msgstr ""
 "すべてを右側にコピー"
 
 #. ID_ALL_LEFT
-#: Merge.rc:5346
+#: Merge.rc:5345
 msgid ""
 "\n"
 "Copy All to Left"
@@ -7749,7 +7744,7 @@ msgstr ""
 "すべてを左側にコピー"
 
 #. ID_AUTO_MERGE
-#: Merge.rc:5347
+#: Merge.rc:5346
 msgid ""
 "\n"
 "Auto Merge (Ctrl+Alt+M)"
@@ -7758,7 +7753,7 @@ msgstr ""
 "自動マージ (Ctrl+Alt+M)"
 
 #. ID_FIRSTFILE
-#: Merge.rc:5348
+#: Merge.rc:5347
 msgid ""
 "\n"
 "First File"
@@ -7767,7 +7762,7 @@ msgstr ""
 "最初のファイル"
 
 #. ID_NEXTFILE
-#: Merge.rc:5349
+#: Merge.rc:5348
 msgid ""
 "\n"
 "Next File (Ctrl+F8)"
@@ -7776,7 +7771,7 @@ msgstr ""
 "次のファイル (Ctrl+F8)"
 
 #. ID_LASTFILE
-#: Merge.rc:5350
+#: Merge.rc:5349
 msgid ""
 "\n"
 "Last File"
@@ -7785,7 +7780,7 @@ msgstr ""
 "最後のファイル"
 
 #. ID_PREVFILE
-#: Merge.rc:5351
+#: Merge.rc:5350
 msgid ""
 "\n"
 "Previous File (Ctrl+F7)"
@@ -7794,141 +7789,141 @@ msgstr ""
 "前のファイル (Ctrl+F7)"
 
 #. IDS_UNPACK_AUTO
-#: Merge.rc:5358
+#: Merge.rc:5357
 msgid "Adapted unpacker applied to both files (one needs extension)."
 msgstr "自動的に展開プラグインを選択し、両側のファイルに適用します (どちらかのファイルに拡張子が必要です)"
 
 #. IDS_NO_PREDIFFER
-#: Merge.rc:5359
+#: Merge.rc:5358
 msgid "No Prediffer (Normal)"
 msgstr "比較前処理プラグインを使用しない (標準)"
 
 #. IDS_SUGGESTED_PLUGINS
-#: Merge.rc:5360
+#: Merge.rc:5359
 msgid "Suggested Plugins"
 msgstr "関連するプラグイン"
 
 #. IDS_NOT_SUGGESTED_PLUGINS
-#: Merge.rc:5361
+#: Merge.rc:5360
 msgid "All Plugins"
 msgstr "すべてのプラグイン"
 
 #. IDS_PRIVATEBUILD_FMT
-#: Merge.rc:5367
+#: Merge.rc:5366
 #, c-format
 msgid "Private Build: %1"
 msgstr "Private Build: %1"
 
 #. IDS_ALLRIGHTS_RESERVED
-#: Merge.rc:5368
+#: Merge.rc:5367
 msgid " - All rights reserved."
 msgstr " - All rights reserved."
 
 #. IDS_TITLE_PLUGINS_SETTINGS
-#: Merge.rc:5374
+#: Merge.rc:5373
 msgid "Plugin Settings"
 msgstr "プラグイン設定"
 
 #. IDS_NO_SCT_SCRIPTS
-#: Merge.rc:5376
+#: Merge.rc:5375
 msgid "WSH not found - .sct scripts disabled"
 msgstr "WSH が見つかりません - .sct スクリプトは無効化されました"
 
 #. IDS_LOCBAR_GOTOLINE_FMT
-#: Merge.rc:5384
+#: Merge.rc:5383
 #, c-format
 msgid "G&o to Line %1"
 msgstr "行 %1 に移動(&O)"
 
 #. IDS_GOTO_MOVED_LINE
-#: Merge.rc:5390
+#: Merge.rc:5389
 msgid "Go to Moved Line\tCtrl+Shift+G"
 msgstr "移動行に移動\tCtrl+Shift+G"
 
 #. IDS_AUTOCOMPLETE_DISABLED
-#: Merge.rc:5396
+#: Merge.rc:5395
 msgctxt "Options dialog|General|Open dialog Auto completion"
 msgid "Disabled"
 msgstr "無効"
 
 #. IDS_AUTOCOMPLETE_FILE_SYS
-#: Merge.rc:5397
+#: Merge.rc:5396
 msgid "From file system"
 msgstr "ファイル システム"
 
 #. IDS_AUTOCOMPLETE_MRU
-#: Merge.rc:5398
+#: Merge.rc:5397
 msgid "From Most Recently Used list"
 msgstr "最近使ったリスト"
 
 #. IDS_COLORSCHEME_PLAIN
-#: Merge.rc:5404
+#: Merge.rc:5403
 msgid "No Highlighting"
 msgstr "ハイライトなし"
 
 #. IDS_COLORSCHEME_PO
-#: Merge.rc:5439
+#: Merge.rc:5438
 msgid "Portable Object"
 msgstr "Portable Object(.po)"
 
 #. IDS_COLORSCHEME_RSRC
-#: Merge.rc:5444
+#: Merge.rc:5443
 msgid "Resources"
 msgstr "Resources"
 
 #. IDS_COLORSCHEME_SH
-#: Merge.rc:5448
+#: Merge.rc:5447
 msgid "Shell"
 msgstr "Shell"
 
 #. IDS_CLOSE_LEFT_TABS
-#: Merge.rc:5469
+#: Merge.rc:5468
 msgid "Close &Left Tabs"
 msgstr "左側のタブをすべて閉じる(&L)"
 
 #. IDS_CLOSE_RIGHT_TABS
-#: Merge.rc:5470
+#: Merge.rc:5469
 msgid "Close R&ight Tabs"
 msgstr "右側のタブをすべて閉じる(&I)"
 
 #. IDS_CLOSE_OTHER_TABS
-#: Merge.rc:5471
+#: Merge.rc:5470
 msgid "Close &Other Tabs"
 msgstr "他のタブをすべて閉じる(&O)"
 
 #. IDS_TABBAR_AUTO_MAXWIDTH
-#: Merge.rc:5472
+#: Merge.rc:5471
 msgid "Enable &Auto Max Width"
 msgstr "タブ幅の自動調整を有効にする(&A)"
 
 #. IDS_WEBPAGE_MENU
-#: Merge.rc:5482
+#: Merge.rc:5481
 msgid "We&bpage"
 msgstr "Webページ(&B)"
 
 #. IDS_VIEW_WRAP_TEXT
-#: Merge.rc:5487
+#: Merge.rc:5486
 msgid "W&rap Text"
 msgstr "折り返して全体を表示(&R)"
 
 #. IDS_NOTINSTALLED
-#: Merge.rc:5492
+#: Merge.rc:5491
 msgid "%1 is not installed."
 msgstr "%1 がインストールされていません。"
 
 #. IDS_CREATE_FOLDER
-#: Merge.rc:5497
+#: Merge.rc:5496
 #, c-format
 msgid "%1 does not exist. Create it?"
 msgstr "%1 は存在しません。作成しますか?"
 
 #. IDS_CREATE_FOLDER_ERROR
-#: Merge.rc:5498
+#: Merge.rc:5497
 msgid "Failed to create folder."
 msgstr "フォルダーの作成に失敗しました。"
 
 #. IDC_EXT_EDITOR_PATH
-#: Merge.rc:5503
+#: Merge.rc:5502
 msgid ""
 "Parameters:\n"
 "$file: Current file path\n"
@@ -7939,491 +7934,491 @@ msgstr ""
 "$linenum: 現在のカーソル位置の行番号"
 
 #. IDS_DIFF_ALGORITHM_DEFAULT
-#: Merge.rc:5508
+#: Merge.rc:5507
 msgid "default"
 msgstr "default"
 
 #. IDS_DIFF_ALGORITHM_MINIMAL
-#: Merge.rc:5509
+#: Merge.rc:5508
 msgid "minimal"
 msgstr "minimal"
 
 #. IDS_DIFF_ALGORITHM_PATIENCE
-#: Merge.rc:5510
+#: Merge.rc:5509
 msgid "patience"
 msgstr "patience"
 
 #. IDS_DIFF_ALGORITHM_HISTOGRAM
-#: Merge.rc:5511
+#: Merge.rc:5510
 msgid "histogram"
 msgstr "histogram"
 
 #. IDS_DIFF_ALGORITHM_NONE
-#: Merge.rc:5512
+#: Merge.rc:5511
 msgid "none"
 msgstr "none"
 
 #. IDS_RENDERING_MODE_GDI
-#: Merge.rc:5517
+#: Merge.rc:5516
 msgid "GDI"
 msgstr "GDI"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_DEFAULT
-#: Merge.rc:5518
+#: Merge.rc:5517
 msgid "DirectWrite Default"
 msgstr "DirectWrite Default"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_ALIASED
-#: Merge.rc:5519
+#: Merge.rc:5518
 msgid "DirectWrite Aliased"
 msgstr "DirectWrite Aliased"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_GDI_CLASSIC
-#: Merge.rc:5520
+#: Merge.rc:5519
 msgid "DirectWrite GDI Classic"
 msgstr "DirectWrite GDI Classic"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_GDI_NATURAL
-#: Merge.rc:5521
+#: Merge.rc:5520
 msgid "DirectWrite GDI Natural"
 msgstr "DirectWrite GDI Natural"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_NATURAL
-#: Merge.rc:5522
+#: Merge.rc:5521
 msgid "DirectWrite Natural"
 msgstr "DirectWrite Natural"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_NATURAL_SYMMETRIC
-#: Merge.rc:5523
+#: Merge.rc:5522
 msgid "DirectWrite Natural Symmetric"
 msgstr "DirectWrite Natural Symmetric"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_DISABLED
-#: Merge.rc:5528
+#: Merge.rc:5527
 msgctxt "Options dialog|General|Close windows with Esc"
 msgid "Disabled"
 msgstr "無効"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_1
-#: Merge.rc:5529
+#: Merge.rc:5528
 msgid "MDI child window or main window"
 msgstr "MDI 子ウインドウまたはメインウインドウ"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_2
-#: Merge.rc:5530
+#: Merge.rc:5529
 msgid "MDI child window only"
 msgstr "MDI 子ウインドウのみ"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_3
-#: Merge.rc:5531
+#: Merge.rc:5530
 msgid "Close main window if only one MDI child window"
 msgstr "MDI 子ウィンドウが 1 つしかない場合、メインウィンドウを閉じる"
 
 #. IDS_DIFF_GROUP
-#: Merge.rc:5536
+#: Merge.rc:5535
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Diff"
 msgstr "差異"
 
 #. IDS_DIFF_HIGHLIGHT
-#: Merge.rc:5537
+#: Merge.rc:5536
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Highlight"
 msgstr "差異表示"
 
 #. IDS_DIFF_BLINK
-#: Merge.rc:5538
+#: Merge.rc:5537
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Blink"
 msgstr "点滅"
 
 #. IDS_DIFF_BLOCKSIZE
-#: Merge.rc:5539
+#: Merge.rc:5538
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Block Size"
 msgstr "ブロック サイズ"
 
 #. IDS_DIFF_BLOCKALPHA
-#: Merge.rc:5540
+#: Merge.rc:5539
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Block Alpha"
 msgstr "ブロック透明度"
 
 #. IDS_DIFF_CDTHRESHOLD
-#: Merge.rc:5541
+#: Merge.rc:5540
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "CD Threshold"
 msgstr "色距離閾値"
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION
-#: Merge.rc:5542
+#: Merge.rc:5541
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Ins/Del Detection"
 msgstr "挿入/削除検出"
 
 #. IDS_OVERLAY_MODE_NONE
-#: Merge.rc:5543 Merge.rc:5548
+#: Merge.rc:5542 Merge.rc:5547
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "None"
 msgstr "なし"
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION_VERTICAL
-#: Merge.rc:5544
+#: Merge.rc:5543
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Vertical"
 msgstr "垂直方向"
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION_HORIZONTAL
-#: Merge.rc:5545
+#: Merge.rc:5544
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Horizontal"
 msgstr "水平方向"
 
 #. IDS_OVERLAY_GROUP
-#: Merge.rc:5546
+#: Merge.rc:5545
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Overlay"
 msgstr "重ね合わせ"
 
 #. IDS_OVERLAY_ALPHA
-#: Merge.rc:5547
+#: Merge.rc:5546
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha"
 msgstr "透明度"
 
 #. IDS_OVERLAY_MODE_XOR
-#: Merge.rc:5549
+#: Merge.rc:5548
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "XOR"
 msgstr "XOR"
 
 #. IDS_OVERLAY_MODE_ALPHA
-#: Merge.rc:5550
+#: Merge.rc:5549
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha Blend"
 msgstr "アルファブレンド"
 
 #. IDS_OVERLAY_MODE_ALPHA_ANIMATION
-#: Merge.rc:5551
+#: Merge.rc:5550
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha Animation"
 msgstr "アニメ表示"
 
 #. IDS_ZOOM
-#: Merge.rc:5552
+#: Merge.rc:5551
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Zoom"
 msgstr "拡大"
 
 #. IDS_PAGE
-#: Merge.rc:5553
+#: Merge.rc:5552
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Page:"
 msgstr "ページ:"
 
 #. IDS_IMGCMP_STATUS_PT_RGBA_FMT
-#: Merge.rc:5554
+#: Merge.rc:5553
 #, c-format
 msgid "Pt: (%d, %d)  RGBA: (%d, %d, %d, %d)  "
 msgstr "Pt: (%d, %d)  RGBA: (%d, %d, %d, %d)  "
 
 #. IDS_IMGCMP_STATUS_DIST1_FMT
-#: Merge.rc:5555
+#: Merge.rc:5554
 #, c-format
 msgid "Dist: %g  "
 msgstr "色距離: %g  "
 
 #. IDS_IMGCMP_STATUS_DIST2_FMT
-#: Merge.rc:5556
+#: Merge.rc:5555
 #, c-format
 msgid "Dist: %g, %g  "
 msgstr "色距離: %g, %g  "
 
 #. IDS_IMGCMP_STATUS_PAGE_ZOOM_SIZE_BPP_FMT
-#: Merge.rc:5557
+#: Merge.rc:5556
 #, c-format
 msgid "Page: %d/%d  Zoom: %d%%  %dx%dpx  %dbpp  "
 msgstr "ページ: %d/%d  拡大: %d%%  %dx%dpx  %dbpp  "
 
 #. IDS_IMGCMP_STATUS_RC_FMT
-#: Merge.rc:5558
+#: Merge.rc:5557
 #, c-format
 msgid "Rc: (%d, %d)  "
 msgstr "範囲: (%d, %d)  "
 
 #. IDS_IMGCMP_STATUS_FLIPPED_FMT
-#: Merge.rc:5559
+#: Merge.rc:5558
 #, c-format
 msgid "Flipped: %s  "
 msgstr "反転: %s  "
 
 #. IDS_IMGCMP_STATUS_ROTATED_FMT
-#: Merge.rc:5560
+#: Merge.rc:5559
 #, c-format
 msgid "Rotated: %d  "
 msgstr "回転: %d°  "
 
 #. IDS_IMGCMP_REPORT_ALLPAGES
-#: Merge.rc:5561
+#: Merge.rc:5560
 msgid "All pages"
 msgstr "全ページ"
 
 #. IDS_IGNSUB_STR1
-#: Merge.rc:5566
+#: Merge.rc:5565
 msgid "<Edit here>"
 msgstr "<ここを編集>"
 
 #. IDS_IGNSUB_STR2
-#: Merge.rc:5567
+#: Merge.rc:5566
 msgid "No differences found to select"
 msgstr "選択する差異がありません"
 
 #. IDS_IGNSUB_STR3
-#: Merge.rc:5568
+#: Merge.rc:5567
 msgid "No differences found to add as substitution filter"
 msgstr "置換フィルターに追加する差異がありません"
 
 #. IDS_IGNSUB_STR4
-#: Merge.rc:5569
+#: Merge.rc:5568
 msgid "The pair is already in the Substitution Filters list"
 msgstr "このペアは、既に置換フィルターのリストに存在しています"
 
 #. IDS_IGNSUB_STR5
-#: Merge.rc:5570
+#: Merge.rc:5569
 msgid "Add this change to Substitution Filters?"
 msgstr "この差異を置換フィルターに追加しますか?"
 
 #. IDS_OCRRESULT_TEXTONLY
-#: Merge.rc:5575
+#: Merge.rc:5574
 msgid "Text only"
 msgstr "テキストのみ"
 
 #. IDS_OCRRESULT_POS_LINE
-#: Merge.rc:5576
+#: Merge.rc:5575
 msgid "Line-by-line position and text"
 msgstr "行毎の位置情報とテキスト"
 
 #. IDS_OCRRESULT_POS_WORD
-#: Merge.rc:5577
+#: Merge.rc:5576
 msgid "Word-by-word position and text"
 msgstr "単語毎の位置情報とテキスト"
 
 #. IDS_USERDATAFOLDER_APPDATA
-#: Merge.rc:5582
+#: Merge.rc:5581
 msgid "AppData (Roaming) folder"
 msgstr "AppData (Roaming) フォルダー"
 
 #. IDS_USERDATAFOLDER_INSTALL
-#: Merge.rc:5583
+#: Merge.rc:5582
 msgid "Install folder"
 msgstr "インストール フォルダー"
 
 #. IDS_USERDATAFOLDER_DOCUMENTS
-#: Merge.rc:5584
+#: Merge.rc:5583
 msgid "Documents folder"
 msgstr "ドキュメントフォルダー"
 
 #. IDS_SINGLEINSTANCE_DISABLED
-#: Merge.rc:5589
+#: Merge.rc:5588
 msgctxt "Options dialog|General|Single instance mode"
 msgid "Disabled"
 msgstr "無効"
 
 #. IDS_SINGLEINSTANCE_STR1
-#: Merge.rc:5590
+#: Merge.rc:5589
 msgid "Allow only one instance to run"
 msgstr "1 つのみインスタンスを起動する"
 
 #. IDS_CLIPBOARD_HISTORY
-#: Merge.rc:5591
+#: Merge.rc:5590
 msgid "Clipboard &History"
 msgstr "クリップボード履歴(&H)"
 
 #. IDS_SINGLEINSTANCE_STR2
-#: Merge.rc:5592
+#: Merge.rc:5591
 msgid "Allow only one instance; wait for termination"
 msgstr "1 つのみインスタンスを起動し、既起動インスタンスの終了を待つ"
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_DISABLED
-#: Merge.rc:5597
+#: Merge.rc:5596
 msgctxt "Options dialog|General|Auto-reload modified files"
 msgid "Disabled"
 msgstr "無効"
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_STR1
-#: Merge.rc:5598
+#: Merge.rc:5597
 msgid "Only on window activated"
 msgstr "ウインドウがアクティブになった時のみ"
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_STR2
-#: Merge.rc:5599
+#: Merge.rc:5598
 msgid "Immediately"
 msgstr "即時"
 
 #. IDS_PLUGIN_ALL
-#: Merge.rc:5604
+#: Merge.rc:5603
 msgid "Al&l"
 msgstr "すべて(&L)"
 
 #. IDS_PLUGIN_OTHERS
-#: Merge.rc:5605
+#: Merge.rc:5604
 msgid "&Others"
 msgstr "その他(&O)"
 
-#: Merge.rc:5607
+#: Merge.rc:5606
 #, c-format
 msgid "Missing plugin name in pipeline: %1"
 msgstr "プラグイン パイプラインにプラグイン名が指定されていません: %1"
 
-#: Merge.rc:5609
+#: Merge.rc:5608
 #, c-format
 msgid "Missing quote in plugin pipeline: %1"
 msgstr "プラグイン パイプラインが引用符で閉じていません: %1"
 
 #. IDS_PLUGIN_NAME_ALREADY_EXISTS
-#: Merge.rc:5610
+#: Merge.rc:5609
 #, c-format
 msgid "Plugin name '%1' already exists."
 msgstr "プラグイン名 '%1' は既に存在しています。"
 
 #. IDS_PLUGIN_TITLE1
-#: Merge.rc:5611
+#: Merge.rc:5610
 msgid "Specify plugin arguments"
 msgstr "プラグイン引数を指定してください"
 
-#: Merge.rc:5613
+#: Merge.rc:5612
 #, c-format
 msgid "Plugin not found or invalid: %1"
 msgstr "プラグインが見つからないまたは無効です: %1"
 
 #. IDS_PLUGIN_NOT_UNPACK
-#: Merge.rc:5614
+#: Merge.rc:5613
 #, c-format
 msgid "'%1' is not an unpacker plugin"
 msgstr "'%1'は展開プラグインではありません"
 
 #. IDS_PLUGIN_NOT_PREDIFF
-#: Merge.rc:5615
+#: Merge.rc:5614
 #, c-format
 msgid "'%1' is not a prediffer plugin"
 msgstr "'%1'は比較前処理プラグインではありません"
 
-#: Merge.rc:5617
+#: Merge.rc:5616
 #, c-format
 msgid "Error prediffing '%1' with '%2'. Prediffing disabled."
 msgstr "プラグイン'%2'でファイル'%1'の比較前処理を実行中にエラーが発生しました。比較前処理は適用されませんでした。"
 
 #. IDS_PLUGIN_CIRCULAR_REFERENCE
-#: Merge.rc:5618
+#: Merge.rc:5617
 #, c-format
 msgid "Circular reference in plugin pipeline: %1"
 msgstr "プラグインパイプラインに循環参照があります: %1"
 
 #. IDS_PLUGIN_TYPE1
-#: Merge.rc:5619
+#: Merge.rc:5618
 msgid "URL Handler"
 msgstr "URL処理プラグイン"
 
 #. IDS_PLUGIN_TYPE2
-#: Merge.rc:5620
+#: Merge.rc:5619
 msgid "File Unpacker"
 msgstr "ファイル展開プラグイン"
 
 #. IDS_PLUGIN_TYPE3
-#: Merge.rc:5621
+#: Merge.rc:5620
 msgid "File or Folder Unpacker"
 msgstr "ファイルまたはフォルダー展開プラグイン"
 
 #. IDS_PLUGIN_TYPE5
-#: Merge.rc:5623
+#: Merge.rc:5622
 msgid "Alias for Unpacker"
 msgstr "展開プラグインのエイリアス"
 
 #. IDS_PLUGIN_TYPE6
-#: Merge.rc:5624
+#: Merge.rc:5623
 msgid "Alias for Prediffer"
 msgstr "比較前処理プラグインのエイリアス"
 
 #. IDS_PLUGIN_TYPE7
-#: Merge.rc:5625
+#: Merge.rc:5624
 msgid "Alias for Editor script"
 msgstr "エディタースクリプトのエイリアス"
 
 #. IDS_PLUGIN_ALIAS_DESC
-#: Merge.rc:5626
+#: Merge.rc:5625
 #, c-format
 msgid "Alias for plugin pipeline '%1'"
 msgstr "プラグインパイプライン '%1' のエイリアス"
 
 #. IDS_PLUGIN_NEW_DESC
-#: Merge.rc:5627
+#: Merge.rc:5626
 msgid "New plugin description"
 msgstr "新しいプラグインの説明"
 
 #. IDS_PLUGIN_TARGETS_ALL
-#: Merge.rc:5628
+#: Merge.rc:5627
 msgid "All"
 msgstr "すべて"
 
 #. IDS_PLUGIN_TARGETS_1ST
-#: Merge.rc:5629
+#: Merge.rc:5628
 msgid "1st"
 msgstr "1番目"
 
 #. IDS_PLUGIN_TARGETS_2ND
-#: Merge.rc:5630
+#: Merge.rc:5629
 msgid "2nd"
 msgstr "2番目"
 
 #. IDS_PLUGIN_TARGETS_3RD
-#: Merge.rc:5631
+#: Merge.rc:5630
 msgid "3rd"
 msgstr "3番目"
 
 #. IDS_PLUGIN_TARGETS_1ST_2ND
-#: Merge.rc:5632
+#: Merge.rc:5631
 msgid "1st and 2nd"
 msgstr "1番目と2番目"
 
 #. IDS_PLUGIN_TARGETS_1ST_3RD
-#: Merge.rc:5633
+#: Merge.rc:5632
 msgid "1st and 3rd"
 msgstr "1番目と3番目"
 
 #. IDS_PLUGIN_TARGETS_2ND_3RD
-#: Merge.rc:5634
+#: Merge.rc:5633
 msgid "2nd and 3rd"
 msgstr "2番目と3番目"
 
 #. IDS_PLUGIN_CTRL_CLICK
-#: Merge.rc:5635
+#: Merge.rc:5634
 msgid "(Ctrl+Click to add to pipeline)"
 msgstr "(Ctrl+クリックでパイプラインに追加)"
 
 #. IDS_FILTER_APPLIED
-#: Merge.rc:5640
+#: Merge.rc:5639
 msgid "Filter applied"
 msgstr "フィルター適用"
 
 #. IDS_FILTERMENU_COMPARE
-#: Merge.rc:5645
+#: Merge.rc:5644
 #, c-format
 msgid "Compare %1"
 msgstr "%1 を比較"
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN2
-#: Merge.rc:5647
+#: Merge.rc:5646
 msgid "&Filter by This Column..."
 msgstr "この列でフィルター(&F)..."
 
 #. IDS_CLIPBOARDHISTORY_TIME
-#: Merge.rc:5652
+#: Merge.rc:5651
 #, c-format
 msgid "Clipboard at %s"
 msgstr "クリップボード %s"
 
 #. IDS_CLIPBOARDHISTORY_DISABLED
-#: Merge.rc:5653
+#: Merge.rc:5652
 msgid ""
 "Clipboard history disabled.\r\n"
 "Enable: Windows logo key + V, then Turn on."
@@ -8431,115 +8426,115 @@ msgstr ""
 "クリップボード履歴が無効になっています。\r\n"
 "クリップボード履歴を有効にするには、Windows キー + V を押下後、[有効にする] ボタンをクリックしてください。"
 
-#: Merge.rc:5655
+#: Merge.rc:5654
 msgid "This system does not support clipboard history."
 msgstr "このシステムではクリップボード履歴はサポートされていません。"
 
-#: Merge.rc:5657
+#: Merge.rc:5656
 msgid "32-bit WinMerge does not support Clipboard Compare"
 msgstr "32bit版 WinMerge ではクリップボード比較はサポートされていません。"
 
 #. IDS_WEBVIEW2_RUNTIME_NOT_INSTALLED
-#: Merge.rc:5662
+#: Merge.rc:5661
 msgid "WebView2 runtime not installed. Download it?"
 msgstr "WebView2 ランタイムがインストールされていません。ダウンロードしますか?"
 
 #. IDS_JUMPLIST_NEW_TEXT_COMPARE
-#: Merge.rc:5667
+#: Merge.rc:5666
 msgid "New Text Compare"
 msgstr "新規テキスト比較"
 
 #. IDS_JUMPLIST_NEW_TABLE_COMPARE
-#: Merge.rc:5668
+#: Merge.rc:5667
 msgid "New Table Compare"
 msgstr "新規テーブル比較"
 
 #. IDS_JUMPLIST_NEW_BINARY_COMPARE
-#: Merge.rc:5669
+#: Merge.rc:5668
 msgid "New Binary Compare"
 msgstr "新規バイナリ比較"
 
 #. IDS_JUMPLIST_NEW_IMAGE_COMPARE
-#: Merge.rc:5670
+#: Merge.rc:5669
 msgid "New Image Compare"
 msgstr "新規画像比較"
 
 #. IDS_JUMPLIST_NEW_WEBPAGE_COMPARE
-#: Merge.rc:5671
+#: Merge.rc:5670
 msgid "New Webpage Compare"
 msgstr "新規Webページ比較"
 
 #. IDS_JUMPLIST_NEW_FOLDER_COMPARE
-#: Merge.rc:5672
+#: Merge.rc:5671
 msgid "New Folder Compare"
 msgstr "新規フォルダー比較"
 
 #. IDS_JUMPLIST_CLIPBOARD_COMPARE
-#: Merge.rc:5673
+#: Merge.rc:5672
 msgid "Clipboard Compare"
 msgstr "クリップボード比較"
 
 #. IDS_PREVIEWBAR_PRINT
-#: Merge.rc:5678
+#: Merge.rc:5677
 msgid "&Print..."
 msgstr "印刷(&P)..."
 
 #. IDS_PREVIEWBAR_PREVPAGE
-#: Merge.rc:5680
+#: Merge.rc:5679
 msgid "Pre&v Page"
 msgstr "前ページ(&V)"
 
 #. IDS_PREVIEWBAR_TWOPAGE
-#: Merge.rc:5681
+#: Merge.rc:5680
 msgid "&Two Page"
 msgstr "2ページ(&T)"
 
 #. IDS_PREVIEWBAR_ONEPAGE
-#: Merge.rc:5682
+#: Merge.rc:5681
 msgid "&One Page"
 msgstr "1ページ(&O)"
 
 #. IDS_PREVIEWBAR_ZOOMIN
-#: Merge.rc:5683
+#: Merge.rc:5682
 msgid "Zoom &In"
 msgstr "拡大(&I)"
 
 #. IDS_PREVIEWBAR_ZOOMOUT
-#: Merge.rc:5684
+#: Merge.rc:5683
 msgid "Zoom &Out"
 msgstr "縮小(&O)"
 
 #. IDS_WEBPAGE_COMPARING
-#: Merge.rc:5690
+#: Merge.rc:5689
 msgid "Comparing..."
 msgstr "比較しています..."
 
 #. IDS_WEBPAGE_ZOOM
-#: Merge.rc:5691
+#: Merge.rc:5690
 msgid "Zoom:"
 msgstr "拡大率:"
 
 #. IDS_COPY_GRANULARITY_DIFFHUNK
-#: Merge.rc:5696
+#: Merge.rc:5695
 msgid "Diff hunk"
 msgstr "差異ブロック"
 
 #. IDS_COPY_GRANULARITY_INLINE
-#: Merge.rc:5697
+#: Merge.rc:5696
 msgid "Inline diff"
 msgstr "行内差異"
 
 #. IDS_COPY_GRANULARITY_LINE
-#: Merge.rc:5698
+#: Merge.rc:5697
 msgid "Line"
 msgstr "行"
 
-#: Merge.rc:5699
+#: Merge.rc:5698
 msgid "Character"
 msgstr "文字"
 
 #. ID_MICE_PREVDIFF
-#: Merge.rc:5704
+#: Merge.rc:5703
 msgid ""
 "\n"
 "Previous Difference (Alt+Up)\n"
@@ -8552,7 +8547,7 @@ msgstr ""
 "(Alt+Wheel Up)"
 
 #. ID_MICE_NEXTDIFF
-#: Merge.rc:5705
+#: Merge.rc:5704
 msgid ""
 "\n"
 "Next Difference (Alt+Down)\n"
@@ -8565,7 +8560,7 @@ msgstr ""
 "(Alt+Wheel Down)"
 
 #. ID_MICE_L2R
-#: Merge.rc:5706
+#: Merge.rc:5705
 msgid ""
 "\n"
 "Copy to Right (Alt+Right)\n"
@@ -8580,7 +8575,7 @@ msgstr ""
 "(Alt+Shift+Wheel Down)"
 
 #. ID_MICE_R2L
-#: Merge.rc:5707
+#: Merge.rc:5706
 msgid ""
 "\n"
 "Copy to Left (Alt+Left)\n"
@@ -8595,7 +8590,7 @@ msgstr ""
 "(Alt+Shift+Wheel Up)"
 
 #. ID_MICE_L2RNEXT
-#: Merge.rc:5708
+#: Merge.rc:5707
 msgid ""
 "\n"
 "Copy to Right and Advance (Ctrl+Alt+Right)\n"
@@ -8608,7 +8603,7 @@ msgstr ""
 "(Ctrl+Alt+Shift+Wheel Down)"
 
 #. ID_MICE_R2LNEXT
-#: Merge.rc:5709
+#: Merge.rc:5708
 msgid ""
 "\n"
 "Copy to Left and Advance (Ctrl+Alt+Left)\n"
@@ -8621,257 +8616,257 @@ msgstr ""
 "(Ctrl+Alt+Shift+Wheel Up)"
 
 #. IDS_LOG_COMPARING_2
-#: Merge.rc:5719
+#: Merge.rc:5718
 #, c-format
 msgid "Comparing %1 with %2"
 msgstr "%1 と %2 を比較しています"
 
 #. IDS_LOG_COMPARING_3
-#: Merge.rc:5720
+#: Merge.rc:5719
 #, c-format
 msgid "Comparing %1 with %2 and %3"
 msgstr "%1 と %2 と %3 を比較しています"
 
 #. IDS_LOG_COMPARE_COMPLETED
-#: Merge.rc:5721
+#: Merge.rc:5720
 msgid "Comparison completed"
 msgstr "比較が完了しました"
 
 #. IDS_LOG_COMPARE_ERROR_2
-#: Merge.rc:5722
+#: Merge.rc:5721
 #, c-format
 msgid "Failed to compare %1 with %2: "
 msgstr "%1 と %2 の比較に失敗しました: "
 
 #. IDS_LOG_COMPARE_ERROR_3
-#: Merge.rc:5723
+#: Merge.rc:5722
 #, c-format
 msgid "Failed to compare %1 with %2 and %3: "
 msgstr "%1 と %2 と %3 の比較に失敗しました: "
 
 #. IDS_LOG_FILE_SAVED
-#: Merge.rc:5724
+#: Merge.rc:5723
 msgid "File saved"
 msgstr "ファイルが保存されました"
 
 #. IDS_LOG_COPYING_FILES
-#: Merge.rc:5725
+#: Merge.rc:5724
 msgid "Copying files..."
 msgstr "ファイルをコピーしています..."
 
 #. IDS_LOG_MOVING_FILES
-#: Merge.rc:5726
+#: Merge.rc:5725
 msgid "Moving files..."
 msgstr "ファイルを移動しています..."
 
 #. IDS_LOG_DELETING_FILES
-#: Merge.rc:5727
+#: Merge.rc:5726
 msgid "Deleting files..."
 msgstr "ファイルを削除しています..."
 
 #. IDS_LOG_RECYCLEBIN
-#: Merge.rc:5728
+#: Merge.rc:5727
 msgid "Recycle Bin"
 msgstr "ゴミ箱"
 
 #. IDS_LOG_PERMANENTLY_DELETED
-#: Merge.rc:5729
+#: Merge.rc:5728
 msgid "Permanently deleted"
 msgstr "完全に削除"
 
 #. IDS_LOG_FILEOPERATION_COMPLETED
-#: Merge.rc:5730
+#: Merge.rc:5729
 msgid "File operation completed successfully"
 msgstr "ファイル操作が正常に完了しました"
 
 #. IDS_LOG_FILEOPERATION_CANCELED
-#: Merge.rc:5731
+#: Merge.rc:5730
 msgid "File operation canceled"
 msgstr "ファイル操作がキャンセルされました"
 
 #. IDS_FILTER_ERROR_NO_ERROR
-#: Merge.rc:5736
+#: Merge.rc:5735
 msgid "No error"
 msgstr "エラーはありません"
 
 #. IDS_FILTER_ERROR_EMPTY_EXPRESSION
-#: Merge.rc:5737
+#: Merge.rc:5736
 msgid "Filter expression is empty"
 msgstr "フィルター式が空です"
 
 #. IDS_FILTER_ERROR_UNKNOWN_CHAR
-#: Merge.rc:5738
+#: Merge.rc:5737
 msgid "Unknown character in filter expression"
 msgstr "フィルター式に不明な文字があります"
 
 #. IDS_FILTER_ERROR_UNTERMINATED_STRING
-#: Merge.rc:5739
+#: Merge.rc:5738
 msgid "Unterminated string literal"
 msgstr "文字列リテラルが閉じられていません"
 
 #. IDS_FILTER_ERROR_SYNTAX_ERROR
-#: Merge.rc:5740
+#: Merge.rc:5739
 msgid "Syntax error in filter expression"
 msgstr "フィルター式の構文エラーです"
 
 #. IDS_FILTER_ERROR_PARSE_FAILURE
-#: Merge.rc:5741
+#: Merge.rc:5740
 msgid "Failed to parse filter expression"
 msgstr "フィルター式の解析に失敗しました"
 
 #. IDS_FILTER_ERROR_INVALID_LITERAL
-#: Merge.rc:5742
+#: Merge.rc:5741
 msgid "Invalid literal value"
 msgstr "無効なリテラル値です"
 
 #. IDS_FILTER_ERROR_INVALID_REGULAR_EXPRESSION
-#: Merge.rc:5743
+#: Merge.rc:5742
 msgid "Invalid regular expression"
 msgstr "無効な正規表現です"
 
 #. IDS_FILTER_ERROR_UNDEFINED_IDENTIFIER
-#: Merge.rc:5744
+#: Merge.rc:5743
 msgid "Undefined identifier"
 msgstr "未定義の識別子です"
 
 #. IDS_FILTER_ERROR_INVALID_ARGUMENT_COUNT
-#: Merge.rc:5745
+#: Merge.rc:5744
 msgid "Invalid number of arguments"
 msgstr "引数の数が正しくありません"
 
 #. IDS_FILTER_ERROR_FILTER_NAME_NOT_FOUND
-#: Merge.rc:5746
+#: Merge.rc:5745
 msgid "Filter name not found"
 msgstr "フィルター名が見つかりません"
 
 #. IDS_FILTER_ERROR_DIVIDE_BY_ZERO
-#: Merge.rc:5747
+#: Merge.rc:5746
 msgid "Division by zero in filter expression"
 msgstr "フィルター式で0による除算が行われました"
 
 #. IDS_FILTER_ERROR_UNKNOWN_ERROR
-#: Merge.rc:5748
+#: Merge.rc:5747
 msgid "Unknown error"
 msgstr "不明なエラーです"
 
 #. IDS_FILTER_ERROR_INVALID_PROPERTY_NAME
-#: Merge.rc:5749
+#: Merge.rc:5748
 msgid "Invalid property name"
 msgstr "無効なプロパティ名です"
 
 #. IDS_FILTER_ERROR_INVALID_DIRECTIVE
-#: Merge.rc:5750
+#: Merge.rc:5749
 msgid "Invalid directive"
 msgstr "無効なディレクティブです"
 
 #. IDS_FILTER_OP_EQUALS
-#: Merge.rc:5755
+#: Merge.rc:5754
 msgid "Equals"
 msgstr "等しい"
 
 #. IDS_FILTER_OP_NOT_EQUALS
-#: Merge.rc:5756
+#: Merge.rc:5755
 msgid "Does not equal"
 msgstr "等しくない"
 
 #. IDS_FILTER_OP_LESS_THAN
-#: Merge.rc:5757
+#: Merge.rc:5756
 msgid "Less than"
 msgstr "より小さい"
 
 #. IDS_FILTER_OP_LESS_EQUAL
-#: Merge.rc:5758
+#: Merge.rc:5757
 msgid "Less than or equal to"
 msgstr "以下"
 
 #. IDS_FILTER_OP_GREATER_EQUAL
-#: Merge.rc:5759
+#: Merge.rc:5758
 msgid "Greater than or equal to"
 msgstr "以上"
 
 #. IDS_FILTER_OP_GREATER_THAN
-#: Merge.rc:5760
+#: Merge.rc:5759
 msgid "Greater than"
 msgstr "より大きい"
 
 #. IDS_FILTER_OP_BETWEEN
-#: Merge.rc:5761
+#: Merge.rc:5760
 msgid "Between"
 msgstr "範囲内"
 
 #. IDS_FILTER_OP_NOT_BETWEEN
-#: Merge.rc:5762
+#: Merge.rc:5761
 msgid "Not Between"
 msgstr "範囲外"
 
 #. IDS_FILTER_OP_CONTAINS
-#: Merge.rc:5763
+#: Merge.rc:5762
 msgid "Contains"
 msgstr "含む"
 
 #. IDS_FILTER_OP_NOT_CONTAINS
-#: Merge.rc:5764
+#: Merge.rc:5763
 msgid "Not Contains"
 msgstr "含まない"
 
 #. IDS_FILTER_OP_RECONTAINS
-#: Merge.rc:5765
+#: Merge.rc:5764
 msgid "Contains (regex)"
 msgstr "含む(正規表現)"
 
 #. IDS_FILTER_OP_NOT_RECONTAINS
-#: Merge.rc:5766
+#: Merge.rc:5765
 msgid "Not Contains (regex)"
 msgstr "含まない(正規表現)"
 
 #. IDS_FILTER_OP_LIKE
-#: Merge.rc:5767
+#: Merge.rc:5766
 msgid "Match (wildcard)"
 msgstr "一致(ワイルドカード)"
 
 #. IDS_FILTER_OP_NOT_LIKE
-#: Merge.rc:5768
+#: Merge.rc:5767
 msgid "Not match (wildcard)"
 msgstr "不一致(ワイルドカード)"
 
 #. IDS_FILTER_OP_MATCHES
-#: Merge.rc:5769
+#: Merge.rc:5768
 msgid "Match (regex)"
 msgstr "一致(正規表現)"
 
 #. IDS_FILTER_OP_NOT_MATCHES
-#: Merge.rc:5770
+#: Merge.rc:5769
 msgid "Not match (regex)"
 msgstr "不一致(正規表現)"
 
 #. IDS_COLORMODE_LIGHT
-#: Merge.rc:5775
+#: Merge.rc:5774
 msgid "Light"
 msgstr "ライト"
 
 #. IDS_COLORMODE_DARK
-#: Merge.rc:5776
+#: Merge.rc:5775
 msgid "Dark"
 msgstr "ダーク"
 
 #. IDS_COLORMODE_FOLLOWSYSTEM
-#: Merge.rc:5777
+#: Merge.rc:5776
 msgid "Follow system"
 msgstr "システムに従う"
 
 #. IDS_EXAMPLE
-#: Merge.rc:5782
+#: Merge.rc:5781
 #, c-format
 msgid "e.g. %1"
 msgstr "例: %1"
 
 #. IDS_DETECTED_PREVIOUS_CRASH
-#: Merge.rc:5787
+#: Merge.rc:5786
 msgid "WinMerge detected a previous crash. Please report this if possible."
 msgstr "以前の WinMerge のクラッシュを検出しました。可能であればご報告ください。"
 
 #. IDS_REGEX_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5792
+#: Merge.rc:5791
 msgid ""
 "# Regex replacement list\r\n"
 "# Format: regex<TAB>replacement\r\n"
@@ -8886,7 +8881,7 @@ msgstr ""
 "(\\d{4})-(\\d{2})-(\\d{2})\t$1_$2_$3\r\n"
 
 #. IDS_STRING_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5793
+#: Merge.rc:5792
 msgid ""
 "# Replacement list\r\n"
 "# Format: search<TAB>replacement\r\n"
@@ -8903,22 +8898,22 @@ msgstr ""
 "from2\tto2\r\n"
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_ONLY
-#: Merge.rc:5798
+#: Merge.rc:5797
 msgid "Built-in only"
 msgstr "組み込みのみ使用"
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_FIRST
-#: Merge.rc:5799
+#: Merge.rc:5798
 msgid "Built-in first"
 msgstr "組み込みを優先"
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_FIRST
-#: Merge.rc:5800
+#: Merge.rc:5799
 msgid "Tree-sitter first"
 msgstr "Tree-sitter を優先"
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_ONLY
-#: Merge.rc:5801
+#: Merge.rc:5800
 msgid "Tree-sitter only"
 msgstr "Tree-sitter のみ使用"
 

--- a/Translations/WinMerge/Korean.po
+++ b/Translations/WinMerge/Korean.po
@@ -30,7 +30,7 @@ msgstr ""
 "X-Poedit-Bookmarks: 308,-1,-1,-1,-1,-1,-1,-1,-1,-1\n"
 
 #. LANGUAGE, SUBLANGUAGE
-#: Merge.rc:26 Merge.rc:59 Merge.rc:5818
+#: Merge.rc:26 Merge.rc:59 Merge.rc:5817
 #, c-format
 msgid "LANG_ENGLISH, SUBLANG_ENGLISH_US"
 msgstr "LANG_KOREAN, SUBLANG_DEFAULT"
@@ -180,7 +180,7 @@ msgstr "스크립트(&S)"
 #. IDS_NO_EDIT_SCRIPTS
 #: Merge.rc:127 Merge.rc:352 Merge.rc:463 Merge.rc:673 Merge.rc:678
 #: Merge.rc:887 Merge.rc:899 Merge.rc:906 Merge.rc:963 Merge.rc:1210
-#: Merge.rc:5375
+#: Merge.rc:5374
 #, c-format
 msgid "< Empty >"
 msgstr "< 비어 있음 >"
@@ -247,7 +247,7 @@ msgid "Auto-Fit All Columns"
 msgstr "모든 열 자동 맞춤"
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN
-#: Merge.rc:153 Merge.rc:5646
+#: Merge.rc:153 Merge.rc:5645
 msgid "&Filter by This Column"
 msgstr "이 열로 필터링(&F)"
 
@@ -313,7 +313,7 @@ msgid "&Previous Page"
 msgstr "이전 페이지(&P)"
 
 #. IDS_PREVIEWBAR_NEXTPAGE
-#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5679
+#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5678
 #, c-format
 msgid "&Next Page"
 msgstr "다음 페이지(&N)"
@@ -581,7 +581,7 @@ msgstr "바이너리(&B)"
 #. IDS_IMAGE_MENU
 #: Merge.rc:329 Merge.rc:338 Merge.rc:432 Merge.rc:441 Merge.rc:609
 #: Merge.rc:618 Merge.rc:670 Merge.rc:960 Merge.rc:1187 Merge.rc:1200
-#: Merge.rc:5477
+#: Merge.rc:5476
 #, c-format
 msgid "&Image"
 msgstr "이미지(&I)"
@@ -719,7 +719,7 @@ msgid "&Huge"
 msgstr "매우 크게(&H)"
 
 #. IDS_VIEW_MENU_BAR
-#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5714
+#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5713
 msgid "Men&u Bar"
 msgstr "메뉴 표시줄(&U)"
 
@@ -1482,7 +1482,7 @@ msgid "Lo&cation Pane"
 msgstr "위치 창(&C)"
 
 #. IDS_OUTPUTBAR_CAPTION
-#: Merge.rc:782 Merge.rc:5252
+#: Merge.rc:782 Merge.rc:5251
 msgid "Output Pane"
 msgstr "출력 창"
 
@@ -1778,55 +1778,55 @@ msgid "Co&mpare As"
 msgstr "다른 방식으로 비교(&M)"
 
 #. IDS_COPY_LEFT_TO_MIDDLE2
-#: Merge.rc:968 Merge.rc:980 Merge.rc:4852
+#: Merge.rc:968 Merge.rc:980 Merge.rc:4851
 #, c-format
 msgid "Left to Middle (%1 of %2)"
 msgstr "왼쪽에서 가운데로 (%1 / %2)"
 
 #. IDS_COPY_LEFT_TO_RIGHT2
-#: Merge.rc:969 Merge.rc:981 Merge.rc:4851
+#: Merge.rc:969 Merge.rc:981 Merge.rc:4850
 #, c-format
 msgid "Left to Right (%1 of %2)"
 msgstr "왼쪽에서 오른쪽으로 (%1 / %2)"
 
 #. IDS_MOVE_LEFT_TO2
-#: Merge.rc:970 Merge.rc:982 Merge.rc:1045 Merge.rc:4863 Merge.rc:4892
+#: Merge.rc:970 Merge.rc:982 Merge.rc:1045 Merge.rc:4862 Merge.rc:4891
 #, c-format
 msgid "Left to... (%1 of %2)"
 msgstr "왼쪽에서... (%1 / %2)"
 
 #. IDS_COPY_MIDDLE_TO_LEFT2
-#: Merge.rc:971 Merge.rc:983 Merge.rc:4849
+#: Merge.rc:971 Merge.rc:983 Merge.rc:4848
 #, c-format
 msgid "Middle to Left (%1 of %2)"
 msgstr "가운데에서 왼쪽으로 (%1 / %2)"
 
 #. IDS_COPY_MIDDLE_TO_RIGHT2
-#: Merge.rc:972 Merge.rc:984 Merge.rc:4850
+#: Merge.rc:972 Merge.rc:984 Merge.rc:4849
 #, c-format
 msgid "Middle to Right (%1 of %2)"
 msgstr "가운데에서 오른쪽으로 (%1 / %2)"
 
 #. IDS_MOVE_MIDDLE_TO2
-#: Merge.rc:973 Merge.rc:985 Merge.rc:1046 Merge.rc:4864 Merge.rc:4893
+#: Merge.rc:973 Merge.rc:985 Merge.rc:1046 Merge.rc:4863 Merge.rc:4892
 #, c-format
 msgid "Middle to... (%1 of %2)"
 msgstr "가운데에서... (%1 / %2)"
 
 #. IDS_COPY_RIGHT_TO_MIDDLE2
-#: Merge.rc:974 Merge.rc:986 Merge.rc:4848
+#: Merge.rc:974 Merge.rc:986 Merge.rc:4847
 #, c-format
 msgid "Right to Middle (%1 of %2)"
 msgstr "오른쪽에서 가운데로 (%1 / %2)"
 
 #. IDS_COPY_RIGHT_TO_LEFT2
-#: Merge.rc:975 Merge.rc:987 Merge.rc:4847
+#: Merge.rc:975 Merge.rc:987 Merge.rc:4846
 #, c-format
 msgid "Right to Left (%1 of %2)"
 msgstr "오른쪽에서 왼쪽으로 (%1 / %2)"
 
 #. IDS_MOVE_RIGHT_TO2
-#: Merge.rc:976 Merge.rc:988 Merge.rc:1047 Merge.rc:4865 Merge.rc:4894
+#: Merge.rc:976 Merge.rc:988 Merge.rc:1047 Merge.rc:4864 Merge.rc:4893
 #, c-format
 msgid "Right to... (%1 of %2)"
 msgstr "오른쪽에서... (%1 / %2)"
@@ -1892,31 +1892,31 @@ msgid "Cop&y Paths"
 msgstr "경로 복사(&Y)"
 
 #. IDS_DEL_LEFT_FMT2
-#: Merge.rc:1026 Merge.rc:1035 Merge.rc:4880
+#: Merge.rc:1026 Merge.rc:1035 Merge.rc:4879
 #, c-format
 msgid "Left (%1 of %2)"
 msgstr "왼쪽 (%1 / %2)"
 
 #. IDS_DEL_MIDDLE_FMT2
-#: Merge.rc:1027 Merge.rc:1036 Merge.rc:4881
+#: Merge.rc:1027 Merge.rc:1036 Merge.rc:4880
 #, c-format
 msgid "Middle (%1 of %2)"
 msgstr "가운데 (%1 / %2)"
 
 #. IDS_DEL_RIGHT_FMT2
-#: Merge.rc:1028 Merge.rc:1037 Merge.rc:4882
+#: Merge.rc:1028 Merge.rc:1037 Merge.rc:4881
 #, c-format
 msgid "Right (%1 of %2)"
 msgstr "오른쪽 (%1 / %2)"
 
 #. IDS_DEL_BOTH_FMT2
-#: Merge.rc:1029 Merge.rc:1038 Merge.rc:4883
+#: Merge.rc:1029 Merge.rc:1038 Merge.rc:4882
 #, c-format
 msgid "Both (%1 of %2)"
 msgstr "양쪽 (%1 / %2)"
 
 #. IDS_DEL_ALL_FMT2
-#: Merge.rc:1030 Merge.rc:1039 Merge.rc:4888
+#: Merge.rc:1030 Merge.rc:1039 Merge.rc:4887
 #, c-format
 msgid "All (%1 of %2)"
 msgstr "전체 (%1 / %2)"
@@ -1945,19 +1945,19 @@ msgid "&Zip"
 msgstr "Zip 압축(&Z)"
 
 #. IDS_COPY_BOTH_TO2
-#: Merge.rc:1048 Merge.rc:4866
+#: Merge.rc:1048 Merge.rc:4865
 #, c-format
 msgid "Both to... (%1 of %2)"
 msgstr "양쪽... (%1 / %2)"
 
 #. IDS_COPY_ALL_TO2
-#: Merge.rc:1049 Merge.rc:4867
+#: Merge.rc:1049 Merge.rc:4866
 #, c-format
 msgid "All to... (%1 of %2)"
 msgstr "모두... (%1 / %2)"
 
 #. IDS_COPY_DIFFERENCES_TO2
-#: Merge.rc:1050 Merge.rc:4868
+#: Merge.rc:1050 Merge.rc:4867
 #, c-format
 msgid "Differences to... (%1 of %2)"
 msgstr "차이... (%1 / %2)"
@@ -2030,13 +2030,13 @@ msgstr "압축 풀기 설정"
 
 #. IDS_USERCHOICE_NONE
 #: Merge.rc:1088 Merge.rc:1094 Merge.rc:1836 Merge.rc:1840 Merge.rc:2031
-#: Merge.rc:2035 Merge.rc:5377
+#: Merge.rc:2035 Merge.rc:5376
 #, c-format
 msgid "<None>"
 msgstr "<없음>"
 
 #. IDS_USERCHOICE_AUTOMATIC
-#: Merge.rc:1089 Merge.rc:1095 Merge.rc:5378
+#: Merge.rc:1089 Merge.rc:1095 Merge.rc:5377
 #, c-format
 msgid "<Automatic>"
 msgstr "<자동>"
@@ -2988,13 +2988,13 @@ msgid "Text files only"
 msgstr "텍스트 파일만"
 
 #. IDS_EOL_NONE
-#: Merge.rc:1667 Merge.rc:1918 Merge.rc:5304
+#: Merge.rc:1667 Merge.rc:1918 Merge.rc:5303
 #, c-format
 msgid "None"
 msgstr "없음"
 
 #. IDS_EOL_MIXED
-#: Merge.rc:1668 Merge.rc:5299
+#: Merge.rc:1668 Merge.rc:5298
 #, c-format
 msgid "Mixed"
 msgstr "혼합됨"
@@ -3268,14 +3268,14 @@ msgstr "줄 상태(&S)"
 
 #. IDS_DIFFERENT
 #: Merge.rc:1904 Merge.rc:1988 Merge.rc:2866 Merge.rc:3036 Merge.rc:3077
-#: Merge.rc:5058
+#: Merge.rc:5057
 #, c-format
 msgid "Different"
 msgstr "다름"
 
 #. IDS_IDENTICAL
 #: Merge.rc:1905 Merge.rc:1989 Merge.rc:2865 Merge.rc:3055 Merge.rc:3116
-#: Merge.rc:5048
+#: Merge.rc:5047
 #, c-format
 msgid "Identical"
 msgstr "동일"
@@ -3296,7 +3296,7 @@ msgid "Missing"
 msgstr "누락됨"
 
 #. IDS_MOVED
-#: Merge.rc:1910 Merge.rc:5076
+#: Merge.rc:1910 Merge.rc:5075
 msgid "Moved"
 msgstr "이동됨"
 
@@ -4124,7 +4124,7 @@ msgid "&Use custom system colors"
 msgstr "사용자 지정 시스템 색상 사용 (일부 UI 요소는 적용되지 않을 수 있습니다)"
 
 #. IDS_PRPCAT_SYSTEM
-#: Merge.rc:2565 Merge.rc:4559 Merge.rc:4560 Merge.rc:5007
+#: Merge.rc:2565 Merge.rc:4559 Merge.rc:4560 Merge.rc:5006
 #, c-format
 msgid "System"
 msgstr "시스템"
@@ -4575,7 +4575,7 @@ msgid "Items compared:"
 msgstr "비교된 항목:"
 
 #. IDS_PREVIEWBAR_CLOSE
-#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5685
+#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5684
 #, c-format
 msgid "&Close"
 msgstr "닫기(&C)"
@@ -5268,7 +5268,7 @@ msgid "A&ppend timestamp"
 msgstr "타임스탬프 추가(&P)"
 
 #. IDS_CONFIRM_COPY_CAPTION
-#: Merge.rc:3214 Merge.rc:4915
+#: Merge.rc:3214 Merge.rc:4914
 #, c-format
 msgid "Confirm Copy"
 msgstr "복사 확인"
@@ -5529,7 +5529,7 @@ msgid "&Character Set..."
 msgstr "문자셋(&C)..."
 
 #. IDS_PRPCAT_IMAGE
-#: Merge.rc:3351 Merge.rc:4574 Merge.rc:5015
+#: Merge.rc:3351 Merge.rc:4574 Merge.rc:5014
 msgid "Image"
 msgstr "이미지"
 
@@ -5965,7 +5965,7 @@ msgid "Project"
 msgstr "프로젝트"
 
 #. IDS_COLHDR_NSDIFFS
-#: Merge.rc:4566 Merge.rc:4990
+#: Merge.rc:4566 Merge.rc:4989
 #, c-format
 msgid "Differences"
 msgstr "차이"
@@ -6125,13 +6125,13 @@ msgid "File Type"
 msgstr "파일 유형"
 
 #. IDS_COLHDR_EXTENSION
-#: Merge.rc:4653 Merge.rc:4947
+#: Merge.rc:4653 Merge.rc:4946
 #, c-format
 msgid "Extension"
 msgstr "확장자"
 
 #. IDS_PRPCAT_MESSAGE
-#: Merge.rc:4659 Merge.rc:5019
+#: Merge.rc:4659 Merge.rc:5018
 msgid "Message"
 msgstr "메시지"
 
@@ -6171,7 +6171,7 @@ msgid "Hidden Items"
 msgstr "숨겨진 항목"
 
 #. IDS_PLUGINSLIST_NAME
-#: Merge.rc:4680 Merge.rc:5311
+#: Merge.rc:4680 Merge.rc:5310
 #, c-format
 msgid "Name"
 msgstr "이름"
@@ -6195,7 +6195,7 @@ msgid "[F] "
 msgstr "[F] "
 
 #. IDS_PLUGINSLIST_DESC
-#: Merge.rc:4684 Merge.rc:5313
+#: Merge.rc:4684 Merge.rc:5312
 #, c-format
 msgid "Description"
 msgstr "설명"
@@ -6378,170 +6378,164 @@ msgstr "줄: %s  열: %d/%d  문자: %d/%d"
 msgid "  Sel: %d | %d"
 msgstr "  선택: %d | %d"
 
-#. IDS_MERGEMODE_MERGING
-#: Merge.rc:4734
-#, c-format
-msgid "Merge"
-msgstr "병합"
-
 #. IDS_DIFF_NUMBER_STATUS_FMT
-#: Merge.rc:4735
+#: Merge.rc:4734
 #, c-format
 msgid "Difference %1 of %2"
 msgstr "차이 %1 / %2"
 
 #. IDS_NO_DIFF_SEL_FMT
-#: Merge.rc:4736
+#: Merge.rc:4735
 #, c-format
 msgid "%1 Differences Found"
 msgstr "%1개 차이 발견"
 
 #. IDS_1_DIFF_FOUND
-#: Merge.rc:4737
+#: Merge.rc:4736
 #, c-format
 msgid "1 Difference Found"
 msgstr "1개 차이 발견"
 
 #. IDS_NO_ERR_SEL_FMT
-#: Merge.rc:4738
+#: Merge.rc:4737
 #, c-format
 msgid "%1 Errors Found"
 msgstr "%1개의 오류 발견"
 
 #. IDS_1_ERR_FOUND
-#: Merge.rc:4739
+#: Merge.rc:4738
 msgid "1 Error Found"
 msgstr "1개의 오류 발견"
 
 #. IDS_STATUSBAR_READONLY, Abbreviation from "Read Only"
-#: Merge.rc:4740
+#: Merge.rc:4739
 #, c-format
 msgid "RO"
 msgstr "RO"
 
 #. IDS_DIRVIEW_STATUS_FMT_FOCUS
-#: Merge.rc:4746
+#: Merge.rc:4745
 #, c-format
 msgid "Item %1 of %2"
 msgstr "항목 %1 / %2"
 
 #. IDS_DIRVIEW_STATUS_FMT_NOFOCUS
-#: Merge.rc:4747
+#: Merge.rc:4746
 #, c-format
 msgid "Items: %1"
 msgstr "항목: %1"
 
 #. IDS_DIRVIEW_STATUS_COMPARING
-#: Merge.rc:4748
+#: Merge.rc:4747
 #, c-format
 msgid "Comparing items..."
 msgstr "항목 비교 중..."
 
 #. IDS_ITEMS_PER_SEC
-#: Merge.rc:4749
+#: Merge.rc:4748
 #, c-format
 msgid "%.1f[items/sec]"
 msgstr "%.1f[항목/초]"
 
 #. IDS_ERROR_INCOMPARABLE
-#: Merge.rc:4755
+#: Merge.rc:4754
 msgid "Select two existing folders/files to compare."
 msgstr "비교할 기존의 폴더나 파일 두 개를 선택하세요."
 
 #. IDS_DIRSEL_TAG
-#: Merge.rc:4756
+#: Merge.rc:4755
 #, c-format
 msgid "Folder Selection"
 msgstr "폴더 선택"
 
 #. IDS_OPEN_FILESDIRS
-#: Merge.rc:4757
+#: Merge.rc:4756
 #, c-format
 msgid "Select two (or three) folders/files to compare."
 msgstr "비교할 2-3개의 폴더 또는 파일을 선택하세요."
 
 #. IDS_OPEN_LEFTINVALID
-#: Merge.rc:4758
+#: Merge.rc:4757
 #, c-format
 msgid "Left (1st) path is invalid!"
 msgstr "왼쪽 (첫 번째) 경로가 잘못되었습니다!"
 
 #. IDS_OPEN_MIDDLEINVALID
-#: Merge.rc:4759
+#: Merge.rc:4758
 #, c-format
 msgid "Middle (2nd) path is invalid!"
 msgstr "가운데 (두 번째) 경로가 잘못되었습니다!"
 
 #. IDS_OPEN_RIGHTINVALID2
-#: Merge.rc:4760
+#: Merge.rc:4759
 #, c-format
 msgid "Right (2nd) path is invalid!"
 msgstr "오른쪽 (두 번째) 경로가 잘못되었습니다!"
 
 #. IDS_OPEN_RIGHTINVALID3
-#: Merge.rc:4761
+#: Merge.rc:4760
 #, c-format
 msgid "Right (3rd) path is invalid!"
 msgstr "오른쪽 (세 번째) 경로가 잘못되었습니다!"
 
 #. IDS_OPEN_BOTHINVALID
-#: Merge.rc:4762
+#: Merge.rc:4761
 #, c-format
 msgid "Both paths are invalid!"
 msgstr "양쪽 모두 잘못된 경로입니다!"
 
-#: Merge.rc:4764
+#: Merge.rc:4763
 #, c-format
 msgid "Left (1st) and Middle (2nd) paths are invalid!"
 msgstr "왼쪽 (첫 번째)와 가운데 (두 번째) 경로가 잘못되었습니다!"
 
 #. IDS_OPEN_LEFTRIGHTINVALID
-#: Merge.rc:4765
+#: Merge.rc:4764
 #, c-format
 msgid "Left (1st) and Right (3rd) paths are invalid!"
 msgstr "왼쪽 (첫 번째)와 오른쪽 (세 번째) 경로가 잘못되었습니다!"
 
-#: Merge.rc:4767
+#: Merge.rc:4766
 msgid "Middle (2nd) and Right (3rd) paths are invalid!"
 msgstr "가운데 (두 번째)와 오른쪽 (세 번째) 경로가 잘못되었습니다!"
 
 #. IDS_OPEN_ALLINVALID
-#: Merge.rc:4768
+#: Merge.rc:4767
 #, c-format
 msgid "All paths are invalid!"
 msgstr "모든 경로가 잘못되었습니다!"
 
 #. IDS_OPEN_UNPACKERDISABLED
-#: Merge.rc:4769
+#: Merge.rc:4768
 msgid "Only enabled for file comparisons"
 msgstr "파일 비교에만 사용"
 
 #. IDS_OPEN_MISMATCH
-#: Merge.rc:4770
+#: Merge.rc:4769
 #, c-format
 msgid "Cannot compare file and folder!"
 msgstr "파일 및 폴더를 비교할 수 없습니다!"
 
 #. IDS_ERROR_FILE_NOT_FOUND
-#: Merge.rc:4776
+#: Merge.rc:4775
 #, c-format
 msgid "File not found: %1"
 msgstr "파일을 찾을 수 없습니다: %1"
 
 #. IDS_ERROR_FOLDER_NOT_FOUND
-#: Merge.rc:4777
+#: Merge.rc:4776
 #, c-format
 msgid "Folder not found: %1"
 msgstr "폴더를 찾을 수 없습니다: %1"
 
 #. IDS_ERROR_FILE_NOT_UNPACKED
-#: Merge.rc:4778
+#: Merge.rc:4777
 #, c-format
 msgid "File not unpacked: %1"
 msgstr "파일의 자료 변환을 하지 않았습니다: %1"
 
 #. IDS_ERROR_FILEOPEN
-#: Merge.rc:4779
+#: Merge.rc:4778
 #, c-format
 msgid ""
 "Cannot open file\n"
@@ -6555,13 +6549,13 @@ msgstr ""
 "%2"
 
 #. IDS_ERROR_CONF_RESOLVE
-#: Merge.rc:4780
+#: Merge.rc:4779
 #, c-format
 msgid "Failed to parse conflict file."
 msgstr "불일치 파일 분석에 실패함."
 
 #. IDS_NOT_CONFLICT_FILE
-#: Merge.rc:4781
+#: Merge.rc:4780
 #, c-format
 msgid ""
 "The file\n"
@@ -6573,7 +6567,7 @@ msgstr ""
 "파일은 충돌 파일이 아닙니다."
 
 #. IDS_COMPARE_LARGE_FILES
-#: Merge.rc:4782
+#: Merge.rc:4781
 msgid ""
 "Comparing large files requires significant memory.\n"
 "Show only comparison results (not file contents)?"
@@ -6582,30 +6576,30 @@ msgstr ""
 "파일 내용이 아닌 비교 결과만 표시하시겠습니까?"
 
 #. IDS_SAVE_AS_TITLE
-#: Merge.rc:4788
+#: Merge.rc:4787
 #, c-format
 msgid "Save As"
 msgstr "다른 이름으로 저장"
 
 #. IDS_SAVE_FMT
-#: Merge.rc:4789
+#: Merge.rc:4788
 #, c-format
 msgid "Save changes to %1?"
 msgstr "변경 내용을 %1에 저장하시겠습니까?"
 
 #. IDS_SAVEREADONLY_FMT
-#: Merge.rc:4790
+#: Merge.rc:4789
 #, c-format
 msgid "%1 is read-only. Override? Or 'No' to save as new filename?"
 msgstr "%1은(는) 읽기 전용입니다. 재정의하시겠습니까? 아니면 새 파일 이름으로 저장하려면 '아니요'를 선택하시겠습니까?"
 
 #. IDS_ERROR_BACKUP
-#: Merge.rc:4791
+#: Merge.rc:4790
 #, c-format
 msgid "Error backing up file"
 msgstr "파일 백업 중 오류"
 
-#: Merge.rc:4793
+#: Merge.rc:4792
 #, c-format
 msgid ""
 "Unable to backup original file:\n"
@@ -6619,7 +6613,7 @@ msgstr ""
 "그래도 계속하시겠습니까?"
 
 #. IDS_FILESAVE_FAILED
-#: Merge.rc:4794
+#: Merge.rc:4793
 #, c-format
 msgid ""
 "Saving file failed.\n"
@@ -6635,7 +6629,7 @@ msgstr ""
 "\t- 다른 파일 이름 사용 (확인 누르기)\n"
 "\t- 현재 작업 중단 (취소 누르기)"
 
-#: Merge.rc:4796
+#: Merge.rc:4795
 #, c-format
 msgid ""
 "Plugin '%2' cannot pack changes to left file into '%1'.\n"
@@ -6648,7 +6642,7 @@ msgstr ""
 "\n"
 "압축을 푼 버전을 다른 파일에 저장하시겠습니까?"
 
-#: Merge.rc:4798
+#: Merge.rc:4797
 #, c-format
 msgid ""
 "Plugin '%2' cannot pack changes to middle file into '%1'.\n"
@@ -6661,7 +6655,7 @@ msgstr ""
 "\n"
 "압축을 푼 버전을 다른 파일에 저장하시겠습니까?"
 
-#: Merge.rc:4800
+#: Merge.rc:4799
 #, c-format
 msgid ""
 "Plugin '%2' cannot pack changes to right file into '%1'.\n"
@@ -6675,7 +6669,7 @@ msgstr ""
 "압축을 푼 버전을 다른 파일에 저장하시겠습니까?"
 
 #. IDS_FILECHANGED_ONDISK
-#: Merge.rc:4801
+#: Merge.rc:4800
 #, c-format
 msgid ""
 "Another application updated\n"
@@ -6691,7 +6685,7 @@ msgstr ""
 "변경된 파일을 덮어쓰시겠습니까?"
 
 #. IDS_SAVEREADONLY_MULTI
-#: Merge.rc:4802
+#: Merge.rc:4801
 #, c-format
 msgid ""
 "%1\n"
@@ -6701,7 +6695,7 @@ msgstr ""
 "읽기 전용으로 표시됩니다. 읽기 전용 항목을 재정의하시겠습니까?"
 
 #. IDS_FILECHANGED_RESCAN
-#: Merge.rc:4803
+#: Merge.rc:4802
 #, c-format
 msgid ""
 "Another application updated\n"
@@ -6717,25 +6711,25 @@ msgstr ""
 "파일을 다시 불러오시겠습니까?"
 
 #. IDS_SAVE_LEFT_AS
-#: Merge.rc:4804
+#: Merge.rc:4803
 #, c-format
 msgid "Save Left File As"
 msgstr "왼쪽 파일 다른 이름으로 저장"
 
 #. IDS_SAVE_MIDDLE_AS
-#: Merge.rc:4805
+#: Merge.rc:4804
 #, c-format
 msgid "Save Middle File As"
 msgstr "가운데 파일 다른 이름으로 저장"
 
 #. IDS_SAVE_RIGHT_AS
-#: Merge.rc:4806
+#: Merge.rc:4805
 #, c-format
 msgid "Save Right File As"
 msgstr "오른쪽 파일 다른 이름으로 저장"
 
 #. IDS_FILE_DISAPPEARED
-#: Merge.rc:4811
+#: Merge.rc:4810
 #, c-format
 msgid ""
 "File\n"
@@ -6747,7 +6741,7 @@ msgstr ""
 "이 사라졌습니다. 계속하려면 이 파일의 사본을 저장하세요."
 
 #. IDS_VIEWS_OUTOFSYNC
-#: Merge.rc:4817
+#: Merge.rc:4816
 #, c-format
 msgid ""
 "Cannot merge unsynched documents.\n"
@@ -6759,124 +6753,124 @@ msgstr ""
 "계속하기 전에 문서를 새로 고침하세요."
 
 #. IDS_BREAK_ON_WHITESPACE
-#: Merge.rc:4822
+#: Merge.rc:4821
 msgid "Break at whitespace"
 msgstr "공백에서 줄바꿈"
 
 #. IDS_BREAK_ON_PUNCTUATION
-#: Merge.rc:4823
+#: Merge.rc:4822
 msgid "Break at whitespace or punctuation"
 msgstr "공백 또는 구두점에서 줄바꿈"
 
 #. IDS_L2M
-#: Merge.rc:4829
+#: Merge.rc:4828
 msgid "Copy to &Middle\tAlt+Right"
 msgstr "가운데로 복사(&M)\tAlt+Right"
 
 #. IDS_R2M
-#: Merge.rc:4830
+#: Merge.rc:4829
 msgid "Copy to &Middle\tAlt+Left"
 msgstr "가운데로 복사(&M)\tAlt+Left"
 
 #. IDS_COPY_FROM_MIDDLE_R
-#: Merge.rc:4831
+#: Merge.rc:4830
 msgid "Copy from Middle\tAlt+Shift+Right"
 msgstr "가운데에서 복사\tAlt+Shift+Right"
 
 #. IDS_COPY_FROM_MIDDLE_L
-#: Merge.rc:4832
+#: Merge.rc:4831
 msgid "Copy from Middle\tAlt+Shift+Left"
 msgstr "가운데에서 복사\tAlt+Shift+Left"
 
 #. IDS_L2MNEXT
-#: Merge.rc:4833
+#: Merge.rc:4832
 msgid "Copy to Middle and Advance\tCtrl+Alt+Right"
 msgstr "가운데로 복사 후 진행\tCtrl+Alt+Right"
 
 #. IDS_R2MNEXT
-#: Merge.rc:4834
+#: Merge.rc:4833
 msgid "Copy to Middle and Advance\tCtrl+Alt+Left"
 msgstr "가운데로 복사 후 진행\tCtrl+Alt+Left"
 
 #. IDS_ALL_MIDDLE
-#: Merge.rc:4835
+#: Merge.rc:4834
 msgid "Copy All to Middle"
 msgstr "모두 가운데로 복사"
 
 #. IDS_COPY_RIGHT_TO_LEFT
-#: Merge.rc:4841
+#: Merge.rc:4840
 #, c-format
 msgid "Right to Left (%1)"
 msgstr "오른쪽에서 왼쪽으로 (%1)"
 
 #. IDS_COPY_RIGHT_TO_MIDDLE
-#: Merge.rc:4842
+#: Merge.rc:4841
 #, c-format
 msgid "Right to Middle (%1)"
 msgstr "오른쪽에서 가운데로 (%1)"
 
 #. IDS_COPY_MIDDLE_TO_LEFT
-#: Merge.rc:4843
+#: Merge.rc:4842
 #, c-format
 msgid "Middle to Left (%1)"
 msgstr "가운데에서 왼쪽으로 (%1)"
 
 #. IDS_COPY_MIDDLE_TO_RIGHT
-#: Merge.rc:4844
+#: Merge.rc:4843
 #, c-format
 msgid "Middle to Right (%1)"
 msgstr "가운데에서 오른쪽으로 (%1)"
 
 #. IDS_COPY_LEFT_TO_RIGHT
-#: Merge.rc:4845
+#: Merge.rc:4844
 #, c-format
 msgid "Left to Right (%1)"
 msgstr "왼쪽에서 오른쪽으로 (%1)"
 
 #. IDS_COPY_LEFT_TO_MIDDLE
-#: Merge.rc:4846
+#: Merge.rc:4845
 #, c-format
 msgid "Left to Middle (%1)"
 msgstr "왼쪽에서 가운데로 (%1)"
 
 #. IDS_MOVE_LEFT_TO
-#: Merge.rc:4857 Merge.rc:4889
+#: Merge.rc:4856 Merge.rc:4888
 #, c-format
 msgid "Left to... (%1)"
 msgstr "왼쪽에서... (%1)"
 
 #. IDS_MOVE_MIDDLE_TO
-#: Merge.rc:4858 Merge.rc:4890
+#: Merge.rc:4857 Merge.rc:4889
 #, c-format
 msgid "Middle to... (%1)"
 msgstr "가운데에서... (%1)"
 
 #. IDS_MOVE_RIGHT_TO
-#: Merge.rc:4859 Merge.rc:4891
+#: Merge.rc:4858 Merge.rc:4890
 #, c-format
 msgid "Right to... (%1)"
 msgstr "오른쪽에서... (%1)"
 
 #. IDS_COPY_BOTH_TO
-#: Merge.rc:4860
+#: Merge.rc:4859
 #, c-format
 msgid "Both to... (%1)"
 msgstr "양쪽... (%1)"
 
 #. IDS_COPY_ALL_TO
-#: Merge.rc:4861
+#: Merge.rc:4860
 #, c-format
 msgid "All to... (%1)"
 msgstr "모두... (%1)"
 
 #. IDS_COPY_DIFFERENCES_TO
-#: Merge.rc:4862
+#: Merge.rc:4861
 #, c-format
 msgid "Differences to... (%1)"
 msgstr "차이... (%1)"
 
 #. IDS_ONLYDIFFITEMS_CONFIRM
-#: Merge.rc:4869
+#: Merge.rc:4868
 msgid ""
 "Some selected items are identical or skipped.\n"
 "Process only items with differences?"
@@ -6885,67 +6879,67 @@ msgstr ""
 "차이점이 있는 항목만 처리하시겠습니까?"
 
 #. IDS_DEL_LEFT_FMT
-#: Merge.rc:4875
+#: Merge.rc:4874
 #, c-format
 msgid "Left (%1)"
 msgstr "왼쪽 (%1)"
 
 #. IDS_DEL_MIDDLE_FMT
-#: Merge.rc:4876
+#: Merge.rc:4875
 #, c-format
 msgid "Middle (%1)"
 msgstr "가운데 (%1)"
 
 #. IDS_DEL_RIGHT_FMT
-#: Merge.rc:4877
+#: Merge.rc:4876
 #, c-format
 msgid "Right (%1)"
 msgstr "오른쪽 (%1)"
 
 #. IDS_DEL_BOTH_FMT
-#: Merge.rc:4878
+#: Merge.rc:4877
 #, c-format
 msgid "Both (%1)"
 msgstr "양쪽 (%1)"
 
 #. IDS_DEL_ALL_FMT
-#: Merge.rc:4879
+#: Merge.rc:4878
 #, c-format
 msgid "All (%1)"
 msgstr "전체 (%1)"
 
 #. IDS_SELECT_DEST_LEFT
-#: Merge.rc:4895
+#: Merge.rc:4894
 #, c-format
 msgid "Left Side - Select Destination Folder:"
 msgstr "왼쪽 - 대상 폴더를 선택하세요:"
 
 #. IDS_SELECT_DEST_MIDDLE
-#: Merge.rc:4896
+#: Merge.rc:4895
 #, c-format
 msgid "Middle Side - Select Destination Folder:"
 msgstr "가운데 - 대상 폴더를 선택하세요:"
 
 #. IDS_SELECT_DEST_RIGHT
-#: Merge.rc:4897
+#: Merge.rc:4896
 #, c-format
 msgid "Right Side - Select Destination Folder:"
 msgstr "오른쪽 - 대상 폴더를 선택하세요:"
 
 #. IDS_FILES_AFFECTED_FMT
-#: Merge.rc:4898
+#: Merge.rc:4897
 #, c-format
 msgid "(%1 Files Affected)"
 msgstr "(%1 파일 변경됨)"
 
 #. IDS_FILES_AFFECTED_FMT2
-#: Merge.rc:4899
+#: Merge.rc:4898
 #, c-format
 msgid "(%1 of %2 Files Affected)"
 msgstr "(%1 / %2 파일 변경됨)"
 
 #. IDS_CONFIRM_DELETE_SINGLE
-#: Merge.rc:4905
+#: Merge.rc:4904
 #, c-format
 msgid ""
 "Are you sure you want to delete\n"
@@ -6957,18 +6951,18 @@ msgstr ""
 "위 내용을 정말 삭제하시겠습니까?"
 
 #. IDS_CONFIRM_SINGLE_COPY
-#: Merge.rc:4906
+#: Merge.rc:4905
 msgid "Are you sure you want to copy?"
 msgstr "복사하시겠습니까?"
 
 #. IDS_CONFIRM_MULTIPLE_COPY
-#: Merge.rc:4907
+#: Merge.rc:4906
 #, c-format
 msgid "Are you sure you want to copy %d items?"
 msgstr "%d개의 항목을 복사하시겠습니까?"
 
 #. IDS_DIRCMP_NOTSYNC
-#: Merge.rc:4908
+#: Merge.rc:4907
 #, c-format
 msgid ""
 "Operation aborted!\n"
@@ -6987,49 +6981,49 @@ msgstr ""
 "비교를 새로 고침하세요."
 
 #. IDS_CONFIRM_SINGLE_MOVE
-#: Merge.rc:4913
+#: Merge.rc:4912
 msgid "Are you sure you want to move?"
 msgstr "정말로 이동하시겠습니까?"
 
 #. IDS_CONFIRM_MULTIPLE_MOVE
-#: Merge.rc:4914
+#: Merge.rc:4913
 #, c-format
 msgid "Are you sure you want to move %d items?"
 msgstr "%d개 항목을 이동하시겠습니까?"
 
 #. IDS_CONFIRM_MOVE_CAPTION
-#: Merge.rc:4916
+#: Merge.rc:4915
 #, c-format
 msgid "Confirm Move"
 msgstr "이동 확인"
 
-#: Merge.rc:4918
+#: Merge.rc:4917
 #, c-format
 msgid "Close the folder comparison window?"
 msgstr "폴더를 비교하는 창을 닫으려고 합니다. 창을 닫으시겠습니까?"
 
-#: Merge.rc:4920
+#: Merge.rc:4919
 msgid "Close the folder comparison window, which took a long time?"
 msgstr "시간이 많이 걸린 폴더 비교 창을 닫으려고 합니다. 창을 닫으시겠습니까?"
 
 #. IDS_ERROR_INVALID_DIR_FILE_NAME
-#: Merge.rc:4921
+#: Merge.rc:4920
 msgid "The file or folder name is invalid."
 msgstr "파일 또는 폴더 이름이 잘못되었습니다."
 
 #. IDS_ERROR_EXECUTE_FILE
-#: Merge.rc:4927
+#: Merge.rc:4926
 #, c-format
 msgid "Failed to execute external editor: %1"
 msgstr "외부 편집기 실행 실패: %1"
 
 #. IDS_UNKNOWN_ARCHIVE_FORMAT
-#: Merge.rc:4933
+#: Merge.rc:4932
 #, c-format
 msgid "Unknown archive format"
 msgstr "알 수 없는 압축 형식"
 
-#: Merge.rc:4935
+#: Merge.rc:4934
 msgid ""
 "Failed to extract archive.\n"
 "Compare as text file?"
@@ -7038,560 +7032,560 @@ msgstr ""
 "압축 파일을 텍스트 파일로 비교하시겠습니까?"
 
 #. IDS_COLHDR_FILENAME
-#: Merge.rc:4941
+#: Merge.rc:4940
 #, c-format
 msgid "Filename"
 msgstr "파일 이름"
 
 #. IDS_COLHDR_DIR
-#: Merge.rc:4942
+#: Merge.rc:4941
 msgctxt "DirView|ColumnHeader"
 msgid "Folder"
 msgstr "폴더"
 
 #. IDS_COLHDR_RESULT
-#: Merge.rc:4943
+#: Merge.rc:4942
 #, c-format
 msgid "Comparison Result"
 msgstr "비교 결과"
 
 #. IDS_COLHDR_LTIMEM
-#: Merge.rc:4944
+#: Merge.rc:4943
 #, c-format
 msgid "Left Date"
 msgstr "왼쪽 날짜"
 
 #. IDS_COLHDR_RTIMEM
-#: Merge.rc:4945
+#: Merge.rc:4944
 #, c-format
 msgid "Right Date"
 msgstr "오른쪽 날짜"
 
 #. IDS_COLHDR_MTIMEM
-#: Merge.rc:4946
+#: Merge.rc:4945
 #, c-format
 msgid "Middle Date"
 msgstr "가운데 날짜"
 
 #. IDS_COLHDR_LSIZE
-#: Merge.rc:4948
+#: Merge.rc:4947
 #, c-format
 msgid "Left Size"
 msgstr "왼쪽 크기"
 
 #. IDS_COLHDR_RSIZE
-#: Merge.rc:4949
+#: Merge.rc:4948
 #, c-format
 msgid "Right Size"
 msgstr "오른쪽 크기"
 
 #. IDS_COLHDR_MSIZE
-#: Merge.rc:4954
+#: Merge.rc:4953
 #, c-format
 msgid "Middle Size"
 msgstr "가운데 크기"
 
 #. IDS_COLHDR_RSIZE_SHORT
-#: Merge.rc:4955
+#: Merge.rc:4954
 #, c-format
 msgid "Right Size (Short)"
 msgstr "오른쪽 크기 (짧게)"
 
 #. IDS_COLHDR_LSIZE_SHORT
-#: Merge.rc:4956
+#: Merge.rc:4955
 #, c-format
 msgid "Left Size (Short)"
 msgstr "왼쪽 크기 (짧게)"
 
 #. IDS_COLHDR_MSIZE_SHORT
-#: Merge.rc:4957
+#: Merge.rc:4956
 #, c-format
 msgid "Middle Size (Short)"
 msgstr "가운데 크기 (짧게)"
 
 #. IDS_COLHDR_LTIMEC
-#: Merge.rc:4963
+#: Merge.rc:4962
 #, c-format
 msgid "Left Creation Time"
 msgstr "왼쪽 생성 시간"
 
 #. IDS_COLHDR_RTIMEC
-#: Merge.rc:4964
+#: Merge.rc:4963
 #, c-format
 msgid "Right Creation Time"
 msgstr "오른쪽 생성 시간"
 
 #. IDS_COLHDR_MTIMEC
-#: Merge.rc:4965
+#: Merge.rc:4964
 #, c-format
 msgid "Middle Creation Time"
 msgstr "가운데 생성 시간"
 
 #. IDS_COLHDR_NEWER
-#: Merge.rc:4966
+#: Merge.rc:4965
 #, c-format
 msgid "Newer File"
 msgstr "최신 파일"
 
 #. IDS_COLHDR_LVERSION
-#: Merge.rc:4967
+#: Merge.rc:4966
 #, c-format
 msgid "Left File Version"
 msgstr "왼쪽 파일 버전"
 
 #. IDS_COLHDR_RVERSION
-#: Merge.rc:4968
+#: Merge.rc:4967
 #, c-format
 msgid "Right File Version"
 msgstr "오른쪽 파일 버전"
 
 #. IDS_COLHDR_MVERSION
-#: Merge.rc:4969
+#: Merge.rc:4968
 #, c-format
 msgid "Middle File Version"
 msgstr "가운데 파일 버전"
 
 #. IDS_COLHDR_RESULT_ABBR
-#: Merge.rc:4970
+#: Merge.rc:4969
 #, c-format
 msgid "Short Result"
 msgstr "짧은 결과"
 
 #. IDS_COLHDR_LATTRIBUTES
-#: Merge.rc:4971
+#: Merge.rc:4970
 #, c-format
 msgid "Left Attributes"
 msgstr "왼쪽 속성"
 
 #. IDS_COLHDR_RATTRIBUTES
-#: Merge.rc:4972
+#: Merge.rc:4971
 #, c-format
 msgid "Right Attributes"
 msgstr "오른쪽 속성"
 
 #. IDS_COLHDR_MATTRIBUTES
-#: Merge.rc:4973
+#: Merge.rc:4972
 #, c-format
 msgid "Middle Attributes"
 msgstr "가운데 속성"
 
 #. IDS_COLHDR_LEOL_TYPE
-#: Merge.rc:4978
+#: Merge.rc:4977
 #, c-format
 msgid "Left EOL"
 msgstr "왼쪽 줄끝"
 
 #. IDS_COLHDR_MEOL_TYPE
-#: Merge.rc:4979
+#: Merge.rc:4978
 #, c-format
 msgid "Middle EOL"
 msgstr "가운데 줄끝"
 
 #. IDS_COLHDR_REOL_TYPE
-#: Merge.rc:4980
+#: Merge.rc:4979
 #, c-format
 msgid "Right EOL"
 msgstr "오른쪽 줄끝"
 
 #. IDS_COLHDR_LENCODING
-#: Merge.rc:4986
+#: Merge.rc:4985
 #, c-format
 msgid "Left Encoding"
 msgstr "왼쪽 인코딩"
 
 #. IDS_COLHDR_RENCODING
-#: Merge.rc:4987
+#: Merge.rc:4986
 #, c-format
 msgid "Right Encoding"
 msgstr "오른쪽 인코딩"
 
 #. IDS_COLHDR_MENCODING
-#: Merge.rc:4988
+#: Merge.rc:4987
 #, c-format
 msgid "Middle Encoding"
 msgstr "가운데 인코딩"
 
 #. IDS_COLHDR_NIDIFFS
-#: Merge.rc:4989
+#: Merge.rc:4988
 msgid "Ignored Diff"
 msgstr "무시된 차이"
 
 #. IDS_COLHDR_BINARY
-#: Merge.rc:4991
+#: Merge.rc:4990
 msgctxt "DirView|ColumnHeader"
 msgid "Binary"
 msgstr "바이너리"
 
 #. IDS_PLUGINS_TYPE_UNPACKER
-#: Merge.rc:4992 Merge.rc:5314
+#: Merge.rc:4991 Merge.rc:5313
 #, c-format
 msgid "Unpacker"
 msgstr "압축 풀기"
 
 #. IDS_PLUGIN_TYPE4
-#: Merge.rc:4993 Merge.rc:5315 Merge.rc:5622
+#: Merge.rc:4992 Merge.rc:5314 Merge.rc:5621
 #, c-format
 msgid "Prediffer"
 msgstr "사전 차이"
 
 #. IDS_COLHDR_LEFT
-#: Merge.rc:4994
+#: Merge.rc:4993
 msgid "Left"
 msgstr "왼쪽"
 
 #. IDS_COLHDR_MIDDLE
-#: Merge.rc:4995
+#: Merge.rc:4994
 msgid "Middle"
 msgstr "가운데"
 
 #. IDS_COLHDR_RIGHT
-#: Merge.rc:4996
+#: Merge.rc:4995
 msgid "Right"
 msgstr "오른쪽"
 
 #. IDS_COLHDR_DIFF
-#: Merge.rc:4997
+#: Merge.rc:4996
 msgid "Diff"
 msgstr "차이"
 
 #. IDS_COLHDR_LEFT_DUPLICATE
-#: Merge.rc:4998
+#: Merge.rc:4997
 msgid "Left Duplicate Count"
 msgstr "왼쪽 중복 개수"
 
 #. IDS_COLHDR_RIGHT_DUPLICATE
-#: Merge.rc:4999
+#: Merge.rc:4998
 msgid "Right Duplicate Count"
 msgstr "오른쪽 중복 개수"
 
 #. IDS_COLHDR_MIDDLE_DUPLICATE
-#: Merge.rc:5000
+#: Merge.rc:4999
 msgid "Middle Duplicate Count"
 msgstr "가운데 중복 개수"
 
 #. IDS_COLHDR_MOVE
-#: Merge.rc:5001
+#: Merge.rc:5000
 msgid "Move"
 msgstr "이동"
 
 #. IDS_PRPCAT_AUDIO
-#: Merge.rc:5008
+#: Merge.rc:5007
 msgid "Audio"
 msgstr "오디오"
 
 #. IDS_PRPCAT_CALENDAR
-#: Merge.rc:5009
+#: Merge.rc:5008
 msgid "Calendar"
 msgstr "캘린더"
 
 #. IDS_PRPCAT_COMMUNICATION
-#: Merge.rc:5010
+#: Merge.rc:5009
 msgid "Communication"
 msgstr "대화"
 
 #. IDS_PRPCAT_CONTACT
-#: Merge.rc:5011
+#: Merge.rc:5010
 msgid "Contact"
 msgstr "연락처"
 
 #. IDS_PRPCAT_DEVICES
-#: Merge.rc:5012
+#: Merge.rc:5011
 msgid "Devices"
 msgstr "장치"
 
 #. IDS_PRPCAT_DOCUMENT
-#: Merge.rc:5013
+#: Merge.rc:5012
 msgid "Document"
 msgstr "문서"
 
 #. IDS_PRPCAT_HOME
-#: Merge.rc:5014
+#: Merge.rc:5013
 msgid "Home"
 msgstr "홈"
 
 #. IDS_PRPCAT_JOURNAL
-#: Merge.rc:5016
+#: Merge.rc:5015
 msgid "Journal"
 msgstr "저널"
 
 #. IDS_PRPCAT_LINK
-#: Merge.rc:5017
+#: Merge.rc:5016
 msgid "Link"
 msgstr "링크"
 
 #. IDS_PRPCAT_MEDIA
-#: Merge.rc:5018
+#: Merge.rc:5017
 msgid "Media"
 msgstr "미디어"
 
 #. IDS_PRPCAT_MUSIC
-#: Merge.rc:5020
+#: Merge.rc:5019
 msgid "Music"
 msgstr "음악"
 
 #. IDS_PRPCAT_NOTE
-#: Merge.rc:5021
+#: Merge.rc:5020
 msgid "Note"
 msgstr "메모"
 
 #. IDS_PRPCAT_PHOTO
-#: Merge.rc:5022
+#: Merge.rc:5021
 msgid "Photo"
 msgstr "사진"
 
 #. IDS_PRPCAT_RECORDEDTV
-#: Merge.rc:5023
+#: Merge.rc:5022
 msgid "RecordedTV"
 msgstr "녹회된 TV"
 
 #. IDS_PRPCAT_SEARCH
-#: Merge.rc:5024
+#: Merge.rc:5023
 msgid "Search"
 msgstr "검색"
 
 #. IDS_PRPCAT_SECURITY
-#: Merge.rc:5025
+#: Merge.rc:5024
 msgid "Security"
 msgstr "보안"
 
 #. IDS_PRPCAT_SOFTWARE
-#: Merge.rc:5026
+#: Merge.rc:5025
 msgid "Software"
 msgstr "소프트웨어"
 
 #. IDS_PRPCAT_TASK
-#: Merge.rc:5027
+#: Merge.rc:5026
 msgid "Task"
 msgstr "작업"
 
 #. IDS_PRPCAT_VIDEO
-#: Merge.rc:5028
+#: Merge.rc:5027
 msgid "Video"
 msgstr "비디오"
 
 #. IDS_PRPCAT_HASH
-#: Merge.rc:5029
+#: Merge.rc:5028
 msgid "Hash"
 msgstr "해쉬"
 
 #. IDS_CANT_COMPARE_FILES
-#: Merge.rc:5035
+#: Merge.rc:5034
 #, c-format
 msgid "Unable to compare files"
 msgstr "파일을 비교할 수 없습니다"
 
 #. IDS_ABORTED_ITEM
-#: Merge.rc:5036
+#: Merge.rc:5035
 #, c-format
 msgid "Item aborted"
 msgstr "취소된 항목"
 
 #. IDS_FILE_SKIPPED
-#: Merge.rc:5037
+#: Merge.rc:5036
 #, c-format
 msgid "File skipped"
 msgstr "파일을 건너뛰었습니다"
 
 #. IDS_DIR_SKIPPED
-#: Merge.rc:5038
+#: Merge.rc:5037
 #, c-format
 msgid "Folder skipped"
 msgstr "건너뛴 폴더"
 
 #. IDS_LEFT_ONLY_IN_FMT
-#: Merge.rc:5039
+#: Merge.rc:5038
 #, c-format
 msgid "Left only: %1"
 msgstr "왼쪽만: %1"
 
 #. IDS_MIDDLE_ONLY_IN_FMT
-#: Merge.rc:5040
+#: Merge.rc:5039
 #, c-format
 msgid "Middle only: %1"
 msgstr "가운데만: %1"
 
 #. IDS_RIGHT_ONLY_IN_FMT
-#: Merge.rc:5041
+#: Merge.rc:5040
 #, c-format
 msgid "Right only: %1"
 msgstr "오른쪽만: %1"
 
 #. IDS_DOES_NOT_EXIST_IN_FMT
-#: Merge.rc:5042
+#: Merge.rc:5041
 #, c-format
 msgid "Does not exist in %1"
 msgstr "%1에 존재하지 않습니다"
 
 #. IDS_BIN_FILES_SAME
-#: Merge.rc:5043
+#: Merge.rc:5042
 #, c-format
 msgid "Binary files are identical"
 msgstr "바이너리 파일이 동일합니다"
 
 #. IDS_BIN_FILES_DIFF
-#: Merge.rc:5049
+#: Merge.rc:5048
 #, c-format
 msgid "Binary files are different"
 msgstr "바이너리 파일이 다릅니다"
 
 #. IDS_FILES_ARE_DIFFERENT
-#: Merge.rc:5050
+#: Merge.rc:5049
 #, c-format
 msgid "Files are different"
 msgstr "파일이 서로 다릅니다"
 
 #. IDS_FOLDERS_ARE_DIFFERENT
-#: Merge.rc:5051
+#: Merge.rc:5050
 #, c-format
 msgid "Folders are different"
 msgstr "폴더가 다릅니다"
 
 #. IDS_LEFTONLY
-#: Merge.rc:5052
+#: Merge.rc:5051
 #, c-format
 msgid "Left Only"
 msgstr "왼쪽만"
 
 #. IDS_RIGHTONLY
-#: Merge.rc:5053
+#: Merge.rc:5052
 #, c-format
 msgid "Right Only"
 msgstr "오른쪽만"
 
 #. IDS_MIDDLEONLY
-#: Merge.rc:5054
+#: Merge.rc:5053
 #, c-format
 msgid "Middle Only"
 msgstr "가운데만"
 
 #. IDS_NOITEMLEFT
-#: Merge.rc:5055
+#: Merge.rc:5054
 #, c-format
 msgid "No item in left"
 msgstr "왼쪽에 항목 없음"
 
 #. IDS_NOITEMRIGHT
-#: Merge.rc:5056
+#: Merge.rc:5055
 #, c-format
 msgid "No item in right"
 msgstr "오른쪽에 항목 없음"
 
 #. IDS_NOITEMMIDDLE
-#: Merge.rc:5057
+#: Merge.rc:5056
 #, c-format
 msgid "No item in middle"
 msgstr "가운데에 항목 없음"
 
 #. IDS_CMPRES_ERROR
-#: Merge.rc:5059
+#: Merge.rc:5058
 #, c-format
 msgid "Error"
 msgstr "오류"
 
 #. IDS_TEXT_FILES_SAME
-#: Merge.rc:5060
+#: Merge.rc:5059
 #, c-format
 msgid "Text files are identical"
 msgstr "텍스트 파일이 같습니다"
 
 #. IDS_LEFTONLY_DIFF
-#: Merge.rc:5061
+#: Merge.rc:5060
 msgid " (Middle and right are identical)"
 msgstr " (가운데와 오른쪽은 동일합니다)"
 
 #. IDS_MIDDLEONLY_DIFF
-#: Merge.rc:5062
+#: Merge.rc:5061
 msgid " (Left and right are identical)"
 msgstr " (왼쪽과 오른쪽은 동일합니다)"
 
 #. IDS_RIGHTONLY_DIFF
-#: Merge.rc:5063
+#: Merge.rc:5062
 msgid " (Left and middle are identical)"
 msgstr " (왼쪽과 가운데는 동일합니다)"
 
 #. IDS_PATH_MISMATCH
-#: Merge.rc:5064
+#: Merge.rc:5063
 msgid " (paths differ)"
 msgstr " (경로가 다름)"
 
 #. IDS_TEXT_FILES_DIFF
-#: Merge.rc:5065
+#: Merge.rc:5064
 #, c-format
 msgid "Text files are different"
 msgstr "텍스트 파일이 다릅니다"
 
 #. IDS_IMAGE_FILES_SAME
-#: Merge.rc:5066
+#: Merge.rc:5065
 msgid "Image files are identical"
 msgstr "이미지 파일이 동일합니다"
 
 #. IDS_IMAGE_FILES_DIFF
-#: Merge.rc:5067
+#: Merge.rc:5066
 msgid "Image files are different"
 msgstr "이미지 파일이 다릅니다"
 
 #. IDS_EXPR_DIFF
-#: Merge.rc:5068
+#: Merge.rc:5067
 #, c-format
 msgid "Files are different (expr: %1)"
 msgstr "추가 비교 조건: 파일이 다릅니다 (식: %1)"
 
 #. IDS_HASH_GROUP
-#: Merge.rc:5069
+#: Merge.rc:5068
 #, c-format
 msgid "Group%d"
 msgstr "그룹%d"
 
 #. IDS_RENAME_MOVE_DETECTION_DISALBED
-#: Merge.rc:5070
+#: Merge.rc:5069
 msgctxt "Options dialog|Compare|Folder|Detect renames and moves"
 msgid "Disabled"
 msgstr "사용 안 함"
 
 #. IDS_RENAME_MOVE_DETECTION_RENAME
-#: Merge.rc:5071
+#: Merge.rc:5070
 msgid "Detect renames"
 msgstr "이름 바꾸기 감지"
 
 #. IDS_RENAME_MOVE_DETECTION_RENAME_MOVE
-#: Merge.rc:5072
+#: Merge.rc:5071
 msgid "Detect renames and moves"
 msgstr "이름 바꾸기 및 이동 감지"
 
 #. IDS_RENAME_MOVE_MERGE_MODE_RENAME
-#: Merge.rc:5073
+#: Merge.rc:5072
 msgid "Merge renames"
 msgstr "이름 바꾸기 병합"
 
 #. IDS_RENAME_MOVE_MERGE_MODE_RENAME_MOVE
-#: Merge.rc:5074
+#: Merge.rc:5073
 msgid "Merge renames and moves"
 msgstr "이름 바꾸기 및 이동 병합"
 
 #. IDS_RENAMED
-#: Merge.rc:5075
+#: Merge.rc:5074
 msgid "Renamed"
 msgstr "이름 바뀜"
 
 #. IDS_RENAMED_MOVED
-#: Merge.rc:5077
+#: Merge.rc:5076
 msgid "Renamed/Moved"
 msgstr "이름 바뀜/이동됨"
 
 #. IDS_RENAMED_MOVED_ITEMS
-#: Merge.rc:5078
+#: Merge.rc:5077
 #, c-format
 msgid "(%1 items)"
 msgstr "(%1개 항목)"
 
 #. IDS_RENAMED_MOVED_RESULT
-#: Merge.rc:5079
+#: Merge.rc:5078
 #, c-format
 msgid "%1 (set %2): "
 msgstr "%1 (세트 %2): "
 
 #. IDS_SWITCH_FLAT_MODE
-#: Merge.rc:5080
+#: Merge.rc:5079
 msgid ""
 "Some moved items have been merged.\n"
 "In Tree Mode, these items may appear in positions that do not reflect the actual folder structure, which can be confusing.\n"
@@ -7602,268 +7596,268 @@ msgstr ""
 "플랫 모드로 전환하시겠습니까?"
 
 #. IDS_ELAPSED_TIME
-#: Merge.rc:5086
+#: Merge.rc:5085
 #, c-format
 msgid "Elapsed time: %ld ms"
 msgstr "경과 시간: %ld ms"
 
 #. IDS_STATUS_SELITEM1
-#: Merge.rc:5087
+#: Merge.rc:5086
 #, c-format
 msgid "1 item selected"
 msgstr "1개 항목 선택"
 
 #. IDS_STATUS_SELITEMS
-#: Merge.rc:5088
+#: Merge.rc:5087
 #, c-format
 msgid "%1 items selected"
 msgstr "%1개 항목 선택"
 
 #. IDS_COLDESC_FILENAME
-#: Merge.rc:5094
+#: Merge.rc:5093
 #, c-format
 msgid "Filename or folder name."
 msgstr "파일 이름 또는 폴더 이름."
 
 #. IDS_COLDESC_DIR
-#: Merge.rc:5095
+#: Merge.rc:5094
 #, c-format
 msgid "Subfolder name when subfolders are included."
 msgstr "하위 폴더를 포함할 때 하위 폴더 이름."
 
 #. IDS_COLDESC_RESULT
-#: Merge.rc:5096
+#: Merge.rc:5095
 #, c-format
 msgid "Comparison result, long form."
 msgstr "비교 결과 세부 내역."
 
 #. IDS_COLDESC_LTIMEM
-#: Merge.rc:5101
+#: Merge.rc:5100
 #, c-format
 msgid "Left side modification date."
 msgstr "왼쪽 변경 날짜."
 
 #. IDS_COLDESC_RTIMEM
-#: Merge.rc:5102
+#: Merge.rc:5101
 #, c-format
 msgid "Right side modification date."
 msgstr "오른쪽 변경 날짜."
 
 #. IDS_COLDESC_MTIMEM
-#: Merge.rc:5103
+#: Merge.rc:5102
 #, c-format
 msgid "Middle side modification date."
 msgstr "가운데 변경 날짜."
 
 #. IDS_COLDESC_EXTENSION
-#: Merge.rc:5104
+#: Merge.rc:5103
 #, c-format
 msgid "File's extension."
 msgstr "파일 확장자."
 
 #. IDS_COLDESC_LSIZE
-#: Merge.rc:5105
+#: Merge.rc:5104
 #, c-format
 msgid "Left file size in bytes."
 msgstr "왼쪽 파일 크기를 바이트로."
 
 #. IDS_COLDESC_RSIZE
-#: Merge.rc:5106
+#: Merge.rc:5105
 #, c-format
 msgid "Right file size in bytes."
 msgstr "오른쪽 파일 크기를 바이트로."
 
 #. IDS_COLDESC_MSIZE
-#: Merge.rc:5107
+#: Merge.rc:5106
 #, c-format
 msgid "Middle file size in bytes."
 msgstr "가운데 파일 크기를 바이트로."
 
 #. IDS_COLDESC_LSIZE_SHORT
-#: Merge.rc:5108
+#: Merge.rc:5107
 #, c-format
 msgid "Left file size abbreviated."
 msgstr "축약된 왼쪽 파일 크기."
 
 #. IDS_COLDESC_RSIZE_SHORT
-#: Merge.rc:5109
+#: Merge.rc:5108
 #, c-format
 msgid "Right file size abbreviated."
 msgstr "축약된 오른쪽 파일 크기."
 
 #. IDS_COLDESC_MSIZE_SHORT
-#: Merge.rc:5110
+#: Merge.rc:5109
 #, c-format
 msgid "Middle file size abbreviated."
 msgstr "축약된 가운데 파일 크기."
 
 #. IDS_COLDESC_LTIMEC
-#: Merge.rc:5116
+#: Merge.rc:5115
 #, c-format
 msgid "Left side creation time."
 msgstr "왼쪽 파일 만든 날짜."
 
 #. IDS_COLDESC_RTIMEC
-#: Merge.rc:5117
+#: Merge.rc:5116
 #, c-format
 msgid "Right side creation time."
 msgstr "오른쪽 파일 만든 날짜."
 
 #. IDS_COLDESC_MTIMEC
-#: Merge.rc:5118
+#: Merge.rc:5117
 #, c-format
 msgid "Middle side creation time."
 msgstr "가운데 파일 만든 날짜."
 
 #. IDS_COLDESC_NEWER
-#: Merge.rc:5119
+#: Merge.rc:5118
 #, c-format
 msgid "Tells which side has newer modification date."
 msgstr "어느 쪽이 더 최근에 수정되었는지 알려줍니다."
 
 #. IDS_COLDESC_LVERSION
-#: Merge.rc:5120
+#: Merge.rc:5119
 msgid "Left side file version, only for some file types."
 msgstr "왼쪽 파일 버전, 몇몇 파일 형식만."
 
 #. IDS_COLDESC_RVERSION
-#: Merge.rc:5121
+#: Merge.rc:5120
 msgid "Right side file version, only for some file types."
 msgstr "오른쪽 파일 버전, 몇몇 파일 형식만."
 
 #. IDS_COLDESC_MVERSION
-#: Merge.rc:5126
+#: Merge.rc:5125
 msgid "Middle side file version, only for some file types."
 msgstr "가운데 파일 버전, 몇몇 파일 형식만."
 
 #. IDS_COLDESC_RESULT_ABBR
-#: Merge.rc:5127
+#: Merge.rc:5126
 #, c-format
 msgid "Short comparison result."
 msgstr "짧은 비교 결과."
 
 #. IDS_COLDESC_LATTRIBUTES
-#: Merge.rc:5128
+#: Merge.rc:5127
 #, c-format
 msgid "Left side attributes."
 msgstr "왼쪽 속성."
 
 #. IDS_COLDESC_RATTRIBUTES
-#: Merge.rc:5129
+#: Merge.rc:5128
 #, c-format
 msgid "Right side attributes."
 msgstr "오른쪽 속성."
 
 #. IDS_COLDESC_MATTRIBUTES
-#: Merge.rc:5130
+#: Merge.rc:5129
 #, c-format
 msgid "Middle side attributes."
 msgstr "가운데 속성."
 
 #. IDS_COLDESC_LEOL_TYPE
-#: Merge.rc:5131
+#: Merge.rc:5130
 msgid "Left side file EOL type."
 msgstr "왼쪽 파일 줄끝 형식."
 
 #. IDS_COLDESC_REOL_TYPE
-#: Merge.rc:5132
+#: Merge.rc:5131
 msgid "Right side file EOL type."
 msgstr "오른쪽 파일 줄끝 형식."
 
 #. IDS_COLDESC_MEOL_TYPE
-#: Merge.rc:5133
+#: Merge.rc:5132
 msgid "Middle side file EOL type."
 msgstr "가운데 파일 줄끝 형식."
 
 #. IDS_COLDESC_LENCODING
-#: Merge.rc:5139
+#: Merge.rc:5138
 #, c-format
 msgid "Left side encoding."
 msgstr "왼쪽 인코딩."
 
 #. IDS_COLDESC_RENCODING
-#: Merge.rc:5140
+#: Merge.rc:5139
 #, c-format
 msgid "Right side encoding."
 msgstr "오른쪽 인코딩."
 
 #. IDS_COLDESC_MENCODING
-#: Merge.rc:5141
+#: Merge.rc:5140
 #, c-format
 msgid "Middle side encoding."
 msgstr "가운데 인코딩."
 
 #. IDS_COLDESC_NIDIFFS
-#: Merge.rc:5142
+#: Merge.rc:5141
 #, c-format
 msgid "Number of ignored differences in file. Ignored and cannot be merged."
 msgstr "파일에서 무시된 차이의 수입니다. 무시되어 병합할 수 없습니다."
 
 #. IDS_COLDESC_NSDIFFS
-#: Merge.rc:5143
+#: Merge.rc:5142
 #, c-format
 msgid "Number of differences in file (excluding ignored)."
 msgstr "파일에서 무시된 차이의 수입니다 (무시된 항목 제외)."
 
 #. IDS_COLDESC_BINARY
-#: Merge.rc:5144
+#: Merge.rc:5143
 #, c-format
 msgid "Shows an asterisk (*) if the file is binary."
 msgstr "파일이 이진 파일인 경우 별표(*)를 표시합니다."
 
 #. IDS_COLDESC_UNPACKER
-#: Merge.rc:5145
+#: Merge.rc:5144
 msgid "Unpacker plugin name or pipeline."
 msgstr "압축 풀기 플러그인 이름 또는 파이프라인입니다."
 
 #. IDS_COLDESC_PREDIFFER
-#: Merge.rc:5146
+#: Merge.rc:5145
 msgid "Prediffer plugin name or pipeline."
 msgstr "사전 차이 플러그인 이름 또는 파이프라인입니다."
 
 #. IDS_DIRECTORY_REPORT_TITLE
-#: Merge.rc:5152
+#: Merge.rc:5151
 #, c-format
 msgid "Compare %1 with %2"
 msgstr "%1을 %2와 비교"
 
 #. IDS_DIRECTORY_REPORT_TITLE3
-#: Merge.rc:5153
+#: Merge.rc:5152
 #, c-format
 msgid "Compare %1 with %2 and %3"
 msgstr "%1을 %2 및 %3과(와) 비교"
 
 #. IDS_REPORT_COMMALIST
-#: Merge.rc:5154
+#: Merge.rc:5153
 #, c-format
 msgid "Comma-separated list"
 msgstr "쉼표로 분리된 목록"
 
 #. IDS_REPORT_TABLIST
-#: Merge.rc:5155
+#: Merge.rc:5154
 #, c-format
 msgid "Tab-separated list"
 msgstr "탭으로 분리된 목록"
 
 #. IDS_REPORT_SIMPLEHTML
-#: Merge.rc:5156
+#: Merge.rc:5155
 #, c-format
 msgid "Simple HTML"
 msgstr "단순한 HTML"
 
 #. IDS_REPORT_SIMPLEXML
-#: Merge.rc:5157
+#: Merge.rc:5156
 #, c-format
 msgid "Simple XML"
 msgstr "단순한 XML"
 
-#: Merge.rc:5159
+#: Merge.rc:5158
 #, c-format
 msgid "Report file already exists. Overwrite?"
 msgstr "보고서 파일이 이미 있습니다. 기존 파일을 덮어쓰시겠습니까?"
 
 #. IDS_REPORT_ERROR
-#: Merge.rc:5164
+#: Merge.rc:5163
 #, c-format
 msgid ""
 "Error creating the report:\n"
@@ -7873,30 +7867,30 @@ msgstr ""
 "%1"
 
 #. IDS_REPORT_SUCCESS
-#: Merge.rc:5165
+#: Merge.rc:5164
 #, c-format
 msgid "Report created successfully."
 msgstr "보고서를 성공적으로 만들었습니다."
 
 #. IDS_SYNCPOINT_LASTBLOCK
-#: Merge.rc:5171
+#: Merge.rc:5170
 msgid "Cannot add a synchronization point at this line."
 msgstr "이 줄에 동기화 지점을 추가할 수 없습니다."
 
 #. IDS_FILE_TO_ITSELF
-#: Merge.rc:5177
+#: Merge.rc:5176
 #, c-format
 msgid "Same file is opened in both panes."
 msgstr "같은 파일을 양쪽 창에 열었습니다."
 
 #. IDS_FILESSAME
-#: Merge.rc:5178
+#: Merge.rc:5177
 #, c-format
 msgid "Selected files are identical."
 msgstr "선택한 파일들은 동일합니다."
 
 #. IDS_FILESSAME_CURCFG
-#: Merge.rc:5179
+#: Merge.rc:5178
 msgid ""
 "Selected files are identical (with current settings).\r\n"
 "Checking binary identity..."
@@ -7905,7 +7899,7 @@ msgstr ""
 "바이너리 동일성 확인 중..."
 
 #. IDS_FILESSAME_BINERROR
-#: Merge.rc:5180
+#: Merge.rc:5179
 msgid ""
 "Selected files are identical (with current settings).\r\n"
 "But binary comparison failed."
@@ -7914,12 +7908,12 @@ msgstr ""
 "그러나 바이너리 비교가 실패했습니다."
 
 #. IDS_FILESSAME_BINSAME
-#: Merge.rc:5181
+#: Merge.rc:5180
 msgid "Selected files are identical (binary match)."
 msgstr "선택된 파일들은 동일합니다 (이진 일치)."
 
 #. IDS_FILESSAME_BINDIFF
-#: Merge.rc:5182
+#: Merge.rc:5181
 msgid ""
 "Selected files are identical (with current settings).\r\n"
 "But differ at the binary level."
@@ -7928,19 +7922,19 @@ msgstr ""
 "그러나 바이너리 수준에서는 차이가 있습니다."
 
 #. IDS_FILEERROR
-#: Merge.rc:5183
+#: Merge.rc:5182
 #, c-format
 msgid "An error occurred while comparing files."
 msgstr "파일 비교 중 오류가 발생했습니다."
 
 #. IDS_TEMP_FILEERROR
-#: Merge.rc:5184
+#: Merge.rc:5183
 #, c-format
 msgid "Could not create temporary files. Check your temporary path settings."
 msgstr "임시 파일을 만들 수 없습니다. 임시 경로 설정을 확인하세요."
 
 #. IDS_SUGGEST_IGNOREEOL
-#: Merge.rc:5185
+#: Merge.rc:5184
 msgid ""
 "Files use different EOL.\n"
 "\n"
@@ -7955,19 +7949,19 @@ msgstr ""
 "참고: 모든 캐리지 리턴을 항상 동등하게 처리하려면, 편집 메뉴 -> 옵션 대화상자의 비교 탭에서 '케리지 리턴 차이 무시 (윈도우/유닉스/맥)' 옵션을 설정하면 됩니다."
 
 #. IDS_INVALID_DIRECTORY
-#: Merge.rc:5186
+#: Merge.rc:5185
 #, c-format
 msgid "Selected folder is invalid."
 msgstr "선택한 폴더는 무효합니다."
 
 #. IDS_CANNOT_OPEN_BINARYFILE
-#: Merge.rc:5187
+#: Merge.rc:5186
 #, c-format
 msgid "Cannot open a binary file in Editor."
 msgstr "바이너리 파일은 편집기로 열 수 없습니다."
 
 #. IDS_CREATE_PAIR_FOLDER
-#: Merge.rc:5188
+#: Merge.rc:5187
 #, c-format
 msgid ""
 "Create matching folder:\n"
@@ -7981,45 +7975,45 @@ msgstr ""
 "을(를) 다른 쪽에 만들고 이 폴더를 여시겠습니까?"
 
 #. IDS_CONFIRM_COPY_ALL_DIFFS
-#: Merge.rc:5189
+#: Merge.rc:5188
 msgid "Copy all differences to other file?"
 msgstr "모든 차이를 다른 파일에 복사하시겠습니까?"
 
 #. IDS_MOVE_TO_NEXTFILE
-#: Merge.rc:5194
+#: Merge.rc:5193
 #, c-format
 msgid "Move to next file?"
 msgstr "다음 파일로 이동하시겠습니까?"
 
 #. IDS_MOVE_TO_PREVFILE
-#: Merge.rc:5195
+#: Merge.rc:5194
 #, c-format
 msgid "Move to previous file?"
 msgstr "이전 파일로 이동하시겠습니까?"
 
 #. IDS_MOVE_TO_NEXTPAGE
-#: Merge.rc:5196
+#: Merge.rc:5195
 #, c-format
 msgid "Move to next page?"
 msgstr "다음 페이지로 이동하시겠습니까?"
 
 #. IDS_MOVE_TO_PREVPAGE
-#: Merge.rc:5197
+#: Merge.rc:5196
 #, c-format
 msgid "Move to previous page?"
 msgstr "이전 페이지로 이동하시겠습니까?"
 
 #. IDS_MOVE_TO_FIRSTFILE
-#: Merge.rc:5198
+#: Merge.rc:5197
 msgid "Move to first file?"
 msgstr "첫 번째 파일로 이동하시겠습니까?"
 
 #. IDS_MOVE_TO_LASTFILE
-#: Merge.rc:5199
+#: Merge.rc:5198
 msgid "Move to last file?"
 msgstr "마지막 파일로 이동하시겠습니까?"
 
-#: Merge.rc:5206
+#: Merge.rc:5205
 #, c-format
 msgid ""
 "Different codepages: left (cp%d), right (cp%d).\n"
@@ -8030,57 +8024,57 @@ msgstr ""
 "각 파일을 코드페이지에 표시하면 더 잘 표시되지만 병합/복사는 위험할 수 있습니다.\n"
 "두 파일을 모두 기본 Windows 코드페이지에 있는 것으로 처리하시겠습니까 (권장)?"
 
-#: Merge.rc:5208
+#: Merge.rc:5207
 #, c-format
 msgid "Information lost due to encoding errors: both files"
 msgstr "인코딩 오류로 인해 손실된 정보: 두 파일 모두"
 
-#: Merge.rc:5210
+#: Merge.rc:5209
 #, c-format
 msgid "Information lost due to encoding errors: first file"
 msgstr "인코딩 오류로 인해 손실된 정보: 첫 번째 파일"
 
-#: Merge.rc:5212
+#: Merge.rc:5211
 #, c-format
 msgid "Information lost due to encoding errors: second file"
 msgstr "인코딩 오류로 인해 손실된 정보: 두 번째 파일"
 
-#: Merge.rc:5214
+#: Merge.rc:5213
 #, c-format
 msgid "Information lost due to encoding errors: third file"
 msgstr "인코딩 오류로 인해 손실된 정보: 세 번째 파일"
 
 #. IDS_LINEDIFF_NODIFF
-#: Merge.rc:5220
+#: Merge.rc:5219
 #, c-format
 msgid "No difference"
 msgstr "차이 없음"
 
 #. IDS_LINEDIFF_NODIFF_CAPTION
-#: Merge.rc:5221
+#: Merge.rc:5220
 #, c-format
 msgid "Line difference"
 msgstr "줄 차이"
 
 #. IDS_NUM_REPLACED
-#: Merge.rc:5227
+#: Merge.rc:5226
 #, c-format
 msgid "Replaced %1 string(s)."
 msgstr "%1개 문자열을 바꿨습니다."
 
 #. IDS_EDIT_TEXT_NOT_FOUND
-#: Merge.rc:5228
+#: Merge.rc:5227
 #, c-format
 msgid "Cannot find string \"%s\"."
 msgstr "다음 문자열을 찾을 수 없습니다: \"%s\"."
 
 #. IDS_MERGE_MODE
-#: Merge.rc:5234
+#: Merge.rc:5233
 msgid "Entering Merge Mode. Press F9 to turn off."
 msgstr "지금 병합 모드에 진입 중입니다. 병합 모드를 끄고 싶으면 F9 키를 누르세요."
 
 #. IDS_AUTO_MERGE
-#: Merge.rc:5240
+#: Merge.rc:5239
 #, c-format
 msgid ""
 "Automatic merges: %1\n"
@@ -8090,97 +8084,97 @@ msgstr ""
 "미해결 충돌 개수: %2"
 
 #. IDS_CODEPAGE_MERGED
-#: Merge.rc:5241
+#: Merge.rc:5240
 msgid "Codepage change merged."
 msgstr "코드페이지 변경사항을 병합했습니다."
 
 #. IDS_CODEPAGE_CONFLICT
-#: Merge.rc:5242
+#: Merge.rc:5241
 msgid "Codepage changes are conflicting."
 msgstr "코드페이지 변경사항이 충돌하고 있습니다."
 
 #. IDS_EOL_MERGED
-#: Merge.rc:5243
+#: Merge.rc:5242
 msgid "EOL change merged."
 msgstr "줄끝 변경사항을 병합했습니다."
 
 #. IDS_EOL_CONFLICT
-#: Merge.rc:5244
+#: Merge.rc:5243
 msgid "EOL changes are conflicting."
 msgstr "줄끝 변경사항이 충돌하고 있습니다."
 
 #. IDS_LOCBAR_CAPTION
-#: Merge.rc:5250
+#: Merge.rc:5249
 #, c-format
 msgid "Location Pane"
 msgstr "위치 창"
 
 #. IDS_DIFFBAR_CAPTION
-#: Merge.rc:5251
+#: Merge.rc:5250
 #, c-format
 msgid "Diff Pane"
 msgstr "차이 창"
 
 #. IDS_DIFF_SUCCEEDED
-#: Merge.rc:5258
+#: Merge.rc:5257
 #, c-format
 msgid "Patch file written."
 msgstr "패치 파일을 성공적으로 기록했습니다."
 
 #. IDS_DIFF_FILEOVERWRITE
-#: Merge.rc:5259
+#: Merge.rc:5258
 #, c-format
 msgid "Patch file already exists. Overwrite?"
 msgstr "패치 파일이 이미 존재합니다. 덮어쓰시겠습니까?"
 
 #. IDS_DIFF_SELECTEDFILES
-#: Merge.rc:5260
+#: Merge.rc:5259
 #, c-format
 msgid "[%1 files selected]"
 msgstr "[%1 개의 파일 선택됨]"
 
 #. IDS_DIFF_NORMAL
-#: Merge.rc:5261
+#: Merge.rc:5260
 #, c-format
 msgid "Normal"
 msgstr "보통"
 
 #. IDS_DIFF_CONTEXT
-#: Merge.rc:5262
+#: Merge.rc:5261
 #, c-format
 msgid "Context"
 msgstr "문맥"
 
 #. IDS_DIFF_UNIFIED
-#: Merge.rc:5263
+#: Merge.rc:5262
 #, c-format
 msgid "Unified"
 msgstr "통합"
 
 #. IDS_FILEWRITE_ERROR
-#: Merge.rc:5265
+#: Merge.rc:5264
 #, c-format
 msgid "Could not write to file %1."
 msgstr "%1 파일에 쓸 수 없습니다."
 
 #. IDS_PATH_NOT_ABSOLUTE
-#: Merge.rc:5266
+#: Merge.rc:5265
 #, c-format
 msgid "Output path is not absolute: %1"
 msgstr "지정한 출력 경로는 절대 경로가 아닙니다: %1"
 
 #. IDS_MUST_SPECIFY_OUTPUT
-#: Merge.rc:5267
+#: Merge.rc:5266
 msgid "Specify an output file."
 msgstr "출력 파일 지정."
 
-#: Merge.rc:5269
+#: Merge.rc:5268
 #, c-format
 msgid "Cannot create patch from binary files."
 msgstr "바이너리 파일에서는 패치 파일을 만들 수 없습니다."
 
 #. IDS_SAVEFILES_FORPATCH
-#: Merge.rc:5270
+#: Merge.rc:5269
 #, c-format
 msgid ""
 "Save all files first.\n"
@@ -8192,18 +8186,18 @@ msgstr ""
 "패치를 만들려면 파일에 저장되지 않은 변경 사항이 없어야 합니다."
 
 #. IDS_FOLDER_NOTEXIST
-#: Merge.rc:5271
+#: Merge.rc:5270
 #, c-format
 msgid "Folder does not exist."
 msgstr "폴더가 존재하지 않습니다."
 
 #. IDS_ARCHIVE_SUCCEEDED
-#: Merge.rc:5277
+#: Merge.rc:5276
 msgid "Archive file written."
 msgstr "압축 파일이 작성되었습니다."
 
 #. IDS_ARCHIVE_SAVEFILES
-#: Merge.rc:5278
+#: Merge.rc:5277
 msgid ""
 "Save all files first.\n"
 "\n"
@@ -8214,7 +8208,7 @@ msgstr ""
 "아카이브를 생성하려면 저장되지 않은 변경 사항이 필요하지 않습니다."
 
 #. IDS_NO_ZIP_SUPPORT
-#: Merge.rc:5283
+#: Merge.rc:5282
 msgid ""
 "Archive support not enabled.\n"
 "7-Zip and/or Merge7z*.dll not found.\n"
@@ -8225,43 +8219,43 @@ msgstr ""
 "압축 지원에 대한 추가 정보와 사용법은 매뉴얼을 참조하세요."
 
 #. IDS_OPT_EXPORT_CAPTION
-#: Merge.rc:5284
+#: Merge.rc:5283
 #, c-format
 msgid "Select file for export"
 msgstr "내보낼 파일을 선택하세요"
 
 #. IDS_OPT_IMPORT_CAPTION
-#: Merge.rc:5285
+#: Merge.rc:5284
 #, c-format
 msgid "Select file for import"
 msgstr "가져올 파일을 선택하세요"
 
 #. IDS_OPT_IMPORT_DONE
-#: Merge.rc:5286
+#: Merge.rc:5285
 #, c-format
 msgid "Options imported from file."
 msgstr "파일에서 가져온 옵션입니다."
 
 #. IDS_OPT_EXPORT_DONE
-#: Merge.rc:5287
+#: Merge.rc:5286
 #, c-format
 msgid "Options exported to file."
 msgstr "파일로 내보낸 옵션입니다."
 
 #. IDS_OPT_IMPORT_ERR
-#: Merge.rc:5288
+#: Merge.rc:5287
 #, c-format
 msgid "Failed to import options from file."
 msgstr "파일에서 옵션을 가져오지 못했습니다."
 
 #. IDS_OPT_EXPORT_ERR
-#: Merge.rc:5289
+#: Merge.rc:5288
 #, c-format
 msgid "Failed to write options to file."
 msgstr "파일에 옵션을 쓰지 못했습니다."
 
 #. IDS_CLOSEALL_WINDOWS
-#: Merge.rc:5290
+#: Merge.rc:5289
 #, c-format
 msgid ""
 "Close multiple compare windows?\n"
@@ -8273,36 +8267,36 @@ msgstr ""
 "계속하시겠습니까?"
 
 #. IDS_EOL_BIN
-#: Merge.rc:5300
+#: Merge.rc:5299
 msgctxt "EOL Type"
 msgid "Binary"
 msgstr "바이너리"
 
 #. IDS_MARKER_COLOR_FMT
-#: Merge.rc:5305
+#: Merge.rc:5304
 #, c-format
 msgid "Marker Color %d"
 msgstr "마커 색상 %d"
 
 #. IDS_MARKER_NEW_PATTERN
-#: Merge.rc:5306
+#: Merge.rc:5305
 msgid "New Pattern"
 msgstr "새 패턴"
 
 #. IDS_PLUGINSLIST_TYPE
-#: Merge.rc:5312
+#: Merge.rc:5311
 #, c-format
 msgid "Type"
 msgstr "유형"
 
 #. IDS_PLUGINS_TYPE_EDITSCRIPT
-#: Merge.rc:5316
+#: Merge.rc:5315
 #, c-format
 msgid "Editor script"
 msgstr "편집기 스크립트"
 
 #. ID_SELECTLINEDIFF
-#: Merge.rc:5322
+#: Merge.rc:5321
 #, c-format
 msgid ""
 "\n"
@@ -8312,7 +8306,7 @@ msgstr ""
 "현재 줄의 차이 (F4)"
 
 #. ID_OPTIONS
-#: Merge.rc:5323
+#: Merge.rc:5322
 #, c-format
 msgid ""
 "\n"
@@ -8322,7 +8316,7 @@ msgstr ""
 "옵션"
 
 #. ID_REFRESH
-#: Merge.rc:5324
+#: Merge.rc:5323
 #, c-format
 msgid ""
 "\n"
@@ -8332,7 +8326,7 @@ msgstr ""
 "새로 고침 (F5)"
 
 #. ID_PREVDIFF
-#: Merge.rc:5330
+#: Merge.rc:5329
 #, c-format
 msgid ""
 "\n"
@@ -8342,7 +8336,7 @@ msgstr ""
 "이전 차이 (Alt+Up)"
 
 #. ID_NEXTDIFF
-#: Merge.rc:5331
+#: Merge.rc:5330
 #, c-format
 msgid ""
 "\n"
@@ -8352,7 +8346,7 @@ msgstr ""
 "다음 차이 (Alt+Down)"
 
 #. ID_PREVCONFLICT
-#: Merge.rc:5332
+#: Merge.rc:5331
 #, c-format
 msgid ""
 "\n"
@@ -8362,7 +8356,7 @@ msgstr ""
 "이전 충돌 (Alt+Shift+Up)"
 
 #. ID_NEXTCONFLICT
-#: Merge.rc:5333
+#: Merge.rc:5332
 #, c-format
 msgid ""
 "\n"
@@ -8372,7 +8366,7 @@ msgstr ""
 "다음 충돌 (Alt+Shift+Down)"
 
 #. ID_FIRSTDIFF
-#: Merge.rc:5338
+#: Merge.rc:5337
 #, c-format
 msgid ""
 "\n"
@@ -8382,7 +8376,7 @@ msgstr ""
 "첫 차이 (Alt+Home)"
 
 #. ID_CURDIFF
-#: Merge.rc:5339
+#: Merge.rc:5338
 #, c-format
 msgid ""
 "\n"
@@ -8392,7 +8386,7 @@ msgstr ""
 "현재 차이 (Alt+Enter)"
 
 #. ID_LASTDIFF
-#: Merge.rc:5340
+#: Merge.rc:5339
 #, c-format
 msgid ""
 "\n"
@@ -8402,7 +8396,7 @@ msgstr ""
 "마지막 차이 (Alt+End)"
 
 #. ID_L2R
-#: Merge.rc:5341
+#: Merge.rc:5340
 msgid ""
 "\n"
 "Copy to Right (Alt+Right)"
@@ -8411,7 +8405,7 @@ msgstr ""
 "오른쪽으로 복사 (Alt+Right)"
 
 #. ID_R2L
-#: Merge.rc:5342
+#: Merge.rc:5341
 msgid ""
 "\n"
 "Copy to Left (Alt+Left)"
@@ -8420,7 +8414,7 @@ msgstr ""
 "왼쪽으로 복사 (Alt+Left)"
 
 #. ID_L2RNEXT
-#: Merge.rc:5343
+#: Merge.rc:5342
 msgid ""
 "\n"
 "Copy to Right and Advance (Ctrl+Alt+Right)"
@@ -8429,7 +8423,7 @@ msgstr ""
 "오른쪽으로 복사 후 진행 (Ctrl+Alt+Right)"
 
 #. ID_R2LNEXT
-#: Merge.rc:5344
+#: Merge.rc:5343
 msgid ""
 "\n"
 "Copy to Left and Advance (Ctrl+Alt+Left)"
@@ -8438,7 +8432,7 @@ msgstr ""
 "왼쪽으로 복사 후 진행 (Ctrl+Alt+Left)"
 
 #. ID_ALL_RIGHT
-#: Merge.rc:5345
+#: Merge.rc:5344
 msgid ""
 "\n"
 "Copy All to Right"
@@ -8447,7 +8441,7 @@ msgstr ""
 "모두 오른쪽으로 복사"
 
 #. ID_ALL_LEFT
-#: Merge.rc:5346
+#: Merge.rc:5345
 msgid ""
 "\n"
 "Copy All to Left"
@@ -8456,7 +8450,7 @@ msgstr ""
 "모두 왼쪽으로 복사"
 
 #. ID_AUTO_MERGE
-#: Merge.rc:5347
+#: Merge.rc:5346
 #, c-format
 msgid ""
 "\n"
@@ -8466,7 +8460,7 @@ msgstr ""
 "자동 병합 (Ctrl+Alt+M)"
 
 #. ID_FIRSTFILE
-#: Merge.rc:5348
+#: Merge.rc:5347
 msgid ""
 "\n"
 "First File"
@@ -8475,7 +8469,7 @@ msgstr ""
 "첫 파일"
 
 #. ID_NEXTFILE
-#: Merge.rc:5349
+#: Merge.rc:5348
 msgid ""
 "\n"
 "Next File (Ctrl+F8)"
@@ -8484,7 +8478,7 @@ msgstr ""
 "다음 파일 (Ctrl+F8)"
 
 #. ID_LASTFILE
-#: Merge.rc:5350
+#: Merge.rc:5349
 msgid ""
 "\n"
 "Last File"
@@ -8493,7 +8487,7 @@ msgstr ""
 " 마지막 파일"
 
 #. ID_PREVFILE
-#: Merge.rc:5351
+#: Merge.rc:5350
 msgid ""
 "\n"
 "Previous File (Ctrl+F7)"
@@ -8502,156 +8496,156 @@ msgstr ""
 "이전 파일 (Ctrl+F7)"
 
 #. IDS_UNPACK_AUTO
-#: Merge.rc:5358
+#: Merge.rc:5357
 msgid "Adapted unpacker applied to both files (one needs extension)."
 msgstr "적용된 압푹축 풀기는 두 파일 모두에 적용됩니다 한 파일만 확장자가 필요함)."
 
 #. IDS_NO_PREDIFFER
-#: Merge.rc:5359
+#: Merge.rc:5358
 #, c-format
 msgid "No Prediffer (Normal)"
 msgstr "사전 차이 없음 (보통)"
 
 #. IDS_SUGGESTED_PLUGINS
-#: Merge.rc:5360
+#: Merge.rc:5359
 #, c-format
 msgid "Suggested Plugins"
 msgstr "추천 플러그인"
 
 #. IDS_NOT_SUGGESTED_PLUGINS
-#: Merge.rc:5361
+#: Merge.rc:5360
 msgid "All Plugins"
 msgstr "모든 플러그인"
 
 #. IDS_PRIVATEBUILD_FMT
-#: Merge.rc:5367
+#: Merge.rc:5366
 #, c-format
 msgid "Private Build: %1"
 msgstr "개인 빌드: %1"
 
 #. IDS_ALLRIGHTS_RESERVED
-#: Merge.rc:5368
+#: Merge.rc:5367
 msgid " - All rights reserved."
 msgstr " - 모든 권리 보유."
 
 #. IDS_TITLE_PLUGINS_SETTINGS
-#: Merge.rc:5374
+#: Merge.rc:5373
 #, c-format
 msgid "Plugin Settings"
 msgstr "플러그인 설정"
 
 #. IDS_NO_SCT_SCRIPTS
-#: Merge.rc:5376
+#: Merge.rc:5375
 #, c-format
 msgid "WSH not found - .sct scripts disabled"
 msgstr "WSH를 찾을 수 없음 - .sct 스크립트 비활성화됨"
 
 #. IDS_LOCBAR_GOTOLINE_FMT
-#: Merge.rc:5384
+#: Merge.rc:5383
 #, c-format
 msgid "G&o to Line %1"
 msgstr "%1줄로 이동(&O)"
 
 #. IDS_GOTO_MOVED_LINE
-#: Merge.rc:5390
+#: Merge.rc:5389
 msgid "Go to Moved Line\tCtrl+Shift+G"
 msgstr "이동된 줄로 이동\tCtrl+Shift+G"
 
 #. IDS_AUTOCOMPLETE_DISABLED
-#: Merge.rc:5396
+#: Merge.rc:5395
 msgctxt "Options dialog|General|Open dialog Auto completion"
 msgid "Disabled"
 msgstr "사용 안 함"
 
 #. IDS_AUTOCOMPLETE_FILE_SYS
-#: Merge.rc:5397
+#: Merge.rc:5396
 #, c-format
 msgid "From file system"
 msgstr "파일 시스템에서"
 
 #. IDS_AUTOCOMPLETE_MRU
-#: Merge.rc:5398
+#: Merge.rc:5397
 #, c-format
 msgid "From Most Recently Used list"
 msgstr "최근 목록에서"
 
 #. IDS_COLORSCHEME_PLAIN
-#: Merge.rc:5404
+#: Merge.rc:5403
 #, c-format
 msgid "No Highlighting"
 msgstr "강조 표시 없음"
 
 #. IDS_COLORSCHEME_PO
-#: Merge.rc:5439
+#: Merge.rc:5438
 #, c-format
 msgid "Portable Object"
 msgstr "포터블 개체"
 
 #. IDS_COLORSCHEME_RSRC
-#: Merge.rc:5444
+#: Merge.rc:5443
 #, c-format
 msgid "Resources"
 msgstr "리소스"
 
 #. IDS_COLORSCHEME_SH
-#: Merge.rc:5448
+#: Merge.rc:5447
 #, c-format
 msgid "Shell"
 msgstr "쉘"
 
 #. IDS_CLOSE_LEFT_TABS
-#: Merge.rc:5469
+#: Merge.rc:5468
 #, c-format
 msgid "Close &Left Tabs"
 msgstr "왼쪽 탭 닫기(&L)"
 
 #. IDS_CLOSE_RIGHT_TABS
-#: Merge.rc:5470
+#: Merge.rc:5469
 #, c-format
 msgid "Close R&ight Tabs"
 msgstr "오른쪽 탭 닫기(&I)"
 
 #. IDS_CLOSE_OTHER_TABS
-#: Merge.rc:5471
+#: Merge.rc:5470
 #, c-format
 msgid "Close &Other Tabs"
 msgstr "다른 탭 닫기(&O)"
 
 #. IDS_TABBAR_AUTO_MAXWIDTH
-#: Merge.rc:5472
+#: Merge.rc:5471
 #, c-format
 msgid "Enable &Auto Max Width"
 msgstr "자동 최대 너비 사용(&A)"
 
 #. IDS_WEBPAGE_MENU
-#: Merge.rc:5482
+#: Merge.rc:5481
 msgid "We&bpage"
 msgstr "웹페이지(&B)"
 
 #. IDS_VIEW_WRAP_TEXT
-#: Merge.rc:5487
+#: Merge.rc:5486
 msgid "W&rap Text"
 msgstr "텍스트 줄 바꿈(&R)"
 
 #. IDS_NOTINSTALLED
-#: Merge.rc:5492
+#: Merge.rc:5491
 msgid "%1 is not installed."
 msgstr "%1가 설치되지 않았습니다."
 
 #. IDS_CREATE_FOLDER
-#: Merge.rc:5497
+#: Merge.rc:5496
 #, c-format
 msgid "%1 does not exist. Create it?"
 msgstr "%1이(가) 존재하지 않습니다. 생성하시겠습니까?"
 
 #. IDS_CREATE_FOLDER_ERROR
-#: Merge.rc:5498
+#: Merge.rc:5497
 #, c-format
 msgid "Failed to create folder."
 msgstr "폴더 생성에 실패했습니다."
 
 #. IDC_EXT_EDITOR_PATH
-#: Merge.rc:5503
+#: Merge.rc:5502
 #, c-format
 msgid ""
 "Parameters:\n"
@@ -8663,492 +8657,492 @@ msgstr ""
 "$linenum: 현재 커서 위치의 줄 번호"
 
 #. IDS_DIFF_ALGORITHM_DEFAULT
-#: Merge.rc:5508
+#: Merge.rc:5507
 msgid "default"
 msgstr "기본"
 
 #. IDS_DIFF_ALGORITHM_MINIMAL
-#: Merge.rc:5509
+#: Merge.rc:5508
 msgid "minimal"
 msgstr "최소화"
 
 #. IDS_DIFF_ALGORITHM_PATIENCE
-#: Merge.rc:5510
+#: Merge.rc:5509
 msgid "patience"
 msgstr "페이션스"
 
 #. IDS_DIFF_ALGORITHM_HISTOGRAM
-#: Merge.rc:5511
+#: Merge.rc:5510
 msgid "histogram"
 msgstr "히스토그램"
 
 #. IDS_DIFF_ALGORITHM_NONE
-#: Merge.rc:5512
+#: Merge.rc:5511
 msgid "none"
 msgstr "없음"
 
 #. IDS_RENDERING_MODE_GDI
-#: Merge.rc:5517
+#: Merge.rc:5516
 msgid "GDI"
 msgstr "GDI"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_DEFAULT
-#: Merge.rc:5518
+#: Merge.rc:5517
 msgid "DirectWrite Default"
 msgstr "DirectWrite 기본"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_ALIASED
-#: Merge.rc:5519
+#: Merge.rc:5518
 msgid "DirectWrite Aliased"
 msgstr "DirectWrite Aliased"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_GDI_CLASSIC
-#: Merge.rc:5520
+#: Merge.rc:5519
 msgid "DirectWrite GDI Classic"
 msgstr "DirectWrite GDI Classic"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_GDI_NATURAL
-#: Merge.rc:5521
+#: Merge.rc:5520
 msgid "DirectWrite GDI Natural"
 msgstr "DirectWrite GDI Natural"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_NATURAL
-#: Merge.rc:5522
+#: Merge.rc:5521
 msgid "DirectWrite Natural"
 msgstr "DirectWrite Natural"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_NATURAL_SYMMETRIC
-#: Merge.rc:5523
+#: Merge.rc:5522
 msgid "DirectWrite Natural Symmetric"
 msgstr "DirectWrite Natural Symmetric"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_DISABLED
-#: Merge.rc:5528
+#: Merge.rc:5527
 msgctxt "Options dialog|General|Close windows with Esc"
 msgid "Disabled"
 msgstr "사용 안 함"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_1
-#: Merge.rc:5529
+#: Merge.rc:5528
 msgid "MDI child window or main window"
 msgstr "MDI 하위 창 또는 기본 창"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_2
-#: Merge.rc:5530
+#: Merge.rc:5529
 msgid "MDI child window only"
 msgstr "MDI 하위 창만"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_3
-#: Merge.rc:5531
+#: Merge.rc:5530
 msgid "Close main window if only one MDI child window"
 msgstr "MDI 하위 창이 하나만 있는 경우 기본 창 닫기"
 
 #. IDS_DIFF_GROUP
-#: Merge.rc:5536
+#: Merge.rc:5535
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Diff"
 msgstr "차이"
 
 #. IDS_DIFF_HIGHLIGHT
-#: Merge.rc:5537
+#: Merge.rc:5536
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Highlight"
 msgstr "강조 표시"
 
 #. IDS_DIFF_BLINK
-#: Merge.rc:5538
+#: Merge.rc:5537
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Blink"
 msgstr "깜박임"
 
 #. IDS_DIFF_BLOCKSIZE
-#: Merge.rc:5539
+#: Merge.rc:5538
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Block Size"
 msgstr "블록 크기"
 
 #. IDS_DIFF_BLOCKALPHA
-#: Merge.rc:5540
+#: Merge.rc:5539
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Block Alpha"
 msgstr "블록 알파"
 
 #. IDS_DIFF_CDTHRESHOLD
-#: Merge.rc:5541
+#: Merge.rc:5540
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "CD Threshold"
 msgstr "CD 임계값"
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION
-#: Merge.rc:5542
+#: Merge.rc:5541
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Ins/Del Detection"
 msgstr "삽입/삭제 감지"
 
 #. IDS_OVERLAY_MODE_NONE
-#: Merge.rc:5543 Merge.rc:5548
+#: Merge.rc:5542 Merge.rc:5547
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "None"
 msgstr "없음"
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION_VERTICAL
-#: Merge.rc:5544
+#: Merge.rc:5543
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Vertical"
 msgstr "수직"
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION_HORIZONTAL
-#: Merge.rc:5545
+#: Merge.rc:5544
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Horizontal"
 msgstr "수평"
 
 #. IDS_OVERLAY_GROUP
-#: Merge.rc:5546
+#: Merge.rc:5545
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Overlay"
 msgstr "오버레이"
 
 #. IDS_OVERLAY_ALPHA
-#: Merge.rc:5547
+#: Merge.rc:5546
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha"
 msgstr "알파"
 
 #. IDS_OVERLAY_MODE_XOR
-#: Merge.rc:5549
+#: Merge.rc:5548
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "XOR"
 msgstr "XOR"
 
 #. IDS_OVERLAY_MODE_ALPHA
-#: Merge.rc:5550
+#: Merge.rc:5549
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha Blend"
 msgstr "알파 혼합"
 
 #. IDS_OVERLAY_MODE_ALPHA_ANIMATION
-#: Merge.rc:5551
+#: Merge.rc:5550
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha Animation"
 msgstr "알파 애니메이션"
 
 #. IDS_ZOOM
-#: Merge.rc:5552
+#: Merge.rc:5551
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Zoom"
 msgstr "확대/축소"
 
 #. IDS_PAGE
-#: Merge.rc:5553
+#: Merge.rc:5552
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Page:"
 msgstr "페이지:"
 
 #. IDS_IMGCMP_STATUS_PT_RGBA_FMT
-#: Merge.rc:5554
+#: Merge.rc:5553
 #, c-format
 msgid "Pt: (%d, %d)  RGBA: (%d, %d, %d, %d)  "
 msgstr "Pt: (%d, %d)  RGBA: (%d, %d, %d, %d)  "
 
 #. IDS_IMGCMP_STATUS_DIST1_FMT
-#: Merge.rc:5555
+#: Merge.rc:5554
 #, c-format
 msgid "Dist: %g  "
 msgstr "치수: %g  "
 
 #. IDS_IMGCMP_STATUS_DIST2_FMT
-#: Merge.rc:5556
+#: Merge.rc:5555
 #, c-format
 msgid "Dist: %g, %g  "
 msgstr "치수: %g, %g  "
 
 #. IDS_IMGCMP_STATUS_PAGE_ZOOM_SIZE_BPP_FMT
-#: Merge.rc:5557
+#: Merge.rc:5556
 #, c-format
 msgid "Page: %d/%d  Zoom: %d%%  %dx%dpx  %dbpp  "
 msgstr "페이지: %d/%d  줌: %d%%  %dx%dpx  %dbpp  "
 
 #. IDS_IMGCMP_STATUS_RC_FMT
-#: Merge.rc:5558
+#: Merge.rc:5557
 #, c-format
 msgid "Rc: (%d, %d)  "
 msgstr "Rc: (%d, %d)  "
 
 #. IDS_IMGCMP_STATUS_FLIPPED_FMT
-#: Merge.rc:5559
+#: Merge.rc:5558
 #, c-format
 msgid "Flipped: %s  "
 msgstr "뒤집음: %s  "
 
 #. IDS_IMGCMP_STATUS_ROTATED_FMT
-#: Merge.rc:5560
+#: Merge.rc:5559
 #, c-format
 msgid "Rotated: %d  "
 msgstr "회전됨: %d  "
 
 #. IDS_IMGCMP_REPORT_ALLPAGES
-#: Merge.rc:5561
+#: Merge.rc:5560
 msgid "All pages"
 msgstr "모든 페이지"
 
 #. IDS_IGNSUB_STR1
-#: Merge.rc:5566
+#: Merge.rc:5565
 msgid "<Edit here>"
 msgstr "<여기서 편집>"
 
 #. IDS_IGNSUB_STR2
-#: Merge.rc:5567
+#: Merge.rc:5566
 msgid "No differences found to select"
 msgstr "선택할 차이을 찾을 수 없습니다"
 
 #. IDS_IGNSUB_STR3
-#: Merge.rc:5568
+#: Merge.rc:5567
 msgid "No differences found to add as substitution filter"
 msgstr "대체 필터로 추가할 차이를 찾을 수 없습니다"
 
 #. IDS_IGNSUB_STR4
-#: Merge.rc:5569
+#: Merge.rc:5568
 msgid "The pair is already in the Substitution Filters list"
 msgstr "쌍이 이미 대체 필터 목록에 있습니다"
 
 #. IDS_IGNSUB_STR5
-#: Merge.rc:5570
+#: Merge.rc:5569
 msgid "Add this change to Substitution Filters?"
 msgstr "대체 필터에 이 변경 사항을 추가하시겠습니까?"
 
 #. IDS_OCRRESULT_TEXTONLY
-#: Merge.rc:5575
+#: Merge.rc:5574
 msgid "Text only"
 msgstr "텍스트만"
 
 #. IDS_OCRRESULT_POS_LINE
-#: Merge.rc:5576
+#: Merge.rc:5575
 msgid "Line-by-line position and text"
 msgstr "줄별 위치 및 텍스트"
 
 #. IDS_OCRRESULT_POS_WORD
-#: Merge.rc:5577
+#: Merge.rc:5576
 msgid "Word-by-word position and text"
 msgstr "단어별 위치 및 텍스트"
 
 #. IDS_USERDATAFOLDER_APPDATA
-#: Merge.rc:5582
+#: Merge.rc:5581
 msgid "AppData (Roaming) folder"
 msgstr "AppData (Roaming) 폴더"
 
 #. IDS_USERDATAFOLDER_INSTALL
-#: Merge.rc:5583
+#: Merge.rc:5582
 msgid "Install folder"
 msgstr "설치 폴더"
 
 #. IDS_USERDATAFOLDER_DOCUMENTS
-#: Merge.rc:5584
+#: Merge.rc:5583
 msgid "Documents folder"
 msgstr "문서 폴더"
 
 #. IDS_SINGLEINSTANCE_DISABLED
-#: Merge.rc:5589
+#: Merge.rc:5588
 msgctxt "Options dialog|General|Single instance mode"
 msgid "Disabled"
 msgstr "사용 안 함"
 
 #. IDS_SINGLEINSTANCE_STR1
-#: Merge.rc:5590
+#: Merge.rc:5589
 #, c-format
 msgid "Allow only one instance to run"
 msgstr "하나의 인스턴스만 실행 허용"
 
 #. IDS_CLIPBOARD_HISTORY
-#: Merge.rc:5591
+#: Merge.rc:5590
 msgid "Clipboard &History"
 msgstr "클립보드 기록(&H)"
 
 #. IDS_SINGLEINSTANCE_STR2
-#: Merge.rc:5592
+#: Merge.rc:5591
 msgid "Allow only one instance; wait for termination"
 msgstr "하나의 인스턴스만 실행하고 인스턴스가 종료될 때까지 대기"
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_DISABLED
-#: Merge.rc:5597
+#: Merge.rc:5596
 msgctxt "Options dialog|General|Auto-reload modified files"
 msgid "Disabled"
 msgstr "사용 안 함"
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_STR1
-#: Merge.rc:5598
+#: Merge.rc:5597
 msgid "Only on window activated"
 msgstr "창에서만 활성화됨"
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_STR2
-#: Merge.rc:5599
+#: Merge.rc:5598
 msgid "Immediately"
 msgstr "즉시"
 
 #. IDS_PLUGIN_ALL
-#: Merge.rc:5604
+#: Merge.rc:5603
 msgid "Al&l"
 msgstr "모두(&L)"
 
 #. IDS_PLUGIN_OTHERS
-#: Merge.rc:5605
+#: Merge.rc:5604
 msgid "&Others"
 msgstr "기타(&O)"
 
-#: Merge.rc:5607
+#: Merge.rc:5606
 #, c-format
 msgid "Missing plugin name in pipeline: %1"
 msgstr "플러그인 파이프라인에 누락된 플러그인 이름: %1"
 
-#: Merge.rc:5609
+#: Merge.rc:5608
 #, c-format
 msgid "Missing quote in plugin pipeline: %1"
 msgstr "플러그인 파이프라인에 따옴표가 없습니다: %1"
 
 #. IDS_PLUGIN_NAME_ALREADY_EXISTS
-#: Merge.rc:5610
+#: Merge.rc:5609
 #, c-format
 msgid "Plugin name '%1' already exists."
 msgstr "플러그인 이름 '%1'이(가) 이미 있습니다."
 
 #. IDS_PLUGIN_TITLE1
-#: Merge.rc:5611
+#: Merge.rc:5610
 msgid "Specify plugin arguments"
 msgstr "플러그인 인수 지정"
 
-#: Merge.rc:5613
+#: Merge.rc:5612
 #, c-format
 msgid "Plugin not found or invalid: %1"
 msgstr "플러그인을 찾을 수 없거나 잘못되었습니다: %1"
 
 #. IDS_PLUGIN_NOT_UNPACK
-#: Merge.rc:5614
+#: Merge.rc:5613
 #, c-format
 msgid "'%1' is not an unpacker plugin"
 msgstr "'%1'은(는) 압축 풀기 플러그인이 아닙니다"
 
 #. IDS_PLUGIN_NOT_PREDIFF
-#: Merge.rc:5615
+#: Merge.rc:5614
 #, c-format
 msgid "'%1' is not a prediffer plugin"
 msgstr "'%1'은(는) 사전 차이 플러그인이 아닙니다"
 
-#: Merge.rc:5617
+#: Merge.rc:5616
 #, c-format
 msgid "Error prediffing '%1' with '%2'. Prediffing disabled."
 msgstr "'%1' 파일을 '%2' 플러그인과 미리 비교하는 동안 오류가 발생했습니다. 미리 비교은 더 이상 적용되지 않습니다."
 
 #. IDS_PLUGIN_CIRCULAR_REFERENCE
-#: Merge.rc:5618
+#: Merge.rc:5617
 #, c-format
 msgid "Circular reference in plugin pipeline: %1"
 msgstr "플러그인 파이프라인의 순환 참조: %1"
 
 #. IDS_PLUGIN_TYPE1
-#: Merge.rc:5619
+#: Merge.rc:5618
 msgid "URL Handler"
 msgstr "URL 처리기"
 
 #. IDS_PLUGIN_TYPE2
-#: Merge.rc:5620
+#: Merge.rc:5619
 msgid "File Unpacker"
 msgstr "파일 압축 풀기"
 
 #. IDS_PLUGIN_TYPE3
-#: Merge.rc:5621
+#: Merge.rc:5620
 msgid "File or Folder Unpacker"
 msgstr "파일 또는 폴더 압축 풀기"
 
 #. IDS_PLUGIN_TYPE5
-#: Merge.rc:5623
+#: Merge.rc:5622
 msgid "Alias for Unpacker"
 msgstr "압축 풀기의 별칭"
 
 #. IDS_PLUGIN_TYPE6
-#: Merge.rc:5624
+#: Merge.rc:5623
 msgid "Alias for Prediffer"
 msgstr "사전 차이의 별칭"
 
 #. IDS_PLUGIN_TYPE7
-#: Merge.rc:5625
+#: Merge.rc:5624
 msgid "Alias for Editor script"
 msgstr "편집기 스크립트의 별칭"
 
 #. IDS_PLUGIN_ALIAS_DESC
-#: Merge.rc:5626
+#: Merge.rc:5625
 #, c-format
 msgid "Alias for plugin pipeline '%1'"
 msgstr "플러그인 파이프라인 '%1'의 별칭"
 
 #. IDS_PLUGIN_NEW_DESC
-#: Merge.rc:5627
+#: Merge.rc:5626
 msgid "New plugin description"
 msgstr "새 플러그인 설명"
 
 #. IDS_PLUGIN_TARGETS_ALL
-#: Merge.rc:5628
+#: Merge.rc:5627
 msgid "All"
 msgstr "모두"
 
 #. IDS_PLUGIN_TARGETS_1ST
-#: Merge.rc:5629
+#: Merge.rc:5628
 msgid "1st"
 msgstr "첫 번째"
 
 #. IDS_PLUGIN_TARGETS_2ND
-#: Merge.rc:5630
+#: Merge.rc:5629
 msgid "2nd"
 msgstr "두 번째"
 
 #. IDS_PLUGIN_TARGETS_3RD
-#: Merge.rc:5631
+#: Merge.rc:5630
 msgid "3rd"
 msgstr "세 번째"
 
 #. IDS_PLUGIN_TARGETS_1ST_2ND
-#: Merge.rc:5632
+#: Merge.rc:5631
 msgid "1st and 2nd"
 msgstr "첫 번째 및 두 번쩨"
 
 #. IDS_PLUGIN_TARGETS_1ST_3RD
-#: Merge.rc:5633
+#: Merge.rc:5632
 msgid "1st and 3rd"
 msgstr "척 번째 및 세번째"
 
 #. IDS_PLUGIN_TARGETS_2ND_3RD
-#: Merge.rc:5634
+#: Merge.rc:5633
 msgid "2nd and 3rd"
 msgstr "두 번째 및 세번째"
 
 #. IDS_PLUGIN_CTRL_CLICK
-#: Merge.rc:5635
+#: Merge.rc:5634
 msgid "(Ctrl+Click to add to pipeline)"
 msgstr ""
 
 #. IDS_FILTER_APPLIED
-#: Merge.rc:5640
+#: Merge.rc:5639
 msgid "Filter applied"
 msgstr "필터 적용됨"
 
 #. IDS_FILTERMENU_COMPARE
-#: Merge.rc:5645
+#: Merge.rc:5644
 #, c-format
 msgid "Compare %1"
 msgstr "비교 %1"
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN2
-#: Merge.rc:5647
+#: Merge.rc:5646
 msgid "&Filter by This Column..."
 msgstr "이 열로 필터링(&F)..."
 
 #. IDS_CLIPBOARDHISTORY_TIME
-#: Merge.rc:5652
+#: Merge.rc:5651
 #, c-format
 msgid "Clipboard at %s"
 msgstr "%s의 클립보드"
 
 #. IDS_CLIPBOARDHISTORY_DISABLED
-#: Merge.rc:5653
+#: Merge.rc:5652
 msgid ""
 "Clipboard history disabled.\r\n"
 "Enable: Windows logo key + V, then Turn on."
@@ -9156,115 +9150,115 @@ msgstr ""
 "클립보드 기록울 사용할 수 없습니다.\r\n"
 "사용함: Windows 로고 키 + V를 누른 다음 켭니다."
 
-#: Merge.rc:5655
+#: Merge.rc:5654
 msgid "This system does not support clipboard history."
 msgstr "이 시스템은 클립보드 기록을 지원하지 않습니다."
 
-#: Merge.rc:5657
+#: Merge.rc:5656
 msgid "32-bit WinMerge does not support Clipboard Compare"
 msgstr "32비트 버전의 WinMerge는 클립보드 비교를 지원하지 않습니다"
 
 #. IDS_WEBVIEW2_RUNTIME_NOT_INSTALLED
-#: Merge.rc:5662
+#: Merge.rc:5661
 msgid "WebView2 runtime not installed. Download it?"
 msgstr "WebView2 런타임이 설치되지 않았습니다. 다운로드하시겠습니까?"
 
 #. IDS_JUMPLIST_NEW_TEXT_COMPARE
-#: Merge.rc:5667
+#: Merge.rc:5666
 msgid "New Text Compare"
 msgstr "새 텍스트 비교"
 
 #. IDS_JUMPLIST_NEW_TABLE_COMPARE
-#: Merge.rc:5668
+#: Merge.rc:5667
 msgid "New Table Compare"
 msgstr "새 테이블 비교"
 
 #. IDS_JUMPLIST_NEW_BINARY_COMPARE
-#: Merge.rc:5669
+#: Merge.rc:5668
 msgid "New Binary Compare"
 msgstr "새 바이너리 비교"
 
 #. IDS_JUMPLIST_NEW_IMAGE_COMPARE
-#: Merge.rc:5670
+#: Merge.rc:5669
 msgid "New Image Compare"
 msgstr "새 이미지 비교"
 
 #. IDS_JUMPLIST_NEW_WEBPAGE_COMPARE
-#: Merge.rc:5671
+#: Merge.rc:5670
 msgid "New Webpage Compare"
 msgstr "새 웹 페이지 비교"
 
 #. IDS_JUMPLIST_NEW_FOLDER_COMPARE
-#: Merge.rc:5672
+#: Merge.rc:5671
 msgid "New Folder Compare"
 msgstr "새 폴더 비교"
 
 #. IDS_JUMPLIST_CLIPBOARD_COMPARE
-#: Merge.rc:5673
+#: Merge.rc:5672
 msgid "Clipboard Compare"
 msgstr "클립보드 비교"
 
 #. IDS_PREVIEWBAR_PRINT
-#: Merge.rc:5678
+#: Merge.rc:5677
 msgid "&Print..."
 msgstr "인쇄(&P)..."
 
 #. IDS_PREVIEWBAR_PREVPAGE
-#: Merge.rc:5680
+#: Merge.rc:5679
 msgid "Pre&v Page"
 msgstr "이전 페이지(&V)"
 
 #. IDS_PREVIEWBAR_TWOPAGE
-#: Merge.rc:5681
+#: Merge.rc:5680
 msgid "&Two Page"
 msgstr "2 페이지(&T)"
 
 #. IDS_PREVIEWBAR_ONEPAGE
-#: Merge.rc:5682
+#: Merge.rc:5681
 msgid "&One Page"
 msgstr "1 페이지(&O)"
 
 #. IDS_PREVIEWBAR_ZOOMIN
-#: Merge.rc:5683
+#: Merge.rc:5682
 msgid "Zoom &In"
 msgstr "확대(&I)"
 
 #. IDS_PREVIEWBAR_ZOOMOUT
-#: Merge.rc:5684
+#: Merge.rc:5683
 msgid "Zoom &Out"
 msgstr "축소(&O)"
 
 #. IDS_WEBPAGE_COMPARING
-#: Merge.rc:5690
+#: Merge.rc:5689
 msgid "Comparing..."
 msgstr "비교 중..."
 
 #. IDS_WEBPAGE_ZOOM
-#: Merge.rc:5691
+#: Merge.rc:5690
 msgid "Zoom:"
 msgstr "확대/축소:"
 
 #. IDS_COPY_GRANULARITY_DIFFHUNK
-#: Merge.rc:5696
+#: Merge.rc:5695
 msgid "Diff hunk"
 msgstr "차이 덩어리"
 
 #. IDS_COPY_GRANULARITY_INLINE
-#: Merge.rc:5697
+#: Merge.rc:5696
 msgid "Inline diff"
 msgstr "인라인 차이"
 
 #. IDS_COPY_GRANULARITY_LINE
-#: Merge.rc:5698
+#: Merge.rc:5697
 msgid "Line"
 msgstr "줄"
 
-#: Merge.rc:5699
+#: Merge.rc:5698
 msgid "Character"
 msgstr "문자"
 
 #. ID_MICE_PREVDIFF
-#: Merge.rc:5704
+#: Merge.rc:5703
 msgid ""
 "\n"
 "Previous Difference (Alt+Up)\n"
@@ -9277,7 +9271,7 @@ msgstr ""
 "(Alt+휠 ⭡)"
 
 #. ID_MICE_NEXTDIFF
-#: Merge.rc:5705
+#: Merge.rc:5704
 msgid ""
 "\n"
 "Next Difference (Alt+Down)\n"
@@ -9290,7 +9284,7 @@ msgstr ""
 "(Alt+휠 ⭣)"
 
 #. ID_MICE_L2R
-#: Merge.rc:5706
+#: Merge.rc:5705
 msgid ""
 "\n"
 "Copy to Right (Alt+Right)\n"
@@ -9305,7 +9299,7 @@ msgstr ""
 "(Alt+Shift+휠 ⭣)"
 
 #. ID_MICE_R2L
-#: Merge.rc:5707
+#: Merge.rc:5706
 msgid ""
 "\n"
 "Copy to Left (Alt+Left)\n"
@@ -9320,7 +9314,7 @@ msgstr ""
 "(Alt+Shift+휠 ⭡)"
 
 #. ID_MICE_L2RNEXT
-#: Merge.rc:5708
+#: Merge.rc:5707
 msgid ""
 "\n"
 "Copy to Right and Advance (Ctrl+Alt+Right)\n"
@@ -9333,7 +9327,7 @@ msgstr ""
 "(Ctrl+Alt+Shift+휠 ⭣)"
 
 #. ID_MICE_R2LNEXT
-#: Merge.rc:5709
+#: Merge.rc:5708
 msgid ""
 "\n"
 "Copy to Left and Advance (Ctrl+Alt+Left)\n"
@@ -9346,257 +9340,257 @@ msgstr ""
 "(Ctrl+Alt+Shift+휠 ⭡)"
 
 #. IDS_LOG_COMPARING_2
-#: Merge.rc:5719
+#: Merge.rc:5718
 #, c-format
 msgid "Comparing %1 with %2"
 msgstr "%1과 %2 비교"
 
 #. IDS_LOG_COMPARING_3
-#: Merge.rc:5720
+#: Merge.rc:5719
 #, c-format
 msgid "Comparing %1 with %2 and %3"
 msgstr "%1과 %2 및 %3 비교"
 
 #. IDS_LOG_COMPARE_COMPLETED
-#: Merge.rc:5721
+#: Merge.rc:5720
 msgid "Comparison completed"
 msgstr "비교 완료"
 
 #. IDS_LOG_COMPARE_ERROR_2
-#: Merge.rc:5722
+#: Merge.rc:5721
 #, c-format
 msgid "Failed to compare %1 with %2: "
 msgstr "%1과 %2를 비교하지 못했습니다: "
 
 #. IDS_LOG_COMPARE_ERROR_3
-#: Merge.rc:5723
+#: Merge.rc:5722
 #, c-format
 msgid "Failed to compare %1 with %2 and %3: "
 msgstr "%1과 %2 및 %3을 비교하지 못했습니다: "
 
 #. IDS_LOG_FILE_SAVED
-#: Merge.rc:5724
+#: Merge.rc:5723
 msgid "File saved"
 msgstr "파일이 저장되었습니다"
 
 #. IDS_LOG_COPYING_FILES
-#: Merge.rc:5725
+#: Merge.rc:5724
 msgid "Copying files..."
 msgstr "파일 복사 중..."
 
 #. IDS_LOG_MOVING_FILES
-#: Merge.rc:5726
+#: Merge.rc:5725
 msgid "Moving files..."
 msgstr "파일 이동 중..."
 
 #. IDS_LOG_DELETING_FILES
-#: Merge.rc:5727
+#: Merge.rc:5726
 msgid "Deleting files..."
 msgstr "파일 삭제 중..."
 
 #. IDS_LOG_RECYCLEBIN
-#: Merge.rc:5728
+#: Merge.rc:5727
 msgid "Recycle Bin"
 msgstr "휴지통"
 
 #. IDS_LOG_PERMANENTLY_DELETED
-#: Merge.rc:5729
+#: Merge.rc:5728
 msgid "Permanently deleted"
 msgstr "영구 삭제"
 
 #. IDS_LOG_FILEOPERATION_COMPLETED
-#: Merge.rc:5730
+#: Merge.rc:5729
 msgid "File operation completed successfully"
 msgstr "파일 작업이 성공적으로 완료되었습니다"
 
 #. IDS_LOG_FILEOPERATION_CANCELED
-#: Merge.rc:5731
+#: Merge.rc:5730
 msgid "File operation canceled"
 msgstr "파일 작업이 취소되었습니다"
 
 #. IDS_FILTER_ERROR_NO_ERROR
-#: Merge.rc:5736
+#: Merge.rc:5735
 msgid "No error"
 msgstr "오류 없음"
 
 #. IDS_FILTER_ERROR_EMPTY_EXPRESSION
-#: Merge.rc:5737
+#: Merge.rc:5736
 msgid "Filter expression is empty"
 msgstr "필터 표현식이 비어 있습니다"
 
 #. IDS_FILTER_ERROR_UNKNOWN_CHAR
-#: Merge.rc:5738
+#: Merge.rc:5737
 msgid "Unknown character in filter expression"
 msgstr "필터 표현식에서 알 수 없는 문자"
 
 #. IDS_FILTER_ERROR_UNTERMINATED_STRING
-#: Merge.rc:5739
+#: Merge.rc:5738
 msgid "Unterminated string literal"
 msgstr "종료되지 않은 문자열 리터럴"
 
 #. IDS_FILTER_ERROR_SYNTAX_ERROR
-#: Merge.rc:5740
+#: Merge.rc:5739
 msgid "Syntax error in filter expression"
 msgstr "필터 표현식의 구문 오류"
 
 #. IDS_FILTER_ERROR_PARSE_FAILURE
-#: Merge.rc:5741
+#: Merge.rc:5740
 msgid "Failed to parse filter expression"
 msgstr "필터 표현식을 구문 분석하지 못했습니다"
 
 #. IDS_FILTER_ERROR_INVALID_LITERAL
-#: Merge.rc:5742
+#: Merge.rc:5741
 msgid "Invalid literal value"
 msgstr "잘못된 문자 그대로의 값"
 
 #. IDS_FILTER_ERROR_INVALID_REGULAR_EXPRESSION
-#: Merge.rc:5743
+#: Merge.rc:5742
 msgid "Invalid regular expression"
 msgstr "잘못된 정규 표현식"
 
 #. IDS_FILTER_ERROR_UNDEFINED_IDENTIFIER
-#: Merge.rc:5744
+#: Merge.rc:5743
 msgid "Undefined identifier"
 msgstr "정의되지 않은 식별자"
 
 #. IDS_FILTER_ERROR_INVALID_ARGUMENT_COUNT
-#: Merge.rc:5745
+#: Merge.rc:5744
 msgid "Invalid number of arguments"
 msgstr "인수 수가 잘못되었습니다"
 
 #. IDS_FILTER_ERROR_FILTER_NAME_NOT_FOUND
-#: Merge.rc:5746
+#: Merge.rc:5745
 msgid "Filter name not found"
 msgstr "필터 이름을 찾을 수 없습니다"
 
 #. IDS_FILTER_ERROR_DIVIDE_BY_ZERO
-#: Merge.rc:5747
+#: Merge.rc:5746
 msgid "Division by zero in filter expression"
 msgstr "필터 표현식에서 0으로 나눕니다"
 
 #. IDS_FILTER_ERROR_UNKNOWN_ERROR
-#: Merge.rc:5748
+#: Merge.rc:5747
 msgid "Unknown error"
 msgstr "알 수 없는 오류"
 
 #. IDS_FILTER_ERROR_INVALID_PROPERTY_NAME
-#: Merge.rc:5749
+#: Merge.rc:5748
 msgid "Invalid property name"
 msgstr "잘못된 속성 이름"
 
 #. IDS_FILTER_ERROR_INVALID_DIRECTIVE
-#: Merge.rc:5750
+#: Merge.rc:5749
 msgid "Invalid directive"
 msgstr "잘못된 지침"
 
 #. IDS_FILTER_OP_EQUALS
-#: Merge.rc:5755
+#: Merge.rc:5754
 msgid "Equals"
 msgstr "같음"
 
 #. IDS_FILTER_OP_NOT_EQUALS
-#: Merge.rc:5756
+#: Merge.rc:5755
 msgid "Does not equal"
 msgstr "같지 않음"
 
 #. IDS_FILTER_OP_LESS_THAN
-#: Merge.rc:5757
+#: Merge.rc:5756
 msgid "Less than"
 msgstr "보다 적은"
 
 #. IDS_FILTER_OP_LESS_EQUAL
-#: Merge.rc:5758
+#: Merge.rc:5757
 msgid "Less than or equal to"
 msgstr "작거나 같음"
 
 #. IDS_FILTER_OP_GREATER_EQUAL
-#: Merge.rc:5759
+#: Merge.rc:5758
 msgid "Greater than or equal to"
 msgstr "크거나 같음"
 
 #. IDS_FILTER_OP_GREATER_THAN
-#: Merge.rc:5760
+#: Merge.rc:5759
 msgid "Greater than"
 msgstr "보다 적은"
 
 #. IDS_FILTER_OP_BETWEEN
-#: Merge.rc:5761
+#: Merge.rc:5760
 msgid "Between"
 msgstr "사이에"
 
 #. IDS_FILTER_OP_NOT_BETWEEN
-#: Merge.rc:5762
+#: Merge.rc:5761
 msgid "Not Between"
 msgstr "사이가 아님"
 
 #. IDS_FILTER_OP_CONTAINS
-#: Merge.rc:5763
+#: Merge.rc:5762
 msgid "Contains"
 msgstr "포함"
 
 #. IDS_FILTER_OP_NOT_CONTAINS
-#: Merge.rc:5764
+#: Merge.rc:5763
 msgid "Not Contains"
 msgstr "포함하지 않음"
 
 #. IDS_FILTER_OP_RECONTAINS
-#: Merge.rc:5765
+#: Merge.rc:5764
 msgid "Contains (regex)"
 msgstr "포함 (정규식)"
 
 #. IDS_FILTER_OP_NOT_RECONTAINS
-#: Merge.rc:5766
+#: Merge.rc:5765
 msgid "Not Contains (regex)"
 msgstr "포함하지 않음 (정규식)"
 
 #. IDS_FILTER_OP_LIKE
-#: Merge.rc:5767
+#: Merge.rc:5766
 msgid "Match (wildcard)"
 msgstr "일치 (와일드카드)"
 
 #. IDS_FILTER_OP_NOT_LIKE
-#: Merge.rc:5768
+#: Merge.rc:5767
 msgid "Not match (wildcard)"
 msgstr "일치하지 않음 (와일드카드)"
 
 #. IDS_FILTER_OP_MATCHES
-#: Merge.rc:5769
+#: Merge.rc:5768
 msgid "Match (regex)"
 msgstr "일치 (정규 표현식)"
 
 #. IDS_FILTER_OP_NOT_MATCHES
-#: Merge.rc:5770
+#: Merge.rc:5769
 msgid "Not match (regex)"
 msgstr "일치하지 않음 (정규 표현식)"
 
 #. IDS_COLORMODE_LIGHT
-#: Merge.rc:5775
+#: Merge.rc:5774
 msgid "Light"
 msgstr "밝은"
 
 #. IDS_COLORMODE_DARK
-#: Merge.rc:5776
+#: Merge.rc:5775
 msgid "Dark"
 msgstr "어두운"
 
 #. IDS_COLORMODE_FOLLOWSYSTEM
-#: Merge.rc:5777
+#: Merge.rc:5776
 msgid "Follow system"
 msgstr "시스템을 따름"
 
 #. IDS_EXAMPLE
-#: Merge.rc:5782
+#: Merge.rc:5781
 #, c-format
 msgid "e.g. %1"
 msgstr "예: %1"
 
 #. IDS_DETECTED_PREVIOUS_CRASH
-#: Merge.rc:5787
+#: Merge.rc:5786
 msgid "WinMerge detected a previous crash. Please report this if possible."
 msgstr "WinMerge가 이전 충돌을 감지했습니다. 가능하다면 이를 보고해 주세요."
 
 #. IDS_REGEX_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5792
+#: Merge.rc:5791
 msgid ""
 "# Regex replacement list\r\n"
 "# Format: regex<TAB>replacement\r\n"
@@ -9611,7 +9605,7 @@ msgstr ""
 "(\\d{4})-(\\d{2})-(\\d{2})\t$1_$2_$3\r\n"
 
 #. IDS_STRING_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5793
+#: Merge.rc:5792
 msgid ""
 "# Replacement list\r\n"
 "# Format: search<TAB>replacement\r\n"
@@ -9628,22 +9622,22 @@ msgstr ""
 "2부터\t2까지\r\n"
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_ONLY
-#: Merge.rc:5798
+#: Merge.rc:5797
 msgid "Built-in only"
 msgstr "내장만"
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_FIRST
-#: Merge.rc:5799
+#: Merge.rc:5798
 msgid "Built-in first"
 msgstr "내장 우선"
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_FIRST
-#: Merge.rc:5800
+#: Merge.rc:5799
 msgid "Tree-sitter first"
 msgstr "트리 시터 우선"
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_ONLY
-#: Merge.rc:5801
+#: Merge.rc:5800
 msgid "Tree-sitter only"
 msgstr "트리 시터만"
 

--- a/Translations/WinMerge/Lithuanian.po
+++ b/Translations/WinMerge/Lithuanian.po
@@ -23,7 +23,7 @@ msgstr ""
 "X-Generator: Poedit 3.9.1\n"
 
 #. LANGUAGE, SUBLANGUAGE
-#: Merge.rc:26 Merge.rc:59 Merge.rc:5818
+#: Merge.rc:26 Merge.rc:59 Merge.rc:5817
 msgid "LANG_ENGLISH, SUBLANG_ENGLISH_US"
 msgstr "LANG_LITHUANIAN, SUBLANG_DEFAULT"
 
@@ -165,7 +165,7 @@ msgstr "&Skriptai"
 #. IDS_NO_EDIT_SCRIPTS
 #: Merge.rc:127 Merge.rc:352 Merge.rc:463 Merge.rc:673 Merge.rc:678
 #: Merge.rc:887 Merge.rc:899 Merge.rc:906 Merge.rc:963 Merge.rc:1210
-#: Merge.rc:5375
+#: Merge.rc:5374
 msgid "< Empty >"
 msgstr "< Tuščia >"
 
@@ -230,7 +230,7 @@ msgid "Auto-Fit All Columns"
 msgstr "Automatiškai talpinti visus stulpelius"
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN
-#: Merge.rc:153 Merge.rc:5646
+#: Merge.rc:153 Merge.rc:5645
 msgid "&Filter by This Column"
 msgstr "&Filtruoti pagal šį stulpelį"
 
@@ -291,7 +291,7 @@ msgid "&Previous Page"
 msgstr "&Praeitas psl."
 
 #. IDS_PREVIEWBAR_NEXTPAGE
-#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5679
+#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5678
 msgid "&Next Page"
 msgstr "&Kitas psl."
 
@@ -542,7 +542,7 @@ msgstr "&Binarinis"
 #. IDS_IMAGE_MENU
 #: Merge.rc:329 Merge.rc:338 Merge.rc:432 Merge.rc:441 Merge.rc:609
 #: Merge.rc:618 Merge.rc:670 Merge.rc:960 Merge.rc:1187 Merge.rc:1200
-#: Merge.rc:5477
+#: Merge.rc:5476
 msgid "&Image"
 msgstr "Pave&ikslėlis"
 
@@ -664,7 +664,7 @@ msgid "&Huge"
 msgstr "&Milžiniški mygtukai"
 
 #. IDS_VIEW_MENU_BAR
-#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5714
+#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5713
 msgid "Men&u Bar"
 msgstr "Meni&u juosta"
 
@@ -1319,7 +1319,7 @@ msgid "Lo&cation Pane"
 msgstr "Vi&etos polangis"
 
 #. IDS_OUTPUTBAR_CAPTION
-#: Merge.rc:782 Merge.rc:5252
+#: Merge.rc:782 Merge.rc:5251
 msgid "Output Pane"
 msgstr "Rezultatų polangis"
 
@@ -1582,55 +1582,55 @@ msgid "Co&mpare As"
 msgstr "Ly&ginti kaip"
 
 #. IDS_COPY_LEFT_TO_MIDDLE2
-#: Merge.rc:968 Merge.rc:980 Merge.rc:4852
+#: Merge.rc:968 Merge.rc:980 Merge.rc:4851
 #, c-format
 msgid "Left to Middle (%1 of %2)"
 msgstr "Kairįjį į Vidurinį (%1 iš %2)"
 
 #. IDS_COPY_LEFT_TO_RIGHT2
-#: Merge.rc:969 Merge.rc:981 Merge.rc:4851
+#: Merge.rc:969 Merge.rc:981 Merge.rc:4850
 #, c-format
 msgid "Left to Right (%1 of %2)"
 msgstr "Kairįjį į Dešinįjį (%1 iš %2)"
 
 #. IDS_MOVE_LEFT_TO2
-#: Merge.rc:970 Merge.rc:982 Merge.rc:1045 Merge.rc:4863 Merge.rc:4892
+#: Merge.rc:970 Merge.rc:982 Merge.rc:1045 Merge.rc:4862 Merge.rc:4891
 #, c-format
 msgid "Left to... (%1 of %2)"
 msgstr "Kairįjį į... (%1 iš %2)"
 
 #. IDS_COPY_MIDDLE_TO_LEFT2
-#: Merge.rc:971 Merge.rc:983 Merge.rc:4849
+#: Merge.rc:971 Merge.rc:983 Merge.rc:4848
 #, c-format
 msgid "Middle to Left (%1 of %2)"
 msgstr "Vidurinį į Kairįjį (%1 iš %2)"
 
 #. IDS_COPY_MIDDLE_TO_RIGHT2
-#: Merge.rc:972 Merge.rc:984 Merge.rc:4850
+#: Merge.rc:972 Merge.rc:984 Merge.rc:4849
 #, c-format
 msgid "Middle to Right (%1 of %2)"
 msgstr "Vidurinį į Dešinįjį (%1 iš %2)"
 
 #. IDS_MOVE_MIDDLE_TO2
-#: Merge.rc:973 Merge.rc:985 Merge.rc:1046 Merge.rc:4864 Merge.rc:4893
+#: Merge.rc:973 Merge.rc:985 Merge.rc:1046 Merge.rc:4863 Merge.rc:4892
 #, c-format
 msgid "Middle to... (%1 of %2)"
 msgstr "Vidurinį į... (%1 iš %2)"
 
 #. IDS_COPY_RIGHT_TO_MIDDLE2
-#: Merge.rc:974 Merge.rc:986 Merge.rc:4848
+#: Merge.rc:974 Merge.rc:986 Merge.rc:4847
 #, c-format
 msgid "Right to Middle (%1 of %2)"
 msgstr "Dešinįjį į Vidurinį (%1 iš %2)"
 
 #. IDS_COPY_RIGHT_TO_LEFT2
-#: Merge.rc:975 Merge.rc:987 Merge.rc:4847
+#: Merge.rc:975 Merge.rc:987 Merge.rc:4846
 #, c-format
 msgid "Right to Left (%1 of %2)"
 msgstr "Dešinįjį į kairįjį (%1 iš %2)"
 
 #. IDS_MOVE_RIGHT_TO2
-#: Merge.rc:976 Merge.rc:988 Merge.rc:1047 Merge.rc:4865 Merge.rc:4894
+#: Merge.rc:976 Merge.rc:988 Merge.rc:1047 Merge.rc:4864 Merge.rc:4893
 #, c-format
 msgid "Right to... (%1 of %2)"
 msgstr "Dešinįjį į... (%1 iš %2)"
@@ -1686,31 +1686,31 @@ msgid "Cop&y Paths"
 msgstr "Kop&ijuoti kelius"
 
 #. IDS_DEL_LEFT_FMT2
-#: Merge.rc:1026 Merge.rc:1035 Merge.rc:4880
+#: Merge.rc:1026 Merge.rc:1035 Merge.rc:4879
 #, c-format
 msgid "Left (%1 of %2)"
 msgstr "Kairėje (%1 iš %2)"
 
 #. IDS_DEL_MIDDLE_FMT2
-#: Merge.rc:1027 Merge.rc:1036 Merge.rc:4881
+#: Merge.rc:1027 Merge.rc:1036 Merge.rc:4880
 #, c-format
 msgid "Middle (%1 of %2)"
 msgstr "Viduryje (%1 iš %2)"
 
 #. IDS_DEL_RIGHT_FMT2
-#: Merge.rc:1028 Merge.rc:1037 Merge.rc:4882
+#: Merge.rc:1028 Merge.rc:1037 Merge.rc:4881
 #, c-format
 msgid "Right (%1 of %2)"
 msgstr "Dešinėje (%1 iš %2)"
 
 #. IDS_DEL_BOTH_FMT2
-#: Merge.rc:1029 Merge.rc:1038 Merge.rc:4883
+#: Merge.rc:1029 Merge.rc:1038 Merge.rc:4882
 #, c-format
 msgid "Both (%1 of %2)"
 msgstr "Abu (%1 iš %2)"
 
 #. IDS_DEL_ALL_FMT2
-#: Merge.rc:1030 Merge.rc:1039 Merge.rc:4888
+#: Merge.rc:1030 Merge.rc:1039 Merge.rc:4887
 #, c-format
 msgid "All (%1 of %2)"
 msgstr "Visi (%1 iš %2)"
@@ -1736,19 +1736,19 @@ msgid "&Zip"
 msgstr "&Zip"
 
 #. IDS_COPY_BOTH_TO2
-#: Merge.rc:1048 Merge.rc:4866
+#: Merge.rc:1048 Merge.rc:4865
 #, c-format
 msgid "Both to... (%1 of %2)"
 msgstr "Abu į... (%1 iš %2)"
 
 #. IDS_COPY_ALL_TO2
-#: Merge.rc:1049 Merge.rc:4867
+#: Merge.rc:1049 Merge.rc:4866
 #, c-format
 msgid "All to... (%1 of %2)"
 msgstr "Viską į... (%1 iš %2)"
 
 #. IDS_COPY_DIFFERENCES_TO2
-#: Merge.rc:1050 Merge.rc:4868
+#: Merge.rc:1050 Merge.rc:4867
 #, c-format
 msgid "Differences to... (%1 of %2)"
 msgstr "Skirtumus į... (%1 iš %2)"
@@ -1815,12 +1815,12 @@ msgstr "Išpakuotojo nuostatos"
 
 #. IDS_USERCHOICE_NONE
 #: Merge.rc:1088 Merge.rc:1094 Merge.rc:1836 Merge.rc:1840 Merge.rc:2031
-#: Merge.rc:2035 Merge.rc:5377
+#: Merge.rc:2035 Merge.rc:5376
 msgid "<None>"
 msgstr "<Nėra>"
 
 #. IDS_USERCHOICE_AUTOMATIC
-#: Merge.rc:1089 Merge.rc:1095 Merge.rc:5378
+#: Merge.rc:1089 Merge.rc:1095 Merge.rc:5377
 msgid "<Automatic>"
 msgstr "<Automatinis>"
 
@@ -2750,12 +2750,12 @@ msgid "Text files only"
 msgstr "Tik tekstiniai failai"
 
 #. IDS_EOL_NONE
-#: Merge.rc:1667 Merge.rc:1918 Merge.rc:5304
+#: Merge.rc:1667 Merge.rc:1918 Merge.rc:5303
 msgid "None"
 msgstr "Nėra"
 
 #. IDS_EOL_MIXED
-#: Merge.rc:1668 Merge.rc:5299
+#: Merge.rc:1668 Merge.rc:5298
 msgid "Mixed"
 msgstr "Mišrus"
 
@@ -3027,13 +3027,13 @@ msgstr "Eilutės &statusas"
 
 #. IDS_DIFFERENT
 #: Merge.rc:1904 Merge.rc:1988 Merge.rc:2866 Merge.rc:3036 Merge.rc:3077
-#: Merge.rc:5058
+#: Merge.rc:5057
 msgid "Different"
 msgstr "Yra skirtingi"
 
 #. IDS_IDENTICAL
 #: Merge.rc:1905 Merge.rc:1989 Merge.rc:2865 Merge.rc:3055 Merge.rc:3116
-#: Merge.rc:5048
+#: Merge.rc:5047
 msgid "Identical"
 msgstr "Yra vienodi"
 
@@ -3053,7 +3053,7 @@ msgid "Missing"
 msgstr "Trūksta"
 
 #. IDS_MOVED
-#: Merge.rc:1910 Merge.rc:5076
+#: Merge.rc:1910 Merge.rc:5075
 msgid "Moved"
 msgstr "Perkelta"
 
@@ -3789,7 +3789,7 @@ msgid "&Use custom system colors"
 msgstr "Na&udoti pasirinkt. sistemos spalvas"
 
 #. IDS_PRPCAT_SYSTEM
-#: Merge.rc:2565 Merge.rc:4559 Merge.rc:4560 Merge.rc:5007
+#: Merge.rc:2565 Merge.rc:4559 Merge.rc:4560 Merge.rc:5006
 msgid "System"
 msgstr "Sistemos"
 
@@ -4189,7 +4189,7 @@ msgid "Items compared:"
 msgstr "Elementų palyginta:"
 
 #. IDS_PREVIEWBAR_CLOSE
-#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5685
+#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5684
 msgid "&Close"
 msgstr "&Užverti"
 
@@ -4804,7 +4804,7 @@ msgid "A&ppend timestamp"
 msgstr "P&ridėti laiko žymą"
 
 #. IDS_CONFIRM_COPY_CAPTION
-#: Merge.rc:3214 Merge.rc:4915
+#: Merge.rc:3214 Merge.rc:4914
 msgid "Confirm Copy"
 msgstr "Patvirtinti kopijavimą"
 
@@ -5041,7 +5041,7 @@ msgid "&Character Set..."
 msgstr "&Simbolių rinkinys..."
 
 #. IDS_PRPCAT_IMAGE
-#: Merge.rc:3351 Merge.rc:4574 Merge.rc:5015
+#: Merge.rc:3351 Merge.rc:4574 Merge.rc:5014
 msgid "Image"
 msgstr "Paveikslėlių"
 
@@ -5386,7 +5386,7 @@ msgid "Project"
 msgstr "Projekto"
 
 #. IDS_COLHDR_NSDIFFS
-#: Merge.rc:4566 Merge.rc:4990
+#: Merge.rc:4566 Merge.rc:4989
 msgid "Differences"
 msgstr "Skirtumų"
 
@@ -5528,12 +5528,12 @@ msgid "File Type"
 msgstr "Failo tipas"
 
 #. IDS_COLHDR_EXTENSION
-#: Merge.rc:4653 Merge.rc:4947
+#: Merge.rc:4653 Merge.rc:4946
 msgid "Extension"
 msgstr "Plėtinys"
 
 #. IDS_PRPCAT_MESSAGE
-#: Merge.rc:4659 Merge.rc:5019
+#: Merge.rc:4659 Merge.rc:5018
 msgid "Message"
 msgstr "Pranešimas"
 
@@ -5573,7 +5573,7 @@ msgid "Hidden Items"
 msgstr "Paslėpti elementai"
 
 #. IDS_PLUGINSLIST_NAME
-#: Merge.rc:4680 Merge.rc:5311
+#: Merge.rc:4680 Merge.rc:5310
 msgid "Name"
 msgstr "Pavadinimas"
 
@@ -5593,7 +5593,7 @@ msgid "[F] "
 msgstr "[F] "
 
 #. IDS_PLUGINSLIST_DESC
-#: Merge.rc:4684 Merge.rc:5313
+#: Merge.rc:4684 Merge.rc:5312
 msgid "Description"
 msgstr "Aprašas"
 
@@ -5719,2734 +5719,2729 @@ msgstr "Eil.: %s  Stlp.: %d/%d  Sk.: %d/%d"
 msgid "  Sel: %d | %d"
 msgstr "  Paž: %d | %d"
 
-#. IDS_MERGEMODE_MERGING
-#: Merge.rc:4734
-msgid "Merge"
-msgstr "Sulieti"
-
 #. IDS_DIFF_NUMBER_STATUS_FMT
-#: Merge.rc:4735
+#: Merge.rc:4734
 #, c-format
 msgid "Difference %1 of %2"
 msgstr "Skirtumas %1 iš %2"
 
 #. IDS_NO_DIFF_SEL_FMT
-#: Merge.rc:4736
+#: Merge.rc:4735
 #, c-format
 msgid "%1 Differences Found"
 msgstr "Rasti (-a) %1 skirtumai (-ų)"
 
 #. IDS_1_DIFF_FOUND
-#: Merge.rc:4737
+#: Merge.rc:4736
 msgid "1 Difference Found"
 msgstr "Rastas 1 skirtumas"
 
 #. IDS_NO_ERR_SEL_FMT
-#: Merge.rc:4738
+#: Merge.rc:4737
 #, c-format
 msgid "%1 Errors Found"
 msgstr "Rastos (-a) %1 klaidos (-ų)"
 
 #. IDS_1_ERR_FOUND
-#: Merge.rc:4739
+#: Merge.rc:4738
 msgid "1 Error Found"
 msgstr "Rasta 1 klaida"
 
 #. IDS_STATUSBAR_READONLY, Abbreviation from "Read Only"
-#: Merge.rc:4740
+#: Merge.rc:4739
 msgid "RO"
 msgstr "RO"
 
 #. IDS_DIRVIEW_STATUS_FMT_FOCUS
-#: Merge.rc:4746
+#: Merge.rc:4745
 #, c-format
 msgid "Item %1 of %2"
 msgstr "Elementas %1 iš %2"
 
 #. IDS_DIRVIEW_STATUS_FMT_NOFOCUS
-#: Merge.rc:4747
+#: Merge.rc:4746
 #, c-format
 msgid "Items: %1"
 msgstr "Elementų: %1"
 
 #. IDS_DIRVIEW_STATUS_COMPARING
-#: Merge.rc:4748
+#: Merge.rc:4747
 msgid "Comparing items..."
 msgstr "Lygina elementus..."
 
 #. IDS_ITEMS_PER_SEC
-#: Merge.rc:4749
+#: Merge.rc:4748
 #, c-format
 msgid "%.1f[items/sec]"
 msgstr "%.1f[elementų/sek.]"
 
 #. IDS_ERROR_INCOMPARABLE
-#: Merge.rc:4755
+#: Merge.rc:4754
 msgid "Select two existing folders/files to compare."
 msgstr "Nurodykite lyginimui du egzistuojančius katalogus ar failus."
 
 #. IDS_DIRSEL_TAG
-#: Merge.rc:4756
+#: Merge.rc:4755
 msgid "Folder Selection"
 msgstr "Katalogo išrinkimas"
 
 #. IDS_OPEN_FILESDIRS
-#: Merge.rc:4757
+#: Merge.rc:4756
 msgid "Select two (or three) folders/files to compare."
 msgstr "Nurodykite lyginimui du (arba tris) katalogus ar failus."
 
 #. IDS_OPEN_LEFTINVALID
-#: Merge.rc:4758
+#: Merge.rc:4757
 msgid "Left (1st) path is invalid!"
 msgstr "Kairysis (1-as) kelias klaidingas!"
 
 #. IDS_OPEN_MIDDLEINVALID
-#: Merge.rc:4759
+#: Merge.rc:4758
 msgid "Middle (2nd) path is invalid!"
 msgstr "Vidurinis (2-as) kelias klaidingas!"
 
 #. IDS_OPEN_RIGHTINVALID2
-#: Merge.rc:4760
+#: Merge.rc:4759
 msgid "Right (2nd) path is invalid!"
 msgstr "Dešinysis (2-as) kelias klaidingas!"
 
 #. IDS_OPEN_RIGHTINVALID3
-#: Merge.rc:4761
+#: Merge.rc:4760
 msgid "Right (3rd) path is invalid!"
 msgstr "Dešinysis (3-ias) kelias klaidingas!"
 
 #. IDS_OPEN_BOTHINVALID
-#: Merge.rc:4762
+#: Merge.rc:4761
 msgid "Both paths are invalid!"
 msgstr "Abu keliai klaidingi!"
 
-#: Merge.rc:4764
+#: Merge.rc:4763
 msgid "Left (1st) and Middle (2nd) paths are invalid!"
 msgstr "Kairysis (1-as) ir vidurinis (2-as) keliai klaidingi!"
 
 #. IDS_OPEN_LEFTRIGHTINVALID
-#: Merge.rc:4765
+#: Merge.rc:4764
 msgid "Left (1st) and Right (3rd) paths are invalid!"
 msgstr "Kairysis (1-as) ir dešinysis (3-ias) keliai klaidingi!"
 
-#: Merge.rc:4767
+#: Merge.rc:4766
 msgid "Middle (2nd) and Right (3rd) paths are invalid!"
 msgstr "Vidurinis (2-as) ir dešinysis (3-ias) keliai klaidingi!"
 
 #. IDS_OPEN_ALLINVALID
-#: Merge.rc:4768
+#: Merge.rc:4767
 msgid "All paths are invalid!"
 msgstr "Visi keliai klaidingi!"
 
 #. IDS_OPEN_UNPACKERDISABLED
-#: Merge.rc:4769
+#: Merge.rc:4768
 msgid "Only enabled for file comparisons"
 msgstr "Leistas tik failų palyginimas"
 
 #. IDS_OPEN_MISMATCH
-#: Merge.rc:4770
+#: Merge.rc:4769
 msgid "Cannot compare file and folder!"
 msgstr "Negalima lyginti failo ir katalogo!"
 
 #. IDS_ERROR_FILE_NOT_FOUND
-#: Merge.rc:4776
+#: Merge.rc:4775
 #, c-format
 msgid "File not found: %1"
 msgstr "Nerastas failas: %1"
 
 #. IDS_ERROR_FOLDER_NOT_FOUND
-#: Merge.rc:4777
+#: Merge.rc:4776
 #, c-format
 msgid "Folder not found: %1"
 msgstr "Nerastas katalogas: %1"
 
 #. IDS_ERROR_FILE_NOT_UNPACKED
-#: Merge.rc:4778
+#: Merge.rc:4777
 #, c-format
 msgid "File not unpacked: %1"
 msgstr "Failas %1 neišpakuotas"
 
 #. IDS_ERROR_FILEOPEN
-#: Merge.rc:4779
+#: Merge.rc:4778
 #, c-format
 msgid "Cannot open file\n%1\n\n%2"
 msgstr "Negalima atidaryti failo\n%1\n\n%2"
 
 #. IDS_ERROR_CONF_RESOLVE
-#: Merge.rc:4780
+#: Merge.rc:4779
 msgid "Failed to parse conflict file."
 msgstr "Nepavyko išnagrinėti konfliktų failo."
 
 #. IDS_NOT_CONFLICT_FILE
-#: Merge.rc:4781
+#: Merge.rc:4780
 #, c-format
 msgid "The file\n%1\nis not a conflict file."
 msgstr "Failas\n%1\nnėra konfliktų failas."
 
 #. IDS_COMPARE_LARGE_FILES
-#: Merge.rc:4782
+#: Merge.rc:4781
 msgid "Comparing large files requires significant memory.\nShow only comparison results (not file contents)?"
 msgstr "Didelių failų palyginimas reikalauja labai daug atminties.\nGal norite matyti tik palyginimo rezultatus, o ne failų turinį?"
 
 #. IDS_SAVE_AS_TITLE
-#: Merge.rc:4788
+#: Merge.rc:4787
 msgid "Save As"
 msgstr "Išsaugoti kaip"
 
 #. IDS_SAVE_FMT
-#: Merge.rc:4789
+#: Merge.rc:4788
 #, c-format
 msgid "Save changes to %1?"
 msgstr "Išsaugoti pakeitimus į %1?"
 
 #. IDS_SAVEREADONLY_FMT
-#: Merge.rc:4790
+#: Merge.rc:4789
 #, c-format
 msgid "%1 is read-only. Override? Or 'No' to save as new filename?"
 msgstr "%1 pažymėtas „Tik skaitymui“. Perrašyti? Arba „Ne“, jei įrašyti nauju vardu?"
 
 #. IDS_ERROR_BACKUP
-#: Merge.rc:4791
+#: Merge.rc:4790
 msgid "Error backing up file"
 msgstr "Klaida kuriant rezervinį failą"
 
-#: Merge.rc:4793
+#: Merge.rc:4792
 #, c-format
 msgid "Unable to backup original file:\n%1\n\nContinue anyway?"
 msgstr "Nepavyko sukurti rezervinės kopijos failui:\n%1\n\nVis tiek tęsti?"
 
 #. IDS_FILESAVE_FAILED
-#: Merge.rc:4794
+#: Merge.rc:4793
 #, c-format
 msgid "Saving file failed.\n%1\n%2\n\t- Use different filename (OK)\n\t- Abort (Cancel)?"
 msgstr "Failo įrašyti nepavyko.\n%1\n%2\n\t- panaudoti kitą failo vardą („Gerai“)\n\t- nutraukti šią operaciją („Atsisakyti“)?"
 
-#: Merge.rc:4796
+#: Merge.rc:4795
 #, c-format
 msgid "Plugin '%2' cannot pack changes to left file into '%1'.\n\nOriginal unchanged. Save unpacked version?"
 msgstr "Papildinys '%2' negali supakuoti pakeitimų kairiajame faile atgal į '%1'.\n\nPradinis failas nebus pakeistas. Išsaugoti išpakuotą versiją?"
 
-#: Merge.rc:4798
+#: Merge.rc:4797
 #, c-format
 msgid "Plugin '%2' cannot pack changes to middle file into '%1'.\n\nOriginal unchanged. Save unpacked version?"
 msgstr "Papildinys '%2' negali supakuoti pakeitimų viduriniame faile atgal į '%1'.\n\nPradinis failas nebus pakeistas. Išsaugoti išpakuotą versiją?"
 
-#: Merge.rc:4800
+#: Merge.rc:4799
 #, c-format
 msgid "Plugin '%2' cannot pack changes to right file into '%1'.\n\nOriginal unchanged. Save unpacked version?"
 msgstr "Papildinys '%2' negali supakuoti pakeitimų dešiniajame faile atgal į '%1'.\n\nPradinis failas nebus pakeistas. Išsaugoti išpakuotą versiją?"
 
 #. IDS_FILECHANGED_ONDISK
-#: Merge.rc:4801
+#: Merge.rc:4800
 #, c-format
 msgid "Another application updated\n%1\nsince WinMerge loaded it.\n\nOverwrite?"
 msgstr "Kita programa pakeitė failą\n%1\npo to, kai jis buvo įkeltas į „Winmerge“.\n\nPerrašyti pakeistą failą?"
 
 #. IDS_SAVEREADONLY_MULTI
-#: Merge.rc:4802
+#: Merge.rc:4801
 #, c-format
 msgid "%1\nis read-only. Override?"
 msgstr "%1\npažymėtas „Tik skaitymui“. Perrašyti?"
 
 #. IDS_FILECHANGED_RESCAN
-#: Merge.rc:4803
+#: Merge.rc:4802
 #, c-format
 msgid "Another application updated\n%1\nsince last scan.\n\nReload?"
 msgstr "Kita programa pakeitė\n%1\npo to, kai jis buvo paskutinį kartą skanuotas.\n\nĮkelti iš naujo?"
 
 #. IDS_SAVE_LEFT_AS
-#: Merge.rc:4804
+#: Merge.rc:4803
 msgid "Save Left File As"
 msgstr "Išsaugoti kairįjį failą kaip"
 
 #. IDS_SAVE_MIDDLE_AS
-#: Merge.rc:4805
+#: Merge.rc:4804
 msgid "Save Middle File As"
 msgstr "Išsaugoti vidurinį failą kaip"
 
 #. IDS_SAVE_RIGHT_AS
-#: Merge.rc:4806
+#: Merge.rc:4805
 msgid "Save Right File As"
 msgstr "Išsaugoti dašinįjį failą kaip"
 
 #. IDS_FILE_DISAPPEARED
-#: Merge.rc:4811
+#: Merge.rc:4810
 #, c-format
 msgid "File\n%1\nnot found. Save a copy to continue."
 msgstr "Failas\n% 1\nnerastas. Norėdami tęsti, įrašykite kopiją."
 
 #. IDS_VIEWS_OUTOFSYNC
-#: Merge.rc:4817
+#: Merge.rc:4816
 msgid "Cannot merge unsynched documents.\n\nRefresh before continuing."
 msgstr "Negalima sulieti nesinchronizuotų dokumentų.\n\nAtnaujinkite prieš tęsiant."
 
 #. IDS_BREAK_ON_WHITESPACE
-#: Merge.rc:4822
+#: Merge.rc:4821
 msgid "Break at whitespace"
 msgstr "Skaidyti per tarpą"
 
 #. IDS_BREAK_ON_PUNCTUATION
-#: Merge.rc:4823
+#: Merge.rc:4822
 msgid "Break at whitespace or punctuation"
 msgstr "Skaidyti per tarpą ar skirtuką"
 
 #. IDS_L2M
-#: Merge.rc:4829
+#: Merge.rc:4828
 msgid "Copy to &Middle\tAlt+Right"
 msgstr "Kopijuoti į &Vidurį\tAlt+Right"
 
 #. IDS_R2M
-#: Merge.rc:4830
+#: Merge.rc:4829
 msgid "Copy to &Middle\tAlt+Left"
 msgstr "Kopijuoti į &Vidurį\tAlt+Left"
 
 #. IDS_COPY_FROM_MIDDLE_R
-#: Merge.rc:4831
+#: Merge.rc:4830
 msgid "Copy from Middle\tAlt+Shift+Right"
 msgstr "Kopijuoti iš Vidurio\tAlt+Shift+Right"
 
 #. IDS_COPY_FROM_MIDDLE_L
-#: Merge.rc:4832
+#: Merge.rc:4831
 msgid "Copy from Middle\tAlt+Shift+Left"
 msgstr "Kopijuoti iš Vidurio\tAlt+Shift+Left"
 
 #. IDS_L2MNEXT
-#: Merge.rc:4833
+#: Merge.rc:4832
 msgid "Copy to Middle and Advance\tCtrl+Alt+Right"
 msgstr "Kopijuoti į vidurį ir Daugiau\tCtrl+Alt+Right"
 
 #. IDS_R2MNEXT
-#: Merge.rc:4834
+#: Merge.rc:4833
 msgid "Copy to Middle and Advance\tCtrl+Alt+Left"
 msgstr "Kopijuoti į vidurį ir Daugiau\tCtrl+Alt+Left"
 
 #. IDS_ALL_MIDDLE
-#: Merge.rc:4835
+#: Merge.rc:4834
 msgid "Copy All to Middle"
 msgstr "Kopijuoti viską į vidurį"
 
 #. IDS_COPY_RIGHT_TO_LEFT
-#: Merge.rc:4841
+#: Merge.rc:4840
 #, c-format
 msgid "Right to Left (%1)"
 msgstr "Dešinįjį į Kairįjį (%1)"
 
 #. IDS_COPY_RIGHT_TO_MIDDLE
-#: Merge.rc:4842
+#: Merge.rc:4841
 #, c-format
 msgid "Right to Middle (%1)"
 msgstr "Dešinįjį į Vidurinį (%1)"
 
 #. IDS_COPY_MIDDLE_TO_LEFT
-#: Merge.rc:4843
+#: Merge.rc:4842
 #, c-format
 msgid "Middle to Left (%1)"
 msgstr "Vidurinį į Kairįjį (%1 iš %2)"
 
 #. IDS_COPY_MIDDLE_TO_RIGHT
-#: Merge.rc:4844
+#: Merge.rc:4843
 #, c-format
 msgid "Middle to Right (%1)"
 msgstr "Vidurinį į Dešinįjį (%1)"
 
 #. IDS_COPY_LEFT_TO_RIGHT
-#: Merge.rc:4845
+#: Merge.rc:4844
 #, c-format
 msgid "Left to Right (%1)"
 msgstr "Kairįjį į Dešinįjį (%1)"
 
 #. IDS_COPY_LEFT_TO_MIDDLE
-#: Merge.rc:4846
+#: Merge.rc:4845
 #, c-format
 msgid "Left to Middle (%1)"
 msgstr "Kairįjį į Vidurinį (%1)"
 
 #. IDS_MOVE_LEFT_TO
-#: Merge.rc:4857 Merge.rc:4889
+#: Merge.rc:4856 Merge.rc:4888
 #, c-format
 msgid "Left to... (%1)"
 msgstr "Kairįjį į... (%1)"
 
 #. IDS_MOVE_MIDDLE_TO
-#: Merge.rc:4858 Merge.rc:4890
+#: Merge.rc:4857 Merge.rc:4889
 #, c-format
 msgid "Middle to... (%1)"
 msgstr "Vidurinį į... (%1)"
 
 #. IDS_MOVE_RIGHT_TO
-#: Merge.rc:4859 Merge.rc:4891
+#: Merge.rc:4858 Merge.rc:4890
 #, c-format
 msgid "Right to... (%1)"
 msgstr "Dešinįjį į... (%1)"
 
 #. IDS_COPY_BOTH_TO
-#: Merge.rc:4860
+#: Merge.rc:4859
 #, c-format
 msgid "Both to... (%1)"
 msgstr "Abu į... (%1)"
 
 #. IDS_COPY_ALL_TO
-#: Merge.rc:4861
+#: Merge.rc:4860
 #, c-format
 msgid "All to... (%1)"
 msgstr "Viską į... (%1)"
 
 #. IDS_COPY_DIFFERENCES_TO
-#: Merge.rc:4862
+#: Merge.rc:4861
 #, c-format
 msgid "Differences to... (%1)"
 msgstr "Skirtumus į... (%1)"
 
 #. IDS_ONLYDIFFITEMS_CONFIRM
-#: Merge.rc:4869
+#: Merge.rc:4868
 msgid "Some selected items are identical or skipped.\nProcess only items with differences?"
 msgstr "Kai kurie pasirinkti elementai yra identiški arba praleisti.\nApdoroti tik besiskiriančius elementus?"
 
 #. IDS_DEL_LEFT_FMT
-#: Merge.rc:4875
+#: Merge.rc:4874
 #, c-format
 msgid "Left (%1)"
 msgstr "Kairėje (%1)"
 
 #. IDS_DEL_MIDDLE_FMT
-#: Merge.rc:4876
+#: Merge.rc:4875
 #, c-format
 msgid "Middle (%1)"
 msgstr "Viduryje (%1)"
 
 #. IDS_DEL_RIGHT_FMT
-#: Merge.rc:4877
+#: Merge.rc:4876
 #, c-format
 msgid "Right (%1)"
 msgstr "Dešinėje (%1)"
 
 #. IDS_DEL_BOTH_FMT
-#: Merge.rc:4878
+#: Merge.rc:4877
 #, c-format
 msgid "Both (%1)"
 msgstr "Abu (%1)"
 
 #. IDS_DEL_ALL_FMT
-#: Merge.rc:4879
+#: Merge.rc:4878
 #, c-format
 msgid "All (%1)"
 msgstr "Visi (%1)"
 
 #. IDS_SELECT_DEST_LEFT
-#: Merge.rc:4895
+#: Merge.rc:4894
 msgid "Left Side - Select Destination Folder:"
 msgstr "Kairioji pusė - nurodykit rezultatų katalogą:"
 
 #. IDS_SELECT_DEST_MIDDLE
-#: Merge.rc:4896
+#: Merge.rc:4895
 msgid "Middle Side - Select Destination Folder:"
 msgstr "Vidurys - nurodykit rezultatų katalogą:"
 
 #. IDS_SELECT_DEST_RIGHT
-#: Merge.rc:4897
+#: Merge.rc:4896
 msgid "Right Side - Select Destination Folder:"
 msgstr "Dešinioji pusė - nurodykit rezultatų katalogą:"
 
 #. IDS_FILES_AFFECTED_FMT
-#: Merge.rc:4898
+#: Merge.rc:4897
 #, c-format
 msgid "(%1 Files Affected)"
 msgstr "(Paveikta %1 failų)"
 
 #. IDS_FILES_AFFECTED_FMT2
-#: Merge.rc:4899
+#: Merge.rc:4898
 #, c-format
 msgid "(%1 of %2 Files Affected)"
 msgstr "(Paveikta %1 iš %2 failų)"
 
 #. IDS_CONFIRM_DELETE_SINGLE
-#: Merge.rc:4905
+#: Merge.rc:4904
 #, c-format
 msgid "Are you sure you want to delete\n\n%1 ?"
 msgstr "Ar tikrai norite ištrinti\n\n%1 ?"
 
 #. IDS_CONFIRM_SINGLE_COPY
-#: Merge.rc:4906
+#: Merge.rc:4905
 msgid "Are you sure you want to copy?"
 msgstr "Ar tikrai norite nukopijuoti?"
 
 #. IDS_CONFIRM_MULTIPLE_COPY
-#: Merge.rc:4907
+#: Merge.rc:4906
 #, c-format
 msgid "Are you sure you want to copy %d items?"
 msgstr "Ar tikrai norite nukopijuoti %d elementus?"
 
 #. IDS_DIRCMP_NOTSYNC
-#: Merge.rc:4908
+#: Merge.rc:4907
 #, c-format
 msgid "Operation aborted!\n\nFolder contents changed, path\n%1\nnot found.\n\nRefresh the compare."
 msgstr "Operacija nutraukta!\n\nPasikeitė katalogų turinys, kelias\n%1\nnerastas.\n\nAtnaujinkite palyginimą."
 
 #. IDS_CONFIRM_SINGLE_MOVE
-#: Merge.rc:4913
+#: Merge.rc:4912
 msgid "Are you sure you want to move?"
 msgstr "Ar tikrai norite perkelti?"
 
 #. IDS_CONFIRM_MULTIPLE_MOVE
-#: Merge.rc:4914
+#: Merge.rc:4913
 #, c-format
 msgid "Are you sure you want to move %d items?"
 msgstr "Ar tikrai norite perkelti %d elementus?"
 
 #. IDS_CONFIRM_MOVE_CAPTION
-#: Merge.rc:4916
+#: Merge.rc:4915
 msgid "Confirm Move"
 msgstr "Patvirtinti perkėlimą"
 
-#: Merge.rc:4918
+#: Merge.rc:4917
 msgid "Close the folder comparison window?"
 msgstr "Užverti katalogų lyginimo langą?"
 
-#: Merge.rc:4920
+#: Merge.rc:4919
 msgid "Close the folder comparison window, which took a long time?"
 msgstr "Užverti katalogų lyginimo langą, kurio suformavimas užtruko nemažai laiko?"
 
 #. IDS_ERROR_INVALID_DIR_FILE_NAME
-#: Merge.rc:4921
+#: Merge.rc:4920
 msgid "The file or folder name is invalid."
 msgstr "Netinkamas failo ar katalogo pavadinimas."
 
 #. IDS_ERROR_EXECUTE_FILE
-#: Merge.rc:4927
+#: Merge.rc:4926
 #, c-format
 msgid "Failed to execute external editor: %1"
 msgstr "Nepavyko paleisti išorinio redaktoriaus: %1"
 
 #. IDS_UNKNOWN_ARCHIVE_FORMAT
-#: Merge.rc:4933
+#: Merge.rc:4932
 msgid "Unknown archive format"
 msgstr "Nežinomo formato archyvas"
 
-#: Merge.rc:4935
+#: Merge.rc:4934
 msgid "Failed to extract archive.\nCompare as text file?"
 msgstr "Nepavyko išskleisti archyvo.\nLyginti kaip tekstinį failą?"
 
 #. IDS_COLHDR_FILENAME
-#: Merge.rc:4941
+#: Merge.rc:4940
 msgid "Filename"
 msgstr "Failas"
 
 #. IDS_COLHDR_DIR
-#: Merge.rc:4942
+#: Merge.rc:4941
 msgctxt "DirView|ColumnHeader"
 msgid "Folder"
 msgstr "Katalogas"
 
 #. IDS_COLHDR_RESULT
-#: Merge.rc:4943
+#: Merge.rc:4942
 msgid "Comparison Result"
 msgstr "Lyginimo rezultatas"
 
 #. IDS_COLHDR_LTIMEM
-#: Merge.rc:4944
+#: Merge.rc:4943
 msgid "Left Date"
 msgstr "Kairiojo data"
 
 #. IDS_COLHDR_RTIMEM
-#: Merge.rc:4945
+#: Merge.rc:4944
 msgid "Right Date"
 msgstr "Dešiniojo data"
 
 #. IDS_COLHDR_MTIMEM
-#: Merge.rc:4946
+#: Merge.rc:4945
 msgid "Middle Date"
 msgstr "Vidurinio data"
 
 #. IDS_COLHDR_LSIZE
-#: Merge.rc:4948
+#: Merge.rc:4947
 msgid "Left Size"
 msgstr "Kairiojo dydis"
 
 #. IDS_COLHDR_RSIZE
-#: Merge.rc:4949
+#: Merge.rc:4948
 msgid "Right Size"
 msgstr "Dešiniojo dydis"
 
 #. IDS_COLHDR_MSIZE
-#: Merge.rc:4954
+#: Merge.rc:4953
 msgid "Middle Size"
 msgstr "Vidurinio dydis"
 
 #. IDS_COLHDR_RSIZE_SHORT
-#: Merge.rc:4955
+#: Merge.rc:4954
 msgid "Right Size (Short)"
 msgstr "Dešiniojo dydis (trumpas)"
 
 #. IDS_COLHDR_LSIZE_SHORT
-#: Merge.rc:4956
+#: Merge.rc:4955
 msgid "Left Size (Short)"
 msgstr "Kairiojo dydis (trumpas)"
 
 #. IDS_COLHDR_MSIZE_SHORT
-#: Merge.rc:4957
+#: Merge.rc:4956
 msgid "Middle Size (Short)"
 msgstr "Vidurinio dydis (trumpas)"
 
 #. IDS_COLHDR_LTIMEC
-#: Merge.rc:4963
+#: Merge.rc:4962
 msgid "Left Creation Time"
 msgstr "Kairiojo sukūrimo laikas"
 
 #. IDS_COLHDR_RTIMEC
-#: Merge.rc:4964
+#: Merge.rc:4963
 msgid "Right Creation Time"
 msgstr "Dešiniojo sukūrimo laikas"
 
 #. IDS_COLHDR_MTIMEC
-#: Merge.rc:4965
+#: Merge.rc:4964
 msgid "Middle Creation Time"
 msgstr "Vidurinio sukūrimo laikas"
 
 #. IDS_COLHDR_NEWER
-#: Merge.rc:4966
+#: Merge.rc:4965
 msgid "Newer File"
 msgstr "Naujesnis failas"
 
 #. IDS_COLHDR_LVERSION
-#: Merge.rc:4967
+#: Merge.rc:4966
 msgid "Left File Version"
 msgstr "Kairiojo failo versija"
 
 #. IDS_COLHDR_RVERSION
-#: Merge.rc:4968
+#: Merge.rc:4967
 msgid "Right File Version"
 msgstr "Dešiniojo failo versija"
 
 #. IDS_COLHDR_MVERSION
-#: Merge.rc:4969
+#: Merge.rc:4968
 msgid "Middle File Version"
 msgstr "Vidurinio failo versija"
 
 #. IDS_COLHDR_RESULT_ABBR
-#: Merge.rc:4970
+#: Merge.rc:4969
 msgid "Short Result"
 msgstr "Trumpas rezultatas"
 
 #. IDS_COLHDR_LATTRIBUTES
-#: Merge.rc:4971
+#: Merge.rc:4970
 msgid "Left Attributes"
 msgstr "Kairiojo atributai"
 
 #. IDS_COLHDR_RATTRIBUTES
-#: Merge.rc:4972
+#: Merge.rc:4971
 msgid "Right Attributes"
 msgstr "Dešiniojo atributai"
 
 #. IDS_COLHDR_MATTRIBUTES
-#: Merge.rc:4973
+#: Merge.rc:4972
 msgid "Middle Attributes"
 msgstr "Vidurinio atributai"
 
 #. IDS_COLHDR_LEOL_TYPE
-#: Merge.rc:4978
+#: Merge.rc:4977
 msgid "Left EOL"
 msgstr "Kairiojo EPF"
 
 #. IDS_COLHDR_MEOL_TYPE
-#: Merge.rc:4979
+#: Merge.rc:4978
 msgid "Middle EOL"
 msgstr "Viduriniojo EPF"
 
 #. IDS_COLHDR_REOL_TYPE
-#: Merge.rc:4980
+#: Merge.rc:4979
 msgid "Right EOL"
 msgstr "Dešiniojo EPF"
 
 #. IDS_COLHDR_LENCODING
-#: Merge.rc:4986
+#: Merge.rc:4985
 msgid "Left Encoding"
 msgstr "Kairiojo koduotė"
 
 #. IDS_COLHDR_RENCODING
-#: Merge.rc:4987
+#: Merge.rc:4986
 msgid "Right Encoding"
 msgstr "Dešiniojo koduotė"
 
 #. IDS_COLHDR_MENCODING
-#: Merge.rc:4988
+#: Merge.rc:4987
 msgid "Middle Encoding"
 msgstr "Vidurinio koduotė"
 
 #. IDS_COLHDR_NIDIFFS
-#: Merge.rc:4989
+#: Merge.rc:4988
 msgid "Ignored Diff"
 msgstr "Ignoruoti skirtumai"
 
 #. IDS_COLHDR_BINARY
-#: Merge.rc:4991
+#: Merge.rc:4990
 msgctxt "DirView|ColumnHeader"
 msgid "Binary"
 msgstr "Binarinis"
 
 #. IDS_PLUGINS_TYPE_UNPACKER
-#: Merge.rc:4992 Merge.rc:5314
+#: Merge.rc:4991 Merge.rc:5313
 msgid "Unpacker"
 msgstr "Išpakuotojas"
 
 #. IDS_PLUGIN_TYPE4
-#: Merge.rc:4993 Merge.rc:5315 Merge.rc:5622
+#: Merge.rc:4992 Merge.rc:5314 Merge.rc:5621
 msgid "Prediffer"
 msgstr "Parengėjas"
 
 #. IDS_COLHDR_LEFT
-#: Merge.rc:4994
+#: Merge.rc:4993
 msgid "Left"
 msgstr "Kairėje"
 
 #. IDS_COLHDR_MIDDLE
-#: Merge.rc:4995
+#: Merge.rc:4994
 msgid "Middle"
 msgstr "Viduryje"
 
 #. IDS_COLHDR_RIGHT
-#: Merge.rc:4996
+#: Merge.rc:4995
 msgid "Right"
 msgstr "Dešinėje"
 
 #. IDS_COLHDR_DIFF
-#: Merge.rc:4997
+#: Merge.rc:4996
 msgid "Diff"
 msgstr "Skirtumai"
 
 #. IDS_COLHDR_LEFT_DUPLICATE
-#: Merge.rc:4998
+#: Merge.rc:4997
 msgid "Left Duplicate Count"
 msgstr "Dublikatų kiekis kairėje"
 
 #. IDS_COLHDR_RIGHT_DUPLICATE
-#: Merge.rc:4999
+#: Merge.rc:4998
 msgid "Right Duplicate Count"
 msgstr "Dublikatų kiekis dešinėje"
 
 #. IDS_COLHDR_MIDDLE_DUPLICATE
-#: Merge.rc:5000
+#: Merge.rc:4999
 msgid "Middle Duplicate Count"
 msgstr "Dublikatų kiekis viduryje"
 
 #. IDS_COLHDR_MOVE
-#: Merge.rc:5001
+#: Merge.rc:5000
 msgid "Move"
 msgstr "Perkelti"
 
 #. IDS_PRPCAT_AUDIO
-#: Merge.rc:5008
+#: Merge.rc:5007
 msgid "Audio"
 msgstr "Audio"
 
 #. IDS_PRPCAT_CALENDAR
-#: Merge.rc:5009
+#: Merge.rc:5008
 msgid "Calendar"
 msgstr "Kalendorius"
 
 #. IDS_PRPCAT_COMMUNICATION
-#: Merge.rc:5010
+#: Merge.rc:5009
 msgid "Communication"
 msgstr "Komunikavimas"
 
 #. IDS_PRPCAT_CONTACT
-#: Merge.rc:5011
+#: Merge.rc:5010
 msgid "Contact"
 msgstr "Kontaktas"
 
 #. IDS_PRPCAT_DEVICES
-#: Merge.rc:5012
+#: Merge.rc:5011
 msgid "Devices"
 msgstr "Įrenginiai"
 
 #. IDS_PRPCAT_DOCUMENT
-#: Merge.rc:5013
+#: Merge.rc:5012
 msgid "Document"
 msgstr "Dokumentas"
 
 #. IDS_PRPCAT_HOME
-#: Merge.rc:5014
+#: Merge.rc:5013
 msgid "Home"
 msgstr "Namas"
 
 #. IDS_PRPCAT_JOURNAL
-#: Merge.rc:5016
+#: Merge.rc:5015
 msgid "Journal"
 msgstr "Žurnalas"
 
 #. IDS_PRPCAT_LINK
-#: Merge.rc:5017
+#: Merge.rc:5016
 msgid "Link"
 msgstr "Nuoroda"
 
 #. IDS_PRPCAT_MEDIA
-#: Merge.rc:5018
+#: Merge.rc:5017
 msgid "Media"
 msgstr "Media"
 
 #. IDS_PRPCAT_MUSIC
-#: Merge.rc:5020
+#: Merge.rc:5019
 msgid "Music"
 msgstr "Muzika"
 
 #. IDS_PRPCAT_NOTE
-#: Merge.rc:5021
+#: Merge.rc:5020
 msgid "Note"
 msgstr "Pastaba"
 
 #. IDS_PRPCAT_PHOTO
-#: Merge.rc:5022
+#: Merge.rc:5021
 msgid "Photo"
 msgstr "Fotografija"
 
 #. IDS_PRPCAT_RECORDEDTV
-#: Merge.rc:5023
+#: Merge.rc:5022
 msgid "RecordedTV"
 msgstr "TV įrašas"
 
 #. IDS_PRPCAT_SEARCH
-#: Merge.rc:5024
+#: Merge.rc:5023
 msgid "Search"
 msgstr "Paieška"
 
 #. IDS_PRPCAT_SECURITY
-#: Merge.rc:5025
+#: Merge.rc:5024
 msgid "Security"
 msgstr "Saugumas"
 
 #. IDS_PRPCAT_SOFTWARE
-#: Merge.rc:5026
+#: Merge.rc:5025
 msgid "Software"
 msgstr "Programinė įranga"
 
 #. IDS_PRPCAT_TASK
-#: Merge.rc:5027
+#: Merge.rc:5026
 msgid "Task"
 msgstr "Užduotis"
 
 #. IDS_PRPCAT_VIDEO
-#: Merge.rc:5028
+#: Merge.rc:5027
 msgid "Video"
 msgstr "Video"
 
 #. IDS_PRPCAT_HASH
-#: Merge.rc:5029
+#: Merge.rc:5028
 msgid "Hash"
 msgstr "Maiša"
 
 #. IDS_CANT_COMPARE_FILES
-#: Merge.rc:5035
+#: Merge.rc:5034
 msgid "Unable to compare files"
 msgstr "Neįmanoma palyginti failų"
 
 #. IDS_ABORTED_ITEM
-#: Merge.rc:5036
+#: Merge.rc:5035
 msgid "Item aborted"
 msgstr "Elementų praleista"
 
 #. IDS_FILE_SKIPPED
-#: Merge.rc:5037
+#: Merge.rc:5036
 msgid "File skipped"
 msgstr "Praleistas failas"
 
 #. IDS_DIR_SKIPPED
-#: Merge.rc:5038
+#: Merge.rc:5037
 msgid "Folder skipped"
 msgstr "Praleistas katalogas"
 
 #. IDS_LEFT_ONLY_IN_FMT
-#: Merge.rc:5039
+#: Merge.rc:5038
 #, c-format
 msgid "Left only: %1"
 msgstr "Yra tik kairėje: %1"
 
 #. IDS_MIDDLE_ONLY_IN_FMT
-#: Merge.rc:5040
+#: Merge.rc:5039
 #, c-format
 msgid "Middle only: %1"
 msgstr "Yra tik viduryje: %1"
 
 #. IDS_RIGHT_ONLY_IN_FMT
-#: Merge.rc:5041
+#: Merge.rc:5040
 #, c-format
 msgid "Right only: %1"
 msgstr "Yra tik dešinėje: %1"
 
 #. IDS_DOES_NOT_EXIST_IN_FMT
-#: Merge.rc:5042
+#: Merge.rc:5041
 #, c-format
 msgid "Does not exist in %1"
 msgstr "Nėra %1"
 
 #. IDS_BIN_FILES_SAME
-#: Merge.rc:5043
+#: Merge.rc:5042
 msgid "Binary files are identical"
 msgstr "Binariniai failai vienodi"
 
 #. IDS_BIN_FILES_DIFF
-#: Merge.rc:5049
+#: Merge.rc:5048
 msgid "Binary files are different"
 msgstr "Binariniai failai skiriasi"
 
 #. IDS_FILES_ARE_DIFFERENT
-#: Merge.rc:5050
+#: Merge.rc:5049
 msgid "Files are different"
 msgstr "Failai skiriasi"
 
 #. IDS_FOLDERS_ARE_DIFFERENT
-#: Merge.rc:5051
+#: Merge.rc:5050
 msgid "Folders are different"
 msgstr "Katalogai skiriasi"
 
 #. IDS_LEFTONLY
-#: Merge.rc:5052
+#: Merge.rc:5051
 msgid "Left Only"
 msgstr "Yra tik kairysis"
 
 #. IDS_RIGHTONLY
-#: Merge.rc:5053
+#: Merge.rc:5052
 msgid "Right Only"
 msgstr "Yra tik dešinysis"
 
 #. IDS_MIDDLEONLY
-#: Merge.rc:5054
+#: Merge.rc:5053
 msgid "Middle Only"
 msgstr "Yra tik vidurinis"
 
 #. IDS_NOITEMLEFT
-#: Merge.rc:5055
+#: Merge.rc:5054
 msgid "No item in left"
 msgstr "Nėra elemento kairėje"
 
 #. IDS_NOITEMRIGHT
-#: Merge.rc:5056
+#: Merge.rc:5055
 msgid "No item in right"
 msgstr "Nėra elemento dešinėje"
 
 #. IDS_NOITEMMIDDLE
-#: Merge.rc:5057
+#: Merge.rc:5056
 msgid "No item in middle"
 msgstr "Nėra elemento viduryje"
 
 #. IDS_CMPRES_ERROR
-#: Merge.rc:5059
+#: Merge.rc:5058
 msgid "Error"
 msgstr "Klaida"
 
 #. IDS_TEXT_FILES_SAME
-#: Merge.rc:5060
+#: Merge.rc:5059
 msgid "Text files are identical"
 msgstr "Tekstiniai failai vienodi"
 
 #. IDS_LEFTONLY_DIFF
-#: Merge.rc:5061
+#: Merge.rc:5060
 msgid " (Middle and right are identical)"
 msgstr " (Vidurinis ir dešinysis yra vienodi)"
 
 #. IDS_MIDDLEONLY_DIFF
-#: Merge.rc:5062
+#: Merge.rc:5061
 msgid " (Left and right are identical)"
 msgstr " (Kairysis ir dešinysis yra vienodi)"
 
 #. IDS_RIGHTONLY_DIFF
-#: Merge.rc:5063
+#: Merge.rc:5062
 msgid " (Left and middle are identical)"
 msgstr " (Kairysis ir vidurinis yra vienodi)"
 
 #. IDS_PATH_MISMATCH
-#: Merge.rc:5064
+#: Merge.rc:5063
 msgid " (paths differ)"
 msgstr " (keliai skiriasi)"
 
 #. IDS_TEXT_FILES_DIFF
-#: Merge.rc:5065
+#: Merge.rc:5064
 msgid "Text files are different"
 msgstr "Tekstiniai failai skiriasi"
 
 #. IDS_IMAGE_FILES_SAME
-#: Merge.rc:5066
+#: Merge.rc:5065
 msgid "Image files are identical"
 msgstr "Paveikslėliai vienodi"
 
 #. IDS_IMAGE_FILES_DIFF
-#: Merge.rc:5067
+#: Merge.rc:5066
 msgid "Image files are different"
 msgstr "Paveikslėliai skiriasi"
 
 #. IDS_EXPR_DIFF
-#: Merge.rc:5068
+#: Merge.rc:5067
 #, c-format
 msgid "Files are different (expr: %1)"
 msgstr "Failai skiriasi (išraiška: %1)"
 
 #. IDS_HASH_GROUP
-#: Merge.rc:5069
+#: Merge.rc:5068
 #, c-format
 msgid "Group%d"
 msgstr "Grupė%d"
 
 #. IDS_RENAME_MOVE_DETECTION_DISALBED
-#: Merge.rc:5070
+#: Merge.rc:5069
 msgctxt "Options dialog|Compare|Folder|Detect renames and moves"
 msgid "Disabled"
 msgstr "Išjungta"
 
 #. IDS_RENAME_MOVE_DETECTION_RENAME
-#: Merge.rc:5071
+#: Merge.rc:5070
 msgid "Detect renames"
 msgstr "Aptikti pervardijimą"
 
 #. IDS_RENAME_MOVE_DETECTION_RENAME_MOVE
-#: Merge.rc:5072
+#: Merge.rc:5071
 msgid "Detect renames and moves"
 msgstr "Aptikti pervardijimą ir perkėlimą"
 
 #. IDS_RENAME_MOVE_MERGE_MODE_RENAME
-#: Merge.rc:5073
+#: Merge.rc:5072
 msgid "Merge renames"
 msgstr "Sulieti pervardijimus"
 
 #. IDS_RENAME_MOVE_MERGE_MODE_RENAME_MOVE
-#: Merge.rc:5074
+#: Merge.rc:5073
 msgid "Merge renames and moves"
 msgstr "Sulieti pervardijimus ir perkėlimus"
 
 #. IDS_RENAMED
-#: Merge.rc:5075
+#: Merge.rc:5074
 msgid "Renamed"
 msgstr "Pervardinta"
 
 #. IDS_RENAMED_MOVED
-#: Merge.rc:5077
+#: Merge.rc:5076
 msgid "Renamed/Moved"
 msgstr "Pervardinta/Perkelta"
 
 #. IDS_RENAMED_MOVED_ITEMS
-#: Merge.rc:5078
+#: Merge.rc:5077
 #, c-format
 msgid "(%1 items)"
 msgstr "(%1 elementai)"
 
 #. IDS_RENAMED_MOVED_RESULT
-#: Merge.rc:5079
+#: Merge.rc:5078
 #, c-format
 msgid "%1 (set %2): "
 msgstr "%1 (nust. %2): "
 
 #. IDS_SWITCH_FLAT_MODE
-#: Merge.rc:5080
+#: Merge.rc:5079
 msgid "Some moved items have been merged.\nIn Tree Mode, these items may appear in positions that do not reflect the actual folder structure, which can be confusing.\nSwitch to Flat Mode?"
 msgstr "Kai kurie perkelti elementai buvo sujungti.\nMedžio režimu šie elementai gali būti rodomi pozicijose, neatspindinčiose tikrosios aplanko struktūros, kas gali kelti painiavą.\nPerjungti į plokščiąjį režimą?"
 
 #. IDS_ELAPSED_TIME
-#: Merge.rc:5086
+#: Merge.rc:5085
 #, c-format
 msgid "Elapsed time: %ld ms"
 msgstr "Praėjęs laikas: %ld ms"
 
 #. IDS_STATUS_SELITEM1
-#: Merge.rc:5087
+#: Merge.rc:5086
 msgid "1 item selected"
 msgstr "pasirinktas 1 elementas"
 
 #. IDS_STATUS_SELITEMS
-#: Merge.rc:5088
+#: Merge.rc:5087
 #, c-format
 msgid "%1 items selected"
 msgstr "pasirinkta %1 elementų"
 
 #. IDS_COLDESC_FILENAME
-#: Merge.rc:5094
+#: Merge.rc:5093
 msgid "Filename or folder name."
 msgstr "Failo arba katalogo vardas."
 
 #. IDS_COLDESC_DIR
-#: Merge.rc:5095
+#: Merge.rc:5094
 msgid "Subfolder name when subfolders are included."
 msgstr "Pakatalogio pavadinimas, jei įtraukiami pakatalogiai."
 
 #. IDS_COLDESC_RESULT
-#: Merge.rc:5096
+#: Merge.rc:5095
 msgid "Comparison result, long form."
 msgstr "Lyginimo rezultatas, išsami forma."
 
 #. IDS_COLDESC_LTIMEM
-#: Merge.rc:5101
+#: Merge.rc:5100
 msgid "Left side modification date."
 msgstr "Kairiosios pusės redagavimo data."
 
 #. IDS_COLDESC_RTIMEM
-#: Merge.rc:5102
+#: Merge.rc:5101
 msgid "Right side modification date."
 msgstr "Dešiniosios pusės redagavimo data."
 
 #. IDS_COLDESC_MTIMEM
-#: Merge.rc:5103
+#: Merge.rc:5102
 msgid "Middle side modification date."
 msgstr "Vidurinės pusės redagavimo data."
 
 #. IDS_COLDESC_EXTENSION
-#: Merge.rc:5104
+#: Merge.rc:5103
 msgid "File's extension."
 msgstr "Failo plėtinys."
 
 #. IDS_COLDESC_LSIZE
-#: Merge.rc:5105
+#: Merge.rc:5104
 msgid "Left file size in bytes."
 msgstr "Kairiojo failo dydis baitais."
 
 #. IDS_COLDESC_RSIZE
-#: Merge.rc:5106
+#: Merge.rc:5105
 msgid "Right file size in bytes."
 msgstr "Dešiniojo failo dydis baitais."
 
 #. IDS_COLDESC_MSIZE
-#: Merge.rc:5107
+#: Merge.rc:5106
 msgid "Middle file size in bytes."
 msgstr "Vidurinio failo dydis baitais."
 
 #. IDS_COLDESC_LSIZE_SHORT
-#: Merge.rc:5108
+#: Merge.rc:5107
 msgid "Left file size abbreviated."
 msgstr "Kairiojo failo dydis sutrumpintas."
 
 #. IDS_COLDESC_RSIZE_SHORT
-#: Merge.rc:5109
+#: Merge.rc:5108
 msgid "Right file size abbreviated."
 msgstr "Dešiniojo failo dydis sutrumpintas."
 
 #. IDS_COLDESC_MSIZE_SHORT
-#: Merge.rc:5110
+#: Merge.rc:5109
 msgid "Middle file size abbreviated."
 msgstr "Vidurinio failo dydis sutrumpintas."
 
 #. IDS_COLDESC_LTIMEC
-#: Merge.rc:5116
+#: Merge.rc:5115
 msgid "Left side creation time."
 msgstr "Kairiosios pusės sukūrimo laikas."
 
 #. IDS_COLDESC_RTIMEC
-#: Merge.rc:5117
+#: Merge.rc:5116
 msgid "Right side creation time."
 msgstr "Dešiniosios pusės sukūrimo laikas."
 
 #. IDS_COLDESC_MTIMEC
-#: Merge.rc:5118
+#: Merge.rc:5117
 msgid "Middle side creation time."
 msgstr "Vidurinės pusės sukūrimo laikas."
 
 #. IDS_COLDESC_NEWER
-#: Merge.rc:5119
+#: Merge.rc:5118
 msgid "Tells which side has newer modification date."
 msgstr "Parodo, kurioje pusėje yra naujesnė modifikavimo data."
 
 #. IDS_COLDESC_LVERSION
-#: Merge.rc:5120
+#: Merge.rc:5119
 msgid "Left side file version, only for some file types."
 msgstr "Kairiojo failo versija, tik kai kuriems failų tipams."
 
 #. IDS_COLDESC_RVERSION
-#: Merge.rc:5121
+#: Merge.rc:5120
 msgid "Right side file version, only for some file types."
 msgstr "Dešiniojo failo versija, tik kai kuriems failų tipams."
 
 #. IDS_COLDESC_MVERSION
-#: Merge.rc:5126
+#: Merge.rc:5125
 msgid "Middle side file version, only for some file types."
 msgstr "Vidurinio failo versija, tik kai kuriems failų tipams."
 
 #. IDS_COLDESC_RESULT_ABBR
-#: Merge.rc:5127
+#: Merge.rc:5126
 msgid "Short comparison result."
 msgstr "Trumpo palyginimo rezultatai."
 
 #. IDS_COLDESC_LATTRIBUTES
-#: Merge.rc:5128
+#: Merge.rc:5127
 msgid "Left side attributes."
 msgstr "Kairiosios pusės atributai."
 
 #. IDS_COLDESC_RATTRIBUTES
-#: Merge.rc:5129
+#: Merge.rc:5128
 msgid "Right side attributes."
 msgstr "Dešiniosios pusės atributai."
 
 #. IDS_COLDESC_MATTRIBUTES
-#: Merge.rc:5130
+#: Merge.rc:5129
 msgid "Middle side attributes."
 msgstr "Vidurinės pusės atributai."
 
 #. IDS_COLDESC_LEOL_TYPE
-#: Merge.rc:5131
+#: Merge.rc:5130
 msgid "Left side file EOL type."
 msgstr "Kairiojo failo eilučių pabaigos formatas."
 
 #. IDS_COLDESC_REOL_TYPE
-#: Merge.rc:5132
+#: Merge.rc:5131
 msgid "Right side file EOL type."
 msgstr "Dešiniojo failo eilučių pabaigos formatas."
 
 #. IDS_COLDESC_MEOL_TYPE
-#: Merge.rc:5133
+#: Merge.rc:5132
 msgid "Middle side file EOL type."
 msgstr "Vidurinio failo eilučių pabaigos formatas."
 
 #. IDS_COLDESC_LENCODING
-#: Merge.rc:5139
+#: Merge.rc:5138
 msgid "Left side encoding."
 msgstr "Kairiosios pusės koduotė."
 
 #. IDS_COLDESC_RENCODING
-#: Merge.rc:5140
+#: Merge.rc:5139
 msgid "Right side encoding."
 msgstr "Dešiniosios pusės koduotė."
 
 #. IDS_COLDESC_MENCODING
-#: Merge.rc:5141
+#: Merge.rc:5140
 msgid "Middle side encoding."
 msgstr "Vidurinės pusės koduotė."
 
 #. IDS_COLDESC_NIDIFFS
-#: Merge.rc:5142
+#: Merge.rc:5141
 msgid "Number of ignored differences in file. Ignored and cannot be merged."
 msgstr "Ignoruotų skirtumų skaičius faile. Šie skirtumai yra „WinMerge“ ignoruoti ir negali būti sulieti."
 
 #. IDS_COLDESC_NSDIFFS
-#: Merge.rc:5143
+#: Merge.rc:5142
 msgid "Number of differences in file (excluding ignored)."
 msgstr "Skirtumų skaičius faile. Šis skaičius neapima ignoruotų skirtumų."
 
 #. IDS_COLDESC_BINARY
-#: Merge.rc:5144
+#: Merge.rc:5143
 msgid "Shows an asterisk (*) if the file is binary."
 msgstr "Rodyti žvaigždutę (*) jei failas yra binarinis."
 
 #. IDS_COLDESC_UNPACKER
-#: Merge.rc:5145
+#: Merge.rc:5144
 msgid "Unpacker plugin name or pipeline."
 msgstr "Išpakuotojo papildinio pavadinimas arba komandų grandinė."
 
 #. IDS_COLDESC_PREDIFFER
-#: Merge.rc:5146
+#: Merge.rc:5145
 msgid "Prediffer plugin name or pipeline."
 msgstr "Parengėjo papildinio pavadinimas arba komandų grandinė."
 
 #. IDS_DIRECTORY_REPORT_TITLE
-#: Merge.rc:5152
+#: Merge.rc:5151
 #, c-format
 msgid "Compare %1 with %2"
 msgstr "Lyginti %1 su %2"
 
 #. IDS_DIRECTORY_REPORT_TITLE3
-#: Merge.rc:5153
+#: Merge.rc:5152
 #, c-format
 msgid "Compare %1 with %2 and %3"
 msgstr "Lyginti %1 su %2 ir %3"
 
 #. IDS_REPORT_COMMALIST
-#: Merge.rc:5154
+#: Merge.rc:5153
 msgid "Comma-separated list"
 msgstr "Kableliais sudalintas sąrašas"
 
 #. IDS_REPORT_TABLIST
-#: Merge.rc:5155
+#: Merge.rc:5154
 msgid "Tab-separated list"
 msgstr "TAB simboliais sudalintas sąrašas"
 
 #. IDS_REPORT_SIMPLEHTML
-#: Merge.rc:5156
+#: Merge.rc:5155
 msgid "Simple HTML"
 msgstr "Paprastas HTML"
 
 #. IDS_REPORT_SIMPLEXML
-#: Merge.rc:5157
+#: Merge.rc:5156
 msgid "Simple XML"
 msgstr "Paprastas XML"
 
-#: Merge.rc:5159
+#: Merge.rc:5158
 msgid "Report file already exists. Overwrite?"
 msgstr "Ataskaitos failas jau yra. Perrašyti?"
 
 #. IDS_REPORT_ERROR
-#: Merge.rc:5164
+#: Merge.rc:5163
 #, c-format
 msgid "Error creating the report:\n%1"
 msgstr "Klaida kuriant ataskaitą:\n%1"
 
 #. IDS_REPORT_SUCCESS
-#: Merge.rc:5165
+#: Merge.rc:5164
 msgid "Report created successfully."
 msgstr "Ataskaita sukurta sėkmingai."
 
 #. IDS_SYNCPOINT_LASTBLOCK
-#: Merge.rc:5171
+#: Merge.rc:5170
 msgid "Cannot add a synchronization point at this line."
 msgstr "Šioje eilutėje negalima pridėti sinchronizavimo taško."
 
 #. IDS_FILE_TO_ITSELF
-#: Merge.rc:5177
+#: Merge.rc:5176
 msgid "Same file is opened in both panes."
 msgstr "Tas pats failas pasirinktas abiejose pusėse."
 
 #. IDS_FILESSAME
-#: Merge.rc:5178
+#: Merge.rc:5177
 msgid "Selected files are identical."
 msgstr "Pasirinkti failai yra vienodi."
 
 #. IDS_FILESSAME_CURCFG
-#: Merge.rc:5179
+#: Merge.rc:5178
 msgid "Selected files are identical (with current settings).\r\nChecking binary identity..."
 msgstr "Pasirinkti failai yra vienodi (su dabartiniais nustatymais).\r\nTikrinamas binarinis tapatumas..."
 
 #. IDS_FILESSAME_BINERROR
-#: Merge.rc:5180
+#: Merge.rc:5179
 msgid "Selected files are identical (with current settings).\r\nBut binary comparison failed."
 msgstr "Pasirinkti failai yra vienodi (su dabartiniais nustatymais).\r\nTačiau binarinis palyginimas nepavyko."
 
 #. IDS_FILESSAME_BINSAME
-#: Merge.rc:5181
+#: Merge.rc:5180
 msgid "Selected files are identical (binary match)."
 msgstr "Pasirinkti failai yra vienodi (taip pat ir binariniame lygmenyje)"
 
 #. IDS_FILESSAME_BINDIFF
-#: Merge.rc:5182
+#: Merge.rc:5181
 msgid "Selected files are identical (with current settings).\r\nBut differ at the binary level."
 msgstr "Pasirinkti failai yra vienodi (su dabartiniais nustatymais).\r\nBet skiriasi binariniame lygmenyje."
 
 #. IDS_FILEERROR
-#: Merge.rc:5183
+#: Merge.rc:5182
 msgid "An error occurred while comparing files."
 msgstr "Lyginant failus įvyko klaida."
 
 #. IDS_TEMP_FILEERROR
-#: Merge.rc:5184
+#: Merge.rc:5183
 msgid "Could not create temporary files. Check your temporary path settings."
 msgstr "Nepavyko sukurti laikinų failų. Patikrinkite laikinųjų kelių nustatymus."
 
 #. IDS_SUGGEST_IGNOREEOL
-#: Merge.rc:5185
+#: Merge.rc:5184
 msgid "Files use different EOL.\n\nTreat all EOL as equivalent?\n\nSet 'Ignore EOL differences (Windows/Unix/Mac)' in Compare section of Options."
 msgstr "Failai naudoja skirtingus eilučių pabaigos tipus.\n\nAr norite, kad į tai nebūtų kreipiamas dėmesys?\n\n„Nuostatų“ (Redaguoti / Nuostatos...) ekrano „Lyginimo“ dalyje įjunkite „Ignoruoti eilučių pabaigos skirtumus (Windows/Unix/Mac)“."
 
 #. IDS_INVALID_DIRECTORY
-#: Merge.rc:5186
+#: Merge.rc:5185
 msgid "Selected folder is invalid."
 msgstr "Pasirinktas katalogas yra netinkamas."
 
 #. IDS_CANNOT_OPEN_BINARYFILE
-#: Merge.rc:5187
+#: Merge.rc:5186
 msgid "Cannot open a binary file in Editor."
 msgstr "Negalima atidaryti binarinio failo redaktoriuje."
 
 #. IDS_CREATE_PAIR_FOLDER
-#: Merge.rc:5188
+#: Merge.rc:5187
 #, c-format
 msgid "Create matching folder:\n%1\non the other side and open?"
 msgstr "Norite sukurti atitinkamą katalogą:\n%1\nkitoje pusėje ir atverti šiuos katalogus?"
 
 #. IDS_CONFIRM_COPY_ALL_DIFFS
-#: Merge.rc:5189
+#: Merge.rc:5188
 msgid "Copy all differences to other file?"
 msgstr "Nukopijuoti visus skirtumus į kitą failą?"
 
 #. IDS_MOVE_TO_NEXTFILE
-#: Merge.rc:5194
+#: Merge.rc:5193
 msgid "Move to next file?"
 msgstr "Pereiti prie kito failo?"
 
 #. IDS_MOVE_TO_PREVFILE
-#: Merge.rc:5195
+#: Merge.rc:5194
 msgid "Move to previous file?"
 msgstr "Pereiti prie praeito failo?"
 
 #. IDS_MOVE_TO_NEXTPAGE
-#: Merge.rc:5196
+#: Merge.rc:5195
 msgid "Move to next page?"
 msgstr "Pereiti prie kito puslapio?"
 
 #. IDS_MOVE_TO_PREVPAGE
-#: Merge.rc:5197
+#: Merge.rc:5196
 msgid "Move to previous page?"
 msgstr "Pereiti prie praeito puslapio?"
 
 #. IDS_MOVE_TO_FIRSTFILE
-#: Merge.rc:5198
+#: Merge.rc:5197
 msgid "Move to first file?"
 msgstr "Pereiti prie pirmo failo?"
 
 #. IDS_MOVE_TO_LASTFILE
-#: Merge.rc:5199
+#: Merge.rc:5198
 msgid "Move to last file?"
 msgstr "Pereiti prie paskutinio failo?"
 
-#: Merge.rc:5206
+#: Merge.rc:5205
 #, c-format
 msgid "Different codepages: left (cp%d), right (cp%d).\nDisplay in codepage (better display) or default Windows codepage (safer merging)?\n(Recommended: default Windows codepage)"
 msgstr "Skiriasi failų koduotės: kairiojo (cp%d), dešiniojo (cp%d).\nKiekvieno failo rodymas savoje koduotėje duos geresnį vaizdą, bet gali būti pavojingas suliejant ar kopijuojant.\nNorite, kad abu failai būtų rodomi numatytoje „Windows“ koduotėje (rekomenduojama)?"
 
-#: Merge.rc:5208
+#: Merge.rc:5207
 msgid "Information lost due to encoding errors: both files"
 msgstr "Informacija prarasta dėl kodavimo klaidų: abu failai"
 
-#: Merge.rc:5210
+#: Merge.rc:5209
 msgid "Information lost due to encoding errors: first file"
 msgstr "Informacija prarasta dėl kodavimo klaidų: pirmasis failas"
 
-#: Merge.rc:5212
+#: Merge.rc:5211
 msgid "Information lost due to encoding errors: second file"
 msgstr "Informacija prarasta dėl kodavimo klaidų: antrasis failas"
 
-#: Merge.rc:5214
+#: Merge.rc:5213
 msgid "Information lost due to encoding errors: third file"
 msgstr "Informacija prarasta dėl kodavimo klaidų: trečiasis failas"
 
 #. IDS_LINEDIFF_NODIFF
-#: Merge.rc:5220
+#: Merge.rc:5219
 msgid "No difference"
 msgstr "Nėra skirtumų"
 
 #. IDS_LINEDIFF_NODIFF_CAPTION
-#: Merge.rc:5221
+#: Merge.rc:5220
 msgid "Line difference"
 msgstr "Skirtumai eilutėje"
 
 #. IDS_NUM_REPLACED
-#: Merge.rc:5227
+#: Merge.rc:5226
 #, c-format
 msgid "Replaced %1 string(s)."
 msgstr "Pakeista %1 eilutė(-ės)."
 
 #. IDS_EDIT_TEXT_NOT_FOUND
-#: Merge.rc:5228
+#: Merge.rc:5227
 #, c-format
 msgid "Cannot find string \"%s\"."
 msgstr "Nerasta eilutė \"%s\"."
 
 #. IDS_MERGE_MODE
-#: Merge.rc:5234
+#: Merge.rc:5233
 msgid "Entering Merge Mode. Press F9 to turn off."
 msgstr "Dabar įeinate į Suliejimo režimą. Paspauskite F9 klavišą, jei norite išjungti."
 
 #. IDS_AUTO_MERGE
-#: Merge.rc:5240
+#: Merge.rc:5239
 #, c-format
 msgid "Automatic merges: %1\nUnresolved conflicts: %2"
 msgstr "Automatiškai sulietų pakeitimų skaičius: %1\nNeišspręstų konfliktų skaičius: %2"
 
 #. IDS_CODEPAGE_MERGED
-#: Merge.rc:5241
+#: Merge.rc:5240
 msgid "Codepage change merged."
 msgstr "Koduotės pasikeitimas buvo sulietas."
 
 #. IDS_CODEPAGE_CONFLICT
-#: Merge.rc:5242
+#: Merge.rc:5241
 msgid "Codepage changes are conflicting."
 msgstr "Koduotės pakeitimai yra prieštaringi."
 
 #. IDS_EOL_MERGED
-#: Merge.rc:5243
+#: Merge.rc:5242
 msgid "EOL change merged."
 msgstr "Eilučių pabaigos formato pasikeitimas buvo sulietas."
 
 #. IDS_EOL_CONFLICT
-#: Merge.rc:5244
+#: Merge.rc:5243
 msgid "EOL changes are conflicting."
 msgstr "Eilučių pabaigos formato pakeitimai yra prieštaringi."
 
 #. IDS_LOCBAR_CAPTION
-#: Merge.rc:5250
+#: Merge.rc:5249
 msgid "Location Pane"
 msgstr "Vietos polangis"
 
 #. IDS_DIFFBAR_CAPTION
-#: Merge.rc:5251
+#: Merge.rc:5250
 msgid "Diff Pane"
 msgstr "Skirtumų polangis"
 
 #. IDS_DIFF_SUCCEEDED
-#: Merge.rc:5258
+#: Merge.rc:5257
 msgid "Patch file written."
 msgstr "Pataisų failas įrašytas."
 
 #. IDS_DIFF_FILEOVERWRITE
-#: Merge.rc:5259
+#: Merge.rc:5258
 msgid "Patch file already exists. Overwrite?"
 msgstr "Pataisų failas jau yra. Perrašyti?"
 
 #. IDS_DIFF_SELECTEDFILES
-#: Merge.rc:5260
+#: Merge.rc:5259
 #, c-format
 msgid "[%1 files selected]"
 msgstr "[pasirinkta %1 failų]"
 
 #. IDS_DIFF_NORMAL
-#: Merge.rc:5261
+#: Merge.rc:5260
 msgid "Normal"
 msgstr "Normalus"
 
 #. IDS_DIFF_CONTEXT
-#: Merge.rc:5262
+#: Merge.rc:5261
 msgid "Context"
 msgstr "Kontekstinis"
 
 #. IDS_DIFF_UNIFIED
-#: Merge.rc:5263
+#: Merge.rc:5262
 msgid "Unified"
 msgstr "Unifikuotas"
 
 #. IDS_FILEWRITE_ERROR
-#: Merge.rc:5265
+#: Merge.rc:5264
 #, c-format
 msgid "Could not write to file %1."
 msgstr "Nepavyko rašymas į failą %1."
 
 #. IDS_PATH_NOT_ABSOLUTE
-#: Merge.rc:5266
+#: Merge.rc:5265
 #, c-format
 msgid "Output path is not absolute: %1"
 msgstr "Rezultato kelias nėra absoliutus kelias: %1"
 
 #. IDS_MUST_SPECIFY_OUTPUT
-#: Merge.rc:5267
+#: Merge.rc:5266
 msgid "Specify an output file."
 msgstr "Nurodykite failą rezultatams."
 
-#: Merge.rc:5269
+#: Merge.rc:5268
 msgid "Cannot create patch from binary files."
 msgstr "Negalima kurti pataisų failo iš binarinių failų."
 
 #. IDS_SAVEFILES_FORPATCH
-#: Merge.rc:5270
+#: Merge.rc:5269
 msgid "Save all files first.\n\nCreating a patch requires no unsaved changes."
 msgstr "Pirmiausia išsaugokite visus failus.\n\nPataisos kūrimui reikia, kad nebūtų neišsaugotų pakeitimų."
 
 #. IDS_FOLDER_NOTEXIST
-#: Merge.rc:5271
+#: Merge.rc:5270
 msgid "Folder does not exist."
 msgstr "Katalogas nerastas."
 
 #. IDS_ARCHIVE_SUCCEEDED
-#: Merge.rc:5277
+#: Merge.rc:5276
 msgid "Archive file written."
 msgstr "Archyvo failas įrašytas."
 
 #. IDS_ARCHIVE_SAVEFILES
-#: Merge.rc:5278
+#: Merge.rc:5277
 msgid "Save all files first.\n\nCreating an archive requires no unsaved changes."
 msgstr "Pirmiausia išsaugokite visus failus.\n\nKuriant archyvą reikia, kad nebūtų neišsaugotų pakeitimų."
 
 #. IDS_NO_ZIP_SUPPORT
-#: Merge.rc:5283
+#: Merge.rc:5282
 msgid "Archive support not enabled.\n7-Zip and/or Merge7z*.dll not found.\nSee manual for archive support."
 msgstr "Archyvų palaikymas nėra įjungtas.\nNerasti 7-Zip ir/arba Merge7z*.dll.\nInformacijos apie archyvų palaikymą ieškokite naudotojo vadove."
 
 #. IDS_OPT_EXPORT_CAPTION
-#: Merge.rc:5284
+#: Merge.rc:5283
 msgid "Select file for export"
 msgstr "Pasirinkite failą eksportui"
 
 #. IDS_OPT_IMPORT_CAPTION
-#: Merge.rc:5285
+#: Merge.rc:5284
 msgid "Select file for import"
 msgstr "Pasirinkite failą importui"
 
 #. IDS_OPT_IMPORT_DONE
-#: Merge.rc:5286
+#: Merge.rc:5285
 msgid "Options imported from file."
 msgstr "Iš failo importuoti parametrai."
 
 #. IDS_OPT_EXPORT_DONE
-#: Merge.rc:5287
+#: Merge.rc:5286
 msgid "Options exported to file."
 msgstr "Į failą eksportuoti parametrai."
 
 #. IDS_OPT_IMPORT_ERR
-#: Merge.rc:5288
+#: Merge.rc:5287
 msgid "Failed to import options from file."
 msgstr "Nepavyko importuoti parametrų iš failo."
 
 #. IDS_OPT_EXPORT_ERR
-#: Merge.rc:5289
+#: Merge.rc:5288
 msgid "Failed to write options to file."
 msgstr "Nepavyko įrašyti parametrų į failą."
 
 #. IDS_CLOSEALL_WINDOWS
-#: Merge.rc:5290
+#: Merge.rc:5289
 msgid "Close multiple compare windows?\n\nContinue?"
 msgstr "Ketinate užverti keletą palyginimo langų.\n\nNorite tęsti?"
 
 #. IDS_EOL_BIN
-#: Merge.rc:5300
+#: Merge.rc:5299
 msgctxt "EOL Type"
 msgid "Binary"
 msgstr "Binarinių"
 
 #. IDS_MARKER_COLOR_FMT
-#: Merge.rc:5305
+#: Merge.rc:5304
 #, c-format
 msgid "Marker Color %d"
 msgstr "Žymeklio spalva %d"
 
 #. IDS_MARKER_NEW_PATTERN
-#: Merge.rc:5306
+#: Merge.rc:5305
 msgid "New Pattern"
 msgstr "Naujas šablonas"
 
 #. IDS_PLUGINSLIST_TYPE
-#: Merge.rc:5312
+#: Merge.rc:5311
 msgid "Type"
 msgstr "Tipas"
 
 #. IDS_PLUGINS_TYPE_EDITSCRIPT
-#: Merge.rc:5316
+#: Merge.rc:5315
 msgid "Editor script"
 msgstr "Redaktoriaus skriptas"
 
 #. ID_SELECTLINEDIFF
-#: Merge.rc:5322
+#: Merge.rc:5321
 msgid "\nDifference in Current Line (F4)"
 msgstr "\nSkirtumas dabartinėje eilutėje (F4)"
 
 #. ID_OPTIONS
-#: Merge.rc:5323
+#: Merge.rc:5322
 msgid "\nOptions"
 msgstr "\nNuostatos"
 
 #. ID_REFRESH
-#: Merge.rc:5324
+#: Merge.rc:5323
 msgid "\nRefresh (F5)"
 msgstr "\nAtnaujinti (F5)"
 
 #. ID_PREVDIFF
-#: Merge.rc:5330
+#: Merge.rc:5329
 msgid "\nPrevious Difference (Alt+Up)"
 msgstr "\nPraeitas skirtumas (Alt+Up)"
 
 #. ID_NEXTDIFF
-#: Merge.rc:5331
+#: Merge.rc:5330
 msgid "\nNext Difference (Alt+Down)"
 msgstr "\nKitas skirtumas (Alt+Down)"
 
 #. ID_PREVCONFLICT
-#: Merge.rc:5332
+#: Merge.rc:5331
 msgid "\nPrevious Conflict (Alt+Shift+Up)"
 msgstr "\nPraeitas konfliktas (Alt+Shift+Up)"
 
 #. ID_NEXTCONFLICT
-#: Merge.rc:5333
+#: Merge.rc:5332
 msgid "\nNext Conflict (Alt+Shift+Down)"
 msgstr "\nKitas konfliktas (Alt+Shift+Down)"
 
 #. ID_FIRSTDIFF
-#: Merge.rc:5338
+#: Merge.rc:5337
 msgid "\nFirst Difference (Alt+Home)"
 msgstr "\nPirmas skirtumas (Alt+Home)"
 
 #. ID_CURDIFF
-#: Merge.rc:5339
+#: Merge.rc:5338
 msgid "\nCurrent Difference (Alt+Enter)"
 msgstr "\nDabartinis skirtumas (Alt+Enter)"
 
 #. ID_LASTDIFF
-#: Merge.rc:5340
+#: Merge.rc:5339
 msgid "\nLast Difference (Alt+End)"
 msgstr "\nPaskutinis skirtumas (Alt+End)"
 
 #. ID_L2R
-#: Merge.rc:5341
+#: Merge.rc:5340
 msgid "\nCopy to Right (Alt+Right)"
 msgstr "\nKopijuoti į dešinę (Alt+Right)"
 
 #. ID_R2L
-#: Merge.rc:5342
+#: Merge.rc:5341
 msgid "\nCopy to Left (Alt+Left)"
 msgstr "\nKopijuoti į kairę (Alt+Left)"
 
 #. ID_L2RNEXT
-#: Merge.rc:5343
+#: Merge.rc:5342
 msgid "\nCopy to Right and Advance (Ctrl+Alt+Right)"
 msgstr "\nKopijuoti į dešinę ir Daugiau (Ctrl+Alt+Right)"
 
 #. ID_R2LNEXT
-#: Merge.rc:5344
+#: Merge.rc:5343
 msgid "\nCopy to Left and Advance (Ctrl+Alt+Left)"
 msgstr "\nKopijuoti į kairę ir Daugiau (Ctrl+Alt+Left)"
 
 #. ID_ALL_RIGHT
-#: Merge.rc:5345
+#: Merge.rc:5344
 msgid "\nCopy All to Right"
 msgstr "\nKopijuoti viską į dešinę"
 
 #. ID_ALL_LEFT
-#: Merge.rc:5346
+#: Merge.rc:5345
 msgid "\nCopy All to Left"
 msgstr "\nKopijuoti viską į kairę"
 
 #. ID_AUTO_MERGE
-#: Merge.rc:5347
+#: Merge.rc:5346
 msgid "\nAuto Merge (Ctrl+Alt+M)"
 msgstr "\nAutomatinis suliejimas (Ctrl+Alt+M)"
 
 #. ID_FIRSTFILE
-#: Merge.rc:5348
+#: Merge.rc:5347
 msgid "\nFirst File"
 msgstr "\nPirmas failas"
 
 #. ID_NEXTFILE
-#: Merge.rc:5349
+#: Merge.rc:5348
 msgid "\nNext File (Ctrl+F8)"
 msgstr "\nKitas failas (Ctrl+F8)"
 
 #. ID_LASTFILE
-#: Merge.rc:5350
+#: Merge.rc:5349
 msgid "\nLast File"
 msgstr "\nPaskutinis failas"
 
 #. ID_PREVFILE
-#: Merge.rc:5351
+#: Merge.rc:5350
 msgid "\nPrevious File (Ctrl+F7)"
 msgstr "\nPraeitas failas (Ctrl+F7)"
 
 #. IDS_UNPACK_AUTO
-#: Merge.rc:5358
+#: Merge.rc:5357
 msgid "Adapted unpacker applied to both files (one needs extension)."
 msgstr "Pritaikytas išpakuotojas taikomas abiems failams (tik vienam reikia plėtinio)."
 
 #. IDS_NO_PREDIFFER
-#: Merge.rc:5359
+#: Merge.rc:5358
 msgid "No Prediffer (Normal)"
 msgstr "Nėra parengėjo (normalu)"
 
 #. IDS_SUGGESTED_PLUGINS
-#: Merge.rc:5360
+#: Merge.rc:5359
 msgid "Suggested Plugins"
 msgstr "Siūlomi papildiniai"
 
 #. IDS_NOT_SUGGESTED_PLUGINS
-#: Merge.rc:5361
+#: Merge.rc:5360
 msgid "All Plugins"
 msgstr "Visi papildiniai"
 
 #. IDS_PRIVATEBUILD_FMT
-#: Merge.rc:5367
+#: Merge.rc:5366
 #, c-format
 msgid "Private Build: %1"
 msgstr "Neoficiali versija: %1"
 
 #. IDS_ALLRIGHTS_RESERVED
-#: Merge.rc:5368
+#: Merge.rc:5367
 msgid " - All rights reserved."
 msgstr " - Visos teisės saugomos."
 
 #. IDS_TITLE_PLUGINS_SETTINGS
-#: Merge.rc:5374
+#: Merge.rc:5373
 msgid "Plugin Settings"
 msgstr "Papildinio nuostatos"
 
 #. IDS_NO_SCT_SCRIPTS
-#: Merge.rc:5376
+#: Merge.rc:5375
 msgid "WSH not found - .sct scripts disabled"
 msgstr "Nerastas WSH - .sct skriptai išjungti"
 
 #. IDS_LOCBAR_GOTOLINE_FMT
-#: Merge.rc:5384
+#: Merge.rc:5383
 #, c-format
 msgid "G&o to Line %1"
 msgstr "E&iti į %1 eilutę"
 
 #. IDS_GOTO_MOVED_LINE
-#: Merge.rc:5390
+#: Merge.rc:5389
 msgid "Go to Moved Line\tCtrl+Shift+G"
 msgstr "Eiti į perkeltą eilutę\tCtrl+Shift+G"
 
 #. IDS_AUTOCOMPLETE_DISABLED
-#: Merge.rc:5396
+#: Merge.rc:5395
 msgctxt "Options dialog|General|Open dialog Auto completion"
 msgid "Disabled"
 msgstr "Išjungta"
 
 #. IDS_AUTOCOMPLETE_FILE_SYS
-#: Merge.rc:5397
+#: Merge.rc:5396
 msgid "From file system"
 msgstr "Iš sistemos"
 
 #. IDS_AUTOCOMPLETE_MRU
-#: Merge.rc:5398
+#: Merge.rc:5397
 msgid "From Most Recently Used list"
 msgstr "Iš dažniausiai naudojamų sąrašo"
 
 #. IDS_COLORSCHEME_PLAIN
-#: Merge.rc:5404
+#: Merge.rc:5403
 msgid "No Highlighting"
 msgstr "Nenaudoti paryškinimo"
 
 #. IDS_COLORSCHEME_PO
-#: Merge.rc:5439
+#: Merge.rc:5438
 msgid "Portable Object"
 msgstr "Portable Object"
 
 #. IDS_COLORSCHEME_RSRC
-#: Merge.rc:5444
+#: Merge.rc:5443
 msgid "Resources"
 msgstr "Resources"
 
 #. IDS_COLORSCHEME_SH
-#: Merge.rc:5448
+#: Merge.rc:5447
 msgid "Shell"
 msgstr "Shell"
 
 #. IDS_CLOSE_LEFT_TABS
-#: Merge.rc:5469
+#: Merge.rc:5468
 msgid "Close &Left Tabs"
 msgstr "Užverti korteles &kairėje"
 
 #. IDS_CLOSE_RIGHT_TABS
-#: Merge.rc:5470
+#: Merge.rc:5469
 msgid "Close R&ight Tabs"
 msgstr "Užverti korteles &dešinėje"
 
 #. IDS_CLOSE_OTHER_TABS
-#: Merge.rc:5471
+#: Merge.rc:5470
 msgid "Close &Other Tabs"
 msgstr "Užverti k&itas korteles"
 
 #. IDS_TABBAR_AUTO_MAXWIDTH
-#: Merge.rc:5472
+#: Merge.rc:5471
 msgid "Enable &Auto Max Width"
 msgstr "Įjungti &Automatinį maks. plotį"
 
 #. IDS_WEBPAGE_MENU
-#: Merge.rc:5482
+#: Merge.rc:5481
 msgid "We&bpage"
 msgstr "Ti&nklapiai"
 
 #. IDS_VIEW_WRAP_TEXT
-#: Merge.rc:5487
+#: Merge.rc:5486
 msgid "W&rap Text"
 msgstr "S&kaidyti tekstą"
 
 #. IDS_NOTINSTALLED
-#: Merge.rc:5492
+#: Merge.rc:5491
 msgid "%1 is not installed."
 msgstr "„%1“ neįdiegtas."
 
 #. IDS_CREATE_FOLDER
-#: Merge.rc:5497
+#: Merge.rc:5496
 #, c-format
 msgid "%1 does not exist. Create it?"
 msgstr "%1 nėra. Norite jį sukurti?"
 
 #. IDS_CREATE_FOLDER_ERROR
-#: Merge.rc:5498
+#: Merge.rc:5497
 msgid "Failed to create folder."
 msgstr "Nepavyko sukurti katalogo."
 
 #. IDC_EXT_EDITOR_PATH
-#: Merge.rc:5503
+#: Merge.rc:5502
 msgid "Parameters:\n$file: Current file path\n$linenum: Current cursor line number"
 msgstr "Parametrai:\n$file: Esamo failo kelio pavadinimas\n$linenum: Esamos žymeklio pozicijos eilutės numeris"
 
 #. IDS_DIFF_ALGORITHM_DEFAULT
-#: Merge.rc:5508
+#: Merge.rc:5507
 msgid "default"
 msgstr "numatytasis"
 
 #. IDS_DIFF_ALGORITHM_MINIMAL
-#: Merge.rc:5509
+#: Merge.rc:5508
 msgid "minimal"
 msgstr "minimalus"
 
 #. IDS_DIFF_ALGORITHM_PATIENCE
-#: Merge.rc:5510
+#: Merge.rc:5509
 msgid "patience"
 msgstr "kantrus"
 
 #. IDS_DIFF_ALGORITHM_HISTOGRAM
-#: Merge.rc:5511
+#: Merge.rc:5510
 msgid "histogram"
 msgstr "histograma"
 
 #. IDS_DIFF_ALGORITHM_NONE
-#: Merge.rc:5512
+#: Merge.rc:5511
 msgid "none"
 msgstr "joks"
 
 #. IDS_RENDERING_MODE_GDI
-#: Merge.rc:5517
+#: Merge.rc:5516
 msgid "GDI"
 msgstr "GDI"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_DEFAULT
-#: Merge.rc:5518
+#: Merge.rc:5517
 msgid "DirectWrite Default"
 msgstr "DirectWrite numatytasis"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_ALIASED
-#: Merge.rc:5519
+#: Merge.rc:5518
 msgid "DirectWrite Aliased"
 msgstr "DirectWrite dantytasis"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_GDI_CLASSIC
-#: Merge.rc:5520
+#: Merge.rc:5519
 msgid "DirectWrite GDI Classic"
 msgstr "DirectWrite GDI klasikinis"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_GDI_NATURAL
-#: Merge.rc:5521
+#: Merge.rc:5520
 msgid "DirectWrite GDI Natural"
 msgstr "DirectWrite GDI naturalus"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_NATURAL
-#: Merge.rc:5522
+#: Merge.rc:5521
 msgid "DirectWrite Natural"
 msgstr "DirectWrite naturalus"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_NATURAL_SYMMETRIC
-#: Merge.rc:5523
+#: Merge.rc:5522
 msgid "DirectWrite Natural Symmetric"
 msgstr "DirectWrite naturalus simetrinis"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_DISABLED
-#: Merge.rc:5528
+#: Merge.rc:5527
 msgctxt "Options dialog|General|Close windows with Esc"
 msgid "Disabled"
 msgstr "Išjungta"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_1
-#: Merge.rc:5529
+#: Merge.rc:5528
 msgid "MDI child window or main window"
 msgstr "MDI antrinį arba pagrindinį langą"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_2
-#: Merge.rc:5530
+#: Merge.rc:5529
 msgid "MDI child window only"
 msgstr "Tik MDI antrinį langą"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_3
-#: Merge.rc:5531
+#: Merge.rc:5530
 msgid "Close main window if only one MDI child window"
 msgstr "Užverti pagrindinį langą, jei yra tik vienas MDI antrinis langas"
 
 #. IDS_DIFF_GROUP
-#: Merge.rc:5536
+#: Merge.rc:5535
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Diff"
 msgstr "Skirtumai"
 
 #. IDS_DIFF_HIGHLIGHT
-#: Merge.rc:5537
+#: Merge.rc:5536
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Highlight"
 msgstr "Paryškinti"
 
 #. IDS_DIFF_BLINK
-#: Merge.rc:5538
+#: Merge.rc:5537
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Blink"
 msgstr "Mirksi"
 
 #. IDS_DIFF_BLOCKSIZE
-#: Merge.rc:5539
+#: Merge.rc:5538
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Block Size"
 msgstr "Bloko dydis"
 
 #. IDS_DIFF_BLOCKALPHA
-#: Merge.rc:5540
+#: Merge.rc:5539
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Block Alpha"
 msgstr "Bloko alfa"
 
 #. IDS_DIFF_CDTHRESHOLD
-#: Merge.rc:5541
+#: Merge.rc:5540
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "CD Threshold"
 msgstr "CD slenkstis"
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION
-#: Merge.rc:5542
+#: Merge.rc:5541
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Ins/Del Detection"
 msgstr "Skirtumų aptikimas"
 
 #. IDS_OVERLAY_MODE_NONE
-#: Merge.rc:5543 Merge.rc:5548
+#: Merge.rc:5542 Merge.rc:5547
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "None"
 msgstr "Nėra"
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION_VERTICAL
-#: Merge.rc:5544
+#: Merge.rc:5543
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Vertical"
 msgstr "Vertikaliai"
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION_HORIZONTAL
-#: Merge.rc:5545
+#: Merge.rc:5544
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Horizontal"
 msgstr "Horizontaliai"
 
 #. IDS_OVERLAY_GROUP
-#: Merge.rc:5546
+#: Merge.rc:5545
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Overlay"
 msgstr "Perdengimas"
 
 #. IDS_OVERLAY_ALPHA
-#: Merge.rc:5547
+#: Merge.rc:5546
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha"
 msgstr "Alfa"
 
 #. IDS_OVERLAY_MODE_XOR
-#: Merge.rc:5549
+#: Merge.rc:5548
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "XOR"
 msgstr "XOR"
 
 #. IDS_OVERLAY_MODE_ALPHA
-#: Merge.rc:5550
+#: Merge.rc:5549
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha Blend"
 msgstr "Alfa sl. suliejimas"
 
 #. IDS_OVERLAY_MODE_ALPHA_ANIMATION
-#: Merge.rc:5551
+#: Merge.rc:5550
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha Animation"
 msgstr "Alfa sl. animacija"
 
 #. IDS_ZOOM
-#: Merge.rc:5552
+#: Merge.rc:5551
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Zoom"
 msgstr "Mastelis"
 
 #. IDS_PAGE
-#: Merge.rc:5553
+#: Merge.rc:5552
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Page:"
 msgstr "Psl.:"
 
 #. IDS_IMGCMP_STATUS_PT_RGBA_FMT
-#: Merge.rc:5554
+#: Merge.rc:5553
 #, c-format
 msgid "Pt: (%d, %d)  RGBA: (%d, %d, %d, %d)  "
 msgstr "Tšk.: (%d, %d)  RGBA: (%d, %d, %d, %d)  "
 
 #. IDS_IMGCMP_STATUS_DIST1_FMT
-#: Merge.rc:5555
+#: Merge.rc:5554
 #, c-format
 msgid "Dist: %g  "
 msgstr "Dist: %g  "
 
 #. IDS_IMGCMP_STATUS_DIST2_FMT
-#: Merge.rc:5556
+#: Merge.rc:5555
 #, c-format
 msgid "Dist: %g, %g  "
 msgstr "Dist: %g, %g  "
 
 #. IDS_IMGCMP_STATUS_PAGE_ZOOM_SIZE_BPP_FMT
-#: Merge.rc:5557
+#: Merge.rc:5556
 #, c-format
 msgid "Page: %d/%d  Zoom: %d%%  %dx%dpx  %dbpp  "
 msgstr "Psl.: %d/%d  Mastelis: %d%%  %dx%dpx  %dbpp  "
 
 #. IDS_IMGCMP_STATUS_RC_FMT
-#: Merge.rc:5558
+#: Merge.rc:5557
 #, c-format
 msgid "Rc: (%d, %d)  "
 msgstr "St.: (%d, %d)  "
 
 #. IDS_IMGCMP_STATUS_FLIPPED_FMT
-#: Merge.rc:5559
+#: Merge.rc:5558
 #, c-format
 msgid "Flipped: %s  "
 msgstr "Apversta: %s  "
 
 #. IDS_IMGCMP_STATUS_ROTATED_FMT
-#: Merge.rc:5560
+#: Merge.rc:5559
 #, c-format
 msgid "Rotated: %d  "
 msgstr "Pasukta: %d  "
 
 #. IDS_IMGCMP_REPORT_ALLPAGES
-#: Merge.rc:5561
+#: Merge.rc:5560
 msgid "All pages"
 msgstr "Visi psl."
 
 #. IDS_IGNSUB_STR1
-#: Merge.rc:5566
+#: Merge.rc:5565
 msgid "<Edit here>"
 msgstr "<Redaguoti čia>"
 
 #. IDS_IGNSUB_STR2
-#: Merge.rc:5567
+#: Merge.rc:5566
 msgid "No differences found to select"
 msgstr "Nerasta skirtumų, kuriuos būtų galima pasirinkti"
 
 #. IDS_IGNSUB_STR3
-#: Merge.rc:5568
+#: Merge.rc:5567
 msgid "No differences found to add as substitution filter"
 msgstr "Nerasta skirtumų, kuriuos būtų galima pridėti kaip keitinio filtrą"
 
 #. IDS_IGNSUB_STR4
-#: Merge.rc:5569
+#: Merge.rc:5568
 msgid "The pair is already in the Substitution Filters list"
 msgstr "Pora jau yra Keitinių filtrų sąraše"
 
 #. IDS_IGNSUB_STR5
-#: Merge.rc:5570
+#: Merge.rc:5569
 msgid "Add this change to Substitution Filters?"
 msgstr "Įtraukti šį skirtumą į Keitinių filtrus?"
 
 #. IDS_OCRRESULT_TEXTONLY
-#: Merge.rc:5575
+#: Merge.rc:5574
 msgid "Text only"
 msgstr "Tik tekstas"
 
 #. IDS_OCRRESULT_POS_LINE
-#: Merge.rc:5576
+#: Merge.rc:5575
 msgid "Line-by-line position and text"
 msgstr "Paeilutinė pozicija ir tekstas"
 
 #. IDS_OCRRESULT_POS_WORD
-#: Merge.rc:5577
+#: Merge.rc:5576
 msgid "Word-by-word position and text"
 msgstr "Pažodinė pozicija ir tekstas"
 
 #. IDS_USERDATAFOLDER_APPDATA
-#: Merge.rc:5582
+#: Merge.rc:5581
 msgid "AppData (Roaming) folder"
 msgstr "„AppData“ (Roaming) kataloge"
 
 #. IDS_USERDATAFOLDER_INSTALL
-#: Merge.rc:5583
+#: Merge.rc:5582
 msgid "Install folder"
 msgstr "Diegimo kataloge"
 
 #. IDS_USERDATAFOLDER_DOCUMENTS
-#: Merge.rc:5584
+#: Merge.rc:5583
 msgid "Documents folder"
 msgstr "„Documents“ kataloge"
 
 #. IDS_SINGLEINSTANCE_DISABLED
-#: Merge.rc:5589
+#: Merge.rc:5588
 msgctxt "Options dialog|General|Single instance mode"
 msgid "Disabled"
 msgstr "Išjungta"
 
 #. IDS_SINGLEINSTANCE_STR1
-#: Merge.rc:5590
+#: Merge.rc:5589
 msgid "Allow only one instance to run"
 msgstr "Leisti vykdyti tik vieną egzempliorių"
 
 #. IDS_CLIPBOARD_HISTORY
-#: Merge.rc:5591
+#: Merge.rc:5590
 msgid "Clipboard &History"
 msgstr "Mainų srities &istorija"
 
 #. IDS_SINGLEINSTANCE_STR2
-#: Merge.rc:5592
+#: Merge.rc:5591
 msgid "Allow only one instance; wait for termination"
 msgstr "Leisti vykdyti tik vieną egzempliorių ir laukti kol jo vykdymas baigsis"
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_DISABLED
-#: Merge.rc:5597
+#: Merge.rc:5596
 msgctxt "Options dialog|General|Auto-reload modified files"
 msgid "Disabled"
 msgstr "Išjungta"
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_STR1
-#: Merge.rc:5598
+#: Merge.rc:5597
 msgid "Only on window activated"
 msgstr "Tik suaktyvinus langą"
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_STR2
-#: Merge.rc:5599
+#: Merge.rc:5598
 msgid "Immediately"
 msgstr "Nedelsiant"
 
 #. IDS_PLUGIN_ALL
-#: Merge.rc:5604
+#: Merge.rc:5603
 msgid "Al&l"
 msgstr "Visi"
 
 #. IDS_PLUGIN_OTHERS
-#: Merge.rc:5605
+#: Merge.rc:5604
 msgid "&Others"
 msgstr "Kita"
 
-#: Merge.rc:5607
+#: Merge.rc:5606
 #, c-format
 msgid "Missing plugin name in pipeline: %1"
 msgstr "Trūksta papildinio pavadinimo komandų grandinėje: %1"
 
-#: Merge.rc:5609
+#: Merge.rc:5608
 #, c-format
 msgid "Missing quote in plugin pipeline: %1"
 msgstr "Trūksta kabučių papildinio komandų grandinėje: %1"
 
 #. IDS_PLUGIN_NAME_ALREADY_EXISTS
-#: Merge.rc:5610
+#: Merge.rc:5609
 #, c-format
 msgid "Plugin name '%1' already exists."
 msgstr "Papildinys '%1' vardu jau yra."
 
 #. IDS_PLUGIN_TITLE1
-#: Merge.rc:5611
+#: Merge.rc:5610
 msgid "Specify plugin arguments"
 msgstr "Nurodykite papildinio argumentus"
 
-#: Merge.rc:5613
+#: Merge.rc:5612
 #, c-format
 msgid "Plugin not found or invalid: %1"
 msgstr "Nerastas arba netinkamas papildinys: %1"
 
 #. IDS_PLUGIN_NOT_UNPACK
-#: Merge.rc:5614
+#: Merge.rc:5613
 #, c-format
 msgid "'%1' is not an unpacker plugin"
 msgstr "'%1' nėra išpakuotojas"
 
 #. IDS_PLUGIN_NOT_PREDIFF
-#: Merge.rc:5615
+#: Merge.rc:5614
 #, c-format
 msgid "'%1' is not a prediffer plugin"
 msgstr "'%1' nėra parengėjas"
 
-#: Merge.rc:5617
+#: Merge.rc:5616
 #, c-format
 msgid "Error prediffing '%1' with '%2'. Prediffing disabled."
 msgstr "Parengimo papildiniui '%2' apdorojant failą '%1' įvyko klaida. Parengimas išjungtas."
 
 #. IDS_PLUGIN_CIRCULAR_REFERENCE
-#: Merge.rc:5618
+#: Merge.rc:5617
 #, c-format
 msgid "Circular reference in plugin pipeline: %1"
 msgstr "Ciklinė nuoroda papildinio komandų grandinėje: %1"
 
 #. IDS_PLUGIN_TYPE1
-#: Merge.rc:5619
+#: Merge.rc:5618
 msgid "URL Handler"
 msgstr "URL apdorotojas"
 
 #. IDS_PLUGIN_TYPE2
-#: Merge.rc:5620
+#: Merge.rc:5619
 msgid "File Unpacker"
 msgstr "Failo išpakuotojas"
 
 #. IDS_PLUGIN_TYPE3
-#: Merge.rc:5621
+#: Merge.rc:5620
 msgid "File or Folder Unpacker"
 msgstr "Failo ar Katalogo išpakuotojas"
 
 #. IDS_PLUGIN_TYPE5
-#: Merge.rc:5623
+#: Merge.rc:5622
 msgid "Alias for Unpacker"
 msgstr "Išpakuotojo pseudonimas"
 
 #. IDS_PLUGIN_TYPE6
-#: Merge.rc:5624
+#: Merge.rc:5623
 msgid "Alias for Prediffer"
 msgstr "Parengėjo pseudonimas"
 
 #. IDS_PLUGIN_TYPE7
-#: Merge.rc:5625
+#: Merge.rc:5624
 msgid "Alias for Editor script"
 msgstr "Redaktoriaus skripto pseudonimas"
 
 #. IDS_PLUGIN_ALIAS_DESC
-#: Merge.rc:5626
+#: Merge.rc:5625
 #, c-format
 msgid "Alias for plugin pipeline '%1'"
 msgstr "Papildinio komandų grandinės '%1' pseudonimas"
 
 #. IDS_PLUGIN_NEW_DESC
-#: Merge.rc:5627
+#: Merge.rc:5626
 msgid "New plugin description"
 msgstr "Naujo papildinio aprašas"
 
 #. IDS_PLUGIN_TARGETS_ALL
-#: Merge.rc:5628
+#: Merge.rc:5627
 msgid "All"
 msgstr "Visus"
 
 #. IDS_PLUGIN_TARGETS_1ST
-#: Merge.rc:5629
+#: Merge.rc:5628
 msgid "1st"
 msgstr "1-ą"
 
 #. IDS_PLUGIN_TARGETS_2ND
-#: Merge.rc:5630
+#: Merge.rc:5629
 msgid "2nd"
 msgstr "2-ą"
 
 #. IDS_PLUGIN_TARGETS_3RD
-#: Merge.rc:5631
+#: Merge.rc:5630
 msgid "3rd"
 msgstr "3-ą"
 
 #. IDS_PLUGIN_TARGETS_1ST_2ND
-#: Merge.rc:5632
+#: Merge.rc:5631
 msgid "1st and 2nd"
 msgstr "1-ą ir 2-ą"
 
 #. IDS_PLUGIN_TARGETS_1ST_3RD
-#: Merge.rc:5633
+#: Merge.rc:5632
 msgid "1st and 3rd"
 msgstr "1-ą ir 3-ą"
 
 #. IDS_PLUGIN_TARGETS_2ND_3RD
-#: Merge.rc:5634
+#: Merge.rc:5633
 msgid "2nd and 3rd"
 msgstr "2-ą ir 3-ą"
 
 #. IDS_PLUGIN_CTRL_CLICK
-#: Merge.rc:5635
+#: Merge.rc:5634
 msgid "(Ctrl+Click to add to pipeline)"
 msgstr ""
 
 #. IDS_FILTER_APPLIED
-#: Merge.rc:5640
+#: Merge.rc:5639
 msgid "Filter applied"
 msgstr "Pritaikytas filtras"
 
 #. IDS_FILTERMENU_COMPARE
-#: Merge.rc:5645
+#: Merge.rc:5644
 #, c-format
 msgid "Compare %1"
 msgstr "Palyginti %1"
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN2
-#: Merge.rc:5647
+#: Merge.rc:5646
 msgid "&Filter by This Column..."
 msgstr "&Filtruoti pagal šį stulpelį..."
 
 #. IDS_CLIPBOARDHISTORY_TIME
-#: Merge.rc:5652
+#: Merge.rc:5651
 #, c-format
 msgid "Clipboard at %s"
 msgstr "Mainų sritis %s"
 
 #. IDS_CLIPBOARDHISTORY_DISABLED
-#: Merge.rc:5653
+#: Merge.rc:5652
 msgid "Clipboard history disabled.\r\nEnable: Windows logo key + V, then Turn on."
 msgstr "Mainų srities istorijos funkcionalumas išjungtas.\r\nNorėdami įjungti, paspauskite Win+V klavišus ir tada „Įjungti“ mygtuką."
 
-#: Merge.rc:5655
+#: Merge.rc:5654
 msgid "This system does not support clipboard history."
 msgstr "Ši sistema nepalaiko mainų srities istorijos."
 
-#: Merge.rc:5657
+#: Merge.rc:5656
 msgid "32-bit WinMerge does not support Clipboard Compare"
 msgstr "32 bitų „WinMerge“ versija nepalaiko lyginimo mainų srityje"
 
 #. IDS_WEBVIEW2_RUNTIME_NOT_INSTALLED
-#: Merge.rc:5662
+#: Merge.rc:5661
 msgid "WebView2 runtime not installed. Download it?"
 msgstr "„WebView2“ vykdymo aplinka neįdiegta. Norite ją parsisiųsti?"
 
 #. IDS_JUMPLIST_NEW_TEXT_COMPARE
-#: Merge.rc:5667
+#: Merge.rc:5666
 msgid "New Text Compare"
 msgstr "Naujas teksto palyginimas"
 
 #. IDS_JUMPLIST_NEW_TABLE_COMPARE
-#: Merge.rc:5668
+#: Merge.rc:5667
 msgid "New Table Compare"
 msgstr "Naujas lentelių palyginimas"
 
 #. IDS_JUMPLIST_NEW_BINARY_COMPARE
-#: Merge.rc:5669
+#: Merge.rc:5668
 msgid "New Binary Compare"
 msgstr "Naujas binarinių failų palyginimas"
 
 #. IDS_JUMPLIST_NEW_IMAGE_COMPARE
-#: Merge.rc:5670
+#: Merge.rc:5669
 msgid "New Image Compare"
 msgstr "Naujas vaizdų palyginimas"
 
 #. IDS_JUMPLIST_NEW_WEBPAGE_COMPARE
-#: Merge.rc:5671
+#: Merge.rc:5670
 msgid "New Webpage Compare"
 msgstr "Naujas tinklapių palyginimas"
 
 #. IDS_JUMPLIST_NEW_FOLDER_COMPARE
-#: Merge.rc:5672
+#: Merge.rc:5671
 msgid "New Folder Compare"
 msgstr "Naujas katalogų oalyginimas"
 
 #. IDS_JUMPLIST_CLIPBOARD_COMPARE
-#: Merge.rc:5673
+#: Merge.rc:5672
 msgid "Clipboard Compare"
 msgstr "Mainų srities palyginimas"
 
 #. IDS_PREVIEWBAR_PRINT
-#: Merge.rc:5678
+#: Merge.rc:5677
 msgid "&Print..."
 msgstr "S&pausdinti..."
 
 #. IDS_PREVIEWBAR_PREVPAGE
-#: Merge.rc:5680
+#: Merge.rc:5679
 msgid "Pre&v Page"
 msgstr "P&raeitas psl."
 
 #. IDS_PREVIEWBAR_TWOPAGE
-#: Merge.rc:5681
+#: Merge.rc:5680
 msgid "&Two Page"
 msgstr "&2 psl."
 
 #. IDS_PREVIEWBAR_ONEPAGE
-#: Merge.rc:5682
+#: Merge.rc:5681
 msgid "&One Page"
 msgstr "&1 psl."
 
 #. IDS_PREVIEWBAR_ZOOMIN
-#: Merge.rc:5683
+#: Merge.rc:5682
 msgid "Zoom &In"
 msgstr "Did&inti"
 
 #. IDS_PREVIEWBAR_ZOOMOUT
-#: Merge.rc:5684
+#: Merge.rc:5683
 msgid "Zoom &Out"
 msgstr "Mažin&ti"
 
 #. IDS_WEBPAGE_COMPARING
-#: Merge.rc:5690
+#: Merge.rc:5689
 msgid "Comparing..."
 msgstr "Lygina..."
 
 #. IDS_WEBPAGE_ZOOM
-#: Merge.rc:5691
+#: Merge.rc:5690
 msgid "Zoom:"
 msgstr "Mastelis:"
 
 #. IDS_COPY_GRANULARITY_DIFFHUNK
-#: Merge.rc:5696
+#: Merge.rc:5695
 msgid "Diff hunk"
 msgstr "Skirt. bloke"
 
 #. IDS_COPY_GRANULARITY_INLINE
-#: Merge.rc:5697
+#: Merge.rc:5696
 msgid "Inline diff"
 msgstr "Skirt. eilutėje"
 
 #. IDS_COPY_GRANULARITY_LINE
-#: Merge.rc:5698
+#: Merge.rc:5697
 msgid "Line"
 msgstr "Eilutė"
 
-#: Merge.rc:5699
+#: Merge.rc:5698
 msgid "Character"
 msgstr "Simbolis"
 
 #. ID_MICE_PREVDIFF
-#: Merge.rc:5704
+#: Merge.rc:5703
 msgid "\nPrevious Difference (Alt+Up)\n(Right Button+Wheel Up)\n(Alt+Wheel Up)"
 msgstr "\nPraeitas skirtumas (Alt+Up)\n(Right Button+Wheel Up)\n(Alt+Wheel Up)"
 
 #. ID_MICE_NEXTDIFF
-#: Merge.rc:5705
+#: Merge.rc:5704
 msgid "\nNext Difference (Alt+Down)\n(Right Button+Wheel Down)\n(Alt+Wheel Down)"
 msgstr "\nKitas skirtumas (Alt+Down)\n(Right Button+Wheel Down)\n(Alt+Wheel Down)"
 
 #. ID_MICE_L2R
-#: Merge.rc:5706
+#: Merge.rc:5705
 msgid "\nCopy to Right (Alt+Right)\n(Right Button+Wheel Right)\n(Alt+Wheel Right)\n(Alt+Shift+Wheel Down)"
 msgstr "\nKopijuoti į dešinę (Alt+Right)\n(Right Button+Wheel Right)\n(Alt+Wheel Right)\n(Alt+Shift+Wheel Down)"
 
 #. ID_MICE_R2L
-#: Merge.rc:5707
+#: Merge.rc:5706
 msgid "\nCopy to Left (Alt+Left)\n(Right Button+Wheel Left)\n(Alt+Wheel Left)\n(Alt+Shift+Wheel Up)"
 msgstr "\nKopijuoti į kairę (Alt+Left)\n(Right Button+Wheel Left)\n(Alt+Wheel Left)\n(Alt+Shift+Wheel Up)"
 
 #. ID_MICE_L2RNEXT
-#: Merge.rc:5708
+#: Merge.rc:5707
 msgid "\nCopy to Right and Advance (Ctrl+Alt+Right)\n(Ctrl+Alt+Wheel Right)\n(Ctrl+Alt+Shift+Wheel Down)"
 msgstr "\nKopijuoti į dešinę ir Daugiau (Ctrl+Alt+Right)\n(Ctrl+Alt+Wheel Right)\n(Ctrl+Alt+Shift+Wheel Down)"
 
 #. ID_MICE_R2LNEXT
-#: Merge.rc:5709
+#: Merge.rc:5708
 msgid "\nCopy to Left and Advance (Ctrl+Alt+Left)\n(Ctrl+Alt+Wheel Left)\n(Ctrl+Alt+Shift+Wheel Up)"
 msgstr "\nKopijuoti į kairę ir Daugiau (Ctrl+Alt+Left)\n(Ctrl+Alt+Wheel Left)\n(Ctrl+Alt+Shift+Wheel Up)"
 
 #. IDS_LOG_COMPARING_2
-#: Merge.rc:5719
+#: Merge.rc:5718
 #, c-format
 msgid "Comparing %1 with %2"
 msgstr "Lyginama %1 su %2"
 
 #. IDS_LOG_COMPARING_3
-#: Merge.rc:5720
+#: Merge.rc:5719
 #, c-format
 msgid "Comparing %1 with %2 and %3"
 msgstr "Lyginama %1 su %2 ir %3"
 
 #. IDS_LOG_COMPARE_COMPLETED
-#: Merge.rc:5721
+#: Merge.rc:5720
 msgid "Comparison completed"
 msgstr "Palyginimas baigtas"
 
 #. IDS_LOG_COMPARE_ERROR_2
-#: Merge.rc:5722
+#: Merge.rc:5721
 #, c-format
 msgid "Failed to compare %1 with %2: "
 msgstr "Nepavyko %1 ir %2 palyginimas: "
 
 #. IDS_LOG_COMPARE_ERROR_3
-#: Merge.rc:5723
+#: Merge.rc:5722
 #, c-format
 msgid "Failed to compare %1 with %2 and %3: "
 msgstr "Nepavyko %1, %2 ir %3 palyginimas: "
 
 #. IDS_LOG_FILE_SAVED
-#: Merge.rc:5724
+#: Merge.rc:5723
 msgid "File saved"
 msgstr "Failas išsaugotas"
 
 #. IDS_LOG_COPYING_FILES
-#: Merge.rc:5725
+#: Merge.rc:5724
 msgid "Copying files..."
 msgstr "Failų kopijavimas..."
 
 #. IDS_LOG_MOVING_FILES
-#: Merge.rc:5726
+#: Merge.rc:5725
 msgid "Moving files..."
 msgstr "Failų perkėlimas..."
 
 #. IDS_LOG_DELETING_FILES
-#: Merge.rc:5727
+#: Merge.rc:5726
 msgid "Deleting files..."
 msgstr "Failų trynimas..."
 
 #. IDS_LOG_RECYCLEBIN
-#: Merge.rc:5728
+#: Merge.rc:5727
 msgid "Recycle Bin"
 msgstr "Šiukšliadėžė"
 
 #. IDS_LOG_PERMANENTLY_DELETED
-#: Merge.rc:5729
+#: Merge.rc:5728
 msgid "Permanently deleted"
 msgstr "Ištrinta visam laikui"
 
 #. IDS_LOG_FILEOPERATION_COMPLETED
-#: Merge.rc:5730
+#: Merge.rc:5729
 msgid "File operation completed successfully"
 msgstr "Failo operacija baigta sėkmingai"
 
 #. IDS_LOG_FILEOPERATION_CANCELED
-#: Merge.rc:5731
+#: Merge.rc:5730
 msgid "File operation canceled"
 msgstr "Failo operacija atšaukta"
 
 #. IDS_FILTER_ERROR_NO_ERROR
-#: Merge.rc:5736
+#: Merge.rc:5735
 msgid "No error"
 msgstr "Klaidų nėra"
 
 #. IDS_FILTER_ERROR_EMPTY_EXPRESSION
-#: Merge.rc:5737
+#: Merge.rc:5736
 msgid "Filter expression is empty"
 msgstr "Filtro išraiška tuščia"
 
 #. IDS_FILTER_ERROR_UNKNOWN_CHAR
-#: Merge.rc:5738
+#: Merge.rc:5737
 msgid "Unknown character in filter expression"
 msgstr "Nežinomas simbolis filtro išraiškoje"
 
 #. IDS_FILTER_ERROR_UNTERMINATED_STRING
-#: Merge.rc:5739
+#: Merge.rc:5738
 msgid "Unterminated string literal"
 msgstr "Neužbaigta eilutės tiesioginė išraiška"
 
 #. IDS_FILTER_ERROR_SYNTAX_ERROR
-#: Merge.rc:5740
+#: Merge.rc:5739
 msgid "Syntax error in filter expression"
 msgstr "Sintaksės klaida filtro išraiškoje"
 
 #. IDS_FILTER_ERROR_PARSE_FAILURE
-#: Merge.rc:5741
+#: Merge.rc:5740
 msgid "Failed to parse filter expression"
 msgstr "Nepavyko išanalizuoti filtro išraiškos"
 
 #. IDS_FILTER_ERROR_INVALID_LITERAL
-#: Merge.rc:5742
+#: Merge.rc:5741
 msgid "Invalid literal value"
 msgstr "Klaidinga tiesioginės išraiškos reikšmė"
 
 #. IDS_FILTER_ERROR_INVALID_REGULAR_EXPRESSION
-#: Merge.rc:5743
+#: Merge.rc:5742
 msgid "Invalid regular expression"
 msgstr "Klaidinga reguliarioji išraiška"
 
 #. IDS_FILTER_ERROR_UNDEFINED_IDENTIFIER
-#: Merge.rc:5744
+#: Merge.rc:5743
 msgid "Undefined identifier"
 msgstr "Neapibrėžtas identifikatorius"
 
 #. IDS_FILTER_ERROR_INVALID_ARGUMENT_COUNT
-#: Merge.rc:5745
+#: Merge.rc:5744
 msgid "Invalid number of arguments"
 msgstr "Neteisingas argumentų skaičius"
 
 #. IDS_FILTER_ERROR_FILTER_NAME_NOT_FOUND
-#: Merge.rc:5746
+#: Merge.rc:5745
 msgid "Filter name not found"
 msgstr "Filtro pavadinimas nerastas"
 
 #. IDS_FILTER_ERROR_DIVIDE_BY_ZERO
-#: Merge.rc:5747
+#: Merge.rc:5746
 msgid "Division by zero in filter expression"
 msgstr "Dalyba iš nulio filtro išraiškoje"
 
 #. IDS_FILTER_ERROR_UNKNOWN_ERROR
-#: Merge.rc:5748
+#: Merge.rc:5747
 msgid "Unknown error"
 msgstr "Nežinoma klaida"
 
 #. IDS_FILTER_ERROR_INVALID_PROPERTY_NAME
-#: Merge.rc:5749
+#: Merge.rc:5748
 msgid "Invalid property name"
 msgstr "Netinkamas ypatybės pavadinimas"
 
 #. IDS_FILTER_ERROR_INVALID_DIRECTIVE
-#: Merge.rc:5750
+#: Merge.rc:5749
 msgid "Invalid directive"
 msgstr "Netinkama direktyva"
 
 #. IDS_FILTER_OP_EQUALS
-#: Merge.rc:5755
+#: Merge.rc:5754
 msgid "Equals"
 msgstr "Lygu"
 
 #. IDS_FILTER_OP_NOT_EQUALS
-#: Merge.rc:5756
+#: Merge.rc:5755
 msgid "Does not equal"
 msgstr "Nelygu"
 
 #. IDS_FILTER_OP_LESS_THAN
-#: Merge.rc:5757
+#: Merge.rc:5756
 msgid "Less than"
 msgstr "Mažiau nei"
 
 #. IDS_FILTER_OP_LESS_EQUAL
-#: Merge.rc:5758
+#: Merge.rc:5757
 msgid "Less than or equal to"
 msgstr "Mažiau arba lygu"
 
 #. IDS_FILTER_OP_GREATER_EQUAL
-#: Merge.rc:5759
+#: Merge.rc:5758
 msgid "Greater than or equal to"
 msgstr "Daugiau arba lygu"
 
 #. IDS_FILTER_OP_GREATER_THAN
-#: Merge.rc:5760
+#: Merge.rc:5759
 msgid "Greater than"
 msgstr "Daugiau nei"
 
 #. IDS_FILTER_OP_BETWEEN
-#: Merge.rc:5761
+#: Merge.rc:5760
 msgid "Between"
 msgstr "Tarp"
 
 #. IDS_FILTER_OP_NOT_BETWEEN
-#: Merge.rc:5762
+#: Merge.rc:5761
 msgid "Not Between"
 msgstr "Ne tarp"
 
 #. IDS_FILTER_OP_CONTAINS
-#: Merge.rc:5763
+#: Merge.rc:5762
 msgid "Contains"
 msgstr "Turi"
 
 #. IDS_FILTER_OP_NOT_CONTAINS
-#: Merge.rc:5764
+#: Merge.rc:5763
 msgid "Not Contains"
 msgstr "Neturi"
 
 #. IDS_FILTER_OP_RECONTAINS
-#: Merge.rc:5765
+#: Merge.rc:5764
 msgid "Contains (regex)"
 msgstr "Turi (regex)"
 
 #. IDS_FILTER_OP_NOT_RECONTAINS
-#: Merge.rc:5766
+#: Merge.rc:5765
 msgid "Not Contains (regex)"
 msgstr "Neturi (regex)"
 
 #. IDS_FILTER_OP_LIKE
-#: Merge.rc:5767
+#: Merge.rc:5766
 msgid "Match (wildcard)"
 msgstr "Sutampa (wildcard)"
 
 #. IDS_FILTER_OP_NOT_LIKE
-#: Merge.rc:5768
+#: Merge.rc:5767
 msgid "Not match (wildcard)"
 msgstr "Nesutampa (wildcard)"
 
 #. IDS_FILTER_OP_MATCHES
-#: Merge.rc:5769
+#: Merge.rc:5768
 msgid "Match (regex)"
 msgstr "Sutampa (regex)"
 
 #. IDS_FILTER_OP_NOT_MATCHES
-#: Merge.rc:5770
+#: Merge.rc:5769
 msgid "Not match (regex)"
 msgstr "Nesutampa (regex)"
 
 #. IDS_COLORMODE_LIGHT
-#: Merge.rc:5775
+#: Merge.rc:5774
 msgid "Light"
 msgstr "Šviesi schema"
 
 #. IDS_COLORMODE_DARK
-#: Merge.rc:5776
+#: Merge.rc:5775
 msgid "Dark"
 msgstr "Tamsi schema"
 
 #. IDS_COLORMODE_FOLLOWSYSTEM
-#: Merge.rc:5777
+#: Merge.rc:5776
 msgid "Follow system"
 msgstr "Kaip sistemos"
 
 #. IDS_EXAMPLE
-#: Merge.rc:5782
+#: Merge.rc:5781
 #, c-format
 msgid "e.g. %1"
 msgstr "pvz. %1"
 
 #. IDS_DETECTED_PREVIOUS_CRASH
-#: Merge.rc:5787
+#: Merge.rc:5786
 msgid "WinMerge detected a previous crash. Please report this if possible."
 msgstr "„WinMerge“ aptiko, kad buvo gedimas. Jei įmanoma, praneškite apie tai."
 
 #. IDS_REGEX_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5792
+#: Merge.rc:5791
 msgid "# Regex replacement list\r\n# Format: regex<TAB>replacement\r\n# Backreferences like $1, $2 are supported\r\n\r\n(\\d{4})-(\\d{2})-(\\d{2})\t$1_$2_$3\r\n"
 msgstr "# Regex pakeitimų sąrašas\r\n# Formatas: regex<TAB>replacement\r\n# Backreferences like $1, $2 are supported\r\n\r\n(\\d{4})-(\\d{2})-(\\d{2})\t$1_$2_$3\r\n"
 
 #. IDS_STRING_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5793
+#: Merge.rc:5792
 msgid "# Replacement list\r\n# Format: search<TAB>replacement\r\n# Lines starting with # are ignored\r\n\r\nfrom1\tto1\r\nfrom2\tto2\r\n"
 msgstr "# Pakeitimų sąrašas\r\n# Formatas: search<TAB>replacement\r\n# Lines starting with # are ignored\r\n\r\nfrom1\tto1\r\nfrom2\tto2\r\n"
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_ONLY
-#: Merge.rc:5798
+#: Merge.rc:5797
 msgid "Built-in only"
 msgstr "Tik įtaisytasis"
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_FIRST
-#: Merge.rc:5799
+#: Merge.rc:5798
 msgid "Built-in first"
 msgstr "Pirmiausia įtaisytasis"
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_FIRST
-#: Merge.rc:5800
+#: Merge.rc:5799
 msgid "Tree-sitter first"
 msgstr "Pirmiausia „Tree-sitter“"
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_ONLY
-#: Merge.rc:5801
+#: Merge.rc:5800
 msgid "Tree-sitter only"
 msgstr "Tik „Tree-sitter“"
 

--- a/Translations/WinMerge/Norwegian.po
+++ b/Translations/WinMerge/Norwegian.po
@@ -22,7 +22,7 @@ msgstr ""
 "X-Generator: Poedit 3.0.1\n"
 
 #. LANGUAGE, SUBLANGUAGE
-#: Merge.rc:26 Merge.rc:59 Merge.rc:5818
+#: Merge.rc:26 Merge.rc:59 Merge.rc:5817
 msgid "LANG_ENGLISH, SUBLANG_ENGLISH_US"
 msgstr "LANG_NORWEGIAN, SUBLANG_DEFAULT"
 
@@ -164,7 +164,7 @@ msgstr "&Skript"
 #. IDS_NO_EDIT_SCRIPTS
 #: Merge.rc:127 Merge.rc:352 Merge.rc:463 Merge.rc:673 Merge.rc:678
 #: Merge.rc:887 Merge.rc:899 Merge.rc:906 Merge.rc:963 Merge.rc:1210
-#: Merge.rc:5375
+#: Merge.rc:5374
 msgid "< Empty >"
 msgstr "< Tom >"
 
@@ -229,7 +229,7 @@ msgid "Auto-Fit All Columns"
 msgstr ""
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN
-#: Merge.rc:153 Merge.rc:5646
+#: Merge.rc:153 Merge.rc:5645
 msgid "&Filter by This Column"
 msgstr ""
 
@@ -290,7 +290,7 @@ msgid "&Previous Page"
 msgstr "&Forrige side"
 
 #. IDS_PREVIEWBAR_NEXTPAGE
-#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5679
+#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5678
 msgid "&Next Page"
 msgstr "&Neste side"
 
@@ -541,7 +541,7 @@ msgstr "Bin&ær"
 #. IDS_IMAGE_MENU
 #: Merge.rc:329 Merge.rc:338 Merge.rc:432 Merge.rc:441 Merge.rc:609
 #: Merge.rc:618 Merge.rc:670 Merge.rc:960 Merge.rc:1187 Merge.rc:1200
-#: Merge.rc:5477
+#: Merge.rc:5476
 msgid "&Image"
 msgstr "&Bilde"
 
@@ -663,7 +663,7 @@ msgid "&Huge"
 msgstr ""
 
 #. IDS_VIEW_MENU_BAR
-#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5714
+#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5713
 msgid "Men&u Bar"
 msgstr ""
 
@@ -1318,7 +1318,7 @@ msgid "Lo&cation Pane"
 msgstr "L&okaliseringspanel"
 
 #. IDS_OUTPUTBAR_CAPTION
-#: Merge.rc:782 Merge.rc:5252
+#: Merge.rc:782 Merge.rc:5251
 msgid "Output Pane"
 msgstr ""
 
@@ -1581,55 +1581,55 @@ msgid "Co&mpare As"
 msgstr ""
 
 #. IDS_COPY_LEFT_TO_MIDDLE2
-#: Merge.rc:968 Merge.rc:980 Merge.rc:4852
+#: Merge.rc:968 Merge.rc:980 Merge.rc:4851
 #, c-format
 msgid "Left to Middle (%1 of %2)"
 msgstr ""
 
 #. IDS_COPY_LEFT_TO_RIGHT2
-#: Merge.rc:969 Merge.rc:981 Merge.rc:4851
+#: Merge.rc:969 Merge.rc:981 Merge.rc:4850
 #, c-format
 msgid "Left to Right (%1 of %2)"
 msgstr "Venstre til høyre (%1 av %2)"
 
 #. IDS_MOVE_LEFT_TO2
-#: Merge.rc:970 Merge.rc:982 Merge.rc:1045 Merge.rc:4863 Merge.rc:4892
+#: Merge.rc:970 Merge.rc:982 Merge.rc:1045 Merge.rc:4862 Merge.rc:4891
 #, c-format
 msgid "Left to... (%1 of %2)"
 msgstr "Venstre til... (%1 av %2)"
 
 #. IDS_COPY_MIDDLE_TO_LEFT2
-#: Merge.rc:971 Merge.rc:983 Merge.rc:4849
+#: Merge.rc:971 Merge.rc:983 Merge.rc:4848
 #, c-format
 msgid "Middle to Left (%1 of %2)"
 msgstr ""
 
 #. IDS_COPY_MIDDLE_TO_RIGHT2
-#: Merge.rc:972 Merge.rc:984 Merge.rc:4850
+#: Merge.rc:972 Merge.rc:984 Merge.rc:4849
 #, c-format
 msgid "Middle to Right (%1 of %2)"
 msgstr ""
 
 #. IDS_MOVE_MIDDLE_TO2
-#: Merge.rc:973 Merge.rc:985 Merge.rc:1046 Merge.rc:4864 Merge.rc:4893
+#: Merge.rc:973 Merge.rc:985 Merge.rc:1046 Merge.rc:4863 Merge.rc:4892
 #, c-format
 msgid "Middle to... (%1 of %2)"
 msgstr ""
 
 #. IDS_COPY_RIGHT_TO_MIDDLE2
-#: Merge.rc:974 Merge.rc:986 Merge.rc:4848
+#: Merge.rc:974 Merge.rc:986 Merge.rc:4847
 #, c-format
 msgid "Right to Middle (%1 of %2)"
 msgstr ""
 
 #. IDS_COPY_RIGHT_TO_LEFT2
-#: Merge.rc:975 Merge.rc:987 Merge.rc:4847
+#: Merge.rc:975 Merge.rc:987 Merge.rc:4846
 #, c-format
 msgid "Right to Left (%1 of %2)"
 msgstr "Høyre til venstre (%1 av %2)"
 
 #. IDS_MOVE_RIGHT_TO2
-#: Merge.rc:976 Merge.rc:988 Merge.rc:1047 Merge.rc:4865 Merge.rc:4894
+#: Merge.rc:976 Merge.rc:988 Merge.rc:1047 Merge.rc:4864 Merge.rc:4893
 #, c-format
 msgid "Right to... (%1 of %2)"
 msgstr "Høyre til... (%1 av %2)"
@@ -1685,31 +1685,31 @@ msgid "Cop&y Paths"
 msgstr "Kop&ier baner"
 
 #. IDS_DEL_LEFT_FMT2
-#: Merge.rc:1026 Merge.rc:1035 Merge.rc:4880
+#: Merge.rc:1026 Merge.rc:1035 Merge.rc:4879
 #, c-format
 msgid "Left (%1 of %2)"
 msgstr "Venstre (%1 av %2)"
 
 #. IDS_DEL_MIDDLE_FMT2
-#: Merge.rc:1027 Merge.rc:1036 Merge.rc:4881
+#: Merge.rc:1027 Merge.rc:1036 Merge.rc:4880
 #, c-format
 msgid "Middle (%1 of %2)"
 msgstr ""
 
 #. IDS_DEL_RIGHT_FMT2
-#: Merge.rc:1028 Merge.rc:1037 Merge.rc:4882
+#: Merge.rc:1028 Merge.rc:1037 Merge.rc:4881
 #, c-format
 msgid "Right (%1 of %2)"
 msgstr "Høyre (%1 av %2)"
 
 #. IDS_DEL_BOTH_FMT2
-#: Merge.rc:1029 Merge.rc:1038 Merge.rc:4883
+#: Merge.rc:1029 Merge.rc:1038 Merge.rc:4882
 #, c-format
 msgid "Both (%1 of %2)"
 msgstr "Begge (%1 av %2)"
 
 #. IDS_DEL_ALL_FMT2
-#: Merge.rc:1030 Merge.rc:1039 Merge.rc:4888
+#: Merge.rc:1030 Merge.rc:1039 Merge.rc:4887
 #, c-format
 msgid "All (%1 of %2)"
 msgstr ""
@@ -1735,19 +1735,19 @@ msgid "&Zip"
 msgstr "&Zip"
 
 #. IDS_COPY_BOTH_TO2
-#: Merge.rc:1048 Merge.rc:4866
+#: Merge.rc:1048 Merge.rc:4865
 #, c-format
 msgid "Both to... (%1 of %2)"
 msgstr ""
 
 #. IDS_COPY_ALL_TO2
-#: Merge.rc:1049 Merge.rc:4867
+#: Merge.rc:1049 Merge.rc:4866
 #, c-format
 msgid "All to... (%1 of %2)"
 msgstr ""
 
 #. IDS_COPY_DIFFERENCES_TO2
-#: Merge.rc:1050 Merge.rc:4868
+#: Merge.rc:1050 Merge.rc:4867
 #, c-format
 msgid "Differences to... (%1 of %2)"
 msgstr ""
@@ -1814,12 +1814,12 @@ msgstr ""
 
 #. IDS_USERCHOICE_NONE
 #: Merge.rc:1088 Merge.rc:1094 Merge.rc:1836 Merge.rc:1840 Merge.rc:2031
-#: Merge.rc:2035 Merge.rc:5377
+#: Merge.rc:2035 Merge.rc:5376
 msgid "<None>"
 msgstr "<Ingen>"
 
 #. IDS_USERCHOICE_AUTOMATIC
-#: Merge.rc:1089 Merge.rc:1095 Merge.rc:5378
+#: Merge.rc:1089 Merge.rc:1095 Merge.rc:5377
 msgid "<Automatic>"
 msgstr "<Automatisk>"
 
@@ -2749,12 +2749,12 @@ msgid "Text files only"
 msgstr ""
 
 #. IDS_EOL_NONE
-#: Merge.rc:1667 Merge.rc:1918 Merge.rc:5304
+#: Merge.rc:1667 Merge.rc:1918 Merge.rc:5303
 msgid "None"
 msgstr "Ingen"
 
 #. IDS_EOL_MIXED
-#: Merge.rc:1668 Merge.rc:5299
+#: Merge.rc:1668 Merge.rc:5298
 msgid "Mixed"
 msgstr "Blandet"
 
@@ -3026,13 +3026,13 @@ msgstr ""
 
 #. IDS_DIFFERENT
 #: Merge.rc:1904 Merge.rc:1988 Merge.rc:2866 Merge.rc:3036 Merge.rc:3077
-#: Merge.rc:5058
+#: Merge.rc:5057
 msgid "Different"
 msgstr "Forskjellig"
 
 #. IDS_IDENTICAL
 #: Merge.rc:1905 Merge.rc:1989 Merge.rc:2865 Merge.rc:3055 Merge.rc:3116
-#: Merge.rc:5048
+#: Merge.rc:5047
 msgid "Identical"
 msgstr "Identiske"
 
@@ -3052,7 +3052,7 @@ msgid "Missing"
 msgstr ""
 
 #. IDS_MOVED
-#: Merge.rc:1910 Merge.rc:5076
+#: Merge.rc:1910 Merge.rc:5075
 msgid "Moved"
 msgstr ""
 
@@ -3790,7 +3790,7 @@ msgid "&Use custom system colors"
 msgstr ""
 
 #. IDS_PRPCAT_SYSTEM
-#: Merge.rc:2565 Merge.rc:4559 Merge.rc:4560 Merge.rc:5007
+#: Merge.rc:2565 Merge.rc:4559 Merge.rc:4560 Merge.rc:5006
 msgid "System"
 msgstr "System"
 
@@ -4194,7 +4194,7 @@ msgid "Items compared:"
 msgstr "Objekter sammenlignet:"
 
 #. IDS_PREVIEWBAR_CLOSE
-#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5685
+#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5684
 msgid "&Close"
 msgstr "&Lukk"
 
@@ -4816,7 +4816,7 @@ msgid "A&ppend timestamp"
 msgstr "L&egg til tidsstempel"
 
 #. IDS_CONFIRM_COPY_CAPTION
-#: Merge.rc:3214 Merge.rc:4915
+#: Merge.rc:3214 Merge.rc:4914
 msgid "Confirm Copy"
 msgstr "Bekreft kopiering"
 
@@ -5053,7 +5053,7 @@ msgid "&Character Set..."
 msgstr ""
 
 #. IDS_PRPCAT_IMAGE
-#: Merge.rc:3351 Merge.rc:4574 Merge.rc:5015
+#: Merge.rc:3351 Merge.rc:4574 Merge.rc:5014
 msgid "Image"
 msgstr "Bilde"
 
@@ -5449,7 +5449,7 @@ msgid "Project"
 msgstr "Prosjekt"
 
 #. IDS_COLHDR_NSDIFFS
-#: Merge.rc:4566 Merge.rc:4990
+#: Merge.rc:4566 Merge.rc:4989
 msgid "Differences"
 msgstr "Forskjeller"
 
@@ -5599,12 +5599,12 @@ msgid "File Type"
 msgstr ""
 
 #. IDS_COLHDR_EXTENSION
-#: Merge.rc:4653 Merge.rc:4947
+#: Merge.rc:4653 Merge.rc:4946
 msgid "Extension"
 msgstr "Filtype"
 
 #. IDS_PRPCAT_MESSAGE
-#: Merge.rc:4659 Merge.rc:5019
+#: Merge.rc:4659 Merge.rc:5018
 msgid "Message"
 msgstr ""
 
@@ -5644,7 +5644,7 @@ msgid "Hidden Items"
 msgstr ""
 
 #. IDS_PLUGINSLIST_NAME
-#: Merge.rc:4680 Merge.rc:5311
+#: Merge.rc:4680 Merge.rc:5310
 msgid "Name"
 msgstr "Navn"
 
@@ -5664,7 +5664,7 @@ msgid "[F] "
 msgstr "[F] "
 
 #. IDS_PLUGINSLIST_DESC
-#: Merge.rc:4684 Merge.rc:5313
+#: Merge.rc:4684 Merge.rc:5312
 msgid "Description"
 msgstr "Beskrivelse"
 
@@ -5822,155 +5822,150 @@ msgstr ""
 msgid "  Sel: %d | %d"
 msgstr ""
 
-#. IDS_MERGEMODE_MERGING
-#: Merge.rc:4734
-msgid "Merge"
-msgstr "Slå sammen"
-
 #. IDS_DIFF_NUMBER_STATUS_FMT
-#: Merge.rc:4735
+#: Merge.rc:4734
 #, c-format
 msgid "Difference %1 of %2"
 msgstr "Forskjell %1 av %2"
 
 #. IDS_NO_DIFF_SEL_FMT
-#: Merge.rc:4736
+#: Merge.rc:4735
 #, c-format
 msgid "%1 Differences Found"
 msgstr "%1 forskjeller funnet"
 
 #. IDS_1_DIFF_FOUND
-#: Merge.rc:4737
+#: Merge.rc:4736
 msgid "1 Difference Found"
 msgstr "1 forskjell funnet"
 
 #. IDS_NO_ERR_SEL_FMT
-#: Merge.rc:4738
+#: Merge.rc:4737
 #, c-format
 msgid "%1 Errors Found"
 msgstr ""
 
 #. IDS_1_ERR_FOUND
-#: Merge.rc:4739
+#: Merge.rc:4738
 msgid "1 Error Found"
 msgstr ""
 
 #. IDS_STATUSBAR_READONLY, Abbreviation from "Read Only"
-#: Merge.rc:4740
+#: Merge.rc:4739
 msgid "RO"
 msgstr "SB"
 
 #. IDS_DIRVIEW_STATUS_FMT_FOCUS
-#: Merge.rc:4746
+#: Merge.rc:4745
 #, c-format
 msgid "Item %1 of %2"
 msgstr "Objekt %1 av %2"
 
 #. IDS_DIRVIEW_STATUS_FMT_NOFOCUS
-#: Merge.rc:4747
+#: Merge.rc:4746
 #, c-format
 msgid "Items: %1"
 msgstr "Objekter: %1"
 
 #. IDS_DIRVIEW_STATUS_COMPARING
-#: Merge.rc:4748
+#: Merge.rc:4747
 msgid "Comparing items..."
 msgstr "Sammenligner objekter..."
 
 #. IDS_ITEMS_PER_SEC
-#: Merge.rc:4749
+#: Merge.rc:4748
 #, c-format
 msgid "%.1f[items/sec]"
 msgstr ""
 
 #. IDS_ERROR_INCOMPARABLE
-#: Merge.rc:4755
+#: Merge.rc:4754
 msgid "Select two existing folders/files to compare."
 msgstr "Velg to eksisterende mapper eller filer for å sammenligne."
 
 #. IDS_DIRSEL_TAG
-#: Merge.rc:4756
+#: Merge.rc:4755
 msgid "Folder Selection"
 msgstr "Mappe-valg"
 
 #. IDS_OPEN_FILESDIRS
-#: Merge.rc:4757
+#: Merge.rc:4756
 msgid "Select two (or three) folders/files to compare."
 msgstr ""
 
 #. IDS_OPEN_LEFTINVALID
-#: Merge.rc:4758
+#: Merge.rc:4757
 msgid "Left (1st) path is invalid!"
 msgstr ""
 
 #. IDS_OPEN_MIDDLEINVALID
-#: Merge.rc:4759
+#: Merge.rc:4758
 msgid "Middle (2nd) path is invalid!"
 msgstr ""
 
 #. IDS_OPEN_RIGHTINVALID2
-#: Merge.rc:4760
+#: Merge.rc:4759
 msgid "Right (2nd) path is invalid!"
 msgstr ""
 
 #. IDS_OPEN_RIGHTINVALID3
-#: Merge.rc:4761
+#: Merge.rc:4760
 msgid "Right (3rd) path is invalid!"
 msgstr ""
 
 #. IDS_OPEN_BOTHINVALID
-#: Merge.rc:4762
+#: Merge.rc:4761
 msgid "Both paths are invalid!"
 msgstr "Begge baner er ugyldig!"
 
-#: Merge.rc:4764
+#: Merge.rc:4763
 msgid "Left (1st) and Middle (2nd) paths are invalid!"
 msgstr ""
 
 #. IDS_OPEN_LEFTRIGHTINVALID
-#: Merge.rc:4765
+#: Merge.rc:4764
 msgid "Left (1st) and Right (3rd) paths are invalid!"
 msgstr ""
 
-#: Merge.rc:4767
+#: Merge.rc:4766
 msgid "Middle (2nd) and Right (3rd) paths are invalid!"
 msgstr ""
 
 #. IDS_OPEN_ALLINVALID
-#: Merge.rc:4768
+#: Merge.rc:4767
 msgid "All paths are invalid!"
 msgstr ""
 
 #. IDS_OPEN_UNPACKERDISABLED
-#: Merge.rc:4769
+#: Merge.rc:4768
 msgid "Only enabled for file comparisons"
 msgstr ""
 
 #. IDS_OPEN_MISMATCH
-#: Merge.rc:4770
+#: Merge.rc:4769
 msgid "Cannot compare file and folder!"
 msgstr "Kan ikke sammenligne fil og mappe!"
 
 #. IDS_ERROR_FILE_NOT_FOUND
-#: Merge.rc:4776
+#: Merge.rc:4775
 #, c-format
 msgid "File not found: %1"
 msgstr "Fil ikke funnet: %1"
 
 #. IDS_ERROR_FOLDER_NOT_FOUND
-#: Merge.rc:4777
+#: Merge.rc:4776
 #, c-format
 msgid "Folder not found: %1"
 msgstr ""
 
 #. IDS_ERROR_FILE_NOT_UNPACKED
-#: Merge.rc:4778
+#: Merge.rc:4777
 #, c-format
 msgid "File not unpacked: %1"
 msgstr "Fil ikke pakket ut: %1"
 
 #. IDS_ERROR_FILEOPEN
-#: Merge.rc:4779
+#: Merge.rc:4778
 #, c-format
 msgid ""
 "Cannot open file\n"
@@ -5984,12 +5979,12 @@ msgstr ""
 "%2"
 
 #. IDS_ERROR_CONF_RESOLVE
-#: Merge.rc:4780
+#: Merge.rc:4779
 msgid "Failed to parse conflict file."
 msgstr "Kunne ikke analysere konflikt-fil."
 
 #. IDS_NOT_CONFLICT_FILE
-#: Merge.rc:4781
+#: Merge.rc:4780
 #, c-format
 msgid "The file\n%1\nis not a conflict file."
 msgstr ""
@@ -5998,23 +5993,23 @@ msgstr ""
 "er ikke en konfliktfil."
 
 #. IDS_COMPARE_LARGE_FILES
-#: Merge.rc:4782
+#: Merge.rc:4781
 msgid "Comparing large files requires significant memory.\nShow only comparison results (not file contents)?"
 msgstr ""
 
 #. IDS_SAVE_AS_TITLE
-#: Merge.rc:4788
+#: Merge.rc:4787
 msgid "Save As"
 msgstr "Lagre som"
 
 #. IDS_SAVE_FMT
-#: Merge.rc:4789
+#: Merge.rc:4788
 #, c-format
 msgid "Save changes to %1?"
 msgstr "Lagre endringer til %1?"
 
 #. IDS_SAVEREADONLY_FMT
-#: Merge.rc:4790
+#: Merge.rc:4789
 #, c-format
 msgid "%1 is read-only. Override? Or 'No' to save as new filename?"
 msgstr ""
@@ -6022,11 +6017,11 @@ msgstr ""
 "filen? (Nei for å lagre filen med et annet navn.)"
 
 #. IDS_ERROR_BACKUP
-#: Merge.rc:4791
+#: Merge.rc:4790
 msgid "Error backing up file"
 msgstr "Feil under sikkerhetskopiering av filen"
 
-#: Merge.rc:4793
+#: Merge.rc:4792
 #, c-format
 msgid ""
 "Unable to backup original file:\n"
@@ -6040,7 +6035,7 @@ msgstr ""
 "Fortsette likevel?"
 
 #. IDS_FILESAVE_FAILED
-#: Merge.rc:4794
+#: Merge.rc:4793
 #, c-format
 msgid "Saving file failed.\n%1\n%2\n\t- Use different filename (OK)\n\t- Abort (Cancel)?"
 msgstr ""
@@ -6051,7 +6046,7 @@ msgstr ""
 "\t- bruk et annet filnavn (Klikk OK)\n"
 "\t- avbryt den aktuelle operasjonen (Klikk Avbryt)?"
 
-#: Merge.rc:4796
+#: Merge.rc:4795
 #, c-format
 msgid "Plugin '%2' cannot pack changes to left file into '%1'.\n\nOriginal unchanged. Save unpacked version?"
 msgstr ""
@@ -6062,12 +6057,12 @@ msgstr ""
 "\n"
 "Vil du lagre den utpakkede versjonen til en annen fil?"
 
-#: Merge.rc:4798
+#: Merge.rc:4797
 #, c-format
 msgid "Plugin '%2' cannot pack changes to middle file into '%1'.\n\nOriginal unchanged. Save unpacked version?"
 msgstr ""
 
-#: Merge.rc:4800
+#: Merge.rc:4799
 #, c-format
 msgid "Plugin '%2' cannot pack changes to right file into '%1'.\n\nOriginal unchanged. Save unpacked version?"
 msgstr ""
@@ -6079,7 +6074,7 @@ msgstr ""
 "Vil du lagre den upakkede versjonen fil en annen fil?"
 
 #. IDS_FILECHANGED_ONDISK
-#: Merge.rc:4801
+#: Merge.rc:4800
 #, c-format
 msgid ""
 "Another application updated\n"
@@ -6095,7 +6090,7 @@ msgstr ""
 "Overskrive endret fil?"
 
 #. IDS_SAVEREADONLY_MULTI
-#: Merge.rc:4802
+#: Merge.rc:4801
 #, c-format
 msgid ""
 "%1\n"
@@ -6105,7 +6100,7 @@ msgstr ""
 "er markert skrivebeskyttet. Vil du overskrive det skrivebeskyttede objekt?"
 
 #. IDS_FILECHANGED_RESCAN
-#: Merge.rc:4803
+#: Merge.rc:4802
 #, c-format
 msgid "Another application updated\n%1\nsince last scan.\n\nReload?"
 msgstr ""
@@ -6116,22 +6111,22 @@ msgstr ""
 "Vil du laste inn igjen filen?"
 
 #. IDS_SAVE_LEFT_AS
-#: Merge.rc:4804
+#: Merge.rc:4803
 msgid "Save Left File As"
 msgstr "Lagre venstre fil som"
 
 #. IDS_SAVE_MIDDLE_AS
-#: Merge.rc:4805
+#: Merge.rc:4804
 msgid "Save Middle File As"
 msgstr ""
 
 #. IDS_SAVE_RIGHT_AS
-#: Merge.rc:4806
+#: Merge.rc:4805
 msgid "Save Right File As"
 msgstr "Lagre høyre fil som"
 
 #. IDS_FILE_DISAPPEARED
-#: Merge.rc:4811
+#: Merge.rc:4810
 #, c-format
 msgid ""
 "File\n"
@@ -6143,7 +6138,7 @@ msgstr ""
 "har forsvunnet. Lagre en kopi av filen for å fortsette."
 
 #. IDS_VIEWS_OUTOFSYNC
-#: Merge.rc:4817
+#: Merge.rc:4816
 msgid ""
 "Cannot merge unsynched documents.\n"
 "\n"
@@ -6154,186 +6149,186 @@ msgstr ""
 "Gjenoppfrisk dokumenter før du fortsetter."
 
 #. IDS_BREAK_ON_WHITESPACE
-#: Merge.rc:4822
+#: Merge.rc:4821
 msgid "Break at whitespace"
 msgstr "Bryt ved blanktegn"
 
 #. IDS_BREAK_ON_PUNCTUATION
-#: Merge.rc:4823
+#: Merge.rc:4822
 msgid "Break at whitespace or punctuation"
 msgstr "Bryt ved blanktegn eller tegnsetting"
 
 #. IDS_L2M
-#: Merge.rc:4829
+#: Merge.rc:4828
 msgid "Copy to &Middle\tAlt+Right"
 msgstr "Kopier til &midten\tAlt+Høyre"
 
 #. IDS_R2M
-#: Merge.rc:4830
+#: Merge.rc:4829
 msgid "Copy to &Middle\tAlt+Left"
 msgstr "Kopier til &midten\tAlt+Venstre"
 
 #. IDS_COPY_FROM_MIDDLE_R
-#: Merge.rc:4831
+#: Merge.rc:4830
 msgid "Copy from Middle\tAlt+Shift+Right"
 msgstr "Kopier fra midten\tAlt+Shift+Høyre"
 
 #. IDS_COPY_FROM_MIDDLE_L
-#: Merge.rc:4832
+#: Merge.rc:4831
 msgid "Copy from Middle\tAlt+Shift+Left"
 msgstr "Kopier fra midten\tAlt+Shift+Venstre"
 
 #. IDS_L2MNEXT
-#: Merge.rc:4833
+#: Merge.rc:4832
 msgid "Copy to Middle and Advance\tCtrl+Alt+Right"
 msgstr "Kopier til midten og gå videre\tCtrl+Alt+Høyre"
 
 #. IDS_R2MNEXT
-#: Merge.rc:4834
+#: Merge.rc:4833
 msgid "Copy to Middle and Advance\tCtrl+Alt+Left"
 msgstr "Kopier til midten og gå videre\tCtrl+Alt+Venstre"
 
 #. IDS_ALL_MIDDLE
-#: Merge.rc:4835
+#: Merge.rc:4834
 msgid "Copy All to Middle"
 msgstr "Kopier alt til midten"
 
 #. IDS_COPY_RIGHT_TO_LEFT
-#: Merge.rc:4841
+#: Merge.rc:4840
 #, c-format
 msgid "Right to Left (%1)"
 msgstr "Høyre til venstre (%1)"
 
 #. IDS_COPY_RIGHT_TO_MIDDLE
-#: Merge.rc:4842
+#: Merge.rc:4841
 #, c-format
 msgid "Right to Middle (%1)"
 msgstr ""
 
 #. IDS_COPY_MIDDLE_TO_LEFT
-#: Merge.rc:4843
+#: Merge.rc:4842
 #, c-format
 msgid "Middle to Left (%1)"
 msgstr ""
 
 #. IDS_COPY_MIDDLE_TO_RIGHT
-#: Merge.rc:4844
+#: Merge.rc:4843
 #, c-format
 msgid "Middle to Right (%1)"
 msgstr ""
 
 #. IDS_COPY_LEFT_TO_RIGHT
-#: Merge.rc:4845
+#: Merge.rc:4844
 #, c-format
 msgid "Left to Right (%1)"
 msgstr "Venstre til høyre (%1)"
 
 #. IDS_COPY_LEFT_TO_MIDDLE
-#: Merge.rc:4846
+#: Merge.rc:4845
 #, c-format
 msgid "Left to Middle (%1)"
 msgstr ""
 
 #. IDS_MOVE_LEFT_TO
-#: Merge.rc:4857 Merge.rc:4889
+#: Merge.rc:4856 Merge.rc:4888
 #, c-format
 msgid "Left to... (%1)"
 msgstr "Venstre til... (%1)"
 
 #. IDS_MOVE_MIDDLE_TO
-#: Merge.rc:4858 Merge.rc:4890
+#: Merge.rc:4857 Merge.rc:4889
 #, c-format
 msgid "Middle to... (%1)"
 msgstr ""
 
 #. IDS_MOVE_RIGHT_TO
-#: Merge.rc:4859 Merge.rc:4891
+#: Merge.rc:4858 Merge.rc:4890
 #, c-format
 msgid "Right to... (%1)"
 msgstr "Høyre til... (%1)"
 
 #. IDS_COPY_BOTH_TO
-#: Merge.rc:4860
+#: Merge.rc:4859
 #, c-format
 msgid "Both to... (%1)"
 msgstr ""
 
 #. IDS_COPY_ALL_TO
-#: Merge.rc:4861
+#: Merge.rc:4860
 #, c-format
 msgid "All to... (%1)"
 msgstr ""
 
 #. IDS_COPY_DIFFERENCES_TO
-#: Merge.rc:4862
+#: Merge.rc:4861
 #, c-format
 msgid "Differences to... (%1)"
 msgstr ""
 
 #. IDS_ONLYDIFFITEMS_CONFIRM
-#: Merge.rc:4869
+#: Merge.rc:4868
 msgid "Some selected items are identical or skipped.\nProcess only items with differences?"
 msgstr ""
 
 #. IDS_DEL_LEFT_FMT
-#: Merge.rc:4875
+#: Merge.rc:4874
 #, c-format
 msgid "Left (%1)"
 msgstr "Venstre (%1)"
 
 #. IDS_DEL_MIDDLE_FMT
-#: Merge.rc:4876
+#: Merge.rc:4875
 #, c-format
 msgid "Middle (%1)"
 msgstr ""
 
 #. IDS_DEL_RIGHT_FMT
-#: Merge.rc:4877
+#: Merge.rc:4876
 #, c-format
 msgid "Right (%1)"
 msgstr "Høyre (%1)"
 
 #. IDS_DEL_BOTH_FMT
-#: Merge.rc:4878
+#: Merge.rc:4877
 #, c-format
 msgid "Both (%1)"
 msgstr "Begge (%1)"
 
 #. IDS_DEL_ALL_FMT
-#: Merge.rc:4879
+#: Merge.rc:4878
 #, c-format
 msgid "All (%1)"
 msgstr ""
 
 #. IDS_SELECT_DEST_LEFT
-#: Merge.rc:4895
+#: Merge.rc:4894
 msgid "Left Side - Select Destination Folder:"
 msgstr "Venstre side - velg målmappe:"
 
 #. IDS_SELECT_DEST_MIDDLE
-#: Merge.rc:4896
+#: Merge.rc:4895
 msgid "Middle Side - Select Destination Folder:"
 msgstr ""
 
 #. IDS_SELECT_DEST_RIGHT
-#: Merge.rc:4897
+#: Merge.rc:4896
 msgid "Right Side - Select Destination Folder:"
 msgstr "Høyre side - velg målmappe:"
 
 #. IDS_FILES_AFFECTED_FMT
-#: Merge.rc:4898
+#: Merge.rc:4897
 #, c-format
 msgid "(%1 Files Affected)"
 msgstr "(%1 filer påvirket)"
 
 #. IDS_FILES_AFFECTED_FMT2
-#: Merge.rc:4899
+#: Merge.rc:4898
 #, c-format
 msgid "(%1 of %2 Files Affected)"
 msgstr "(%1 av %2 filer påvirket)"
 
 #. IDS_CONFIRM_DELETE_SINGLE
-#: Merge.rc:4905
+#: Merge.rc:4904
 #, c-format
 msgid ""
 "Are you sure you want to delete\n"
@@ -6345,18 +6340,18 @@ msgstr ""
 "%1 ?"
 
 #. IDS_CONFIRM_SINGLE_COPY
-#: Merge.rc:4906
+#: Merge.rc:4905
 msgid "Are you sure you want to copy?"
 msgstr "Er du sikker på at du vil kopiere?"
 
 #. IDS_CONFIRM_MULTIPLE_COPY
-#: Merge.rc:4907
+#: Merge.rc:4906
 #, c-format
 msgid "Are you sure you want to copy %d items?"
 msgstr "Er du sikker på at du vil kopiere %d objekter?"
 
 #. IDS_DIRCMP_NOTSYNC
-#: Merge.rc:4908
+#: Merge.rc:4907
 #, c-format
 msgid ""
 "Operation aborted!\n"
@@ -6376,794 +6371,794 @@ msgstr ""
 "Gjenoppfrisk sammenligning."
 
 #. IDS_CONFIRM_SINGLE_MOVE
-#: Merge.rc:4913
+#: Merge.rc:4912
 msgid "Are you sure you want to move?"
 msgstr "Er du sikker på at du vil flytte?"
 
 #. IDS_CONFIRM_MULTIPLE_MOVE
-#: Merge.rc:4914
+#: Merge.rc:4913
 #, c-format
 msgid "Are you sure you want to move %d items?"
 msgstr "Er du sikker på at du vil flytte %d objekter?"
 
 #. IDS_CONFIRM_MOVE_CAPTION
-#: Merge.rc:4916
+#: Merge.rc:4915
 msgid "Confirm Move"
 msgstr "Bekreft flytting"
 
-#: Merge.rc:4918
+#: Merge.rc:4917
 msgid "Close the folder comparison window?"
 msgstr ""
 
-#: Merge.rc:4920
+#: Merge.rc:4919
 msgid "Close the folder comparison window, which took a long time?"
 msgstr ""
 
 #. IDS_ERROR_INVALID_DIR_FILE_NAME
-#: Merge.rc:4921
+#: Merge.rc:4920
 msgid "The file or folder name is invalid."
 msgstr ""
 
 #. IDS_ERROR_EXECUTE_FILE
-#: Merge.rc:4927
+#: Merge.rc:4926
 #, c-format
 msgid "Failed to execute external editor: %1"
 msgstr "Feilet i å kjøre eksternt redigeringsprogram: %1"
 
 #. IDS_UNKNOWN_ARCHIVE_FORMAT
-#: Merge.rc:4933
+#: Merge.rc:4932
 msgid "Unknown archive format"
 msgstr "Ukjent arkivformat"
 
-#: Merge.rc:4935
+#: Merge.rc:4934
 msgid "Failed to extract archive.\nCompare as text file?"
 msgstr ""
 
 #. IDS_COLHDR_FILENAME
-#: Merge.rc:4941
+#: Merge.rc:4940
 msgid "Filename"
 msgstr "Filnavn"
 
 #. IDS_COLHDR_DIR
-#: Merge.rc:4942
+#: Merge.rc:4941
 msgctxt "DirView|ColumnHeader"
 msgid "Folder"
 msgstr "Mappe"
 
 #. IDS_COLHDR_RESULT
-#: Merge.rc:4943
+#: Merge.rc:4942
 msgid "Comparison Result"
 msgstr "Resultat av sammenligningen"
 
 #. IDS_COLHDR_LTIMEM
-#: Merge.rc:4944
+#: Merge.rc:4943
 msgid "Left Date"
 msgstr "Venstre dato"
 
 #. IDS_COLHDR_RTIMEM
-#: Merge.rc:4945
+#: Merge.rc:4944
 msgid "Right Date"
 msgstr "Høyre dato"
 
 #. IDS_COLHDR_MTIMEM
-#: Merge.rc:4946
+#: Merge.rc:4945
 msgid "Middle Date"
 msgstr ""
 
 #. IDS_COLHDR_LSIZE
-#: Merge.rc:4948
+#: Merge.rc:4947
 msgid "Left Size"
 msgstr "Venstre størrelse"
 
 #. IDS_COLHDR_RSIZE
-#: Merge.rc:4949
+#: Merge.rc:4948
 msgid "Right Size"
 msgstr "Høyre størrelse"
 
 #. IDS_COLHDR_MSIZE
-#: Merge.rc:4954
+#: Merge.rc:4953
 msgid "Middle Size"
 msgstr ""
 
 #. IDS_COLHDR_RSIZE_SHORT
-#: Merge.rc:4955
+#: Merge.rc:4954
 msgid "Right Size (Short)"
 msgstr "Høyre størrelse (kort)"
 
 #. IDS_COLHDR_LSIZE_SHORT
-#: Merge.rc:4956
+#: Merge.rc:4955
 msgid "Left Size (Short)"
 msgstr "Venstre størrelse (kort)"
 
 #. IDS_COLHDR_MSIZE_SHORT
-#: Merge.rc:4957
+#: Merge.rc:4956
 msgid "Middle Size (Short)"
 msgstr ""
 
 #. IDS_COLHDR_LTIMEC
-#: Merge.rc:4963
+#: Merge.rc:4962
 msgid "Left Creation Time"
 msgstr "Venstre opprettelsestid"
 
 #. IDS_COLHDR_RTIMEC
-#: Merge.rc:4964
+#: Merge.rc:4963
 msgid "Right Creation Time"
 msgstr "Høyre opprettelsestid"
 
 #. IDS_COLHDR_MTIMEC
-#: Merge.rc:4965
+#: Merge.rc:4964
 msgid "Middle Creation Time"
 msgstr ""
 
 #. IDS_COLHDR_NEWER
-#: Merge.rc:4966
+#: Merge.rc:4965
 msgid "Newer File"
 msgstr "Nyere fil"
 
 #. IDS_COLHDR_LVERSION
-#: Merge.rc:4967
+#: Merge.rc:4966
 msgid "Left File Version"
 msgstr "Venstre filversjon"
 
 #. IDS_COLHDR_RVERSION
-#: Merge.rc:4968
+#: Merge.rc:4967
 msgid "Right File Version"
 msgstr "Høyre filversjon"
 
 #. IDS_COLHDR_MVERSION
-#: Merge.rc:4969
+#: Merge.rc:4968
 msgid "Middle File Version"
 msgstr ""
 
 #. IDS_COLHDR_RESULT_ABBR
-#: Merge.rc:4970
+#: Merge.rc:4969
 msgid "Short Result"
 msgstr "Kort resultat"
 
 #. IDS_COLHDR_LATTRIBUTES
-#: Merge.rc:4971
+#: Merge.rc:4970
 msgid "Left Attributes"
 msgstr "Venstre attributter"
 
 #. IDS_COLHDR_RATTRIBUTES
-#: Merge.rc:4972
+#: Merge.rc:4971
 msgid "Right Attributes"
 msgstr "Høyre attributter"
 
 #. IDS_COLHDR_MATTRIBUTES
-#: Merge.rc:4973
+#: Merge.rc:4972
 msgid "Middle Attributes"
 msgstr ""
 
 #. IDS_COLHDR_LEOL_TYPE
-#: Merge.rc:4978
+#: Merge.rc:4977
 msgid "Left EOL"
 msgstr "Venstre EOL"
 
 #. IDS_COLHDR_MEOL_TYPE
-#: Merge.rc:4979
+#: Merge.rc:4978
 msgid "Middle EOL"
 msgstr ""
 
 #. IDS_COLHDR_REOL_TYPE
-#: Merge.rc:4980
+#: Merge.rc:4979
 msgid "Right EOL"
 msgstr "Høyre EOL"
 
 #. IDS_COLHDR_LENCODING
-#: Merge.rc:4986
+#: Merge.rc:4985
 msgid "Left Encoding"
 msgstr "Venstre koding"
 
 #. IDS_COLHDR_RENCODING
-#: Merge.rc:4987
+#: Merge.rc:4986
 msgid "Right Encoding"
 msgstr "Høyre koding"
 
 #. IDS_COLHDR_MENCODING
-#: Merge.rc:4988
+#: Merge.rc:4987
 msgid "Middle Encoding"
 msgstr ""
 
 #. IDS_COLHDR_NIDIFFS
-#: Merge.rc:4989
+#: Merge.rc:4988
 msgid "Ignored Diff"
 msgstr "Ignorerte forskjeller"
 
 #. IDS_COLHDR_BINARY
-#: Merge.rc:4991
+#: Merge.rc:4990
 msgctxt "DirView|ColumnHeader"
 msgid "Binary"
 msgstr "Binær"
 
 #. IDS_PLUGINS_TYPE_UNPACKER
-#: Merge.rc:4992 Merge.rc:5314
+#: Merge.rc:4991 Merge.rc:5313
 msgid "Unpacker"
 msgstr "Utpakker"
 
 #. IDS_PLUGIN_TYPE4
-#: Merge.rc:4993 Merge.rc:5315 Merge.rc:5622
+#: Merge.rc:4992 Merge.rc:5314 Merge.rc:5621
 msgid "Prediffer"
 msgstr "Prediffer"
 
 #. IDS_COLHDR_LEFT
-#: Merge.rc:4994
+#: Merge.rc:4993
 msgid "Left"
 msgstr "Venstre"
 
 #. IDS_COLHDR_MIDDLE
-#: Merge.rc:4995
+#: Merge.rc:4994
 msgid "Middle"
 msgstr "Midten"
 
 #. IDS_COLHDR_RIGHT
-#: Merge.rc:4996
+#: Merge.rc:4995
 msgid "Right"
 msgstr "Høyre"
 
 #. IDS_COLHDR_DIFF
-#: Merge.rc:4997
+#: Merge.rc:4996
 msgid "Diff"
 msgstr ""
 
 #. IDS_COLHDR_LEFT_DUPLICATE
-#: Merge.rc:4998
+#: Merge.rc:4997
 msgid "Left Duplicate Count"
 msgstr ""
 
 #. IDS_COLHDR_RIGHT_DUPLICATE
-#: Merge.rc:4999
+#: Merge.rc:4998
 msgid "Right Duplicate Count"
 msgstr ""
 
 #. IDS_COLHDR_MIDDLE_DUPLICATE
-#: Merge.rc:5000
+#: Merge.rc:4999
 msgid "Middle Duplicate Count"
 msgstr ""
 
 #. IDS_COLHDR_MOVE
-#: Merge.rc:5001
+#: Merge.rc:5000
 msgid "Move"
 msgstr ""
 
 #. IDS_PRPCAT_AUDIO
-#: Merge.rc:5008
+#: Merge.rc:5007
 msgid "Audio"
 msgstr ""
 
 #. IDS_PRPCAT_CALENDAR
-#: Merge.rc:5009
+#: Merge.rc:5008
 msgid "Calendar"
 msgstr ""
 
 #. IDS_PRPCAT_COMMUNICATION
-#: Merge.rc:5010
+#: Merge.rc:5009
 msgid "Communication"
 msgstr ""
 
 #. IDS_PRPCAT_CONTACT
-#: Merge.rc:5011
+#: Merge.rc:5010
 msgid "Contact"
 msgstr ""
 
 #. IDS_PRPCAT_DEVICES
-#: Merge.rc:5012
+#: Merge.rc:5011
 msgid "Devices"
 msgstr ""
 
 #. IDS_PRPCAT_DOCUMENT
-#: Merge.rc:5013
+#: Merge.rc:5012
 msgid "Document"
 msgstr ""
 
 #. IDS_PRPCAT_HOME
-#: Merge.rc:5014
+#: Merge.rc:5013
 msgid "Home"
 msgstr ""
 
 #. IDS_PRPCAT_JOURNAL
-#: Merge.rc:5016
+#: Merge.rc:5015
 msgid "Journal"
 msgstr ""
 
 #. IDS_PRPCAT_LINK
-#: Merge.rc:5017
+#: Merge.rc:5016
 msgid "Link"
 msgstr ""
 
 #. IDS_PRPCAT_MEDIA
-#: Merge.rc:5018
+#: Merge.rc:5017
 msgid "Media"
 msgstr ""
 
 #. IDS_PRPCAT_MUSIC
-#: Merge.rc:5020
+#: Merge.rc:5019
 msgid "Music"
 msgstr ""
 
 #. IDS_PRPCAT_NOTE
-#: Merge.rc:5021
+#: Merge.rc:5020
 msgid "Note"
 msgstr ""
 
 #. IDS_PRPCAT_PHOTO
-#: Merge.rc:5022
+#: Merge.rc:5021
 msgid "Photo"
 msgstr ""
 
 #. IDS_PRPCAT_RECORDEDTV
-#: Merge.rc:5023
+#: Merge.rc:5022
 msgid "RecordedTV"
 msgstr ""
 
 #. IDS_PRPCAT_SEARCH
-#: Merge.rc:5024
+#: Merge.rc:5023
 msgid "Search"
 msgstr ""
 
 #. IDS_PRPCAT_SECURITY
-#: Merge.rc:5025
+#: Merge.rc:5024
 msgid "Security"
 msgstr ""
 
 #. IDS_PRPCAT_SOFTWARE
-#: Merge.rc:5026
+#: Merge.rc:5025
 msgid "Software"
 msgstr ""
 
 #. IDS_PRPCAT_TASK
-#: Merge.rc:5027
+#: Merge.rc:5026
 msgid "Task"
 msgstr ""
 
 #. IDS_PRPCAT_VIDEO
-#: Merge.rc:5028
+#: Merge.rc:5027
 msgid "Video"
 msgstr ""
 
 #. IDS_PRPCAT_HASH
-#: Merge.rc:5029
+#: Merge.rc:5028
 msgid "Hash"
 msgstr ""
 
 #. IDS_CANT_COMPARE_FILES
-#: Merge.rc:5035
+#: Merge.rc:5034
 msgid "Unable to compare files"
 msgstr "Kan ikke sammenligne filer"
 
 #. IDS_ABORTED_ITEM
-#: Merge.rc:5036
+#: Merge.rc:5035
 msgid "Item aborted"
 msgstr "Objekt avbrutt"
 
 #. IDS_FILE_SKIPPED
-#: Merge.rc:5037
+#: Merge.rc:5036
 msgid "File skipped"
 msgstr "Fil hoppet over"
 
 #. IDS_DIR_SKIPPED
-#: Merge.rc:5038
+#: Merge.rc:5037
 msgid "Folder skipped"
 msgstr "Mappe hoppet over"
 
 #. IDS_LEFT_ONLY_IN_FMT
-#: Merge.rc:5039
+#: Merge.rc:5038
 #, c-format
 msgid "Left only: %1"
 msgstr "Bare venstre: %1"
 
 #. IDS_MIDDLE_ONLY_IN_FMT
-#: Merge.rc:5040
+#: Merge.rc:5039
 #, c-format
 msgid "Middle only: %1"
 msgstr ""
 
 #. IDS_RIGHT_ONLY_IN_FMT
-#: Merge.rc:5041
+#: Merge.rc:5040
 #, c-format
 msgid "Right only: %1"
 msgstr "Bare høyre: %1"
 
 #. IDS_DOES_NOT_EXIST_IN_FMT
-#: Merge.rc:5042
+#: Merge.rc:5041
 #, c-format
 msgid "Does not exist in %1"
 msgstr ""
 
 #. IDS_BIN_FILES_SAME
-#: Merge.rc:5043
+#: Merge.rc:5042
 msgid "Binary files are identical"
 msgstr "Binære filer er identiske"
 
 #. IDS_BIN_FILES_DIFF
-#: Merge.rc:5049
+#: Merge.rc:5048
 msgid "Binary files are different"
 msgstr "Binære filer er forskjellige"
 
 #. IDS_FILES_ARE_DIFFERENT
-#: Merge.rc:5050
+#: Merge.rc:5049
 msgid "Files are different"
 msgstr "Filer er forskjellige"
 
 #. IDS_FOLDERS_ARE_DIFFERENT
-#: Merge.rc:5051
+#: Merge.rc:5050
 msgid "Folders are different"
 msgstr "Mapper er forskjellige"
 
 #. IDS_LEFTONLY
-#: Merge.rc:5052
+#: Merge.rc:5051
 msgid "Left Only"
 msgstr "Bare venstre"
 
 #. IDS_RIGHTONLY
-#: Merge.rc:5053
+#: Merge.rc:5052
 msgid "Right Only"
 msgstr "Bare høyre"
 
 #. IDS_MIDDLEONLY
-#: Merge.rc:5054
+#: Merge.rc:5053
 msgid "Middle Only"
 msgstr ""
 
 #. IDS_NOITEMLEFT
-#: Merge.rc:5055
+#: Merge.rc:5054
 msgid "No item in left"
 msgstr ""
 
 #. IDS_NOITEMRIGHT
-#: Merge.rc:5056
+#: Merge.rc:5055
 msgid "No item in right"
 msgstr ""
 
 #. IDS_NOITEMMIDDLE
-#: Merge.rc:5057
+#: Merge.rc:5056
 msgid "No item in middle"
 msgstr ""
 
 #. IDS_CMPRES_ERROR
-#: Merge.rc:5059
+#: Merge.rc:5058
 msgid "Error"
 msgstr "Feil"
 
 #. IDS_TEXT_FILES_SAME
-#: Merge.rc:5060
+#: Merge.rc:5059
 msgid "Text files are identical"
 msgstr "Tekstfiler er identiske"
 
 #. IDS_LEFTONLY_DIFF
-#: Merge.rc:5061
+#: Merge.rc:5060
 msgid " (Middle and right are identical)"
 msgstr ""
 
 #. IDS_MIDDLEONLY_DIFF
-#: Merge.rc:5062
+#: Merge.rc:5061
 msgid " (Left and right are identical)"
 msgstr ""
 
 #. IDS_RIGHTONLY_DIFF
-#: Merge.rc:5063
+#: Merge.rc:5062
 msgid " (Left and middle are identical)"
 msgstr ""
 
 #. IDS_PATH_MISMATCH
-#: Merge.rc:5064
+#: Merge.rc:5063
 msgid " (paths differ)"
 msgstr ""
 
 #. IDS_TEXT_FILES_DIFF
-#: Merge.rc:5065
+#: Merge.rc:5064
 msgid "Text files are different"
 msgstr "Tekstfiler er forskjellige"
 
 #. IDS_IMAGE_FILES_SAME
-#: Merge.rc:5066
+#: Merge.rc:5065
 msgid "Image files are identical"
 msgstr "Bildefiler er identiske"
 
 #. IDS_IMAGE_FILES_DIFF
-#: Merge.rc:5067
+#: Merge.rc:5066
 msgid "Image files are different"
 msgstr "Bildefiler er forskjellige"
 
 #. IDS_EXPR_DIFF
-#: Merge.rc:5068
+#: Merge.rc:5067
 #, c-format
 msgid "Files are different (expr: %1)"
 msgstr ""
 
 #. IDS_HASH_GROUP
-#: Merge.rc:5069
+#: Merge.rc:5068
 #, c-format
 msgid "Group%d"
 msgstr ""
 
 #. IDS_RENAME_MOVE_DETECTION_DISALBED
-#: Merge.rc:5070
+#: Merge.rc:5069
 msgctxt "Options dialog|Compare|Folder|Detect renames and moves"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_RENAME_MOVE_DETECTION_RENAME
-#: Merge.rc:5071
+#: Merge.rc:5070
 msgid "Detect renames"
 msgstr ""
 
 #. IDS_RENAME_MOVE_DETECTION_RENAME_MOVE
-#: Merge.rc:5072
+#: Merge.rc:5071
 msgid "Detect renames and moves"
 msgstr ""
 
 #. IDS_RENAME_MOVE_MERGE_MODE_RENAME
-#: Merge.rc:5073
+#: Merge.rc:5072
 msgid "Merge renames"
 msgstr ""
 
 #. IDS_RENAME_MOVE_MERGE_MODE_RENAME_MOVE
-#: Merge.rc:5074
+#: Merge.rc:5073
 msgid "Merge renames and moves"
 msgstr ""
 
 #. IDS_RENAMED
-#: Merge.rc:5075
+#: Merge.rc:5074
 msgid "Renamed"
 msgstr ""
 
 #. IDS_RENAMED_MOVED
-#: Merge.rc:5077
+#: Merge.rc:5076
 msgid "Renamed/Moved"
 msgstr ""
 
 #. IDS_RENAMED_MOVED_ITEMS
-#: Merge.rc:5078
+#: Merge.rc:5077
 #, c-format
 msgid "(%1 items)"
 msgstr ""
 
 #. IDS_RENAMED_MOVED_RESULT
-#: Merge.rc:5079
+#: Merge.rc:5078
 #, c-format
 msgid "%1 (set %2): "
 msgstr ""
 
 #. IDS_SWITCH_FLAT_MODE
-#: Merge.rc:5080
+#: Merge.rc:5079
 msgid "Some moved items have been merged.\nIn Tree Mode, these items may appear in positions that do not reflect the actual folder structure, which can be confusing.\nSwitch to Flat Mode?"
 msgstr ""
 
 #. IDS_ELAPSED_TIME
-#: Merge.rc:5086
+#: Merge.rc:5085
 #, c-format
 msgid "Elapsed time: %ld ms"
 msgstr "Forløpt tid: %ld ms"
 
 #. IDS_STATUS_SELITEM1
-#: Merge.rc:5087
+#: Merge.rc:5086
 msgid "1 item selected"
 msgstr "1 objekt valgt"
 
 #. IDS_STATUS_SELITEMS
-#: Merge.rc:5088
+#: Merge.rc:5087
 #, c-format
 msgid "%1 items selected"
 msgstr "%1 objekter valgt"
 
 #. IDS_COLDESC_FILENAME
-#: Merge.rc:5094
+#: Merge.rc:5093
 msgid "Filename or folder name."
 msgstr "Fil eller mappe-navn."
 
 #. IDS_COLDESC_DIR
-#: Merge.rc:5095
+#: Merge.rc:5094
 msgid "Subfolder name when subfolders are included."
 msgstr "Undermappenavn når undermapper er inkludert."
 
 #. IDS_COLDESC_RESULT
-#: Merge.rc:5096
+#: Merge.rc:5095
 msgid "Comparison result, long form."
 msgstr "Sammenligningsresultat, lang form."
 
 #. IDS_COLDESC_LTIMEM
-#: Merge.rc:5101
+#: Merge.rc:5100
 msgid "Left side modification date."
 msgstr "Venstre side endringsdato."
 
 #. IDS_COLDESC_RTIMEM
-#: Merge.rc:5102
+#: Merge.rc:5101
 msgid "Right side modification date."
 msgstr "Høyre side endringsdato."
 
 #. IDS_COLDESC_MTIMEM
-#: Merge.rc:5103
+#: Merge.rc:5102
 msgid "Middle side modification date."
 msgstr ""
 
 #. IDS_COLDESC_EXTENSION
-#: Merge.rc:5104
+#: Merge.rc:5103
 msgid "File's extension."
 msgstr "Filtype."
 
 #. IDS_COLDESC_LSIZE
-#: Merge.rc:5105
+#: Merge.rc:5104
 msgid "Left file size in bytes."
 msgstr "Venstre filstørrelse i byte."
 
 #. IDS_COLDESC_RSIZE
-#: Merge.rc:5106
+#: Merge.rc:5105
 msgid "Right file size in bytes."
 msgstr "Høyre filstørrelse i byte."
 
 #. IDS_COLDESC_MSIZE
-#: Merge.rc:5107
+#: Merge.rc:5106
 msgid "Middle file size in bytes."
 msgstr ""
 
 #. IDS_COLDESC_LSIZE_SHORT
-#: Merge.rc:5108
+#: Merge.rc:5107
 msgid "Left file size abbreviated."
 msgstr "Venstre filstørrelse forkortet."
 
 #. IDS_COLDESC_RSIZE_SHORT
-#: Merge.rc:5109
+#: Merge.rc:5108
 msgid "Right file size abbreviated."
 msgstr "Høyre filstørrelse forkortet."
 
 #. IDS_COLDESC_MSIZE_SHORT
-#: Merge.rc:5110
+#: Merge.rc:5109
 msgid "Middle file size abbreviated."
 msgstr ""
 
 #. IDS_COLDESC_LTIMEC
-#: Merge.rc:5116
+#: Merge.rc:5115
 msgid "Left side creation time."
 msgstr "Venstre side opprettelsestid."
 
 #. IDS_COLDESC_RTIMEC
-#: Merge.rc:5117
+#: Merge.rc:5116
 msgid "Right side creation time."
 msgstr "Høyre side opprettelsestid."
 
 #. IDS_COLDESC_MTIMEC
-#: Merge.rc:5118
+#: Merge.rc:5117
 msgid "Middle side creation time."
 msgstr ""
 
 #. IDS_COLDESC_NEWER
-#: Merge.rc:5119
+#: Merge.rc:5118
 msgid "Tells which side has newer modification date."
 msgstr "Forteller hvilken side som har en nyere endringsdato."
 
 #. IDS_COLDESC_LVERSION
-#: Merge.rc:5120
+#: Merge.rc:5119
 msgid "Left side file version, only for some file types."
 msgstr "Venstre side filversjon, bare for noen filtyper."
 
 #. IDS_COLDESC_RVERSION
-#: Merge.rc:5121
+#: Merge.rc:5120
 msgid "Right side file version, only for some file types."
 msgstr "Høyre side filversjon, bare for noen filetyper."
 
 #. IDS_COLDESC_MVERSION
-#: Merge.rc:5126
+#: Merge.rc:5125
 msgid "Middle side file version, only for some file types."
 msgstr ""
 
 #. IDS_COLDESC_RESULT_ABBR
-#: Merge.rc:5127
+#: Merge.rc:5126
 msgid "Short comparison result."
 msgstr "Kort sammenligningsresultat."
 
 #. IDS_COLDESC_LATTRIBUTES
-#: Merge.rc:5128
+#: Merge.rc:5127
 msgid "Left side attributes."
 msgstr "Venstre side attributter."
 
 #. IDS_COLDESC_RATTRIBUTES
-#: Merge.rc:5129
+#: Merge.rc:5128
 msgid "Right side attributes."
 msgstr "Høyre side attributter."
 
 #. IDS_COLDESC_MATTRIBUTES
-#: Merge.rc:5130
+#: Merge.rc:5129
 msgid "Middle side attributes."
 msgstr ""
 
 #. IDS_COLDESC_LEOL_TYPE
-#: Merge.rc:5131
+#: Merge.rc:5130
 msgid "Left side file EOL type."
 msgstr "Venstre side fil EOL type."
 
 #. IDS_COLDESC_REOL_TYPE
-#: Merge.rc:5132
+#: Merge.rc:5131
 msgid "Right side file EOL type."
 msgstr "Høyre side fil EOL type."
 
 #. IDS_COLDESC_MEOL_TYPE
-#: Merge.rc:5133
+#: Merge.rc:5132
 msgid "Middle side file EOL type."
 msgstr ""
 
 #. IDS_COLDESC_LENCODING
-#: Merge.rc:5139
+#: Merge.rc:5138
 msgid "Left side encoding."
 msgstr "Venstre side koding."
 
 #. IDS_COLDESC_RENCODING
-#: Merge.rc:5140
+#: Merge.rc:5139
 msgid "Right side encoding."
 msgstr "Høyre side koding."
 
 #. IDS_COLDESC_MENCODING
-#: Merge.rc:5141
+#: Merge.rc:5140
 msgid "Middle side encoding."
 msgstr ""
 
 #. IDS_COLDESC_NIDIFFS
-#: Merge.rc:5142
+#: Merge.rc:5141
 msgid "Number of ignored differences in file. Ignored and cannot be merged."
 msgstr ""
 "Antall ignorerte forskjeller i filen. Disse forskjeller ignoreres av "
 "WinMerge og kan ikke slås sammen."
 
 #. IDS_COLDESC_NSDIFFS
-#: Merge.rc:5143
+#: Merge.rc:5142
 msgid "Number of differences in file (excluding ignored)."
 msgstr ""
 "Antall forskjeller i filen. Dette antall inkluderer ikke ignorerte "
 "forskjeller."
 
 #. IDS_COLDESC_BINARY
-#: Merge.rc:5144
+#: Merge.rc:5143
 msgid "Shows an asterisk (*) if the file is binary."
 msgstr "Viser asterisk (*) hvis filen er binær."
 
 #. IDS_COLDESC_UNPACKER
-#: Merge.rc:5145
+#: Merge.rc:5144
 msgid "Unpacker plugin name or pipeline."
 msgstr ""
 
 #. IDS_COLDESC_PREDIFFER
-#: Merge.rc:5146
+#: Merge.rc:5145
 msgid "Prediffer plugin name or pipeline."
 msgstr ""
 
 #. IDS_DIRECTORY_REPORT_TITLE
-#: Merge.rc:5152
+#: Merge.rc:5151
 #, c-format
 msgid "Compare %1 with %2"
 msgstr "Sammenligning %1 med %2"
 
 #. IDS_DIRECTORY_REPORT_TITLE3
-#: Merge.rc:5153
+#: Merge.rc:5152
 #, c-format
 msgid "Compare %1 with %2 and %3"
 msgstr ""
 
 #. IDS_REPORT_COMMALIST
-#: Merge.rc:5154
+#: Merge.rc:5153
 msgid "Comma-separated list"
 msgstr "Komma-separert liste"
 
 #. IDS_REPORT_TABLIST
-#: Merge.rc:5155
+#: Merge.rc:5154
 msgid "Tab-separated list"
 msgstr "Tab-separarert liste"
 
 #. IDS_REPORT_SIMPLEHTML
-#: Merge.rc:5156
+#: Merge.rc:5155
 msgid "Simple HTML"
 msgstr "Enkel HTML"
 
 #. IDS_REPORT_SIMPLEXML
-#: Merge.rc:5157
+#: Merge.rc:5156
 msgid "Simple XML"
 msgstr "Enkel XML"
 
-#: Merge.rc:5159
+#: Merge.rc:5158
 msgid "Report file already exists. Overwrite?"
 msgstr "Rapportfilen eksisterer allerede. Vil du overskrive eksisterende fil?"
 
 #. IDS_REPORT_ERROR
-#: Merge.rc:5164
+#: Merge.rc:5163
 #, c-format
 msgid ""
 "Error creating the report:\n"
@@ -7173,59 +7168,59 @@ msgstr ""
 "%1"
 
 #. IDS_REPORT_SUCCESS
-#: Merge.rc:5165
+#: Merge.rc:5164
 msgid "Report created successfully."
 msgstr "Rapporten er vellykket opprettet."
 
 #. IDS_SYNCPOINT_LASTBLOCK
-#: Merge.rc:5171
+#: Merge.rc:5170
 msgid "Cannot add a synchronization point at this line."
 msgstr ""
 
 #. IDS_FILE_TO_ITSELF
-#: Merge.rc:5177
+#: Merge.rc:5176
 msgid "Same file is opened in both panes."
 msgstr "Samme filen er åpen i begge paneler."
 
 #. IDS_FILESSAME
-#: Merge.rc:5178
+#: Merge.rc:5177
 msgid "Selected files are identical."
 msgstr "De valgte filene er identiske."
 
 #. IDS_FILESSAME_CURCFG
-#: Merge.rc:5179
+#: Merge.rc:5178
 msgid "Selected files are identical (with current settings).\r\nChecking binary identity..."
 msgstr ""
 
 #. IDS_FILESSAME_BINERROR
-#: Merge.rc:5180
+#: Merge.rc:5179
 msgid "Selected files are identical (with current settings).\r\nBut binary comparison failed."
 msgstr ""
 
 #. IDS_FILESSAME_BINSAME
-#: Merge.rc:5181
+#: Merge.rc:5180
 msgid "Selected files are identical (binary match)."
 msgstr ""
 
 #. IDS_FILESSAME_BINDIFF
-#: Merge.rc:5182
+#: Merge.rc:5181
 msgid "Selected files are identical (with current settings).\r\nBut differ at the binary level."
 msgstr ""
 
 #. IDS_FILEERROR
-#: Merge.rc:5183
+#: Merge.rc:5182
 msgid "An error occurred while comparing files."
 msgstr "Det skjedde en feil under sammenligning av filene."
 
 #. IDS_TEMP_FILEERROR
-#: Merge.rc:5184
+#: Merge.rc:5183
 msgid ""
 "Could not create temporary files. Check your temporary path settings."
 msgstr ""
 "Midlertidige filer kan ikke opprettes. Sjekk TEMP-mappebane innstillinger."
 
 #. IDS_SUGGEST_IGNOREEOL
-#: Merge.rc:5185
+#: Merge.rc:5184
 msgid "Files use different EOL.\n\nTreat all EOL as equivalent?\n\nSet 'Ignore EOL differences (Windows/Unix/Mac)' in Compare section of Options."
 msgstr ""
 "Disse filene har forskjellig linjeskifttype.\n"
@@ -7238,17 +7233,17 @@ msgstr ""
 "Innstillinger)."
 
 #. IDS_INVALID_DIRECTORY
-#: Merge.rc:5186
+#: Merge.rc:5185
 msgid "Selected folder is invalid."
 msgstr "Den valgte mappen er ugyldig."
 
 #. IDS_CANNOT_OPEN_BINARYFILE
-#: Merge.rc:5187
+#: Merge.rc:5186
 msgid "Cannot open a binary file in Editor."
 msgstr "Kan ikke åpne en binærfil til redigering."
 
 #. IDS_CREATE_PAIR_FOLDER
-#: Merge.rc:5188
+#: Merge.rc:5187
 #, c-format
 msgid "Create matching folder:\n%1\non the other side and open?"
 msgstr ""
@@ -7259,41 +7254,41 @@ msgstr ""
 "på andre siden og åpne disse mapper?"
 
 #. IDS_CONFIRM_COPY_ALL_DIFFS
-#: Merge.rc:5189
+#: Merge.rc:5188
 msgid "Copy all differences to other file?"
 msgstr ""
 
 #. IDS_MOVE_TO_NEXTFILE
-#: Merge.rc:5194
+#: Merge.rc:5193
 msgid "Move to next file?"
 msgstr ""
 
 #. IDS_MOVE_TO_PREVFILE
-#: Merge.rc:5195
+#: Merge.rc:5194
 msgid "Move to previous file?"
 msgstr ""
 
 #. IDS_MOVE_TO_NEXTPAGE
-#: Merge.rc:5196
+#: Merge.rc:5195
 msgid "Move to next page?"
 msgstr ""
 
 #. IDS_MOVE_TO_PREVPAGE
-#: Merge.rc:5197
+#: Merge.rc:5196
 msgid "Move to previous page?"
 msgstr ""
 
 #. IDS_MOVE_TO_FIRSTFILE
-#: Merge.rc:5198
+#: Merge.rc:5197
 msgid "Move to first file?"
 msgstr ""
 
 #. IDS_MOVE_TO_LASTFILE
-#: Merge.rc:5199
+#: Merge.rc:5198
 msgid "Move to last file?"
 msgstr ""
 
-#: Merge.rc:5206
+#: Merge.rc:5205
 #, c-format
 msgid "Different codepages: left (cp%d), right (cp%d).\nDisplay in codepage (better display) or default Windows codepage (safer merging)?\n(Recommended: default Windows codepage)"
 msgstr ""
@@ -7303,51 +7298,51 @@ msgstr ""
 "Vil du behandle begge filer som om de var i standard Windows tegnsett "
 "(anbefales)?"
 
-#: Merge.rc:5208
+#: Merge.rc:5207
 msgid "Information lost due to encoding errors: both files"
 msgstr "Informasjon tapt på grunn av kodings-feil: begge filer"
 
-#: Merge.rc:5210
+#: Merge.rc:5209
 msgid "Information lost due to encoding errors: first file"
 msgstr ""
 
-#: Merge.rc:5212
+#: Merge.rc:5211
 msgid "Information lost due to encoding errors: second file"
 msgstr ""
 
-#: Merge.rc:5214
+#: Merge.rc:5213
 msgid "Information lost due to encoding errors: third file"
 msgstr ""
 
 #. IDS_LINEDIFF_NODIFF
-#: Merge.rc:5220
+#: Merge.rc:5219
 msgid "No difference"
 msgstr "Ingen forskjell"
 
 #. IDS_LINEDIFF_NODIFF_CAPTION
-#: Merge.rc:5221
+#: Merge.rc:5220
 msgid "Line difference"
 msgstr "Linjeforskjell"
 
 #. IDS_NUM_REPLACED
-#: Merge.rc:5227
+#: Merge.rc:5226
 #, c-format
 msgid "Replaced %1 string(s)."
 msgstr "Erstattet %1 streng(er)."
 
 #. IDS_EDIT_TEXT_NOT_FOUND
-#: Merge.rc:5228
+#: Merge.rc:5227
 #, c-format
 msgid "Cannot find string \"%s\"."
 msgstr "Kan ikke finne strengen \"%s\"."
 
 #. IDS_MERGE_MODE
-#: Merge.rc:5234
+#: Merge.rc:5233
 msgid "Entering Merge Mode. Press F9 to turn off."
 msgstr ""
 
 #. IDS_AUTO_MERGE
-#: Merge.rc:5240
+#: Merge.rc:5239
 #, c-format
 msgid ""
 "Automatic merges: %1\n"
@@ -7355,89 +7350,89 @@ msgid ""
 msgstr ""
 
 #. IDS_CODEPAGE_MERGED
-#: Merge.rc:5241
+#: Merge.rc:5240
 msgid "Codepage change merged."
 msgstr ""
 
 #. IDS_CODEPAGE_CONFLICT
-#: Merge.rc:5242
+#: Merge.rc:5241
 msgid "Codepage changes are conflicting."
 msgstr ""
 
 #. IDS_EOL_MERGED
-#: Merge.rc:5243
+#: Merge.rc:5242
 msgid "EOL change merged."
 msgstr ""
 
 #. IDS_EOL_CONFLICT
-#: Merge.rc:5244
+#: Merge.rc:5243
 msgid "EOL changes are conflicting."
 msgstr ""
 
 #. IDS_LOCBAR_CAPTION
-#: Merge.rc:5250
+#: Merge.rc:5249
 msgid "Location Pane"
 msgstr "Lokaliseringspanel"
 
 #. IDS_DIFFBAR_CAPTION
-#: Merge.rc:5251
+#: Merge.rc:5250
 msgid "Diff Pane"
 msgstr "Forskjellspanel"
 
 #. IDS_DIFF_SUCCEEDED
-#: Merge.rc:5258
+#: Merge.rc:5257
 msgid "Patch file written."
 msgstr "Fil med rettelser vellykket skrevet."
 
 #. IDS_DIFF_FILEOVERWRITE
-#: Merge.rc:5259
+#: Merge.rc:5258
 msgid "Patch file already exists. Overwrite?"
 msgstr "Rettelsesfilen eksisterer allerede. Vil du overskrive den?"
 
 #. IDS_DIFF_SELECTEDFILES
-#: Merge.rc:5260
+#: Merge.rc:5259
 #, c-format
 msgid "[%1 files selected]"
 msgstr "[%1 filer valgt]"
 
 #. IDS_DIFF_NORMAL
-#: Merge.rc:5261
+#: Merge.rc:5260
 msgid "Normal"
 msgstr "Normal"
 
 #. IDS_DIFF_CONTEXT
-#: Merge.rc:5262
+#: Merge.rc:5261
 msgid "Context"
 msgstr "Kontekst"
 
 #. IDS_DIFF_UNIFIED
-#: Merge.rc:5263
+#: Merge.rc:5262
 msgid "Unified"
 msgstr "Forenet"
 
 #. IDS_FILEWRITE_ERROR
-#: Merge.rc:5265
+#: Merge.rc:5264
 #, c-format
 msgid "Could not write to file %1."
 msgstr "Kunne ikke skrive til fil %1."
 
 #. IDS_PATH_NOT_ABSOLUTE
-#: Merge.rc:5266
+#: Merge.rc:5265
 #, c-format
 msgid "Output path is not absolute: %1"
 msgstr "Den spesifiserte utdata-bane er ikke en absolutt bane: %1"
 
 #. IDS_MUST_SPECIFY_OUTPUT
-#: Merge.rc:5267
+#: Merge.rc:5266
 msgid "Specify an output file."
 msgstr "Spesifiser en utdata-fil."
 
-#: Merge.rc:5269
+#: Merge.rc:5268
 msgid "Cannot create patch from binary files."
 msgstr "Kan ikke opprette en patch-fil fra binære filer."
 
 #. IDS_SAVEFILES_FORPATCH
-#: Merge.rc:5270
+#: Merge.rc:5269
 msgid ""
 "Save all files first.\n"
 "\n"
@@ -7449,22 +7444,22 @@ msgstr ""
 "filer."
 
 #. IDS_FOLDER_NOTEXIST
-#: Merge.rc:5271
+#: Merge.rc:5270
 msgid "Folder does not exist."
 msgstr "Mappe eksisterer ikke."
 
 #. IDS_ARCHIVE_SUCCEEDED
-#: Merge.rc:5277
+#: Merge.rc:5276
 msgid "Archive file written."
 msgstr ""
 
 #. IDS_ARCHIVE_SAVEFILES
-#: Merge.rc:5278
+#: Merge.rc:5277
 msgid "Save all files first.\n\nCreating an archive requires no unsaved changes."
 msgstr ""
 
 #. IDS_NO_ZIP_SUPPORT
-#: Merge.rc:5283
+#: Merge.rc:5282
 msgid "Archive support not enabled.\n7-Zip and/or Merge7z*.dll not found.\nSee manual for archive support."
 msgstr ""
 "Arkivstøtte er ikke arkivert.\n"
@@ -7473,37 +7468,37 @@ msgstr ""
 "Se manualen for mer informasjon om arkivstøtte og hvordan aktivere den."
 
 #. IDS_OPT_EXPORT_CAPTION
-#: Merge.rc:5284
+#: Merge.rc:5283
 msgid "Select file for export"
 msgstr "Velg fil for eksport"
 
 #. IDS_OPT_IMPORT_CAPTION
-#: Merge.rc:5285
+#: Merge.rc:5284
 msgid "Select file for import"
 msgstr "Velg fil for import"
 
 #. IDS_OPT_IMPORT_DONE
-#: Merge.rc:5286
+#: Merge.rc:5285
 msgid "Options imported from file."
 msgstr "Innstillinger importert fra filen."
 
 #. IDS_OPT_EXPORT_DONE
-#: Merge.rc:5287
+#: Merge.rc:5286
 msgid "Options exported to file."
 msgstr "Innstillinger eksportert til filen."
 
 #. IDS_OPT_IMPORT_ERR
-#: Merge.rc:5288
+#: Merge.rc:5287
 msgid "Failed to import options from file."
 msgstr "Feilet i å  importere innstillinger fra filen."
 
 #. IDS_OPT_EXPORT_ERR
-#: Merge.rc:5289
+#: Merge.rc:5288
 msgid "Failed to write options to file."
 msgstr "Feilet i å skrive innstillinger til filen."
 
 #. IDS_CLOSEALL_WINDOWS
-#: Merge.rc:5290
+#: Merge.rc:5289
 msgid ""
 "Close multiple compare windows?\n"
 "\n"
@@ -7514,34 +7509,34 @@ msgstr ""
 "Vil du fortsette?"
 
 #. IDS_EOL_BIN
-#: Merge.rc:5300
+#: Merge.rc:5299
 msgctxt "EOL Type"
 msgid "Binary"
 msgstr "Binær"
 
 #. IDS_MARKER_COLOR_FMT
-#: Merge.rc:5305
+#: Merge.rc:5304
 #, c-format
 msgid "Marker Color %d"
 msgstr ""
 
 #. IDS_MARKER_NEW_PATTERN
-#: Merge.rc:5306
+#: Merge.rc:5305
 msgid "New Pattern"
 msgstr ""
 
 #. IDS_PLUGINSLIST_TYPE
-#: Merge.rc:5312
+#: Merge.rc:5311
 msgid "Type"
 msgstr "Type"
 
 #. IDS_PLUGINS_TYPE_EDITSCRIPT
-#: Merge.rc:5316
+#: Merge.rc:5315
 msgid "Editor script"
 msgstr "Redigeringsskript"
 
 #. ID_SELECTLINEDIFF
-#: Merge.rc:5322
+#: Merge.rc:5321
 msgid ""
 "\n"
 "Difference in Current Line (F4)"
@@ -7550,7 +7545,7 @@ msgstr ""
 "Forskjell i den gjeldende linjen (F4)"
 
 #. ID_OPTIONS
-#: Merge.rc:5323
+#: Merge.rc:5322
 msgid ""
 "\n"
 "Options"
@@ -7559,7 +7554,7 @@ msgstr ""
 "Innstillinger"
 
 #. ID_REFRESH
-#: Merge.rc:5324
+#: Merge.rc:5323
 msgid ""
 "\n"
 "Refresh (F5)"
@@ -7568,7 +7563,7 @@ msgstr ""
 "Gjenoppfrisk (F5)"
 
 #. ID_PREVDIFF
-#: Merge.rc:5330
+#: Merge.rc:5329
 msgid ""
 "\n"
 "Previous Difference (Alt+Up)"
@@ -7577,7 +7572,7 @@ msgstr ""
 "Forrige forskjell (Alt+Up)"
 
 #. ID_NEXTDIFF
-#: Merge.rc:5331
+#: Merge.rc:5330
 msgid ""
 "\n"
 "Next Difference (Alt+Down)"
@@ -7586,7 +7581,7 @@ msgstr ""
 "Neste forskjell (Alt+Down)"
 
 #. ID_PREVCONFLICT
-#: Merge.rc:5332
+#: Merge.rc:5331
 msgid ""
 "\n"
 "Previous Conflict (Alt+Shift+Up)"
@@ -7595,7 +7590,7 @@ msgstr ""
 "Forrige konflikt (Alt+Shift+Up)"
 
 #. ID_NEXTCONFLICT
-#: Merge.rc:5333
+#: Merge.rc:5332
 msgid ""
 "\n"
 "Next Conflict (Alt+Shift+Down)"
@@ -7604,7 +7599,7 @@ msgstr ""
 "Neste konflikt (Alt+Shift+Down)"
 
 #. ID_FIRSTDIFF
-#: Merge.rc:5338
+#: Merge.rc:5337
 msgid ""
 "\n"
 "First Difference (Alt+Home)"
@@ -7613,7 +7608,7 @@ msgstr ""
 "Første forskjell (Alt+Home)"
 
 #. ID_CURDIFF
-#: Merge.rc:5339
+#: Merge.rc:5338
 msgid ""
 "\n"
 "Current Difference (Alt+Enter)"
@@ -7622,7 +7617,7 @@ msgstr ""
 "Gjeldende forskjell (Alt+Enter)"
 
 #. ID_LASTDIFF
-#: Merge.rc:5340
+#: Merge.rc:5339
 msgid ""
 "\n"
 "Last Difference (Alt+End)"
@@ -7631,37 +7626,37 @@ msgstr ""
 "Siste forskjell (Alt+End)"
 
 #. ID_L2R
-#: Merge.rc:5341
+#: Merge.rc:5340
 msgid "\nCopy to Right (Alt+Right)"
 msgstr "\nKopier høyre (Alt+Høyre)"
 
 #. ID_R2L
-#: Merge.rc:5342
+#: Merge.rc:5341
 msgid "\nCopy to Left (Alt+Left)"
 msgstr "\nKopier venstre (Alt+Venstre)"
 
 #. ID_L2RNEXT
-#: Merge.rc:5343
+#: Merge.rc:5342
 msgid "\nCopy to Right and Advance (Ctrl+Alt+Right)"
 msgstr "\nKopier høyre og gå videre (Ctrl+Alt+Høyre)"
 
 #. ID_R2LNEXT
-#: Merge.rc:5344
+#: Merge.rc:5343
 msgid "\nCopy to Left and Advance (Ctrl+Alt+Left)"
 msgstr "\nKopier venstre og gå videre (Ctrl+Alt+Venstre)"
 
 #. ID_ALL_RIGHT
-#: Merge.rc:5345
+#: Merge.rc:5344
 msgid "\nCopy All to Right"
 msgstr "\nKopier alt til høyre"
 
 #. ID_ALL_LEFT
-#: Merge.rc:5346
+#: Merge.rc:5345
 msgid "\nCopy All to Left"
 msgstr "\nKopier alt til venstre"
 
 #. ID_AUTO_MERGE
-#: Merge.rc:5347
+#: Merge.rc:5346
 msgid ""
 "\n"
 "Auto Merge (Ctrl+Alt+M)"
@@ -7670,7 +7665,7 @@ msgstr ""
 "Auto-sammenslå (Ctrl+Alt+M)"
 
 #. ID_FIRSTFILE
-#: Merge.rc:5348
+#: Merge.rc:5347
 msgid ""
 "\n"
 "First File"
@@ -7679,7 +7674,7 @@ msgstr ""
 "Første fil"
 
 #. ID_NEXTFILE
-#: Merge.rc:5349
+#: Merge.rc:5348
 msgid ""
 "\n"
 "Next File (Ctrl+F8)"
@@ -7688,7 +7683,7 @@ msgstr ""
 "Neste fil (Ctrl+F8)"
 
 #. ID_LASTFILE
-#: Merge.rc:5350
+#: Merge.rc:5349
 msgid ""
 "\n"
 "Last File"
@@ -7697,7 +7692,7 @@ msgstr ""
 "Siste fil"
 
 #. ID_PREVFILE
-#: Merge.rc:5351
+#: Merge.rc:5350
 msgid ""
 "\n"
 "Previous File (Ctrl+F7)"
@@ -7706,143 +7701,143 @@ msgstr ""
 "Forrige fil (Ctrl+F7)"
 
 #. IDS_UNPACK_AUTO
-#: Merge.rc:5358
+#: Merge.rc:5357
 msgid "Adapted unpacker applied to both files (one needs extension)."
 msgstr ""
 "Den tilpassede utpakkeren brukes på begge filer (bare en fil behøver "
 "filendelsen)."
 
 #. IDS_NO_PREDIFFER
-#: Merge.rc:5359
+#: Merge.rc:5358
 msgid "No Prediffer (Normal)"
 msgstr "Ingen prediffer (normal)"
 
 #. IDS_SUGGESTED_PLUGINS
-#: Merge.rc:5360
+#: Merge.rc:5359
 msgid "Suggested Plugins"
 msgstr "Foreslåtte programtillegg"
 
 #. IDS_NOT_SUGGESTED_PLUGINS
-#: Merge.rc:5361
+#: Merge.rc:5360
 msgid "All Plugins"
 msgstr ""
 
 #. IDS_PRIVATEBUILD_FMT
-#: Merge.rc:5367
+#: Merge.rc:5366
 #, c-format
 msgid "Private Build: %1"
 msgstr "Privat Build: %1"
 
 #. IDS_ALLRIGHTS_RESERVED
-#: Merge.rc:5368
+#: Merge.rc:5367
 msgid " - All rights reserved."
 msgstr ""
 
 #. IDS_TITLE_PLUGINS_SETTINGS
-#: Merge.rc:5374
+#: Merge.rc:5373
 msgid "Plugin Settings"
 msgstr "Innstillinger for programtillegg"
 
 #. IDS_NO_SCT_SCRIPTS
-#: Merge.rc:5376
+#: Merge.rc:5375
 msgid "WSH not found - .sct scripts disabled"
 msgstr "WSH ikke funnet - .sct skript ikke aktivert"
 
 #. IDS_LOCBAR_GOTOLINE_FMT
-#: Merge.rc:5384
+#: Merge.rc:5383
 #, c-format
 msgid "G&o to Line %1"
 msgstr "G&å til linje %1"
 
 #. IDS_GOTO_MOVED_LINE
-#: Merge.rc:5390
+#: Merge.rc:5389
 msgid "Go to Moved Line\tCtrl+Shift+G"
 msgstr ""
 
 #. IDS_AUTOCOMPLETE_DISABLED
-#: Merge.rc:5396
+#: Merge.rc:5395
 msgctxt "Options dialog|General|Open dialog Auto completion"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_AUTOCOMPLETE_FILE_SYS
-#: Merge.rc:5397
+#: Merge.rc:5396
 msgid "From file system"
 msgstr "Fra filsystem"
 
 #. IDS_AUTOCOMPLETE_MRU
-#: Merge.rc:5398
+#: Merge.rc:5397
 msgid "From Most Recently Used list"
 msgstr "Fra MRU-liste"
 
 #. IDS_COLORSCHEME_PLAIN
-#: Merge.rc:5404
+#: Merge.rc:5403
 msgid "No Highlighting"
 msgstr "Ingen markering"
 
 #. IDS_COLORSCHEME_PO
-#: Merge.rc:5439
+#: Merge.rc:5438
 msgid "Portable Object"
 msgstr "Portable Object"
 
 #. IDS_COLORSCHEME_RSRC
-#: Merge.rc:5444
+#: Merge.rc:5443
 msgid "Resources"
 msgstr "Resources"
 
 #. IDS_COLORSCHEME_SH
-#: Merge.rc:5448
+#: Merge.rc:5447
 msgid "Shell"
 msgstr "Shell"
 
 #. IDS_CLOSE_LEFT_TABS
-#: Merge.rc:5469
+#: Merge.rc:5468
 msgid "Close &Left Tabs"
 msgstr ""
 
 #. IDS_CLOSE_RIGHT_TABS
-#: Merge.rc:5470
+#: Merge.rc:5469
 msgid "Close R&ight Tabs"
 msgstr ""
 
 #. IDS_CLOSE_OTHER_TABS
-#: Merge.rc:5471
+#: Merge.rc:5470
 msgid "Close &Other Tabs"
 msgstr ""
 
 #. IDS_TABBAR_AUTO_MAXWIDTH
-#: Merge.rc:5472
+#: Merge.rc:5471
 msgid "Enable &Auto Max Width"
 msgstr ""
 
 #. IDS_WEBPAGE_MENU
-#: Merge.rc:5482
+#: Merge.rc:5481
 msgid "We&bpage"
 msgstr ""
 
 #. IDS_VIEW_WRAP_TEXT
-#: Merge.rc:5487
+#: Merge.rc:5486
 msgid "W&rap Text"
 msgstr ""
 
 #. IDS_NOTINSTALLED
-#: Merge.rc:5492
+#: Merge.rc:5491
 msgid "%1 is not installed."
 msgstr ""
 
 #. IDS_CREATE_FOLDER
-#: Merge.rc:5497
+#: Merge.rc:5496
 #, c-format
 msgid "%1 does not exist. Create it?"
 msgstr ""
 
 #. IDS_CREATE_FOLDER_ERROR
-#: Merge.rc:5498
+#: Merge.rc:5497
 msgid "Failed to create folder."
 msgstr ""
 
 #. IDC_EXT_EDITOR_PATH
-#: Merge.rc:5503
+#: Merge.rc:5502
 msgid ""
 "Parameters:\n"
 "$file: Current file path\n"
@@ -7850,908 +7845,908 @@ msgid ""
 msgstr ""
 
 #. IDS_DIFF_ALGORITHM_DEFAULT
-#: Merge.rc:5508
+#: Merge.rc:5507
 msgid "default"
 msgstr ""
 
 #. IDS_DIFF_ALGORITHM_MINIMAL
-#: Merge.rc:5509
+#: Merge.rc:5508
 msgid "minimal"
 msgstr ""
 
 #. IDS_DIFF_ALGORITHM_PATIENCE
-#: Merge.rc:5510
+#: Merge.rc:5509
 msgid "patience"
 msgstr ""
 
 #. IDS_DIFF_ALGORITHM_HISTOGRAM
-#: Merge.rc:5511
+#: Merge.rc:5510
 msgid "histogram"
 msgstr ""
 
 #. IDS_DIFF_ALGORITHM_NONE
-#: Merge.rc:5512
+#: Merge.rc:5511
 msgid "none"
 msgstr ""
 
 #. IDS_RENDERING_MODE_GDI
-#: Merge.rc:5517
+#: Merge.rc:5516
 msgid "GDI"
 msgstr ""
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_DEFAULT
-#: Merge.rc:5518
+#: Merge.rc:5517
 msgid "DirectWrite Default"
 msgstr ""
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_ALIASED
-#: Merge.rc:5519
+#: Merge.rc:5518
 msgid "DirectWrite Aliased"
 msgstr ""
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_GDI_CLASSIC
-#: Merge.rc:5520
+#: Merge.rc:5519
 msgid "DirectWrite GDI Classic"
 msgstr ""
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_GDI_NATURAL
-#: Merge.rc:5521
+#: Merge.rc:5520
 msgid "DirectWrite GDI Natural"
 msgstr ""
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_NATURAL
-#: Merge.rc:5522
+#: Merge.rc:5521
 msgid "DirectWrite Natural"
 msgstr ""
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_NATURAL_SYMMETRIC
-#: Merge.rc:5523
+#: Merge.rc:5522
 msgid "DirectWrite Natural Symmetric"
 msgstr ""
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_DISABLED
-#: Merge.rc:5528
+#: Merge.rc:5527
 msgctxt "Options dialog|General|Close windows with Esc"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_1
-#: Merge.rc:5529
+#: Merge.rc:5528
 msgid "MDI child window or main window"
 msgstr ""
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_2
-#: Merge.rc:5530
+#: Merge.rc:5529
 msgid "MDI child window only"
 msgstr ""
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_3
-#: Merge.rc:5531
+#: Merge.rc:5530
 msgid "Close main window if only one MDI child window"
 msgstr ""
 
 #. IDS_DIFF_GROUP
-#: Merge.rc:5536
+#: Merge.rc:5535
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Diff"
 msgstr ""
 
 #. IDS_DIFF_HIGHLIGHT
-#: Merge.rc:5537
+#: Merge.rc:5536
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Highlight"
 msgstr ""
 
 #. IDS_DIFF_BLINK
-#: Merge.rc:5538
+#: Merge.rc:5537
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Blink"
 msgstr ""
 
 #. IDS_DIFF_BLOCKSIZE
-#: Merge.rc:5539
+#: Merge.rc:5538
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Block Size"
 msgstr ""
 
 #. IDS_DIFF_BLOCKALPHA
-#: Merge.rc:5540
+#: Merge.rc:5539
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Block Alpha"
 msgstr ""
 
 #. IDS_DIFF_CDTHRESHOLD
-#: Merge.rc:5541
+#: Merge.rc:5540
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "CD Threshold"
 msgstr ""
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION
-#: Merge.rc:5542
+#: Merge.rc:5541
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Ins/Del Detection"
 msgstr ""
 
 #. IDS_OVERLAY_MODE_NONE
-#: Merge.rc:5543 Merge.rc:5548
+#: Merge.rc:5542 Merge.rc:5547
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "None"
 msgstr ""
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION_VERTICAL
-#: Merge.rc:5544
+#: Merge.rc:5543
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Vertical"
 msgstr ""
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION_HORIZONTAL
-#: Merge.rc:5545
+#: Merge.rc:5544
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Horizontal"
 msgstr ""
 
 #. IDS_OVERLAY_GROUP
-#: Merge.rc:5546
+#: Merge.rc:5545
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Overlay"
 msgstr ""
 
 #. IDS_OVERLAY_ALPHA
-#: Merge.rc:5547
+#: Merge.rc:5546
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha"
 msgstr ""
 
 #. IDS_OVERLAY_MODE_XOR
-#: Merge.rc:5549
+#: Merge.rc:5548
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "XOR"
 msgstr ""
 
 #. IDS_OVERLAY_MODE_ALPHA
-#: Merge.rc:5550
+#: Merge.rc:5549
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha Blend"
 msgstr ""
 
 #. IDS_OVERLAY_MODE_ALPHA_ANIMATION
-#: Merge.rc:5551
+#: Merge.rc:5550
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha Animation"
 msgstr ""
 
 #. IDS_ZOOM
-#: Merge.rc:5552
+#: Merge.rc:5551
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Zoom"
 msgstr ""
 
 #. IDS_PAGE
-#: Merge.rc:5553
+#: Merge.rc:5552
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Page:"
 msgstr ""
 
 #. IDS_IMGCMP_STATUS_PT_RGBA_FMT
-#: Merge.rc:5554
+#: Merge.rc:5553
 #, c-format
 msgid "Pt: (%d, %d)  RGBA: (%d, %d, %d, %d)  "
 msgstr ""
 
 #. IDS_IMGCMP_STATUS_DIST1_FMT
-#: Merge.rc:5555
+#: Merge.rc:5554
 #, c-format
 msgid "Dist: %g  "
 msgstr ""
 
 #. IDS_IMGCMP_STATUS_DIST2_FMT
-#: Merge.rc:5556
+#: Merge.rc:5555
 #, c-format
 msgid "Dist: %g, %g  "
 msgstr ""
 
 #. IDS_IMGCMP_STATUS_PAGE_ZOOM_SIZE_BPP_FMT
-#: Merge.rc:5557
+#: Merge.rc:5556
 #, c-format
 msgid "Page: %d/%d  Zoom: %d%%  %dx%dpx  %dbpp  "
 msgstr ""
 
 #. IDS_IMGCMP_STATUS_RC_FMT
-#: Merge.rc:5558
+#: Merge.rc:5557
 #, c-format
 msgid "Rc: (%d, %d)  "
 msgstr ""
 
 #. IDS_IMGCMP_STATUS_FLIPPED_FMT
-#: Merge.rc:5559
+#: Merge.rc:5558
 #, c-format
 msgid "Flipped: %s  "
 msgstr ""
 
 #. IDS_IMGCMP_STATUS_ROTATED_FMT
-#: Merge.rc:5560
+#: Merge.rc:5559
 #, c-format
 msgid "Rotated: %d  "
 msgstr ""
 
 #. IDS_IMGCMP_REPORT_ALLPAGES
-#: Merge.rc:5561
+#: Merge.rc:5560
 msgid "All pages"
 msgstr ""
 
 #. IDS_IGNSUB_STR1
-#: Merge.rc:5566
+#: Merge.rc:5565
 msgid "<Edit here>"
 msgstr ""
 
 #. IDS_IGNSUB_STR2
-#: Merge.rc:5567
+#: Merge.rc:5566
 msgid "No differences found to select"
 msgstr ""
 
 #. IDS_IGNSUB_STR3
-#: Merge.rc:5568
+#: Merge.rc:5567
 msgid "No differences found to add as substitution filter"
 msgstr ""
 
 #. IDS_IGNSUB_STR4
-#: Merge.rc:5569
+#: Merge.rc:5568
 msgid "The pair is already in the Substitution Filters list"
 msgstr ""
 
 #. IDS_IGNSUB_STR5
-#: Merge.rc:5570
+#: Merge.rc:5569
 msgid "Add this change to Substitution Filters?"
 msgstr ""
 
 #. IDS_OCRRESULT_TEXTONLY
-#: Merge.rc:5575
+#: Merge.rc:5574
 msgid "Text only"
 msgstr ""
 
 #. IDS_OCRRESULT_POS_LINE
-#: Merge.rc:5576
+#: Merge.rc:5575
 msgid "Line-by-line position and text"
 msgstr ""
 
 #. IDS_OCRRESULT_POS_WORD
-#: Merge.rc:5577
+#: Merge.rc:5576
 msgid "Word-by-word position and text"
 msgstr ""
 
 #. IDS_USERDATAFOLDER_APPDATA
-#: Merge.rc:5582
+#: Merge.rc:5581
 msgid "AppData (Roaming) folder"
 msgstr ""
 
 #. IDS_USERDATAFOLDER_INSTALL
-#: Merge.rc:5583
+#: Merge.rc:5582
 msgid "Install folder"
 msgstr ""
 
 #. IDS_USERDATAFOLDER_DOCUMENTS
-#: Merge.rc:5584
+#: Merge.rc:5583
 msgid "Documents folder"
 msgstr ""
 
 #. IDS_SINGLEINSTANCE_DISABLED
-#: Merge.rc:5589
+#: Merge.rc:5588
 msgctxt "Options dialog|General|Single instance mode"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_SINGLEINSTANCE_STR1
-#: Merge.rc:5590
+#: Merge.rc:5589
 msgid "Allow only one instance to run"
 msgstr "Tillat bare en instans å kjøre"
 
 #. IDS_CLIPBOARD_HISTORY
-#: Merge.rc:5591
+#: Merge.rc:5590
 msgid "Clipboard &History"
 msgstr ""
 
 #. IDS_SINGLEINSTANCE_STR2
-#: Merge.rc:5592
+#: Merge.rc:5591
 msgid "Allow only one instance; wait for termination"
 msgstr ""
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_DISABLED
-#: Merge.rc:5597
+#: Merge.rc:5596
 msgctxt "Options dialog|General|Auto-reload modified files"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_STR1
-#: Merge.rc:5598
+#: Merge.rc:5597
 msgid "Only on window activated"
 msgstr ""
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_STR2
-#: Merge.rc:5599
+#: Merge.rc:5598
 msgid "Immediately"
 msgstr ""
 
 #. IDS_PLUGIN_ALL
-#: Merge.rc:5604
+#: Merge.rc:5603
 msgid "Al&l"
 msgstr ""
 
 #. IDS_PLUGIN_OTHERS
-#: Merge.rc:5605
+#: Merge.rc:5604
 msgid "&Others"
 msgstr ""
 
-#: Merge.rc:5607
+#: Merge.rc:5606
 #, c-format
 msgid "Missing plugin name in pipeline: %1"
 msgstr ""
 
-#: Merge.rc:5609
+#: Merge.rc:5608
 #, c-format
 msgid "Missing quote in plugin pipeline: %1"
 msgstr ""
 
 #. IDS_PLUGIN_NAME_ALREADY_EXISTS
-#: Merge.rc:5610
+#: Merge.rc:5609
 #, c-format
 msgid "Plugin name '%1' already exists."
 msgstr ""
 
 #. IDS_PLUGIN_TITLE1
-#: Merge.rc:5611
+#: Merge.rc:5610
 msgid "Specify plugin arguments"
 msgstr ""
 
-#: Merge.rc:5613
+#: Merge.rc:5612
 #, c-format
 msgid "Plugin not found or invalid: %1"
 msgstr ""
 
 #. IDS_PLUGIN_NOT_UNPACK
-#: Merge.rc:5614
+#: Merge.rc:5613
 #, c-format
 msgid "'%1' is not an unpacker plugin"
 msgstr ""
 
 #. IDS_PLUGIN_NOT_PREDIFF
-#: Merge.rc:5615
+#: Merge.rc:5614
 #, c-format
 msgid "'%1' is not a prediffer plugin"
 msgstr ""
 
-#: Merge.rc:5617
+#: Merge.rc:5616
 #, c-format
 msgid "Error prediffing '%1' with '%2'. Prediffing disabled."
 msgstr ""
 
 #. IDS_PLUGIN_CIRCULAR_REFERENCE
-#: Merge.rc:5618
+#: Merge.rc:5617
 #, c-format
 msgid "Circular reference in plugin pipeline: %1"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE1
-#: Merge.rc:5619
+#: Merge.rc:5618
 msgid "URL Handler"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE2
-#: Merge.rc:5620
+#: Merge.rc:5619
 msgid "File Unpacker"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE3
-#: Merge.rc:5621
+#: Merge.rc:5620
 msgid "File or Folder Unpacker"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE5
-#: Merge.rc:5623
+#: Merge.rc:5622
 msgid "Alias for Unpacker"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE6
-#: Merge.rc:5624
+#: Merge.rc:5623
 msgid "Alias for Prediffer"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE7
-#: Merge.rc:5625
+#: Merge.rc:5624
 msgid "Alias for Editor script"
 msgstr ""
 
 #. IDS_PLUGIN_ALIAS_DESC
-#: Merge.rc:5626
+#: Merge.rc:5625
 #, c-format
 msgid "Alias for plugin pipeline '%1'"
 msgstr ""
 
 #. IDS_PLUGIN_NEW_DESC
-#: Merge.rc:5627
+#: Merge.rc:5626
 msgid "New plugin description"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_ALL
-#: Merge.rc:5628
+#: Merge.rc:5627
 msgid "All"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_1ST
-#: Merge.rc:5629
+#: Merge.rc:5628
 msgid "1st"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_2ND
-#: Merge.rc:5630
+#: Merge.rc:5629
 msgid "2nd"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_3RD
-#: Merge.rc:5631
+#: Merge.rc:5630
 msgid "3rd"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_1ST_2ND
-#: Merge.rc:5632
+#: Merge.rc:5631
 msgid "1st and 2nd"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_1ST_3RD
-#: Merge.rc:5633
+#: Merge.rc:5632
 msgid "1st and 3rd"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_2ND_3RD
-#: Merge.rc:5634
+#: Merge.rc:5633
 msgid "2nd and 3rd"
 msgstr ""
 
 #. IDS_PLUGIN_CTRL_CLICK
-#: Merge.rc:5635
+#: Merge.rc:5634
 msgid "(Ctrl+Click to add to pipeline)"
 msgstr ""
 
 #. IDS_FILTER_APPLIED
-#: Merge.rc:5640
+#: Merge.rc:5639
 msgid "Filter applied"
 msgstr ""
 
 #. IDS_FILTERMENU_COMPARE
-#: Merge.rc:5645
+#: Merge.rc:5644
 #, c-format
 msgid "Compare %1"
 msgstr ""
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN2
-#: Merge.rc:5647
+#: Merge.rc:5646
 msgid "&Filter by This Column..."
 msgstr ""
 
 #. IDS_CLIPBOARDHISTORY_TIME
-#: Merge.rc:5652
+#: Merge.rc:5651
 #, c-format
 msgid "Clipboard at %s"
 msgstr ""
 
 #. IDS_CLIPBOARDHISTORY_DISABLED
-#: Merge.rc:5653
+#: Merge.rc:5652
 msgid "Clipboard history disabled.\r\nEnable: Windows logo key + V, then Turn on."
 msgstr ""
 
-#: Merge.rc:5655
+#: Merge.rc:5654
 msgid "This system does not support clipboard history."
 msgstr ""
 
-#: Merge.rc:5657
+#: Merge.rc:5656
 msgid "32-bit WinMerge does not support Clipboard Compare"
 msgstr ""
 
 #. IDS_WEBVIEW2_RUNTIME_NOT_INSTALLED
-#: Merge.rc:5662
+#: Merge.rc:5661
 msgid "WebView2 runtime not installed. Download it?"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_TEXT_COMPARE
-#: Merge.rc:5667
+#: Merge.rc:5666
 msgid "New Text Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_TABLE_COMPARE
-#: Merge.rc:5668
+#: Merge.rc:5667
 msgid "New Table Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_BINARY_COMPARE
-#: Merge.rc:5669
+#: Merge.rc:5668
 msgid "New Binary Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_IMAGE_COMPARE
-#: Merge.rc:5670
+#: Merge.rc:5669
 msgid "New Image Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_WEBPAGE_COMPARE
-#: Merge.rc:5671
+#: Merge.rc:5670
 msgid "New Webpage Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_FOLDER_COMPARE
-#: Merge.rc:5672
+#: Merge.rc:5671
 msgid "New Folder Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_CLIPBOARD_COMPARE
-#: Merge.rc:5673
+#: Merge.rc:5672
 msgid "Clipboard Compare"
 msgstr ""
 
 #. IDS_PREVIEWBAR_PRINT
-#: Merge.rc:5678
+#: Merge.rc:5677
 msgid "&Print..."
 msgstr ""
 
 #. IDS_PREVIEWBAR_PREVPAGE
-#: Merge.rc:5680
+#: Merge.rc:5679
 msgid "Pre&v Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_TWOPAGE
-#: Merge.rc:5681
+#: Merge.rc:5680
 msgid "&Two Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_ONEPAGE
-#: Merge.rc:5682
+#: Merge.rc:5681
 msgid "&One Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_ZOOMIN
-#: Merge.rc:5683
+#: Merge.rc:5682
 msgid "Zoom &In"
 msgstr ""
 
 #. IDS_PREVIEWBAR_ZOOMOUT
-#: Merge.rc:5684
+#: Merge.rc:5683
 msgid "Zoom &Out"
 msgstr ""
 
 #. IDS_WEBPAGE_COMPARING
-#: Merge.rc:5690
+#: Merge.rc:5689
 msgid "Comparing..."
 msgstr ""
 
 #. IDS_WEBPAGE_ZOOM
-#: Merge.rc:5691
+#: Merge.rc:5690
 msgid "Zoom:"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_DIFFHUNK
-#: Merge.rc:5696
+#: Merge.rc:5695
 msgid "Diff hunk"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_INLINE
-#: Merge.rc:5697
+#: Merge.rc:5696
 msgid "Inline diff"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_LINE
-#: Merge.rc:5698
+#: Merge.rc:5697
 msgid "Line"
 msgstr ""
 
-#: Merge.rc:5699
+#: Merge.rc:5698
 msgid "Character"
 msgstr ""
 
 #. ID_MICE_PREVDIFF
-#: Merge.rc:5704
+#: Merge.rc:5703
 msgid "\nPrevious Difference (Alt+Up)\n(Right Button+Wheel Up)\n(Alt+Wheel Up)"
 msgstr ""
 
 #. ID_MICE_NEXTDIFF
-#: Merge.rc:5705
+#: Merge.rc:5704
 msgid "\nNext Difference (Alt+Down)\n(Right Button+Wheel Down)\n(Alt+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_L2R
-#: Merge.rc:5706
+#: Merge.rc:5705
 msgid "\nCopy to Right (Alt+Right)\n(Right Button+Wheel Right)\n(Alt+Wheel Right)\n(Alt+Shift+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_R2L
-#: Merge.rc:5707
+#: Merge.rc:5706
 msgid "\nCopy to Left (Alt+Left)\n(Right Button+Wheel Left)\n(Alt+Wheel Left)\n(Alt+Shift+Wheel Up)"
 msgstr ""
 
 #. ID_MICE_L2RNEXT
-#: Merge.rc:5708
+#: Merge.rc:5707
 msgid "\nCopy to Right and Advance (Ctrl+Alt+Right)\n(Ctrl+Alt+Wheel Right)\n(Ctrl+Alt+Shift+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_R2LNEXT
-#: Merge.rc:5709
+#: Merge.rc:5708
 msgid "\nCopy to Left and Advance (Ctrl+Alt+Left)\n(Ctrl+Alt+Wheel Left)\n(Ctrl+Alt+Shift+Wheel Up)"
 msgstr ""
 
 #. IDS_LOG_COMPARING_2
-#: Merge.rc:5719
+#: Merge.rc:5718
 #, c-format
 msgid "Comparing %1 with %2"
 msgstr ""
 
 #. IDS_LOG_COMPARING_3
-#: Merge.rc:5720
+#: Merge.rc:5719
 #, c-format
 msgid "Comparing %1 with %2 and %3"
 msgstr ""
 
 #. IDS_LOG_COMPARE_COMPLETED
-#: Merge.rc:5721
+#: Merge.rc:5720
 msgid "Comparison completed"
 msgstr ""
 
 #. IDS_LOG_COMPARE_ERROR_2
-#: Merge.rc:5722
+#: Merge.rc:5721
 #, c-format
 msgid "Failed to compare %1 with %2: "
 msgstr ""
 
 #. IDS_LOG_COMPARE_ERROR_3
-#: Merge.rc:5723
+#: Merge.rc:5722
 #, c-format
 msgid "Failed to compare %1 with %2 and %3: "
 msgstr ""
 
 #. IDS_LOG_FILE_SAVED
-#: Merge.rc:5724
+#: Merge.rc:5723
 msgid "File saved"
 msgstr ""
 
 #. IDS_LOG_COPYING_FILES
-#: Merge.rc:5725
+#: Merge.rc:5724
 msgid "Copying files..."
 msgstr ""
 
 #. IDS_LOG_MOVING_FILES
-#: Merge.rc:5726
+#: Merge.rc:5725
 msgid "Moving files..."
 msgstr ""
 
 #. IDS_LOG_DELETING_FILES
-#: Merge.rc:5727
+#: Merge.rc:5726
 msgid "Deleting files..."
 msgstr ""
 
 #. IDS_LOG_RECYCLEBIN
-#: Merge.rc:5728
+#: Merge.rc:5727
 msgid "Recycle Bin"
 msgstr ""
 
 #. IDS_LOG_PERMANENTLY_DELETED
-#: Merge.rc:5729
+#: Merge.rc:5728
 msgid "Permanently deleted"
 msgstr ""
 
 #. IDS_LOG_FILEOPERATION_COMPLETED
-#: Merge.rc:5730
+#: Merge.rc:5729
 msgid "File operation completed successfully"
 msgstr ""
 
 #. IDS_LOG_FILEOPERATION_CANCELED
-#: Merge.rc:5731
+#: Merge.rc:5730
 msgid "File operation canceled"
 msgstr ""
 
 #. IDS_FILTER_ERROR_NO_ERROR
-#: Merge.rc:5736
+#: Merge.rc:5735
 msgid "No error"
 msgstr ""
 
 #. IDS_FILTER_ERROR_EMPTY_EXPRESSION
-#: Merge.rc:5737
+#: Merge.rc:5736
 msgid "Filter expression is empty"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNKNOWN_CHAR
-#: Merge.rc:5738
+#: Merge.rc:5737
 msgid "Unknown character in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNTERMINATED_STRING
-#: Merge.rc:5739
+#: Merge.rc:5738
 msgid "Unterminated string literal"
 msgstr ""
 
 #. IDS_FILTER_ERROR_SYNTAX_ERROR
-#: Merge.rc:5740
+#: Merge.rc:5739
 msgid "Syntax error in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_PARSE_FAILURE
-#: Merge.rc:5741
+#: Merge.rc:5740
 msgid "Failed to parse filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_LITERAL
-#: Merge.rc:5742
+#: Merge.rc:5741
 msgid "Invalid literal value"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_REGULAR_EXPRESSION
-#: Merge.rc:5743
+#: Merge.rc:5742
 msgid "Invalid regular expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNDEFINED_IDENTIFIER
-#: Merge.rc:5744
+#: Merge.rc:5743
 msgid "Undefined identifier"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_ARGUMENT_COUNT
-#: Merge.rc:5745
+#: Merge.rc:5744
 msgid "Invalid number of arguments"
 msgstr ""
 
 #. IDS_FILTER_ERROR_FILTER_NAME_NOT_FOUND
-#: Merge.rc:5746
+#: Merge.rc:5745
 msgid "Filter name not found"
 msgstr ""
 
 #. IDS_FILTER_ERROR_DIVIDE_BY_ZERO
-#: Merge.rc:5747
+#: Merge.rc:5746
 msgid "Division by zero in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNKNOWN_ERROR
-#: Merge.rc:5748
+#: Merge.rc:5747
 msgid "Unknown error"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_PROPERTY_NAME
-#: Merge.rc:5749
+#: Merge.rc:5748
 msgid "Invalid property name"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_DIRECTIVE
-#: Merge.rc:5750
+#: Merge.rc:5749
 msgid "Invalid directive"
 msgstr ""
 
 #. IDS_FILTER_OP_EQUALS
-#: Merge.rc:5755
+#: Merge.rc:5754
 msgid "Equals"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_EQUALS
-#: Merge.rc:5756
+#: Merge.rc:5755
 msgid "Does not equal"
 msgstr ""
 
 #. IDS_FILTER_OP_LESS_THAN
-#: Merge.rc:5757
+#: Merge.rc:5756
 msgid "Less than"
 msgstr ""
 
 #. IDS_FILTER_OP_LESS_EQUAL
-#: Merge.rc:5758
+#: Merge.rc:5757
 msgid "Less than or equal to"
 msgstr ""
 
 #. IDS_FILTER_OP_GREATER_EQUAL
-#: Merge.rc:5759
+#: Merge.rc:5758
 msgid "Greater than or equal to"
 msgstr ""
 
 #. IDS_FILTER_OP_GREATER_THAN
-#: Merge.rc:5760
+#: Merge.rc:5759
 msgid "Greater than"
 msgstr ""
 
 #. IDS_FILTER_OP_BETWEEN
-#: Merge.rc:5761
+#: Merge.rc:5760
 msgid "Between"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_BETWEEN
-#: Merge.rc:5762
+#: Merge.rc:5761
 msgid "Not Between"
 msgstr ""
 
 #. IDS_FILTER_OP_CONTAINS
-#: Merge.rc:5763
+#: Merge.rc:5762
 msgid "Contains"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_CONTAINS
-#: Merge.rc:5764
+#: Merge.rc:5763
 msgid "Not Contains"
 msgstr ""
 
 #. IDS_FILTER_OP_RECONTAINS
-#: Merge.rc:5765
+#: Merge.rc:5764
 msgid "Contains (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_RECONTAINS
-#: Merge.rc:5766
+#: Merge.rc:5765
 msgid "Not Contains (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_LIKE
-#: Merge.rc:5767
+#: Merge.rc:5766
 msgid "Match (wildcard)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_LIKE
-#: Merge.rc:5768
+#: Merge.rc:5767
 msgid "Not match (wildcard)"
 msgstr ""
 
 #. IDS_FILTER_OP_MATCHES
-#: Merge.rc:5769
+#: Merge.rc:5768
 msgid "Match (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_MATCHES
-#: Merge.rc:5770
+#: Merge.rc:5769
 msgid "Not match (regex)"
 msgstr ""
 
 #. IDS_COLORMODE_LIGHT
-#: Merge.rc:5775
+#: Merge.rc:5774
 msgid "Light"
 msgstr ""
 
 #. IDS_COLORMODE_DARK
-#: Merge.rc:5776
+#: Merge.rc:5775
 msgid "Dark"
 msgstr ""
 
 #. IDS_COLORMODE_FOLLOWSYSTEM
-#: Merge.rc:5777
+#: Merge.rc:5776
 msgid "Follow system"
 msgstr ""
 
 #. IDS_EXAMPLE
-#: Merge.rc:5782
+#: Merge.rc:5781
 #, c-format
 msgid "e.g. %1"
 msgstr ""
 
 #. IDS_DETECTED_PREVIOUS_CRASH
-#: Merge.rc:5787
+#: Merge.rc:5786
 msgid "WinMerge detected a previous crash. Please report this if possible."
 msgstr ""
 
 #. IDS_REGEX_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5792
+#: Merge.rc:5791
 msgid "# Regex replacement list\r\n# Format: regex<TAB>replacement\r\n# Backreferences like $1, $2 are supported\r\n\r\n(\\d{4})-(\\d{2})-(\\d{2})\t$1_$2_$3\r\n"
 msgstr ""
 
 #. IDS_STRING_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5793
+#: Merge.rc:5792
 msgid "# Replacement list\r\n# Format: search<TAB>replacement\r\n# Lines starting with # are ignored\r\n\r\nfrom1\tto1\r\nfrom2\tto2\r\n"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_ONLY
-#: Merge.rc:5798
+#: Merge.rc:5797
 msgid "Built-in only"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_FIRST
-#: Merge.rc:5799
+#: Merge.rc:5798
 msgid "Built-in first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_FIRST
-#: Merge.rc:5800
+#: Merge.rc:5799
 msgid "Tree-sitter first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_ONLY
-#: Merge.rc:5801
+#: Merge.rc:5800
 msgid "Tree-sitter only"
 msgstr ""
 

--- a/Translations/WinMerge/Persian.po
+++ b/Translations/WinMerge/Persian.po
@@ -22,7 +22,7 @@ msgstr ""
 "X-Generator: Poedit 1.5.7\n"
 
 #. LANGUAGE, SUBLANGUAGE
-#: Merge.rc:26 Merge.rc:59 Merge.rc:5818
+#: Merge.rc:26 Merge.rc:59 Merge.rc:5817
 #, c-format
 msgid "LANG_ENGLISH, SUBLANG_ENGLISH_US"
 msgstr "LANG_FARSI, SUBLANG_DEFAULT"
@@ -172,7 +172,7 @@ msgstr "&S دست نويسها "
 #. IDS_NO_EDIT_SCRIPTS
 #: Merge.rc:127 Merge.rc:352 Merge.rc:463 Merge.rc:673 Merge.rc:678
 #: Merge.rc:887 Merge.rc:899 Merge.rc:906 Merge.rc:963 Merge.rc:1210
-#: Merge.rc:5375
+#: Merge.rc:5374
 #, c-format
 msgid "< Empty >"
 msgstr "<خالي>"
@@ -239,7 +239,7 @@ msgid "Auto-Fit All Columns"
 msgstr ""
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN
-#: Merge.rc:153 Merge.rc:5646
+#: Merge.rc:153 Merge.rc:5645
 msgid "&Filter by This Column"
 msgstr ""
 
@@ -305,7 +305,7 @@ msgid "&Previous Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_NEXTPAGE
-#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5679
+#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5678
 #, c-format
 msgid "&Next Page"
 msgstr ""
@@ -573,7 +573,7 @@ msgstr "&B دودويي"
 #. IDS_IMAGE_MENU
 #: Merge.rc:329 Merge.rc:338 Merge.rc:432 Merge.rc:441 Merge.rc:609
 #: Merge.rc:618 Merge.rc:670 Merge.rc:960 Merge.rc:1187 Merge.rc:1200
-#: Merge.rc:5477
+#: Merge.rc:5476
 #, c-format
 msgid "&Image"
 msgstr ""
@@ -711,7 +711,7 @@ msgid "&Huge"
 msgstr ""
 
 #. IDS_VIEW_MENU_BAR
-#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5714
+#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5713
 msgid "Men&u Bar"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgid "Lo&cation Pane"
 msgstr "&c چهارگوش مکان يابي "
 
 #. IDS_OUTPUTBAR_CAPTION
-#: Merge.rc:782 Merge.rc:5252
+#: Merge.rc:782 Merge.rc:5251
 msgid "Output Pane"
 msgstr ""
 
@@ -1770,55 +1770,55 @@ msgid "Co&mpare As"
 msgstr "&m  همسنجي به صورت "
 
 #. IDS_COPY_LEFT_TO_MIDDLE2
-#: Merge.rc:968 Merge.rc:980 Merge.rc:4852
+#: Merge.rc:968 Merge.rc:980 Merge.rc:4851
 #, c-format
 msgid "Left to Middle (%1 of %2)"
 msgstr ""
 
 #. IDS_COPY_LEFT_TO_RIGHT2
-#: Merge.rc:969 Merge.rc:981 Merge.rc:4851
+#: Merge.rc:969 Merge.rc:981 Merge.rc:4850
 #, c-format
 msgid "Left to Right (%1 of %2)"
 msgstr "  چپ به راست - %1 از %2 "
 
 #. IDS_MOVE_LEFT_TO2
-#: Merge.rc:970 Merge.rc:982 Merge.rc:1045 Merge.rc:4863 Merge.rc:4892
+#: Merge.rc:970 Merge.rc:982 Merge.rc:1045 Merge.rc:4862 Merge.rc:4891
 #, c-format
 msgid "Left to... (%1 of %2)"
 msgstr "  چپ به ... - %1 از %2 "
 
 #. IDS_COPY_MIDDLE_TO_LEFT2
-#: Merge.rc:971 Merge.rc:983 Merge.rc:4849
+#: Merge.rc:971 Merge.rc:983 Merge.rc:4848
 #, c-format
 msgid "Middle to Left (%1 of %2)"
 msgstr ""
 
 #. IDS_COPY_MIDDLE_TO_RIGHT2
-#: Merge.rc:972 Merge.rc:984 Merge.rc:4850
+#: Merge.rc:972 Merge.rc:984 Merge.rc:4849
 #, c-format
 msgid "Middle to Right (%1 of %2)"
 msgstr ""
 
 #. IDS_MOVE_MIDDLE_TO2
-#: Merge.rc:973 Merge.rc:985 Merge.rc:1046 Merge.rc:4864 Merge.rc:4893
+#: Merge.rc:973 Merge.rc:985 Merge.rc:1046 Merge.rc:4863 Merge.rc:4892
 #, c-format
 msgid "Middle to... (%1 of %2)"
 msgstr ""
 
 #. IDS_COPY_RIGHT_TO_MIDDLE2
-#: Merge.rc:974 Merge.rc:986 Merge.rc:4848
+#: Merge.rc:974 Merge.rc:986 Merge.rc:4847
 #, c-format
 msgid "Right to Middle (%1 of %2)"
 msgstr ""
 
 #. IDS_COPY_RIGHT_TO_LEFT2
-#: Merge.rc:975 Merge.rc:987 Merge.rc:4847
+#: Merge.rc:975 Merge.rc:987 Merge.rc:4846
 #, c-format
 msgid "Right to Left (%1 of %2)"
 msgstr "  راست  به چپ - %1 از %2 "
 
 #. IDS_MOVE_RIGHT_TO2
-#: Merge.rc:976 Merge.rc:988 Merge.rc:1047 Merge.rc:4865 Merge.rc:4894
+#: Merge.rc:976 Merge.rc:988 Merge.rc:1047 Merge.rc:4864 Merge.rc:4893
 #, c-format
 msgid "Right to... (%1 of %2)"
 msgstr "  راست به ... - %1 از %2 "
@@ -1884,31 +1884,31 @@ msgid "Cop&y Paths"
 msgstr "&y رونوشت برداري از نام مسيرها "
 
 #. IDS_DEL_LEFT_FMT2
-#: Merge.rc:1026 Merge.rc:1035 Merge.rc:4880
+#: Merge.rc:1026 Merge.rc:1035 Merge.rc:4879
 #, c-format
 msgid "Left (%1 of %2)"
 msgstr " چپ - %1 از %2"
 
 #. IDS_DEL_MIDDLE_FMT2
-#: Merge.rc:1027 Merge.rc:1036 Merge.rc:4881
+#: Merge.rc:1027 Merge.rc:1036 Merge.rc:4880
 #, c-format
 msgid "Middle (%1 of %2)"
 msgstr ""
 
 #. IDS_DEL_RIGHT_FMT2
-#: Merge.rc:1028 Merge.rc:1037 Merge.rc:4882
+#: Merge.rc:1028 Merge.rc:1037 Merge.rc:4881
 #, c-format
 msgid "Right (%1 of %2)"
 msgstr " راست - %1 از %2"
 
 #. IDS_DEL_BOTH_FMT2
-#: Merge.rc:1029 Merge.rc:1038 Merge.rc:4883
+#: Merge.rc:1029 Merge.rc:1038 Merge.rc:4882
 #, c-format
 msgid "Both (%1 of %2)"
 msgstr " هر دو سمت - %1 از %2"
 
 #. IDS_DEL_ALL_FMT2
-#: Merge.rc:1030 Merge.rc:1039 Merge.rc:4888
+#: Merge.rc:1030 Merge.rc:1039 Merge.rc:4887
 #, c-format
 msgid "All (%1 of %2)"
 msgstr ""
@@ -1937,19 +1937,19 @@ msgid "&Zip"
 msgstr "&Z فشرده سازي "
 
 #. IDS_COPY_BOTH_TO2
-#: Merge.rc:1048 Merge.rc:4866
+#: Merge.rc:1048 Merge.rc:4865
 #, c-format
 msgid "Both to... (%1 of %2)"
 msgstr ""
 
 #. IDS_COPY_ALL_TO2
-#: Merge.rc:1049 Merge.rc:4867
+#: Merge.rc:1049 Merge.rc:4866
 #, c-format
 msgid "All to... (%1 of %2)"
 msgstr ""
 
 #. IDS_COPY_DIFFERENCES_TO2
-#: Merge.rc:1050 Merge.rc:4868
+#: Merge.rc:1050 Merge.rc:4867
 #, c-format
 msgid "Differences to... (%1 of %2)"
 msgstr ""
@@ -2022,13 +2022,13 @@ msgstr ""
 
 #. IDS_USERCHOICE_NONE
 #: Merge.rc:1088 Merge.rc:1094 Merge.rc:1836 Merge.rc:1840 Merge.rc:2031
-#: Merge.rc:2035 Merge.rc:5377
+#: Merge.rc:2035 Merge.rc:5376
 #, c-format
 msgid "<None>"
 msgstr "<هيچکدام>"
 
 #. IDS_USERCHOICE_AUTOMATIC
-#: Merge.rc:1089 Merge.rc:1095 Merge.rc:5378
+#: Merge.rc:1089 Merge.rc:1095 Merge.rc:5377
 #, c-format
 msgid "<Automatic>"
 msgstr "<خودکار>"
@@ -2980,13 +2980,13 @@ msgid "Text files only"
 msgstr ""
 
 #. IDS_EOL_NONE
-#: Merge.rc:1667 Merge.rc:1918 Merge.rc:5304
+#: Merge.rc:1667 Merge.rc:1918 Merge.rc:5303
 #, c-format
 msgid "None"
 msgstr " هيچيک "
 
 #. IDS_EOL_MIXED
-#: Merge.rc:1668 Merge.rc:5299
+#: Merge.rc:1668 Merge.rc:5298
 #, c-format
 msgid "Mixed"
 msgstr " مخلوط "
@@ -3260,14 +3260,14 @@ msgstr ""
 
 #. IDS_DIFFERENT
 #: Merge.rc:1904 Merge.rc:1988 Merge.rc:2866 Merge.rc:3036 Merge.rc:3077
-#: Merge.rc:5058
+#: Merge.rc:5057
 #, c-format
 msgid "Different"
 msgstr " متمايز"
 
 #. IDS_IDENTICAL
 #: Merge.rc:1905 Merge.rc:1989 Merge.rc:2865 Merge.rc:3055 Merge.rc:3116
-#: Merge.rc:5048
+#: Merge.rc:5047
 #, c-format
 msgid "Identical"
 msgstr " يکسان "
@@ -3288,7 +3288,7 @@ msgid "Missing"
 msgstr ""
 
 #. IDS_MOVED
-#: Merge.rc:1910 Merge.rc:5076
+#: Merge.rc:1910 Merge.rc:5075
 msgid "Moved"
 msgstr ""
 
@@ -4118,7 +4118,7 @@ msgid "&Use custom system colors"
 msgstr ""
 
 #. IDS_PRPCAT_SYSTEM
-#: Merge.rc:2565 Merge.rc:4559 Merge.rc:4560 Merge.rc:5007
+#: Merge.rc:2565 Merge.rc:4559 Merge.rc:4560 Merge.rc:5006
 #, c-format
 msgid "System"
 msgstr "سامانه"
@@ -4571,7 +4571,7 @@ msgid "Items compared:"
 msgstr " موارد مقايسه شده : "
 
 #. IDS_PREVIEWBAR_CLOSE
-#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5685
+#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5684
 #, c-format
 msgid "&Close"
 msgstr "&C بستن "
@@ -5260,7 +5260,7 @@ msgid "A&ppend timestamp"
 msgstr "&p پيوند مهر زمان "
 
 #. IDS_CONFIRM_COPY_CAPTION
-#: Merge.rc:3214 Merge.rc:4915
+#: Merge.rc:3214 Merge.rc:4914
 #, c-format
 msgid "Confirm Copy"
 msgstr " تاييد رونوشت برداري "
@@ -5521,7 +5521,7 @@ msgid "&Character Set..."
 msgstr ""
 
 #. IDS_PRPCAT_IMAGE
-#: Merge.rc:3351 Merge.rc:4574 Merge.rc:5015
+#: Merge.rc:3351 Merge.rc:4574 Merge.rc:5014
 msgid "Image"
 msgstr ""
 
@@ -5928,7 +5928,7 @@ msgid "Project"
 msgstr ""
 
 #. IDS_COLHDR_NSDIFFS
-#: Merge.rc:4566 Merge.rc:4990
+#: Merge.rc:4566 Merge.rc:4989
 #, c-format
 msgid "Differences"
 msgstr " تفاوتها "
@@ -6093,13 +6093,13 @@ msgid "File Type"
 msgstr ""
 
 #. IDS_COLHDR_EXTENSION
-#: Merge.rc:4653 Merge.rc:4947
+#: Merge.rc:4653 Merge.rc:4946
 #, c-format
 msgid "Extension"
 msgstr " توسعه "
 
 #. IDS_PRPCAT_MESSAGE
-#: Merge.rc:4659 Merge.rc:5019
+#: Merge.rc:4659 Merge.rc:5018
 msgid "Message"
 msgstr ""
 
@@ -6139,7 +6139,7 @@ msgid "Hidden Items"
 msgstr ""
 
 #. IDS_PLUGINSLIST_NAME
-#: Merge.rc:4680 Merge.rc:5311
+#: Merge.rc:4680 Merge.rc:5310
 #, c-format
 msgid "Name"
 msgstr " نام "
@@ -6163,7 +6163,7 @@ msgid "[F] "
 msgstr "[F] "
 
 #. IDS_PLUGINSLIST_DESC
-#: Merge.rc:4684 Merge.rc:5313
+#: Merge.rc:4684 Merge.rc:5312
 #, c-format
 msgid "Description"
 msgstr " شرح "
@@ -6340,171 +6340,165 @@ msgstr "Ln: %s  Col: %d/%d  Ch: %d/%d"
 msgid "  Sel: %d | %d"
 msgstr ""
 
-#. IDS_MERGEMODE_MERGING
-#: Merge.rc:4734
-#, c-format
-msgid "Merge"
-msgstr " پيوند زدن  "
-
 #. IDS_DIFF_NUMBER_STATUS_FMT
-#: Merge.rc:4735
+#: Merge.rc:4734
 #, c-format
 msgid "Difference %1 of %2"
 msgstr " تفاوت %1 از %2"
 
 #. IDS_NO_DIFF_SEL_FMT
-#: Merge.rc:4736
+#: Merge.rc:4735
 #, c-format
 msgid "%1 Differences Found"
 msgstr " تفاوتهاي پيدا شده = %1"
 
 #. IDS_1_DIFF_FOUND
-#: Merge.rc:4737
+#: Merge.rc:4736
 #, c-format
 msgid "1 Difference Found"
 msgstr " يک تفاوت پيدا شد "
 
 #. IDS_NO_ERR_SEL_FMT
-#: Merge.rc:4738
+#: Merge.rc:4737
 #, c-format
 msgid "%1 Errors Found"
 msgstr ""
 
 #. IDS_1_ERR_FOUND
-#: Merge.rc:4739
+#: Merge.rc:4738
 msgid "1 Error Found"
 msgstr ""
 
 #. IDS_STATUSBAR_READONLY, Abbreviation from "Read Only"
-#: Merge.rc:4740
+#: Merge.rc:4739
 #, c-format
 msgid "RO"
 msgstr "RO"
 
 #. IDS_DIRVIEW_STATUS_FMT_FOCUS
-#: Merge.rc:4746
+#: Merge.rc:4745
 #, c-format
 msgid "Item %1 of %2"
 msgstr "  مورد %1 از %2"
 
 #. IDS_DIRVIEW_STATUS_FMT_NOFOCUS
-#: Merge.rc:4747
+#: Merge.rc:4746
 #, c-format
 msgid "Items: %1"
 msgstr " موارد : %1"
 
 #. IDS_DIRVIEW_STATUS_COMPARING
-#: Merge.rc:4748
+#: Merge.rc:4747
 #, c-format
 msgid "Comparing items..."
 msgstr " همسنجي موارد  ... "
 
 #. IDS_ITEMS_PER_SEC
-#: Merge.rc:4749
+#: Merge.rc:4748
 #, c-format
 msgid "%.1f[items/sec]"
 msgstr ""
 
 #. IDS_ERROR_INCOMPARABLE
-#: Merge.rc:4755
+#: Merge.rc:4754
 msgid "Select two existing folders/files to compare."
 msgstr " انتخاب دو پوشه يا پرونده موجود براي مقايسه؟ "
 
 #. IDS_DIRSEL_TAG
-#: Merge.rc:4756
+#: Merge.rc:4755
 #, c-format
 msgid "Folder Selection"
 msgstr " انتخاب پوشه "
 
 #. IDS_OPEN_FILESDIRS
-#: Merge.rc:4757
+#: Merge.rc:4756
 #, c-format
 msgid "Select two (or three) folders/files to compare."
 msgstr ""
 
 #. IDS_OPEN_LEFTINVALID
-#: Merge.rc:4758
+#: Merge.rc:4757
 #, c-format
 msgid "Left (1st) path is invalid!"
 msgstr ""
 
 #. IDS_OPEN_MIDDLEINVALID
-#: Merge.rc:4759
+#: Merge.rc:4758
 #, c-format
 msgid "Middle (2nd) path is invalid!"
 msgstr ""
 
 #. IDS_OPEN_RIGHTINVALID2
-#: Merge.rc:4760
+#: Merge.rc:4759
 #, c-format
 msgid "Right (2nd) path is invalid!"
 msgstr ""
 
 #. IDS_OPEN_RIGHTINVALID3
-#: Merge.rc:4761
+#: Merge.rc:4760
 #, c-format
 msgid "Right (3rd) path is invalid!"
 msgstr ""
 
 #. IDS_OPEN_BOTHINVALID
-#: Merge.rc:4762
+#: Merge.rc:4761
 #, c-format
 msgid "Both paths are invalid!"
 msgstr " هر دو مسير وجود ندارند ! "
 
-#: Merge.rc:4764
+#: Merge.rc:4763
 #, c-format
 msgid "Left (1st) and Middle (2nd) paths are invalid!"
 msgstr ""
 
 #. IDS_OPEN_LEFTRIGHTINVALID
-#: Merge.rc:4765
+#: Merge.rc:4764
 #, c-format
 msgid "Left (1st) and Right (3rd) paths are invalid!"
 msgstr ""
 
-#: Merge.rc:4767
+#: Merge.rc:4766
 #, c-format
 msgid "Middle (2nd) and Right (3rd) paths are invalid!"
 msgstr ""
 
 #. IDS_OPEN_ALLINVALID
-#: Merge.rc:4768
+#: Merge.rc:4767
 #, c-format
 msgid "All paths are invalid!"
 msgstr ""
 
 #. IDS_OPEN_UNPACKERDISABLED
-#: Merge.rc:4769
+#: Merge.rc:4768
 msgid "Only enabled for file comparisons"
 msgstr ""
 
 #. IDS_OPEN_MISMATCH
-#: Merge.rc:4770
+#: Merge.rc:4769
 #, c-format
 msgid "Cannot compare file and folder!"
 msgstr " نميتوان پوشه و پرونده را مقايسه کرد ! "
 
 #. IDS_ERROR_FILE_NOT_FOUND
-#: Merge.rc:4776
+#: Merge.rc:4775
 #, c-format
 msgid "File not found: %1"
 msgstr " پرونده روبرو پيدا نشد : %1"
 
 #. IDS_ERROR_FOLDER_NOT_FOUND
-#: Merge.rc:4777
+#: Merge.rc:4776
 #, c-format
 msgid "Folder not found: %1"
 msgstr ""
 
 #. IDS_ERROR_FILE_NOT_UNPACKED
-#: Merge.rc:4778
+#: Merge.rc:4777
 #, c-format
 msgid "File not unpacked: %1"
 msgstr " بسته پرونده روبرو باز نشد : %1"
 
 #. IDS_ERROR_FILEOPEN
-#: Merge.rc:4779
+#: Merge.rc:4778
 #, c-format
 msgid ""
 "Cannot open file\n"
@@ -6518,13 +6512,13 @@ msgstr ""
 "%2"
 
 #. IDS_ERROR_CONF_RESOLVE
-#: Merge.rc:4780
+#: Merge.rc:4779
 #, c-format
 msgid "Failed to parse conflict file."
 msgstr " ناموفق بودن تجزيه و تحليل پرونده تعارض "
 
 #. IDS_NOT_CONFLICT_FILE
-#: Merge.rc:4781
+#: Merge.rc:4780
 #, c-format
 msgid "The file\n%1\nis not a conflict file."
 msgstr ""
@@ -6533,24 +6527,24 @@ msgstr ""
 "يک پرونده تعارض، نمي باشد "
 
 #. IDS_COMPARE_LARGE_FILES
-#: Merge.rc:4782
+#: Merge.rc:4781
 msgid "Comparing large files requires significant memory.\nShow only comparison results (not file contents)?"
 msgstr ""
 
 #. IDS_SAVE_AS_TITLE
-#: Merge.rc:4788
+#: Merge.rc:4787
 #, c-format
 msgid "Save As"
 msgstr " ذخيره کردن به صورت "
 
 #. IDS_SAVE_FMT
-#: Merge.rc:4789
+#: Merge.rc:4788
 #, c-format
 msgid "Save changes to %1?"
 msgstr " آيا تغييرات در %1 ذخيره شود؟"
 
 #. IDS_SAVEREADONLY_FMT
-#: Merge.rc:4790
+#: Merge.rc:4789
 #, c-format
 msgid "%1 is read-only. Override? Or 'No' to save as new filename?"
 msgstr ""
@@ -6558,12 +6552,12 @@ msgstr ""
 "خواندني   باطل گردد؟ - با نام جديد ذخيره نگردد "
 
 #. IDS_ERROR_BACKUP
-#: Merge.rc:4791
+#: Merge.rc:4790
 #, c-format
 msgid "Error backing up file"
 msgstr " خطا در تهيه پرونده پشتيبان "
 
-#: Merge.rc:4793
+#: Merge.rc:4792
 #, c-format
 msgid ""
 "Unable to backup original file:\n"
@@ -6577,7 +6571,7 @@ msgstr ""
 " به هر حال کار ادامه يابد؟ "
 
 #. IDS_FILESAVE_FAILED
-#: Merge.rc:4794
+#: Merge.rc:4793
 #, c-format
 msgid "Saving file failed.\n%1\n%2\n\t- Use different filename (OK)\n\t- Abort (Cancel)?"
 msgstr ""
@@ -6588,7 +6582,7 @@ msgstr ""
 "\t- يک نام پرونده متفاوت استفاده کنيد - تاييد را بفشاريد \n"
 "\t- عمل جاري لغو شود - لغو را بفشاريد ؟"
 
-#: Merge.rc:4796
+#: Merge.rc:4795
 #, c-format
 msgid "Plugin '%2' cannot pack changes to left file into '%1'.\n\nOriginal unchanged. Save unpacked version?"
 msgstr ""
@@ -6599,12 +6593,12 @@ msgstr ""
 "\n"
 " آيا مي خواهيد که نسخه با بسته بازشده به صورت پرونده ديگري ذخيره شود؟ "
 
-#: Merge.rc:4798
+#: Merge.rc:4797
 #, c-format
 msgid "Plugin '%2' cannot pack changes to middle file into '%1'.\n\nOriginal unchanged. Save unpacked version?"
 msgstr ""
 
-#: Merge.rc:4800
+#: Merge.rc:4799
 #, c-format
 msgid "Plugin '%2' cannot pack changes to right file into '%1'.\n\nOriginal unchanged. Save unpacked version?"
 msgstr ""
@@ -6616,7 +6610,7 @@ msgstr ""
 " آيا مي خواهيد که نسخه با بسته بازشده به صورت پرونده ديگري ذخيره شود؟ "
 
 #. IDS_FILECHANGED_ONDISK
-#: Merge.rc:4801
+#: Merge.rc:4800
 #, c-format
 msgid ""
 "Another application updated\n"
@@ -6632,7 +6626,7 @@ msgstr ""
 "  پرونده تغيير يافته دوباره نويسي شود؟"
 
 #. IDS_SAVEREADONLY_MULTI
-#: Merge.rc:4802
+#: Merge.rc:4801
 #, c-format
 msgid ""
 "%1\n"
@@ -6643,7 +6637,7 @@ msgstr ""
 "باطل گردد؟ "
 
 #. IDS_FILECHANGED_RESCAN
-#: Merge.rc:4803
+#: Merge.rc:4802
 #, c-format
 msgid "Another application updated\n%1\nsince last scan.\n\nReload?"
 msgstr ""
@@ -6654,25 +6648,25 @@ msgstr ""
 " آيا مايل هستيد که پرونده دوباره بارگيري شود؟"
 
 #. IDS_SAVE_LEFT_AS
-#: Merge.rc:4804
+#: Merge.rc:4803
 #, c-format
 msgid "Save Left File As"
 msgstr " ذخيره پرونده چپ به صورت "
 
 #. IDS_SAVE_MIDDLE_AS
-#: Merge.rc:4805
+#: Merge.rc:4804
 #, c-format
 msgid "Save Middle File As"
 msgstr ""
 
 #. IDS_SAVE_RIGHT_AS
-#: Merge.rc:4806
+#: Merge.rc:4805
 #, c-format
 msgid "Save Right File As"
 msgstr " ذخيره پرونده راست به صورت "
 
 #. IDS_FILE_DISAPPEARED
-#: Merge.rc:4811
+#: Merge.rc:4810
 #, c-format
 msgid ""
 "File\n"
@@ -6684,7 +6678,7 @@ msgstr ""
 " ناپديد شده است. لطفا يک رونوشت از پرونده را ذخيره نماييد تا کار ادامه يابد "
 
 #. IDS_VIEWS_OUTOFSYNC
-#: Merge.rc:4817
+#: Merge.rc:4816
 #, c-format
 msgid ""
 "Cannot merge unsynched documents.\n"
@@ -6696,189 +6690,189 @@ msgstr ""
 " اسناد قبل از ادامه کار بازسازي / تازه شوند "
 
 #. IDS_BREAK_ON_WHITESPACE
-#: Merge.rc:4822
+#: Merge.rc:4821
 msgid "Break at whitespace"
 msgstr " توقف در فاصله سفيد"
 
 #. IDS_BREAK_ON_PUNCTUATION
-#: Merge.rc:4823
+#: Merge.rc:4822
 msgid "Break at whitespace or punctuation"
 msgstr "توقف در فاصله سفيد يا نقطه / نشان گذارى   "
 
 #. IDS_L2M
-#: Merge.rc:4829
+#: Merge.rc:4828
 msgid "Copy to &Middle\tAlt+Right"
 msgstr ""
 
 #. IDS_R2M
-#: Merge.rc:4830
+#: Merge.rc:4829
 msgid "Copy to &Middle\tAlt+Left"
 msgstr ""
 
 #. IDS_COPY_FROM_MIDDLE_R
-#: Merge.rc:4831
+#: Merge.rc:4830
 msgid "Copy from Middle\tAlt+Shift+Right"
 msgstr ""
 
 #. IDS_COPY_FROM_MIDDLE_L
-#: Merge.rc:4832
+#: Merge.rc:4831
 msgid "Copy from Middle\tAlt+Shift+Left"
 msgstr ""
 
 #. IDS_L2MNEXT
-#: Merge.rc:4833
+#: Merge.rc:4832
 msgid "Copy to Middle and Advance\tCtrl+Alt+Right"
 msgstr ""
 
 #. IDS_R2MNEXT
-#: Merge.rc:4834
+#: Merge.rc:4833
 msgid "Copy to Middle and Advance\tCtrl+Alt+Left"
 msgstr ""
 
 #. IDS_ALL_MIDDLE
-#: Merge.rc:4835
+#: Merge.rc:4834
 msgid "Copy All to Middle"
 msgstr ""
 
 #. IDS_COPY_RIGHT_TO_LEFT
-#: Merge.rc:4841
+#: Merge.rc:4840
 #, c-format
 msgid "Right to Left (%1)"
 msgstr " راست به چپ - %1"
 
 #. IDS_COPY_RIGHT_TO_MIDDLE
-#: Merge.rc:4842
+#: Merge.rc:4841
 #, c-format
 msgid "Right to Middle (%1)"
 msgstr ""
 
 #. IDS_COPY_MIDDLE_TO_LEFT
-#: Merge.rc:4843
+#: Merge.rc:4842
 #, c-format
 msgid "Middle to Left (%1)"
 msgstr ""
 
 #. IDS_COPY_MIDDLE_TO_RIGHT
-#: Merge.rc:4844
+#: Merge.rc:4843
 #, c-format
 msgid "Middle to Right (%1)"
 msgstr ""
 
 #. IDS_COPY_LEFT_TO_RIGHT
-#: Merge.rc:4845
+#: Merge.rc:4844
 #, c-format
 msgid "Left to Right (%1)"
 msgstr " چپ به راست - %1"
 
 #. IDS_COPY_LEFT_TO_MIDDLE
-#: Merge.rc:4846
+#: Merge.rc:4845
 #, c-format
 msgid "Left to Middle (%1)"
 msgstr ""
 
 #. IDS_MOVE_LEFT_TO
-#: Merge.rc:4857 Merge.rc:4889
+#: Merge.rc:4856 Merge.rc:4888
 #, c-format
 msgid "Left to... (%1)"
 msgstr " چپ به ... - %1"
 
 #. IDS_MOVE_MIDDLE_TO
-#: Merge.rc:4858 Merge.rc:4890
+#: Merge.rc:4857 Merge.rc:4889
 #, c-format
 msgid "Middle to... (%1)"
 msgstr ""
 
 #. IDS_MOVE_RIGHT_TO
-#: Merge.rc:4859 Merge.rc:4891
+#: Merge.rc:4858 Merge.rc:4890
 #, c-format
 msgid "Right to... (%1)"
 msgstr " راست به ... - %1"
 
 #. IDS_COPY_BOTH_TO
-#: Merge.rc:4860
+#: Merge.rc:4859
 #, c-format
 msgid "Both to... (%1)"
 msgstr ""
 
 #. IDS_COPY_ALL_TO
-#: Merge.rc:4861
+#: Merge.rc:4860
 #, c-format
 msgid "All to... (%1)"
 msgstr ""
 
 #. IDS_COPY_DIFFERENCES_TO
-#: Merge.rc:4862
+#: Merge.rc:4861
 #, c-format
 msgid "Differences to... (%1)"
 msgstr ""
 
 #. IDS_ONLYDIFFITEMS_CONFIRM
-#: Merge.rc:4869
+#: Merge.rc:4868
 msgid "Some selected items are identical or skipped.\nProcess only items with differences?"
 msgstr ""
 
 #. IDS_DEL_LEFT_FMT
-#: Merge.rc:4875
+#: Merge.rc:4874
 #, c-format
 msgid "Left (%1)"
 msgstr " چپ - %1"
 
 #. IDS_DEL_MIDDLE_FMT
-#: Merge.rc:4876
+#: Merge.rc:4875
 #, c-format
 msgid "Middle (%1)"
 msgstr ""
 
 #. IDS_DEL_RIGHT_FMT
-#: Merge.rc:4877
+#: Merge.rc:4876
 #, c-format
 msgid "Right (%1)"
 msgstr " راست - %1"
 
 #. IDS_DEL_BOTH_FMT
-#: Merge.rc:4878
+#: Merge.rc:4877
 #, c-format
 msgid "Both (%1)"
 msgstr " هر دو سمت - %1"
 
 #. IDS_DEL_ALL_FMT
-#: Merge.rc:4879
+#: Merge.rc:4878
 #, c-format
 msgid "All (%1)"
 msgstr ""
 
 #. IDS_SELECT_DEST_LEFT
-#: Merge.rc:4895
+#: Merge.rc:4894
 #, c-format
 msgid "Left Side - Select Destination Folder:"
 msgstr " طرف چپ - انتخاب پوشه مقصد : "
 
 #. IDS_SELECT_DEST_MIDDLE
-#: Merge.rc:4896
+#: Merge.rc:4895
 #, c-format
 msgid "Middle Side - Select Destination Folder:"
 msgstr ""
 
 #. IDS_SELECT_DEST_RIGHT
-#: Merge.rc:4897
+#: Merge.rc:4896
 #, c-format
 msgid "Right Side - Select Destination Folder:"
 msgstr " طرف راست - انتخاب پوشه مقصد : "
 
 #. IDS_FILES_AFFECTED_FMT
-#: Merge.rc:4898
+#: Merge.rc:4897
 #, c-format
 msgid "(%1 Files Affected)"
 msgstr "{  پرونده هاي تحت تاثير واقع شده:  %1 }"
 
 #. IDS_FILES_AFFECTED_FMT2
-#: Merge.rc:4899
+#: Merge.rc:4898
 #, c-format
 msgid "(%1 of %2 Files Affected)"
 msgstr "{  پرونده هاي تحت تاثير واقع شده: %1 از %2  }"
 
 #. IDS_CONFIRM_DELETE_SINGLE
-#: Merge.rc:4905
+#: Merge.rc:4904
 #, c-format
 msgid ""
 "Are you sure you want to delete\n"
@@ -6890,18 +6884,18 @@ msgstr ""
 " را حذف نماييد %1 ?"
 
 #. IDS_CONFIRM_SINGLE_COPY
-#: Merge.rc:4906
+#: Merge.rc:4905
 msgid "Are you sure you want to copy?"
 msgstr " آيا مطمئن هستيد که ميخواهيد رونوشت برداري نماييد از؟  "
 
 #. IDS_CONFIRM_MULTIPLE_COPY
-#: Merge.rc:4907
+#: Merge.rc:4906
 #, c-format
 msgid "Are you sure you want to copy %d items?"
 msgstr " فقره رونوشت برداري شود؟ %d آيا مطمئن هستيد که مي خواهيد از "
 
 #. IDS_DIRCMP_NOTSYNC
-#: Merge.rc:4908
+#: Merge.rc:4907
 #, c-format
 msgid ""
 "Operation aborted!\n"
@@ -6920,804 +6914,804 @@ msgstr ""
 " لطفا مقايسه را تجديد نماييد "
 
 #. IDS_CONFIRM_SINGLE_MOVE
-#: Merge.rc:4913
+#: Merge.rc:4912
 msgid "Are you sure you want to move?"
 msgstr " آيا مطمئن هستيد که ميخواهيد اين را جابجا نماييد؟"
 
 #. IDS_CONFIRM_MULTIPLE_MOVE
-#: Merge.rc:4914
+#: Merge.rc:4913
 #, c-format
 msgid "Are you sure you want to move %d items?"
 msgstr " مورد جابجا شود؟ %d"
 
 #. IDS_CONFIRM_MOVE_CAPTION
-#: Merge.rc:4916
+#: Merge.rc:4915
 #, c-format
 msgid "Confirm Move"
 msgstr " تاييد جابجايي "
 
-#: Merge.rc:4918
+#: Merge.rc:4917
 #, c-format
 msgid "Close the folder comparison window?"
 msgstr ""
 
-#: Merge.rc:4920
+#: Merge.rc:4919
 msgid "Close the folder comparison window, which took a long time?"
 msgstr ""
 
 #. IDS_ERROR_INVALID_DIR_FILE_NAME
-#: Merge.rc:4921
+#: Merge.rc:4920
 msgid "The file or folder name is invalid."
 msgstr ""
 
 #. IDS_ERROR_EXECUTE_FILE
-#: Merge.rc:4927
+#: Merge.rc:4926
 #, c-format
 msgid "Failed to execute external editor: %1"
 msgstr " اجراي ناموفق ويراستار خارجي : %1"
 
 #. IDS_UNKNOWN_ARCHIVE_FORMAT
-#: Merge.rc:4933
+#: Merge.rc:4932
 #, c-format
 msgid "Unknown archive format"
 msgstr " بايگاني با قالب بندي ناشناس "
 
-#: Merge.rc:4935
+#: Merge.rc:4934
 msgid "Failed to extract archive.\nCompare as text file?"
 msgstr ""
 
 #. IDS_COLHDR_FILENAME
-#: Merge.rc:4941
+#: Merge.rc:4940
 #, c-format
 msgid "Filename"
 msgstr " نام پرونده "
 
 #. IDS_COLHDR_DIR
-#: Merge.rc:4942
+#: Merge.rc:4941
 msgctxt "DirView|ColumnHeader"
 msgid "Folder"
 msgstr " پوشه "
 
 #. IDS_COLHDR_RESULT
-#: Merge.rc:4943
+#: Merge.rc:4942
 #, c-format
 msgid "Comparison Result"
 msgstr " نتيجه مقايسه "
 
 #. IDS_COLHDR_LTIMEM
-#: Merge.rc:4944
+#: Merge.rc:4943
 #, c-format
 msgid "Left Date"
 msgstr " تاريخ چپ "
 
 #. IDS_COLHDR_RTIMEM
-#: Merge.rc:4945
+#: Merge.rc:4944
 #, c-format
 msgid "Right Date"
 msgstr " تاريخ راست "
 
 #. IDS_COLHDR_MTIMEM
-#: Merge.rc:4946
+#: Merge.rc:4945
 #, c-format
 msgid "Middle Date"
 msgstr ""
 
 #. IDS_COLHDR_LSIZE
-#: Merge.rc:4948
+#: Merge.rc:4947
 #, c-format
 msgid "Left Size"
 msgstr " اندازه چپ "
 
 #. IDS_COLHDR_RSIZE
-#: Merge.rc:4949
+#: Merge.rc:4948
 #, c-format
 msgid "Right Size"
 msgstr " اندازه راست "
 
 #. IDS_COLHDR_MSIZE
-#: Merge.rc:4954
+#: Merge.rc:4953
 #, c-format
 msgid "Middle Size"
 msgstr ""
 
 #. IDS_COLHDR_RSIZE_SHORT
-#: Merge.rc:4955
+#: Merge.rc:4954
 #, c-format
 msgid "Right Size (Short)"
 msgstr " سمت راست - مختصر "
 
 #. IDS_COLHDR_LSIZE_SHORT
-#: Merge.rc:4956
+#: Merge.rc:4955
 #, c-format
 msgid "Left Size (Short)"
 msgstr " سمت چپ - مختصر "
 
 #. IDS_COLHDR_MSIZE_SHORT
-#: Merge.rc:4957
+#: Merge.rc:4956
 #, c-format
 msgid "Middle Size (Short)"
 msgstr ""
 
 #. IDS_COLHDR_LTIMEC
-#: Merge.rc:4963
+#: Merge.rc:4962
 #, c-format
 msgid "Left Creation Time"
 msgstr " زمان ايجاد چپي "
 
 #. IDS_COLHDR_RTIMEC
-#: Merge.rc:4964
+#: Merge.rc:4963
 #, c-format
 msgid "Right Creation Time"
 msgstr " زمان ايجاد راستي "
 
 #. IDS_COLHDR_MTIMEC
-#: Merge.rc:4965
+#: Merge.rc:4964
 #, c-format
 msgid "Middle Creation Time"
 msgstr ""
 
 #. IDS_COLHDR_NEWER
-#: Merge.rc:4966
+#: Merge.rc:4965
 #, c-format
 msgid "Newer File"
 msgstr " پرونده جديدتر "
 
 #. IDS_COLHDR_LVERSION
-#: Merge.rc:4967
+#: Merge.rc:4966
 #, c-format
 msgid "Left File Version"
 msgstr " نسخه پرونده چپ "
 
 #. IDS_COLHDR_RVERSION
-#: Merge.rc:4968
+#: Merge.rc:4967
 #, c-format
 msgid "Right File Version"
 msgstr " نسخه پرونده راست "
 
 #. IDS_COLHDR_MVERSION
-#: Merge.rc:4969
+#: Merge.rc:4968
 #, c-format
 msgid "Middle File Version"
 msgstr ""
 
 #. IDS_COLHDR_RESULT_ABBR
-#: Merge.rc:4970
+#: Merge.rc:4969
 #, c-format
 msgid "Short Result"
 msgstr " نتيجه کوتاه "
 
 #. IDS_COLHDR_LATTRIBUTES
-#: Merge.rc:4971
+#: Merge.rc:4970
 #, c-format
 msgid "Left Attributes"
 msgstr " خصيصه هاي چپي "
 
 #. IDS_COLHDR_RATTRIBUTES
-#: Merge.rc:4972
+#: Merge.rc:4971
 #, c-format
 msgid "Right Attributes"
 msgstr " خصيصه هاي راستي "
 
 #. IDS_COLHDR_MATTRIBUTES
-#: Merge.rc:4973
+#: Merge.rc:4972
 #, c-format
 msgid "Middle Attributes"
 msgstr ""
 
 #. IDS_COLHDR_LEOL_TYPE
-#: Merge.rc:4978
+#: Merge.rc:4977
 #, c-format
 msgid "Left EOL"
 msgstr "آخر خط چپ چين"
 
 #. IDS_COLHDR_MEOL_TYPE
-#: Merge.rc:4979
+#: Merge.rc:4978
 #, c-format
 msgid "Middle EOL"
 msgstr ""
 
 #. IDS_COLHDR_REOL_TYPE
-#: Merge.rc:4980
+#: Merge.rc:4979
 #, c-format
 msgid "Right EOL"
 msgstr "آخر خط راست چين"
 
 #. IDS_COLHDR_LENCODING
-#: Merge.rc:4986
+#: Merge.rc:4985
 #, c-format
 msgid "Left Encoding"
 msgstr " کدبندي چپ "
 
 #. IDS_COLHDR_RENCODING
-#: Merge.rc:4987
+#: Merge.rc:4986
 #, c-format
 msgid "Right Encoding"
 msgstr " کدبندي راست "
 
 #. IDS_COLHDR_MENCODING
-#: Merge.rc:4988
+#: Merge.rc:4987
 #, c-format
 msgid "Middle Encoding"
 msgstr ""
 
 #. IDS_COLHDR_NIDIFFS
-#: Merge.rc:4989
+#: Merge.rc:4988
 msgid "Ignored Diff"
 msgstr " تفاوت چشم پوشي شده "
 
 #. IDS_COLHDR_BINARY
-#: Merge.rc:4991
+#: Merge.rc:4990
 msgctxt "DirView|ColumnHeader"
 msgid "Binary"
 msgstr " دودويي "
 
 #. IDS_PLUGINS_TYPE_UNPACKER
-#: Merge.rc:4992 Merge.rc:5314
+#: Merge.rc:4991 Merge.rc:5313
 #, c-format
 msgid "Unpacker"
 msgstr " باز کننده بسته "
 
 #. IDS_PLUGIN_TYPE4
-#: Merge.rc:4993 Merge.rc:5315 Merge.rc:5622
+#: Merge.rc:4992 Merge.rc:5314 Merge.rc:5621
 #, c-format
 msgid "Prediffer"
 msgstr " پيش فرق گذار "
 
 #. IDS_COLHDR_LEFT
-#: Merge.rc:4994
+#: Merge.rc:4993
 msgid "Left"
 msgstr ""
 
 #. IDS_COLHDR_MIDDLE
-#: Merge.rc:4995
+#: Merge.rc:4994
 msgid "Middle"
 msgstr ""
 
 #. IDS_COLHDR_RIGHT
-#: Merge.rc:4996
+#: Merge.rc:4995
 msgid "Right"
 msgstr ""
 
 #. IDS_COLHDR_DIFF
-#: Merge.rc:4997
+#: Merge.rc:4996
 msgid "Diff"
 msgstr ""
 
 #. IDS_COLHDR_LEFT_DUPLICATE
-#: Merge.rc:4998
+#: Merge.rc:4997
 msgid "Left Duplicate Count"
 msgstr ""
 
 #. IDS_COLHDR_RIGHT_DUPLICATE
-#: Merge.rc:4999
+#: Merge.rc:4998
 msgid "Right Duplicate Count"
 msgstr ""
 
 #. IDS_COLHDR_MIDDLE_DUPLICATE
-#: Merge.rc:5000
+#: Merge.rc:4999
 msgid "Middle Duplicate Count"
 msgstr ""
 
 #. IDS_COLHDR_MOVE
-#: Merge.rc:5001
+#: Merge.rc:5000
 msgid "Move"
 msgstr ""
 
 #. IDS_PRPCAT_AUDIO
-#: Merge.rc:5008
+#: Merge.rc:5007
 msgid "Audio"
 msgstr ""
 
 #. IDS_PRPCAT_CALENDAR
-#: Merge.rc:5009
+#: Merge.rc:5008
 msgid "Calendar"
 msgstr ""
 
 #. IDS_PRPCAT_COMMUNICATION
-#: Merge.rc:5010
+#: Merge.rc:5009
 msgid "Communication"
 msgstr ""
 
 #. IDS_PRPCAT_CONTACT
-#: Merge.rc:5011
+#: Merge.rc:5010
 msgid "Contact"
 msgstr ""
 
 #. IDS_PRPCAT_DEVICES
-#: Merge.rc:5012
+#: Merge.rc:5011
 msgid "Devices"
 msgstr ""
 
 #. IDS_PRPCAT_DOCUMENT
-#: Merge.rc:5013
+#: Merge.rc:5012
 msgid "Document"
 msgstr ""
 
 #. IDS_PRPCAT_HOME
-#: Merge.rc:5014
+#: Merge.rc:5013
 msgid "Home"
 msgstr ""
 
 #. IDS_PRPCAT_JOURNAL
-#: Merge.rc:5016
+#: Merge.rc:5015
 msgid "Journal"
 msgstr ""
 
 #. IDS_PRPCAT_LINK
-#: Merge.rc:5017
+#: Merge.rc:5016
 msgid "Link"
 msgstr ""
 
 #. IDS_PRPCAT_MEDIA
-#: Merge.rc:5018
+#: Merge.rc:5017
 msgid "Media"
 msgstr ""
 
 #. IDS_PRPCAT_MUSIC
-#: Merge.rc:5020
+#: Merge.rc:5019
 msgid "Music"
 msgstr ""
 
 #. IDS_PRPCAT_NOTE
-#: Merge.rc:5021
+#: Merge.rc:5020
 msgid "Note"
 msgstr ""
 
 #. IDS_PRPCAT_PHOTO
-#: Merge.rc:5022
+#: Merge.rc:5021
 msgid "Photo"
 msgstr ""
 
 #. IDS_PRPCAT_RECORDEDTV
-#: Merge.rc:5023
+#: Merge.rc:5022
 msgid "RecordedTV"
 msgstr ""
 
 #. IDS_PRPCAT_SEARCH
-#: Merge.rc:5024
+#: Merge.rc:5023
 msgid "Search"
 msgstr ""
 
 #. IDS_PRPCAT_SECURITY
-#: Merge.rc:5025
+#: Merge.rc:5024
 msgid "Security"
 msgstr ""
 
 #. IDS_PRPCAT_SOFTWARE
-#: Merge.rc:5026
+#: Merge.rc:5025
 msgid "Software"
 msgstr ""
 
 #. IDS_PRPCAT_TASK
-#: Merge.rc:5027
+#: Merge.rc:5026
 msgid "Task"
 msgstr ""
 
 #. IDS_PRPCAT_VIDEO
-#: Merge.rc:5028
+#: Merge.rc:5027
 msgid "Video"
 msgstr ""
 
 #. IDS_PRPCAT_HASH
-#: Merge.rc:5029
+#: Merge.rc:5028
 msgid "Hash"
 msgstr ""
 
 #. IDS_CANT_COMPARE_FILES
-#: Merge.rc:5035
+#: Merge.rc:5034
 #, c-format
 msgid "Unable to compare files"
 msgstr " ناتوان از همسنجي پرونده هاست"
 
 #. IDS_ABORTED_ITEM
-#: Merge.rc:5036
+#: Merge.rc:5035
 #, c-format
 msgid "Item aborted"
 msgstr " مورد انصرافي "
 
 #. IDS_FILE_SKIPPED
-#: Merge.rc:5037
+#: Merge.rc:5036
 #, c-format
 msgid "File skipped"
 msgstr " پرونده از قلم افتاده "
 
 #. IDS_DIR_SKIPPED
-#: Merge.rc:5038
+#: Merge.rc:5037
 #, c-format
 msgid "Folder skipped"
 msgstr " پوشه از قلم افتاده "
 
 #. IDS_LEFT_ONLY_IN_FMT
-#: Merge.rc:5039
+#: Merge.rc:5038
 #, c-format
 msgid "Left only: %1"
 msgstr " فقط چپ : %1"
 
 #. IDS_MIDDLE_ONLY_IN_FMT
-#: Merge.rc:5040
+#: Merge.rc:5039
 #, c-format
 msgid "Middle only: %1"
 msgstr ""
 
 #. IDS_RIGHT_ONLY_IN_FMT
-#: Merge.rc:5041
+#: Merge.rc:5040
 #, c-format
 msgid "Right only: %1"
 msgstr " فقط راست : %1"
 
 #. IDS_DOES_NOT_EXIST_IN_FMT
-#: Merge.rc:5042
+#: Merge.rc:5041
 #, c-format
 msgid "Does not exist in %1"
 msgstr ""
 
 #. IDS_BIN_FILES_SAME
-#: Merge.rc:5043
+#: Merge.rc:5042
 #, c-format
 msgid "Binary files are identical"
 msgstr " پرونده هاي دودويي همسان هستند "
 
 #. IDS_BIN_FILES_DIFF
-#: Merge.rc:5049
+#: Merge.rc:5048
 #, c-format
 msgid "Binary files are different"
 msgstr " پرونده هاي دودويي متفاوت هستند "
 
 #. IDS_FILES_ARE_DIFFERENT
-#: Merge.rc:5050
+#: Merge.rc:5049
 #, c-format
 msgid "Files are different"
 msgstr " پرونده ها متفاوت هستند "
 
 #. IDS_FOLDERS_ARE_DIFFERENT
-#: Merge.rc:5051
+#: Merge.rc:5050
 #, c-format
 msgid "Folders are different"
 msgstr " پوشه ها متفاوت هستند "
 
 #. IDS_LEFTONLY
-#: Merge.rc:5052
+#: Merge.rc:5051
 #, c-format
 msgid "Left Only"
 msgstr " فقط چپ "
 
 #. IDS_RIGHTONLY
-#: Merge.rc:5053
+#: Merge.rc:5052
 #, c-format
 msgid "Right Only"
 msgstr " فقط راست "
 
 #. IDS_MIDDLEONLY
-#: Merge.rc:5054
+#: Merge.rc:5053
 #, c-format
 msgid "Middle Only"
 msgstr ""
 
 #. IDS_NOITEMLEFT
-#: Merge.rc:5055
+#: Merge.rc:5054
 #, c-format
 msgid "No item in left"
 msgstr ""
 
 #. IDS_NOITEMRIGHT
-#: Merge.rc:5056
+#: Merge.rc:5055
 #, c-format
 msgid "No item in right"
 msgstr ""
 
 #. IDS_NOITEMMIDDLE
-#: Merge.rc:5057
+#: Merge.rc:5056
 #, c-format
 msgid "No item in middle"
 msgstr ""
 
 #. IDS_CMPRES_ERROR
-#: Merge.rc:5059
+#: Merge.rc:5058
 #, c-format
 msgid "Error"
 msgstr " خطا "
 
 #. IDS_TEXT_FILES_SAME
-#: Merge.rc:5060
+#: Merge.rc:5059
 #, c-format
 msgid "Text files are identical"
 msgstr " پرونده هاي متني همسان هستند "
 
 #. IDS_LEFTONLY_DIFF
-#: Merge.rc:5061
+#: Merge.rc:5060
 msgid " (Middle and right are identical)"
 msgstr ""
 
 #. IDS_MIDDLEONLY_DIFF
-#: Merge.rc:5062
+#: Merge.rc:5061
 msgid " (Left and right are identical)"
 msgstr ""
 
 #. IDS_RIGHTONLY_DIFF
-#: Merge.rc:5063
+#: Merge.rc:5062
 msgid " (Left and middle are identical)"
 msgstr ""
 
 #. IDS_PATH_MISMATCH
-#: Merge.rc:5064
+#: Merge.rc:5063
 msgid " (paths differ)"
 msgstr ""
 
 #. IDS_TEXT_FILES_DIFF
-#: Merge.rc:5065
+#: Merge.rc:5064
 #, c-format
 msgid "Text files are different"
 msgstr " پرونده هاي متني متفاوت هستند "
 
 #. IDS_IMAGE_FILES_SAME
-#: Merge.rc:5066
+#: Merge.rc:5065
 msgid "Image files are identical"
 msgstr ""
 
 #. IDS_IMAGE_FILES_DIFF
-#: Merge.rc:5067
+#: Merge.rc:5066
 msgid "Image files are different"
 msgstr ""
 
 #. IDS_EXPR_DIFF
-#: Merge.rc:5068
+#: Merge.rc:5067
 #, c-format
 msgid "Files are different (expr: %1)"
 msgstr ""
 
 #. IDS_HASH_GROUP
-#: Merge.rc:5069
+#: Merge.rc:5068
 #, c-format
 msgid "Group%d"
 msgstr ""
 
 #. IDS_RENAME_MOVE_DETECTION_DISALBED
-#: Merge.rc:5070
+#: Merge.rc:5069
 msgctxt "Options dialog|Compare|Folder|Detect renames and moves"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_RENAME_MOVE_DETECTION_RENAME
-#: Merge.rc:5071
+#: Merge.rc:5070
 msgid "Detect renames"
 msgstr ""
 
 #. IDS_RENAME_MOVE_DETECTION_RENAME_MOVE
-#: Merge.rc:5072
+#: Merge.rc:5071
 msgid "Detect renames and moves"
 msgstr ""
 
 #. IDS_RENAME_MOVE_MERGE_MODE_RENAME
-#: Merge.rc:5073
+#: Merge.rc:5072
 msgid "Merge renames"
 msgstr ""
 
 #. IDS_RENAME_MOVE_MERGE_MODE_RENAME_MOVE
-#: Merge.rc:5074
+#: Merge.rc:5073
 msgid "Merge renames and moves"
 msgstr ""
 
 #. IDS_RENAMED
-#: Merge.rc:5075
+#: Merge.rc:5074
 msgid "Renamed"
 msgstr ""
 
 #. IDS_RENAMED_MOVED
-#: Merge.rc:5077
+#: Merge.rc:5076
 msgid "Renamed/Moved"
 msgstr ""
 
 #. IDS_RENAMED_MOVED_ITEMS
-#: Merge.rc:5078
+#: Merge.rc:5077
 #, c-format
 msgid "(%1 items)"
 msgstr ""
 
 #. IDS_RENAMED_MOVED_RESULT
-#: Merge.rc:5079
+#: Merge.rc:5078
 #, c-format
 msgid "%1 (set %2): "
 msgstr ""
 
 #. IDS_SWITCH_FLAT_MODE
-#: Merge.rc:5080
+#: Merge.rc:5079
 msgid "Some moved items have been merged.\nIn Tree Mode, these items may appear in positions that do not reflect the actual folder structure, which can be confusing.\nSwitch to Flat Mode?"
 msgstr ""
 
 #. IDS_ELAPSED_TIME
-#: Merge.rc:5086
+#: Merge.rc:5085
 #, c-format
 msgid "Elapsed time: %ld ms"
 msgstr " زمان سپري شده - ميلي ثانيه : %ld"
 
 #. IDS_STATUS_SELITEM1
-#: Merge.rc:5087
+#: Merge.rc:5086
 #, c-format
 msgid "1 item selected"
 msgstr " يک مورد انتخاب شد "
 
 #. IDS_STATUS_SELITEMS
-#: Merge.rc:5088
+#: Merge.rc:5087
 #, c-format
 msgid "%1 items selected"
 msgstr "موارد انتخاب شده = %1"
 
 #. IDS_COLDESC_FILENAME
-#: Merge.rc:5094
+#: Merge.rc:5093
 #, c-format
 msgid "Filename or folder name."
 msgstr " نام پرونده يا پوشه "
 
 #. IDS_COLDESC_DIR
-#: Merge.rc:5095
+#: Merge.rc:5094
 #, c-format
 msgid "Subfolder name when subfolders are included."
 msgstr " نام زيرپوشه موقعي که زيرپوشه ها شامل هستند "
 
 #. IDS_COLDESC_RESULT
-#: Merge.rc:5096
+#: Merge.rc:5095
 #, c-format
 msgid "Comparison result, long form."
 msgstr " شکل مبسوط نتايج همسنجي / مقايسه "
 
 #. IDS_COLDESC_LTIMEM
-#: Merge.rc:5101
+#: Merge.rc:5100
 #, c-format
 msgid "Left side modification date."
 msgstr " تاريخ تغيير سمت چپي "
 
 #. IDS_COLDESC_RTIMEM
-#: Merge.rc:5102
+#: Merge.rc:5101
 #, c-format
 msgid "Right side modification date."
 msgstr " تاريخ تغيير سمت راستي "
 
 #. IDS_COLDESC_MTIMEM
-#: Merge.rc:5103
+#: Merge.rc:5102
 #, c-format
 msgid "Middle side modification date."
 msgstr ""
 
 #. IDS_COLDESC_EXTENSION
-#: Merge.rc:5104
+#: Merge.rc:5103
 #, c-format
 msgid "File's extension."
 msgstr " توسعه پرونده "
 
 #. IDS_COLDESC_LSIZE
-#: Merge.rc:5105
+#: Merge.rc:5104
 #, c-format
 msgid "Left file size in bytes."
 msgstr " اندازه پرونده چپ به بايت "
 
 #. IDS_COLDESC_RSIZE
-#: Merge.rc:5106
+#: Merge.rc:5105
 #, c-format
 msgid "Right file size in bytes."
 msgstr " اندازه پرونده راست به بايت "
 
 #. IDS_COLDESC_MSIZE
-#: Merge.rc:5107
+#: Merge.rc:5106
 #, c-format
 msgid "Middle file size in bytes."
 msgstr ""
 
 #. IDS_COLDESC_LSIZE_SHORT
-#: Merge.rc:5108
+#: Merge.rc:5107
 #, c-format
 msgid "Left file size abbreviated."
 msgstr " اندازه پرونده سمت چپ بصورت مختصر نمايش داده مي شود "
 
 #. IDS_COLDESC_RSIZE_SHORT
-#: Merge.rc:5109
+#: Merge.rc:5108
 #, c-format
 msgid "Right file size abbreviated."
 msgstr " اندازه پرونده سمت راست بصورت مختصر نمايش داده مي شود "
 
 #. IDS_COLDESC_MSIZE_SHORT
-#: Merge.rc:5110
+#: Merge.rc:5109
 #, c-format
 msgid "Middle file size abbreviated."
 msgstr ""
 
 #. IDS_COLDESC_LTIMEC
-#: Merge.rc:5116
+#: Merge.rc:5115
 #, c-format
 msgid "Left side creation time."
 msgstr " زمان ايجاد طرف چپ "
 
 #. IDS_COLDESC_RTIMEC
-#: Merge.rc:5117
+#: Merge.rc:5116
 #, c-format
 msgid "Right side creation time."
 msgstr " زمان ايجاد طرف راست "
 
 #. IDS_COLDESC_MTIMEC
-#: Merge.rc:5118
+#: Merge.rc:5117
 #, c-format
 msgid "Middle side creation time."
 msgstr ""
 
 #. IDS_COLDESC_NEWER
-#: Merge.rc:5119
+#: Merge.rc:5118
 #, c-format
 msgid "Tells which side has newer modification date."
 msgstr " مي گويد که تاريخ تغيير کدام سمت جديدتر است "
 
 #. IDS_COLDESC_LVERSION
-#: Merge.rc:5120
+#: Merge.rc:5119
 msgid "Left side file version, only for some file types."
 msgstr " نگارش پرونده سمت چپ، فقط براي برخي از انواع پرونده ها "
 
 #. IDS_COLDESC_RVERSION
-#: Merge.rc:5121
+#: Merge.rc:5120
 msgid "Right side file version, only for some file types."
 msgstr " نگارش پرونده سمت راست، فقط براي برخي از انواع پرونده ها "
 
 #. IDS_COLDESC_MVERSION
-#: Merge.rc:5126
+#: Merge.rc:5125
 msgid "Middle side file version, only for some file types."
 msgstr ""
 
 #. IDS_COLDESC_RESULT_ABBR
-#: Merge.rc:5127
+#: Merge.rc:5126
 #, c-format
 msgid "Short comparison result."
 msgstr " نتيجه همسنجي بطور کوتاه "
 
 #. IDS_COLDESC_LATTRIBUTES
-#: Merge.rc:5128
+#: Merge.rc:5127
 #, c-format
 msgid "Left side attributes."
 msgstr " خصيصه هاي سمت چپ "
 
 #. IDS_COLDESC_RATTRIBUTES
-#: Merge.rc:5129
+#: Merge.rc:5128
 #, c-format
 msgid "Right side attributes."
 msgstr " خصيصه هاي سمت راست "
 
 #. IDS_COLDESC_MATTRIBUTES
-#: Merge.rc:5130
+#: Merge.rc:5129
 #, c-format
 msgid "Middle side attributes."
 msgstr ""
 
 #. IDS_COLDESC_LEOL_TYPE
-#: Merge.rc:5131
+#: Merge.rc:5130
 msgid "Left side file EOL type."
 msgstr " نوع انتهاي خط در پرونده سمت چپ"
 
 #. IDS_COLDESC_REOL_TYPE
-#: Merge.rc:5132
+#: Merge.rc:5131
 msgid "Right side file EOL type."
 msgstr " نوع انتهاي خط در پزونده سمت راست"
 
 #. IDS_COLDESC_MEOL_TYPE
-#: Merge.rc:5133
+#: Merge.rc:5132
 msgid "Middle side file EOL type."
 msgstr ""
 
 #. IDS_COLDESC_LENCODING
-#: Merge.rc:5139
+#: Merge.rc:5138
 #, c-format
 msgid "Left side encoding."
 msgstr " کدبندي سمت چپ "
 
 #. IDS_COLDESC_RENCODING
-#: Merge.rc:5140
+#: Merge.rc:5139
 #, c-format
 msgid "Right side encoding."
 msgstr " کدبندي سمت راست "
 
 #. IDS_COLDESC_MENCODING
-#: Merge.rc:5141
+#: Merge.rc:5140
 #, c-format
 msgid "Middle side encoding."
 msgstr ""
 
 #. IDS_COLDESC_NIDIFFS
-#: Merge.rc:5142
+#: Merge.rc:5141
 #, c-format
 msgid "Number of ignored differences in file. Ignored and cannot be merged."
 msgstr ""
@@ -7725,72 +7719,72 @@ msgstr ""
 "است و قابل پيوند زدن نيست "
 
 #. IDS_COLDESC_NSDIFFS
-#: Merge.rc:5143
+#: Merge.rc:5142
 #, c-format
 msgid "Number of differences in file (excluding ignored)."
 msgstr ""
 " شماره تفاوتها در پرونده. اين شماره شامل تفاوتهاي چشم پوشي شده نمي شود "
 
 #. IDS_COLDESC_BINARY
-#: Merge.rc:5144
+#: Merge.rc:5143
 #, c-format
 msgid "Shows an asterisk (*) if the file is binary."
 msgstr " نمايش يک ستاره * در صورتيکه پرونده دودويي باشد "
 
 #. IDS_COLDESC_UNPACKER
-#: Merge.rc:5145
+#: Merge.rc:5144
 msgid "Unpacker plugin name or pipeline."
 msgstr ""
 
 #. IDS_COLDESC_PREDIFFER
-#: Merge.rc:5146
+#: Merge.rc:5145
 msgid "Prediffer plugin name or pipeline."
 msgstr ""
 
 #. IDS_DIRECTORY_REPORT_TITLE
-#: Merge.rc:5152
+#: Merge.rc:5151
 #, c-format
 msgid "Compare %1 with %2"
 msgstr " همسنجي  %1 با  %2"
 
 #. IDS_DIRECTORY_REPORT_TITLE3
-#: Merge.rc:5153
+#: Merge.rc:5152
 #, c-format
 msgid "Compare %1 with %2 and %3"
 msgstr ""
 
 #. IDS_REPORT_COMMALIST
-#: Merge.rc:5154
+#: Merge.rc:5153
 #, c-format
 msgid "Comma-separated list"
 msgstr " فهرستي که با کاما جدا شده باشد "
 
 #. IDS_REPORT_TABLIST
-#: Merge.rc:5155
+#: Merge.rc:5154
 #, c-format
 msgid "Tab-separated list"
 msgstr " فهرست جداشده با کليد جهش "
 
 #. IDS_REPORT_SIMPLEHTML
-#: Merge.rc:5156
+#: Merge.rc:5155
 #, c-format
 msgid "Simple HTML"
 msgstr " ساده اچ تي ام ال"
 
 #. IDS_REPORT_SIMPLEXML
-#: Merge.rc:5157
+#: Merge.rc:5156
 #, c-format
 msgid "Simple XML"
 msgstr " ساده ايکس ام ال "
 
-#: Merge.rc:5159
+#: Merge.rc:5158
 #, c-format
 msgid "Report file already exists. Overwrite?"
 msgstr ""
 " پيش از اين، پرونده گزارش وجود داشته است. آيا مايليد که پرونده جايگزين شود ؟ "
 
 #. IDS_REPORT_ERROR
-#: Merge.rc:5164
+#: Merge.rc:5163
 #, c-format
 msgid ""
 "Error creating the report:\n"
@@ -7800,56 +7794,56 @@ msgstr ""
 "%1"
 
 #. IDS_REPORT_SUCCESS
-#: Merge.rc:5165
+#: Merge.rc:5164
 #, c-format
 msgid "Report created successfully."
 msgstr " گزارش با موفقيت ايجاد شده است  "
 
 #. IDS_SYNCPOINT_LASTBLOCK
-#: Merge.rc:5171
+#: Merge.rc:5170
 msgid "Cannot add a synchronization point at this line."
 msgstr ""
 
 #. IDS_FILE_TO_ITSELF
-#: Merge.rc:5177
+#: Merge.rc:5176
 #, c-format
 msgid "Same file is opened in both panes."
 msgstr "  يک  پرونده در هر دو تابلو باز شده است"
 
 #. IDS_FILESSAME
-#: Merge.rc:5178
+#: Merge.rc:5177
 #, c-format
 msgid "Selected files are identical."
 msgstr " پرونده هاي انتخاب شده همسان هستند  "
 
 #. IDS_FILESSAME_CURCFG
-#: Merge.rc:5179
+#: Merge.rc:5178
 msgid "Selected files are identical (with current settings).\r\nChecking binary identity..."
 msgstr ""
 
 #. IDS_FILESSAME_BINERROR
-#: Merge.rc:5180
+#: Merge.rc:5179
 msgid "Selected files are identical (with current settings).\r\nBut binary comparison failed."
 msgstr ""
 
 #. IDS_FILESSAME_BINSAME
-#: Merge.rc:5181
+#: Merge.rc:5180
 msgid "Selected files are identical (binary match)."
 msgstr ""
 
 #. IDS_FILESSAME_BINDIFF
-#: Merge.rc:5182
+#: Merge.rc:5181
 msgid "Selected files are identical (with current settings).\r\nBut differ at the binary level."
 msgstr ""
 
 #. IDS_FILEERROR
-#: Merge.rc:5183
+#: Merge.rc:5182
 #, c-format
 msgid "An error occurred while comparing files."
 msgstr " به هنگام همسنجي پرونده ها خطايي رخ داد "
 
 #. IDS_TEMP_FILEERROR
-#: Merge.rc:5184
+#: Merge.rc:5183
 #, c-format
 msgid ""
 "Could not create temporary files. Check your temporary path settings."
@@ -7857,7 +7851,7 @@ msgstr ""
 " پرونده هاي موقتي را نمي توان ايجاد نمود. تنظيمات مسير موقت بررسي گردد "
 
 #. IDS_SUGGEST_IGNOREEOL
-#: Merge.rc:5185
+#: Merge.rc:5184
 msgid "Files use different EOL.\n\nTreat all EOL as equivalent?\n\nSet 'Ignore EOL differences (Windows/Unix/Mac)' in Compare section of Options."
 msgstr ""
 " اين پرونده ها از نوع متفاوتي از علامت بازگشت به سر سطر استفاده مي نمايند \n"
@@ -7871,19 +7865,19 @@ msgstr ""
 "ويرايش>خيارات} علامت زده شود "
 
 #. IDS_INVALID_DIRECTORY
-#: Merge.rc:5186
+#: Merge.rc:5185
 #, c-format
 msgid "Selected folder is invalid."
 msgstr " پوشه انتخاب شده وجود ندارد  "
 
 #. IDS_CANNOT_OPEN_BINARYFILE
-#: Merge.rc:5187
+#: Merge.rc:5186
 #, c-format
 msgid "Cannot open a binary file in Editor."
 msgstr " نمي تواند پرونده دودويي را در ويراستار باز نمايد "
 
 #. IDS_CREATE_PAIR_FOLDER
-#: Merge.rc:5188
+#: Merge.rc:5187
 #, c-format
 msgid "Create matching folder:\n%1\non the other side and open?"
 msgstr ""
@@ -7894,45 +7888,45 @@ msgstr ""
 "به سمت ديگر و بازشدن اين پوشه ها ؟ "
 
 #. IDS_CONFIRM_COPY_ALL_DIFFS
-#: Merge.rc:5189
+#: Merge.rc:5188
 msgid "Copy all differences to other file?"
 msgstr ""
 
 #. IDS_MOVE_TO_NEXTFILE
-#: Merge.rc:5194
+#: Merge.rc:5193
 #, c-format
 msgid "Move to next file?"
 msgstr ""
 
 #. IDS_MOVE_TO_PREVFILE
-#: Merge.rc:5195
+#: Merge.rc:5194
 #, c-format
 msgid "Move to previous file?"
 msgstr ""
 
 #. IDS_MOVE_TO_NEXTPAGE
-#: Merge.rc:5196
+#: Merge.rc:5195
 #, c-format
 msgid "Move to next page?"
 msgstr ""
 
 #. IDS_MOVE_TO_PREVPAGE
-#: Merge.rc:5197
+#: Merge.rc:5196
 #, c-format
 msgid "Move to previous page?"
 msgstr ""
 
 #. IDS_MOVE_TO_FIRSTFILE
-#: Merge.rc:5198
+#: Merge.rc:5197
 msgid "Move to first file?"
 msgstr ""
 
 #. IDS_MOVE_TO_LASTFILE
-#: Merge.rc:5199
+#: Merge.rc:5198
 msgid "Move to last file?"
 msgstr ""
 
-#: Merge.rc:5206
+#: Merge.rc:5205
 #, c-format
 msgid "Different codepages: left (cp%d), right (cp%d).\nDisplay in codepage (better display) or default Windows codepage (safer merging)?\n(Recommended: default Windows codepage)"
 msgstr ""
@@ -7942,154 +7936,154 @@ msgstr ""
 " آيا مايل هستيد تا با هر دو پرونده به شکلي که در صفحه کد پيش فرض ويندوز مي "
 "باشد، کار شود - اينگونه توصيه ميشود - ؟"
 
-#: Merge.rc:5208
+#: Merge.rc:5207
 #, c-format
 msgid "Information lost due to encoding errors: both files"
 msgstr "  اطلاعات به دليل خطاهاي کدبندي از دست رفت : در پرونده هر دو سمت "
 
-#: Merge.rc:5210
+#: Merge.rc:5209
 #, c-format
 msgid "Information lost due to encoding errors: first file"
 msgstr ""
 
-#: Merge.rc:5212
+#: Merge.rc:5211
 #, c-format
 msgid "Information lost due to encoding errors: second file"
 msgstr ""
 
-#: Merge.rc:5214
+#: Merge.rc:5213
 #, c-format
 msgid "Information lost due to encoding errors: third file"
 msgstr ""
 
 #. IDS_LINEDIFF_NODIFF
-#: Merge.rc:5220
+#: Merge.rc:5219
 #, c-format
 msgid "No difference"
 msgstr " بدون فرق"
 
 #. IDS_LINEDIFF_NODIFF_CAPTION
-#: Merge.rc:5221
+#: Merge.rc:5220
 #, c-format
 msgid "Line difference"
 msgstr " تفاوت خط به خط "
 
 #. IDS_NUM_REPLACED
-#: Merge.rc:5227
+#: Merge.rc:5226
 #, c-format
 msgid "Replaced %1 string(s)."
 msgstr "  رشته {هاي} جايگزين شده : %1"
 
 #. IDS_EDIT_TEXT_NOT_FOUND
-#: Merge.rc:5228
+#: Merge.rc:5227
 #, c-format
 msgid "Cannot find string \"%s\"."
 msgstr " نمي توان رشته روبرو را پيدا کرد :  \"%s\""
 
 #. IDS_MERGE_MODE
-#: Merge.rc:5234
+#: Merge.rc:5233
 msgid "Entering Merge Mode. Press F9 to turn off."
 msgstr ""
 
 #. IDS_AUTO_MERGE
-#: Merge.rc:5240
+#: Merge.rc:5239
 #, c-format
 msgid "Automatic merges: %1\nUnresolved conflicts: %2"
 msgstr ""
 
 #. IDS_CODEPAGE_MERGED
-#: Merge.rc:5241
+#: Merge.rc:5240
 msgid "Codepage change merged."
 msgstr ""
 
 #. IDS_CODEPAGE_CONFLICT
-#: Merge.rc:5242
+#: Merge.rc:5241
 msgid "Codepage changes are conflicting."
 msgstr ""
 
 #. IDS_EOL_MERGED
-#: Merge.rc:5243
+#: Merge.rc:5242
 msgid "EOL change merged."
 msgstr ""
 
 #. IDS_EOL_CONFLICT
-#: Merge.rc:5244
+#: Merge.rc:5243
 msgid "EOL changes are conflicting."
 msgstr ""
 
 #. IDS_LOCBAR_CAPTION
-#: Merge.rc:5250
+#: Merge.rc:5249
 #, c-format
 msgid "Location Pane"
 msgstr " چهارگوش مکان "
 
 #. IDS_DIFFBAR_CAPTION
-#: Merge.rc:5251
+#: Merge.rc:5250
 #, c-format
 msgid "Diff Pane"
 msgstr " چهارگوش تفاوت "
 
 #. IDS_DIFF_SUCCEEDED
-#: Merge.rc:5258
+#: Merge.rc:5257
 #, c-format
 msgid "Patch file written."
 msgstr " پرونده وصله  با موفقيت نوشته شد "
 
 #. IDS_DIFF_FILEOVERWRITE
-#: Merge.rc:5259
+#: Merge.rc:5258
 #, c-format
 msgid "Patch file already exists. Overwrite?"
 msgstr ""
 " پرونده وصله در حال حاضر موجود مي باشد. آيا مي خواهيد تا بازنويسي شود؟ "
 
 #. IDS_DIFF_SELECTEDFILES
-#: Merge.rc:5260
+#: Merge.rc:5259
 #, c-format
 msgid "[%1 files selected]"
 msgstr "{  پرونده هاي انتخاب شده:   %1 }"
 
 #. IDS_DIFF_NORMAL
-#: Merge.rc:5261
+#: Merge.rc:5260
 #, c-format
 msgid "Normal"
 msgstr " عادي "
 
 #. IDS_DIFF_CONTEXT
-#: Merge.rc:5262
+#: Merge.rc:5261
 #, c-format
 msgid "Context"
 msgstr " متن "
 
 #. IDS_DIFF_UNIFIED
-#: Merge.rc:5263
+#: Merge.rc:5262
 #, c-format
 msgid "Unified"
 msgstr " يکپارچه شده "
 
 #. IDS_FILEWRITE_ERROR
-#: Merge.rc:5265
+#: Merge.rc:5264
 #, c-format
 msgid "Could not write to file %1."
 msgstr "نمي تواند در پرونده 1%  بنويسد "
 
 #. IDS_PATH_NOT_ABSOLUTE
-#: Merge.rc:5266
+#: Merge.rc:5265
 #, c-format
 msgid "Output path is not absolute: %1"
 msgstr " مسير خروجي مشخص شده يک مسير مطلق نمي باشد : %1"
 
 #. IDS_MUST_SPECIFY_OUTPUT
-#: Merge.rc:5267
+#: Merge.rc:5266
 msgid "Specify an output file."
 msgstr " يک پرونده خروجي را مشخص نماييد "
 
-#: Merge.rc:5269
+#: Merge.rc:5268
 #, c-format
 msgid "Cannot create patch from binary files."
 msgstr " نمي توان يک وصله پرونده از پرونده هاي دودويي تهيه نمود "
 
 #. IDS_SAVEFILES_FORPATCH
-#: Merge.rc:5270
+#: Merge.rc:5269
 #, c-format
 msgid ""
 "Save all files first.\n"
@@ -8102,23 +8096,23 @@ msgstr ""
 "نداشته باشد "
 
 #. IDS_FOLDER_NOTEXIST
-#: Merge.rc:5271
+#: Merge.rc:5270
 #, c-format
 msgid "Folder does not exist."
 msgstr " پوشه وجود ندارد "
 
 #. IDS_ARCHIVE_SUCCEEDED
-#: Merge.rc:5277
+#: Merge.rc:5276
 msgid "Archive file written."
 msgstr ""
 
 #. IDS_ARCHIVE_SAVEFILES
-#: Merge.rc:5278
+#: Merge.rc:5277
 msgid "Save all files first.\n\nCreating an archive requires no unsaved changes."
 msgstr ""
 
 #. IDS_NO_ZIP_SUPPORT
-#: Merge.rc:5283
+#: Merge.rc:5282
 msgid "Archive support not enabled.\n7-Zip and/or Merge7z*.dll not found.\nSee manual for archive support."
 msgstr ""
 "  پشتيباني از بايگاني فعال نشده است \n"
@@ -8128,43 +8122,43 @@ msgstr ""
 "ببينيد"
 
 #. IDS_OPT_EXPORT_CAPTION
-#: Merge.rc:5284
+#: Merge.rc:5283
 #, c-format
 msgid "Select file for export"
 msgstr " انتخاب پرونده براي صدور "
 
 #. IDS_OPT_IMPORT_CAPTION
-#: Merge.rc:5285
+#: Merge.rc:5284
 #, c-format
 msgid "Select file for import"
 msgstr " انتخاب پرونده براي ورود "
 
 #. IDS_OPT_IMPORT_DONE
-#: Merge.rc:5286
+#: Merge.rc:5285
 #, c-format
 msgid "Options imported from file."
 msgstr " خيارات از پرونده وارد شد "
 
 #. IDS_OPT_EXPORT_DONE
-#: Merge.rc:5287
+#: Merge.rc:5286
 #, c-format
 msgid "Options exported to file."
 msgstr " خيارات به پرونده صادر شد "
 
 #. IDS_OPT_IMPORT_ERR
-#: Merge.rc:5288
+#: Merge.rc:5287
 #, c-format
 msgid "Failed to import options from file."
 msgstr " ورود خيارات از پرونده ناموفق بود "
 
 #. IDS_OPT_EXPORT_ERR
-#: Merge.rc:5289
+#: Merge.rc:5288
 #, c-format
 msgid "Failed to write options to file."
 msgstr " نگارش خيارات در پرونده ناموفق بود "
 
 #. IDS_CLOSEALL_WINDOWS
-#: Merge.rc:5290
+#: Merge.rc:5289
 #, c-format
 msgid ""
 "Close multiple compare windows?\n"
@@ -8176,1209 +8170,1209 @@ msgstr ""
 "آيا مايل به ادامه هستيد ؟ "
 
 #. IDS_EOL_BIN
-#: Merge.rc:5300
+#: Merge.rc:5299
 msgctxt "EOL Type"
 msgid "Binary"
 msgstr ""
 
 #. IDS_MARKER_COLOR_FMT
-#: Merge.rc:5305
+#: Merge.rc:5304
 #, c-format
 msgid "Marker Color %d"
 msgstr ""
 
 #. IDS_MARKER_NEW_PATTERN
-#: Merge.rc:5306
+#: Merge.rc:5305
 msgid "New Pattern"
 msgstr ""
 
 #. IDS_PLUGINSLIST_TYPE
-#: Merge.rc:5312
+#: Merge.rc:5311
 #, c-format
 msgid "Type"
 msgstr " نوع "
 
 #. IDS_PLUGINS_TYPE_EDITSCRIPT
-#: Merge.rc:5316
+#: Merge.rc:5315
 #, c-format
 msgid "Editor script"
 msgstr "دست نوشته براي ويراستار   "
 
 #. ID_SELECTLINEDIFF
-#: Merge.rc:5322
+#: Merge.rc:5321
 #, c-format
 msgid "\nDifference in Current Line (F4)"
 msgstr ""
 
 #. ID_OPTIONS
-#: Merge.rc:5323
+#: Merge.rc:5322
 #, c-format
 msgid "\nOptions"
 msgstr ""
 
 #. ID_REFRESH
-#: Merge.rc:5324
+#: Merge.rc:5323
 #, c-format
 msgid "\nRefresh (F5)"
 msgstr ""
 
 #. ID_PREVDIFF
-#: Merge.rc:5330
+#: Merge.rc:5329
 #, c-format
 msgid "\nPrevious Difference (Alt+Up)"
 msgstr ""
 
 #. ID_NEXTDIFF
-#: Merge.rc:5331
+#: Merge.rc:5330
 #, c-format
 msgid "\nNext Difference (Alt+Down)"
 msgstr ""
 
 #. ID_PREVCONFLICT
-#: Merge.rc:5332
+#: Merge.rc:5331
 #, c-format
 msgid "\nPrevious Conflict (Alt+Shift+Up)"
 msgstr ""
 
 #. ID_NEXTCONFLICT
-#: Merge.rc:5333
+#: Merge.rc:5332
 #, c-format
 msgid "\nNext Conflict (Alt+Shift+Down)"
 msgstr ""
 
 #. ID_FIRSTDIFF
-#: Merge.rc:5338
+#: Merge.rc:5337
 #, c-format
 msgid "\nFirst Difference (Alt+Home)"
 msgstr ""
 
 #. ID_CURDIFF
-#: Merge.rc:5339
+#: Merge.rc:5338
 #, c-format
 msgid "\nCurrent Difference (Alt+Enter)"
 msgstr ""
 
 #. ID_LASTDIFF
-#: Merge.rc:5340
+#: Merge.rc:5339
 #, c-format
 msgid "\nLast Difference (Alt+End)"
 msgstr ""
 
 #. ID_L2R
-#: Merge.rc:5341
+#: Merge.rc:5340
 msgid "\nCopy to Right (Alt+Right)"
 msgstr ""
 
 #. ID_R2L
-#: Merge.rc:5342
+#: Merge.rc:5341
 msgid "\nCopy to Left (Alt+Left)"
 msgstr ""
 
 #. ID_L2RNEXT
-#: Merge.rc:5343
+#: Merge.rc:5342
 msgid "\nCopy to Right and Advance (Ctrl+Alt+Right)"
 msgstr ""
 
 #. ID_R2LNEXT
-#: Merge.rc:5344
+#: Merge.rc:5343
 msgid "\nCopy to Left and Advance (Ctrl+Alt+Left)"
 msgstr ""
 
 #. ID_ALL_RIGHT
-#: Merge.rc:5345
+#: Merge.rc:5344
 msgid "\nCopy All to Right"
 msgstr "\nرونوشت برداري همه به راست"
 
 #. ID_ALL_LEFT
-#: Merge.rc:5346
+#: Merge.rc:5345
 msgid "\nCopy All to Left"
 msgstr "\nرونوشت برداري همه به چپ"
 
 #. ID_AUTO_MERGE
-#: Merge.rc:5347
+#: Merge.rc:5346
 #, c-format
 msgid "\nAuto Merge (Ctrl+Alt+M)"
 msgstr ""
 
 #. ID_FIRSTFILE
-#: Merge.rc:5348
+#: Merge.rc:5347
 msgid "\nFirst File"
 msgstr ""
 
 #. ID_NEXTFILE
-#: Merge.rc:5349
+#: Merge.rc:5348
 msgid "\nNext File (Ctrl+F8)"
 msgstr ""
 
 #. ID_LASTFILE
-#: Merge.rc:5350
+#: Merge.rc:5349
 msgid "\nLast File"
 msgstr ""
 
 #. ID_PREVFILE
-#: Merge.rc:5351
+#: Merge.rc:5350
 msgid "\nPrevious File (Ctrl+F7)"
 msgstr ""
 
 #. IDS_UNPACK_AUTO
-#: Merge.rc:5358
+#: Merge.rc:5357
 msgid "Adapted unpacker applied to both files (one needs extension)."
 msgstr " بازکننده بسته تطبيق داده شده روي هر دو پرونده ها بکار بسته مي شود "
 
 #. IDS_NO_PREDIFFER
-#: Merge.rc:5359
+#: Merge.rc:5358
 #, c-format
 msgid "No Prediffer (Normal)"
 msgstr " بدون پيش فرق گذار - عادي "
 
 #. IDS_SUGGESTED_PLUGINS
-#: Merge.rc:5360
+#: Merge.rc:5359
 #, c-format
 msgid "Suggested Plugins"
 msgstr " افزايه هاي پيشنهادي "
 
 #. IDS_NOT_SUGGESTED_PLUGINS
-#: Merge.rc:5361
+#: Merge.rc:5360
 msgid "All Plugins"
 msgstr ""
 
 #. IDS_PRIVATEBUILD_FMT
-#: Merge.rc:5367
+#: Merge.rc:5366
 #, c-format
 msgid "Private Build: %1"
 msgstr " ساخت شخصي : %1 "
 
 #. IDS_ALLRIGHTS_RESERVED
-#: Merge.rc:5368
+#: Merge.rc:5367
 msgid " - All rights reserved."
 msgstr ""
 
 #. IDS_TITLE_PLUGINS_SETTINGS
-#: Merge.rc:5374
+#: Merge.rc:5373
 #, c-format
 msgid "Plugin Settings"
 msgstr " قرارگاههاي افزايه ها"
 
 #. IDS_NO_SCT_SCRIPTS
-#: Merge.rc:5376
+#: Merge.rc:5375
 #, c-format
 msgid "WSH not found - .sct scripts disabled"
 msgstr " .sct پيدا نشد -  دست نوشته ها غير فعال شد WSH  "
 
 #. IDS_LOCBAR_GOTOLINE_FMT
-#: Merge.rc:5384
+#: Merge.rc:5383
 #, c-format
 msgid "G&o to Line %1"
 msgstr "&G   برو به خط  %1 "
 
 #. IDS_GOTO_MOVED_LINE
-#: Merge.rc:5390
+#: Merge.rc:5389
 msgid "Go to Moved Line\tCtrl+Shift+G"
 msgstr ""
 
 #. IDS_AUTOCOMPLETE_DISABLED
-#: Merge.rc:5396
+#: Merge.rc:5395
 msgctxt "Options dialog|General|Open dialog Auto completion"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_AUTOCOMPLETE_FILE_SYS
-#: Merge.rc:5397
+#: Merge.rc:5396
 #, c-format
 msgid "From file system"
 msgstr " از دستگاه (سيستم) پرونده ها  "
 
 #. IDS_AUTOCOMPLETE_MRU
-#: Merge.rc:5398
+#: Merge.rc:5397
 #, c-format
 msgid "From Most Recently Used list"
 msgstr " از فهرست آخرين پرونده ها "
 
 #. IDS_COLORSCHEME_PLAIN
-#: Merge.rc:5404
+#: Merge.rc:5403
 #, c-format
 msgid "No Highlighting"
 msgstr " برجسته نکردن "
 
 #. IDS_COLORSCHEME_PO
-#: Merge.rc:5439
+#: Merge.rc:5438
 #, c-format
 msgid "Portable Object"
 msgstr " شيئ حمل شدني "
 
 #. IDS_COLORSCHEME_RSRC
-#: Merge.rc:5444
+#: Merge.rc:5443
 #, c-format
 msgid "Resources"
 msgstr " منابع "
 
 #. IDS_COLORSCHEME_SH
-#: Merge.rc:5448
+#: Merge.rc:5447
 #, c-format
 msgid "Shell"
 msgstr " پوسته "
 
 #. IDS_CLOSE_LEFT_TABS
-#: Merge.rc:5469
+#: Merge.rc:5468
 #, c-format
 msgid "Close &Left Tabs"
 msgstr ""
 
 #. IDS_CLOSE_RIGHT_TABS
-#: Merge.rc:5470
+#: Merge.rc:5469
 #, c-format
 msgid "Close R&ight Tabs"
 msgstr ""
 
 #. IDS_CLOSE_OTHER_TABS
-#: Merge.rc:5471
+#: Merge.rc:5470
 #, c-format
 msgid "Close &Other Tabs"
 msgstr ""
 
 #. IDS_TABBAR_AUTO_MAXWIDTH
-#: Merge.rc:5472
+#: Merge.rc:5471
 #, c-format
 msgid "Enable &Auto Max Width"
 msgstr ""
 
 #. IDS_WEBPAGE_MENU
-#: Merge.rc:5482
+#: Merge.rc:5481
 msgid "We&bpage"
 msgstr ""
 
 #. IDS_VIEW_WRAP_TEXT
-#: Merge.rc:5487
+#: Merge.rc:5486
 msgid "W&rap Text"
 msgstr ""
 
 #. IDS_NOTINSTALLED
-#: Merge.rc:5492
+#: Merge.rc:5491
 msgid "%1 is not installed."
 msgstr ""
 
 #. IDS_CREATE_FOLDER
-#: Merge.rc:5497
+#: Merge.rc:5496
 #, c-format
 msgid "%1 does not exist. Create it?"
 msgstr ""
 
 #. IDS_CREATE_FOLDER_ERROR
-#: Merge.rc:5498
+#: Merge.rc:5497
 #, c-format
 msgid "Failed to create folder."
 msgstr ""
 
 #. IDC_EXT_EDITOR_PATH
-#: Merge.rc:5503
+#: Merge.rc:5502
 #, c-format
 msgid "Parameters:\n$file: Current file path\n$linenum: Current cursor line number"
 msgstr ""
 
 #. IDS_DIFF_ALGORITHM_DEFAULT
-#: Merge.rc:5508
+#: Merge.rc:5507
 msgid "default"
 msgstr ""
 
 #. IDS_DIFF_ALGORITHM_MINIMAL
-#: Merge.rc:5509
+#: Merge.rc:5508
 msgid "minimal"
 msgstr ""
 
 #. IDS_DIFF_ALGORITHM_PATIENCE
-#: Merge.rc:5510
+#: Merge.rc:5509
 msgid "patience"
 msgstr ""
 
 #. IDS_DIFF_ALGORITHM_HISTOGRAM
-#: Merge.rc:5511
+#: Merge.rc:5510
 msgid "histogram"
 msgstr ""
 
 #. IDS_DIFF_ALGORITHM_NONE
-#: Merge.rc:5512
+#: Merge.rc:5511
 msgid "none"
 msgstr ""
 
 #. IDS_RENDERING_MODE_GDI
-#: Merge.rc:5517
+#: Merge.rc:5516
 msgid "GDI"
 msgstr ""
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_DEFAULT
-#: Merge.rc:5518
+#: Merge.rc:5517
 msgid "DirectWrite Default"
 msgstr ""
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_ALIASED
-#: Merge.rc:5519
+#: Merge.rc:5518
 msgid "DirectWrite Aliased"
 msgstr ""
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_GDI_CLASSIC
-#: Merge.rc:5520
+#: Merge.rc:5519
 msgid "DirectWrite GDI Classic"
 msgstr ""
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_GDI_NATURAL
-#: Merge.rc:5521
+#: Merge.rc:5520
 msgid "DirectWrite GDI Natural"
 msgstr ""
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_NATURAL
-#: Merge.rc:5522
+#: Merge.rc:5521
 msgid "DirectWrite Natural"
 msgstr ""
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_NATURAL_SYMMETRIC
-#: Merge.rc:5523
+#: Merge.rc:5522
 msgid "DirectWrite Natural Symmetric"
 msgstr ""
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_DISABLED
-#: Merge.rc:5528
+#: Merge.rc:5527
 msgctxt "Options dialog|General|Close windows with Esc"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_1
-#: Merge.rc:5529
+#: Merge.rc:5528
 msgid "MDI child window or main window"
 msgstr ""
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_2
-#: Merge.rc:5530
+#: Merge.rc:5529
 msgid "MDI child window only"
 msgstr ""
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_3
-#: Merge.rc:5531
+#: Merge.rc:5530
 msgid "Close main window if only one MDI child window"
 msgstr ""
 
 #. IDS_DIFF_GROUP
-#: Merge.rc:5536
+#: Merge.rc:5535
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Diff"
 msgstr ""
 
 #. IDS_DIFF_HIGHLIGHT
-#: Merge.rc:5537
+#: Merge.rc:5536
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Highlight"
 msgstr ""
 
 #. IDS_DIFF_BLINK
-#: Merge.rc:5538
+#: Merge.rc:5537
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Blink"
 msgstr ""
 
 #. IDS_DIFF_BLOCKSIZE
-#: Merge.rc:5539
+#: Merge.rc:5538
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Block Size"
 msgstr ""
 
 #. IDS_DIFF_BLOCKALPHA
-#: Merge.rc:5540
+#: Merge.rc:5539
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Block Alpha"
 msgstr ""
 
 #. IDS_DIFF_CDTHRESHOLD
-#: Merge.rc:5541
+#: Merge.rc:5540
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "CD Threshold"
 msgstr ""
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION
-#: Merge.rc:5542
+#: Merge.rc:5541
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Ins/Del Detection"
 msgstr ""
 
 #. IDS_OVERLAY_MODE_NONE
-#: Merge.rc:5543 Merge.rc:5548
+#: Merge.rc:5542 Merge.rc:5547
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "None"
 msgstr ""
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION_VERTICAL
-#: Merge.rc:5544
+#: Merge.rc:5543
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Vertical"
 msgstr ""
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION_HORIZONTAL
-#: Merge.rc:5545
+#: Merge.rc:5544
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Horizontal"
 msgstr ""
 
 #. IDS_OVERLAY_GROUP
-#: Merge.rc:5546
+#: Merge.rc:5545
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Overlay"
 msgstr ""
 
 #. IDS_OVERLAY_ALPHA
-#: Merge.rc:5547
+#: Merge.rc:5546
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha"
 msgstr ""
 
 #. IDS_OVERLAY_MODE_XOR
-#: Merge.rc:5549
+#: Merge.rc:5548
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "XOR"
 msgstr ""
 
 #. IDS_OVERLAY_MODE_ALPHA
-#: Merge.rc:5550
+#: Merge.rc:5549
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha Blend"
 msgstr ""
 
 #. IDS_OVERLAY_MODE_ALPHA_ANIMATION
-#: Merge.rc:5551
+#: Merge.rc:5550
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha Animation"
 msgstr ""
 
 #. IDS_ZOOM
-#: Merge.rc:5552
+#: Merge.rc:5551
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Zoom"
 msgstr ""
 
 #. IDS_PAGE
-#: Merge.rc:5553
+#: Merge.rc:5552
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Page:"
 msgstr ""
 
 #. IDS_IMGCMP_STATUS_PT_RGBA_FMT
-#: Merge.rc:5554
+#: Merge.rc:5553
 #, c-format
 msgid "Pt: (%d, %d)  RGBA: (%d, %d, %d, %d)  "
 msgstr ""
 
 #. IDS_IMGCMP_STATUS_DIST1_FMT
-#: Merge.rc:5555
+#: Merge.rc:5554
 #, c-format
 msgid "Dist: %g  "
 msgstr ""
 
 #. IDS_IMGCMP_STATUS_DIST2_FMT
-#: Merge.rc:5556
+#: Merge.rc:5555
 #, c-format
 msgid "Dist: %g, %g  "
 msgstr ""
 
 #. IDS_IMGCMP_STATUS_PAGE_ZOOM_SIZE_BPP_FMT
-#: Merge.rc:5557
+#: Merge.rc:5556
 #, c-format
 msgid "Page: %d/%d  Zoom: %d%%  %dx%dpx  %dbpp  "
 msgstr ""
 
 #. IDS_IMGCMP_STATUS_RC_FMT
-#: Merge.rc:5558
+#: Merge.rc:5557
 #, c-format
 msgid "Rc: (%d, %d)  "
 msgstr ""
 
 #. IDS_IMGCMP_STATUS_FLIPPED_FMT
-#: Merge.rc:5559
+#: Merge.rc:5558
 #, c-format
 msgid "Flipped: %s  "
 msgstr ""
 
 #. IDS_IMGCMP_STATUS_ROTATED_FMT
-#: Merge.rc:5560
+#: Merge.rc:5559
 #, c-format
 msgid "Rotated: %d  "
 msgstr ""
 
 #. IDS_IMGCMP_REPORT_ALLPAGES
-#: Merge.rc:5561
+#: Merge.rc:5560
 msgid "All pages"
 msgstr ""
 
 #. IDS_IGNSUB_STR1
-#: Merge.rc:5566
+#: Merge.rc:5565
 msgid "<Edit here>"
 msgstr ""
 
 #. IDS_IGNSUB_STR2
-#: Merge.rc:5567
+#: Merge.rc:5566
 msgid "No differences found to select"
 msgstr ""
 
 #. IDS_IGNSUB_STR3
-#: Merge.rc:5568
+#: Merge.rc:5567
 msgid "No differences found to add as substitution filter"
 msgstr ""
 
 #. IDS_IGNSUB_STR4
-#: Merge.rc:5569
+#: Merge.rc:5568
 msgid "The pair is already in the Substitution Filters list"
 msgstr ""
 
 #. IDS_IGNSUB_STR5
-#: Merge.rc:5570
+#: Merge.rc:5569
 msgid "Add this change to Substitution Filters?"
 msgstr ""
 
 #. IDS_OCRRESULT_TEXTONLY
-#: Merge.rc:5575
+#: Merge.rc:5574
 msgid "Text only"
 msgstr ""
 
 #. IDS_OCRRESULT_POS_LINE
-#: Merge.rc:5576
+#: Merge.rc:5575
 msgid "Line-by-line position and text"
 msgstr ""
 
 #. IDS_OCRRESULT_POS_WORD
-#: Merge.rc:5577
+#: Merge.rc:5576
 msgid "Word-by-word position and text"
 msgstr ""
 
 #. IDS_USERDATAFOLDER_APPDATA
-#: Merge.rc:5582
+#: Merge.rc:5581
 msgid "AppData (Roaming) folder"
 msgstr ""
 
 #. IDS_USERDATAFOLDER_INSTALL
-#: Merge.rc:5583
+#: Merge.rc:5582
 msgid "Install folder"
 msgstr ""
 
 #. IDS_USERDATAFOLDER_DOCUMENTS
-#: Merge.rc:5584
+#: Merge.rc:5583
 msgid "Documents folder"
 msgstr ""
 
 #. IDS_SINGLEINSTANCE_DISABLED
-#: Merge.rc:5589
+#: Merge.rc:5588
 msgctxt "Options dialog|General|Single instance mode"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_SINGLEINSTANCE_STR1
-#: Merge.rc:5590
+#: Merge.rc:5589
 #, c-format
 msgid "Allow only one instance to run"
 msgstr "اجازه اجراي همزمان تنها يک نسخه از نرم افزار  "
 
 #. IDS_CLIPBOARD_HISTORY
-#: Merge.rc:5591
+#: Merge.rc:5590
 msgid "Clipboard &History"
 msgstr ""
 
 #. IDS_SINGLEINSTANCE_STR2
-#: Merge.rc:5592
+#: Merge.rc:5591
 msgid "Allow only one instance; wait for termination"
 msgstr ""
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_DISABLED
-#: Merge.rc:5597
+#: Merge.rc:5596
 msgctxt "Options dialog|General|Auto-reload modified files"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_STR1
-#: Merge.rc:5598
+#: Merge.rc:5597
 msgid "Only on window activated"
 msgstr ""
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_STR2
-#: Merge.rc:5599
+#: Merge.rc:5598
 msgid "Immediately"
 msgstr ""
 
 #. IDS_PLUGIN_ALL
-#: Merge.rc:5604
+#: Merge.rc:5603
 msgid "Al&l"
 msgstr ""
 
 #. IDS_PLUGIN_OTHERS
-#: Merge.rc:5605
+#: Merge.rc:5604
 msgid "&Others"
 msgstr ""
 
-#: Merge.rc:5607
+#: Merge.rc:5606
 #, c-format
 msgid "Missing plugin name in pipeline: %1"
 msgstr ""
 
-#: Merge.rc:5609
+#: Merge.rc:5608
 #, c-format
 msgid "Missing quote in plugin pipeline: %1"
 msgstr ""
 
 #. IDS_PLUGIN_NAME_ALREADY_EXISTS
-#: Merge.rc:5610
+#: Merge.rc:5609
 #, c-format
 msgid "Plugin name '%1' already exists."
 msgstr ""
 
 #. IDS_PLUGIN_TITLE1
-#: Merge.rc:5611
+#: Merge.rc:5610
 msgid "Specify plugin arguments"
 msgstr ""
 
-#: Merge.rc:5613
+#: Merge.rc:5612
 #, c-format
 msgid "Plugin not found or invalid: %1"
 msgstr ""
 
 #. IDS_PLUGIN_NOT_UNPACK
-#: Merge.rc:5614
+#: Merge.rc:5613
 #, c-format
 msgid "'%1' is not an unpacker plugin"
 msgstr ""
 
 #. IDS_PLUGIN_NOT_PREDIFF
-#: Merge.rc:5615
+#: Merge.rc:5614
 #, c-format
 msgid "'%1' is not a prediffer plugin"
 msgstr ""
 
-#: Merge.rc:5617
+#: Merge.rc:5616
 #, c-format
 msgid "Error prediffing '%1' with '%2'. Prediffing disabled."
 msgstr ""
 
 #. IDS_PLUGIN_CIRCULAR_REFERENCE
-#: Merge.rc:5618
+#: Merge.rc:5617
 #, c-format
 msgid "Circular reference in plugin pipeline: %1"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE1
-#: Merge.rc:5619
+#: Merge.rc:5618
 msgid "URL Handler"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE2
-#: Merge.rc:5620
+#: Merge.rc:5619
 msgid "File Unpacker"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE3
-#: Merge.rc:5621
+#: Merge.rc:5620
 msgid "File or Folder Unpacker"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE5
-#: Merge.rc:5623
+#: Merge.rc:5622
 msgid "Alias for Unpacker"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE6
-#: Merge.rc:5624
+#: Merge.rc:5623
 msgid "Alias for Prediffer"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE7
-#: Merge.rc:5625
+#: Merge.rc:5624
 msgid "Alias for Editor script"
 msgstr ""
 
 #. IDS_PLUGIN_ALIAS_DESC
-#: Merge.rc:5626
+#: Merge.rc:5625
 #, c-format
 msgid "Alias for plugin pipeline '%1'"
 msgstr ""
 
 #. IDS_PLUGIN_NEW_DESC
-#: Merge.rc:5627
+#: Merge.rc:5626
 msgid "New plugin description"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_ALL
-#: Merge.rc:5628
+#: Merge.rc:5627
 msgid "All"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_1ST
-#: Merge.rc:5629
+#: Merge.rc:5628
 msgid "1st"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_2ND
-#: Merge.rc:5630
+#: Merge.rc:5629
 msgid "2nd"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_3RD
-#: Merge.rc:5631
+#: Merge.rc:5630
 msgid "3rd"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_1ST_2ND
-#: Merge.rc:5632
+#: Merge.rc:5631
 msgid "1st and 2nd"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_1ST_3RD
-#: Merge.rc:5633
+#: Merge.rc:5632
 msgid "1st and 3rd"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_2ND_3RD
-#: Merge.rc:5634
+#: Merge.rc:5633
 msgid "2nd and 3rd"
 msgstr ""
 
 #. IDS_PLUGIN_CTRL_CLICK
-#: Merge.rc:5635
+#: Merge.rc:5634
 msgid "(Ctrl+Click to add to pipeline)"
 msgstr ""
 
 #. IDS_FILTER_APPLIED
-#: Merge.rc:5640
+#: Merge.rc:5639
 msgid "Filter applied"
 msgstr ""
 
 #. IDS_FILTERMENU_COMPARE
-#: Merge.rc:5645
+#: Merge.rc:5644
 #, c-format
 msgid "Compare %1"
 msgstr ""
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN2
-#: Merge.rc:5647
+#: Merge.rc:5646
 msgid "&Filter by This Column..."
 msgstr ""
 
 #. IDS_CLIPBOARDHISTORY_TIME
-#: Merge.rc:5652
+#: Merge.rc:5651
 #, c-format
 msgid "Clipboard at %s"
 msgstr ""
 
 #. IDS_CLIPBOARDHISTORY_DISABLED
-#: Merge.rc:5653
+#: Merge.rc:5652
 msgid "Clipboard history disabled.\r\nEnable: Windows logo key + V, then Turn on."
 msgstr ""
 
-#: Merge.rc:5655
+#: Merge.rc:5654
 msgid "This system does not support clipboard history."
 msgstr ""
 
-#: Merge.rc:5657
+#: Merge.rc:5656
 msgid "32-bit WinMerge does not support Clipboard Compare"
 msgstr ""
 
 #. IDS_WEBVIEW2_RUNTIME_NOT_INSTALLED
-#: Merge.rc:5662
+#: Merge.rc:5661
 msgid "WebView2 runtime not installed. Download it?"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_TEXT_COMPARE
-#: Merge.rc:5667
+#: Merge.rc:5666
 msgid "New Text Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_TABLE_COMPARE
-#: Merge.rc:5668
+#: Merge.rc:5667
 msgid "New Table Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_BINARY_COMPARE
-#: Merge.rc:5669
+#: Merge.rc:5668
 msgid "New Binary Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_IMAGE_COMPARE
-#: Merge.rc:5670
+#: Merge.rc:5669
 msgid "New Image Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_WEBPAGE_COMPARE
-#: Merge.rc:5671
+#: Merge.rc:5670
 msgid "New Webpage Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_FOLDER_COMPARE
-#: Merge.rc:5672
+#: Merge.rc:5671
 msgid "New Folder Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_CLIPBOARD_COMPARE
-#: Merge.rc:5673
+#: Merge.rc:5672
 msgid "Clipboard Compare"
 msgstr ""
 
 #. IDS_PREVIEWBAR_PRINT
-#: Merge.rc:5678
+#: Merge.rc:5677
 msgid "&Print..."
 msgstr ""
 
 #. IDS_PREVIEWBAR_PREVPAGE
-#: Merge.rc:5680
+#: Merge.rc:5679
 msgid "Pre&v Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_TWOPAGE
-#: Merge.rc:5681
+#: Merge.rc:5680
 msgid "&Two Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_ONEPAGE
-#: Merge.rc:5682
+#: Merge.rc:5681
 msgid "&One Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_ZOOMIN
-#: Merge.rc:5683
+#: Merge.rc:5682
 msgid "Zoom &In"
 msgstr ""
 
 #. IDS_PREVIEWBAR_ZOOMOUT
-#: Merge.rc:5684
+#: Merge.rc:5683
 msgid "Zoom &Out"
 msgstr ""
 
 #. IDS_WEBPAGE_COMPARING
-#: Merge.rc:5690
+#: Merge.rc:5689
 msgid "Comparing..."
 msgstr ""
 
 #. IDS_WEBPAGE_ZOOM
-#: Merge.rc:5691
+#: Merge.rc:5690
 msgid "Zoom:"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_DIFFHUNK
-#: Merge.rc:5696
+#: Merge.rc:5695
 msgid "Diff hunk"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_INLINE
-#: Merge.rc:5697
+#: Merge.rc:5696
 msgid "Inline diff"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_LINE
-#: Merge.rc:5698
+#: Merge.rc:5697
 msgid "Line"
 msgstr ""
 
-#: Merge.rc:5699
+#: Merge.rc:5698
 msgid "Character"
 msgstr ""
 
 #. ID_MICE_PREVDIFF
-#: Merge.rc:5704
+#: Merge.rc:5703
 msgid "\nPrevious Difference (Alt+Up)\n(Right Button+Wheel Up)\n(Alt+Wheel Up)"
 msgstr ""
 
 #. ID_MICE_NEXTDIFF
-#: Merge.rc:5705
+#: Merge.rc:5704
 msgid "\nNext Difference (Alt+Down)\n(Right Button+Wheel Down)\n(Alt+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_L2R
-#: Merge.rc:5706
+#: Merge.rc:5705
 msgid "\nCopy to Right (Alt+Right)\n(Right Button+Wheel Right)\n(Alt+Wheel Right)\n(Alt+Shift+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_R2L
-#: Merge.rc:5707
+#: Merge.rc:5706
 msgid "\nCopy to Left (Alt+Left)\n(Right Button+Wheel Left)\n(Alt+Wheel Left)\n(Alt+Shift+Wheel Up)"
 msgstr ""
 
 #. ID_MICE_L2RNEXT
-#: Merge.rc:5708
+#: Merge.rc:5707
 msgid "\nCopy to Right and Advance (Ctrl+Alt+Right)\n(Ctrl+Alt+Wheel Right)\n(Ctrl+Alt+Shift+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_R2LNEXT
-#: Merge.rc:5709
+#: Merge.rc:5708
 msgid "\nCopy to Left and Advance (Ctrl+Alt+Left)\n(Ctrl+Alt+Wheel Left)\n(Ctrl+Alt+Shift+Wheel Up)"
 msgstr ""
 
 #. IDS_LOG_COMPARING_2
-#: Merge.rc:5719
+#: Merge.rc:5718
 #, c-format
 msgid "Comparing %1 with %2"
 msgstr ""
 
 #. IDS_LOG_COMPARING_3
-#: Merge.rc:5720
+#: Merge.rc:5719
 #, c-format
 msgid "Comparing %1 with %2 and %3"
 msgstr ""
 
 #. IDS_LOG_COMPARE_COMPLETED
-#: Merge.rc:5721
+#: Merge.rc:5720
 msgid "Comparison completed"
 msgstr ""
 
 #. IDS_LOG_COMPARE_ERROR_2
-#: Merge.rc:5722
+#: Merge.rc:5721
 #, c-format
 msgid "Failed to compare %1 with %2: "
 msgstr ""
 
 #. IDS_LOG_COMPARE_ERROR_3
-#: Merge.rc:5723
+#: Merge.rc:5722
 #, c-format
 msgid "Failed to compare %1 with %2 and %3: "
 msgstr ""
 
 #. IDS_LOG_FILE_SAVED
-#: Merge.rc:5724
+#: Merge.rc:5723
 msgid "File saved"
 msgstr ""
 
 #. IDS_LOG_COPYING_FILES
-#: Merge.rc:5725
+#: Merge.rc:5724
 msgid "Copying files..."
 msgstr ""
 
 #. IDS_LOG_MOVING_FILES
-#: Merge.rc:5726
+#: Merge.rc:5725
 msgid "Moving files..."
 msgstr ""
 
 #. IDS_LOG_DELETING_FILES
-#: Merge.rc:5727
+#: Merge.rc:5726
 msgid "Deleting files..."
 msgstr ""
 
 #. IDS_LOG_RECYCLEBIN
-#: Merge.rc:5728
+#: Merge.rc:5727
 msgid "Recycle Bin"
 msgstr ""
 
 #. IDS_LOG_PERMANENTLY_DELETED
-#: Merge.rc:5729
+#: Merge.rc:5728
 msgid "Permanently deleted"
 msgstr ""
 
 #. IDS_LOG_FILEOPERATION_COMPLETED
-#: Merge.rc:5730
+#: Merge.rc:5729
 msgid "File operation completed successfully"
 msgstr ""
 
 #. IDS_LOG_FILEOPERATION_CANCELED
-#: Merge.rc:5731
+#: Merge.rc:5730
 msgid "File operation canceled"
 msgstr ""
 
 #. IDS_FILTER_ERROR_NO_ERROR
-#: Merge.rc:5736
+#: Merge.rc:5735
 msgid "No error"
 msgstr ""
 
 #. IDS_FILTER_ERROR_EMPTY_EXPRESSION
-#: Merge.rc:5737
+#: Merge.rc:5736
 msgid "Filter expression is empty"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNKNOWN_CHAR
-#: Merge.rc:5738
+#: Merge.rc:5737
 msgid "Unknown character in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNTERMINATED_STRING
-#: Merge.rc:5739
+#: Merge.rc:5738
 msgid "Unterminated string literal"
 msgstr ""
 
 #. IDS_FILTER_ERROR_SYNTAX_ERROR
-#: Merge.rc:5740
+#: Merge.rc:5739
 msgid "Syntax error in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_PARSE_FAILURE
-#: Merge.rc:5741
+#: Merge.rc:5740
 msgid "Failed to parse filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_LITERAL
-#: Merge.rc:5742
+#: Merge.rc:5741
 msgid "Invalid literal value"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_REGULAR_EXPRESSION
-#: Merge.rc:5743
+#: Merge.rc:5742
 msgid "Invalid regular expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNDEFINED_IDENTIFIER
-#: Merge.rc:5744
+#: Merge.rc:5743
 msgid "Undefined identifier"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_ARGUMENT_COUNT
-#: Merge.rc:5745
+#: Merge.rc:5744
 msgid "Invalid number of arguments"
 msgstr ""
 
 #. IDS_FILTER_ERROR_FILTER_NAME_NOT_FOUND
-#: Merge.rc:5746
+#: Merge.rc:5745
 msgid "Filter name not found"
 msgstr ""
 
 #. IDS_FILTER_ERROR_DIVIDE_BY_ZERO
-#: Merge.rc:5747
+#: Merge.rc:5746
 msgid "Division by zero in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNKNOWN_ERROR
-#: Merge.rc:5748
+#: Merge.rc:5747
 msgid "Unknown error"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_PROPERTY_NAME
-#: Merge.rc:5749
+#: Merge.rc:5748
 msgid "Invalid property name"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_DIRECTIVE
-#: Merge.rc:5750
+#: Merge.rc:5749
 msgid "Invalid directive"
 msgstr ""
 
 #. IDS_FILTER_OP_EQUALS
-#: Merge.rc:5755
+#: Merge.rc:5754
 msgid "Equals"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_EQUALS
-#: Merge.rc:5756
+#: Merge.rc:5755
 msgid "Does not equal"
 msgstr ""
 
 #. IDS_FILTER_OP_LESS_THAN
-#: Merge.rc:5757
+#: Merge.rc:5756
 msgid "Less than"
 msgstr ""
 
 #. IDS_FILTER_OP_LESS_EQUAL
-#: Merge.rc:5758
+#: Merge.rc:5757
 msgid "Less than or equal to"
 msgstr ""
 
 #. IDS_FILTER_OP_GREATER_EQUAL
-#: Merge.rc:5759
+#: Merge.rc:5758
 msgid "Greater than or equal to"
 msgstr ""
 
 #. IDS_FILTER_OP_GREATER_THAN
-#: Merge.rc:5760
+#: Merge.rc:5759
 msgid "Greater than"
 msgstr ""
 
 #. IDS_FILTER_OP_BETWEEN
-#: Merge.rc:5761
+#: Merge.rc:5760
 msgid "Between"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_BETWEEN
-#: Merge.rc:5762
+#: Merge.rc:5761
 msgid "Not Between"
 msgstr ""
 
 #. IDS_FILTER_OP_CONTAINS
-#: Merge.rc:5763
+#: Merge.rc:5762
 msgid "Contains"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_CONTAINS
-#: Merge.rc:5764
+#: Merge.rc:5763
 msgid "Not Contains"
 msgstr ""
 
 #. IDS_FILTER_OP_RECONTAINS
-#: Merge.rc:5765
+#: Merge.rc:5764
 msgid "Contains (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_RECONTAINS
-#: Merge.rc:5766
+#: Merge.rc:5765
 msgid "Not Contains (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_LIKE
-#: Merge.rc:5767
+#: Merge.rc:5766
 msgid "Match (wildcard)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_LIKE
-#: Merge.rc:5768
+#: Merge.rc:5767
 msgid "Not match (wildcard)"
 msgstr ""
 
 #. IDS_FILTER_OP_MATCHES
-#: Merge.rc:5769
+#: Merge.rc:5768
 msgid "Match (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_MATCHES
-#: Merge.rc:5770
+#: Merge.rc:5769
 msgid "Not match (regex)"
 msgstr ""
 
 #. IDS_COLORMODE_LIGHT
-#: Merge.rc:5775
+#: Merge.rc:5774
 msgid "Light"
 msgstr ""
 
 #. IDS_COLORMODE_DARK
-#: Merge.rc:5776
+#: Merge.rc:5775
 msgid "Dark"
 msgstr ""
 
 #. IDS_COLORMODE_FOLLOWSYSTEM
-#: Merge.rc:5777
+#: Merge.rc:5776
 msgid "Follow system"
 msgstr ""
 
 #. IDS_EXAMPLE
-#: Merge.rc:5782
+#: Merge.rc:5781
 #, c-format
 msgid "e.g. %1"
 msgstr ""
 
 #. IDS_DETECTED_PREVIOUS_CRASH
-#: Merge.rc:5787
+#: Merge.rc:5786
 msgid "WinMerge detected a previous crash. Please report this if possible."
 msgstr ""
 
 #. IDS_REGEX_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5792
+#: Merge.rc:5791
 msgid "# Regex replacement list\r\n# Format: regex<TAB>replacement\r\n# Backreferences like $1, $2 are supported\r\n\r\n(\\d{4})-(\\d{2})-(\\d{2})\t$1_$2_$3\r\n"
 msgstr ""
 
 #. IDS_STRING_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5793
+#: Merge.rc:5792
 msgid "# Replacement list\r\n# Format: search<TAB>replacement\r\n# Lines starting with # are ignored\r\n\r\nfrom1\tto1\r\nfrom2\tto2\r\n"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_ONLY
-#: Merge.rc:5798
+#: Merge.rc:5797
 msgid "Built-in only"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_FIRST
-#: Merge.rc:5799
+#: Merge.rc:5798
 msgid "Built-in first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_FIRST
-#: Merge.rc:5800
+#: Merge.rc:5799
 msgid "Tree-sitter first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_ONLY
-#: Merge.rc:5801
+#: Merge.rc:5800
 msgid "Tree-sitter only"
 msgstr ""
 

--- a/Translations/WinMerge/Polish.po
+++ b/Translations/WinMerge/Polish.po
@@ -24,7 +24,7 @@ msgstr ""
 "X-Poedit-Basepath: ../../Src/\n"
 
 #. LANGUAGE, SUBLANGUAGE
-#: Merge.rc:26 Merge.rc:59 Merge.rc:5818
+#: Merge.rc:26 Merge.rc:59 Merge.rc:5817
 msgid "LANG_ENGLISH, SUBLANG_ENGLISH_US"
 msgstr "LANG_POLISH, SUBLANG_DEFAULT"
 
@@ -166,7 +166,7 @@ msgstr "&Skrypty"
 #. IDS_NO_EDIT_SCRIPTS
 #: Merge.rc:127 Merge.rc:352 Merge.rc:463 Merge.rc:673 Merge.rc:678
 #: Merge.rc:887 Merge.rc:899 Merge.rc:906 Merge.rc:963 Merge.rc:1210
-#: Merge.rc:5375
+#: Merge.rc:5374
 msgid "< Empty >"
 msgstr "< Pusty >"
 
@@ -231,7 +231,7 @@ msgid "Auto-Fit All Columns"
 msgstr "Automatycznie dopasuj wszystkie kolumny"
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN
-#: Merge.rc:153 Merge.rc:5646
+#: Merge.rc:153 Merge.rc:5645
 msgid "&Filter by This Column"
 msgstr "Filtruj według tej kolumny"
 
@@ -292,7 +292,7 @@ msgid "&Previous Page"
 msgstr "Poprzednia strona"
 
 #. IDS_PREVIEWBAR_NEXTPAGE
-#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5679
+#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5678
 msgid "&Next Page"
 msgstr "Następna strona"
 
@@ -543,7 +543,7 @@ msgstr "&Binarny"
 #. IDS_IMAGE_MENU
 #: Merge.rc:329 Merge.rc:338 Merge.rc:432 Merge.rc:441 Merge.rc:609
 #: Merge.rc:618 Merge.rc:670 Merge.rc:960 Merge.rc:1187 Merge.rc:1200
-#: Merge.rc:5477
+#: Merge.rc:5476
 msgid "&Image"
 msgstr "Obraz"
 
@@ -665,7 +665,7 @@ msgid "&Huge"
 msgstr "Ogromny"
 
 #. IDS_VIEW_MENU_BAR
-#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5714
+#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5713
 msgid "Men&u Bar"
 msgstr "Pasek menu"
 
@@ -1320,7 +1320,7 @@ msgid "Lo&cation Pane"
 msgstr "Panel lokaliza&cji"
 
 #. IDS_OUTPUTBAR_CAPTION
-#: Merge.rc:782 Merge.rc:5252
+#: Merge.rc:782 Merge.rc:5251
 msgid "Output Pane"
 msgstr "Panel wyników"
 
@@ -1583,55 +1583,55 @@ msgid "Co&mpare As"
 msgstr "Porównaj jako"
 
 #. IDS_COPY_LEFT_TO_MIDDLE2
-#: Merge.rc:968 Merge.rc:980 Merge.rc:4852
+#: Merge.rc:968 Merge.rc:980 Merge.rc:4851
 #, c-format
 msgid "Left to Middle (%1 of %2)"
 msgstr "Lewy do środka (%1 z %2)"
 
 #. IDS_COPY_LEFT_TO_RIGHT2
-#: Merge.rc:969 Merge.rc:981 Merge.rc:4851
+#: Merge.rc:969 Merge.rc:981 Merge.rc:4850
 #, c-format
 msgid "Left to Right (%1 of %2)"
 msgstr "Lewy do prawej (%1 z %2)"
 
 #. IDS_MOVE_LEFT_TO2
-#: Merge.rc:970 Merge.rc:982 Merge.rc:1045 Merge.rc:4863 Merge.rc:4892
+#: Merge.rc:970 Merge.rc:982 Merge.rc:1045 Merge.rc:4862 Merge.rc:4891
 #, c-format
 msgid "Left to... (%1 of %2)"
 msgstr "Lewy do... (%1 z %2)"
 
 #. IDS_COPY_MIDDLE_TO_LEFT2
-#: Merge.rc:971 Merge.rc:983 Merge.rc:4849
+#: Merge.rc:971 Merge.rc:983 Merge.rc:4848
 #, c-format
 msgid "Middle to Left (%1 of %2)"
 msgstr "Środek do lewej (%1 z %2)"
 
 #. IDS_COPY_MIDDLE_TO_RIGHT2
-#: Merge.rc:972 Merge.rc:984 Merge.rc:4850
+#: Merge.rc:972 Merge.rc:984 Merge.rc:4849
 #, c-format
 msgid "Middle to Right (%1 of %2)"
 msgstr "Środek do prawej (%1 z %2)"
 
 #. IDS_MOVE_MIDDLE_TO2
-#: Merge.rc:973 Merge.rc:985 Merge.rc:1046 Merge.rc:4864 Merge.rc:4893
+#: Merge.rc:973 Merge.rc:985 Merge.rc:1046 Merge.rc:4863 Merge.rc:4892
 #, c-format
 msgid "Middle to... (%1 of %2)"
 msgstr "Środek do... (%1 z %2)"
 
 #. IDS_COPY_RIGHT_TO_MIDDLE2
-#: Merge.rc:974 Merge.rc:986 Merge.rc:4848
+#: Merge.rc:974 Merge.rc:986 Merge.rc:4847
 #, c-format
 msgid "Right to Middle (%1 of %2)"
 msgstr "Prawy do środka (%1 z %2)"
 
 #. IDS_COPY_RIGHT_TO_LEFT2
-#: Merge.rc:975 Merge.rc:987 Merge.rc:4847
+#: Merge.rc:975 Merge.rc:987 Merge.rc:4846
 #, c-format
 msgid "Right to Left (%1 of %2)"
 msgstr "Prawy do lewej (%1 z %2)"
 
 #. IDS_MOVE_RIGHT_TO2
-#: Merge.rc:976 Merge.rc:988 Merge.rc:1047 Merge.rc:4865 Merge.rc:4894
+#: Merge.rc:976 Merge.rc:988 Merge.rc:1047 Merge.rc:4864 Merge.rc:4893
 #, c-format
 msgid "Right to... (%1 of %2)"
 msgstr "Prawy do... (%1 z %2)"
@@ -1687,31 +1687,31 @@ msgid "Cop&y Paths"
 msgstr "Kopiuj nazwy ścieżek"
 
 #. IDS_DEL_LEFT_FMT2
-#: Merge.rc:1026 Merge.rc:1035 Merge.rc:4880
+#: Merge.rc:1026 Merge.rc:1035 Merge.rc:4879
 #, c-format
 msgid "Left (%1 of %2)"
 msgstr "Lewy (%1 z %2)"
 
 #. IDS_DEL_MIDDLE_FMT2
-#: Merge.rc:1027 Merge.rc:1036 Merge.rc:4881
+#: Merge.rc:1027 Merge.rc:1036 Merge.rc:4880
 #, c-format
 msgid "Middle (%1 of %2)"
 msgstr "Środkowy (%1 z %2)"
 
 #. IDS_DEL_RIGHT_FMT2
-#: Merge.rc:1028 Merge.rc:1037 Merge.rc:4882
+#: Merge.rc:1028 Merge.rc:1037 Merge.rc:4881
 #, c-format
 msgid "Right (%1 of %2)"
 msgstr "Prawy (%1 z %2)"
 
 #. IDS_DEL_BOTH_FMT2
-#: Merge.rc:1029 Merge.rc:1038 Merge.rc:4883
+#: Merge.rc:1029 Merge.rc:1038 Merge.rc:4882
 #, c-format
 msgid "Both (%1 of %2)"
 msgstr "Oba (%1 z %2)"
 
 #. IDS_DEL_ALL_FMT2
-#: Merge.rc:1030 Merge.rc:1039 Merge.rc:4888
+#: Merge.rc:1030 Merge.rc:1039 Merge.rc:4887
 #, c-format
 msgid "All (%1 of %2)"
 msgstr "Wszystkie (%1 z %2)"
@@ -1737,19 +1737,19 @@ msgid "&Zip"
 msgstr "Spakuj"
 
 #. IDS_COPY_BOTH_TO2
-#: Merge.rc:1048 Merge.rc:4866
+#: Merge.rc:1048 Merge.rc:4865
 #, c-format
 msgid "Both to... (%1 of %2)"
 msgstr "Oba do... (%1 z %2)"
 
 #. IDS_COPY_ALL_TO2
-#: Merge.rc:1049 Merge.rc:4867
+#: Merge.rc:1049 Merge.rc:4866
 #, c-format
 msgid "All to... (%1 of %2)"
 msgstr "Wszystkie do... (%1 z %2)"
 
 #. IDS_COPY_DIFFERENCES_TO2
-#: Merge.rc:1050 Merge.rc:4868
+#: Merge.rc:1050 Merge.rc:4867
 #, c-format
 msgid "Differences to... (%1 of %2)"
 msgstr "Różnice do... (%1 z %2)"
@@ -1816,12 +1816,12 @@ msgstr "Ustawienia programu rozpakowującego"
 
 #. IDS_USERCHOICE_NONE
 #: Merge.rc:1088 Merge.rc:1094 Merge.rc:1836 Merge.rc:1840 Merge.rc:2031
-#: Merge.rc:2035 Merge.rc:5377
+#: Merge.rc:2035 Merge.rc:5376
 msgid "<None>"
 msgstr "<Brak>"
 
 #. IDS_USERCHOICE_AUTOMATIC
-#: Merge.rc:1089 Merge.rc:1095 Merge.rc:5378
+#: Merge.rc:1089 Merge.rc:1095 Merge.rc:5377
 msgid "<Automatic>"
 msgstr "<Automatycznie>"
 
@@ -2751,12 +2751,12 @@ msgid "Text files only"
 msgstr "Tylko pliki tekstowe"
 
 #. IDS_EOL_NONE
-#: Merge.rc:1667 Merge.rc:1918 Merge.rc:5304
+#: Merge.rc:1667 Merge.rc:1918 Merge.rc:5303
 msgid "None"
 msgstr "Brak"
 
 #. IDS_EOL_MIXED
-#: Merge.rc:1668 Merge.rc:5299
+#: Merge.rc:1668 Merge.rc:5298
 msgid "Mixed"
 msgstr "Mieszany"
 
@@ -3028,13 +3028,13 @@ msgstr "Status wiersza"
 
 #. IDS_DIFFERENT
 #: Merge.rc:1904 Merge.rc:1988 Merge.rc:2866 Merge.rc:3036 Merge.rc:3077
-#: Merge.rc:5058
+#: Merge.rc:5057
 msgid "Different"
 msgstr "Różne"
 
 #. IDS_IDENTICAL
 #: Merge.rc:1905 Merge.rc:1989 Merge.rc:2865 Merge.rc:3055 Merge.rc:3116
-#: Merge.rc:5048
+#: Merge.rc:5047
 msgid "Identical"
 msgstr "Identyczne"
 
@@ -3054,7 +3054,7 @@ msgid "Missing"
 msgstr "Brakuje"
 
 #. IDS_MOVED
-#: Merge.rc:1910 Merge.rc:5076
+#: Merge.rc:1910 Merge.rc:5075
 msgid "Moved"
 msgstr "Przeniesiono"
 
@@ -3790,7 +3790,7 @@ msgid "&Use custom system colors"
 msgstr "Użyj niestandardowych kolorów systemowych"
 
 #. IDS_PRPCAT_SYSTEM
-#: Merge.rc:2565 Merge.rc:4559 Merge.rc:4560 Merge.rc:5007
+#: Merge.rc:2565 Merge.rc:4559 Merge.rc:4560 Merge.rc:5006
 msgid "System"
 msgstr "System"
 
@@ -4190,7 +4190,7 @@ msgid "Items compared:"
 msgstr "Porównano elementów:"
 
 #. IDS_PREVIEWBAR_CLOSE
-#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5685
+#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5684
 msgid "&Close"
 msgstr "Zamknij"
 
@@ -4805,7 +4805,7 @@ msgid "A&ppend timestamp"
 msgstr "Dodaj czas utworzenia"
 
 #. IDS_CONFIRM_COPY_CAPTION
-#: Merge.rc:3214 Merge.rc:4915
+#: Merge.rc:3214 Merge.rc:4914
 msgid "Confirm Copy"
 msgstr "Potwierdź kopiowanie"
 
@@ -5042,7 +5042,7 @@ msgid "&Character Set..."
 msgstr "Zestaw znaków..."
 
 #. IDS_PRPCAT_IMAGE
-#: Merge.rc:3351 Merge.rc:4574 Merge.rc:5015
+#: Merge.rc:3351 Merge.rc:4574 Merge.rc:5014
 msgid "Image"
 msgstr "Obraz"
 
@@ -5387,7 +5387,7 @@ msgid "Project"
 msgstr "Projekt"
 
 #. IDS_COLHDR_NSDIFFS
-#: Merge.rc:4566 Merge.rc:4990
+#: Merge.rc:4566 Merge.rc:4989
 msgid "Differences"
 msgstr "Różnice"
 
@@ -5529,12 +5529,12 @@ msgid "File Type"
 msgstr "Typ pliku"
 
 #. IDS_COLHDR_EXTENSION
-#: Merge.rc:4653 Merge.rc:4947
+#: Merge.rc:4653 Merge.rc:4946
 msgid "Extension"
 msgstr "Rozszerzenie"
 
 #. IDS_PRPCAT_MESSAGE
-#: Merge.rc:4659 Merge.rc:5019
+#: Merge.rc:4659 Merge.rc:5018
 msgid "Message"
 msgstr "Komunikat"
 
@@ -5574,7 +5574,7 @@ msgid "Hidden Items"
 msgstr "Ukryte elementy"
 
 #. IDS_PLUGINSLIST_NAME
-#: Merge.rc:4680 Merge.rc:5311
+#: Merge.rc:4680 Merge.rc:5310
 msgid "Name"
 msgstr "Nazwa"
 
@@ -5594,7 +5594,7 @@ msgid "[F] "
 msgstr "[F] "
 
 #. IDS_PLUGINSLIST_DESC
-#: Merge.rc:4684 Merge.rc:5313
+#: Merge.rc:4684 Merge.rc:5312
 msgid "Description"
 msgstr "Opis"
 
@@ -5720,2734 +5720,2729 @@ msgstr "Wiersz: %s  Kolumna: %d/%d  Znak: %d/%d"
 msgid "  Sel: %d | %d"
 msgstr "  Zaznaczono: %d | %d"
 
-#. IDS_MERGEMODE_MERGING
-#: Merge.rc:4734
-msgid "Merge"
-msgstr "Scal"
-
 #. IDS_DIFF_NUMBER_STATUS_FMT
-#: Merge.rc:4735
+#: Merge.rc:4734
 #, c-format
 msgid "Difference %1 of %2"
 msgstr "Różnica %1 z %2"
 
 #. IDS_NO_DIFF_SEL_FMT
-#: Merge.rc:4736
+#: Merge.rc:4735
 #, c-format
 msgid "%1 Differences Found"
 msgstr "Znaleziono %1 różnic(e)"
 
 #. IDS_1_DIFF_FOUND
-#: Merge.rc:4737
+#: Merge.rc:4736
 msgid "1 Difference Found"
 msgstr "Znaleziono 1 różnicę"
 
 #. IDS_NO_ERR_SEL_FMT
-#: Merge.rc:4738
+#: Merge.rc:4737
 #, c-format
 msgid "%1 Errors Found"
 msgstr "Znaleziono %1 błędów"
 
 #. IDS_1_ERR_FOUND
-#: Merge.rc:4739
+#: Merge.rc:4738
 msgid "1 Error Found"
 msgstr "Znaleziono 1 błąd"
 
 #. IDS_STATUSBAR_READONLY, Abbreviation from "Read Only"
-#: Merge.rc:4740
+#: Merge.rc:4739
 msgid "RO"
 msgstr "Tylko odczyt"
 
 #. IDS_DIRVIEW_STATUS_FMT_FOCUS
-#: Merge.rc:4746
+#: Merge.rc:4745
 #, c-format
 msgid "Item %1 of %2"
 msgstr "Element %1 z %2"
 
 #. IDS_DIRVIEW_STATUS_FMT_NOFOCUS
-#: Merge.rc:4747
+#: Merge.rc:4746
 #, c-format
 msgid "Items: %1"
 msgstr "Elementy: %1"
 
 #. IDS_DIRVIEW_STATUS_COMPARING
-#: Merge.rc:4748
+#: Merge.rc:4747
 msgid "Comparing items..."
 msgstr "Porównywanie elementów..."
 
 #. IDS_ITEMS_PER_SEC
-#: Merge.rc:4749
+#: Merge.rc:4748
 #, c-format
 msgid "%.1f[items/sec]"
 msgstr "%.1f[elementów/sek]"
 
 #. IDS_ERROR_INCOMPARABLE
-#: Merge.rc:4755
+#: Merge.rc:4754
 msgid "Select two existing folders/files to compare."
 msgstr "Wybierz dwa istniejące foldery lub pliki do porównania."
 
 #. IDS_DIRSEL_TAG
-#: Merge.rc:4756
+#: Merge.rc:4755
 msgid "Folder Selection"
 msgstr "Wybierz folder"
 
 #. IDS_OPEN_FILESDIRS
-#: Merge.rc:4757
+#: Merge.rc:4756
 msgid "Select two (or three) folders/files to compare."
 msgstr "Wybierz dwa (lub trzy) foldery bądź dwa (lub trzy) pliki do porównania."
 
 #. IDS_OPEN_LEFTINVALID
-#: Merge.rc:4758
+#: Merge.rc:4757
 msgid "Left (1st) path is invalid!"
 msgstr "Lewa (pierwsza) ścieżka jest nieprawidłowa!"
 
 #. IDS_OPEN_MIDDLEINVALID
-#: Merge.rc:4759
+#: Merge.rc:4758
 msgid "Middle (2nd) path is invalid!"
 msgstr "Środkowa (druga) ścieżka jest nieprawidłowa!"
 
 #. IDS_OPEN_RIGHTINVALID2
-#: Merge.rc:4760
+#: Merge.rc:4759
 msgid "Right (2nd) path is invalid!"
 msgstr "Prawa (druga) ścieżka jest nieprawidłowa!"
 
 #. IDS_OPEN_RIGHTINVALID3
-#: Merge.rc:4761
+#: Merge.rc:4760
 msgid "Right (3rd) path is invalid!"
 msgstr "Prawa (trzecia) ścieżka jest nieprawidłowa!"
 
 #. IDS_OPEN_BOTHINVALID
-#: Merge.rc:4762
+#: Merge.rc:4761
 msgid "Both paths are invalid!"
 msgstr "Obie ścieżki są nieprawidłowe!"
 
-#: Merge.rc:4764
+#: Merge.rc:4763
 msgid "Left (1st) and Middle (2nd) paths are invalid!"
 msgstr "Lewa (pierwsza) i środkowa (druga) ścieżka jest nieprawidłowa!"
 
 #. IDS_OPEN_LEFTRIGHTINVALID
-#: Merge.rc:4765
+#: Merge.rc:4764
 msgid "Left (1st) and Right (3rd) paths are invalid!"
 msgstr "Lewa (pierwsza) i prawa (trzecia) ścieżka jest nieprawidłowa!"
 
-#: Merge.rc:4767
+#: Merge.rc:4766
 msgid "Middle (2nd) and Right (3rd) paths are invalid!"
 msgstr "Środkowa (druga) i prawa (trzecia) ścieżka jest nieprawidłowa!"
 
 #. IDS_OPEN_ALLINVALID
-#: Merge.rc:4768
+#: Merge.rc:4767
 msgid "All paths are invalid!"
 msgstr "Wszystkie ścieżki są nieprawidłowe!"
 
 #. IDS_OPEN_UNPACKERDISABLED
-#: Merge.rc:4769
+#: Merge.rc:4768
 msgid "Only enabled for file comparisons"
 msgstr "Aktywne tylko w przypadku porównywania plików"
 
 #. IDS_OPEN_MISMATCH
-#: Merge.rc:4770
+#: Merge.rc:4769
 msgid "Cannot compare file and folder!"
 msgstr "Nie można porównać pliku i folderu!"
 
 #. IDS_ERROR_FILE_NOT_FOUND
-#: Merge.rc:4776
+#: Merge.rc:4775
 #, c-format
 msgid "File not found: %1"
 msgstr "Nie znaleziono pliku: %1"
 
 #. IDS_ERROR_FOLDER_NOT_FOUND
-#: Merge.rc:4777
+#: Merge.rc:4776
 #, c-format
 msgid "Folder not found: %1"
 msgstr "Nie znaleziono folderu: %1"
 
 #. IDS_ERROR_FILE_NOT_UNPACKED
-#: Merge.rc:4778
+#: Merge.rc:4777
 #, c-format
 msgid "File not unpacked: %1"
 msgstr "Nie rozpakowano pliku: %1"
 
 #. IDS_ERROR_FILEOPEN
-#: Merge.rc:4779
+#: Merge.rc:4778
 #, c-format
 msgid "Cannot open file\n%1\n\n%2"
 msgstr "Nie można otworzyć pliku\n%1\n\n%2"
 
 #. IDS_ERROR_CONF_RESOLVE
-#: Merge.rc:4780
+#: Merge.rc:4779
 msgid "Failed to parse conflict file."
 msgstr "Nie udało się przeanalizować pliku konfliktu."
 
 #. IDS_NOT_CONFLICT_FILE
-#: Merge.rc:4781
+#: Merge.rc:4780
 #, c-format
 msgid "The file\n%1\nis not a conflict file."
 msgstr "Plik\n%1\nnie jest plikiem konfliktu."
 
 #. IDS_COMPARE_LARGE_FILES
-#: Merge.rc:4782
+#: Merge.rc:4781
 msgid "Comparing large files requires significant memory.\nShow only comparison results (not file contents)?"
 msgstr "Porównanie dużych plików wymaga znacznej ilości pamięci.\nWyświetlić tylko wyniki porównania (bez zawartości plików)?"
 
 #. IDS_SAVE_AS_TITLE
-#: Merge.rc:4788
+#: Merge.rc:4787
 msgid "Save As"
 msgstr "Zapisz jako"
 
 #. IDS_SAVE_FMT
-#: Merge.rc:4789
+#: Merge.rc:4788
 #, c-format
 msgid "Save changes to %1?"
 msgstr "Zapisać zmiany w %1?"
 
 #. IDS_SAVEREADONLY_FMT
-#: Merge.rc:4790
+#: Merge.rc:4789
 #, c-format
 msgid "%1 is read-only. Override? Or 'No' to save as new filename?"
 msgstr "%1 jest tylko do odczytu. Nadpisać go? Wybierz 'Nie', aby zapisać pod nową nazwą."
 
 #. IDS_ERROR_BACKUP
-#: Merge.rc:4791
+#: Merge.rc:4790
 msgid "Error backing up file"
 msgstr "Błąd przy tworzeniu kopii zapasowej pliku"
 
-#: Merge.rc:4793
+#: Merge.rc:4792
 #, c-format
 msgid "Unable to backup original file:\n%1\n\nContinue anyway?"
 msgstr "Nie można wykonać kopii zapasowej oryginalnego pliku:\n%1\n\nKontynuować mimo wszystko?"
 
 #. IDS_FILESAVE_FAILED
-#: Merge.rc:4794
+#: Merge.rc:4793
 #, c-format
 msgid "Saving file failed.\n%1\n%2\n\t- Use different filename (OK)\n\t- Abort (Cancel)?"
 msgstr "Zapis pliku nieudany.\n%1\n%2\n\t- użyć innej nazwy pliku (OK)\n\t- przerwij bieżącą operację (Anuluj)?"
 
-#: Merge.rc:4796
+#: Merge.rc:4795
 #, c-format
 msgid "Plugin '%2' cannot pack changes to left file into '%1'.\n\nOriginal unchanged. Save unpacked version?"
 msgstr "Wtyczka '%2' nie może spakować zmian wprowadzonych w lewym pliku do '%1'.\n\nOryginalny plik pozostał niezmieniony.\n\nZapisać rozpakowaną wersję?"
 
-#: Merge.rc:4798
+#: Merge.rc:4797
 #, c-format
 msgid "Plugin '%2' cannot pack changes to middle file into '%1'.\n\nOriginal unchanged. Save unpacked version?"
 msgstr "Wtyczka '%2' nie może spakować zmian wprowadzonych w środkowym pliku do '%1'.\n\nOryginalny plik pozostał niezmieniony.\n\nZapisać rozpakowaną wersję?"
 
-#: Merge.rc:4800
+#: Merge.rc:4799
 #, c-format
 msgid "Plugin '%2' cannot pack changes to right file into '%1'.\n\nOriginal unchanged. Save unpacked version?"
 msgstr "Wtyczka '%2' nie może spakować zmian wprowadzonych w prawym pliku do '%1'.\n\nOryginalny plik pozostał niezmieniony.\n\nZapisać rozpakowaną wersję?"
 
 #. IDS_FILECHANGED_ONDISK
-#: Merge.rc:4801
+#: Merge.rc:4800
 #, c-format
 msgid "Another application updated\n%1\nsince WinMerge loaded it.\n\nOverwrite?"
 msgstr "Inna aplikacja dokonała zmian w pliku\n%1\npo tym jak WinMerge go wczytał.\n\nNadpisać?"
 
 #. IDS_SAVEREADONLY_MULTI
-#: Merge.rc:4802
+#: Merge.rc:4801
 #, c-format
 msgid "%1\nis read-only. Override?"
 msgstr "%1\njest tylko do odczytu. Nadpisać?"
 
 #. IDS_FILECHANGED_RESCAN
-#: Merge.rc:4803
+#: Merge.rc:4802
 #, c-format
 msgid "Another application updated\n%1\nsince last scan.\n\nReload?"
 msgstr "Plik\n%1\nzostał zmodyfikowany przez inną aplikację.\n\nWczytać ponownie?"
 
 #. IDS_SAVE_LEFT_AS
-#: Merge.rc:4804
+#: Merge.rc:4803
 msgid "Save Left File As"
 msgstr "Zapisz lewy plik jako"
 
 #. IDS_SAVE_MIDDLE_AS
-#: Merge.rc:4805
+#: Merge.rc:4804
 msgid "Save Middle File As"
 msgstr "Zapisz środkowy plik jako"
 
 #. IDS_SAVE_RIGHT_AS
-#: Merge.rc:4806
+#: Merge.rc:4805
 msgid "Save Right File As"
 msgstr "Zapisz prawy plik jako"
 
 #. IDS_FILE_DISAPPEARED
-#: Merge.rc:4811
+#: Merge.rc:4810
 #, c-format
 msgid "File\n%1\nnot found. Save a copy to continue."
 msgstr "Plik\n%1\nzostał usunięty. Proszę zapisać kopię pliku, aby móc kontynuować."
 
 #. IDS_VIEWS_OUTOFSYNC
-#: Merge.rc:4817
+#: Merge.rc:4816
 msgid "Cannot merge unsynched documents.\n\nRefresh before continuing."
 msgstr "Nie można połączyć różnic, jeśli dokumenty nie są zsynchronizowane.\n\nPrzed kontynuowaniem odśwież dokumenty."
 
 #. IDS_BREAK_ON_WHITESPACE
-#: Merge.rc:4822
+#: Merge.rc:4821
 msgid "Break at whitespace"
 msgstr "Zatrzymaj na białym znaku"
 
 #. IDS_BREAK_ON_PUNCTUATION
-#: Merge.rc:4823
+#: Merge.rc:4822
 msgid "Break at whitespace or punctuation"
 msgstr "Zatrzymaj na białym znaku lub interpunkcji"
 
 #. IDS_L2M
-#: Merge.rc:4829
+#: Merge.rc:4828
 msgid "Copy to &Middle\tAlt+Right"
 msgstr "Kopiuj do środka\tAlt+Right"
 
 #. IDS_R2M
-#: Merge.rc:4830
+#: Merge.rc:4829
 msgid "Copy to &Middle\tAlt+Left"
 msgstr "Kopiuj do środka\tAlt+Left"
 
 #. IDS_COPY_FROM_MIDDLE_R
-#: Merge.rc:4831
+#: Merge.rc:4830
 msgid "Copy from Middle\tAlt+Shift+Right"
 msgstr "Kopiuj ze środka\tAlt+Shift+Right"
 
 #. IDS_COPY_FROM_MIDDLE_L
-#: Merge.rc:4832
+#: Merge.rc:4831
 msgid "Copy from Middle\tAlt+Shift+Left"
 msgstr "Kopiuj ze środka\tAlt+Shift+Left"
 
 #. IDS_L2MNEXT
-#: Merge.rc:4833
+#: Merge.rc:4832
 msgid "Copy to Middle and Advance\tCtrl+Alt+Right"
 msgstr "Kopiuj do środka i przejdź dalej\tCtrl+Alt+Right"
 
 #. IDS_R2MNEXT
-#: Merge.rc:4834
+#: Merge.rc:4833
 msgid "Copy to Middle and Advance\tCtrl+Alt+Left"
 msgstr "Kopiuj do środka i przejdź dalej\tCtrl+Alt+Left"
 
 #. IDS_ALL_MIDDLE
-#: Merge.rc:4835
+#: Merge.rc:4834
 msgid "Copy All to Middle"
 msgstr "Kopiuj wszystko do środka"
 
 #. IDS_COPY_RIGHT_TO_LEFT
-#: Merge.rc:4841
+#: Merge.rc:4840
 #, c-format
 msgid "Right to Left (%1)"
 msgstr "Prawy do lewego (%1)"
 
 #. IDS_COPY_RIGHT_TO_MIDDLE
-#: Merge.rc:4842
+#: Merge.rc:4841
 #, c-format
 msgid "Right to Middle (%1)"
 msgstr "Prawy do środka (%1)"
 
 #. IDS_COPY_MIDDLE_TO_LEFT
-#: Merge.rc:4843
+#: Merge.rc:4842
 #, c-format
 msgid "Middle to Left (%1)"
 msgstr "Środek do lewego (%1)"
 
 #. IDS_COPY_MIDDLE_TO_RIGHT
-#: Merge.rc:4844
+#: Merge.rc:4843
 #, c-format
 msgid "Middle to Right (%1)"
 msgstr "Środek do prawego (%1)"
 
 #. IDS_COPY_LEFT_TO_RIGHT
-#: Merge.rc:4845
+#: Merge.rc:4844
 #, c-format
 msgid "Left to Right (%1)"
 msgstr "Lewy do prawego (%1)"
 
 #. IDS_COPY_LEFT_TO_MIDDLE
-#: Merge.rc:4846
+#: Merge.rc:4845
 #, c-format
 msgid "Left to Middle (%1)"
 msgstr "Lewy do środka (%1)"
 
 #. IDS_MOVE_LEFT_TO
-#: Merge.rc:4857 Merge.rc:4889
+#: Merge.rc:4856 Merge.rc:4888
 #, c-format
 msgid "Left to... (%1)"
 msgstr "Lewy do... (%1)"
 
 #. IDS_MOVE_MIDDLE_TO
-#: Merge.rc:4858 Merge.rc:4890
+#: Merge.rc:4857 Merge.rc:4889
 #, c-format
 msgid "Middle to... (%1)"
 msgstr "Środek do... (%1)"
 
 #. IDS_MOVE_RIGHT_TO
-#: Merge.rc:4859 Merge.rc:4891
+#: Merge.rc:4858 Merge.rc:4890
 #, c-format
 msgid "Right to... (%1)"
 msgstr "Prawy do... (%1)"
 
 #. IDS_COPY_BOTH_TO
-#: Merge.rc:4860
+#: Merge.rc:4859
 #, c-format
 msgid "Both to... (%1)"
 msgstr "Obie do... (%1)"
 
 #. IDS_COPY_ALL_TO
-#: Merge.rc:4861
+#: Merge.rc:4860
 #, c-format
 msgid "All to... (%1)"
 msgstr "Wszystkie do... (%1)"
 
 #. IDS_COPY_DIFFERENCES_TO
-#: Merge.rc:4862
+#: Merge.rc:4861
 #, c-format
 msgid "Differences to... (%1)"
 msgstr "Różnice do... (%1)"
 
 #. IDS_ONLYDIFFITEMS_CONFIRM
-#: Merge.rc:4869
+#: Merge.rc:4868
 msgid "Some selected items are identical or skipped.\nProcess only items with differences?"
 msgstr "Niektóre wybrane elementy są identyczne lub zostały pominięte.\nPrzetworzyć tylko elementy z różnicami?"
 
 #. IDS_DEL_LEFT_FMT
-#: Merge.rc:4875
+#: Merge.rc:4874
 #, c-format
 msgid "Left (%1)"
 msgstr "Lewy (%1)"
 
 #. IDS_DEL_MIDDLE_FMT
-#: Merge.rc:4876
+#: Merge.rc:4875
 #, c-format
 msgid "Middle (%1)"
 msgstr "Środek (%1)"
 
 #. IDS_DEL_RIGHT_FMT
-#: Merge.rc:4877
+#: Merge.rc:4876
 #, c-format
 msgid "Right (%1)"
 msgstr "Prawy (%1)"
 
 #. IDS_DEL_BOTH_FMT
-#: Merge.rc:4878
+#: Merge.rc:4877
 #, c-format
 msgid "Both (%1)"
 msgstr "Obie (%1)"
 
 #. IDS_DEL_ALL_FMT
-#: Merge.rc:4879
+#: Merge.rc:4878
 #, c-format
 msgid "All (%1)"
 msgstr "Wszystkie (%1)"
 
 #. IDS_SELECT_DEST_LEFT
-#: Merge.rc:4895
+#: Merge.rc:4894
 msgid "Left Side - Select Destination Folder:"
 msgstr "Lewa strona - wybierz folder docelowy:"
 
 #. IDS_SELECT_DEST_MIDDLE
-#: Merge.rc:4896
+#: Merge.rc:4895
 msgid "Middle Side - Select Destination Folder:"
 msgstr "Środkowa strona - wybierz folder docelowy:"
 
 #. IDS_SELECT_DEST_RIGHT
-#: Merge.rc:4897
+#: Merge.rc:4896
 msgid "Right Side - Select Destination Folder:"
 msgstr "Prawa strona - wybierz folder docelowy:"
 
 #. IDS_FILES_AFFECTED_FMT
-#: Merge.rc:4898
+#: Merge.rc:4897
 #, c-format
 msgid "(%1 Files Affected)"
 msgstr "(%1 objętych plików)"
 
 #. IDS_FILES_AFFECTED_FMT2
-#: Merge.rc:4899
+#: Merge.rc:4898
 #, c-format
 msgid "(%1 of %2 Files Affected)"
 msgstr "(%1 z %2 objętych plików)"
 
 #. IDS_CONFIRM_DELETE_SINGLE
-#: Merge.rc:4905
+#: Merge.rc:4904
 #, c-format
 msgid "Are you sure you want to delete\n\n%1 ?"
 msgstr "Czy na pewno chcesz usunąć\n\n%1 ?"
 
 #. IDS_CONFIRM_SINGLE_COPY
-#: Merge.rc:4906
+#: Merge.rc:4905
 msgid "Are you sure you want to copy?"
 msgstr "Czy na pewno chcesz skopiować?"
 
 #. IDS_CONFIRM_MULTIPLE_COPY
-#: Merge.rc:4907
+#: Merge.rc:4906
 #, c-format
 msgid "Are you sure you want to copy %d items?"
 msgstr "Czy na pewno chcesz skopiować %d elementów?"
 
 #. IDS_DIRCMP_NOTSYNC
-#: Merge.rc:4908
+#: Merge.rc:4907
 #, c-format
 msgid "Operation aborted!\n\nFolder contents changed, path\n%1\nnot found.\n\nRefresh the compare."
 msgstr "Operacja przerwana!\n\nZawartość folderu na dysku została zmieniona. Ścieżka\n%1\nnie została odnaleziona.\n\nProszę odświeżyć porównanie."
 
 #. IDS_CONFIRM_SINGLE_MOVE
-#: Merge.rc:4913
+#: Merge.rc:4912
 msgid "Are you sure you want to move?"
 msgstr "Czy na pewno chcesz przenieść?"
 
 #. IDS_CONFIRM_MULTIPLE_MOVE
-#: Merge.rc:4914
+#: Merge.rc:4913
 #, c-format
 msgid "Are you sure you want to move %d items?"
 msgstr "Czy na pewno chcesz przenieść %d elementów?"
 
 #. IDS_CONFIRM_MOVE_CAPTION
-#: Merge.rc:4916
+#: Merge.rc:4915
 msgid "Confirm Move"
 msgstr "Potwierdź przenoszenie"
 
-#: Merge.rc:4918
+#: Merge.rc:4917
 msgid "Close the folder comparison window?"
 msgstr "Zamknąć okno porównywania folderu?"
 
-#: Merge.rc:4920
+#: Merge.rc:4919
 msgid "Close the folder comparison window, which took a long time?"
 msgstr "Zamknąć okno porównywania folderu, któremu poświęcono znaczną ilość czasu?"
 
 #. IDS_ERROR_INVALID_DIR_FILE_NAME
-#: Merge.rc:4921
+#: Merge.rc:4920
 msgid "The file or folder name is invalid."
 msgstr "Nazwa pliku lub folderu jest nieprawidłowa."
 
 #. IDS_ERROR_EXECUTE_FILE
-#: Merge.rc:4927
+#: Merge.rc:4926
 #, c-format
 msgid "Failed to execute external editor: %1"
 msgstr "Nie można uruchomić zewnętrznego edytora: %1"
 
 #. IDS_UNKNOWN_ARCHIVE_FORMAT
-#: Merge.rc:4933
+#: Merge.rc:4932
 msgid "Unknown archive format"
 msgstr "Nieznany format archiwum"
 
-#: Merge.rc:4935
+#: Merge.rc:4934
 msgid "Failed to extract archive.\nCompare as text file?"
 msgstr "Nie udało się wyodrębnić archiwum.\nPorównać jako plik tekstowy?"
 
 #. IDS_COLHDR_FILENAME
-#: Merge.rc:4941
+#: Merge.rc:4940
 msgid "Filename"
 msgstr "Nazwa pliku"
 
 #. IDS_COLHDR_DIR
-#: Merge.rc:4942
+#: Merge.rc:4941
 msgctxt "DirView|ColumnHeader"
 msgid "Folder"
 msgstr "Folder"
 
 #. IDS_COLHDR_RESULT
-#: Merge.rc:4943
+#: Merge.rc:4942
 msgid "Comparison Result"
 msgstr "Wynik porównania"
 
 #. IDS_COLHDR_LTIMEM
-#: Merge.rc:4944
+#: Merge.rc:4943
 msgid "Left Date"
 msgstr "Data lewego pliku"
 
 #. IDS_COLHDR_RTIMEM
-#: Merge.rc:4945
+#: Merge.rc:4944
 msgid "Right Date"
 msgstr "Data prawego pliku"
 
 #. IDS_COLHDR_MTIMEM
-#: Merge.rc:4946
+#: Merge.rc:4945
 msgid "Middle Date"
 msgstr "Data środkowego pliku"
 
 #. IDS_COLHDR_LSIZE
-#: Merge.rc:4948
+#: Merge.rc:4947
 msgid "Left Size"
 msgstr "Rozmiar lewego pliku"
 
 #. IDS_COLHDR_RSIZE
-#: Merge.rc:4949
+#: Merge.rc:4948
 msgid "Right Size"
 msgstr "Rozmiar prawego pliku"
 
 #. IDS_COLHDR_MSIZE
-#: Merge.rc:4954
+#: Merge.rc:4953
 msgid "Middle Size"
 msgstr "Rozmiar środkowego pliku"
 
 #. IDS_COLHDR_RSIZE_SHORT
-#: Merge.rc:4955
+#: Merge.rc:4954
 msgid "Right Size (Short)"
 msgstr "Rozmiar prawego pliku (krótki)"
 
 #. IDS_COLHDR_LSIZE_SHORT
-#: Merge.rc:4956
+#: Merge.rc:4955
 msgid "Left Size (Short)"
 msgstr "Rozmiar lewego pliku (krótki)"
 
 #. IDS_COLHDR_MSIZE_SHORT
-#: Merge.rc:4957
+#: Merge.rc:4956
 msgid "Middle Size (Short)"
 msgstr "Rozmiar środkowego pliku (krótki)"
 
 #. IDS_COLHDR_LTIMEC
-#: Merge.rc:4963
+#: Merge.rc:4962
 msgid "Left Creation Time"
 msgstr "Czas utworzenia lewego pliku"
 
 #. IDS_COLHDR_RTIMEC
-#: Merge.rc:4964
+#: Merge.rc:4963
 msgid "Right Creation Time"
 msgstr "Czas utworzenia prawego pliku"
 
 #. IDS_COLHDR_MTIMEC
-#: Merge.rc:4965
+#: Merge.rc:4964
 msgid "Middle Creation Time"
 msgstr "Czas utworzenia środkowego pliku"
 
 #. IDS_COLHDR_NEWER
-#: Merge.rc:4966
+#: Merge.rc:4965
 msgid "Newer File"
 msgstr "Nowszy plik"
 
 #. IDS_COLHDR_LVERSION
-#: Merge.rc:4967
+#: Merge.rc:4966
 msgid "Left File Version"
 msgstr "Wersja lewego pliku"
 
 #. IDS_COLHDR_RVERSION
-#: Merge.rc:4968
+#: Merge.rc:4967
 msgid "Right File Version"
 msgstr "Wersja prawego pliku"
 
 #. IDS_COLHDR_MVERSION
-#: Merge.rc:4969
+#: Merge.rc:4968
 msgid "Middle File Version"
 msgstr "Wersja środkowego pliku"
 
 #. IDS_COLHDR_RESULT_ABBR
-#: Merge.rc:4970
+#: Merge.rc:4969
 msgid "Short Result"
 msgstr "Skrócony wynik"
 
 #. IDS_COLHDR_LATTRIBUTES
-#: Merge.rc:4971
+#: Merge.rc:4970
 msgid "Left Attributes"
 msgstr "Atrybuty lewego pliku"
 
 #. IDS_COLHDR_RATTRIBUTES
-#: Merge.rc:4972
+#: Merge.rc:4971
 msgid "Right Attributes"
 msgstr "Atrybuty prawego pliku"
 
 #. IDS_COLHDR_MATTRIBUTES
-#: Merge.rc:4973
+#: Merge.rc:4972
 msgid "Middle Attributes"
 msgstr "Atrybuty środkowego pliku"
 
 #. IDS_COLHDR_LEOL_TYPE
-#: Merge.rc:4978
+#: Merge.rc:4977
 msgid "Left EOL"
 msgstr "Lewy znak końca linii"
 
 #. IDS_COLHDR_MEOL_TYPE
-#: Merge.rc:4979
+#: Merge.rc:4978
 msgid "Middle EOL"
 msgstr "Środkowy znak końca linii"
 
 #. IDS_COLHDR_REOL_TYPE
-#: Merge.rc:4980
+#: Merge.rc:4979
 msgid "Right EOL"
 msgstr "Prawy znak końca linii"
 
 #. IDS_COLHDR_LENCODING
-#: Merge.rc:4986
+#: Merge.rc:4985
 msgid "Left Encoding"
 msgstr "Lewe kodowanie"
 
 #. IDS_COLHDR_RENCODING
-#: Merge.rc:4987
+#: Merge.rc:4986
 msgid "Right Encoding"
 msgstr "Prawe kodowanie"
 
 #. IDS_COLHDR_MENCODING
-#: Merge.rc:4988
+#: Merge.rc:4987
 msgid "Middle Encoding"
 msgstr "Środkowe kodowanie"
 
 #. IDS_COLHDR_NIDIFFS
-#: Merge.rc:4989
+#: Merge.rc:4988
 msgid "Ignored Diff"
 msgstr "Zignorowana różnica"
 
 #. IDS_COLHDR_BINARY
-#: Merge.rc:4991
+#: Merge.rc:4990
 msgctxt "DirView|ColumnHeader"
 msgid "Binary"
 msgstr "Binarny"
 
 #. IDS_PLUGINS_TYPE_UNPACKER
-#: Merge.rc:4992 Merge.rc:5314
+#: Merge.rc:4991 Merge.rc:5313
 msgid "Unpacker"
 msgstr "Program rozpakowujący"
 
 #. IDS_PLUGIN_TYPE4
-#: Merge.rc:4993 Merge.rc:5315 Merge.rc:5622
+#: Merge.rc:4992 Merge.rc:5314 Merge.rc:5621
 msgid "Prediffer"
 msgstr "Porównywanie"
 
 #. IDS_COLHDR_LEFT
-#: Merge.rc:4994
+#: Merge.rc:4993
 msgid "Left"
 msgstr "Lewy"
 
 #. IDS_COLHDR_MIDDLE
-#: Merge.rc:4995
+#: Merge.rc:4994
 msgid "Middle"
 msgstr "Środkowy"
 
 #. IDS_COLHDR_RIGHT
-#: Merge.rc:4996
+#: Merge.rc:4995
 msgid "Right"
 msgstr "Prawy"
 
 #. IDS_COLHDR_DIFF
-#: Merge.rc:4997
+#: Merge.rc:4996
 msgid "Diff"
 msgstr "Różnica"
 
 #. IDS_COLHDR_LEFT_DUPLICATE
-#: Merge.rc:4998
+#: Merge.rc:4997
 msgid "Left Duplicate Count"
 msgstr "Liczba duplikatów po lewej"
 
 #. IDS_COLHDR_RIGHT_DUPLICATE
-#: Merge.rc:4999
+#: Merge.rc:4998
 msgid "Right Duplicate Count"
 msgstr "Liczba duplikatów po prawej"
 
 #. IDS_COLHDR_MIDDLE_DUPLICATE
-#: Merge.rc:5000
+#: Merge.rc:4999
 msgid "Middle Duplicate Count"
 msgstr "Liczba duplikatów na środku"
 
 #. IDS_COLHDR_MOVE
-#: Merge.rc:5001
+#: Merge.rc:5000
 msgid "Move"
 msgstr "Przesuń"
 
 #. IDS_PRPCAT_AUDIO
-#: Merge.rc:5008
+#: Merge.rc:5007
 msgid "Audio"
 msgstr "Dźwięk"
 
 #. IDS_PRPCAT_CALENDAR
-#: Merge.rc:5009
+#: Merge.rc:5008
 msgid "Calendar"
 msgstr "Kalendarz"
 
 #. IDS_PRPCAT_COMMUNICATION
-#: Merge.rc:5010
+#: Merge.rc:5009
 msgid "Communication"
 msgstr "Komunikacja"
 
 #. IDS_PRPCAT_CONTACT
-#: Merge.rc:5011
+#: Merge.rc:5010
 msgid "Contact"
 msgstr "Kontakt"
 
 #. IDS_PRPCAT_DEVICES
-#: Merge.rc:5012
+#: Merge.rc:5011
 msgid "Devices"
 msgstr "Urządzenia"
 
 #. IDS_PRPCAT_DOCUMENT
-#: Merge.rc:5013
+#: Merge.rc:5012
 msgid "Document"
 msgstr "Dokument"
 
 #. IDS_PRPCAT_HOME
-#: Merge.rc:5014
+#: Merge.rc:5013
 msgid "Home"
 msgstr "Dom"
 
 #. IDS_PRPCAT_JOURNAL
-#: Merge.rc:5016
+#: Merge.rc:5015
 msgid "Journal"
 msgstr "Dziennik"
 
 #. IDS_PRPCAT_LINK
-#: Merge.rc:5017
+#: Merge.rc:5016
 msgid "Link"
 msgstr "Odnośnik"
 
 #. IDS_PRPCAT_MEDIA
-#: Merge.rc:5018
+#: Merge.rc:5017
 msgid "Media"
 msgstr "Media"
 
 #. IDS_PRPCAT_MUSIC
-#: Merge.rc:5020
+#: Merge.rc:5019
 msgid "Music"
 msgstr "Muzyka"
 
 #. IDS_PRPCAT_NOTE
-#: Merge.rc:5021
+#: Merge.rc:5020
 msgid "Note"
 msgstr "Notatka"
 
 #. IDS_PRPCAT_PHOTO
-#: Merge.rc:5022
+#: Merge.rc:5021
 msgid "Photo"
 msgstr "Zdjęcie"
 
 #. IDS_PRPCAT_RECORDEDTV
-#: Merge.rc:5023
+#: Merge.rc:5022
 msgid "RecordedTV"
 msgstr "Nagranie TV"
 
 #. IDS_PRPCAT_SEARCH
-#: Merge.rc:5024
+#: Merge.rc:5023
 msgid "Search"
 msgstr "Szukaj"
 
 #. IDS_PRPCAT_SECURITY
-#: Merge.rc:5025
+#: Merge.rc:5024
 msgid "Security"
 msgstr "Bezpieczeństwo"
 
 #. IDS_PRPCAT_SOFTWARE
-#: Merge.rc:5026
+#: Merge.rc:5025
 msgid "Software"
 msgstr "Oprogramowanie"
 
 #. IDS_PRPCAT_TASK
-#: Merge.rc:5027
+#: Merge.rc:5026
 msgid "Task"
 msgstr "Zadanie"
 
 #. IDS_PRPCAT_VIDEO
-#: Merge.rc:5028
+#: Merge.rc:5027
 msgid "Video"
 msgstr "Wideo"
 
 #. IDS_PRPCAT_HASH
-#: Merge.rc:5029
+#: Merge.rc:5028
 msgid "Hash"
 msgstr "Hash"
 
 #. IDS_CANT_COMPARE_FILES
-#: Merge.rc:5035
+#: Merge.rc:5034
 msgid "Unable to compare files"
 msgstr "Nie można porównać plików"
 
 #. IDS_ABORTED_ITEM
-#: Merge.rc:5036
+#: Merge.rc:5035
 msgid "Item aborted"
 msgstr "Anulowany"
 
 #. IDS_FILE_SKIPPED
-#: Merge.rc:5037
+#: Merge.rc:5036
 msgid "File skipped"
 msgstr "Plik pominięty"
 
 #. IDS_DIR_SKIPPED
-#: Merge.rc:5038
+#: Merge.rc:5037
 msgid "Folder skipped"
 msgstr "Folder pominięty"
 
 #. IDS_LEFT_ONLY_IN_FMT
-#: Merge.rc:5039
+#: Merge.rc:5038
 #, c-format
 msgid "Left only: %1"
 msgstr "Tylko po lewej: %1"
 
 #. IDS_MIDDLE_ONLY_IN_FMT
-#: Merge.rc:5040
+#: Merge.rc:5039
 #, c-format
 msgid "Middle only: %1"
 msgstr "Tylko na środku: %1"
 
 #. IDS_RIGHT_ONLY_IN_FMT
-#: Merge.rc:5041
+#: Merge.rc:5040
 #, c-format
 msgid "Right only: %1"
 msgstr "Tylko po prawej: %1"
 
 #. IDS_DOES_NOT_EXIST_IN_FMT
-#: Merge.rc:5042
+#: Merge.rc:5041
 #, c-format
 msgid "Does not exist in %1"
 msgstr "Nie istnieje w %1"
 
 #. IDS_BIN_FILES_SAME
-#: Merge.rc:5043
+#: Merge.rc:5042
 msgid "Binary files are identical"
 msgstr "Pliki binarne są identyczne"
 
 #. IDS_BIN_FILES_DIFF
-#: Merge.rc:5049
+#: Merge.rc:5048
 msgid "Binary files are different"
 msgstr "Pliki binarne są różne"
 
 #. IDS_FILES_ARE_DIFFERENT
-#: Merge.rc:5050
+#: Merge.rc:5049
 msgid "Files are different"
 msgstr "Pliki są różne"
 
 #. IDS_FOLDERS_ARE_DIFFERENT
-#: Merge.rc:5051
+#: Merge.rc:5050
 msgid "Folders are different"
 msgstr "Foldery są różne"
 
 #. IDS_LEFTONLY
-#: Merge.rc:5052
+#: Merge.rc:5051
 msgid "Left Only"
 msgstr "Tylko po lewej"
 
 #. IDS_RIGHTONLY
-#: Merge.rc:5053
+#: Merge.rc:5052
 msgid "Right Only"
 msgstr "Tylko po prawej"
 
 #. IDS_MIDDLEONLY
-#: Merge.rc:5054
+#: Merge.rc:5053
 msgid "Middle Only"
 msgstr "Tylko na środku"
 
 #. IDS_NOITEMLEFT
-#: Merge.rc:5055
+#: Merge.rc:5054
 msgid "No item in left"
 msgstr "Brak elementu po lewej"
 
 #. IDS_NOITEMRIGHT
-#: Merge.rc:5056
+#: Merge.rc:5055
 msgid "No item in right"
 msgstr "Brak elementu po prawej"
 
 #. IDS_NOITEMMIDDLE
-#: Merge.rc:5057
+#: Merge.rc:5056
 msgid "No item in middle"
 msgstr "Brak elementu na środku"
 
 #. IDS_CMPRES_ERROR
-#: Merge.rc:5059
+#: Merge.rc:5058
 msgid "Error"
 msgstr "Błąd"
 
 #. IDS_TEXT_FILES_SAME
-#: Merge.rc:5060
+#: Merge.rc:5059
 msgid "Text files are identical"
 msgstr "Pliki tekstowe są identyczne"
 
 #. IDS_LEFTONLY_DIFF
-#: Merge.rc:5061
+#: Merge.rc:5060
 msgid " (Middle and right are identical)"
 msgstr " (Środkowy i prawy są identyczne)"
 
 #. IDS_MIDDLEONLY_DIFF
-#: Merge.rc:5062
+#: Merge.rc:5061
 msgid " (Left and right are identical)"
 msgstr " (Lewy i prawy są identyczne)"
 
 #. IDS_RIGHTONLY_DIFF
-#: Merge.rc:5063
+#: Merge.rc:5062
 msgid " (Left and middle are identical)"
 msgstr " (Lewy i środkowy są identyczne)"
 
 #. IDS_PATH_MISMATCH
-#: Merge.rc:5064
+#: Merge.rc:5063
 msgid " (paths differ)"
 msgstr " (różne ścieżki)"
 
 #. IDS_TEXT_FILES_DIFF
-#: Merge.rc:5065
+#: Merge.rc:5064
 msgid "Text files are different"
 msgstr "Pliki tekstowe są różne"
 
 #. IDS_IMAGE_FILES_SAME
-#: Merge.rc:5066
+#: Merge.rc:5065
 msgid "Image files are identical"
 msgstr "Pliki obrazów są identyczne"
 
 #. IDS_IMAGE_FILES_DIFF
-#: Merge.rc:5067
+#: Merge.rc:5066
 msgid "Image files are different"
 msgstr "Pliki obrazów są różne"
 
 #. IDS_EXPR_DIFF
-#: Merge.rc:5068
+#: Merge.rc:5067
 #, c-format
 msgid "Files are different (expr: %1)"
 msgstr "Pliki są różne (wyrażenie: %1)"
 
 #. IDS_HASH_GROUP
-#: Merge.rc:5069
+#: Merge.rc:5068
 #, c-format
 msgid "Group%d"
 msgstr "Grupa%d"
 
 #. IDS_RENAME_MOVE_DETECTION_DISALBED
-#: Merge.rc:5070
+#: Merge.rc:5069
 msgctxt "Options dialog|Compare|Folder|Detect renames and moves"
 msgid "Disabled"
 msgstr "Wyłączony"
 
 #. IDS_RENAME_MOVE_DETECTION_RENAME
-#: Merge.rc:5071
+#: Merge.rc:5070
 msgid "Detect renames"
 msgstr "Wykryj zmiany nazw"
 
 #. IDS_RENAME_MOVE_DETECTION_RENAME_MOVE
-#: Merge.rc:5072
+#: Merge.rc:5071
 msgid "Detect renames and moves"
 msgstr "Wykryj zmiany nazw i przeniesienia"
 
 #. IDS_RENAME_MOVE_MERGE_MODE_RENAME
-#: Merge.rc:5073
+#: Merge.rc:5072
 msgid "Merge renames"
 msgstr "Scal zmiany nazw"
 
 #. IDS_RENAME_MOVE_MERGE_MODE_RENAME_MOVE
-#: Merge.rc:5074
+#: Merge.rc:5073
 msgid "Merge renames and moves"
 msgstr "Scal zmiany nazw i przeniesienia"
 
 #. IDS_RENAMED
-#: Merge.rc:5075
+#: Merge.rc:5074
 msgid "Renamed"
 msgstr "Zmieniono nazwę"
 
 #. IDS_RENAMED_MOVED
-#: Merge.rc:5077
+#: Merge.rc:5076
 msgid "Renamed/Moved"
 msgstr "Zmieniono nazwę/przeniesiono"
 
 #. IDS_RENAMED_MOVED_ITEMS
-#: Merge.rc:5078
+#: Merge.rc:5077
 #, c-format
 msgid "(%1 items)"
 msgstr "(%1 elementy(ów))"
 
 #. IDS_RENAMED_MOVED_RESULT
-#: Merge.rc:5079
+#: Merge.rc:5078
 #, c-format
 msgid "%1 (set %2): "
 msgstr ""
 
 #. IDS_SWITCH_FLAT_MODE
-#: Merge.rc:5080
+#: Merge.rc:5079
 msgid "Some moved items have been merged.\nIn Tree Mode, these items may appear in positions that do not reflect the actual folder structure, which can be confusing.\nSwitch to Flat Mode?"
 msgstr "Niektóre przeniesione elementy zostały scalone.\nW trybie drzewa elementy te mogą pojawiać się w miejscach, które nie odzwierciedlają rzeczywistej struktury folderów, co może być mylące.\nPrzełączyć na tryb płaski?"
 
 #. IDS_ELAPSED_TIME
-#: Merge.rc:5086
+#: Merge.rc:5085
 #, c-format
 msgid "Elapsed time: %ld ms"
 msgstr "Upłynęło: %ld ms"
 
 #. IDS_STATUS_SELITEM1
-#: Merge.rc:5087
+#: Merge.rc:5086
 msgid "1 item selected"
 msgstr "Zaznaczono 1 element"
 
 #. IDS_STATUS_SELITEMS
-#: Merge.rc:5088
+#: Merge.rc:5087
 #, c-format
 msgid "%1 items selected"
 msgstr "Zaznaczono %1 elementy(ów)"
 
 #. IDS_COLDESC_FILENAME
-#: Merge.rc:5094
+#: Merge.rc:5093
 msgid "Filename or folder name."
 msgstr "Nazwa pliku lub nazwa folderu."
 
 #. IDS_COLDESC_DIR
-#: Merge.rc:5095
+#: Merge.rc:5094
 msgid "Subfolder name when subfolders are included."
 msgstr "Nazwa podfolderu, gdy podfoldery są przetwarzane."
 
 #. IDS_COLDESC_RESULT
-#: Merge.rc:5096
+#: Merge.rc:5095
 msgid "Comparison result, long form."
 msgstr "Wynik porównania – długi formularz."
 
 #. IDS_COLDESC_LTIMEM
-#: Merge.rc:5101
+#: Merge.rc:5100
 msgid "Left side modification date."
 msgstr "Data modyfikacji lewej strony."
 
 #. IDS_COLDESC_RTIMEM
-#: Merge.rc:5102
+#: Merge.rc:5101
 msgid "Right side modification date."
 msgstr "Data modyfikacji prawej strony."
 
 #. IDS_COLDESC_MTIMEM
-#: Merge.rc:5103
+#: Merge.rc:5102
 msgid "Middle side modification date."
 msgstr "Data modyfikacji środkowej strony."
 
 #. IDS_COLDESC_EXTENSION
-#: Merge.rc:5104
+#: Merge.rc:5103
 msgid "File's extension."
 msgstr "Rozszerzenie pliku."
 
 #. IDS_COLDESC_LSIZE
-#: Merge.rc:5105
+#: Merge.rc:5104
 msgid "Left file size in bytes."
 msgstr "Rozmiar lewego pliku w bajtach."
 
 #. IDS_COLDESC_RSIZE
-#: Merge.rc:5106
+#: Merge.rc:5105
 msgid "Right file size in bytes."
 msgstr "Rozmiar prawego pliku w bajtach."
 
 #. IDS_COLDESC_MSIZE
-#: Merge.rc:5107
+#: Merge.rc:5106
 msgid "Middle file size in bytes."
 msgstr "Rozmiar środkowego pliku w bajtach."
 
 #. IDS_COLDESC_LSIZE_SHORT
-#: Merge.rc:5108
+#: Merge.rc:5107
 msgid "Left file size abbreviated."
 msgstr "Skrócony rozmiar lewego pliku."
 
 #. IDS_COLDESC_RSIZE_SHORT
-#: Merge.rc:5109
+#: Merge.rc:5108
 msgid "Right file size abbreviated."
 msgstr "Skrócony rozmiar prawego pliku."
 
 #. IDS_COLDESC_MSIZE_SHORT
-#: Merge.rc:5110
+#: Merge.rc:5109
 msgid "Middle file size abbreviated."
 msgstr "Skrócony rozmiar środkowego pliku."
 
 #. IDS_COLDESC_LTIMEC
-#: Merge.rc:5116
+#: Merge.rc:5115
 msgid "Left side creation time."
 msgstr "Czas utworzenia lewej strony."
 
 #. IDS_COLDESC_RTIMEC
-#: Merge.rc:5117
+#: Merge.rc:5116
 msgid "Right side creation time."
 msgstr "Czas utworzenia prawej strony."
 
 #. IDS_COLDESC_MTIMEC
-#: Merge.rc:5118
+#: Merge.rc:5117
 msgid "Middle side creation time."
 msgstr "Czas utworzenia środkowej strony."
 
 #. IDS_COLDESC_NEWER
-#: Merge.rc:5119
+#: Merge.rc:5118
 msgid "Tells which side has newer modification date."
 msgstr "Pokazuje, która strona ma nowszą datę modyfikacji."
 
 #. IDS_COLDESC_LVERSION
-#: Merge.rc:5120
+#: Merge.rc:5119
 msgid "Left side file version, only for some file types."
 msgstr "Wersja pliku lewej strony, tylko dla niektórych typów plików."
 
 #. IDS_COLDESC_RVERSION
-#: Merge.rc:5121
+#: Merge.rc:5120
 msgid "Right side file version, only for some file types."
 msgstr "Wersja pliku prawej strony, tylko dla niektórych typów plików."
 
 #. IDS_COLDESC_MVERSION
-#: Merge.rc:5126
+#: Merge.rc:5125
 msgid "Middle side file version, only for some file types."
 msgstr "Wersja pliku środkowej strony, tylko dla niektórych typów plików."
 
 #. IDS_COLDESC_RESULT_ABBR
-#: Merge.rc:5127
+#: Merge.rc:5126
 msgid "Short comparison result."
 msgstr "Skrócony wynik porównania."
 
 #. IDS_COLDESC_LATTRIBUTES
-#: Merge.rc:5128
+#: Merge.rc:5127
 msgid "Left side attributes."
 msgstr "Atrybuty lewej strony."
 
 #. IDS_COLDESC_RATTRIBUTES
-#: Merge.rc:5129
+#: Merge.rc:5128
 msgid "Right side attributes."
 msgstr "Atrybuty prawej strony."
 
 #. IDS_COLDESC_MATTRIBUTES
-#: Merge.rc:5130
+#: Merge.rc:5129
 msgid "Middle side attributes."
 msgstr "Atrybuty środkowej strony."
 
 #. IDS_COLDESC_LEOL_TYPE
-#: Merge.rc:5131
+#: Merge.rc:5130
 msgid "Left side file EOL type."
 msgstr "Typ znaków końca linii z lewej strony."
 
 #. IDS_COLDESC_REOL_TYPE
-#: Merge.rc:5132
+#: Merge.rc:5131
 msgid "Right side file EOL type."
 msgstr "Typ znaków końca linii z prawej strony."
 
 #. IDS_COLDESC_MEOL_TYPE
-#: Merge.rc:5133
+#: Merge.rc:5132
 msgid "Middle side file EOL type."
 msgstr "Typ znaków końca linii na środku."
 
 #. IDS_COLDESC_LENCODING
-#: Merge.rc:5139
+#: Merge.rc:5138
 msgid "Left side encoding."
 msgstr "Kodowanie lewej strony."
 
 #. IDS_COLDESC_RENCODING
-#: Merge.rc:5140
+#: Merge.rc:5139
 msgid "Right side encoding."
 msgstr "Kodowanie prawej strony."
 
 #. IDS_COLDESC_MENCODING
-#: Merge.rc:5141
+#: Merge.rc:5140
 msgid "Middle side encoding."
 msgstr "Kodowanie środkowej strony."
 
 #. IDS_COLDESC_NIDIFFS
-#: Merge.rc:5142
+#: Merge.rc:5141
 msgid "Number of ignored differences in file. Ignored and cannot be merged."
 msgstr "Liczba zignorowanych różnic w pliku. Różnice te zostały zignorowane przez WinMerge i nie mogą zostać połączone."
 
 #. IDS_COLDESC_NSDIFFS
-#: Merge.rc:5143
+#: Merge.rc:5142
 msgid "Number of differences in file (excluding ignored)."
 msgstr "Liczba różnic w pliku. Liczba ta nie zawiera zignorowanych różnic."
 
 #. IDS_COLDESC_BINARY
-#: Merge.rc:5144
+#: Merge.rc:5143
 msgid "Shows an asterisk (*) if the file is binary."
 msgstr "Pokazuje gwiazdkę (*) jeśli plik jest binarny."
 
 #. IDS_COLDESC_UNPACKER
-#: Merge.rc:5145
+#: Merge.rc:5144
 msgid "Unpacker plugin name or pipeline."
 msgstr "Nazwa wtyczki rozpakowującej lub pipeline."
 
 #. IDS_COLDESC_PREDIFFER
-#: Merge.rc:5146
+#: Merge.rc:5145
 msgid "Prediffer plugin name or pipeline."
 msgstr "Nazwa wtyczki porównywającej lub pipeline."
 
 #. IDS_DIRECTORY_REPORT_TITLE
-#: Merge.rc:5152
+#: Merge.rc:5151
 #, c-format
 msgid "Compare %1 with %2"
 msgstr "Porównaj %1 z %2"
 
 #. IDS_DIRECTORY_REPORT_TITLE3
-#: Merge.rc:5153
+#: Merge.rc:5152
 #, c-format
 msgid "Compare %1 with %2 and %3"
 msgstr "Porównaj %1 z %2 i %3"
 
 #. IDS_REPORT_COMMALIST
-#: Merge.rc:5154
+#: Merge.rc:5153
 msgid "Comma-separated list"
 msgstr "Lista z przecinkami"
 
 #. IDS_REPORT_TABLIST
-#: Merge.rc:5155
+#: Merge.rc:5154
 msgid "Tab-separated list"
 msgstr "Lista z tabulatorami"
 
 #. IDS_REPORT_SIMPLEHTML
-#: Merge.rc:5156
+#: Merge.rc:5155
 msgid "Simple HTML"
 msgstr "Prosty HTML"
 
 #. IDS_REPORT_SIMPLEXML
-#: Merge.rc:5157
+#: Merge.rc:5156
 msgid "Simple XML"
 msgstr "Prosty XML"
 
-#: Merge.rc:5159
+#: Merge.rc:5158
 msgid "Report file already exists. Overwrite?"
 msgstr "Plik raportu już istnieje. Nadpisać?"
 
 #. IDS_REPORT_ERROR
-#: Merge.rc:5164
+#: Merge.rc:5163
 #, c-format
 msgid "Error creating the report:\n%1"
 msgstr "Błąd przy tworzeniu raportu:\n%1"
 
 #. IDS_REPORT_SUCCESS
-#: Merge.rc:5165
+#: Merge.rc:5164
 msgid "Report created successfully."
 msgstr "Raport został pomyślnie utworzony."
 
 #. IDS_SYNCPOINT_LASTBLOCK
-#: Merge.rc:5171
+#: Merge.rc:5170
 msgid "Cannot add a synchronization point at this line."
 msgstr "Nie można dodać punktu synchronizacji w tym wierszu."
 
 #. IDS_FILE_TO_ITSELF
-#: Merge.rc:5177
+#: Merge.rc:5176
 msgid "Same file is opened in both panes."
 msgstr "Ten sam plik został otwarty w obu panelach."
 
 #. IDS_FILESSAME
-#: Merge.rc:5178
+#: Merge.rc:5177
 msgid "Selected files are identical."
 msgstr "Wybrane pliki są identyczne."
 
 #. IDS_FILESSAME_CURCFG
-#: Merge.rc:5179
+#: Merge.rc:5178
 msgid "Selected files are identical (with current settings).\r\nChecking binary identity..."
 msgstr "Wybrane pliki są identyczne (przy aktualnych ustawieniach).\r\nSprawdzanie tożsamości binarnej..."
 
 #. IDS_FILESSAME_BINERROR
-#: Merge.rc:5180
+#: Merge.rc:5179
 msgid "Selected files are identical (with current settings).\r\nBut binary comparison failed."
 msgstr "Wybrane pliki są identyczne (przy aktualnych ustawieniach).\r\nAle porównanie binarne nie powiodło się."
 
 #. IDS_FILESSAME_BINSAME
-#: Merge.rc:5181
+#: Merge.rc:5180
 msgid "Selected files are identical (binary match)."
 msgstr "Wybrane pliki są identyczne (zgodność binarna)."
 
 #. IDS_FILESSAME_BINDIFF
-#: Merge.rc:5182
+#: Merge.rc:5181
 msgid "Selected files are identical (with current settings).\r\nBut differ at the binary level."
 msgstr "Wybrane pliki są identyczne (przy aktualnych ustawieniach).\r\nAle różnią się na poziomie binarnym."
 
 #. IDS_FILEERROR
-#: Merge.rc:5183
+#: Merge.rc:5182
 msgid "An error occurred while comparing files."
 msgstr "Wystąpił błąd podczas porównywania plików."
 
 #. IDS_TEMP_FILEERROR
-#: Merge.rc:5184
+#: Merge.rc:5183
 msgid "Could not create temporary files. Check your temporary path settings."
 msgstr "Nie można utworzyć plików tymczasowych. Sprawdź ustawienie ścieżki tymczasowej."
 
 #. IDS_SUGGEST_IGNOREEOL
-#: Merge.rc:5185
+#: Merge.rc:5184
 msgid "Files use different EOL.\n\nTreat all EOL as equivalent?\n\nSet 'Ignore EOL differences (Windows/Unix/Mac)' in Compare section of Options."
 msgstr "Pliki używają różnych znaków końca linii.\n\nCzy traktować wszystkie znaki końca linii jako równoważne?\n\nUstaw 'Ignoruj znaki końca linii (Windows/Unix/Mac)' w Edycja/Opcje/Porównaj."
 
 #. IDS_INVALID_DIRECTORY
-#: Merge.rc:5186
+#: Merge.rc:5185
 msgid "Selected folder is invalid."
 msgstr "Wybrany folder jest nieprawidłowy."
 
 #. IDS_CANNOT_OPEN_BINARYFILE
-#: Merge.rc:5187
+#: Merge.rc:5186
 msgid "Cannot open a binary file in Editor."
 msgstr "Nie można otworzyć w edytorze pliku binarnego."
 
 #. IDS_CREATE_PAIR_FOLDER
-#: Merge.rc:5188
+#: Merge.rc:5187
 #, c-format
 msgid "Create matching folder:\n%1\non the other side and open?"
 msgstr "Folder istnieje tylko na jednej ze stron i nie może zostać otwarty.\n\nCzy utworzyć pasujący folder:\n%1\npo drugiej stronie i otworzyć te foldery?"
 
 #. IDS_CONFIRM_COPY_ALL_DIFFS
-#: Merge.rc:5189
+#: Merge.rc:5188
 msgid "Copy all differences to other file?"
 msgstr "Skopiować wszystkie różnice do innego pliku?"
 
 #. IDS_MOVE_TO_NEXTFILE
-#: Merge.rc:5194
+#: Merge.rc:5193
 msgid "Move to next file?"
 msgstr "Przejść do następnego pliku?"
 
 #. IDS_MOVE_TO_PREVFILE
-#: Merge.rc:5195
+#: Merge.rc:5194
 msgid "Move to previous file?"
 msgstr "Przejść do poprzedniego pliku?"
 
 #. IDS_MOVE_TO_NEXTPAGE
-#: Merge.rc:5196
+#: Merge.rc:5195
 msgid "Move to next page?"
 msgstr "Przejść do następnej strony?"
 
 #. IDS_MOVE_TO_PREVPAGE
-#: Merge.rc:5197
+#: Merge.rc:5196
 msgid "Move to previous page?"
 msgstr "Przejść do poprzedniej strony?"
 
 #. IDS_MOVE_TO_FIRSTFILE
-#: Merge.rc:5198
+#: Merge.rc:5197
 msgid "Move to first file?"
 msgstr "Przejść do pierwszego pliku?"
 
 #. IDS_MOVE_TO_LASTFILE
-#: Merge.rc:5199
+#: Merge.rc:5198
 msgid "Move to last file?"
 msgstr "Przejść do ostatniego pliku?"
 
-#: Merge.rc:5206
+#: Merge.rc:5205
 #, c-format
 msgid "Different codepages: left (cp%d), right (cp%d).\nDisplay in codepage (better display) or default Windows codepage (safer merging)?\n(Recommended: default Windows codepage)"
 msgstr "Różne strony kodowe: lewa (cp%d), prawa (cp%d).\nWyświetlić w stronie kodowej (lepszy wynik) czy w domyślnej stronie kodowej Windows (bezpieczne scalanie)?\n(Zalecane: domyślna strona kodowa Windows)"
 
-#: Merge.rc:5208
+#: Merge.rc:5207
 msgid "Information lost due to encoding errors: both files"
 msgstr "Utracono informacje z powodu błędów kodowania: oba pliki"
 
-#: Merge.rc:5210
+#: Merge.rc:5209
 msgid "Information lost due to encoding errors: first file"
 msgstr "Utracono informacje z powodu błędów kodowania: pierwszy plik"
 
-#: Merge.rc:5212
+#: Merge.rc:5211
 msgid "Information lost due to encoding errors: second file"
 msgstr "Utracono informacje z powodu błędów kodowania: drugi plik"
 
-#: Merge.rc:5214
+#: Merge.rc:5213
 msgid "Information lost due to encoding errors: third file"
 msgstr "Utracono informacje z powodu błędów kodowania: trzeci plik"
 
 #. IDS_LINEDIFF_NODIFF
-#: Merge.rc:5220
+#: Merge.rc:5219
 msgid "No difference"
 msgstr "Brak różnic"
 
 #. IDS_LINEDIFF_NODIFF_CAPTION
-#: Merge.rc:5221
+#: Merge.rc:5220
 msgid "Line difference"
 msgstr "Różniące się wiersze"
 
 #. IDS_NUM_REPLACED
-#: Merge.rc:5227
+#: Merge.rc:5226
 #, c-format
 msgid "Replaced %1 string(s)."
 msgstr "Zastąpiono %1 sekwencję(i) znaków."
 
 #. IDS_EDIT_TEXT_NOT_FOUND
-#: Merge.rc:5228
+#: Merge.rc:5227
 #, c-format
 msgid "Cannot find string \"%s\"."
 msgstr "Nie znaleziono ciągu znaków \"%s\"."
 
 #. IDS_MERGE_MODE
-#: Merge.rc:5234
+#: Merge.rc:5233
 msgid "Entering Merge Mode. Press F9 to turn off."
 msgstr "Przechodzisz do trybu scalania. Naciśnij F9, aby go wyłączyć."
 
 #. IDS_AUTO_MERGE
-#: Merge.rc:5240
+#: Merge.rc:5239
 #, c-format
 msgid "Automatic merges: %1\nUnresolved conflicts: %2"
 msgstr "Liczba automatycznie scalonych zmian: %1\nLiczba nierozwiązanych konfliktów: %2"
 
 #. IDS_CODEPAGE_MERGED
-#: Merge.rc:5241
+#: Merge.rc:5240
 msgid "Codepage change merged."
 msgstr "Zmiana strony kodowej została scalona."
 
 #. IDS_CODEPAGE_CONFLICT
-#: Merge.rc:5242
+#: Merge.rc:5241
 msgid "Codepage changes are conflicting."
 msgstr "Zmiana strony kodowej powoduje konflikt."
 
 #. IDS_EOL_MERGED
-#: Merge.rc:5243
+#: Merge.rc:5242
 msgid "EOL change merged."
 msgstr "Zmiana znaku końca linii została scalona."
 
 #. IDS_EOL_CONFLICT
-#: Merge.rc:5244
+#: Merge.rc:5243
 msgid "EOL changes are conflicting."
 msgstr "Zmiany znaków końca linii powodują konflikt."
 
 #. IDS_LOCBAR_CAPTION
-#: Merge.rc:5250
+#: Merge.rc:5249
 msgid "Location Pane"
 msgstr "Panel lokalizacji"
 
 #. IDS_DIFFBAR_CAPTION
-#: Merge.rc:5251
+#: Merge.rc:5250
 msgid "Diff Pane"
 msgstr "Panel różnic"
 
 #. IDS_DIFF_SUCCEEDED
-#: Merge.rc:5258
+#: Merge.rc:5257
 msgid "Patch file written."
 msgstr "Łatka została utworzona."
 
 #. IDS_DIFF_FILEOVERWRITE
-#: Merge.rc:5259
+#: Merge.rc:5258
 msgid "Patch file already exists. Overwrite?"
 msgstr "Plik łatki już istnieje. Nadpisać?"
 
 #. IDS_DIFF_SELECTEDFILES
-#: Merge.rc:5260
+#: Merge.rc:5259
 #, c-format
 msgid "[%1 files selected]"
 msgstr "[Wybrano %1 plik(ów)]"
 
 #. IDS_DIFF_NORMAL
-#: Merge.rc:5261
+#: Merge.rc:5260
 msgid "Normal"
 msgstr "Normalny"
 
 #. IDS_DIFF_CONTEXT
-#: Merge.rc:5262
+#: Merge.rc:5261
 msgid "Context"
 msgstr "Kontekst"
 
 #. IDS_DIFF_UNIFIED
-#: Merge.rc:5263
+#: Merge.rc:5262
 msgid "Unified"
 msgstr "Ujednolicony"
 
 #. IDS_FILEWRITE_ERROR
-#: Merge.rc:5265
+#: Merge.rc:5264
 #, c-format
 msgid "Could not write to file %1."
 msgstr "Nie można zapisać do pliku %1."
 
 #. IDS_PATH_NOT_ABSOLUTE
-#: Merge.rc:5266
+#: Merge.rc:5265
 #, c-format
 msgid "Output path is not absolute: %1"
 msgstr "Wybrana ścieżka docelowa nie jest absolutna: %1"
 
 #. IDS_MUST_SPECIFY_OUTPUT
-#: Merge.rc:5267
+#: Merge.rc:5266
 msgid "Specify an output file."
 msgstr "Określ plik wyjściowy."
 
-#: Merge.rc:5269
+#: Merge.rc:5268
 msgid "Cannot create patch from binary files."
 msgstr "Nie można utworzyć łatki z plików binarnych."
 
 #. IDS_SAVEFILES_FORPATCH
-#: Merge.rc:5270
+#: Merge.rc:5269
 msgid "Save all files first.\n\nCreating a patch requires no unsaved changes."
 msgstr "Najpierw zapisz wszystkie pliki.\n\nAby utworzyć łatkę, wymagane jest, aby w plikach nie było żadnych niezapisanych zmian."
 
 #. IDS_FOLDER_NOTEXIST
-#: Merge.rc:5271
+#: Merge.rc:5270
 msgid "Folder does not exist."
 msgstr "Folder nie istnieje."
 
 #. IDS_ARCHIVE_SUCCEEDED
-#: Merge.rc:5277
+#: Merge.rc:5276
 msgid "Archive file written."
 msgstr "Zapisano plik archiwum."
 
 #. IDS_ARCHIVE_SAVEFILES
-#: Merge.rc:5278
+#: Merge.rc:5277
 msgid "Save all files first.\n\nCreating an archive requires no unsaved changes."
 msgstr "Najpierw zapisz wszystkie pliki.\n\nAby utworzyć archiwum, wszystkie zmiany muszą być zapisane."
 
 #. IDS_NO_ZIP_SUPPORT
-#: Merge.rc:5283
+#: Merge.rc:5282
 msgid "Archive support not enabled.\n7-Zip and/or Merge7z*.dll not found.\nSee manual for archive support."
 msgstr "Obsługa archiwów nie została włączona.\nNie znaleziono wszystkich potrzebnych komponentów (7-Zip i/lub Merge7z*.dll) do obsługi archiwów.\nWięcej informacji na temat obsługi archiwów i sposobu jej włączania znajdziesz w podręczniku."
 
 #. IDS_OPT_EXPORT_CAPTION
-#: Merge.rc:5284
+#: Merge.rc:5283
 msgid "Select file for export"
 msgstr "Wybierz plik do eksportu"
 
 #. IDS_OPT_IMPORT_CAPTION
-#: Merge.rc:5285
+#: Merge.rc:5284
 msgid "Select file for import"
 msgstr "Wybierz plik do importu"
 
 #. IDS_OPT_IMPORT_DONE
-#: Merge.rc:5286
+#: Merge.rc:5285
 msgid "Options imported from file."
 msgstr "Zaimportowano opcje z pliku."
 
 #. IDS_OPT_EXPORT_DONE
-#: Merge.rc:5287
+#: Merge.rc:5286
 msgid "Options exported to file."
 msgstr "Wyeksportowano opcje do pliku."
 
 #. IDS_OPT_IMPORT_ERR
-#: Merge.rc:5288
+#: Merge.rc:5287
 msgid "Failed to import options from file."
 msgstr "Błąd podczas importu opcji z pliku."
 
 #. IDS_OPT_EXPORT_ERR
-#: Merge.rc:5289
+#: Merge.rc:5288
 msgid "Failed to write options to file."
 msgstr "Błąd podczas eksportu opcji do pliku."
 
 #. IDS_CLOSEALL_WINDOWS
-#: Merge.rc:5290
+#: Merge.rc:5289
 msgid "Close multiple compare windows?\n\nContinue?"
 msgstr "Zamierzasz zamknąć wiele okien porównywania.\n\nKontynuować?"
 
 #. IDS_EOL_BIN
-#: Merge.rc:5300
+#: Merge.rc:5299
 msgctxt "EOL Type"
 msgid "Binary"
 msgstr "Binarny"
 
 #. IDS_MARKER_COLOR_FMT
-#: Merge.rc:5305
+#: Merge.rc:5304
 #, c-format
 msgid "Marker Color %d"
 msgstr "Kolor markera %d"
 
 #. IDS_MARKER_NEW_PATTERN
-#: Merge.rc:5306
+#: Merge.rc:5305
 msgid "New Pattern"
 msgstr "Nowy szablon"
 
 #. IDS_PLUGINSLIST_TYPE
-#: Merge.rc:5312
+#: Merge.rc:5311
 msgid "Type"
 msgstr "Typ"
 
 #. IDS_PLUGINS_TYPE_EDITSCRIPT
-#: Merge.rc:5316
+#: Merge.rc:5315
 msgid "Editor script"
 msgstr "Edytor skryptu"
 
 #. ID_SELECTLINEDIFF
-#: Merge.rc:5322
+#: Merge.rc:5321
 msgid "\nDifference in Current Line (F4)"
 msgstr "\nRóżnica w bieżącym wierszu (F4)"
 
 #. ID_OPTIONS
-#: Merge.rc:5323
+#: Merge.rc:5322
 msgid "\nOptions"
 msgstr "\nOpcje"
 
 #. ID_REFRESH
-#: Merge.rc:5324
+#: Merge.rc:5323
 msgid "\nRefresh (F5)"
 msgstr "\nOdśwież (F5)"
 
 #. ID_PREVDIFF
-#: Merge.rc:5330
+#: Merge.rc:5329
 msgid "\nPrevious Difference (Alt+Up)"
 msgstr "\nPoprzednia różnica (Alt+Up)"
 
 #. ID_NEXTDIFF
-#: Merge.rc:5331
+#: Merge.rc:5330
 msgid "\nNext Difference (Alt+Down)"
 msgstr "\nNastępna różnica (Alt+Down)"
 
 #. ID_PREVCONFLICT
-#: Merge.rc:5332
+#: Merge.rc:5331
 msgid "\nPrevious Conflict (Alt+Shift+Up)"
 msgstr "\nPoprzedni konflikt (Alt+Shift+Up)"
 
 #. ID_NEXTCONFLICT
-#: Merge.rc:5333
+#: Merge.rc:5332
 msgid "\nNext Conflict (Alt+Shift+Down)"
 msgstr "\nNastępny konflikt (Alt+Shift+Down)"
 
 #. ID_FIRSTDIFF
-#: Merge.rc:5338
+#: Merge.rc:5337
 msgid "\nFirst Difference (Alt+Home)"
 msgstr "\nPierwsza różnica (Alt+Home)"
 
 #. ID_CURDIFF
-#: Merge.rc:5339
+#: Merge.rc:5338
 msgid "\nCurrent Difference (Alt+Enter)"
 msgstr "\nBieżąca różnica (Alt+Enter)"
 
 #. ID_LASTDIFF
-#: Merge.rc:5340
+#: Merge.rc:5339
 msgid "\nLast Difference (Alt+End)"
 msgstr "\nOstatnia różnica (Alt+End)"
 
 #. ID_L2R
-#: Merge.rc:5341
+#: Merge.rc:5340
 msgid "\nCopy to Right (Alt+Right)"
 msgstr "\nKopiuj do prawej (Alt+Right)"
 
 #. ID_R2L
-#: Merge.rc:5342
+#: Merge.rc:5341
 msgid "\nCopy to Left (Alt+Left)"
 msgstr "\nKopiuj do lewej (Alt+Left)"
 
 #. ID_L2RNEXT
-#: Merge.rc:5343
+#: Merge.rc:5342
 msgid "\nCopy to Right and Advance (Ctrl+Alt+Right)"
 msgstr "\nKopiuj do prawej i przejdź dalej (Ctrl+Alt+Right)"
 
 #. ID_R2LNEXT
-#: Merge.rc:5344
+#: Merge.rc:5343
 msgid "\nCopy to Left and Advance (Ctrl+Alt+Left)"
 msgstr "\nKopiuj do lewej i przejdź dalej (Ctrl+Alt+Left)"
 
 #. ID_ALL_RIGHT
-#: Merge.rc:5345
+#: Merge.rc:5344
 msgid "\nCopy All to Right"
 msgstr "\nKopiuj wszystko do prawej"
 
 #. ID_ALL_LEFT
-#: Merge.rc:5346
+#: Merge.rc:5345
 msgid "\nCopy All to Left"
 msgstr "\nKopiuj wszystko do lewej"
 
 #. ID_AUTO_MERGE
-#: Merge.rc:5347
+#: Merge.rc:5346
 msgid "\nAuto Merge (Ctrl+Alt+M)"
 msgstr "\nAutomatyczne scalanie (Ctrl+Alt+M)"
 
 #. ID_FIRSTFILE
-#: Merge.rc:5348
+#: Merge.rc:5347
 msgid "\nFirst File"
 msgstr "\nPierwszy plik"
 
 #. ID_NEXTFILE
-#: Merge.rc:5349
+#: Merge.rc:5348
 msgid "\nNext File (Ctrl+F8)"
 msgstr "\nNastępny plik (Ctrl+F8)"
 
 #. ID_LASTFILE
-#: Merge.rc:5350
+#: Merge.rc:5349
 msgid "\nLast File"
 msgstr "\nOstatni plik"
 
 #. ID_PREVFILE
-#: Merge.rc:5351
+#: Merge.rc:5350
 msgid "\nPrevious File (Ctrl+F7)"
 msgstr "\nPoprzedni plik (Ctrl+F7)"
 
 #. IDS_UNPACK_AUTO
-#: Merge.rc:5358
+#: Merge.rc:5357
 msgid "Adapted unpacker applied to both files (one needs extension)."
 msgstr "Program rozpakowujący zostanie uruchomiony dla obu plików (tylko jeden plik wymaga rozszerzenia)."
 
 #. IDS_NO_PREDIFFER
-#: Merge.rc:5359
+#: Merge.rc:5358
 msgid "No Prediffer (Normal)"
 msgstr "Bez porównywania (normalne)"
 
 #. IDS_SUGGESTED_PLUGINS
-#: Merge.rc:5360
+#: Merge.rc:5359
 msgid "Suggested Plugins"
 msgstr "Sugerowane wtyczki"
 
 #. IDS_NOT_SUGGESTED_PLUGINS
-#: Merge.rc:5361
+#: Merge.rc:5360
 msgid "All Plugins"
 msgstr "Wszystkie wtyczki"
 
 #. IDS_PRIVATEBUILD_FMT
-#: Merge.rc:5367
+#: Merge.rc:5366
 #, c-format
 msgid "Private Build: %1"
 msgstr "Kompilacja prywatna: %1"
 
 #. IDS_ALLRIGHTS_RESERVED
-#: Merge.rc:5368
+#: Merge.rc:5367
 msgid " - All rights reserved."
 msgstr " - wszelkie prawa zastrzeżone."
 
 #. IDS_TITLE_PLUGINS_SETTINGS
-#: Merge.rc:5374
+#: Merge.rc:5373
 msgid "Plugin Settings"
 msgstr "Ustawienia wtyczki"
 
 #. IDS_NO_SCT_SCRIPTS
-#: Merge.rc:5376
+#: Merge.rc:5375
 msgid "WSH not found - .sct scripts disabled"
 msgstr "Nie znaleziono WSH – skrypty .sct wyłączone"
 
 #. IDS_LOCBAR_GOTOLINE_FMT
-#: Merge.rc:5384
+#: Merge.rc:5383
 #, c-format
 msgid "G&o to Line %1"
 msgstr "Idź do wiersza %1"
 
 #. IDS_GOTO_MOVED_LINE
-#: Merge.rc:5390
+#: Merge.rc:5389
 msgid "Go to Moved Line\tCtrl+Shift+G"
 msgstr "Idź do przeniesionego wiersza\tCtrl+Shift+G"
 
 #. IDS_AUTOCOMPLETE_DISABLED
-#: Merge.rc:5396
+#: Merge.rc:5395
 msgctxt "Options dialog|General|Open dialog Auto completion"
 msgid "Disabled"
 msgstr "Wyłączony"
 
 #. IDS_AUTOCOMPLETE_FILE_SYS
-#: Merge.rc:5397
+#: Merge.rc:5396
 msgid "From file system"
 msgstr "Z systemu plików"
 
 #. IDS_AUTOCOMPLETE_MRU
-#: Merge.rc:5398
+#: Merge.rc:5397
 msgid "From Most Recently Used list"
 msgstr "Z listy ostatnio używanych"
 
 #. IDS_COLORSCHEME_PLAIN
-#: Merge.rc:5404
+#: Merge.rc:5403
 msgid "No Highlighting"
 msgstr "Bez podświetlenia"
 
 #. IDS_COLORSCHEME_PO
-#: Merge.rc:5439
+#: Merge.rc:5438
 msgid "Portable Object"
 msgstr "Obiekt przenośny"
 
 #. IDS_COLORSCHEME_RSRC
-#: Merge.rc:5444
+#: Merge.rc:5443
 msgid "Resources"
 msgstr "Zasoby"
 
 #. IDS_COLORSCHEME_SH
-#: Merge.rc:5448
+#: Merge.rc:5447
 msgid "Shell"
 msgstr "Powłoka"
 
 #. IDS_CLOSE_LEFT_TABS
-#: Merge.rc:5469
+#: Merge.rc:5468
 msgid "Close &Left Tabs"
 msgstr "Zamknij karty po lewej"
 
 #. IDS_CLOSE_RIGHT_TABS
-#: Merge.rc:5470
+#: Merge.rc:5469
 msgid "Close R&ight Tabs"
 msgstr "Zamknij karty po prawej"
 
 #. IDS_CLOSE_OTHER_TABS
-#: Merge.rc:5471
+#: Merge.rc:5470
 msgid "Close &Other Tabs"
 msgstr "Zamknij inne karty"
 
 #. IDS_TABBAR_AUTO_MAXWIDTH
-#: Merge.rc:5472
+#: Merge.rc:5471
 msgid "Enable &Auto Max Width"
 msgstr "Włącz automatyczną szerokość kart"
 
 #. IDS_WEBPAGE_MENU
-#: Merge.rc:5482
+#: Merge.rc:5481
 msgid "We&bpage"
 msgstr "Strona internetowa"
 
 #. IDS_VIEW_WRAP_TEXT
-#: Merge.rc:5487
+#: Merge.rc:5486
 msgid "W&rap Text"
 msgstr "Zawijaj tekst"
 
 #. IDS_NOTINSTALLED
-#: Merge.rc:5492
+#: Merge.rc:5491
 msgid "%1 is not installed."
 msgstr "%1 nie został zainstalowany."
 
 #. IDS_CREATE_FOLDER
-#: Merge.rc:5497
+#: Merge.rc:5496
 #, c-format
 msgid "%1 does not exist. Create it?"
 msgstr "%1 nie istnieje. Utworzyć go?"
 
 #. IDS_CREATE_FOLDER_ERROR
-#: Merge.rc:5498
+#: Merge.rc:5497
 msgid "Failed to create folder."
 msgstr "Nie udało się utworzyć folderu."
 
 #. IDC_EXT_EDITOR_PATH
-#: Merge.rc:5503
+#: Merge.rc:5502
 msgid "Parameters:\n$file: Current file path\n$linenum: Current cursor line number"
 msgstr "Możesz podać następujące parametry ścieżki:\n$file: Nazwa ścieżki do bieżącego pliku\n$linenum: Numer wiersza dla aktualnej pozycji kursora"
 
 #. IDS_DIFF_ALGORITHM_DEFAULT
-#: Merge.rc:5508
+#: Merge.rc:5507
 msgid "default"
 msgstr "Domyślny"
 
 #. IDS_DIFF_ALGORITHM_MINIMAL
-#: Merge.rc:5509
+#: Merge.rc:5508
 msgid "minimal"
 msgstr "Minimalny"
 
 #. IDS_DIFF_ALGORITHM_PATIENCE
-#: Merge.rc:5510
+#: Merge.rc:5509
 msgid "patience"
 msgstr "Cierpliwy"
 
 #. IDS_DIFF_ALGORITHM_HISTOGRAM
-#: Merge.rc:5511
+#: Merge.rc:5510
 msgid "histogram"
 msgstr "Histogram"
 
 #. IDS_DIFF_ALGORITHM_NONE
-#: Merge.rc:5512
+#: Merge.rc:5511
 msgid "none"
 msgstr "Brak"
 
 #. IDS_RENDERING_MODE_GDI
-#: Merge.rc:5517
+#: Merge.rc:5516
 msgid "GDI"
 msgstr "GDI"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_DEFAULT
-#: Merge.rc:5518
+#: Merge.rc:5517
 msgid "DirectWrite Default"
 msgstr "DirectWrite Domyślny"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_ALIASED
-#: Merge.rc:5519
+#: Merge.rc:5518
 msgid "DirectWrite Aliased"
 msgstr "DirectWrite Aliased"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_GDI_CLASSIC
-#: Merge.rc:5520
+#: Merge.rc:5519
 msgid "DirectWrite GDI Classic"
 msgstr "DirectWrite GDI Klasyczny"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_GDI_NATURAL
-#: Merge.rc:5521
+#: Merge.rc:5520
 msgid "DirectWrite GDI Natural"
 msgstr "DirectWrite GDI Naturalny"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_NATURAL
-#: Merge.rc:5522
+#: Merge.rc:5521
 msgid "DirectWrite Natural"
 msgstr "DirectWrite Naturalny"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_NATURAL_SYMMETRIC
-#: Merge.rc:5523
+#: Merge.rc:5522
 msgid "DirectWrite Natural Symmetric"
 msgstr "DirectWrite Naturalny Symetryczny"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_DISABLED
-#: Merge.rc:5528
+#: Merge.rc:5527
 msgctxt "Options dialog|General|Close windows with Esc"
 msgid "Disabled"
 msgstr "Wyłączony"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_1
-#: Merge.rc:5529
+#: Merge.rc:5528
 msgid "MDI child window or main window"
 msgstr "Okno podrzędne lub okno główne"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_2
-#: Merge.rc:5530
+#: Merge.rc:5529
 msgid "MDI child window only"
 msgstr "Tylko okno podrzędne"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_3
-#: Merge.rc:5531
+#: Merge.rc:5530
 msgid "Close main window if only one MDI child window"
 msgstr "Zamknij okno główne, jeśli istnieje tylko jedno okno podrzędne"
 
 #. IDS_DIFF_GROUP
-#: Merge.rc:5536
+#: Merge.rc:5535
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Diff"
 msgstr "Różnica"
 
 #. IDS_DIFF_HIGHLIGHT
-#: Merge.rc:5537
+#: Merge.rc:5536
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Highlight"
 msgstr "Podświetl"
 
 #. IDS_DIFF_BLINK
-#: Merge.rc:5538
+#: Merge.rc:5537
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Blink"
 msgstr "Mrugaj"
 
 #. IDS_DIFF_BLOCKSIZE
-#: Merge.rc:5539
+#: Merge.rc:5538
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Block Size"
 msgstr "Rozmiar bloku"
 
 #. IDS_DIFF_BLOCKALPHA
-#: Merge.rc:5540
+#: Merge.rc:5539
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Block Alpha"
 msgstr "Przezroczystość bloku"
 
 #. IDS_DIFF_CDTHRESHOLD
-#: Merge.rc:5541
+#: Merge.rc:5540
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "CD Threshold"
 msgstr "Próg CD"
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION
-#: Merge.rc:5542
+#: Merge.rc:5541
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Ins/Del Detection"
 msgstr "Wykrywanie Ins/Del"
 
 #. IDS_OVERLAY_MODE_NONE
-#: Merge.rc:5543 Merge.rc:5548
+#: Merge.rc:5542 Merge.rc:5547
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "None"
 msgstr "Brak"
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION_VERTICAL
-#: Merge.rc:5544
+#: Merge.rc:5543
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Vertical"
 msgstr "Pionowe"
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION_HORIZONTAL
-#: Merge.rc:5545
+#: Merge.rc:5544
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Horizontal"
 msgstr "Poziome"
 
 #. IDS_OVERLAY_GROUP
-#: Merge.rc:5546
+#: Merge.rc:5545
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Overlay"
 msgstr "Nakładka"
 
 #. IDS_OVERLAY_ALPHA
-#: Merge.rc:5547
+#: Merge.rc:5546
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha"
 msgstr "Przezroczystość"
 
 #. IDS_OVERLAY_MODE_XOR
-#: Merge.rc:5549
+#: Merge.rc:5548
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "XOR"
 msgstr "XOR"
 
 #. IDS_OVERLAY_MODE_ALPHA
-#: Merge.rc:5550
+#: Merge.rc:5549
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha Blend"
 msgstr "Przenikanie"
 
 #. IDS_OVERLAY_MODE_ALPHA_ANIMATION
-#: Merge.rc:5551
+#: Merge.rc:5550
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha Animation"
 msgstr "Animacja"
 
 #. IDS_ZOOM
-#: Merge.rc:5552
+#: Merge.rc:5551
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Zoom"
 msgstr "Powiększenie"
 
 #. IDS_PAGE
-#: Merge.rc:5553
+#: Merge.rc:5552
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Page:"
 msgstr "Strona:"
 
 #. IDS_IMGCMP_STATUS_PT_RGBA_FMT
-#: Merge.rc:5554
+#: Merge.rc:5553
 #, c-format
 msgid "Pt: (%d, %d)  RGBA: (%d, %d, %d, %d)  "
 msgstr "Poz: (%d, %d)  RGBA: (%d, %d, %d, %d)  "
 
 #. IDS_IMGCMP_STATUS_DIST1_FMT
-#: Merge.rc:5555
+#: Merge.rc:5554
 #, c-format
 msgid "Dist: %g  "
 msgstr "Odległość: %g  "
 
 #. IDS_IMGCMP_STATUS_DIST2_FMT
-#: Merge.rc:5556
+#: Merge.rc:5555
 #, c-format
 msgid "Dist: %g, %g  "
 msgstr "Odległość: %g, %g  "
 
 #. IDS_IMGCMP_STATUS_PAGE_ZOOM_SIZE_BPP_FMT
-#: Merge.rc:5557
+#: Merge.rc:5556
 #, c-format
 msgid "Page: %d/%d  Zoom: %d%%  %dx%dpx  %dbpp  "
 msgstr "Strona: %d/%d  Powiększenie: %d%%  %dx%dpx  %dbpp  "
 
 #. IDS_IMGCMP_STATUS_RC_FMT
-#: Merge.rc:5558
+#: Merge.rc:5557
 #, c-format
 msgid "Rc: (%d, %d)  "
 msgstr "Rozm. zazn.: (%d, %d)  "
 
 #. IDS_IMGCMP_STATUS_FLIPPED_FMT
-#: Merge.rc:5559
+#: Merge.rc:5558
 #, c-format
 msgid "Flipped: %s  "
 msgstr "Odbicie: %s  "
 
 #. IDS_IMGCMP_STATUS_ROTATED_FMT
-#: Merge.rc:5560
+#: Merge.rc:5559
 #, c-format
 msgid "Rotated: %d  "
 msgstr "Obrót: %d  "
 
 #. IDS_IMGCMP_REPORT_ALLPAGES
-#: Merge.rc:5561
+#: Merge.rc:5560
 msgid "All pages"
 msgstr "Wszystkie strony"
 
 #. IDS_IGNSUB_STR1
-#: Merge.rc:5566
+#: Merge.rc:5565
 msgid "<Edit here>"
 msgstr "<Edytuj tutaj>"
 
 #. IDS_IGNSUB_STR2
-#: Merge.rc:5567
+#: Merge.rc:5566
 msgid "No differences found to select"
 msgstr "Nie znaleziono różnic, które można by zaznaczyć"
 
 #. IDS_IGNSUB_STR3
-#: Merge.rc:5568
+#: Merge.rc:5567
 msgid "No differences found to add as substitution filter"
 msgstr "Nie znaleziono różnic, które można by dodać jako filtr zamiany"
 
 #. IDS_IGNSUB_STR4
-#: Merge.rc:5569
+#: Merge.rc:5568
 msgid "The pair is already in the Substitution Filters list"
 msgstr "Ta para jest już obecna na liście filtrów zamiany"
 
 #. IDS_IGNSUB_STR5
-#: Merge.rc:5570
+#: Merge.rc:5569
 msgid "Add this change to Substitution Filters?"
 msgstr "Dodać tę zmianę do filtrów zamiany?"
 
 #. IDS_OCRRESULT_TEXTONLY
-#: Merge.rc:5575
+#: Merge.rc:5574
 msgid "Text only"
 msgstr "Tylko tekst"
 
 #. IDS_OCRRESULT_POS_LINE
-#: Merge.rc:5576
+#: Merge.rc:5575
 msgid "Line-by-line position and text"
 msgstr "Pozycja i tekst wiersz-po-wierszu"
 
 #. IDS_OCRRESULT_POS_WORD
-#: Merge.rc:5577
+#: Merge.rc:5576
 msgid "Word-by-word position and text"
 msgstr "Pozycja i tekst słowo-po-słowie"
 
 #. IDS_USERDATAFOLDER_APPDATA
-#: Merge.rc:5582
+#: Merge.rc:5581
 msgid "AppData (Roaming) folder"
 msgstr "Folder AppData (Roaming)"
 
 #. IDS_USERDATAFOLDER_INSTALL
-#: Merge.rc:5583
+#: Merge.rc:5582
 msgid "Install folder"
 msgstr "Folder instalacji"
 
 #. IDS_USERDATAFOLDER_DOCUMENTS
-#: Merge.rc:5584
+#: Merge.rc:5583
 msgid "Documents folder"
 msgstr "Folder Dokumenty"
 
 #. IDS_SINGLEINSTANCE_DISABLED
-#: Merge.rc:5589
+#: Merge.rc:5588
 msgctxt "Options dialog|General|Single instance mode"
 msgid "Disabled"
 msgstr "Wyłączony"
 
 #. IDS_SINGLEINSTANCE_STR1
-#: Merge.rc:5590
+#: Merge.rc:5589
 msgid "Allow only one instance to run"
 msgstr "Zezwól na uruchomienie tylko jednej instancji programu"
 
 #. IDS_CLIPBOARD_HISTORY
-#: Merge.rc:5591
+#: Merge.rc:5590
 msgid "Clipboard &History"
 msgstr "Historia schowka"
 
 #. IDS_SINGLEINSTANCE_STR2
-#: Merge.rc:5592
+#: Merge.rc:5591
 msgid "Allow only one instance; wait for termination"
 msgstr "Zezwól na uruchomienie tylko jednej instancji i poczekaj, aż zakończy pracę"
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_DISABLED
-#: Merge.rc:5597
+#: Merge.rc:5596
 msgctxt "Options dialog|General|Auto-reload modified files"
 msgid "Disabled"
 msgstr "Wyłączony"
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_STR1
-#: Merge.rc:5598
+#: Merge.rc:5597
 msgid "Only on window activated"
 msgstr "Tylko w aktywnym oknie"
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_STR2
-#: Merge.rc:5599
+#: Merge.rc:5598
 msgid "Immediately"
 msgstr "Natychmiast"
 
 #. IDS_PLUGIN_ALL
-#: Merge.rc:5604
+#: Merge.rc:5603
 msgid "Al&l"
 msgstr "Wszystkie"
 
 #. IDS_PLUGIN_OTHERS
-#: Merge.rc:5605
+#: Merge.rc:5604
 msgid "&Others"
 msgstr "Pozostałe"
 
-#: Merge.rc:5607
+#: Merge.rc:5606
 #, c-format
 msgid "Missing plugin name in pipeline: %1"
 msgstr "Brakująca nazwa wtyczki we wtyczce pipeline: %1"
 
-#: Merge.rc:5609
+#: Merge.rc:5608
 #, c-format
 msgid "Missing quote in plugin pipeline: %1"
 msgstr "Brakujący cudzysłów we wtyczce pipeline: %1"
 
 #. IDS_PLUGIN_NAME_ALREADY_EXISTS
-#: Merge.rc:5610
+#: Merge.rc:5609
 #, c-format
 msgid "Plugin name '%1' already exists."
 msgstr "Wtyczka o nazwie '%1' już istnieje."
 
 #. IDS_PLUGIN_TITLE1
-#: Merge.rc:5611
+#: Merge.rc:5610
 msgid "Specify plugin arguments"
 msgstr "Określ argumenty wtyczki"
 
-#: Merge.rc:5613
+#: Merge.rc:5612
 #, c-format
 msgid "Plugin not found or invalid: %1"
 msgstr "Nie znaleziono wtyczki lub jest ona nieprawidłowa: %1"
 
 #. IDS_PLUGIN_NOT_UNPACK
-#: Merge.rc:5614
+#: Merge.rc:5613
 #, c-format
 msgid "'%1' is not an unpacker plugin"
 msgstr "'%1' nie jest wtyczką rozpakowującą"
 
 #. IDS_PLUGIN_NOT_PREDIFF
-#: Merge.rc:5615
+#: Merge.rc:5614
 #, c-format
 msgid "'%1' is not a prediffer plugin"
 msgstr "'%1' nie jest wtyczką porównującą"
 
-#: Merge.rc:5617
+#: Merge.rc:5616
 #, c-format
 msgid "Error prediffing '%1' with '%2'. Prediffing disabled."
 msgstr "Błąd porównywania '%1' z '%2'. Porównywanie wyłączone."
 
 #. IDS_PLUGIN_CIRCULAR_REFERENCE
-#: Merge.rc:5618
+#: Merge.rc:5617
 #, c-format
 msgid "Circular reference in plugin pipeline: %1"
 msgstr "Odwołanie cykliczne we wtyczce pipeline: %1"
 
 #. IDS_PLUGIN_TYPE1
-#: Merge.rc:5619
+#: Merge.rc:5618
 msgid "URL Handler"
 msgstr "Obsługa adresu URL"
 
 #. IDS_PLUGIN_TYPE2
-#: Merge.rc:5620
+#: Merge.rc:5619
 msgid "File Unpacker"
 msgstr "Program do rozpakowywania plików"
 
 #. IDS_PLUGIN_TYPE3
-#: Merge.rc:5621
+#: Merge.rc:5620
 msgid "File or Folder Unpacker"
 msgstr "Program do rozpakowywania plików lub folderów"
 
 #. IDS_PLUGIN_TYPE5
-#: Merge.rc:5623
+#: Merge.rc:5622
 msgid "Alias for Unpacker"
 msgstr "Alias dla programu rozpakowującego"
 
 #. IDS_PLUGIN_TYPE6
-#: Merge.rc:5624
+#: Merge.rc:5623
 msgid "Alias for Prediffer"
 msgstr "Alias dla porównywania"
 
 #. IDS_PLUGIN_TYPE7
-#: Merge.rc:5625
+#: Merge.rc:5624
 msgid "Alias for Editor script"
 msgstr "Alias dla edytora skryptu"
 
 #. IDS_PLUGIN_ALIAS_DESC
-#: Merge.rc:5626
+#: Merge.rc:5625
 #, c-format
 msgid "Alias for plugin pipeline '%1'"
 msgstr "Alias dla wtyczki pipeline '%1'"
 
 #. IDS_PLUGIN_NEW_DESC
-#: Merge.rc:5627
+#: Merge.rc:5626
 msgid "New plugin description"
 msgstr "Opis nowej wtyczki"
 
 #. IDS_PLUGIN_TARGETS_ALL
-#: Merge.rc:5628
+#: Merge.rc:5627
 msgid "All"
 msgstr "Wszystko"
 
 #. IDS_PLUGIN_TARGETS_1ST
-#: Merge.rc:5629
+#: Merge.rc:5628
 msgid "1st"
 msgstr "1"
 
 #. IDS_PLUGIN_TARGETS_2ND
-#: Merge.rc:5630
+#: Merge.rc:5629
 msgid "2nd"
 msgstr "2"
 
 #. IDS_PLUGIN_TARGETS_3RD
-#: Merge.rc:5631
+#: Merge.rc:5630
 msgid "3rd"
 msgstr "3"
 
 #. IDS_PLUGIN_TARGETS_1ST_2ND
-#: Merge.rc:5632
+#: Merge.rc:5631
 msgid "1st and 2nd"
 msgstr "1 i 2"
 
 #. IDS_PLUGIN_TARGETS_1ST_3RD
-#: Merge.rc:5633
+#: Merge.rc:5632
 msgid "1st and 3rd"
 msgstr "1 i 3"
 
 #. IDS_PLUGIN_TARGETS_2ND_3RD
-#: Merge.rc:5634
+#: Merge.rc:5633
 msgid "2nd and 3rd"
 msgstr "2 i 3"
 
 #. IDS_PLUGIN_CTRL_CLICK
-#: Merge.rc:5635
+#: Merge.rc:5634
 msgid "(Ctrl+Click to add to pipeline)"
 msgstr "(Ctrl+Klik, aby dodać do pipeline)"
 
 #. IDS_FILTER_APPLIED
-#: Merge.rc:5640
+#: Merge.rc:5639
 msgid "Filter applied"
 msgstr "Zastosowano filtr"
 
 #. IDS_FILTERMENU_COMPARE
-#: Merge.rc:5645
+#: Merge.rc:5644
 #, c-format
 msgid "Compare %1"
 msgstr "Porównaj %1"
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN2
-#: Merge.rc:5647
+#: Merge.rc:5646
 msgid "&Filter by This Column..."
 msgstr "Filtruj według tej kolumny..."
 
 #. IDS_CLIPBOARDHISTORY_TIME
-#: Merge.rc:5652
+#: Merge.rc:5651
 #, c-format
 msgid "Clipboard at %s"
 msgstr "Schowek w %s"
 
 #. IDS_CLIPBOARDHISTORY_DISABLED
-#: Merge.rc:5653
+#: Merge.rc:5652
 msgid "Clipboard history disabled.\r\nEnable: Windows logo key + V, then Turn on."
 msgstr "Historia schowka jest wyłączona.\r\nAby włączyć historię schowka, naciśnij klawisz logo Windows + V, a następnie kliknij przycisk Włącz."
 
-#: Merge.rc:5655
+#: Merge.rc:5654
 msgid "This system does not support clipboard history."
 msgstr "Ten system nie obsługuje historii schowka."
 
-#: Merge.rc:5657
+#: Merge.rc:5656
 msgid "32-bit WinMerge does not support Clipboard Compare"
 msgstr "32-bitowa wersja programu WinMerge nie obsługuje funkcji porównywania schowka"
 
 #. IDS_WEBVIEW2_RUNTIME_NOT_INSTALLED
-#: Merge.rc:5662
+#: Merge.rc:5661
 msgid "WebView2 runtime not installed. Download it?"
 msgstr "WebView2 Runtime nie został zainstalowany. Pobrać go?"
 
 #. IDS_JUMPLIST_NEW_TEXT_COMPARE
-#: Merge.rc:5667
+#: Merge.rc:5666
 msgid "New Text Compare"
 msgstr "Porównaj nowy tekst"
 
 #. IDS_JUMPLIST_NEW_TABLE_COMPARE
-#: Merge.rc:5668
+#: Merge.rc:5667
 msgid "New Table Compare"
 msgstr "Porównaj nową tabelę"
 
 #. IDS_JUMPLIST_NEW_BINARY_COMPARE
-#: Merge.rc:5669
+#: Merge.rc:5668
 msgid "New Binary Compare"
 msgstr "Porównaj nowe pliki binarne"
 
 #. IDS_JUMPLIST_NEW_IMAGE_COMPARE
-#: Merge.rc:5670
+#: Merge.rc:5669
 msgid "New Image Compare"
 msgstr "Porównaj nowy obraz"
 
 #. IDS_JUMPLIST_NEW_WEBPAGE_COMPARE
-#: Merge.rc:5671
+#: Merge.rc:5670
 msgid "New Webpage Compare"
 msgstr "Porównaj nową stronę internetową"
 
 #. IDS_JUMPLIST_NEW_FOLDER_COMPARE
-#: Merge.rc:5672
+#: Merge.rc:5671
 msgid "New Folder Compare"
 msgstr "Porównaj nowy folder"
 
 #. IDS_JUMPLIST_CLIPBOARD_COMPARE
-#: Merge.rc:5673
+#: Merge.rc:5672
 msgid "Clipboard Compare"
 msgstr "Porównaj schowek"
 
 #. IDS_PREVIEWBAR_PRINT
-#: Merge.rc:5678
+#: Merge.rc:5677
 msgid "&Print..."
 msgstr "Drukuj..."
 
 #. IDS_PREVIEWBAR_PREVPAGE
-#: Merge.rc:5680
+#: Merge.rc:5679
 msgid "Pre&v Page"
 msgstr "Poprzednia strona"
 
 #. IDS_PREVIEWBAR_TWOPAGE
-#: Merge.rc:5681
+#: Merge.rc:5680
 msgid "&Two Page"
 msgstr "Dwie strony"
 
 #. IDS_PREVIEWBAR_ONEPAGE
-#: Merge.rc:5682
+#: Merge.rc:5681
 msgid "&One Page"
 msgstr "Jedna strona"
 
 #. IDS_PREVIEWBAR_ZOOMIN
-#: Merge.rc:5683
+#: Merge.rc:5682
 msgid "Zoom &In"
 msgstr "Powiększ"
 
 #. IDS_PREVIEWBAR_ZOOMOUT
-#: Merge.rc:5684
+#: Merge.rc:5683
 msgid "Zoom &Out"
 msgstr "Pomniejsz"
 
 #. IDS_WEBPAGE_COMPARING
-#: Merge.rc:5690
+#: Merge.rc:5689
 msgid "Comparing..."
 msgstr "Porównywanie..."
 
 #. IDS_WEBPAGE_ZOOM
-#: Merge.rc:5691
+#: Merge.rc:5690
 msgid "Zoom:"
 msgstr "Powiększenie:"
 
 #. IDS_COPY_GRANULARITY_DIFFHUNK
-#: Merge.rc:5696
+#: Merge.rc:5695
 msgid "Diff hunk"
 msgstr "Fragment różnicy"
 
 #. IDS_COPY_GRANULARITY_INLINE
-#: Merge.rc:5697
+#: Merge.rc:5696
 msgid "Inline diff"
 msgstr "Różnica w linii"
 
 #. IDS_COPY_GRANULARITY_LINE
-#: Merge.rc:5698
+#: Merge.rc:5697
 msgid "Line"
 msgstr "Wiersz"
 
-#: Merge.rc:5699
+#: Merge.rc:5698
 msgid "Character"
 msgstr "Znak"
 
 #. ID_MICE_PREVDIFF
-#: Merge.rc:5704
+#: Merge.rc:5703
 msgid "\nPrevious Difference (Alt+Up)\n(Right Button+Wheel Up)\n(Alt+Wheel Up)"
 msgstr "\nPoprzednia różnica (Alt+Klawisz w górę)\n(Prawy przycisk+Kółko w górę)\n(Alt+Kółko w górę)"
 
 #. ID_MICE_NEXTDIFF
-#: Merge.rc:5705
+#: Merge.rc:5704
 msgid "\nNext Difference (Alt+Down)\n(Right Button+Wheel Down)\n(Alt+Wheel Down)"
 msgstr "\nNastępna różnica (Alt+Klawisz w dół)\n(Prawy przycisk+Kółko w dół)\n(Alt+Kółko w dół"
 
 #. ID_MICE_L2R
-#: Merge.rc:5706
+#: Merge.rc:5705
 msgid "\nCopy to Right (Alt+Right)\n(Right Button+Wheel Right)\n(Alt+Wheel Right)\n(Alt+Shift+Wheel Down)"
 msgstr "\nKopiuj do prawej (Alt+Prawo)\n(Prawy przycisk+Kółko w prawo)\n(Alt+Kółko w prawo)\n(Alt+Shift+Kółko w dół)"
 
 #. ID_MICE_R2L
-#: Merge.rc:5707
+#: Merge.rc:5706
 msgid "\nCopy to Left (Alt+Left)\n(Right Button+Wheel Left)\n(Alt+Wheel Left)\n(Alt+Shift+Wheel Up)"
 msgstr "\nKopiuj do lewej (Alt+Lewo)\n(Prawy przycisk+Kółko w lewo)\n(Alt+Kółko w lewo)\n(Alt+Shift+Kółko w górę)"
 
 #. ID_MICE_L2RNEXT
-#: Merge.rc:5708
+#: Merge.rc:5707
 msgid "\nCopy to Right and Advance (Ctrl+Alt+Right)\n(Ctrl+Alt+Wheel Right)\n(Ctrl+Alt+Shift+Wheel Down)"
 msgstr "\nKopiuj do prawej i przejdź dalej (Ctrl+Alt+Prawo)\n(Ctrl+Alt+Kółko w prawo)\n(Ctrl+Alt+Shift+Kółko w dół)"
 
 #. ID_MICE_R2LNEXT
-#: Merge.rc:5709
+#: Merge.rc:5708
 msgid "\nCopy to Left and Advance (Ctrl+Alt+Left)\n(Ctrl+Alt+Wheel Left)\n(Ctrl+Alt+Shift+Wheel Up)"
 msgstr "\nKopiuj do lewej i przejdź dalej (Ctrl+Alt+Lewo)\n(Ctrl+Alt+Kółko w lewo)\n(Ctrl+Alt+Shift+Kółko w górę)"
 
 #. IDS_LOG_COMPARING_2
-#: Merge.rc:5719
+#: Merge.rc:5718
 #, c-format
 msgid "Comparing %1 with %2"
 msgstr "Porównywanie %1 z %2"
 
 #. IDS_LOG_COMPARING_3
-#: Merge.rc:5720
+#: Merge.rc:5719
 #, c-format
 msgid "Comparing %1 with %2 and %3"
 msgstr "Porównywanie %1 z %2 i %3"
 
 #. IDS_LOG_COMPARE_COMPLETED
-#: Merge.rc:5721
+#: Merge.rc:5720
 msgid "Comparison completed"
 msgstr "Porównywanie zakończone"
 
 #. IDS_LOG_COMPARE_ERROR_2
-#: Merge.rc:5722
+#: Merge.rc:5721
 #, c-format
 msgid "Failed to compare %1 with %2: "
 msgstr "Nie udało się porównać %1 z %2: "
 
 #. IDS_LOG_COMPARE_ERROR_3
-#: Merge.rc:5723
+#: Merge.rc:5722
 #, c-format
 msgid "Failed to compare %1 with %2 and %3: "
 msgstr "Nie udało się porównać %1 z %2 i %3: "
 
 #. IDS_LOG_FILE_SAVED
-#: Merge.rc:5724
+#: Merge.rc:5723
 msgid "File saved"
 msgstr "Plik został zapisany"
 
 #. IDS_LOG_COPYING_FILES
-#: Merge.rc:5725
+#: Merge.rc:5724
 msgid "Copying files..."
 msgstr "Kopiowanie plików..."
 
 #. IDS_LOG_MOVING_FILES
-#: Merge.rc:5726
+#: Merge.rc:5725
 msgid "Moving files..."
 msgstr "Przenoszenie plików..."
 
 #. IDS_LOG_DELETING_FILES
-#: Merge.rc:5727
+#: Merge.rc:5726
 msgid "Deleting files..."
 msgstr "Usuwanie plików..."
 
 #. IDS_LOG_RECYCLEBIN
-#: Merge.rc:5728
+#: Merge.rc:5727
 msgid "Recycle Bin"
 msgstr "Kosz"
 
 #. IDS_LOG_PERMANENTLY_DELETED
-#: Merge.rc:5729
+#: Merge.rc:5728
 msgid "Permanently deleted"
 msgstr "Trwale usunięty"
 
 #. IDS_LOG_FILEOPERATION_COMPLETED
-#: Merge.rc:5730
+#: Merge.rc:5729
 msgid "File operation completed successfully"
 msgstr "Operacja na pliku zakończona pomyślnie"
 
 #. IDS_LOG_FILEOPERATION_CANCELED
-#: Merge.rc:5731
+#: Merge.rc:5730
 msgid "File operation canceled"
 msgstr "Operacja na pliku została anulowana"
 
 #. IDS_FILTER_ERROR_NO_ERROR
-#: Merge.rc:5736
+#: Merge.rc:5735
 msgid "No error"
 msgstr "Brak błędu"
 
 #. IDS_FILTER_ERROR_EMPTY_EXPRESSION
-#: Merge.rc:5737
+#: Merge.rc:5736
 msgid "Filter expression is empty"
 msgstr "Wyrażenie filtrujące jest puste"
 
 #. IDS_FILTER_ERROR_UNKNOWN_CHAR
-#: Merge.rc:5738
+#: Merge.rc:5737
 msgid "Unknown character in filter expression"
 msgstr "Nieznany znak w wyrażeniu filtrującym"
 
 #. IDS_FILTER_ERROR_UNTERMINATED_STRING
-#: Merge.rc:5739
+#: Merge.rc:5738
 msgid "Unterminated string literal"
 msgstr "Niezakończony literał łańcuchowy"
 
 #. IDS_FILTER_ERROR_SYNTAX_ERROR
-#: Merge.rc:5740
+#: Merge.rc:5739
 msgid "Syntax error in filter expression"
 msgstr "Błąd składni w wyrażeniu filtrującym"
 
 #. IDS_FILTER_ERROR_PARSE_FAILURE
-#: Merge.rc:5741
+#: Merge.rc:5740
 msgid "Failed to parse filter expression"
 msgstr "Nie udało się przeanalizować wyrażenia filtrującego"
 
 #. IDS_FILTER_ERROR_INVALID_LITERAL
-#: Merge.rc:5742
+#: Merge.rc:5741
 msgid "Invalid literal value"
 msgstr "Nieprawidłowa wartość literału"
 
 #. IDS_FILTER_ERROR_INVALID_REGULAR_EXPRESSION
-#: Merge.rc:5743
+#: Merge.rc:5742
 msgid "Invalid regular expression"
 msgstr "Nieprawidłowe wyrażenie regularne"
 
 #. IDS_FILTER_ERROR_UNDEFINED_IDENTIFIER
-#: Merge.rc:5744
+#: Merge.rc:5743
 msgid "Undefined identifier"
 msgstr "Nieokreślony identyfikator"
 
 #. IDS_FILTER_ERROR_INVALID_ARGUMENT_COUNT
-#: Merge.rc:5745
+#: Merge.rc:5744
 msgid "Invalid number of arguments"
 msgstr "Nieprawidłowa liczba argumentów"
 
 #. IDS_FILTER_ERROR_FILTER_NAME_NOT_FOUND
-#: Merge.rc:5746
+#: Merge.rc:5745
 msgid "Filter name not found"
 msgstr "Nie znaleziono nazwy filtra"
 
 #. IDS_FILTER_ERROR_DIVIDE_BY_ZERO
-#: Merge.rc:5747
+#: Merge.rc:5746
 msgid "Division by zero in filter expression"
 msgstr "Dzielenie przez zero w wyrażeniu filtrującym"
 
 #. IDS_FILTER_ERROR_UNKNOWN_ERROR
-#: Merge.rc:5748
+#: Merge.rc:5747
 msgid "Unknown error"
 msgstr "Nieznany błąd"
 
 #. IDS_FILTER_ERROR_INVALID_PROPERTY_NAME
-#: Merge.rc:5749
+#: Merge.rc:5748
 msgid "Invalid property name"
 msgstr "Nieprawidłowa nazwa właściwości"
 
 #. IDS_FILTER_ERROR_INVALID_DIRECTIVE
-#: Merge.rc:5750
+#: Merge.rc:5749
 msgid "Invalid directive"
 msgstr "Nieprawidłowa dyrektywa"
 
 #. IDS_FILTER_OP_EQUALS
-#: Merge.rc:5755
+#: Merge.rc:5754
 msgid "Equals"
 msgstr "Równe"
 
 #. IDS_FILTER_OP_NOT_EQUALS
-#: Merge.rc:5756
+#: Merge.rc:5755
 msgid "Does not equal"
 msgstr "Nierówne"
 
 #. IDS_FILTER_OP_LESS_THAN
-#: Merge.rc:5757
+#: Merge.rc:5756
 msgid "Less than"
 msgstr "Mniejsze niż"
 
 #. IDS_FILTER_OP_LESS_EQUAL
-#: Merge.rc:5758
+#: Merge.rc:5757
 msgid "Less than or equal to"
 msgstr "Mniejsze lub równe"
 
 #. IDS_FILTER_OP_GREATER_EQUAL
-#: Merge.rc:5759
+#: Merge.rc:5758
 msgid "Greater than or equal to"
 msgstr "Większe lub równe"
 
 #. IDS_FILTER_OP_GREATER_THAN
-#: Merge.rc:5760
+#: Merge.rc:5759
 msgid "Greater than"
 msgstr "Większe niż"
 
 #. IDS_FILTER_OP_BETWEEN
-#: Merge.rc:5761
+#: Merge.rc:5760
 msgid "Between"
 msgstr "Między"
 
 #. IDS_FILTER_OP_NOT_BETWEEN
-#: Merge.rc:5762
+#: Merge.rc:5761
 msgid "Not Between"
 msgstr "Nie między"
 
 #. IDS_FILTER_OP_CONTAINS
-#: Merge.rc:5763
+#: Merge.rc:5762
 msgid "Contains"
 msgstr "Zawiera"
 
 #. IDS_FILTER_OP_NOT_CONTAINS
-#: Merge.rc:5764
+#: Merge.rc:5763
 msgid "Not Contains"
 msgstr "Nie zawiera"
 
 #. IDS_FILTER_OP_RECONTAINS
-#: Merge.rc:5765
+#: Merge.rc:5764
 msgid "Contains (regex)"
 msgstr "Zawiera (wyrażenie regularne)"
 
 #. IDS_FILTER_OP_NOT_RECONTAINS
-#: Merge.rc:5766
+#: Merge.rc:5765
 msgid "Not Contains (regex)"
 msgstr "Nie zawiera (wyrażenie regularne)"
 
 #. IDS_FILTER_OP_LIKE
-#: Merge.rc:5767
+#: Merge.rc:5766
 msgid "Match (wildcard)"
 msgstr "Dopasuj (symbol wieloznaczny)"
 
 #. IDS_FILTER_OP_NOT_LIKE
-#: Merge.rc:5768
+#: Merge.rc:5767
 msgid "Not match (wildcard)"
 msgstr "Nie dopasuj (symbol wieloznaczny)"
 
 #. IDS_FILTER_OP_MATCHES
-#: Merge.rc:5769
+#: Merge.rc:5768
 msgid "Match (regex)"
 msgstr "Dopasuj (wyrażenie regularne)"
 
 #. IDS_FILTER_OP_NOT_MATCHES
-#: Merge.rc:5770
+#: Merge.rc:5769
 msgid "Not match (regex)"
 msgstr "Nie dopasuj (wyrażenie regularne)"
 
 #. IDS_COLORMODE_LIGHT
-#: Merge.rc:5775
+#: Merge.rc:5774
 msgid "Light"
 msgstr "Jasny"
 
 #. IDS_COLORMODE_DARK
-#: Merge.rc:5776
+#: Merge.rc:5775
 msgid "Dark"
 msgstr "Ciemny"
 
 #. IDS_COLORMODE_FOLLOWSYSTEM
-#: Merge.rc:5777
+#: Merge.rc:5776
 msgid "Follow system"
 msgstr "Systemowy"
 
 #. IDS_EXAMPLE
-#: Merge.rc:5782
+#: Merge.rc:5781
 #, c-format
 msgid "e.g. %1"
 msgstr "np. %1"
 
 #. IDS_DETECTED_PREVIOUS_CRASH
-#: Merge.rc:5787
+#: Merge.rc:5786
 msgid "WinMerge detected a previous crash. Please report this if possible."
 msgstr "WinMerge wykrył błąd krytyczny podczas ostatniej sesji. Prosimy o zgłoszenie tego faktu, jeśli to możliwe."
 
 #. IDS_REGEX_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5792
+#: Merge.rc:5791
 msgid "# Regex replacement list\r\n# Format: regex<TAB>replacement\r\n# Backreferences like $1, $2 are supported\r\n\r\n(\\d{4})-(\\d{2})-(\\d{2})\t$1_$2_$3\r\n"
 msgstr "# Lista zastąpionych wyrażeń regularnych\r\n# Format: wyrażenie regularne<TAB>zastąpienie\r\n# Obsługiwane są odwołania wsteczne, takie jak $1, $2\r\n\r\n(\\d{4})-(\\d{2})-(\\d{2})\t$1_$2_$3\r\n"
 
 #. IDS_STRING_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5793
+#: Merge.rc:5792
 msgid "# Replacement list\r\n# Format: search<TAB>replacement\r\n# Lines starting with # are ignored\r\n\r\nfrom1\tto1\r\nfrom2\tto2\r\n"
 msgstr "# Lista zastąpionych\r\n# Format: szukaj<TAB>zastąpienie\r\n# Linie zaczynające się od # są ignorowane\r\n\r\nfrom1\tto1\r\nfrom2\tto2\r\n"
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_ONLY
-#: Merge.rc:5798
+#: Merge.rc:5797
 msgid "Built-in only"
 msgstr "Tylko wbudowane"
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_FIRST
-#: Merge.rc:5799
+#: Merge.rc:5798
 msgid "Built-in first"
 msgstr "Najpierw wbudowane"
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_FIRST
-#: Merge.rc:5800
+#: Merge.rc:5799
 msgid "Tree-sitter first"
 msgstr "Najpierw Tree-sitter"
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_ONLY
-#: Merge.rc:5801
+#: Merge.rc:5800
 msgid "Tree-sitter only"
 msgstr "Tylko Tree-sitter"
 

--- a/Translations/WinMerge/Portuguese.po
+++ b/Translations/WinMerge/Portuguese.po
@@ -24,7 +24,7 @@ msgstr ""
 "X-Generator: Poedit 3.9\n"
 
 #. LANGUAGE, SUBLANGUAGE
-#: Merge.rc:26 Merge.rc:59 Merge.rc:5818
+#: Merge.rc:26 Merge.rc:59 Merge.rc:5817
 msgid "LANG_ENGLISH, SUBLANG_ENGLISH_US"
 msgstr "LANG_PORTUGUESE, SUBLANG_PORTUGUESE"
 
@@ -166,7 +166,7 @@ msgstr "Scripts"
 #. IDS_NO_EDIT_SCRIPTS
 #: Merge.rc:127 Merge.rc:352 Merge.rc:463 Merge.rc:673 Merge.rc:678
 #: Merge.rc:887 Merge.rc:899 Merge.rc:906 Merge.rc:963 Merge.rc:1210
-#: Merge.rc:5375
+#: Merge.rc:5374
 msgid "< Empty >"
 msgstr "< Vazio >"
 
@@ -231,7 +231,7 @@ msgid "Auto-Fit All Columns"
 msgstr "Ajustar automaticamente todas as colunas"
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN
-#: Merge.rc:153 Merge.rc:5646
+#: Merge.rc:153 Merge.rc:5645
 msgid "&Filter by This Column"
 msgstr "&Filtrar por esta coluna"
 
@@ -292,7 +292,7 @@ msgid "&Previous Page"
 msgstr "&Página anterior"
 
 #. IDS_PREVIEWBAR_NEXTPAGE
-#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5679
+#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5678
 msgid "&Next Page"
 msgstr "&Página seguinte"
 
@@ -543,7 +543,7 @@ msgstr "&Binário"
 #. IDS_IMAGE_MENU
 #: Merge.rc:329 Merge.rc:338 Merge.rc:432 Merge.rc:441 Merge.rc:609
 #: Merge.rc:618 Merge.rc:670 Merge.rc:960 Merge.rc:1187 Merge.rc:1200
-#: Merge.rc:5477
+#: Merge.rc:5476
 msgid "&Image"
 msgstr "Imagem"
 
@@ -665,7 +665,7 @@ msgid "&Huge"
 msgstr "&Enorme"
 
 #. IDS_VIEW_MENU_BAR
-#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5714
+#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5713
 msgid "Men&u Bar"
 msgstr "Barra de men&us"
 
@@ -1320,7 +1320,7 @@ msgid "Lo&cation Pane"
 msgstr "Painel de localização"
 
 #. IDS_OUTPUTBAR_CAPTION
-#: Merge.rc:782 Merge.rc:5252
+#: Merge.rc:782 Merge.rc:5251
 msgid "Output Pane"
 msgstr "Painel de resultados"
 
@@ -1583,55 +1583,55 @@ msgid "Co&mpare As"
 msgstr "Co&mparar como"
 
 #. IDS_COPY_LEFT_TO_MIDDLE2
-#: Merge.rc:968 Merge.rc:980 Merge.rc:4852
+#: Merge.rc:968 Merge.rc:980 Merge.rc:4851
 #, c-format
 msgid "Left to Middle (%1 of %2)"
 msgstr "Da esquerda para o meio (%1 de %2)"
 
 #. IDS_COPY_LEFT_TO_RIGHT2
-#: Merge.rc:969 Merge.rc:981 Merge.rc:4851
+#: Merge.rc:969 Merge.rc:981 Merge.rc:4850
 #, c-format
 msgid "Left to Right (%1 of %2)"
 msgstr "Da esquerda para a direita (%1 de %2)"
 
 #. IDS_MOVE_LEFT_TO2
-#: Merge.rc:970 Merge.rc:982 Merge.rc:1045 Merge.rc:4863 Merge.rc:4892
+#: Merge.rc:970 Merge.rc:982 Merge.rc:1045 Merge.rc:4862 Merge.rc:4891
 #, c-format
 msgid "Left to... (%1 of %2)"
 msgstr "Esquerda para... (%1 de %2)"
 
 #. IDS_COPY_MIDDLE_TO_LEFT2
-#: Merge.rc:971 Merge.rc:983 Merge.rc:4849
+#: Merge.rc:971 Merge.rc:983 Merge.rc:4848
 #, c-format
 msgid "Middle to Left (%1 of %2)"
 msgstr "Meio para a esquerda (%1 de %2)"
 
 #. IDS_COPY_MIDDLE_TO_RIGHT2
-#: Merge.rc:972 Merge.rc:984 Merge.rc:4850
+#: Merge.rc:972 Merge.rc:984 Merge.rc:4849
 #, c-format
 msgid "Middle to Right (%1 of %2)"
 msgstr "Meio para a direita (%1 de %2)"
 
 #. IDS_MOVE_MIDDLE_TO2
-#: Merge.rc:973 Merge.rc:985 Merge.rc:1046 Merge.rc:4864 Merge.rc:4893
+#: Merge.rc:973 Merge.rc:985 Merge.rc:1046 Merge.rc:4863 Merge.rc:4892
 #, c-format
 msgid "Middle to... (%1 of %2)"
 msgstr "Meio para... (%1 de %2)"
 
 #. IDS_COPY_RIGHT_TO_MIDDLE2
-#: Merge.rc:974 Merge.rc:986 Merge.rc:4848
+#: Merge.rc:974 Merge.rc:986 Merge.rc:4847
 #, c-format
 msgid "Right to Middle (%1 of %2)"
 msgstr "Direita para o meio (%1 de %2)"
 
 #. IDS_COPY_RIGHT_TO_LEFT2
-#: Merge.rc:975 Merge.rc:987 Merge.rc:4847
+#: Merge.rc:975 Merge.rc:987 Merge.rc:4846
 #, c-format
 msgid "Right to Left (%1 of %2)"
 msgstr "Direita para a esquerda (%1 de %2)"
 
 #. IDS_MOVE_RIGHT_TO2
-#: Merge.rc:976 Merge.rc:988 Merge.rc:1047 Merge.rc:4865 Merge.rc:4894
+#: Merge.rc:976 Merge.rc:988 Merge.rc:1047 Merge.rc:4864 Merge.rc:4893
 #, c-format
 msgid "Right to... (%1 of %2)"
 msgstr "Direita para... (%1 de %2)"
@@ -1687,31 +1687,31 @@ msgid "Cop&y Paths"
 msgstr "Copiar &nomes de localização"
 
 #. IDS_DEL_LEFT_FMT2
-#: Merge.rc:1026 Merge.rc:1035 Merge.rc:4880
+#: Merge.rc:1026 Merge.rc:1035 Merge.rc:4879
 #, c-format
 msgid "Left (%1 of %2)"
 msgstr "Esquerda (%1 de 2)"
 
 #. IDS_DEL_MIDDLE_FMT2
-#: Merge.rc:1027 Merge.rc:1036 Merge.rc:4881
+#: Merge.rc:1027 Merge.rc:1036 Merge.rc:4880
 #, c-format
 msgid "Middle (%1 of %2)"
 msgstr "Meio (%1 de %2)"
 
 #. IDS_DEL_RIGHT_FMT2
-#: Merge.rc:1028 Merge.rc:1037 Merge.rc:4882
+#: Merge.rc:1028 Merge.rc:1037 Merge.rc:4881
 #, c-format
 msgid "Right (%1 of %2)"
 msgstr "Direita (%1 de 2)"
 
 #. IDS_DEL_BOTH_FMT2
-#: Merge.rc:1029 Merge.rc:1038 Merge.rc:4883
+#: Merge.rc:1029 Merge.rc:1038 Merge.rc:4882
 #, c-format
 msgid "Both (%1 of %2)"
 msgstr "Ambos (%1 de %2)"
 
 #. IDS_DEL_ALL_FMT2
-#: Merge.rc:1030 Merge.rc:1039 Merge.rc:4888
+#: Merge.rc:1030 Merge.rc:1039 Merge.rc:4887
 #, c-format
 msgid "All (%1 of %2)"
 msgstr "Tudo (%1 de %2)"
@@ -1737,19 +1737,19 @@ msgid "&Zip"
 msgstr "&Zip"
 
 #. IDS_COPY_BOTH_TO2
-#: Merge.rc:1048 Merge.rc:4866
+#: Merge.rc:1048 Merge.rc:4865
 #, c-format
 msgid "Both to... (%1 of %2)"
 msgstr "Ambos para... (%1 de %2)"
 
 #. IDS_COPY_ALL_TO2
-#: Merge.rc:1049 Merge.rc:4867
+#: Merge.rc:1049 Merge.rc:4866
 #, c-format
 msgid "All to... (%1 of %2)"
 msgstr "Tudo para... (%1 de %2)"
 
 #. IDS_COPY_DIFFERENCES_TO2
-#: Merge.rc:1050 Merge.rc:4868
+#: Merge.rc:1050 Merge.rc:4867
 #, c-format
 msgid "Differences to... (%1 of %2)"
 msgstr "Diferenças para... (%1 de %2)"
@@ -1816,12 +1816,12 @@ msgstr "Definições do descompactador"
 
 #. IDS_USERCHOICE_NONE
 #: Merge.rc:1088 Merge.rc:1094 Merge.rc:1836 Merge.rc:1840 Merge.rc:2031
-#: Merge.rc:2035 Merge.rc:5377
+#: Merge.rc:2035 Merge.rc:5376
 msgid "<None>"
 msgstr "<None>"
 
 #. IDS_USERCHOICE_AUTOMATIC
-#: Merge.rc:1089 Merge.rc:1095 Merge.rc:5378
+#: Merge.rc:1089 Merge.rc:1095 Merge.rc:5377
 msgid "<Automatic>"
 msgstr "<Automatic>"
 
@@ -2751,12 +2751,12 @@ msgid "Text files only"
 msgstr "Apenas ficheiros de texto"
 
 #. IDS_EOL_NONE
-#: Merge.rc:1667 Merge.rc:1918 Merge.rc:5304
+#: Merge.rc:1667 Merge.rc:1918 Merge.rc:5303
 msgid "None"
 msgstr "Nenhum"
 
 #. IDS_EOL_MIXED
-#: Merge.rc:1668 Merge.rc:5299
+#: Merge.rc:1668 Merge.rc:5298
 msgid "Mixed"
 msgstr "Misturado"
 
@@ -3028,13 +3028,13 @@ msgstr "&Estado da Linha"
 
 #. IDS_DIFFERENT
 #: Merge.rc:1904 Merge.rc:1988 Merge.rc:2866 Merge.rc:3036 Merge.rc:3077
-#: Merge.rc:5058
+#: Merge.rc:5057
 msgid "Different"
 msgstr "Diferente"
 
 #. IDS_IDENTICAL
 #: Merge.rc:1905 Merge.rc:1989 Merge.rc:2865 Merge.rc:3055 Merge.rc:3116
-#: Merge.rc:5048
+#: Merge.rc:5047
 msgid "Identical"
 msgstr "Idêntico"
 
@@ -3054,7 +3054,7 @@ msgid "Missing"
 msgstr "Em falta"
 
 #. IDS_MOVED
-#: Merge.rc:1910 Merge.rc:5076
+#: Merge.rc:1910 Merge.rc:5075
 msgid "Moved"
 msgstr "Movidos"
 
@@ -3790,7 +3790,7 @@ msgid "&Use custom system colors"
 msgstr "&Usar cores personalizadas do sistema"
 
 #. IDS_PRPCAT_SYSTEM
-#: Merge.rc:2565 Merge.rc:4559 Merge.rc:4560 Merge.rc:5007
+#: Merge.rc:2565 Merge.rc:4559 Merge.rc:4560 Merge.rc:5006
 msgid "System"
 msgstr "Sistema"
 
@@ -4190,7 +4190,7 @@ msgid "Items compared:"
 msgstr "Itens comparados:"
 
 #. IDS_PREVIEWBAR_CLOSE
-#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5685
+#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5684
 msgid "&Close"
 msgstr "Fechar"
 
@@ -4813,7 +4813,7 @@ msgid "A&ppend timestamp"
 msgstr "A&nexar data"
 
 #. IDS_CONFIRM_COPY_CAPTION
-#: Merge.rc:3214 Merge.rc:4915
+#: Merge.rc:3214 Merge.rc:4914
 msgid "Confirm Copy"
 msgstr "Confirmar cópia"
 
@@ -5050,7 +5050,7 @@ msgid "&Character Set..."
 msgstr "A preparar caráter..."
 
 #. IDS_PRPCAT_IMAGE
-#: Merge.rc:3351 Merge.rc:4574 Merge.rc:5015
+#: Merge.rc:3351 Merge.rc:4574 Merge.rc:5014
 msgid "Image"
 msgstr "Imagem"
 
@@ -5457,7 +5457,7 @@ msgid "Project"
 msgstr "Projecto"
 
 #. IDS_COLHDR_NSDIFFS
-#: Merge.rc:4566 Merge.rc:4990
+#: Merge.rc:4566 Merge.rc:4989
 msgid "Differences"
 msgstr "Diferenças"
 
@@ -5602,12 +5602,12 @@ msgid "File Type"
 msgstr "Tipo de ficheiro"
 
 #. IDS_COLHDR_EXTENSION
-#: Merge.rc:4653 Merge.rc:4947
+#: Merge.rc:4653 Merge.rc:4946
 msgid "Extension"
 msgstr "Extensão"
 
 #. IDS_PRPCAT_MESSAGE
-#: Merge.rc:4659 Merge.rc:5019
+#: Merge.rc:4659 Merge.rc:5018
 msgid "Message"
 msgstr "Mensagem"
 
@@ -5647,7 +5647,7 @@ msgid "Hidden Items"
 msgstr "Itens ocultos"
 
 #. IDS_PLUGINSLIST_NAME
-#: Merge.rc:4680 Merge.rc:5311
+#: Merge.rc:4680 Merge.rc:5310
 msgid "Name"
 msgstr "Nome"
 
@@ -5667,7 +5667,7 @@ msgid "[F] "
 msgstr "[F] "
 
 #. IDS_PLUGINSLIST_DESC
-#: Merge.rc:4684 Merge.rc:5313
+#: Merge.rc:4684 Merge.rc:5312
 msgid "Description"
 msgstr "Descrição"
 
@@ -5835,155 +5835,150 @@ msgstr "Ln: %s  Col: %d/%d  Ch: %d/%d"
 msgid "  Sel: %d | %d"
 msgstr "  Sel: %d | %d"
 
-#. IDS_MERGEMODE_MERGING
-#: Merge.rc:4734
-msgid "Merge"
-msgstr "Fundir"
-
 #. IDS_DIFF_NUMBER_STATUS_FMT
-#: Merge.rc:4735
+#: Merge.rc:4734
 #, c-format
 msgid "Difference %1 of %2"
 msgstr "Diferença %1 de %2"
 
 #. IDS_NO_DIFF_SEL_FMT
-#: Merge.rc:4736
+#: Merge.rc:4735
 #, c-format
 msgid "%1 Differences Found"
 msgstr "%1 diferenças encontradas"
 
 #. IDS_1_DIFF_FOUND
-#: Merge.rc:4737
+#: Merge.rc:4736
 msgid "1 Difference Found"
 msgstr "1 diferença encontrada"
 
 #. IDS_NO_ERR_SEL_FMT
-#: Merge.rc:4738
+#: Merge.rc:4737
 #, c-format
 msgid "%1 Errors Found"
 msgstr "%1 erros encontrados"
 
 #. IDS_1_ERR_FOUND
-#: Merge.rc:4739
+#: Merge.rc:4738
 msgid "1 Error Found"
 msgstr "1 erro encontrado"
 
 #. IDS_STATUSBAR_READONLY, Abbreviation from "Read Only"
-#: Merge.rc:4740
+#: Merge.rc:4739
 msgid "RO"
 msgstr "AL"
 
 #. IDS_DIRVIEW_STATUS_FMT_FOCUS
-#: Merge.rc:4746
+#: Merge.rc:4745
 #, c-format
 msgid "Item %1 of %2"
 msgstr "Item %1 de %2"
 
 #. IDS_DIRVIEW_STATUS_FMT_NOFOCUS
-#: Merge.rc:4747
+#: Merge.rc:4746
 #, c-format
 msgid "Items: %1"
 msgstr "Itens: %1"
 
 #. IDS_DIRVIEW_STATUS_COMPARING
-#: Merge.rc:4748
+#: Merge.rc:4747
 msgid "Comparing items..."
 msgstr "A comparar itens..."
 
 #. IDS_ITEMS_PER_SEC
-#: Merge.rc:4749
+#: Merge.rc:4748
 #, c-format
 msgid "%.1f[items/sec]"
 msgstr "%.1f[itens/seg.]"
 
 #. IDS_ERROR_INCOMPARABLE
-#: Merge.rc:4755
+#: Merge.rc:4754
 msgid "Select two existing folders/files to compare."
 msgstr "Selecione duas pastas existentes ou ficheiros para comparar."
 
 #. IDS_DIRSEL_TAG
-#: Merge.rc:4756
+#: Merge.rc:4755
 msgid "Folder Selection"
 msgstr "Seleção de pasta"
 
 #. IDS_OPEN_FILESDIRS
-#: Merge.rc:4757
+#: Merge.rc:4756
 msgid "Select two (or three) folders/files to compare."
 msgstr "Selecione duas (ou três) pastas ou dois (ou três) ficheiros para comparar."
 
 #. IDS_OPEN_LEFTINVALID
-#: Merge.rc:4758
+#: Merge.rc:4757
 msgid "Left (1st) path is invalid!"
 msgstr "Pasta esquerda (1º) não é válida!"
 
 #. IDS_OPEN_MIDDLEINVALID
-#: Merge.rc:4759
+#: Merge.rc:4758
 msgid "Middle (2nd) path is invalid!"
 msgstr "Pasta do meio (2º) não é válida!"
 
 #. IDS_OPEN_RIGHTINVALID2
-#: Merge.rc:4760
+#: Merge.rc:4759
 msgid "Right (2nd) path is invalid!"
 msgstr "Pasta direita (2º) não é válida!"
 
 #. IDS_OPEN_RIGHTINVALID3
-#: Merge.rc:4761
+#: Merge.rc:4760
 msgid "Right (3rd) path is invalid!"
 msgstr "Pasta direita (3º) não é válida!"
 
 #. IDS_OPEN_BOTHINVALID
-#: Merge.rc:4762
+#: Merge.rc:4761
 msgid "Both paths are invalid!"
 msgstr "Ambas as pastas de destino são inválidas!"
 
-#: Merge.rc:4764
+#: Merge.rc:4763
 msgid "Left (1st) and Middle (2nd) paths are invalid!"
 msgstr "Pasta esquerda (1º) e do meio (2º) não são válidas!"
 
 #. IDS_OPEN_LEFTRIGHTINVALID
-#: Merge.rc:4765
+#: Merge.rc:4764
 msgid "Left (1st) and Right (3rd) paths are invalid!"
 msgstr "Pasta esquerda (1º) e direita (3º) não são válidas!"
 
-#: Merge.rc:4767
+#: Merge.rc:4766
 msgid "Middle (2nd) and Right (3rd) paths are invalid!"
 msgstr "Pasta do meio (2º) e direita (3º) não são válidas!"
 
 #. IDS_OPEN_ALLINVALID
-#: Merge.rc:4768
+#: Merge.rc:4767
 msgid "All paths are invalid!"
 msgstr "Todos as pastas de destino são inválidas!"
 
 #. IDS_OPEN_UNPACKERDISABLED
-#: Merge.rc:4769
+#: Merge.rc:4768
 msgid "Only enabled for file comparisons"
 msgstr "Apenas ativado para comparações de ficheiros"
 
 #. IDS_OPEN_MISMATCH
-#: Merge.rc:4770
+#: Merge.rc:4769
 msgid "Cannot compare file and folder!"
 msgstr "Não é possível comparar ficheiro ou pasta!"
 
 #. IDS_ERROR_FILE_NOT_FOUND
-#: Merge.rc:4776
+#: Merge.rc:4775
 #, c-format
 msgid "File not found: %1"
 msgstr "Ficheiro não encontrado: %1"
 
 #. IDS_ERROR_FOLDER_NOT_FOUND
-#: Merge.rc:4777
+#: Merge.rc:4776
 #, c-format
 msgid "Folder not found: %1"
 msgstr "Pasta não encontrada: %1"
 
 #. IDS_ERROR_FILE_NOT_UNPACKED
-#: Merge.rc:4778
+#: Merge.rc:4777
 #, c-format
 msgid "File not unpacked: %1"
 msgstr "Ficheiro não descompactado: %1"
 
 #. IDS_ERROR_FILEOPEN
-#: Merge.rc:4779
+#: Merge.rc:4778
 #, c-format
 msgid ""
 "Cannot open file\n"
@@ -5997,12 +5992,12 @@ msgstr ""
 "%2"
 
 #. IDS_ERROR_CONF_RESOLVE
-#: Merge.rc:4780
+#: Merge.rc:4779
 msgid "Failed to parse conflict file."
 msgstr "Erro ao analisar ficheiro em conflito."
 
 #. IDS_NOT_CONFLICT_FILE
-#: Merge.rc:4781
+#: Merge.rc:4780
 #, c-format
 msgid ""
 "The file\n"
@@ -6014,7 +6009,7 @@ msgstr ""
 "não está em conflito."
 
 #. IDS_COMPARE_LARGE_FILES
-#: Merge.rc:4782
+#: Merge.rc:4781
 msgid ""
 "Comparing large files requires significant memory.\n"
 "Show only comparison results (not file contents)?"
@@ -6023,28 +6018,28 @@ msgstr ""
 "Mostrar apenas os resultados da comparação (não o conteúdo do ficheiro)?"
 
 #. IDS_SAVE_AS_TITLE
-#: Merge.rc:4788
+#: Merge.rc:4787
 msgid "Save As"
 msgstr "Guardar como"
 
 #. IDS_SAVE_FMT
-#: Merge.rc:4789
+#: Merge.rc:4788
 #, c-format
 msgid "Save changes to %1?"
 msgstr "Guardar alterações em %1?"
 
 #. IDS_SAVEREADONLY_FMT
-#: Merge.rc:4790
+#: Merge.rc:4789
 #, c-format
 msgid "%1 is read-only. Override? Or 'No' to save as new filename?"
 msgstr "%1 é de apenas-leitura. Deseja substituir o ficheiro de apenas-leitura? (não, para guardar com novo nome.)"
 
 #. IDS_ERROR_BACKUP
-#: Merge.rc:4791
+#: Merge.rc:4790
 msgid "Error backing up file"
 msgstr "Erro ao criar cópia de segurança"
 
-#: Merge.rc:4793
+#: Merge.rc:4792
 #, c-format
 msgid ""
 "Unable to backup original file:\n"
@@ -6058,7 +6053,7 @@ msgstr ""
 "Continuar mesmo assim?"
 
 #. IDS_FILESAVE_FAILED
-#: Merge.rc:4794
+#: Merge.rc:4793
 #, c-format
 msgid ""
 "Saving file failed.\n"
@@ -6074,7 +6069,7 @@ msgstr ""
 "\t- usar um nome diferente para o ficheiro (Prima OK)\n"
 "\t- abortar a ação atual (Prima Cancelar)?"
 
-#: Merge.rc:4796
+#: Merge.rc:4795
 #, c-format
 msgid ""
 "Plugin '%2' cannot pack changes to left file into '%1'.\n"
@@ -6087,7 +6082,7 @@ msgstr ""
 "\n"
 "Deseja guardar a versão não compactada num outro ficheiro?"
 
-#: Merge.rc:4798
+#: Merge.rc:4797
 #, c-format
 msgid ""
 "Plugin '%2' cannot pack changes to middle file into '%1'.\n"
@@ -6100,7 +6095,7 @@ msgstr ""
 "\n"
 "Quer guardar a versão compactada noutro ficheiro?"
 
-#: Merge.rc:4800
+#: Merge.rc:4799
 #, c-format
 msgid ""
 "Plugin '%2' cannot pack changes to right file into '%1'.\n"
@@ -6114,7 +6109,7 @@ msgstr ""
 "Deseja guardar a versão não compactada em outro ficheiro?"
 
 #. IDS_FILECHANGED_ONDISK
-#: Merge.rc:4801
+#: Merge.rc:4800
 #, c-format
 msgid ""
 "Another application updated\n"
@@ -6130,7 +6125,7 @@ msgstr ""
 "Substituir o ficheiro modificado?"
 
 #. IDS_SAVEREADONLY_MULTI
-#: Merge.rc:4802
+#: Merge.rc:4801
 #, c-format
 msgid ""
 "%1\n"
@@ -6140,7 +6135,7 @@ msgstr ""
 "é de apenas-leitura. Deseja substituir o item de apenas-leitura?"
 
 #. IDS_FILECHANGED_RESCAN
-#: Merge.rc:4803
+#: Merge.rc:4802
 #, c-format
 msgid ""
 "Another application updated\n"
@@ -6156,22 +6151,22 @@ msgstr ""
 "Deseja recarregar o ficheiro?"
 
 #. IDS_SAVE_LEFT_AS
-#: Merge.rc:4804
+#: Merge.rc:4803
 msgid "Save Left File As"
 msgstr "Guardar o ficheiro da esquerda como"
 
 #. IDS_SAVE_MIDDLE_AS
-#: Merge.rc:4805
+#: Merge.rc:4804
 msgid "Save Middle File As"
 msgstr "Guardar o ficheiro do meio como"
 
 #. IDS_SAVE_RIGHT_AS
-#: Merge.rc:4806
+#: Merge.rc:4805
 msgid "Save Right File As"
 msgstr "Guardar o ficheiro da direita como"
 
 #. IDS_FILE_DISAPPEARED
-#: Merge.rc:4811
+#: Merge.rc:4810
 #, c-format
 msgid ""
 "File\n"
@@ -6183,7 +6178,7 @@ msgstr ""
 "desapareceu. Guarde uma cópia do ficheiro para continuar."
 
 #. IDS_VIEWS_OUTOFSYNC
-#: Merge.rc:4817
+#: Merge.rc:4816
 msgid ""
 "Cannot merge unsynched documents.\n"
 "\n"
@@ -6194,186 +6189,186 @@ msgstr ""
 "Atualizar documentos antes de continuar."
 
 #. IDS_BREAK_ON_WHITESPACE
-#: Merge.rc:4822
+#: Merge.rc:4821
 msgid "Break at whitespace"
 msgstr "Quebra de linha nos espaços em branco"
 
 #. IDS_BREAK_ON_PUNCTUATION
-#: Merge.rc:4823
+#: Merge.rc:4822
 msgid "Break at whitespace or punctuation"
 msgstr "Quebra de linha nos espaços em branco ou pontuação"
 
 #. IDS_L2M
-#: Merge.rc:4829
+#: Merge.rc:4828
 msgid "Copy to &Middle\tAlt+Right"
 msgstr "Copiar para o &meio\tAlt+Direita"
 
 #. IDS_R2M
-#: Merge.rc:4830
+#: Merge.rc:4829
 msgid "Copy to &Middle\tAlt+Left"
 msgstr "Copiar para a &esquerda\tAlt+Esquerda"
 
 #. IDS_COPY_FROM_MIDDLE_R
-#: Merge.rc:4831
+#: Merge.rc:4830
 msgid "Copy from Middle\tAlt+Shift+Right"
 msgstr "Copiar do meio\tAlt+Shift+Direita"
 
 #. IDS_COPY_FROM_MIDDLE_L
-#: Merge.rc:4832
+#: Merge.rc:4831
 msgid "Copy from Middle\tAlt+Shift+Left"
 msgstr "Copiar do meio\tAlt+Shift+Esquerda"
 
 #. IDS_L2MNEXT
-#: Merge.rc:4833
+#: Merge.rc:4832
 msgid "Copy to Middle and Advance\tCtrl+Alt+Right"
 msgstr "Copiar para o meio e avançar\tCtrl+Alt+Direita"
 
 #. IDS_R2MNEXT
-#: Merge.rc:4834
+#: Merge.rc:4833
 msgid "Copy to Middle and Advance\tCtrl+Alt+Left"
 msgstr "Copiar para o meio e avançar\tCtrl+Alt+Esquerda"
 
 #. IDS_ALL_MIDDLE
-#: Merge.rc:4835
+#: Merge.rc:4834
 msgid "Copy All to Middle"
 msgstr "Copiar tudo para o meio"
 
 #. IDS_COPY_RIGHT_TO_LEFT
-#: Merge.rc:4841
+#: Merge.rc:4840
 #, c-format
 msgid "Right to Left (%1)"
 msgstr "Da direita para a esquerda (%1)"
 
 #. IDS_COPY_RIGHT_TO_MIDDLE
-#: Merge.rc:4842
+#: Merge.rc:4841
 #, c-format
 msgid "Right to Middle (%1)"
 msgstr "Da direita para o meio"
 
 #. IDS_COPY_MIDDLE_TO_LEFT
-#: Merge.rc:4843
+#: Merge.rc:4842
 #, c-format
 msgid "Middle to Left (%1)"
 msgstr "Do meio para a esquerda"
 
 #. IDS_COPY_MIDDLE_TO_RIGHT
-#: Merge.rc:4844
+#: Merge.rc:4843
 #, c-format
 msgid "Middle to Right (%1)"
 msgstr "Do meio para a direita"
 
 #. IDS_COPY_LEFT_TO_RIGHT
-#: Merge.rc:4845
+#: Merge.rc:4844
 #, c-format
 msgid "Left to Right (%1)"
 msgstr "Da esquerda para a direita (%1)"
 
 #. IDS_COPY_LEFT_TO_MIDDLE
-#: Merge.rc:4846
+#: Merge.rc:4845
 #, c-format
 msgid "Left to Middle (%1)"
 msgstr "Da esquerda para o meio"
 
 #. IDS_MOVE_LEFT_TO
-#: Merge.rc:4857 Merge.rc:4889
+#: Merge.rc:4856 Merge.rc:4888
 #, c-format
 msgid "Left to... (%1)"
 msgstr "Da esquerda para... (%1)"
 
 #. IDS_MOVE_MIDDLE_TO
-#: Merge.rc:4858 Merge.rc:4890
+#: Merge.rc:4857 Merge.rc:4889
 #, c-format
 msgid "Middle to... (%1)"
 msgstr "Do meio para..."
 
 #. IDS_MOVE_RIGHT_TO
-#: Merge.rc:4859 Merge.rc:4891
+#: Merge.rc:4858 Merge.rc:4890
 #, c-format
 msgid "Right to... (%1)"
 msgstr "Da direita para... (%1)"
 
 #. IDS_COPY_BOTH_TO
-#: Merge.rc:4860
+#: Merge.rc:4859
 #, c-format
 msgid "Both to... (%1)"
 msgstr "Ambos para... (%1)"
 
 #. IDS_COPY_ALL_TO
-#: Merge.rc:4861
+#: Merge.rc:4860
 #, c-format
 msgid "All to... (%1)"
 msgstr "Tudo para... (%1)"
 
 #. IDS_COPY_DIFFERENCES_TO
-#: Merge.rc:4862
+#: Merge.rc:4861
 #, c-format
 msgid "Differences to... (%1)"
 msgstr "Diferenças para... (%1)"
 
 #. IDS_ONLYDIFFITEMS_CONFIRM
-#: Merge.rc:4869
+#: Merge.rc:4868
 msgid "Some selected items are identical or skipped.\nProcess only items with differences?"
 msgstr ""
 
 #. IDS_DEL_LEFT_FMT
-#: Merge.rc:4875
+#: Merge.rc:4874
 #, c-format
 msgid "Left (%1)"
 msgstr "Esquerda (%1)"
 
 #. IDS_DEL_MIDDLE_FMT
-#: Merge.rc:4876
+#: Merge.rc:4875
 #, c-format
 msgid "Middle (%1)"
 msgstr "Meio (%1)"
 
 #. IDS_DEL_RIGHT_FMT
-#: Merge.rc:4877
+#: Merge.rc:4876
 #, c-format
 msgid "Right (%1)"
 msgstr "Direita (%1)"
 
 #. IDS_DEL_BOTH_FMT
-#: Merge.rc:4878
+#: Merge.rc:4877
 #, c-format
 msgid "Both (%1)"
 msgstr "Ambos (%1)"
 
 #. IDS_DEL_ALL_FMT
-#: Merge.rc:4879
+#: Merge.rc:4878
 #, c-format
 msgid "All (%1)"
 msgstr "Tudo (%1)"
 
 #. IDS_SELECT_DEST_LEFT
-#: Merge.rc:4895
+#: Merge.rc:4894
 msgid "Left Side - Select Destination Folder:"
 msgstr "Lado esquerdo - selecione pasta de destino:"
 
 #. IDS_SELECT_DEST_MIDDLE
-#: Merge.rc:4896
+#: Merge.rc:4895
 msgid "Middle Side - Select Destination Folder:"
 msgstr "Do meio - selecione pasta de destino:"
 
 #. IDS_SELECT_DEST_RIGHT
-#: Merge.rc:4897
+#: Merge.rc:4896
 msgid "Right Side - Select Destination Folder:"
 msgstr "Lado direito - selecione pasta de destino:"
 
 #. IDS_FILES_AFFECTED_FMT
-#: Merge.rc:4898
+#: Merge.rc:4897
 #, c-format
 msgid "(%1 Files Affected)"
 msgstr "(%1 ficheiros afetados)"
 
 #. IDS_FILES_AFFECTED_FMT2
-#: Merge.rc:4899
+#: Merge.rc:4898
 #, c-format
 msgid "(%1 of %2 Files Affected)"
 msgstr "(%1 de %2 ficheiros afetados)"
 
 #. IDS_CONFIRM_DELETE_SINGLE
-#: Merge.rc:4905
+#: Merge.rc:4904
 #, c-format
 msgid ""
 "Are you sure you want to delete\n"
@@ -6385,18 +6380,18 @@ msgstr ""
 "%1 ?"
 
 #. IDS_CONFIRM_SINGLE_COPY
-#: Merge.rc:4906
+#: Merge.rc:4905
 msgid "Are you sure you want to copy?"
 msgstr "Tem a certeza que deseja copiar?"
 
 #. IDS_CONFIRM_MULTIPLE_COPY
-#: Merge.rc:4907
+#: Merge.rc:4906
 #, c-format
 msgid "Are you sure you want to copy %d items?"
 msgstr "Tem a certeza que deseja copiar %d itens?"
 
 #. IDS_DIRCMP_NOTSYNC
-#: Merge.rc:4908
+#: Merge.rc:4907
 #, c-format
 msgid ""
 "Operation aborted!\n"
@@ -6415,46 +6410,46 @@ msgstr ""
 "\\Recarregue para comparar."
 
 #. IDS_CONFIRM_SINGLE_MOVE
-#: Merge.rc:4913
+#: Merge.rc:4912
 msgid "Are you sure you want to move?"
 msgstr "Tem a certeza que deseja mover?"
 
 #. IDS_CONFIRM_MULTIPLE_MOVE
-#: Merge.rc:4914
+#: Merge.rc:4913
 #, c-format
 msgid "Are you sure you want to move %d items?"
 msgstr "Tem a certeza que deseja mover %d itens?"
 
 #. IDS_CONFIRM_MOVE_CAPTION
-#: Merge.rc:4916
+#: Merge.rc:4915
 msgid "Confirm Move"
 msgstr "Confirmar"
 
-#: Merge.rc:4918
+#: Merge.rc:4917
 msgid "Close the folder comparison window?"
 msgstr "Fechar a janela de comparação de pastas?"
 
-#: Merge.rc:4920
+#: Merge.rc:4919
 msgid "Close the folder comparison window, which took a long time?"
 msgstr "Fechar a janela de comparação de pastas, que demorou muito tempo?"
 
 #. IDS_ERROR_INVALID_DIR_FILE_NAME
-#: Merge.rc:4921
+#: Merge.rc:4920
 msgid "The file or folder name is invalid."
 msgstr "O nome do ficheiro ou pasta é inválido."
 
 #. IDS_ERROR_EXECUTE_FILE
-#: Merge.rc:4927
+#: Merge.rc:4926
 #, c-format
 msgid "Failed to execute external editor: %1"
 msgstr "Erro ao executar editor externo: %1"
 
 #. IDS_UNKNOWN_ARCHIVE_FORMAT
-#: Merge.rc:4933
+#: Merge.rc:4932
 msgid "Unknown archive format"
 msgstr "Formato de ficheiro desconhecido"
 
-#: Merge.rc:4935
+#: Merge.rc:4934
 msgid ""
 "Failed to extract archive.\n"
 "Compare as text file?"
@@ -6463,514 +6458,514 @@ msgstr ""
 "Quer comparar os ficheiros do arquivo como ficheiros de texto?"
 
 #. IDS_COLHDR_FILENAME
-#: Merge.rc:4941
+#: Merge.rc:4940
 msgid "Filename"
 msgstr "Nome do ficheiro"
 
 #. IDS_COLHDR_DIR
-#: Merge.rc:4942
+#: Merge.rc:4941
 msgctxt "DirView|ColumnHeader"
 msgid "Folder"
 msgstr "Pasta"
 
 #. IDS_COLHDR_RESULT
-#: Merge.rc:4943
+#: Merge.rc:4942
 msgid "Comparison Result"
 msgstr "Resultado da comparação"
 
 #. IDS_COLHDR_LTIMEM
-#: Merge.rc:4944
+#: Merge.rc:4943
 msgid "Left Date"
 msgstr "Data da esquerda"
 
 #. IDS_COLHDR_RTIMEM
-#: Merge.rc:4945
+#: Merge.rc:4944
 msgid "Right Date"
 msgstr "Data da direita"
 
 #. IDS_COLHDR_MTIMEM
-#: Merge.rc:4946
+#: Merge.rc:4945
 msgid "Middle Date"
 msgstr "Data do meio"
 
 #. IDS_COLHDR_LSIZE
-#: Merge.rc:4948
+#: Merge.rc:4947
 msgid "Left Size"
 msgstr "Lado esquerdo"
 
 #. IDS_COLHDR_RSIZE
-#: Merge.rc:4949
+#: Merge.rc:4948
 msgid "Right Size"
 msgstr "Lado direito"
 
 #. IDS_COLHDR_MSIZE
-#: Merge.rc:4954
+#: Merge.rc:4953
 msgid "Middle Size"
 msgstr "Do meio"
 
 #. IDS_COLHDR_RSIZE_SHORT
-#: Merge.rc:4955
+#: Merge.rc:4954
 msgid "Right Size (Short)"
 msgstr "Lado direito (Curto)"
 
 #. IDS_COLHDR_LSIZE_SHORT
-#: Merge.rc:4956
+#: Merge.rc:4955
 msgid "Left Size (Short)"
 msgstr "Lado esquerdo (Curto)"
 
 #. IDS_COLHDR_MSIZE_SHORT
-#: Merge.rc:4957
+#: Merge.rc:4956
 msgid "Middle Size (Short)"
 msgstr "Meio (Curto)"
 
 #. IDS_COLHDR_LTIMEC
-#: Merge.rc:4963
+#: Merge.rc:4962
 msgid "Left Creation Time"
 msgstr "Data de criação - Esquerda"
 
 #. IDS_COLHDR_RTIMEC
-#: Merge.rc:4964
+#: Merge.rc:4963
 msgid "Right Creation Time"
 msgstr "Data de criação - Direita"
 
 #. IDS_COLHDR_MTIMEC
-#: Merge.rc:4965
+#: Merge.rc:4964
 msgid "Middle Creation Time"
 msgstr "Data de criação - Meio"
 
 #. IDS_COLHDR_NEWER
-#: Merge.rc:4966
+#: Merge.rc:4965
 msgid "Newer File"
 msgstr "Ficheiro mais recente"
 
 #. IDS_COLHDR_LVERSION
-#: Merge.rc:4967
+#: Merge.rc:4966
 msgid "Left File Version"
 msgstr "Versão do ficheiro da esquerda"
 
 #. IDS_COLHDR_RVERSION
-#: Merge.rc:4968
+#: Merge.rc:4967
 msgid "Right File Version"
 msgstr "Versão do ficheiro da direita"
 
 #. IDS_COLHDR_MVERSION
-#: Merge.rc:4969
+#: Merge.rc:4968
 msgid "Middle File Version"
 msgstr "Versão do ficheiro do meio"
 
 #. IDS_COLHDR_RESULT_ABBR
-#: Merge.rc:4970
+#: Merge.rc:4969
 msgid "Short Result"
 msgstr "Resultado resumido"
 
 #. IDS_COLHDR_LATTRIBUTES
-#: Merge.rc:4971
+#: Merge.rc:4970
 msgid "Left Attributes"
 msgstr "Atributos esquerda"
 
 #. IDS_COLHDR_RATTRIBUTES
-#: Merge.rc:4972
+#: Merge.rc:4971
 msgid "Right Attributes"
 msgstr "Atributos direita"
 
 #. IDS_COLHDR_MATTRIBUTES
-#: Merge.rc:4973
+#: Merge.rc:4972
 msgid "Middle Attributes"
 msgstr "Atributos meio"
 
 #. IDS_COLHDR_LEOL_TYPE
-#: Merge.rc:4978
+#: Merge.rc:4977
 msgid "Left EOL"
 msgstr "EOL Esquerda"
 
 #. IDS_COLHDR_MEOL_TYPE
-#: Merge.rc:4979
+#: Merge.rc:4978
 msgid "Middle EOL"
 msgstr "EOL Meio"
 
 #. IDS_COLHDR_REOL_TYPE
-#: Merge.rc:4980
+#: Merge.rc:4979
 msgid "Right EOL"
 msgstr "EOL Direita"
 
 #. IDS_COLHDR_LENCODING
-#: Merge.rc:4986
+#: Merge.rc:4985
 msgid "Left Encoding"
 msgstr "Codificação esquerda"
 
 #. IDS_COLHDR_RENCODING
-#: Merge.rc:4987
+#: Merge.rc:4986
 msgid "Right Encoding"
 msgstr "Codificação direita"
 
 #. IDS_COLHDR_MENCODING
-#: Merge.rc:4988
+#: Merge.rc:4987
 msgid "Middle Encoding"
 msgstr "Codificação meio"
 
 #. IDS_COLHDR_NIDIFFS
-#: Merge.rc:4989
+#: Merge.rc:4988
 msgid "Ignored Diff"
 msgstr "Diferença ignorada"
 
 #. IDS_COLHDR_BINARY
-#: Merge.rc:4991
+#: Merge.rc:4990
 msgctxt "DirView|ColumnHeader"
 msgid "Binary"
 msgstr "Binário"
 
 #. IDS_PLUGINS_TYPE_UNPACKER
-#: Merge.rc:4992 Merge.rc:5314
+#: Merge.rc:4991 Merge.rc:5313
 msgid "Unpacker"
 msgstr "Descompactador"
 
 #. IDS_PLUGIN_TYPE4
-#: Merge.rc:4993 Merge.rc:5315 Merge.rc:5622
+#: Merge.rc:4992 Merge.rc:5314 Merge.rc:5621
 msgid "Prediffer"
 msgstr "Pré-diferenciar"
 
 #. IDS_COLHDR_LEFT
-#: Merge.rc:4994
+#: Merge.rc:4993
 msgid "Left"
 msgstr "Esquerda"
 
 #. IDS_COLHDR_MIDDLE
-#: Merge.rc:4995
+#: Merge.rc:4994
 msgid "Middle"
 msgstr "Meio"
 
 #. IDS_COLHDR_RIGHT
-#: Merge.rc:4996
+#: Merge.rc:4995
 msgid "Right"
 msgstr "Direita"
 
 #. IDS_COLHDR_DIFF
-#: Merge.rc:4997
+#: Merge.rc:4996
 msgid "Diff"
 msgstr "Diferença"
 
 #. IDS_COLHDR_LEFT_DUPLICATE
-#: Merge.rc:4998
+#: Merge.rc:4997
 msgid "Left Duplicate Count"
 msgstr "Contagem em duplicado à esquerda"
 
 #. IDS_COLHDR_RIGHT_DUPLICATE
-#: Merge.rc:4999
+#: Merge.rc:4998
 msgid "Right Duplicate Count"
 msgstr "Contagem em duplicado à direita"
 
 #. IDS_COLHDR_MIDDLE_DUPLICATE
-#: Merge.rc:5000
+#: Merge.rc:4999
 msgid "Middle Duplicate Count"
 msgstr "Contagem em duplicado ao meio"
 
 #. IDS_COLHDR_MOVE
-#: Merge.rc:5001
+#: Merge.rc:5000
 msgid "Move"
 msgstr "Mover"
 
 #. IDS_PRPCAT_AUDIO
-#: Merge.rc:5008
+#: Merge.rc:5007
 msgid "Audio"
 msgstr "Áudio"
 
 #. IDS_PRPCAT_CALENDAR
-#: Merge.rc:5009
+#: Merge.rc:5008
 msgid "Calendar"
 msgstr "Calendário"
 
 #. IDS_PRPCAT_COMMUNICATION
-#: Merge.rc:5010
+#: Merge.rc:5009
 msgid "Communication"
 msgstr "Comunicação"
 
 #. IDS_PRPCAT_CONTACT
-#: Merge.rc:5011
+#: Merge.rc:5010
 msgid "Contact"
 msgstr "Contacto"
 
 #. IDS_PRPCAT_DEVICES
-#: Merge.rc:5012
+#: Merge.rc:5011
 msgid "Devices"
 msgstr "Dispositivos"
 
 #. IDS_PRPCAT_DOCUMENT
-#: Merge.rc:5013
+#: Merge.rc:5012
 msgid "Document"
 msgstr "Documento"
 
 # Context of the word "Home"?
 #. IDS_PRPCAT_HOME
-#: Merge.rc:5014
+#: Merge.rc:5013
 msgid "Home"
 msgstr "Casa"
 
 #. IDS_PRPCAT_JOURNAL
-#: Merge.rc:5016
+#: Merge.rc:5015
 msgid "Journal"
 msgstr "Jornal"
 
 #. IDS_PRPCAT_LINK
-#: Merge.rc:5017
+#: Merge.rc:5016
 msgid "Link"
 msgstr "Ligação"
 
 #. IDS_PRPCAT_MEDIA
-#: Merge.rc:5018
+#: Merge.rc:5017
 msgid "Media"
 msgstr "Multimédia"
 
 #. IDS_PRPCAT_MUSIC
-#: Merge.rc:5020
+#: Merge.rc:5019
 msgid "Music"
 msgstr "Música"
 
 #. IDS_PRPCAT_NOTE
-#: Merge.rc:5021
+#: Merge.rc:5020
 msgid "Note"
 msgstr "Nota"
 
 #. IDS_PRPCAT_PHOTO
-#: Merge.rc:5022
+#: Merge.rc:5021
 msgid "Photo"
 msgstr "Foto"
 
 #. IDS_PRPCAT_RECORDEDTV
-#: Merge.rc:5023
+#: Merge.rc:5022
 msgid "RecordedTV"
 msgstr "TV gravada"
 
 #. IDS_PRPCAT_SEARCH
-#: Merge.rc:5024
+#: Merge.rc:5023
 msgid "Search"
 msgstr "Pesquisa"
 
 #. IDS_PRPCAT_SECURITY
-#: Merge.rc:5025
+#: Merge.rc:5024
 msgid "Security"
 msgstr "Segurança"
 
 #. IDS_PRPCAT_SOFTWARE
-#: Merge.rc:5026
+#: Merge.rc:5025
 msgid "Software"
 msgstr "Software"
 
 #. IDS_PRPCAT_TASK
-#: Merge.rc:5027
+#: Merge.rc:5026
 msgid "Task"
 msgstr "Tarefa"
 
 #. IDS_PRPCAT_VIDEO
-#: Merge.rc:5028
+#: Merge.rc:5027
 msgid "Video"
 msgstr "Vídeo"
 
 #. IDS_PRPCAT_HASH
-#: Merge.rc:5029
+#: Merge.rc:5028
 msgid "Hash"
 msgstr "Hash"
 
 #. IDS_CANT_COMPARE_FILES
-#: Merge.rc:5035
+#: Merge.rc:5034
 msgid "Unable to compare files"
 msgstr "Não é possível comparar ficheiros"
 
 #. IDS_ABORTED_ITEM
-#: Merge.rc:5036
+#: Merge.rc:5035
 msgid "Item aborted"
 msgstr "Item abortado"
 
 #. IDS_FILE_SKIPPED
-#: Merge.rc:5037
+#: Merge.rc:5036
 msgid "File skipped"
 msgstr "Ficheiro ignorado"
 
 #. IDS_DIR_SKIPPED
-#: Merge.rc:5038
+#: Merge.rc:5037
 msgid "Folder skipped"
 msgstr "Pasta ignorada"
 
 #. IDS_LEFT_ONLY_IN_FMT
-#: Merge.rc:5039
+#: Merge.rc:5038
 #, c-format
 msgid "Left only: %1"
 msgstr "Apenas da esquerda: %1"
 
 #. IDS_MIDDLE_ONLY_IN_FMT
-#: Merge.rc:5040
+#: Merge.rc:5039
 #, c-format
 msgid "Middle only: %1"
 msgstr "Apenas do meio: %1"
 
 #. IDS_RIGHT_ONLY_IN_FMT
-#: Merge.rc:5041
+#: Merge.rc:5040
 #, c-format
 msgid "Right only: %1"
 msgstr "Apenas da direita: %1"
 
 #. IDS_DOES_NOT_EXIST_IN_FMT
-#: Merge.rc:5042
+#: Merge.rc:5041
 #, c-format
 msgid "Does not exist in %1"
 msgstr "Não existe no %1"
 
 #. IDS_BIN_FILES_SAME
-#: Merge.rc:5043
+#: Merge.rc:5042
 msgid "Binary files are identical"
 msgstr "Os ficheiros binários são idênticos"
 
 #. IDS_BIN_FILES_DIFF
-#: Merge.rc:5049
+#: Merge.rc:5048
 msgid "Binary files are different"
 msgstr "Os ficheiros binários são diferentes"
 
 #. IDS_FILES_ARE_DIFFERENT
-#: Merge.rc:5050
+#: Merge.rc:5049
 msgid "Files are different"
 msgstr "Os ficheiros são diferentes"
 
 #. IDS_FOLDERS_ARE_DIFFERENT
-#: Merge.rc:5051
+#: Merge.rc:5050
 msgid "Folders are different"
 msgstr "As pastas são diferentes"
 
 #. IDS_LEFTONLY
-#: Merge.rc:5052
+#: Merge.rc:5051
 msgid "Left Only"
 msgstr "Apenas o da esquerda"
 
 #. IDS_RIGHTONLY
-#: Merge.rc:5053
+#: Merge.rc:5052
 msgid "Right Only"
 msgstr "Apenas o da direita"
 
 #. IDS_MIDDLEONLY
-#: Merge.rc:5054
+#: Merge.rc:5053
 msgid "Middle Only"
 msgstr "Apenas o do meio"
 
 #. IDS_NOITEMLEFT
-#: Merge.rc:5055
+#: Merge.rc:5054
 msgid "No item in left"
 msgstr "Sem itens à esquerda"
 
 #. IDS_NOITEMRIGHT
-#: Merge.rc:5056
+#: Merge.rc:5055
 msgid "No item in right"
 msgstr "Sem itens à direita"
 
 #. IDS_NOITEMMIDDLE
-#: Merge.rc:5057
+#: Merge.rc:5056
 msgid "No item in middle"
 msgstr "Sem itens no meio"
 
 #. IDS_CMPRES_ERROR
-#: Merge.rc:5059
+#: Merge.rc:5058
 msgid "Error"
 msgstr "Erro"
 
 #. IDS_TEXT_FILES_SAME
-#: Merge.rc:5060
+#: Merge.rc:5059
 msgid "Text files are identical"
 msgstr "Os ficheiros de texto são idênticos"
 
 #. IDS_LEFTONLY_DIFF
-#: Merge.rc:5061
+#: Merge.rc:5060
 msgid " (Middle and right are identical)"
 msgstr " (o do meio e o da direita são idênticos)"
 
 #. IDS_MIDDLEONLY_DIFF
-#: Merge.rc:5062
+#: Merge.rc:5061
 msgid " (Left and right are identical)"
 msgstr " (o da esquerda e o da direita são idênticos)"
 
 #. IDS_RIGHTONLY_DIFF
-#: Merge.rc:5063
+#: Merge.rc:5062
 msgid " (Left and middle are identical)"
 msgstr " (o da esquerda e o do meio são idênticos)"
 
 #. IDS_PATH_MISMATCH
-#: Merge.rc:5064
+#: Merge.rc:5063
 msgid " (paths differ)"
 msgstr " (os caminhos diferem)"
 
 #. IDS_TEXT_FILES_DIFF
-#: Merge.rc:5065
+#: Merge.rc:5064
 msgid "Text files are different"
 msgstr "Os ficheiros de texto são diferentes"
 
 #. IDS_IMAGE_FILES_SAME
-#: Merge.rc:5066
+#: Merge.rc:5065
 msgid "Image files are identical"
 msgstr "Os ficheiros de imagem são idênticos"
 
 #. IDS_IMAGE_FILES_DIFF
-#: Merge.rc:5067
+#: Merge.rc:5066
 msgid "Image files are different"
 msgstr "Os ficheiros de imagem são diferentes"
 
 #. IDS_EXPR_DIFF
-#: Merge.rc:5068
+#: Merge.rc:5067
 #, c-format
 msgid "Files are different (expr: %1)"
 msgstr "Os ficheiros são diferentes (expr: %1)"
 
 #. IDS_HASH_GROUP
-#: Merge.rc:5069
+#: Merge.rc:5068
 #, c-format
 msgid "Group%d"
 msgstr "Grupo%d"
 
 #. IDS_RENAME_MOVE_DETECTION_DISALBED
-#: Merge.rc:5070
+#: Merge.rc:5069
 msgctxt "Options dialog|Compare|Folder|Detect renames and moves"
 msgid "Disabled"
 msgstr "Desativada"
 
 #. IDS_RENAME_MOVE_DETECTION_RENAME
-#: Merge.rc:5071
+#: Merge.rc:5070
 msgid "Detect renames"
 msgstr "Detetar renomeações"
 
 #. IDS_RENAME_MOVE_DETECTION_RENAME_MOVE
-#: Merge.rc:5072
+#: Merge.rc:5071
 msgid "Detect renames and moves"
 msgstr "Detetar renomeações e movimentações"
 
 #. IDS_RENAME_MOVE_MERGE_MODE_RENAME
-#: Merge.rc:5073
+#: Merge.rc:5072
 msgid "Merge renames"
 msgstr "Unir renomeações"
 
 #. IDS_RENAME_MOVE_MERGE_MODE_RENAME_MOVE
-#: Merge.rc:5074
+#: Merge.rc:5073
 msgid "Merge renames and moves"
 msgstr "Unir renomeações e movimentações"
 
 #. IDS_RENAMED
-#: Merge.rc:5075
+#: Merge.rc:5074
 msgid "Renamed"
 msgstr "Renomeados"
 
 #. IDS_RENAMED_MOVED
-#: Merge.rc:5077
+#: Merge.rc:5076
 msgid "Renamed/Moved"
 msgstr "Renomeados/movidos"
 
 #. IDS_RENAMED_MOVED_ITEMS
-#: Merge.rc:5078
+#: Merge.rc:5077
 #, c-format
 msgid "(%1 items)"
 msgstr "(%1 itens)"
 
 #. IDS_RENAMED_MOVED_RESULT
-#: Merge.rc:5079
+#: Merge.rc:5078
 #, c-format
 msgid "%1 (set %2): "
 msgstr "%1 (conjunto %2): "
 
 #. IDS_SWITCH_FLAT_MODE
-#: Merge.rc:5080
+#: Merge.rc:5079
 msgid ""
 "Some moved items have been merged.\n"
 "In Tree Mode, these items may appear in positions that do not reflect the actual folder structure, which can be confusing.\n"
@@ -6981,235 +6976,235 @@ msgstr ""
 "Alternar para o Modo Nivelado?"
 
 #. IDS_ELAPSED_TIME
-#: Merge.rc:5086
+#: Merge.rc:5085
 #, c-format
 msgid "Elapsed time: %ld ms"
 msgstr "Tempo decorrido: %ld ms"
 
 #. IDS_STATUS_SELITEM1
-#: Merge.rc:5087
+#: Merge.rc:5086
 msgid "1 item selected"
 msgstr "1 item selecionado"
 
 #. IDS_STATUS_SELITEMS
-#: Merge.rc:5088
+#: Merge.rc:5087
 #, c-format
 msgid "%1 items selected"
 msgstr "%1 itens selecionados"
 
 #. IDS_COLDESC_FILENAME
-#: Merge.rc:5094
+#: Merge.rc:5093
 msgid "Filename or folder name."
 msgstr "Nome do ficheiro ou pasta."
 
 #. IDS_COLDESC_DIR
-#: Merge.rc:5095
+#: Merge.rc:5094
 msgid "Subfolder name when subfolders are included."
 msgstr "Nome da subpasta quando as subpastas estão incluídas."
 
 #. IDS_COLDESC_RESULT
-#: Merge.rc:5096
+#: Merge.rc:5095
 msgid "Comparison result, long form."
 msgstr "Resultado da comparação, forma extensa."
 
 #. IDS_COLDESC_LTIMEM
-#: Merge.rc:5101
+#: Merge.rc:5100
 msgid "Left side modification date."
 msgstr "Data de modificação do lado esquerdo."
 
 #. IDS_COLDESC_RTIMEM
-#: Merge.rc:5102
+#: Merge.rc:5101
 msgid "Right side modification date."
 msgstr "Data de modificação do lado direito."
 
 #. IDS_COLDESC_MTIMEM
-#: Merge.rc:5103
+#: Merge.rc:5102
 msgid "Middle side modification date."
 msgstr "Data de modificação do meio."
 
 #. IDS_COLDESC_EXTENSION
-#: Merge.rc:5104
+#: Merge.rc:5103
 msgid "File's extension."
 msgstr "Extensão do ficheiro."
 
 #. IDS_COLDESC_LSIZE
-#: Merge.rc:5105
+#: Merge.rc:5104
 msgid "Left file size in bytes."
 msgstr "Tamanho do ficheiro em bytes."
 
 #. IDS_COLDESC_RSIZE
-#: Merge.rc:5106
+#: Merge.rc:5105
 msgid "Right file size in bytes."
 msgstr "Tamanho do ficheiro direito em bytes."
 
 #. IDS_COLDESC_MSIZE
-#: Merge.rc:5107
+#: Merge.rc:5106
 msgid "Middle file size in bytes."
 msgstr "Tamanho do ficheiro do meio em bytes."
 
 #. IDS_COLDESC_LSIZE_SHORT
-#: Merge.rc:5108
+#: Merge.rc:5107
 msgid "Left file size abbreviated."
 msgstr "Tamanho do ficheiro esquerdo abreviado."
 
 #. IDS_COLDESC_RSIZE_SHORT
-#: Merge.rc:5109
+#: Merge.rc:5108
 msgid "Right file size abbreviated."
 msgstr "Tamanho do ficheiro direito abreviado."
 
 #. IDS_COLDESC_MSIZE_SHORT
-#: Merge.rc:5110
+#: Merge.rc:5109
 msgid "Middle file size abbreviated."
 msgstr "Tamanho do ficheiro do meio abreviado."
 
 #. IDS_COLDESC_LTIMEC
-#: Merge.rc:5116
+#: Merge.rc:5115
 msgid "Left side creation time."
 msgstr "Data de criação do lado esquerdo."
 
 #. IDS_COLDESC_RTIMEC
-#: Merge.rc:5117
+#: Merge.rc:5116
 msgid "Right side creation time."
 msgstr "Data de criação do lado direito."
 
 #. IDS_COLDESC_MTIMEC
-#: Merge.rc:5118
+#: Merge.rc:5117
 msgid "Middle side creation time."
 msgstr "Data de criação do meio."
 
 #. IDS_COLDESC_NEWER
-#: Merge.rc:5119
+#: Merge.rc:5118
 msgid "Tells which side has newer modification date."
 msgstr "Indica o lado com a data de modificação mais recente."
 
 #. IDS_COLDESC_LVERSION
-#: Merge.rc:5120
+#: Merge.rc:5119
 msgid "Left side file version, only for some file types."
 msgstr "Versão do ficheiro do lado esquerdo, apenas para alguns tipos de ficheiro."
 
 #. IDS_COLDESC_RVERSION
-#: Merge.rc:5121
+#: Merge.rc:5120
 msgid "Right side file version, only for some file types."
 msgstr "Versão do ficheiro do lado direito, apenas para alguns tipos de ficheiro."
 
 #. IDS_COLDESC_MVERSION
-#: Merge.rc:5126
+#: Merge.rc:5125
 msgid "Middle side file version, only for some file types."
 msgstr "Versão do ficheiro do meio, apenas para alguns tipos de ficheiro."
 
 #. IDS_COLDESC_RESULT_ABBR
-#: Merge.rc:5127
+#: Merge.rc:5126
 msgid "Short comparison result."
 msgstr "Resultado resumido da comparação."
 
 #. IDS_COLDESC_LATTRIBUTES
-#: Merge.rc:5128
+#: Merge.rc:5127
 msgid "Left side attributes."
 msgstr "Atributos do lado esquerdo."
 
 #. IDS_COLDESC_RATTRIBUTES
-#: Merge.rc:5129
+#: Merge.rc:5128
 msgid "Right side attributes."
 msgstr "Atributos do lado direito."
 
 #. IDS_COLDESC_MATTRIBUTES
-#: Merge.rc:5130
+#: Merge.rc:5129
 msgid "Middle side attributes."
 msgstr "Atributos do meio."
 
 #. IDS_COLDESC_LEOL_TYPE
-#: Merge.rc:5131
+#: Merge.rc:5130
 msgid "Left side file EOL type."
 msgstr "Tipo de ficheiro EOL do lado esquerdo."
 
 #. IDS_COLDESC_REOL_TYPE
-#: Merge.rc:5132
+#: Merge.rc:5131
 msgid "Right side file EOL type."
 msgstr "Tipo de ficheiro EOL do lado direito."
 
 #. IDS_COLDESC_MEOL_TYPE
-#: Merge.rc:5133
+#: Merge.rc:5132
 msgid "Middle side file EOL type."
 msgstr "Tipo de ficheiro EOL do meio."
 
 #. IDS_COLDESC_LENCODING
-#: Merge.rc:5139
+#: Merge.rc:5138
 msgid "Left side encoding."
 msgstr "Codificação do lado esquerdo."
 
 #. IDS_COLDESC_RENCODING
-#: Merge.rc:5140
+#: Merge.rc:5139
 msgid "Right side encoding."
 msgstr "Codificação do lado direito."
 
 #. IDS_COLDESC_MENCODING
-#: Merge.rc:5141
+#: Merge.rc:5140
 msgid "Middle side encoding."
 msgstr "Codificação do meio."
 
 #. IDS_COLDESC_NIDIFFS
-#: Merge.rc:5142
+#: Merge.rc:5141
 msgid "Number of ignored differences in file. Ignored and cannot be merged."
 msgstr "Número de diferenças ignoradas no ficheiro. Estas diferenças são ignoradas pelo WinMerge e não podem ser fundidas."
 
 #. IDS_COLDESC_NSDIFFS
-#: Merge.rc:5143
+#: Merge.rc:5142
 msgid "Number of differences in file (excluding ignored)."
 msgstr "Número de diferenças no ficheiro. Este número não inclui diferenças ignoradas."
 
 #. IDS_COLDESC_BINARY
-#: Merge.rc:5144
+#: Merge.rc:5143
 msgid "Shows an asterisk (*) if the file is binary."
 msgstr "Apresenta um asterisco (*) se ficheiro for binário."
 
 #. IDS_COLDESC_UNPACKER
-#: Merge.rc:5145
+#: Merge.rc:5144
 msgid "Unpacker plugin name or pipeline."
 msgstr "Desempacotar nome de plugin ou pipeline."
 
 #. IDS_COLDESC_PREDIFFER
-#: Merge.rc:5146
+#: Merge.rc:5145
 msgid "Prediffer plugin name or pipeline."
 msgstr "Nome ou pipeline do plugin da pré-diferenciação."
 
 #. IDS_DIRECTORY_REPORT_TITLE
-#: Merge.rc:5152
+#: Merge.rc:5151
 #, c-format
 msgid "Compare %1 with %2"
 msgstr "Comparar %1 com %2"
 
 #. IDS_DIRECTORY_REPORT_TITLE3
-#: Merge.rc:5153
+#: Merge.rc:5152
 #, c-format
 msgid "Compare %1 with %2 and %3"
 msgstr "Comparar %1 com %2 e %3"
 
 #. IDS_REPORT_COMMALIST
-#: Merge.rc:5154
+#: Merge.rc:5153
 msgid "Comma-separated list"
 msgstr "Lista separada por vírgulas"
 
 #. IDS_REPORT_TABLIST
-#: Merge.rc:5155
+#: Merge.rc:5154
 msgid "Tab-separated list"
 msgstr "Lista de separadores"
 
 #. IDS_REPORT_SIMPLEHTML
-#: Merge.rc:5156
+#: Merge.rc:5155
 msgid "Simple HTML"
 msgstr "HTML simples"
 
 #. IDS_REPORT_SIMPLEXML
-#: Merge.rc:5157
+#: Merge.rc:5156
 msgid "Simple XML"
 msgstr "XML simples"
 
-#: Merge.rc:5159
+#: Merge.rc:5158
 msgid "Report file already exists. Overwrite?"
 msgstr "O ficheiro de relatório já existe. Pretende substituir o ficheiro existente?"
 
 #. IDS_REPORT_ERROR
-#: Merge.rc:5164
+#: Merge.rc:5163
 #, c-format
 msgid ""
 "Error creating the report:\n"
@@ -7219,27 +7214,27 @@ msgstr ""
 "%1"
 
 #. IDS_REPORT_SUCCESS
-#: Merge.rc:5165
+#: Merge.rc:5164
 msgid "Report created successfully."
 msgstr "O relatório foi criado com sucesso."
 
 #. IDS_SYNCPOINT_LASTBLOCK
-#: Merge.rc:5171
+#: Merge.rc:5170
 msgid "Cannot add a synchronization point at this line."
 msgstr "Não é possível adicionar um ponto de sincronização nesta linha."
 
 #. IDS_FILE_TO_ITSELF
-#: Merge.rc:5177
+#: Merge.rc:5176
 msgid "Same file is opened in both panes."
 msgstr "O mesmo ficheiro está aberto em ambos os painéis."
 
 #. IDS_FILESSAME
-#: Merge.rc:5178
+#: Merge.rc:5177
 msgid "Selected files are identical."
 msgstr "Os ficheiros selecionados são idênticos."
 
 #. IDS_FILESSAME_CURCFG
-#: Merge.rc:5179
+#: Merge.rc:5178
 msgid ""
 "Selected files are identical (with current settings).\r\n"
 "Checking binary identity..."
@@ -7248,7 +7243,7 @@ msgstr ""
 "A verificar a identidade binária..."
 
 #. IDS_FILESSAME_BINERROR
-#: Merge.rc:5180
+#: Merge.rc:5179
 msgid ""
 "Selected files are identical (with current settings).\r\n"
 "But binary comparison failed."
@@ -7257,12 +7252,12 @@ msgstr ""
 "Mas a comparação binária falhou."
 
 #. IDS_FILESSAME_BINSAME
-#: Merge.rc:5181
+#: Merge.rc:5180
 msgid "Selected files are identical (binary match)."
 msgstr "Os ficheiros selecionados são idênticos (correspondência binária)."
 
 #. IDS_FILESSAME_BINDIFF
-#: Merge.rc:5182
+#: Merge.rc:5181
 msgid ""
 "Selected files are identical (with current settings).\r\n"
 "But differ at the binary level."
@@ -7271,17 +7266,17 @@ msgstr ""
 "Mas diferem ao nível binário."
 
 #. IDS_FILEERROR
-#: Merge.rc:5183
+#: Merge.rc:5182
 msgid "An error occurred while comparing files."
 msgstr "Ocorreu um erro ao comparar os ficheiros."
 
 #. IDS_TEMP_FILEERROR
-#: Merge.rc:5184
+#: Merge.rc:5183
 msgid "Could not create temporary files. Check your temporary path settings."
 msgstr "Não é possível criar ficheiros temporários. Verifique as suas definições de ficheiros temporários."
 
 #. IDS_SUGGEST_IGNOREEOL
-#: Merge.rc:5185
+#: Merge.rc:5184
 msgid ""
 "Files use different EOL.\n"
 "\n"
@@ -7296,17 +7291,17 @@ msgstr ""
 "Defina 'Ignorar diferenças de EOL (Windows/Unix/Mac)' na secção Comparar das Opções."
 
 #. IDS_INVALID_DIRECTORY
-#: Merge.rc:5186
+#: Merge.rc:5185
 msgid "Selected folder is invalid."
 msgstr "A pasta selecionada é inválida."
 
 #. IDS_CANNOT_OPEN_BINARYFILE
-#: Merge.rc:5187
+#: Merge.rc:5186
 msgid "Cannot open a binary file in Editor."
 msgstr "Não é possível abrir ficheiro binário no editor."
 
 #. IDS_CREATE_PAIR_FOLDER
-#: Merge.rc:5188
+#: Merge.rc:5187
 #, c-format
 msgid ""
 "Create matching folder:\n"
@@ -7320,41 +7315,41 @@ msgstr ""
 "para o outro lado e abrir essas pastas?"
 
 #. IDS_CONFIRM_COPY_ALL_DIFFS
-#: Merge.rc:5189
+#: Merge.rc:5188
 msgid "Copy all differences to other file?"
 msgstr "Copiar todas as diferenças para o outro ficheiro?"
 
 #. IDS_MOVE_TO_NEXTFILE
-#: Merge.rc:5194
+#: Merge.rc:5193
 msgid "Move to next file?"
 msgstr "Deseja seguir para o próximo ficheiro?"
 
 #. IDS_MOVE_TO_PREVFILE
-#: Merge.rc:5195
+#: Merge.rc:5194
 msgid "Move to previous file?"
 msgstr "Deseja retroceder para o ficheiro anterior?"
 
 #. IDS_MOVE_TO_NEXTPAGE
-#: Merge.rc:5196
+#: Merge.rc:5195
 msgid "Move to next page?"
 msgstr "Deseja seguir para a próxima página?"
 
 #. IDS_MOVE_TO_PREVPAGE
-#: Merge.rc:5197
+#: Merge.rc:5196
 msgid "Move to previous page?"
 msgstr "Deseja retroceder para a página anterior?"
 
 #. IDS_MOVE_TO_FIRSTFILE
-#: Merge.rc:5198
+#: Merge.rc:5197
 msgid "Move to first file?"
 msgstr "Quer passar para o primeiro ficheiro?"
 
 #. IDS_MOVE_TO_LASTFILE
-#: Merge.rc:5199
+#: Merge.rc:5198
 msgid "Move to last file?"
 msgstr "Quer passar para o último ficheiro?"
 
-#: Merge.rc:5206
+#: Merge.rc:5205
 #, c-format
 msgid ""
 "Different codepages: left (cp%d), right (cp%d).\n"
@@ -7365,51 +7360,51 @@ msgstr ""
 "Apresentar cada ficheiro na sua página de código terá melhor visualização, mas combinar/copiar poderá ser arriscado.\\Deseja tratar os dois ficheiros como tendo as páginas de código "
 "predefinidas para as janelas?"
 
-#: Merge.rc:5208
+#: Merge.rc:5207
 msgid "Information lost due to encoding errors: both files"
 msgstr "Informações perdidas devido a erros de codificação: ambos os ficheiros"
 
-#: Merge.rc:5210
+#: Merge.rc:5209
 msgid "Information lost due to encoding errors: first file"
 msgstr "Informações perdidas devido a erros de codificação: primeiro ficheiro"
 
-#: Merge.rc:5212
+#: Merge.rc:5211
 msgid "Information lost due to encoding errors: second file"
 msgstr "Informações perdidas devido a erros de codificação: segundo ficheiro"
 
-#: Merge.rc:5214
+#: Merge.rc:5213
 msgid "Information lost due to encoding errors: third file"
 msgstr "Informações perdidas devido a erros de codificação: terceiro ficheiro"
 
 #. IDS_LINEDIFF_NODIFF
-#: Merge.rc:5220
+#: Merge.rc:5219
 msgid "No difference"
 msgstr "Sem diferenças"
 
 #. IDS_LINEDIFF_NODIFF_CAPTION
-#: Merge.rc:5221
+#: Merge.rc:5220
 msgid "Line difference"
 msgstr "Diferença de linha"
 
 #. IDS_NUM_REPLACED
-#: Merge.rc:5227
+#: Merge.rc:5226
 #, c-format
 msgid "Replaced %1 string(s)."
 msgstr "Substituída(s) %1 frase(s)."
 
 #. IDS_EDIT_TEXT_NOT_FOUND
-#: Merge.rc:5228
+#: Merge.rc:5227
 #, c-format
 msgid "Cannot find string \"%s\"."
 msgstr "Não é possível localizar frase \"%s\"."
 
 #. IDS_MERGE_MODE
-#: Merge.rc:5234
+#: Merge.rc:5233
 msgid "Entering Merge Mode. Press F9 to turn off."
 msgstr "Está a entrar no Modo de Fusão. Se pretende desligar o Modo de Fusão, prima a tecla F9."
 
 #. IDS_AUTO_MERGE
-#: Merge.rc:5240
+#: Merge.rc:5239
 #, c-format
 msgid ""
 "Automatic merges: %1\n"
@@ -7419,89 +7414,89 @@ msgstr ""
 "Número de conflitos não resolvidos: %2"
 
 #. IDS_CODEPAGE_MERGED
-#: Merge.rc:5241
+#: Merge.rc:5240
 msgid "Codepage change merged."
 msgstr "A alteração da página de código foi fundida."
 
 #. IDS_CODEPAGE_CONFLICT
-#: Merge.rc:5242
+#: Merge.rc:5241
 msgid "Codepage changes are conflicting."
 msgstr "As alterações da página de código estão em conflito."
 
 #. IDS_EOL_MERGED
-#: Merge.rc:5243
+#: Merge.rc:5242
 msgid "EOL change merged."
 msgstr "A alteração de EOL foi fundida."
 
 #. IDS_EOL_CONFLICT
-#: Merge.rc:5244
+#: Merge.rc:5243
 msgid "EOL changes are conflicting."
 msgstr "As alterações de EOL estão em conflito."
 
 #. IDS_LOCBAR_CAPTION
-#: Merge.rc:5250
+#: Merge.rc:5249
 msgid "Location Pane"
 msgstr "Painel de localização"
 
 #. IDS_DIFFBAR_CAPTION
-#: Merge.rc:5251
+#: Merge.rc:5250
 msgid "Diff Pane"
 msgstr "Painel de diferenças"
 
 #. IDS_DIFF_SUCCEEDED
-#: Merge.rc:5258
+#: Merge.rc:5257
 msgid "Patch file written."
 msgstr "Ficheiro de correção gravado com sucesso."
 
 #. IDS_DIFF_FILEOVERWRITE
-#: Merge.rc:5259
+#: Merge.rc:5258
 msgid "Patch file already exists. Overwrite?"
 msgstr "O ficheiro de correção já existe. Deseja substituí-lo?"
 
 #. IDS_DIFF_SELECTEDFILES
-#: Merge.rc:5260
+#: Merge.rc:5259
 #, c-format
 msgid "[%1 files selected]"
 msgstr "[%1 itens selecionados]"
 
 #. IDS_DIFF_NORMAL
-#: Merge.rc:5261
+#: Merge.rc:5260
 msgid "Normal"
 msgstr "Normal"
 
 #. IDS_DIFF_CONTEXT
-#: Merge.rc:5262
+#: Merge.rc:5261
 msgid "Context"
 msgstr "Contexto"
 
 #. IDS_DIFF_UNIFIED
-#: Merge.rc:5263
+#: Merge.rc:5262
 msgid "Unified"
 msgstr "Unificado"
 
 #. IDS_FILEWRITE_ERROR
-#: Merge.rc:5265
+#: Merge.rc:5264
 #, c-format
 msgid "Could not write to file %1."
 msgstr "Não é possível gravar para o ficheiro %1."
 
 #. IDS_PATH_NOT_ABSOLUTE
-#: Merge.rc:5266
+#: Merge.rc:5265
 #, c-format
 msgid "Output path is not absolute: %1"
 msgstr "A localização de destino não é uma localização absoluta: %1"
 
 #. IDS_MUST_SPECIFY_OUTPUT
-#: Merge.rc:5267
+#: Merge.rc:5266
 msgid "Specify an output file."
 msgstr "Especifique o ficheiro de destino."
 
-#: Merge.rc:5269
+#: Merge.rc:5268
 msgid "Cannot create patch from binary files."
 msgstr "Não é possível criar um ficheiro de correção a partir de ficheiros binários."
 
 #. IDS_SAVEFILES_FORPATCH
-#: Merge.rc:5270
+#: Merge.rc:5269
 msgid ""
 "Save all files first.\n"
 "\n"
@@ -7512,22 +7507,22 @@ msgstr ""
 "Criar um ficheiro de correção requer a inexistência de alterações por guardar nos ficheiros."
 
 #. IDS_FOLDER_NOTEXIST
-#: Merge.rc:5271
+#: Merge.rc:5270
 msgid "Folder does not exist."
 msgstr "A pasta não existe."
 
 #. IDS_ARCHIVE_SUCCEEDED
-#: Merge.rc:5277
+#: Merge.rc:5276
 msgid "Archive file written."
 msgstr ""
 
 #. IDS_ARCHIVE_SAVEFILES
-#: Merge.rc:5278
+#: Merge.rc:5277
 msgid "Save all files first.\n\nCreating an archive requires no unsaved changes."
 msgstr ""
 
 #. IDS_NO_ZIP_SUPPORT
-#: Merge.rc:5283
+#: Merge.rc:5282
 msgid ""
 "Archive support not enabled.\n"
 "7-Zip and/or Merge7z*.dll not found.\n"
@@ -7538,37 +7533,37 @@ msgstr ""
 "Ver manual para mais informações sobre suporte de arquivo e como o ativar."
 
 #. IDS_OPT_EXPORT_CAPTION
-#: Merge.rc:5284
+#: Merge.rc:5283
 msgid "Select file for export"
 msgstr "Selecione ficheiro a exportar"
 
 #. IDS_OPT_IMPORT_CAPTION
-#: Merge.rc:5285
+#: Merge.rc:5284
 msgid "Select file for import"
 msgstr "Selecione ficheiro a importar"
 
 #. IDS_OPT_IMPORT_DONE
-#: Merge.rc:5286
+#: Merge.rc:5285
 msgid "Options imported from file."
 msgstr "Opções importadas do ficheiro."
 
 #. IDS_OPT_EXPORT_DONE
-#: Merge.rc:5287
+#: Merge.rc:5286
 msgid "Options exported to file."
 msgstr "Opções exportadas para o ficheiro."
 
 #. IDS_OPT_IMPORT_ERR
-#: Merge.rc:5288
+#: Merge.rc:5287
 msgid "Failed to import options from file."
 msgstr "Falha ao importar opções do ficheiro."
 
 #. IDS_OPT_EXPORT_ERR
-#: Merge.rc:5289
+#: Merge.rc:5288
 msgid "Failed to write options to file."
 msgstr "Falha ao gravar opções para o ficheiro."
 
 #. IDS_CLOSEALL_WINDOWS
-#: Merge.rc:5290
+#: Merge.rc:5289
 msgid ""
 "Close multiple compare windows?\n"
 "\n"
@@ -7579,34 +7574,34 @@ msgstr ""
 "Deseja continuar?"
 
 #. IDS_EOL_BIN
-#: Merge.rc:5300
+#: Merge.rc:5299
 msgctxt "EOL Type"
 msgid "Binary"
 msgstr "Binário"
 
 #. IDS_MARKER_COLOR_FMT
-#: Merge.rc:5305
+#: Merge.rc:5304
 #, c-format
 msgid "Marker Color %d"
 msgstr "Cor do marcador %d"
 
 #. IDS_MARKER_NEW_PATTERN
-#: Merge.rc:5306
+#: Merge.rc:5305
 msgid "New Pattern"
 msgstr "Novo padrão"
 
 #. IDS_PLUGINSLIST_TYPE
-#: Merge.rc:5312
+#: Merge.rc:5311
 msgid "Type"
 msgstr "Tipo"
 
 #. IDS_PLUGINS_TYPE_EDITSCRIPT
-#: Merge.rc:5316
+#: Merge.rc:5315
 msgid "Editor script"
 msgstr "Script de edição"
 
 #. ID_SELECTLINEDIFF
-#: Merge.rc:5322
+#: Merge.rc:5321
 msgid ""
 "\n"
 "Difference in Current Line (F4)"
@@ -7615,7 +7610,7 @@ msgstr ""
 "Diferenças na linha atual (F4)"
 
 #. ID_OPTIONS
-#: Merge.rc:5323
+#: Merge.rc:5322
 msgid ""
 "\n"
 "Options"
@@ -7624,7 +7619,7 @@ msgstr ""
 "Opções"
 
 #. ID_REFRESH
-#: Merge.rc:5324
+#: Merge.rc:5323
 msgid ""
 "\n"
 "Refresh (F5)"
@@ -7633,7 +7628,7 @@ msgstr ""
 "Recarregar (F5)"
 
 #. ID_PREVDIFF
-#: Merge.rc:5330
+#: Merge.rc:5329
 msgid ""
 "\n"
 "Previous Difference (Alt+Up)"
@@ -7642,7 +7637,7 @@ msgstr ""
 "Diferença anterior (Alt+Cima)"
 
 #. ID_NEXTDIFF
-#: Merge.rc:5331
+#: Merge.rc:5330
 msgid ""
 "\n"
 "Next Difference (Alt+Down)"
@@ -7651,7 +7646,7 @@ msgstr ""
 "Diferença seguinte (Alt+Baixo)"
 
 #. ID_PREVCONFLICT
-#: Merge.rc:5332
+#: Merge.rc:5331
 msgid ""
 "\n"
 "Previous Conflict (Alt+Shift+Up)"
@@ -7660,7 +7655,7 @@ msgstr ""
 "Conflito Anterior (Alt+Shift+Cima)"
 
 #. ID_NEXTCONFLICT
-#: Merge.rc:5333
+#: Merge.rc:5332
 msgid ""
 "\n"
 "Next Conflict (Alt+Shift+Down)"
@@ -7669,7 +7664,7 @@ msgstr ""
 "Conflito Seguinte (Alt+Shift+Baixo)"
 
 #. ID_FIRSTDIFF
-#: Merge.rc:5338
+#: Merge.rc:5337
 msgid ""
 "\n"
 "First Difference (Alt+Home)"
@@ -7678,7 +7673,7 @@ msgstr ""
 "Primeira diferença (Alt+Home)"
 
 #. ID_CURDIFF
-#: Merge.rc:5339
+#: Merge.rc:5338
 msgid ""
 "\n"
 "Current Difference (Alt+Enter)"
@@ -7687,7 +7682,7 @@ msgstr ""
 "Diferença atual (Alt+Enter)"
 
 #. ID_LASTDIFF
-#: Merge.rc:5340
+#: Merge.rc:5339
 msgid ""
 "\n"
 "Last Difference (Alt+End)"
@@ -7696,7 +7691,7 @@ msgstr ""
 "Última diferença (Alt+End)"
 
 #. ID_L2R
-#: Merge.rc:5341
+#: Merge.rc:5340
 msgid ""
 "\n"
 "Copy to Right (Alt+Right)"
@@ -7705,7 +7700,7 @@ msgstr ""
 "Copiar para a direita (Alt+Direita)"
 
 #. ID_R2L
-#: Merge.rc:5342
+#: Merge.rc:5341
 msgid ""
 "\n"
 "Copy to Left (Alt+Left)"
@@ -7714,7 +7709,7 @@ msgstr ""
 "Copiar para a esquerda (Alt+Esquerda)"
 
 #. ID_L2RNEXT
-#: Merge.rc:5343
+#: Merge.rc:5342
 msgid ""
 "\n"
 "Copy to Right and Advance (Ctrl+Alt+Right)"
@@ -7723,7 +7718,7 @@ msgstr ""
 "Copiar para a direita e avançar (Ctrl+Alt+Direita)"
 
 #. ID_R2LNEXT
-#: Merge.rc:5344
+#: Merge.rc:5343
 msgid ""
 "\n"
 "Copy to Left and Advance (Ctrl+Alt+Left)"
@@ -7732,7 +7727,7 @@ msgstr ""
 "Copiar para a esquerda e avançar (Ctrl+Alt+Esquerda)"
 
 #. ID_ALL_RIGHT
-#: Merge.rc:5345
+#: Merge.rc:5344
 msgid ""
 "\n"
 "Copy All to Right"
@@ -7741,7 +7736,7 @@ msgstr ""
 "Copiar tudo para a direita"
 
 #. ID_ALL_LEFT
-#: Merge.rc:5346
+#: Merge.rc:5345
 msgid ""
 "\n"
 "Copy All to Left"
@@ -7750,7 +7745,7 @@ msgstr ""
 "Copiar tudo para a esquerda"
 
 #. ID_AUTO_MERGE
-#: Merge.rc:5347
+#: Merge.rc:5346
 msgid ""
 "\n"
 "Auto Merge (Ctrl+Alt+M)"
@@ -7759,7 +7754,7 @@ msgstr ""
 "Fundir automaticamente (Ctrl+Alt+M)"
 
 #. ID_FIRSTFILE
-#: Merge.rc:5348
+#: Merge.rc:5347
 msgid ""
 "\n"
 "First File"
@@ -7768,7 +7763,7 @@ msgstr ""
 "Primeiro ficheiro"
 
 #. ID_NEXTFILE
-#: Merge.rc:5349
+#: Merge.rc:5348
 msgid ""
 "\n"
 "Next File (Ctrl+F8)"
@@ -7777,7 +7772,7 @@ msgstr ""
 "Ficheiro seguinte (Ctrl+F8)"
 
 #. ID_LASTFILE
-#: Merge.rc:5350
+#: Merge.rc:5349
 msgid ""
 "\n"
 "Last File"
@@ -7786,7 +7781,7 @@ msgstr ""
 "Último ficheiro"
 
 #. ID_PREVFILE
-#: Merge.rc:5351
+#: Merge.rc:5350
 msgid ""
 "\n"
 "Previous File (Ctrl+F7)"
@@ -7795,142 +7790,142 @@ msgstr ""
 "Ficheiro anterior (Ctrl+F7)"
 
 #. IDS_UNPACK_AUTO
-#: Merge.rc:5358
+#: Merge.rc:5357
 msgid "Adapted unpacker applied to both files (one needs extension)."
 msgstr "O descompactador adotado aplica-se em ambos os ficheiros (apenas um ficheiro necessita de extensão)."
 
 #. IDS_NO_PREDIFFER
-#: Merge.rc:5359
+#: Merge.rc:5358
 msgid "No Prediffer (Normal)"
 msgstr "Sem pré-diferenciação (normal)"
 
 #. IDS_SUGGESTED_PLUGINS
-#: Merge.rc:5360
+#: Merge.rc:5359
 msgid "Suggested Plugins"
 msgstr "Plugins sugeridos"
 
 #. IDS_NOT_SUGGESTED_PLUGINS
-#: Merge.rc:5361
+#: Merge.rc:5360
 msgid "All Plugins"
 msgstr "Todos os plugins"
 
 #. IDS_PRIVATEBUILD_FMT
-#: Merge.rc:5367
+#: Merge.rc:5366
 #, c-format
 msgid "Private Build: %1"
 msgstr "Compilação Privada: %1"
 
 #. IDS_ALLRIGHTS_RESERVED
-#: Merge.rc:5368
+#: Merge.rc:5367
 msgid " - All rights reserved."
 msgstr " - Todos os direitos reservados."
 
 #. IDS_TITLE_PLUGINS_SETTINGS
-#: Merge.rc:5374
+#: Merge.rc:5373
 msgid "Plugin Settings"
 msgstr "Definições de plugins"
 
 #. IDS_NO_SCT_SCRIPTS
-#: Merge.rc:5376
+#: Merge.rc:5375
 msgid "WSH not found - .sct scripts disabled"
 msgstr "WSH não encontrado - scripts .sct desativados"
 
 #. IDS_LOCBAR_GOTOLINE_FMT
-#: Merge.rc:5384
+#: Merge.rc:5383
 #, c-format
 msgid "G&o to Line %1"
 msgstr "Ir para linha %1"
 
 #. IDS_GOTO_MOVED_LINE
-#: Merge.rc:5390
+#: Merge.rc:5389
 msgid "Go to Moved Line\tCtrl+Shift+G"
 msgstr "Ir para linha movida\tCtrl+Shift+G"
 
 #. IDS_AUTOCOMPLETE_DISABLED
-#: Merge.rc:5396
+#: Merge.rc:5395
 msgctxt "Options dialog|General|Open dialog Auto completion"
 msgid "Disabled"
 msgstr "Desativado"
 
 #. IDS_AUTOCOMPLETE_FILE_SYS
-#: Merge.rc:5397
+#: Merge.rc:5396
 msgid "From file system"
 msgstr "Do sistema de ficheiros"
 
 #. IDS_AUTOCOMPLETE_MRU
-#: Merge.rc:5398
+#: Merge.rc:5397
 msgid "From Most Recently Used list"
 msgstr "Da lista MRU"
 
 #. IDS_COLORSCHEME_PLAIN
-#: Merge.rc:5404
+#: Merge.rc:5403
 msgid "No Highlighting"
 msgstr "Sem destaque"
 
 #. IDS_COLORSCHEME_PO
-#: Merge.rc:5439
+#: Merge.rc:5438
 msgid "Portable Object"
 msgstr "Objeto portátil"
 
 #. IDS_COLORSCHEME_RSRC
-#: Merge.rc:5444
+#: Merge.rc:5443
 msgid "Resources"
 msgstr "Recursos"
 
 #. IDS_COLORSCHEME_SH
-#: Merge.rc:5448
+#: Merge.rc:5447
 msgid "Shell"
 msgstr "Contexto"
 
 #. IDS_CLOSE_LEFT_TABS
-#: Merge.rc:5469
+#: Merge.rc:5468
 msgid "Close &Left Tabs"
 msgstr "Fechar separadores da e&squerda"
 
 #. IDS_CLOSE_RIGHT_TABS
-#: Merge.rc:5470
+#: Merge.rc:5469
 msgid "Close R&ight Tabs"
 msgstr "Fechar separadores da d&ireita"
 
 #. IDS_CLOSE_OTHER_TABS
-#: Merge.rc:5471
+#: Merge.rc:5470
 msgid "Close &Other Tabs"
 msgstr "Fechar &outros separadores"
 
 #. IDS_TABBAR_AUTO_MAXWIDTH
-#: Merge.rc:5472
+#: Merge.rc:5471
 msgid "Enable &Auto Max Width"
 msgstr "Ativar largura máxima automática"
 
 #. IDS_WEBPAGE_MENU
-#: Merge.rc:5482
+#: Merge.rc:5481
 msgid "We&bpage"
 msgstr "&Página web"
 
 #. IDS_VIEW_WRAP_TEXT
-#: Merge.rc:5487
+#: Merge.rc:5486
 msgid "W&rap Text"
 msgstr "M&udança de linha"
 
 #. IDS_NOTINSTALLED
-#: Merge.rc:5492
+#: Merge.rc:5491
 #, c-format
 msgid "%1 is not installed."
 msgstr "O %1 não está instalado."
 
 #. IDS_CREATE_FOLDER
-#: Merge.rc:5497
+#: Merge.rc:5496
 #, c-format
 msgid "%1 does not exist. Create it?"
 msgstr "%1 não existe. Deseja criar?"
 
 #. IDS_CREATE_FOLDER_ERROR
-#: Merge.rc:5498
+#: Merge.rc:5497
 msgid "Failed to create folder."
 msgstr "Erro ao criar pasta."
 
 #. IDC_EXT_EDITOR_PATH
-#: Merge.rc:5503
+#: Merge.rc:5502
 msgid ""
 "Parameters:\n"
 "$file: Current file path\n"
@@ -7941,491 +7936,491 @@ msgstr ""
 "$linenum: Número da linha da posição atual do cursor"
 
 #. IDS_DIFF_ALGORITHM_DEFAULT
-#: Merge.rc:5508
+#: Merge.rc:5507
 msgid "default"
 msgstr "predefinição"
 
 #. IDS_DIFF_ALGORITHM_MINIMAL
-#: Merge.rc:5509
+#: Merge.rc:5508
 msgid "minimal"
 msgstr "mínimo"
 
 #. IDS_DIFF_ALGORITHM_PATIENCE
-#: Merge.rc:5510
+#: Merge.rc:5509
 msgid "patience"
 msgstr "paciência"
 
 #. IDS_DIFF_ALGORITHM_HISTOGRAM
-#: Merge.rc:5511
+#: Merge.rc:5510
 msgid "histogram"
 msgstr "histograma"
 
 #. IDS_DIFF_ALGORITHM_NONE
-#: Merge.rc:5512
+#: Merge.rc:5511
 msgid "none"
 msgstr "nenhum"
 
 #. IDS_RENDERING_MODE_GDI
-#: Merge.rc:5517
+#: Merge.rc:5516
 msgid "GDI"
 msgstr "GDI"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_DEFAULT
-#: Merge.rc:5518
+#: Merge.rc:5517
 msgid "DirectWrite Default"
 msgstr "DirectWrite Default"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_ALIASED
-#: Merge.rc:5519
+#: Merge.rc:5518
 msgid "DirectWrite Aliased"
 msgstr "DirectWrite Aliased"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_GDI_CLASSIC
-#: Merge.rc:5520
+#: Merge.rc:5519
 msgid "DirectWrite GDI Classic"
 msgstr "DirectWrite GDI Classic"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_GDI_NATURAL
-#: Merge.rc:5521
+#: Merge.rc:5520
 msgid "DirectWrite GDI Natural"
 msgstr "DirectWrite GDI Natural"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_NATURAL
-#: Merge.rc:5522
+#: Merge.rc:5521
 msgid "DirectWrite Natural"
 msgstr "DirectWrite Natural"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_NATURAL_SYMMETRIC
-#: Merge.rc:5523
+#: Merge.rc:5522
 msgid "DirectWrite Natural Symmetric"
 msgstr "DirectWrite Natural Symmetric"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_DISABLED
-#: Merge.rc:5528
+#: Merge.rc:5527
 msgctxt "Options dialog|General|Close windows with Esc"
 msgid "Disabled"
 msgstr "Desativado"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_1
-#: Merge.rc:5529
+#: Merge.rc:5528
 msgid "MDI child window or main window"
 msgstr "Sub-janela MDI ou janela principal"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_2
-#: Merge.rc:5530
+#: Merge.rc:5529
 msgid "MDI child window only"
 msgstr "Apenas sub-janela MDI"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_3
-#: Merge.rc:5531
+#: Merge.rc:5530
 msgid "Close main window if only one MDI child window"
 msgstr "Fecha a janela principal se houver apenas uma sub-janela MDI"
 
 #. IDS_DIFF_GROUP
-#: Merge.rc:5536
+#: Merge.rc:5535
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Diff"
 msgstr "Diferença"
 
 #. IDS_DIFF_HIGHLIGHT
-#: Merge.rc:5537
+#: Merge.rc:5536
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Highlight"
 msgstr "Destaque"
 
 #. IDS_DIFF_BLINK
-#: Merge.rc:5538
+#: Merge.rc:5537
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Blink"
 msgstr "Piscar"
 
 #. IDS_DIFF_BLOCKSIZE
-#: Merge.rc:5539
+#: Merge.rc:5538
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Block Size"
 msgstr "Tamanho do bloco"
 
 #. IDS_DIFF_BLOCKALPHA
-#: Merge.rc:5540
+#: Merge.rc:5539
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Block Alpha"
 msgstr "Bloco Alfa"
 
 #. IDS_DIFF_CDTHRESHOLD
-#: Merge.rc:5541
+#: Merge.rc:5540
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "CD Threshold"
 msgstr "Limiar do CD"
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION
-#: Merge.rc:5542
+#: Merge.rc:5541
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Ins/Del Detection"
 msgstr "Deteção Ins/Eli"
 
 #. IDS_OVERLAY_MODE_NONE
-#: Merge.rc:5543 Merge.rc:5548
+#: Merge.rc:5542 Merge.rc:5547
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "None"
 msgstr "Nenhum"
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION_VERTICAL
-#: Merge.rc:5544
+#: Merge.rc:5543
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Vertical"
 msgstr "Vertical"
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION_HORIZONTAL
-#: Merge.rc:5545
+#: Merge.rc:5544
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Horizontal"
 msgstr "Horizontal"
 
 #. IDS_OVERLAY_GROUP
-#: Merge.rc:5546
+#: Merge.rc:5545
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Overlay"
 msgstr "Sobreposição"
 
 #. IDS_OVERLAY_ALPHA
-#: Merge.rc:5547
+#: Merge.rc:5546
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha"
 msgstr "Alfa"
 
 #. IDS_OVERLAY_MODE_XOR
-#: Merge.rc:5549
+#: Merge.rc:5548
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "XOR"
 msgstr "XOR"
 
 #. IDS_OVERLAY_MODE_ALPHA
-#: Merge.rc:5550
+#: Merge.rc:5549
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha Blend"
 msgstr "Mistura Alfa"
 
 #. IDS_OVERLAY_MODE_ALPHA_ANIMATION
-#: Merge.rc:5551
+#: Merge.rc:5550
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha Animation"
 msgstr "Animação Alfa"
 
 #. IDS_ZOOM
-#: Merge.rc:5552
+#: Merge.rc:5551
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Zoom"
 msgstr "Zoom"
 
 #. IDS_PAGE
-#: Merge.rc:5553
+#: Merge.rc:5552
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Page:"
 msgstr "Página:"
 
 #. IDS_IMGCMP_STATUS_PT_RGBA_FMT
-#: Merge.rc:5554
+#: Merge.rc:5553
 #, c-format
 msgid "Pt: (%d, %d)  RGBA: (%d, %d, %d, %d)  "
 msgstr "Pt: (%d, %d)  RGBA: (%d, %d, %d, %d)  "
 
 #. IDS_IMGCMP_STATUS_DIST1_FMT
-#: Merge.rc:5555
+#: Merge.rc:5554
 #, c-format
 msgid "Dist: %g  "
 msgstr "Dist: %g  "
 
 #. IDS_IMGCMP_STATUS_DIST2_FMT
-#: Merge.rc:5556
+#: Merge.rc:5555
 #, c-format
 msgid "Dist: %g, %g  "
 msgstr "Dist: %g, %g  "
 
 #. IDS_IMGCMP_STATUS_PAGE_ZOOM_SIZE_BPP_FMT
-#: Merge.rc:5557
+#: Merge.rc:5556
 #, c-format
 msgid "Page: %d/%d  Zoom: %d%%  %dx%dpx  %dbpp  "
 msgstr "Página: %d/%d  Zoom: %d%%  %dx%dpx  %dbpp  "
 
 #. IDS_IMGCMP_STATUS_RC_FMT
-#: Merge.rc:5558
+#: Merge.rc:5557
 #, c-format
 msgid "Rc: (%d, %d)  "
 msgstr "Rc: (%d, %d)  "
 
 #. IDS_IMGCMP_STATUS_FLIPPED_FMT
-#: Merge.rc:5559
+#: Merge.rc:5558
 #, c-format
 msgid "Flipped: %s  "
 msgstr "Virada: %s  "
 
 #. IDS_IMGCMP_STATUS_ROTATED_FMT
-#: Merge.rc:5560
+#: Merge.rc:5559
 #, c-format
 msgid "Rotated: %d  "
 msgstr "Rodado: %d  "
 
 #. IDS_IMGCMP_REPORT_ALLPAGES
-#: Merge.rc:5561
+#: Merge.rc:5560
 msgid "All pages"
 msgstr "Todas as páginas"
 
 #. IDS_IGNSUB_STR1
-#: Merge.rc:5566
+#: Merge.rc:5565
 msgid "<Edit here>"
 msgstr "<Edit here>"
 
 #. IDS_IGNSUB_STR2
-#: Merge.rc:5567
+#: Merge.rc:5566
 msgid "No differences found to select"
 msgstr "Nenhuma diferença a selecionar encontrada"
 
 #. IDS_IGNSUB_STR3
-#: Merge.rc:5568
+#: Merge.rc:5567
 msgid "No differences found to add as substitution filter"
 msgstr "Nenhuma diferença encontrada para adicionar como filtro de substituição"
 
 #. IDS_IGNSUB_STR4
-#: Merge.rc:5569
+#: Merge.rc:5568
 msgid "The pair is already in the Substitution Filters list"
 msgstr "O par já está presente na lista de Filtros de substituição"
 
 #. IDS_IGNSUB_STR5
-#: Merge.rc:5570
+#: Merge.rc:5569
 msgid "Add this change to Substitution Filters?"
 msgstr "Adicionar esta alteração aos Filtros de substituição?"
 
 #. IDS_OCRRESULT_TEXTONLY
-#: Merge.rc:5575
+#: Merge.rc:5574
 msgid "Text only"
 msgstr "Apenas texto"
 
 #. IDS_OCRRESULT_POS_LINE
-#: Merge.rc:5576
+#: Merge.rc:5575
 msgid "Line-by-line position and text"
 msgstr "Posição e texto linha a linha"
 
 #. IDS_OCRRESULT_POS_WORD
-#: Merge.rc:5577
+#: Merge.rc:5576
 msgid "Word-by-word position and text"
 msgstr "Posição e texto palavra por palavra"
 
 #. IDS_USERDATAFOLDER_APPDATA
-#: Merge.rc:5582
+#: Merge.rc:5581
 msgid "AppData (Roaming) folder"
 msgstr "Pasta AppData (Roaming)"
 
 #. IDS_USERDATAFOLDER_INSTALL
-#: Merge.rc:5583
+#: Merge.rc:5582
 msgid "Install folder"
 msgstr "Pasta de instalação"
 
 #. IDS_USERDATAFOLDER_DOCUMENTS
-#: Merge.rc:5584
+#: Merge.rc:5583
 msgid "Documents folder"
 msgstr "Pasta de Documentos"
 
 #. IDS_SINGLEINSTANCE_DISABLED
-#: Merge.rc:5589
+#: Merge.rc:5588
 msgctxt "Options dialog|General|Single instance mode"
 msgid "Disabled"
 msgstr "Desativado"
 
 #. IDS_SINGLEINSTANCE_STR1
-#: Merge.rc:5590
+#: Merge.rc:5589
 msgid "Allow only one instance to run"
 msgstr "Permitir apenas uma execução"
 
 #. IDS_CLIPBOARD_HISTORY
-#: Merge.rc:5591
+#: Merge.rc:5590
 msgid "Clipboard &History"
 msgstr "&Histórico da área de transferência"
 
 #. IDS_SINGLEINSTANCE_STR2
-#: Merge.rc:5592
+#: Merge.rc:5591
 msgid "Allow only one instance; wait for termination"
 msgstr "Permitir apenas executar uma instância e esperar que a instância termine"
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_DISABLED
-#: Merge.rc:5597
+#: Merge.rc:5596
 msgctxt "Options dialog|General|Auto-reload modified files"
 msgid "Disabled"
 msgstr "Desativado"
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_STR1
-#: Merge.rc:5598
+#: Merge.rc:5597
 msgid "Only on window activated"
 msgstr "Apenas na janela ativada"
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_STR2
-#: Merge.rc:5599
+#: Merge.rc:5598
 msgid "Immediately"
 msgstr "Imediatamente"
 
 #. IDS_PLUGIN_ALL
-#: Merge.rc:5604
+#: Merge.rc:5603
 msgid "Al&l"
 msgstr "Tu&do"
 
 #. IDS_PLUGIN_OTHERS
-#: Merge.rc:5605
+#: Merge.rc:5604
 msgid "&Others"
 msgstr "&Outros"
 
-#: Merge.rc:5607
+#: Merge.rc:5606
 #, c-format
 msgid "Missing plugin name in pipeline: %1"
 msgstr "Nome de plugin ausente no pipeline do plugin: %1"
 
-#: Merge.rc:5609
+#: Merge.rc:5608
 #, c-format
 msgid "Missing quote in plugin pipeline: %1"
 msgstr "Marca de cotação em falta no pipeline do plugin: %1"
 
 #. IDS_PLUGIN_NAME_ALREADY_EXISTS
-#: Merge.rc:5610
+#: Merge.rc:5609
 #, c-format
 msgid "Plugin name '%1' already exists."
 msgstr "O nome do plugin '%1' já existe."
 
 #. IDS_PLUGIN_TITLE1
-#: Merge.rc:5611
+#: Merge.rc:5610
 msgid "Specify plugin arguments"
 msgstr "Especificar argumentos de plugin"
 
-#: Merge.rc:5613
+#: Merge.rc:5612
 #, c-format
 msgid "Plugin not found or invalid: %1"
 msgstr "Plugin não encontrado ou inválido: %1"
 
 #. IDS_PLUGIN_NOT_UNPACK
-#: Merge.rc:5614
+#: Merge.rc:5613
 #, c-format
 msgid "'%1' is not an unpacker plugin"
 msgstr "'%1' não é um plugin de descompactação"
 
 #. IDS_PLUGIN_NOT_PREDIFF
-#: Merge.rc:5615
+#: Merge.rc:5614
 #, c-format
 msgid "'%1' is not a prediffer plugin"
 msgstr "'%1' não é um plugin de pré-diferenciação"
 
-#: Merge.rc:5617
+#: Merge.rc:5616
 #, c-format
 msgid "Error prediffing '%1' with '%2'. Prediffing disabled."
 msgstr "Erro na pré-diferenciação de '%1' com '%2'. Pré-diferenciação desativada."
 
 #. IDS_PLUGIN_CIRCULAR_REFERENCE
-#: Merge.rc:5618
+#: Merge.rc:5617
 #, c-format
 msgid "Circular reference in plugin pipeline: %1"
 msgstr "Referência circular no pipeline do plugin: %1"
 
 #. IDS_PLUGIN_TYPE1
-#: Merge.rc:5619
+#: Merge.rc:5618
 msgid "URL Handler"
 msgstr "Gestor de URL"
 
 #. IDS_PLUGIN_TYPE2
-#: Merge.rc:5620
+#: Merge.rc:5619
 msgid "File Unpacker"
 msgstr "Descompactador de ficheiros"
 
 #. IDS_PLUGIN_TYPE3
-#: Merge.rc:5621
+#: Merge.rc:5620
 msgid "File or Folder Unpacker"
 msgstr "Desempacotador de ficheiros ou pastas"
 
 #. IDS_PLUGIN_TYPE5
-#: Merge.rc:5623
+#: Merge.rc:5622
 msgid "Alias for Unpacker"
 msgstr "Abreviatura para desempacotador"
 
 #. IDS_PLUGIN_TYPE6
-#: Merge.rc:5624
+#: Merge.rc:5623
 msgid "Alias for Prediffer"
 msgstr "Abreviatura para pé-diferenciação"
 
 #. IDS_PLUGIN_TYPE7
-#: Merge.rc:5625
+#: Merge.rc:5624
 msgid "Alias for Editor script"
 msgstr "Abreviatura para editor de scripts"
 
 #. IDS_PLUGIN_ALIAS_DESC
-#: Merge.rc:5626
+#: Merge.rc:5625
 #, c-format
 msgid "Alias for plugin pipeline '%1'"
 msgstr "Abreviatura para pipeline do plugin '%1'"
 
 #. IDS_PLUGIN_NEW_DESC
-#: Merge.rc:5627
+#: Merge.rc:5626
 msgid "New plugin description"
 msgstr "Nova descrição do plugin"
 
 #. IDS_PLUGIN_TARGETS_ALL
-#: Merge.rc:5628
+#: Merge.rc:5627
 msgid "All"
 msgstr "Tudo"
 
 #. IDS_PLUGIN_TARGETS_1ST
-#: Merge.rc:5629
+#: Merge.rc:5628
 msgid "1st"
 msgstr "1.º"
 
 #. IDS_PLUGIN_TARGETS_2ND
-#: Merge.rc:5630
+#: Merge.rc:5629
 msgid "2nd"
 msgstr "2.º"
 
 #. IDS_PLUGIN_TARGETS_3RD
-#: Merge.rc:5631
+#: Merge.rc:5630
 msgid "3rd"
 msgstr "3.º"
 
 #. IDS_PLUGIN_TARGETS_1ST_2ND
-#: Merge.rc:5632
+#: Merge.rc:5631
 msgid "1st and 2nd"
 msgstr "1.º e 2.º"
 
 #. IDS_PLUGIN_TARGETS_1ST_3RD
-#: Merge.rc:5633
+#: Merge.rc:5632
 msgid "1st and 3rd"
 msgstr "1.º e 3.º"
 
 #. IDS_PLUGIN_TARGETS_2ND_3RD
-#: Merge.rc:5634
+#: Merge.rc:5633
 msgid "2nd and 3rd"
 msgstr "2.º e 3.º"
 
 #. IDS_PLUGIN_CTRL_CLICK
-#: Merge.rc:5635
+#: Merge.rc:5634
 msgid "(Ctrl+Click to add to pipeline)"
 msgstr ""
 
 #. IDS_FILTER_APPLIED
-#: Merge.rc:5640
+#: Merge.rc:5639
 msgid "Filter applied"
 msgstr "Filtro aplicado"
 
 #. IDS_FILTERMENU_COMPARE
-#: Merge.rc:5645
+#: Merge.rc:5644
 #, c-format
 msgid "Compare %1"
 msgstr "Comparar %1"
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN2
-#: Merge.rc:5647
+#: Merge.rc:5646
 msgid "&Filter by This Column..."
 msgstr "&Filtrar por esta coluna..."
 
 #. IDS_CLIPBOARDHISTORY_TIME
-#: Merge.rc:5652
+#: Merge.rc:5651
 #, c-format
 msgid "Clipboard at %s"
 msgstr "Área de transferência em %s"
 
 #. IDS_CLIPBOARDHISTORY_DISABLED
-#: Merge.rc:5653
+#: Merge.rc:5652
 msgid ""
 "Clipboard history disabled.\r\n"
 "Enable: Windows logo key + V, then Turn on."
@@ -8433,115 +8428,115 @@ msgstr ""
 "O histórico da área de transferência está desativado.\r\n"
 "Para ativar o histórico da área de transferência, prima a tecla do logotipo do Windows + V e clique no botão Ativar."
 
-#: Merge.rc:5655
+#: Merge.rc:5654
 msgid "This system does not support clipboard history."
 msgstr "Este sistema não suporta o histórico da área de transferência."
 
-#: Merge.rc:5657
+#: Merge.rc:5656
 msgid "32-bit WinMerge does not support Clipboard Compare"
 msgstr "A versão de 32 bits do WinMerge não suporta a comparação da área de transferência"
 
 #. IDS_WEBVIEW2_RUNTIME_NOT_INSTALLED
-#: Merge.rc:5662
+#: Merge.rc:5661
 msgid "WebView2 runtime not installed. Download it?"
 msgstr "O runtime WebView2 não está instalado. Quer transferi-lo?"
 
 #. IDS_JUMPLIST_NEW_TEXT_COMPARE
-#: Merge.rc:5667
+#: Merge.rc:5666
 msgid "New Text Compare"
 msgstr "Nova comparação de textos"
 
 #. IDS_JUMPLIST_NEW_TABLE_COMPARE
-#: Merge.rc:5668
+#: Merge.rc:5667
 msgid "New Table Compare"
 msgstr "Nova comparação de tabelas"
 
 #. IDS_JUMPLIST_NEW_BINARY_COMPARE
-#: Merge.rc:5669
+#: Merge.rc:5668
 msgid "New Binary Compare"
 msgstr "Nova comparação de binários"
 
 #. IDS_JUMPLIST_NEW_IMAGE_COMPARE
-#: Merge.rc:5670
+#: Merge.rc:5669
 msgid "New Image Compare"
 msgstr "Nova comparação de imagens"
 
 #. IDS_JUMPLIST_NEW_WEBPAGE_COMPARE
-#: Merge.rc:5671
+#: Merge.rc:5670
 msgid "New Webpage Compare"
 msgstr "Nova comparação de páginas web"
 
 #. IDS_JUMPLIST_NEW_FOLDER_COMPARE
-#: Merge.rc:5672
+#: Merge.rc:5671
 msgid "New Folder Compare"
 msgstr "Nova comparação de pastas"
 
 #. IDS_JUMPLIST_CLIPBOARD_COMPARE
-#: Merge.rc:5673
+#: Merge.rc:5672
 msgid "Clipboard Compare"
 msgstr "Comparação da área de transferência"
 
 #. IDS_PREVIEWBAR_PRINT
-#: Merge.rc:5678
+#: Merge.rc:5677
 msgid "&Print..."
 msgstr "&Imprimir..."
 
 #. IDS_PREVIEWBAR_PREVPAGE
-#: Merge.rc:5680
+#: Merge.rc:5679
 msgid "Pre&v Page"
 msgstr "Pré-&visualizar página"
 
 #. IDS_PREVIEWBAR_TWOPAGE
-#: Merge.rc:5681
+#: Merge.rc:5680
 msgid "&Two Page"
 msgstr "&Duas páginas"
 
 #. IDS_PREVIEWBAR_ONEPAGE
-#: Merge.rc:5682
+#: Merge.rc:5681
 msgid "&One Page"
 msgstr "&Uma página"
 
 #. IDS_PREVIEWBAR_ZOOMIN
-#: Merge.rc:5683
+#: Merge.rc:5682
 msgid "Zoom &In"
 msgstr "&Ampliar"
 
 #. IDS_PREVIEWBAR_ZOOMOUT
-#: Merge.rc:5684
+#: Merge.rc:5683
 msgid "Zoom &Out"
 msgstr "&Reduzir"
 
 #. IDS_WEBPAGE_COMPARING
-#: Merge.rc:5690
+#: Merge.rc:5689
 msgid "Comparing..."
 msgstr "A comparar..."
 
 #. IDS_WEBPAGE_ZOOM
-#: Merge.rc:5691
+#: Merge.rc:5690
 msgid "Zoom:"
 msgstr "Zoom:"
 
 #. IDS_COPY_GRANULARITY_DIFFHUNK
-#: Merge.rc:5696
+#: Merge.rc:5695
 msgid "Diff hunk"
 msgstr "Diferenciar pedaço"
 
 #. IDS_COPY_GRANULARITY_INLINE
-#: Merge.rc:5697
+#: Merge.rc:5696
 msgid "Inline diff"
 msgstr "Diferença em linha"
 
 #. IDS_COPY_GRANULARITY_LINE
-#: Merge.rc:5698
+#: Merge.rc:5697
 msgid "Line"
 msgstr "Linha"
 
-#: Merge.rc:5699
+#: Merge.rc:5698
 msgid "Character"
 msgstr "Caráter"
 
 #. ID_MICE_PREVDIFF
-#: Merge.rc:5704
+#: Merge.rc:5703
 msgid ""
 "\n"
 "Previous Difference (Alt+Up)\n"
@@ -8554,7 +8549,7 @@ msgstr ""
 "(Alt+Roda para cima)"
 
 #. ID_MICE_NEXTDIFF
-#: Merge.rc:5705
+#: Merge.rc:5704
 msgid ""
 "\n"
 "Next Difference (Alt+Down)\n"
@@ -8567,7 +8562,7 @@ msgstr ""
 "(Alt+Roda para baixo)"
 
 #. ID_MICE_L2R
-#: Merge.rc:5706
+#: Merge.rc:5705
 msgid ""
 "\n"
 "Copy to Right (Alt+Right)\n"
@@ -8582,7 +8577,7 @@ msgstr ""
 "(Alt+Shift+Roda para baixo)"
 
 #. ID_MICE_R2L
-#: Merge.rc:5707
+#: Merge.rc:5706
 msgid ""
 "\n"
 "Copy to Left (Alt+Left)\n"
@@ -8597,7 +8592,7 @@ msgstr ""
 "(Alt+Shift+Roda para cima)"
 
 #. ID_MICE_L2RNEXT
-#: Merge.rc:5708
+#: Merge.rc:5707
 msgid ""
 "\n"
 "Copy to Right and Advance (Ctrl+Alt+Right)\n"
@@ -8610,7 +8605,7 @@ msgstr ""
 "(Ctrl+Alt+Shift+Roda para baixo)"
 
 #. ID_MICE_R2LNEXT
-#: Merge.rc:5709
+#: Merge.rc:5708
 msgid ""
 "\n"
 "Copy to Left and Advance (Ctrl+Alt+Left)\n"
@@ -8623,257 +8618,257 @@ msgstr ""
 "(Ctrl+Alt+Shift+Roda para cima)"
 
 #. IDS_LOG_COMPARING_2
-#: Merge.rc:5719
+#: Merge.rc:5718
 #, c-format
 msgid "Comparing %1 with %2"
 msgstr "A comparar %1 com %2"
 
 #. IDS_LOG_COMPARING_3
-#: Merge.rc:5720
+#: Merge.rc:5719
 #, c-format
 msgid "Comparing %1 with %2 and %3"
 msgstr "A comparar %1 com %2 e %3"
 
 #. IDS_LOG_COMPARE_COMPLETED
-#: Merge.rc:5721
+#: Merge.rc:5720
 msgid "Comparison completed"
 msgstr "Comparação concluída"
 
 #. IDS_LOG_COMPARE_ERROR_2
-#: Merge.rc:5722
+#: Merge.rc:5721
 #, c-format
 msgid "Failed to compare %1 with %2: "
 msgstr "Falha ao comparar %1 com %2: "
 
 #. IDS_LOG_COMPARE_ERROR_3
-#: Merge.rc:5723
+#: Merge.rc:5722
 #, c-format
 msgid "Failed to compare %1 with %2 and %3: "
 msgstr "Falha ao comparar %1 com %2 e %3: "
 
 #. IDS_LOG_FILE_SAVED
-#: Merge.rc:5724
+#: Merge.rc:5723
 msgid "File saved"
 msgstr "Ficheiro guardado"
 
 #. IDS_LOG_COPYING_FILES
-#: Merge.rc:5725
+#: Merge.rc:5724
 msgid "Copying files..."
 msgstr "A copiar ficheiros..."
 
 #. IDS_LOG_MOVING_FILES
-#: Merge.rc:5726
+#: Merge.rc:5725
 msgid "Moving files..."
 msgstr "A mover ficheiros..."
 
 #. IDS_LOG_DELETING_FILES
-#: Merge.rc:5727
+#: Merge.rc:5726
 msgid "Deleting files..."
 msgstr "A eliminar ficheiros..."
 
 #. IDS_LOG_RECYCLEBIN
-#: Merge.rc:5728
+#: Merge.rc:5727
 msgid "Recycle Bin"
 msgstr "Reciclagem"
 
 #. IDS_LOG_PERMANENTLY_DELETED
-#: Merge.rc:5729
+#: Merge.rc:5728
 msgid "Permanently deleted"
 msgstr "Eliminado permanentemente"
 
 #. IDS_LOG_FILEOPERATION_COMPLETED
-#: Merge.rc:5730
+#: Merge.rc:5729
 msgid "File operation completed successfully"
 msgstr "Operação de ficheiros concluída com sucesso"
 
 #. IDS_LOG_FILEOPERATION_CANCELED
-#: Merge.rc:5731
+#: Merge.rc:5730
 msgid "File operation canceled"
 msgstr "Operação de ficheiros cancelada"
 
 #. IDS_FILTER_ERROR_NO_ERROR
-#: Merge.rc:5736
+#: Merge.rc:5735
 msgid "No error"
 msgstr "Sem erros"
 
 #. IDS_FILTER_ERROR_EMPTY_EXPRESSION
-#: Merge.rc:5737
+#: Merge.rc:5736
 msgid "Filter expression is empty"
 msgstr "A expressão de filtro está vazia"
 
 #. IDS_FILTER_ERROR_UNKNOWN_CHAR
-#: Merge.rc:5738
+#: Merge.rc:5737
 msgid "Unknown character in filter expression"
 msgstr "Caracter desconhecido na expressão de filtro"
 
 #. IDS_FILTER_ERROR_UNTERMINATED_STRING
-#: Merge.rc:5739
+#: Merge.rc:5738
 msgid "Unterminated string literal"
 msgstr "Sequência de caracteres sem terminação"
 
 #. IDS_FILTER_ERROR_SYNTAX_ERROR
-#: Merge.rc:5740
+#: Merge.rc:5739
 msgid "Syntax error in filter expression"
 msgstr "Erro de sintaxe na expressão do filtro"
 
 #. IDS_FILTER_ERROR_PARSE_FAILURE
-#: Merge.rc:5741
+#: Merge.rc:5740
 msgid "Failed to parse filter expression"
 msgstr "Falha ao analisar a expressão do filtro"
 
 #. IDS_FILTER_ERROR_INVALID_LITERAL
-#: Merge.rc:5742
+#: Merge.rc:5741
 msgid "Invalid literal value"
 msgstr "Valor literal inválido"
 
 #. IDS_FILTER_ERROR_INVALID_REGULAR_EXPRESSION
-#: Merge.rc:5743
+#: Merge.rc:5742
 msgid "Invalid regular expression"
 msgstr "Expressão regular inválida"
 
 #. IDS_FILTER_ERROR_UNDEFINED_IDENTIFIER
-#: Merge.rc:5744
+#: Merge.rc:5743
 msgid "Undefined identifier"
 msgstr "Identificador indefinido"
 
 #. IDS_FILTER_ERROR_INVALID_ARGUMENT_COUNT
-#: Merge.rc:5745
+#: Merge.rc:5744
 msgid "Invalid number of arguments"
 msgstr "Número de argumentos inválido"
 
 #. IDS_FILTER_ERROR_FILTER_NAME_NOT_FOUND
-#: Merge.rc:5746
+#: Merge.rc:5745
 msgid "Filter name not found"
 msgstr "Nome de filtro não encontrado"
 
 #. IDS_FILTER_ERROR_DIVIDE_BY_ZERO
-#: Merge.rc:5747
+#: Merge.rc:5746
 msgid "Division by zero in filter expression"
 msgstr "Divisão por zero em expressão de filtro"
 
 #. IDS_FILTER_ERROR_UNKNOWN_ERROR
-#: Merge.rc:5748
+#: Merge.rc:5747
 msgid "Unknown error"
 msgstr "Erro desconhecido"
 
 #. IDS_FILTER_ERROR_INVALID_PROPERTY_NAME
-#: Merge.rc:5749
+#: Merge.rc:5748
 msgid "Invalid property name"
 msgstr "Nome de propriedade inválido"
 
 #. IDS_FILTER_ERROR_INVALID_DIRECTIVE
-#: Merge.rc:5750
+#: Merge.rc:5749
 msgid "Invalid directive"
 msgstr "Diretiva inválida"
 
 #. IDS_FILTER_OP_EQUALS
-#: Merge.rc:5755
+#: Merge.rc:5754
 msgid "Equals"
 msgstr "Igual a"
 
 #. IDS_FILTER_OP_NOT_EQUALS
-#: Merge.rc:5756
+#: Merge.rc:5755
 msgid "Does not equal"
 msgstr "Não é igual a"
 
 #. IDS_FILTER_OP_LESS_THAN
-#: Merge.rc:5757
+#: Merge.rc:5756
 msgid "Less than"
 msgstr "Menor que"
 
 #. IDS_FILTER_OP_LESS_EQUAL
-#: Merge.rc:5758
+#: Merge.rc:5757
 msgid "Less than or equal to"
 msgstr "Menor ou igual a"
 
 #. IDS_FILTER_OP_GREATER_EQUAL
-#: Merge.rc:5759
+#: Merge.rc:5758
 msgid "Greater than or equal to"
 msgstr "Maior ou igual a"
 
 #. IDS_FILTER_OP_GREATER_THAN
-#: Merge.rc:5760
+#: Merge.rc:5759
 msgid "Greater than"
 msgstr "Maior que"
 
 #. IDS_FILTER_OP_BETWEEN
-#: Merge.rc:5761
+#: Merge.rc:5760
 msgid "Between"
 msgstr "Entre"
 
 #. IDS_FILTER_OP_NOT_BETWEEN
-#: Merge.rc:5762
+#: Merge.rc:5761
 msgid "Not Between"
 msgstr "Não é entre"
 
 #. IDS_FILTER_OP_CONTAINS
-#: Merge.rc:5763
+#: Merge.rc:5762
 msgid "Contains"
 msgstr "Contém"
 
 #. IDS_FILTER_OP_NOT_CONTAINS
-#: Merge.rc:5764
+#: Merge.rc:5763
 msgid "Not Contains"
 msgstr "Não contém"
 
 #. IDS_FILTER_OP_RECONTAINS
-#: Merge.rc:5765
+#: Merge.rc:5764
 msgid "Contains (regex)"
 msgstr "Contém (regex)"
 
 #. IDS_FILTER_OP_NOT_RECONTAINS
-#: Merge.rc:5766
+#: Merge.rc:5765
 msgid "Not Contains (regex)"
 msgstr "Não contém (regex)"
 
 #. IDS_FILTER_OP_LIKE
-#: Merge.rc:5767
+#: Merge.rc:5766
 msgid "Match (wildcard)"
 msgstr "Correspondência (caractere)"
 
 #. IDS_FILTER_OP_NOT_LIKE
-#: Merge.rc:5768
+#: Merge.rc:5767
 msgid "Not match (wildcard)"
 msgstr "Sem correspondência (caractere)"
 
 #. IDS_FILTER_OP_MATCHES
-#: Merge.rc:5769
+#: Merge.rc:5768
 msgid "Match (regex)"
 msgstr "Correspondência (regex)"
 
 #. IDS_FILTER_OP_NOT_MATCHES
-#: Merge.rc:5770
+#: Merge.rc:5769
 msgid "Not match (regex)"
 msgstr "Sem correspondência (regex)"
 
 #. IDS_COLORMODE_LIGHT
-#: Merge.rc:5775
+#: Merge.rc:5774
 msgid "Light"
 msgstr "Claro"
 
 #. IDS_COLORMODE_DARK
-#: Merge.rc:5776
+#: Merge.rc:5775
 msgid "Dark"
 msgstr "Escuro"
 
 #. IDS_COLORMODE_FOLLOWSYSTEM
-#: Merge.rc:5777
+#: Merge.rc:5776
 msgid "Follow system"
 msgstr "Seguir o sistema"
 
 #. IDS_EXAMPLE
-#: Merge.rc:5782
+#: Merge.rc:5781
 #, c-format
 msgid "e.g. %1"
 msgstr "por exemplo, %1"
 
 #. IDS_DETECTED_PREVIOUS_CRASH
-#: Merge.rc:5787
+#: Merge.rc:5786
 msgid "WinMerge detected a previous crash. Please report this if possible."
 msgstr "O WinMerge detetou uma falha anterior. Se possível, informe-nos sobre isso."
 
 #. IDS_REGEX_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5792
+#: Merge.rc:5791
 msgid ""
 "# Regex replacement list\r\n"
 "# Format: regex<TAB>replacement\r\n"
@@ -8888,7 +8883,7 @@ msgstr ""
 "(\\d{4})-(\\d{2})-(\\d{2})\t$1_$2_$3\r\n"
 
 #. IDS_STRING_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5793
+#: Merge.rc:5792
 msgid ""
 "# Replacement list\r\n"
 "# Format: search<TAB>replacement\r\n"
@@ -8905,22 +8900,22 @@ msgstr ""
 "de2\tpara2\r\n"
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_ONLY
-#: Merge.rc:5798
+#: Merge.rc:5797
 msgid "Built-in only"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_FIRST
-#: Merge.rc:5799
+#: Merge.rc:5798
 msgid "Built-in first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_FIRST
-#: Merge.rc:5800
+#: Merge.rc:5799
 msgid "Tree-sitter first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_ONLY
-#: Merge.rc:5801
+#: Merge.rc:5800
 msgid "Tree-sitter only"
 msgstr ""
 

--- a/Translations/WinMerge/Romanian.po
+++ b/Translations/WinMerge/Romanian.po
@@ -22,7 +22,7 @@ msgstr ""
 "X-Generator: Poedit 3.4.1\n"
 
 #. LANGUAGE, SUBLANGUAGE
-#: Merge.rc:26 Merge.rc:59 Merge.rc:5818
+#: Merge.rc:26 Merge.rc:59 Merge.rc:5817
 msgid "LANG_ENGLISH, SUBLANG_ENGLISH_US"
 msgstr "LANG_ROMANIAN, SUBLANG_DEFAULT"
 
@@ -164,7 +164,7 @@ msgstr "&Script-uri"
 #. IDS_NO_EDIT_SCRIPTS
 #: Merge.rc:127 Merge.rc:352 Merge.rc:463 Merge.rc:673 Merge.rc:678
 #: Merge.rc:887 Merge.rc:899 Merge.rc:906 Merge.rc:963 Merge.rc:1210
-#: Merge.rc:5375
+#: Merge.rc:5374
 msgid "< Empty >"
 msgstr "< Gol >"
 
@@ -229,7 +229,7 @@ msgid "Auto-Fit All Columns"
 msgstr "Ajustează automat toate coloanele"
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN
-#: Merge.rc:153 Merge.rc:5646
+#: Merge.rc:153 Merge.rc:5645
 msgid "&Filter by This Column"
 msgstr ""
 
@@ -290,7 +290,7 @@ msgid "&Previous Page"
 msgstr "Pagina &precedentă"
 
 #. IDS_PREVIEWBAR_NEXTPAGE
-#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5679
+#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5678
 msgid "&Next Page"
 msgstr "Pagina următoare"
 
@@ -541,7 +541,7 @@ msgstr "&Binar"
 #. IDS_IMAGE_MENU
 #: Merge.rc:329 Merge.rc:338 Merge.rc:432 Merge.rc:441 Merge.rc:609
 #: Merge.rc:618 Merge.rc:670 Merge.rc:960 Merge.rc:1187 Merge.rc:1200
-#: Merge.rc:5477
+#: Merge.rc:5476
 msgid "&Image"
 msgstr "&Imagine"
 
@@ -663,7 +663,7 @@ msgid "&Huge"
 msgstr "Uriaș"
 
 #. IDS_VIEW_MENU_BAR
-#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5714
+#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5713
 msgid "Men&u Bar"
 msgstr ""
 
@@ -1318,7 +1318,7 @@ msgid "Lo&cation Pane"
 msgstr "Panoul cu lo&cația"
 
 #. IDS_OUTPUTBAR_CAPTION
-#: Merge.rc:782 Merge.rc:5252
+#: Merge.rc:782 Merge.rc:5251
 msgid "Output Pane"
 msgstr ""
 
@@ -1581,55 +1581,55 @@ msgid "Co&mpare As"
 msgstr "Co&mpară ca"
 
 #. IDS_COPY_LEFT_TO_MIDDLE2
-#: Merge.rc:968 Merge.rc:980 Merge.rc:4852
+#: Merge.rc:968 Merge.rc:980 Merge.rc:4851
 #, c-format
 msgid "Left to Middle (%1 of %2)"
 msgstr "Stânga cu mijlocul (%1 din %2)"
 
 #. IDS_COPY_LEFT_TO_RIGHT2
-#: Merge.rc:969 Merge.rc:981 Merge.rc:4851
+#: Merge.rc:969 Merge.rc:981 Merge.rc:4850
 #, c-format
 msgid "Left to Right (%1 of %2)"
 msgstr "De la stânga la dreapta (%1 din %2)"
 
 #. IDS_MOVE_LEFT_TO2
-#: Merge.rc:970 Merge.rc:982 Merge.rc:1045 Merge.rc:4863 Merge.rc:4892
+#: Merge.rc:970 Merge.rc:982 Merge.rc:1045 Merge.rc:4862 Merge.rc:4891
 #, c-format
 msgid "Left to... (%1 of %2)"
 msgstr "Stânga la... (%1 din %2)"
 
 #. IDS_COPY_MIDDLE_TO_LEFT2
-#: Merge.rc:971 Merge.rc:983 Merge.rc:4849
+#: Merge.rc:971 Merge.rc:983 Merge.rc:4848
 #, c-format
 msgid "Middle to Left (%1 of %2)"
 msgstr "Mijlocul cu stânga (%1 din %2)"
 
 #. IDS_COPY_MIDDLE_TO_RIGHT2
-#: Merge.rc:972 Merge.rc:984 Merge.rc:4850
+#: Merge.rc:972 Merge.rc:984 Merge.rc:4849
 #, c-format
 msgid "Middle to Right (%1 of %2)"
 msgstr "Mijlocul cu dreapta (%1 din %2)"
 
 #. IDS_MOVE_MIDDLE_TO2
-#: Merge.rc:973 Merge.rc:985 Merge.rc:1046 Merge.rc:4864 Merge.rc:4893
+#: Merge.rc:973 Merge.rc:985 Merge.rc:1046 Merge.rc:4863 Merge.rc:4892
 #, c-format
 msgid "Middle to... (%1 of %2)"
 msgstr "Mijlocul cu... (%1 from %2)"
 
 #. IDS_COPY_RIGHT_TO_MIDDLE2
-#: Merge.rc:974 Merge.rc:986 Merge.rc:4848
+#: Merge.rc:974 Merge.rc:986 Merge.rc:4847
 #, c-format
 msgid "Right to Middle (%1 of %2)"
 msgstr "Dreapta cu mijlocul (%1 din %2)"
 
 #. IDS_COPY_RIGHT_TO_LEFT2
-#: Merge.rc:975 Merge.rc:987 Merge.rc:4847
+#: Merge.rc:975 Merge.rc:987 Merge.rc:4846
 #, c-format
 msgid "Right to Left (%1 of %2)"
 msgstr "De la dreapta la stânga (%1 din %2)"
 
 #. IDS_MOVE_RIGHT_TO2
-#: Merge.rc:976 Merge.rc:988 Merge.rc:1047 Merge.rc:4865 Merge.rc:4894
+#: Merge.rc:976 Merge.rc:988 Merge.rc:1047 Merge.rc:4864 Merge.rc:4893
 #, c-format
 msgid "Right to... (%1 of %2)"
 msgstr "Dreapta la... (%1 din %2)"
@@ -1685,31 +1685,31 @@ msgid "Cop&y Paths"
 msgstr "Cop&ie căile de fișier"
 
 #. IDS_DEL_LEFT_FMT2
-#: Merge.rc:1026 Merge.rc:1035 Merge.rc:4880
+#: Merge.rc:1026 Merge.rc:1035 Merge.rc:4879
 #, c-format
 msgid "Left (%1 of %2)"
 msgstr "Stânga (%1 din %2)"
 
 #. IDS_DEL_MIDDLE_FMT2
-#: Merge.rc:1027 Merge.rc:1036 Merge.rc:4881
+#: Merge.rc:1027 Merge.rc:1036 Merge.rc:4880
 #, c-format
 msgid "Middle (%1 of %2)"
 msgstr "Mijloc (%1 din %2)"
 
 #. IDS_DEL_RIGHT_FMT2
-#: Merge.rc:1028 Merge.rc:1037 Merge.rc:4882
+#: Merge.rc:1028 Merge.rc:1037 Merge.rc:4881
 #, c-format
 msgid "Right (%1 of %2)"
 msgstr "Dreapta (%1 din %2)"
 
 #. IDS_DEL_BOTH_FMT2
-#: Merge.rc:1029 Merge.rc:1038 Merge.rc:4883
+#: Merge.rc:1029 Merge.rc:1038 Merge.rc:4882
 #, c-format
 msgid "Both (%1 of %2)"
 msgstr "Ambele (%1 din %2)"
 
 #. IDS_DEL_ALL_FMT2
-#: Merge.rc:1030 Merge.rc:1039 Merge.rc:4888
+#: Merge.rc:1030 Merge.rc:1039 Merge.rc:4887
 #, c-format
 msgid "All (%1 of %2)"
 msgstr "Toate (%1 din %2)"
@@ -1735,19 +1735,19 @@ msgid "&Zip"
 msgstr "Arhivea&ză"
 
 #. IDS_COPY_BOTH_TO2
-#: Merge.rc:1048 Merge.rc:4866
+#: Merge.rc:1048 Merge.rc:4865
 #, c-format
 msgid "Both to... (%1 of %2)"
 msgstr "Ambele în... (%1 din %2)"
 
 #. IDS_COPY_ALL_TO2
-#: Merge.rc:1049 Merge.rc:4867
+#: Merge.rc:1049 Merge.rc:4866
 #, c-format
 msgid "All to... (%1 of %2)"
 msgstr "Toate în... (%1 of %2)"
 
 #. IDS_COPY_DIFFERENCES_TO2
-#: Merge.rc:1050 Merge.rc:4868
+#: Merge.rc:1050 Merge.rc:4867
 #, c-format
 msgid "Differences to... (%1 of %2)"
 msgstr "Diferențele în... (%1 din %2)"
@@ -1814,12 +1814,12 @@ msgstr "Setări dezarhivator"
 
 #. IDS_USERCHOICE_NONE
 #: Merge.rc:1088 Merge.rc:1094 Merge.rc:1836 Merge.rc:1840 Merge.rc:2031
-#: Merge.rc:2035 Merge.rc:5377
+#: Merge.rc:2035 Merge.rc:5376
 msgid "<None>"
 msgstr "<Deloc>"
 
 #. IDS_USERCHOICE_AUTOMATIC
-#: Merge.rc:1089 Merge.rc:1095 Merge.rc:5378
+#: Merge.rc:1089 Merge.rc:1095 Merge.rc:5377
 msgid "<Automatic>"
 msgstr "<Automat>"
 
@@ -2749,12 +2749,12 @@ msgid "Text files only"
 msgstr ""
 
 #. IDS_EOL_NONE
-#: Merge.rc:1667 Merge.rc:1918 Merge.rc:5304
+#: Merge.rc:1667 Merge.rc:1918 Merge.rc:5303
 msgid "None"
 msgstr "Nici unul"
 
 #. IDS_EOL_MIXED
-#: Merge.rc:1668 Merge.rc:5299
+#: Merge.rc:1668 Merge.rc:5298
 msgid "Mixed"
 msgstr "Amestecat"
 
@@ -3026,13 +3026,13 @@ msgstr ""
 
 #. IDS_DIFFERENT
 #: Merge.rc:1904 Merge.rc:1988 Merge.rc:2866 Merge.rc:3036 Merge.rc:3077
-#: Merge.rc:5058
+#: Merge.rc:5057
 msgid "Different"
 msgstr "Diferite"
 
 #. IDS_IDENTICAL
 #: Merge.rc:1905 Merge.rc:1989 Merge.rc:2865 Merge.rc:3055 Merge.rc:3116
-#: Merge.rc:5048
+#: Merge.rc:5047
 msgid "Identical"
 msgstr "Identice"
 
@@ -3052,7 +3052,7 @@ msgid "Missing"
 msgstr ""
 
 #. IDS_MOVED
-#: Merge.rc:1910 Merge.rc:5076
+#: Merge.rc:1910 Merge.rc:5075
 msgid "Moved"
 msgstr ""
 
@@ -3794,7 +3794,7 @@ msgid "&Use custom system colors"
 msgstr ""
 
 #. IDS_PRPCAT_SYSTEM
-#: Merge.rc:2565 Merge.rc:4559 Merge.rc:4560 Merge.rc:5007
+#: Merge.rc:2565 Merge.rc:4559 Merge.rc:4560 Merge.rc:5006
 msgid "System"
 msgstr "Sistem"
 
@@ -4198,7 +4198,7 @@ msgid "Items compared:"
 msgstr "Elemente comparate:"
 
 #. IDS_PREVIEWBAR_CLOSE
-#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5685
+#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5684
 msgid "&Close"
 msgstr "În&chide"
 
@@ -4824,7 +4824,7 @@ msgid "A&ppend timestamp"
 msgstr "Adaugă ora"
 
 #. IDS_CONFIRM_COPY_CAPTION
-#: Merge.rc:3214 Merge.rc:4915
+#: Merge.rc:3214 Merge.rc:4914
 msgid "Confirm Copy"
 msgstr "Confirmă copierea"
 
@@ -5061,7 +5061,7 @@ msgid "&Character Set..."
 msgstr "Set &caractere..."
 
 #. IDS_PRPCAT_IMAGE
-#: Merge.rc:3351 Merge.rc:4574 Merge.rc:5015
+#: Merge.rc:3351 Merge.rc:4574 Merge.rc:5014
 msgid "Image"
 msgstr "Imagine"
 
@@ -5459,7 +5459,7 @@ msgid "Project"
 msgstr "Proiect"
 
 #. IDS_COLHDR_NSDIFFS
-#: Merge.rc:4566 Merge.rc:4990
+#: Merge.rc:4566 Merge.rc:4989
 msgid "Differences"
 msgstr "Diferențe"
 
@@ -5609,12 +5609,12 @@ msgid "File Type"
 msgstr "Tip fișier"
 
 #. IDS_COLHDR_EXTENSION
-#: Merge.rc:4653 Merge.rc:4947
+#: Merge.rc:4653 Merge.rc:4946
 msgid "Extension"
 msgstr "Extensie"
 
 #. IDS_PRPCAT_MESSAGE
-#: Merge.rc:4659 Merge.rc:5019
+#: Merge.rc:4659 Merge.rc:5018
 msgid "Message"
 msgstr "Mesaj"
 
@@ -5654,7 +5654,7 @@ msgid "Hidden Items"
 msgstr "Elemente ascunse"
 
 #. IDS_PLUGINSLIST_NAME
-#: Merge.rc:4680 Merge.rc:5311
+#: Merge.rc:4680 Merge.rc:5310
 msgid "Name"
 msgstr "Nume"
 
@@ -5674,7 +5674,7 @@ msgid "[F] "
 msgstr "[F] "
 
 #. IDS_PLUGINSLIST_DESC
-#: Merge.rc:4684 Merge.rc:5313
+#: Merge.rc:4684 Merge.rc:5312
 msgid "Description"
 msgstr "Descriere"
 
@@ -5841,157 +5841,152 @@ msgstr "Rd: %s  Col: %d/%d  Car: %d/%d"
 msgid "  Sel: %d | %d"
 msgstr "  Sel: %d | %d"
 
-#. IDS_MERGEMODE_MERGING
-#: Merge.rc:4734
-msgid "Merge"
-msgstr "Fuziune"
-
 #. IDS_DIFF_NUMBER_STATUS_FMT
-#: Merge.rc:4735
+#: Merge.rc:4734
 #, c-format
 msgid "Difference %1 of %2"
 msgstr "Deferența %1 din %2"
 
 #. IDS_NO_DIFF_SEL_FMT
-#: Merge.rc:4736
+#: Merge.rc:4735
 #, c-format
 msgid "%1 Differences Found"
 msgstr "%1 diferențe găsite"
 
 #. IDS_1_DIFF_FOUND
-#: Merge.rc:4737
+#: Merge.rc:4736
 msgid "1 Difference Found"
 msgstr "O diferență găsită"
 
 #. IDS_NO_ERR_SEL_FMT
-#: Merge.rc:4738
+#: Merge.rc:4737
 #, c-format
 msgid "%1 Errors Found"
 msgstr ""
 
 #. IDS_1_ERR_FOUND
-#: Merge.rc:4739
+#: Merge.rc:4738
 msgid "1 Error Found"
 msgstr ""
 
 #. IDS_STATUSBAR_READONLY, Abbreviation from "Read Only"
-#: Merge.rc:4740
+#: Merge.rc:4739
 msgid "RO"
 msgstr "RO"
 
 #. IDS_DIRVIEW_STATUS_FMT_FOCUS
-#: Merge.rc:4746
+#: Merge.rc:4745
 #, c-format
 msgid "Item %1 of %2"
 msgstr "Element %1 din %2"
 
 #. IDS_DIRVIEW_STATUS_FMT_NOFOCUS
-#: Merge.rc:4747
+#: Merge.rc:4746
 #, c-format
 msgid "Items: %1"
 msgstr "Elemente: %1"
 
 #. IDS_DIRVIEW_STATUS_COMPARING
-#: Merge.rc:4748
+#: Merge.rc:4747
 msgid "Comparing items..."
 msgstr "Comparare elemente..."
 
 #. IDS_ITEMS_PER_SEC
-#: Merge.rc:4749
+#: Merge.rc:4748
 #, c-format
 msgid "%.1f[items/sec]"
 msgstr "%.1f[elem/sec]"
 
 #. IDS_ERROR_INCOMPARABLE
-#: Merge.rc:4755
+#: Merge.rc:4754
 msgid "Select two existing folders/files to compare."
 msgstr "Selectați două directoare sau fișiere existente pentru comparare."
 
 #. IDS_DIRSEL_TAG
-#: Merge.rc:4756
+#: Merge.rc:4755
 msgid "Folder Selection"
 msgstr "Selectare directoare"
 
 #. IDS_OPEN_FILESDIRS
-#: Merge.rc:4757
+#: Merge.rc:4756
 msgid "Select two (or three) folders/files to compare."
 msgstr ""
 "Selectați două (sau trei) directoare ori două (sau trei) fișiere pentru "
 "comparare."
 
 #. IDS_OPEN_LEFTINVALID
-#: Merge.rc:4758
+#: Merge.rc:4757
 msgid "Left (1st) path is invalid!"
 msgstr "Calea din stânga (1) este invalidă!"
 
 #. IDS_OPEN_MIDDLEINVALID
-#: Merge.rc:4759
+#: Merge.rc:4758
 msgid "Middle (2nd) path is invalid!"
 msgstr "Calea din mijloc (2) este invalidă!"
 
 #. IDS_OPEN_RIGHTINVALID2
-#: Merge.rc:4760
+#: Merge.rc:4759
 msgid "Right (2nd) path is invalid!"
 msgstr "Calea din dreapta (2) este invalidă!"
 
 #. IDS_OPEN_RIGHTINVALID3
-#: Merge.rc:4761
+#: Merge.rc:4760
 msgid "Right (3rd) path is invalid!"
 msgstr "Calea din dreapta (3) este invalidă!"
 
 #. IDS_OPEN_BOTHINVALID
-#: Merge.rc:4762
+#: Merge.rc:4761
 msgid "Both paths are invalid!"
 msgstr "Ambele căi sunt nevalide!"
 
-#: Merge.rc:4764
+#: Merge.rc:4763
 msgid "Left (1st) and Middle (2nd) paths are invalid!"
 msgstr "Căile din stânga (1) și mijloc (2) sunt invalide!"
 
 #. IDS_OPEN_LEFTRIGHTINVALID
-#: Merge.rc:4765
+#: Merge.rc:4764
 msgid "Left (1st) and Right (3rd) paths are invalid!"
 msgstr "Căile din stânga (1) și dreapta (3) sunt invalide!"
 
-#: Merge.rc:4767
+#: Merge.rc:4766
 msgid "Middle (2nd) and Right (3rd) paths are invalid!"
 msgstr "Căile din mijloc (2) și dreapta (3) sunt invalide!"
 
 #. IDS_OPEN_ALLINVALID
-#: Merge.rc:4768
+#: Merge.rc:4767
 msgid "All paths are invalid!"
 msgstr "Toate căile sunt invalide!"
 
 #. IDS_OPEN_UNPACKERDISABLED
-#: Merge.rc:4769
+#: Merge.rc:4768
 msgid "Only enabled for file comparisons"
 msgstr "Activat doar pentru comparare de fișiere"
 
 #. IDS_OPEN_MISMATCH
-#: Merge.rc:4770
+#: Merge.rc:4769
 msgid "Cannot compare file and folder!"
 msgstr "Nu se poate compara un fișier cu un director!"
 
 #. IDS_ERROR_FILE_NOT_FOUND
-#: Merge.rc:4776
+#: Merge.rc:4775
 #, c-format
 msgid "File not found: %1"
 msgstr "Fișier negăsit: %1"
 
 #. IDS_ERROR_FOLDER_NOT_FOUND
-#: Merge.rc:4777
+#: Merge.rc:4776
 #, c-format
 msgid "Folder not found: %1"
 msgstr ""
 
 #. IDS_ERROR_FILE_NOT_UNPACKED
-#: Merge.rc:4778
+#: Merge.rc:4777
 #, c-format
 msgid "File not unpacked: %1"
 msgstr "Fișier nedezarhivat: %1"
 
 #. IDS_ERROR_FILEOPEN
-#: Merge.rc:4779
+#: Merge.rc:4778
 #, c-format
 msgid ""
 "Cannot open file\n"
@@ -6005,12 +6000,12 @@ msgstr ""
 "%2"
 
 #. IDS_ERROR_CONF_RESOLVE
-#: Merge.rc:4780
+#: Merge.rc:4779
 msgid "Failed to parse conflict file."
 msgstr "Analizarea fișierului de conflicte a eșuat."
 
 #. IDS_NOT_CONFLICT_FILE
-#: Merge.rc:4781
+#: Merge.rc:4780
 #, c-format
 msgid "The file\n%1\nis not a conflict file."
 msgstr ""
@@ -6019,7 +6014,7 @@ msgstr ""
 "nu e un fișier de conflicte."
 
 #. IDS_COMPARE_LARGE_FILES
-#: Merge.rc:4782
+#: Merge.rc:4781
 msgid "Comparing large files requires significant memory.\nShow only comparison results (not file contents)?"
 msgstr ""
 "Sunteți pe cale să comparați fișiere foarte mari.\n"
@@ -6029,18 +6024,18 @@ msgstr ""
 "\n"
 
 #. IDS_SAVE_AS_TITLE
-#: Merge.rc:4788
+#: Merge.rc:4787
 msgid "Save As"
 msgstr "Salvează ca"
 
 #. IDS_SAVE_FMT
-#: Merge.rc:4789
+#: Merge.rc:4788
 #, c-format
 msgid "Save changes to %1?"
 msgstr "Salvează schimbările în %1?"
 
 #. IDS_SAVEREADONLY_FMT
-#: Merge.rc:4790
+#: Merge.rc:4789
 #, c-format
 msgid "%1 is read-only. Override? Or 'No' to save as new filename?"
 msgstr ""
@@ -6048,11 +6043,11 @@ msgstr ""
 "citire? (Apăsați nu ca să forțați redenumirea.)"
 
 #. IDS_ERROR_BACKUP
-#: Merge.rc:4791
+#: Merge.rc:4790
 msgid "Error backing up file"
 msgstr "Eroare la salvarea copiei de siguranță a fișierului"
 
-#: Merge.rc:4793
+#: Merge.rc:4792
 #, c-format
 msgid ""
 "Unable to backup original file:\n"
@@ -6066,7 +6061,7 @@ msgstr ""
 "Continuați oricum?"
 
 #. IDS_FILESAVE_FAILED
-#: Merge.rc:4794
+#: Merge.rc:4793
 #, c-format
 msgid "Saving file failed.\n%1\n%2\n\t- Use different filename (OK)\n\t- Abort (Cancel)?"
 msgstr ""
@@ -6077,7 +6072,7 @@ msgstr ""
 "\t- folosiți un alt nume de fișier (apăsați OK)\n"
 "\t- renunțați la operația curentă (apăsați Renunță)?"
 
-#: Merge.rc:4796
+#: Merge.rc:4795
 #, c-format
 msgid "Plugin '%2' cannot pack changes to left file into '%1'.\n\nOriginal unchanged. Save unpacked version?"
 msgstr ""
@@ -6088,7 +6083,7 @@ msgstr ""
 "\n"
 "Doriți să salvați versiunea nearhivată în alt fișier?"
 
-#: Merge.rc:4798
+#: Merge.rc:4797
 #, c-format
 msgid "Plugin '%2' cannot pack changes to middle file into '%1'.\n\nOriginal unchanged. Save unpacked version?"
 msgstr ""
@@ -6099,7 +6094,7 @@ msgstr ""
 "\n"
 "Doriți să salvați versiunea nearhivată în alt fișier?"
 
-#: Merge.rc:4800
+#: Merge.rc:4799
 #, c-format
 msgid "Plugin '%2' cannot pack changes to right file into '%1'.\n\nOriginal unchanged. Save unpacked version?"
 msgstr ""
@@ -6111,7 +6106,7 @@ msgstr ""
 "Doriți să salvați versiunea nearhivată în alt fișier?"
 
 #. IDS_FILECHANGED_ONDISK
-#: Merge.rc:4801
+#: Merge.rc:4800
 #, c-format
 msgid ""
 "Another application updated\n"
@@ -6127,7 +6122,7 @@ msgstr ""
 "Suprascrieți fișierul modificat?"
 
 #. IDS_SAVEREADONLY_MULTI
-#: Merge.rc:4802
+#: Merge.rc:4801
 #, c-format
 msgid ""
 "%1\n"
@@ -6138,7 +6133,7 @@ msgstr ""
 "protejat la scriere?"
 
 #. IDS_FILECHANGED_RESCAN
-#: Merge.rc:4803
+#: Merge.rc:4802
 #, c-format
 msgid "Another application updated\n%1\nsince last scan.\n\nReload?"
 msgstr ""
@@ -6149,22 +6144,22 @@ msgstr ""
 "Doriți să reîncărcați fișierul?"
 
 #. IDS_SAVE_LEFT_AS
-#: Merge.rc:4804
+#: Merge.rc:4803
 msgid "Save Left File As"
 msgstr "Salvează fișierul din stânga ca"
 
 #. IDS_SAVE_MIDDLE_AS
-#: Merge.rc:4805
+#: Merge.rc:4804
 msgid "Save Middle File As"
 msgstr "Salvează fișierul din mijloc ca"
 
 #. IDS_SAVE_RIGHT_AS
-#: Merge.rc:4806
+#: Merge.rc:4805
 msgid "Save Right File As"
 msgstr "Salvează fișierul din dreapta ca"
 
 #. IDS_FILE_DISAPPEARED
-#: Merge.rc:4811
+#: Merge.rc:4810
 #, c-format
 msgid ""
 "File\n"
@@ -6176,7 +6171,7 @@ msgstr ""
 "a dispărut. Vă rog salvați o copie a fișierului pentru a continua."
 
 #. IDS_VIEWS_OUTOFSYNC
-#: Merge.rc:4817
+#: Merge.rc:4816
 msgid ""
 "Cannot merge unsynched documents.\n"
 "\n"
@@ -6187,186 +6182,186 @@ msgstr ""
 "Reîmprospătați documentele înainte de a continua."
 
 #. IDS_BREAK_ON_WHITESPACE
-#: Merge.rc:4822
+#: Merge.rc:4821
 msgid "Break at whitespace"
 msgstr "Întrerupe la blanc"
 
 #. IDS_BREAK_ON_PUNCTUATION
-#: Merge.rc:4823
+#: Merge.rc:4822
 msgid "Break at whitespace or punctuation"
 msgstr "Întrerupe la blanc sau semn de punctuație"
 
 #. IDS_L2M
-#: Merge.rc:4829
+#: Merge.rc:4828
 msgid "Copy to &Middle\tAlt+Right"
 msgstr "Copiază în &mijloc\tAlt+Right"
 
 #. IDS_R2M
-#: Merge.rc:4830
+#: Merge.rc:4829
 msgid "Copy to &Middle\tAlt+Left"
 msgstr "Copiază în &mijloc\tAlt+Left"
 
 #. IDS_COPY_FROM_MIDDLE_R
-#: Merge.rc:4831
+#: Merge.rc:4830
 msgid "Copy from Middle\tAlt+Shift+Right"
 msgstr "Copiază din mijloc\tAlt+Shift+Right"
 
 #. IDS_COPY_FROM_MIDDLE_L
-#: Merge.rc:4832
+#: Merge.rc:4831
 msgid "Copy from Middle\tAlt+Shift+Left"
 msgstr "Copiază din mijloc\tAlt+Shift+Left"
 
 #. IDS_L2MNEXT
-#: Merge.rc:4833
+#: Merge.rc:4832
 msgid "Copy to Middle and Advance\tCtrl+Alt+Right"
 msgstr "Copiază în mijloc și avansează\tCtrl+Alt+Right"
 
 #. IDS_R2MNEXT
-#: Merge.rc:4834
+#: Merge.rc:4833
 msgid "Copy to Middle and Advance\tCtrl+Alt+Left"
 msgstr "Copiază în mijloc și avansează\tCtrl+Alt+Left"
 
 #. IDS_ALL_MIDDLE
-#: Merge.rc:4835
+#: Merge.rc:4834
 msgid "Copy All to Middle"
 msgstr "Copiază tot în mijloc"
 
 #. IDS_COPY_RIGHT_TO_LEFT
-#: Merge.rc:4841
+#: Merge.rc:4840
 #, c-format
 msgid "Right to Left (%1)"
 msgstr "Din dreapta în stânga (%1)"
 
 #. IDS_COPY_RIGHT_TO_MIDDLE
-#: Merge.rc:4842
+#: Merge.rc:4841
 #, c-format
 msgid "Right to Middle (%1)"
 msgstr "Din dreapta în mijloc (%1)"
 
 #. IDS_COPY_MIDDLE_TO_LEFT
-#: Merge.rc:4843
+#: Merge.rc:4842
 #, c-format
 msgid "Middle to Left (%1)"
 msgstr "Din mijloc în stânga (%1)"
 
 #. IDS_COPY_MIDDLE_TO_RIGHT
-#: Merge.rc:4844
+#: Merge.rc:4843
 #, c-format
 msgid "Middle to Right (%1)"
 msgstr "Din mijloc în dreapta (%1)"
 
 #. IDS_COPY_LEFT_TO_RIGHT
-#: Merge.rc:4845
+#: Merge.rc:4844
 #, c-format
 msgid "Left to Right (%1)"
 msgstr "Din stânga în dreapta (%1)"
 
 #. IDS_COPY_LEFT_TO_MIDDLE
-#: Merge.rc:4846
+#: Merge.rc:4845
 #, c-format
 msgid "Left to Middle (%1)"
 msgstr "Din stânga în mijloc (%1)"
 
 #. IDS_MOVE_LEFT_TO
-#: Merge.rc:4857 Merge.rc:4889
+#: Merge.rc:4856 Merge.rc:4888
 #, c-format
 msgid "Left to... (%1)"
 msgstr "Din stânga în... (%1)"
 
 #. IDS_MOVE_MIDDLE_TO
-#: Merge.rc:4858 Merge.rc:4890
+#: Merge.rc:4857 Merge.rc:4889
 #, c-format
 msgid "Middle to... (%1)"
 msgstr "Din mijloc în... (%1)"
 
 #. IDS_MOVE_RIGHT_TO
-#: Merge.rc:4859 Merge.rc:4891
+#: Merge.rc:4858 Merge.rc:4890
 #, c-format
 msgid "Right to... (%1)"
 msgstr "Din dreapta în... (%1)"
 
 #. IDS_COPY_BOTH_TO
-#: Merge.rc:4860
+#: Merge.rc:4859
 #, c-format
 msgid "Both to... (%1)"
 msgstr "Ambele în... (%1)"
 
 #. IDS_COPY_ALL_TO
-#: Merge.rc:4861
+#: Merge.rc:4860
 #, c-format
 msgid "All to... (%1)"
 msgstr "Toate în... (%1)"
 
 #. IDS_COPY_DIFFERENCES_TO
-#: Merge.rc:4862
+#: Merge.rc:4861
 #, c-format
 msgid "Differences to... (%1)"
 msgstr "Diferențele în... (%1)"
 
 #. IDS_ONLYDIFFITEMS_CONFIRM
-#: Merge.rc:4869
+#: Merge.rc:4868
 msgid "Some selected items are identical or skipped.\nProcess only items with differences?"
 msgstr ""
 
 #. IDS_DEL_LEFT_FMT
-#: Merge.rc:4875
+#: Merge.rc:4874
 #, c-format
 msgid "Left (%1)"
 msgstr "Stânga (%1)"
 
 #. IDS_DEL_MIDDLE_FMT
-#: Merge.rc:4876
+#: Merge.rc:4875
 #, c-format
 msgid "Middle (%1)"
 msgstr "Mijloc (%1)"
 
 #. IDS_DEL_RIGHT_FMT
-#: Merge.rc:4877
+#: Merge.rc:4876
 #, c-format
 msgid "Right (%1)"
 msgstr "Dreapta (%1)"
 
 #. IDS_DEL_BOTH_FMT
-#: Merge.rc:4878
+#: Merge.rc:4877
 #, c-format
 msgid "Both (%1)"
 msgstr "Ambele (%1)"
 
 #. IDS_DEL_ALL_FMT
-#: Merge.rc:4879
+#: Merge.rc:4878
 #, c-format
 msgid "All (%1)"
 msgstr "Tot (%1)"
 
 #. IDS_SELECT_DEST_LEFT
-#: Merge.rc:4895
+#: Merge.rc:4894
 msgid "Left Side - Select Destination Folder:"
 msgstr "Partea stângă - selectare director destinație:"
 
 #. IDS_SELECT_DEST_MIDDLE
-#: Merge.rc:4896
+#: Merge.rc:4895
 msgid "Middle Side - Select Destination Folder:"
 msgstr "Partea din mijloc - selectare director destinație:"
 
 #. IDS_SELECT_DEST_RIGHT
-#: Merge.rc:4897
+#: Merge.rc:4896
 msgid "Right Side - Select Destination Folder:"
 msgstr "Partea dreaptă - selectare director destinație:"
 
 #. IDS_FILES_AFFECTED_FMT
-#: Merge.rc:4898
+#: Merge.rc:4897
 #, c-format
 msgid "(%1 Files Affected)"
 msgstr "(%1 fișiere afectate)"
 
 #. IDS_FILES_AFFECTED_FMT2
-#: Merge.rc:4899
+#: Merge.rc:4898
 #, c-format
 msgid "(%1 of %2 Files Affected)"
 msgstr "(%1 din %2 fișiere afectate)"
 
 #. IDS_CONFIRM_DELETE_SINGLE
-#: Merge.rc:4905
+#: Merge.rc:4904
 #, c-format
 msgid ""
 "Are you sure you want to delete\n"
@@ -6378,18 +6373,18 @@ msgstr ""
 "%1 ?"
 
 #. IDS_CONFIRM_SINGLE_COPY
-#: Merge.rc:4906
+#: Merge.rc:4905
 msgid "Are you sure you want to copy?"
 msgstr "Sunteți sigur că vreți să copiați?"
 
 #. IDS_CONFIRM_MULTIPLE_COPY
-#: Merge.rc:4907
+#: Merge.rc:4906
 #, c-format
 msgid "Are you sure you want to copy %d items?"
 msgstr "Sunteți sigur că vreți să copiați %d elemente?"
 
 #. IDS_DIRCMP_NOTSYNC
-#: Merge.rc:4908
+#: Merge.rc:4907
 #, c-format
 msgid ""
 "Operation aborted!\n"
@@ -6409,48 +6404,48 @@ msgstr ""
 "Vă rugăm reîmprospătați compararea."
 
 #. IDS_CONFIRM_SINGLE_MOVE
-#: Merge.rc:4913
+#: Merge.rc:4912
 msgid "Are you sure you want to move?"
 msgstr "Sunteți sigur că vreți să mutați?"
 
 #. IDS_CONFIRM_MULTIPLE_MOVE
-#: Merge.rc:4914
+#: Merge.rc:4913
 #, c-format
 msgid "Are you sure you want to move %d items?"
 msgstr "Sunteți sigur că vreți să mutați %d elemente?"
 
 #. IDS_CONFIRM_MOVE_CAPTION
-#: Merge.rc:4916
+#: Merge.rc:4915
 msgid "Confirm Move"
 msgstr "Confirmați mutarea"
 
-#: Merge.rc:4918
+#: Merge.rc:4917
 msgid "Close the folder comparison window?"
 msgstr ""
 "Sunteți pe cale să închideți fereastra care compară directoarele. Sunteți "
 "sigur?"
 
-#: Merge.rc:4920
+#: Merge.rc:4919
 msgid "Close the folder comparison window, which took a long time?"
 msgstr ""
 
 #. IDS_ERROR_INVALID_DIR_FILE_NAME
-#: Merge.rc:4921
+#: Merge.rc:4920
 msgid "The file or folder name is invalid."
 msgstr "Numele fișierului sau al directorului este invalid."
 
 #. IDS_ERROR_EXECUTE_FILE
-#: Merge.rc:4927
+#: Merge.rc:4926
 #, c-format
 msgid "Failed to execute external editor: %1"
 msgstr "Execuția editorului extern a eșuat: %1"
 
 #. IDS_UNKNOWN_ARCHIVE_FORMAT
-#: Merge.rc:4933
+#: Merge.rc:4932
 msgid "Unknown archive format"
 msgstr "Format arhivă necunoscut"
 
-#: Merge.rc:4935
+#: Merge.rc:4934
 msgid ""
 "Failed to extract archive.\n"
 "Compare as text file?"
@@ -6459,749 +6454,749 @@ msgstr ""
 "Doriți să comparați arhivele ca fișiere text?"
 
 #. IDS_COLHDR_FILENAME
-#: Merge.rc:4941
+#: Merge.rc:4940
 msgid "Filename"
 msgstr "Nume fișier"
 
 #. IDS_COLHDR_DIR
-#: Merge.rc:4942
+#: Merge.rc:4941
 msgctxt "DirView|ColumnHeader"
 msgid "Folder"
 msgstr "Director"
 
 #. IDS_COLHDR_RESULT
-#: Merge.rc:4943
+#: Merge.rc:4942
 msgid "Comparison Result"
 msgstr "Rezultat comparare"
 
 #. IDS_COLHDR_LTIMEM
-#: Merge.rc:4944
+#: Merge.rc:4943
 msgid "Left Date"
 msgstr "Dată stânga"
 
 #. IDS_COLHDR_RTIMEM
-#: Merge.rc:4945
+#: Merge.rc:4944
 msgid "Right Date"
 msgstr "Dată dreapta"
 
 #. IDS_COLHDR_MTIMEM
-#: Merge.rc:4946
+#: Merge.rc:4945
 msgid "Middle Date"
 msgstr "Dată mijloc"
 
 #. IDS_COLHDR_LSIZE
-#: Merge.rc:4948
+#: Merge.rc:4947
 msgid "Left Size"
 msgstr "Mărime stânga"
 
 #. IDS_COLHDR_RSIZE
-#: Merge.rc:4949
+#: Merge.rc:4948
 msgid "Right Size"
 msgstr "Mărime dreapta"
 
 #. IDS_COLHDR_MSIZE
-#: Merge.rc:4954
+#: Merge.rc:4953
 msgid "Middle Size"
 msgstr "Mărime mijloc"
 
 #. IDS_COLHDR_RSIZE_SHORT
-#: Merge.rc:4955
+#: Merge.rc:4954
 msgid "Right Size (Short)"
 msgstr "Mărime dreapta (scurt)"
 
 #. IDS_COLHDR_LSIZE_SHORT
-#: Merge.rc:4956
+#: Merge.rc:4955
 msgid "Left Size (Short)"
 msgstr "Mărime stânga (scurt)"
 
 #. IDS_COLHDR_MSIZE_SHORT
-#: Merge.rc:4957
+#: Merge.rc:4956
 msgid "Middle Size (Short)"
 msgstr "Mărime mijloc (scurt)"
 
 #. IDS_COLHDR_LTIMEC
-#: Merge.rc:4963
+#: Merge.rc:4962
 msgid "Left Creation Time"
 msgstr "Timp creare stânga"
 
 #. IDS_COLHDR_RTIMEC
-#: Merge.rc:4964
+#: Merge.rc:4963
 msgid "Right Creation Time"
 msgstr "Timp creare dreapta"
 
 #. IDS_COLHDR_MTIMEC
-#: Merge.rc:4965
+#: Merge.rc:4964
 msgid "Middle Creation Time"
 msgstr "Timp creare mijloc"
 
 #. IDS_COLHDR_NEWER
-#: Merge.rc:4966
+#: Merge.rc:4965
 msgid "Newer File"
 msgstr "Fișier mai nou"
 
 #. IDS_COLHDR_LVERSION
-#: Merge.rc:4967
+#: Merge.rc:4966
 msgid "Left File Version"
 msgstr "Versiune fișier stânga"
 
 #. IDS_COLHDR_RVERSION
-#: Merge.rc:4968
+#: Merge.rc:4967
 msgid "Right File Version"
 msgstr "Versiune fișier dreapta"
 
 #. IDS_COLHDR_MVERSION
-#: Merge.rc:4969
+#: Merge.rc:4968
 msgid "Middle File Version"
 msgstr "Versiune fișier mijloc"
 
 #. IDS_COLHDR_RESULT_ABBR
-#: Merge.rc:4970
+#: Merge.rc:4969
 msgid "Short Result"
 msgstr "Rezultat scurt"
 
 #. IDS_COLHDR_LATTRIBUTES
-#: Merge.rc:4971
+#: Merge.rc:4970
 msgid "Left Attributes"
 msgstr "Atribute stânga"
 
 #. IDS_COLHDR_RATTRIBUTES
-#: Merge.rc:4972
+#: Merge.rc:4971
 msgid "Right Attributes"
 msgstr "Atribute dreapta"
 
 #. IDS_COLHDR_MATTRIBUTES
-#: Merge.rc:4973
+#: Merge.rc:4972
 msgid "Middle Attributes"
 msgstr "Atribute mijloc"
 
 #. IDS_COLHDR_LEOL_TYPE
-#: Merge.rc:4978
+#: Merge.rc:4977
 msgid "Left EOL"
 msgstr "EOL stânga"
 
 #. IDS_COLHDR_MEOL_TYPE
-#: Merge.rc:4979
+#: Merge.rc:4978
 msgid "Middle EOL"
 msgstr "EOL mijloc"
 
 #. IDS_COLHDR_REOL_TYPE
-#: Merge.rc:4980
+#: Merge.rc:4979
 msgid "Right EOL"
 msgstr "EOL dreapta"
 
 #. IDS_COLHDR_LENCODING
-#: Merge.rc:4986
+#: Merge.rc:4985
 msgid "Left Encoding"
 msgstr "Set de caractere stânga"
 
 #. IDS_COLHDR_RENCODING
-#: Merge.rc:4987
+#: Merge.rc:4986
 msgid "Right Encoding"
 msgstr "Set de caractere dreapta"
 
 #. IDS_COLHDR_MENCODING
-#: Merge.rc:4988
+#: Merge.rc:4987
 msgid "Middle Encoding"
 msgstr "Set de caractere mijloc"
 
 #. IDS_COLHDR_NIDIFFS
-#: Merge.rc:4989
+#: Merge.rc:4988
 msgid "Ignored Diff"
 msgstr "Diferențe ignorate"
 
 #. IDS_COLHDR_BINARY
-#: Merge.rc:4991
+#: Merge.rc:4990
 msgctxt "DirView|ColumnHeader"
 msgid "Binary"
 msgstr "Binar"
 
 #. IDS_PLUGINS_TYPE_UNPACKER
-#: Merge.rc:4992 Merge.rc:5314
+#: Merge.rc:4991 Merge.rc:5313
 msgid "Unpacker"
 msgstr "Dezarhivator"
 
 #. IDS_PLUGIN_TYPE4
-#: Merge.rc:4993 Merge.rc:5315 Merge.rc:5622
+#: Merge.rc:4992 Merge.rc:5314 Merge.rc:5621
 msgid "Prediffer"
 msgstr "Prediferențiator"
 
 #. IDS_COLHDR_LEFT
-#: Merge.rc:4994
+#: Merge.rc:4993
 msgid "Left"
 msgstr "Stânga"
 
 #. IDS_COLHDR_MIDDLE
-#: Merge.rc:4995
+#: Merge.rc:4994
 msgid "Middle"
 msgstr "Mijloc"
 
 #. IDS_COLHDR_RIGHT
-#: Merge.rc:4996
+#: Merge.rc:4995
 msgid "Right"
 msgstr "Dreapta"
 
 #. IDS_COLHDR_DIFF
-#: Merge.rc:4997
+#: Merge.rc:4996
 msgid "Diff"
 msgstr "Diferență"
 
 #. IDS_COLHDR_LEFT_DUPLICATE
-#: Merge.rc:4998
+#: Merge.rc:4997
 msgid "Left Duplicate Count"
 msgstr "Număr duplicate stânga"
 
 #. IDS_COLHDR_RIGHT_DUPLICATE
-#: Merge.rc:4999
+#: Merge.rc:4998
 msgid "Right Duplicate Count"
 msgstr "Număr duplicate dreapta"
 
 #. IDS_COLHDR_MIDDLE_DUPLICATE
-#: Merge.rc:5000
+#: Merge.rc:4999
 msgid "Middle Duplicate Count"
 msgstr "Număr duplicate mijloc"
 
 #. IDS_COLHDR_MOVE
-#: Merge.rc:5001
+#: Merge.rc:5000
 msgid "Move"
 msgstr "Mută"
 
 #. IDS_PRPCAT_AUDIO
-#: Merge.rc:5008
+#: Merge.rc:5007
 msgid "Audio"
 msgstr "Audio"
 
 #. IDS_PRPCAT_CALENDAR
-#: Merge.rc:5009
+#: Merge.rc:5008
 msgid "Calendar"
 msgstr "Calendar"
 
 #. IDS_PRPCAT_COMMUNICATION
-#: Merge.rc:5010
+#: Merge.rc:5009
 msgid "Communication"
 msgstr "Comunicare"
 
 #. IDS_PRPCAT_CONTACT
-#: Merge.rc:5011
+#: Merge.rc:5010
 msgid "Contact"
 msgstr "Contact"
 
 #. IDS_PRPCAT_DEVICES
-#: Merge.rc:5012
+#: Merge.rc:5011
 msgid "Devices"
 msgstr "Dispozitive"
 
 #. IDS_PRPCAT_DOCUMENT
-#: Merge.rc:5013
+#: Merge.rc:5012
 msgid "Document"
 msgstr "Document"
 
 #. IDS_PRPCAT_HOME
-#: Merge.rc:5014
+#: Merge.rc:5013
 msgid "Home"
 msgstr "Acasă"
 
 #. IDS_PRPCAT_JOURNAL
-#: Merge.rc:5016
+#: Merge.rc:5015
 msgid "Journal"
 msgstr "Jurnal"
 
 #. IDS_PRPCAT_LINK
-#: Merge.rc:5017
+#: Merge.rc:5016
 msgid "Link"
 msgstr "Legătură"
 
 #. IDS_PRPCAT_MEDIA
-#: Merge.rc:5018
+#: Merge.rc:5017
 msgid "Media"
 msgstr "Media"
 
 #. IDS_PRPCAT_MUSIC
-#: Merge.rc:5020
+#: Merge.rc:5019
 msgid "Music"
 msgstr "Muzică"
 
 #. IDS_PRPCAT_NOTE
-#: Merge.rc:5021
+#: Merge.rc:5020
 msgid "Note"
 msgstr "Notă"
 
 #. IDS_PRPCAT_PHOTO
-#: Merge.rc:5022
+#: Merge.rc:5021
 msgid "Photo"
 msgstr "Foto"
 
 #. IDS_PRPCAT_RECORDEDTV
-#: Merge.rc:5023
+#: Merge.rc:5022
 msgid "RecordedTV"
 msgstr "RecordedTV"
 
 #. IDS_PRPCAT_SEARCH
-#: Merge.rc:5024
+#: Merge.rc:5023
 msgid "Search"
 msgstr "Căutare"
 
 #. IDS_PRPCAT_SECURITY
-#: Merge.rc:5025
+#: Merge.rc:5024
 msgid "Security"
 msgstr "Securitate"
 
 #. IDS_PRPCAT_SOFTWARE
-#: Merge.rc:5026
+#: Merge.rc:5025
 msgid "Software"
 msgstr "Software"
 
 #. IDS_PRPCAT_TASK
-#: Merge.rc:5027
+#: Merge.rc:5026
 msgid "Task"
 msgstr "Sarcină"
 
 #. IDS_PRPCAT_VIDEO
-#: Merge.rc:5028
+#: Merge.rc:5027
 msgid "Video"
 msgstr "Video"
 
 #. IDS_PRPCAT_HASH
-#: Merge.rc:5029
+#: Merge.rc:5028
 msgid "Hash"
 msgstr "Hash"
 
 #. IDS_CANT_COMPARE_FILES
-#: Merge.rc:5035
+#: Merge.rc:5034
 msgid "Unable to compare files"
 msgstr "Imposibil de comparat fișierele"
 
 #. IDS_ABORTED_ITEM
-#: Merge.rc:5036
+#: Merge.rc:5035
 msgid "Item aborted"
 msgstr "Element întrerupt"
 
 #. IDS_FILE_SKIPPED
-#: Merge.rc:5037
+#: Merge.rc:5036
 msgid "File skipped"
 msgstr "Fișier omis"
 
 #. IDS_DIR_SKIPPED
-#: Merge.rc:5038
+#: Merge.rc:5037
 msgid "Folder skipped"
 msgstr "Director omis"
 
 #. IDS_LEFT_ONLY_IN_FMT
-#: Merge.rc:5039
+#: Merge.rc:5038
 #, c-format
 msgid "Left only: %1"
 msgstr "Numai stânga: %1"
 
 #. IDS_MIDDLE_ONLY_IN_FMT
-#: Merge.rc:5040
+#: Merge.rc:5039
 #, c-format
 msgid "Middle only: %1"
 msgstr "Numai mijloc: %1"
 
 #. IDS_RIGHT_ONLY_IN_FMT
-#: Merge.rc:5041
+#: Merge.rc:5040
 #, c-format
 msgid "Right only: %1"
 msgstr "Numai dreapta: %1"
 
 #. IDS_DOES_NOT_EXIST_IN_FMT
-#: Merge.rc:5042
+#: Merge.rc:5041
 #, c-format
 msgid "Does not exist in %1"
 msgstr "Nu există în %1"
 
 #. IDS_BIN_FILES_SAME
-#: Merge.rc:5043
+#: Merge.rc:5042
 msgid "Binary files are identical"
 msgstr "Fișierele binare sunt identice"
 
 #. IDS_BIN_FILES_DIFF
-#: Merge.rc:5049
+#: Merge.rc:5048
 msgid "Binary files are different"
 msgstr "Fișierele binare sunt diferite"
 
 #. IDS_FILES_ARE_DIFFERENT
-#: Merge.rc:5050
+#: Merge.rc:5049
 msgid "Files are different"
 msgstr "Fișierele sunt diferite"
 
 #. IDS_FOLDERS_ARE_DIFFERENT
-#: Merge.rc:5051
+#: Merge.rc:5050
 msgid "Folders are different"
 msgstr "Directoarele sunt diferite"
 
 #. IDS_LEFTONLY
-#: Merge.rc:5052
+#: Merge.rc:5051
 msgid "Left Only"
 msgstr "Numai stânga"
 
 #. IDS_RIGHTONLY
-#: Merge.rc:5053
+#: Merge.rc:5052
 msgid "Right Only"
 msgstr "Numai dreapta"
 
 #. IDS_MIDDLEONLY
-#: Merge.rc:5054
+#: Merge.rc:5053
 msgid "Middle Only"
 msgstr "Numai mijloc"
 
 #. IDS_NOITEMLEFT
-#: Merge.rc:5055
+#: Merge.rc:5054
 msgid "No item in left"
 msgstr "Niciun element în stânga"
 
 #. IDS_NOITEMRIGHT
-#: Merge.rc:5056
+#: Merge.rc:5055
 msgid "No item in right"
 msgstr "Niciun element în dreapta"
 
 #. IDS_NOITEMMIDDLE
-#: Merge.rc:5057
+#: Merge.rc:5056
 msgid "No item in middle"
 msgstr "Niciun element în mijloc"
 
 #. IDS_CMPRES_ERROR
-#: Merge.rc:5059
+#: Merge.rc:5058
 msgid "Error"
 msgstr "Eroare"
 
 #. IDS_TEXT_FILES_SAME
-#: Merge.rc:5060
+#: Merge.rc:5059
 msgid "Text files are identical"
 msgstr "Fișierele text sunt identice"
 
 #. IDS_LEFTONLY_DIFF
-#: Merge.rc:5061
+#: Merge.rc:5060
 msgid " (Middle and right are identical)"
 msgstr " (Mijlocul și stânga sunt identice)"
 
 #. IDS_MIDDLEONLY_DIFF
-#: Merge.rc:5062
+#: Merge.rc:5061
 msgid " (Left and right are identical)"
 msgstr " (Stânga și dreapta sunt identice)"
 
 #. IDS_RIGHTONLY_DIFF
-#: Merge.rc:5063
+#: Merge.rc:5062
 msgid " (Left and middle are identical)"
 msgstr " (Stânga și mijlocul sunt identice)"
 
 #. IDS_PATH_MISMATCH
-#: Merge.rc:5064
+#: Merge.rc:5063
 msgid " (paths differ)"
 msgstr ""
 
 #. IDS_TEXT_FILES_DIFF
-#: Merge.rc:5065
+#: Merge.rc:5064
 msgid "Text files are different"
 msgstr "Fișierele text sunt diferite"
 
 #. IDS_IMAGE_FILES_SAME
-#: Merge.rc:5066
+#: Merge.rc:5065
 msgid "Image files are identical"
 msgstr "Fișierele imagine sunt identice"
 
 #. IDS_IMAGE_FILES_DIFF
-#: Merge.rc:5067
+#: Merge.rc:5066
 msgid "Image files are different"
 msgstr "Fișierele imagine sunt diferite"
 
 #. IDS_EXPR_DIFF
-#: Merge.rc:5068
+#: Merge.rc:5067
 #, c-format
 msgid "Files are different (expr: %1)"
 msgstr ""
 
 #. IDS_HASH_GROUP
-#: Merge.rc:5069
+#: Merge.rc:5068
 #, c-format
 msgid "Group%d"
 msgstr "Grup%d"
 
 #. IDS_RENAME_MOVE_DETECTION_DISALBED
-#: Merge.rc:5070
+#: Merge.rc:5069
 msgctxt "Options dialog|Compare|Folder|Detect renames and moves"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_RENAME_MOVE_DETECTION_RENAME
-#: Merge.rc:5071
+#: Merge.rc:5070
 msgid "Detect renames"
 msgstr ""
 
 #. IDS_RENAME_MOVE_DETECTION_RENAME_MOVE
-#: Merge.rc:5072
+#: Merge.rc:5071
 msgid "Detect renames and moves"
 msgstr ""
 
 #. IDS_RENAME_MOVE_MERGE_MODE_RENAME
-#: Merge.rc:5073
+#: Merge.rc:5072
 msgid "Merge renames"
 msgstr ""
 
 #. IDS_RENAME_MOVE_MERGE_MODE_RENAME_MOVE
-#: Merge.rc:5074
+#: Merge.rc:5073
 msgid "Merge renames and moves"
 msgstr ""
 
 #. IDS_RENAMED
-#: Merge.rc:5075
+#: Merge.rc:5074
 msgid "Renamed"
 msgstr ""
 
 #. IDS_RENAMED_MOVED
-#: Merge.rc:5077
+#: Merge.rc:5076
 msgid "Renamed/Moved"
 msgstr ""
 
 #. IDS_RENAMED_MOVED_ITEMS
-#: Merge.rc:5078
+#: Merge.rc:5077
 #, c-format
 msgid "(%1 items)"
 msgstr ""
 
 #. IDS_RENAMED_MOVED_RESULT
-#: Merge.rc:5079
+#: Merge.rc:5078
 #, c-format
 msgid "%1 (set %2): "
 msgstr ""
 
 #. IDS_SWITCH_FLAT_MODE
-#: Merge.rc:5080
+#: Merge.rc:5079
 msgid "Some moved items have been merged.\nIn Tree Mode, these items may appear in positions that do not reflect the actual folder structure, which can be confusing.\nSwitch to Flat Mode?"
 msgstr ""
 
 #. IDS_ELAPSED_TIME
-#: Merge.rc:5086
+#: Merge.rc:5085
 #, c-format
 msgid "Elapsed time: %ld ms"
 msgstr "Timp scurs: %ld ms"
 
 #. IDS_STATUS_SELITEM1
-#: Merge.rc:5087
+#: Merge.rc:5086
 msgid "1 item selected"
 msgstr "Un element selectat"
 
 #. IDS_STATUS_SELITEMS
-#: Merge.rc:5088
+#: Merge.rc:5087
 #, c-format
 msgid "%1 items selected"
 msgstr "%1 elemente selectate"
 
 #. IDS_COLDESC_FILENAME
-#: Merge.rc:5094
+#: Merge.rc:5093
 msgid "Filename or folder name."
 msgstr "Nume de fișier sau director."
 
 #. IDS_COLDESC_DIR
-#: Merge.rc:5095
+#: Merge.rc:5094
 msgid "Subfolder name when subfolders are included."
 msgstr "Nume subdirector când subdirectoarele sunt incluse."
 
 #. IDS_COLDESC_RESULT
-#: Merge.rc:5096
+#: Merge.rc:5095
 msgid "Comparison result, long form."
 msgstr "Rezultate comparare, forma lungă."
 
 #. IDS_COLDESC_LTIMEM
-#: Merge.rc:5101
+#: Merge.rc:5100
 msgid "Left side modification date."
 msgstr "Data modificării părții stângi."
 
 #. IDS_COLDESC_RTIMEM
-#: Merge.rc:5102
+#: Merge.rc:5101
 msgid "Right side modification date."
 msgstr "Data modificării părții drepte."
 
 #. IDS_COLDESC_MTIMEM
-#: Merge.rc:5103
+#: Merge.rc:5102
 msgid "Middle side modification date."
 msgstr "Data modificării părții din mijloc."
 
 #. IDS_COLDESC_EXTENSION
-#: Merge.rc:5104
+#: Merge.rc:5103
 msgid "File's extension."
 msgstr "Extensia fișierului."
 
 #. IDS_COLDESC_LSIZE
-#: Merge.rc:5105
+#: Merge.rc:5104
 msgid "Left file size in bytes."
 msgstr "Dimensiune fișier stânga în octeți."
 
 #. IDS_COLDESC_RSIZE
-#: Merge.rc:5106
+#: Merge.rc:5105
 msgid "Right file size in bytes."
 msgstr "Dimensiune fișier dreapta în octeți."
 
 #. IDS_COLDESC_MSIZE
-#: Merge.rc:5107
+#: Merge.rc:5106
 msgid "Middle file size in bytes."
 msgstr "Dimensiune fișier mijloc în octeți."
 
 #. IDS_COLDESC_LSIZE_SHORT
-#: Merge.rc:5108
+#: Merge.rc:5107
 msgid "Left file size abbreviated."
 msgstr "Dimensiune fișier stânga prescurtată."
 
 #. IDS_COLDESC_RSIZE_SHORT
-#: Merge.rc:5109
+#: Merge.rc:5108
 msgid "Right file size abbreviated."
 msgstr "Dimensiune fișier dreapta prescurtată."
 
 #. IDS_COLDESC_MSIZE_SHORT
-#: Merge.rc:5110
+#: Merge.rc:5109
 msgid "Middle file size abbreviated."
 msgstr "Dimensiune fișier mijloc prescurtată."
 
 #. IDS_COLDESC_LTIMEC
-#: Merge.rc:5116
+#: Merge.rc:5115
 msgid "Left side creation time."
 msgstr "Timp creare stânga."
 
 #. IDS_COLDESC_RTIMEC
-#: Merge.rc:5117
+#: Merge.rc:5116
 msgid "Right side creation time."
 msgstr "Timp creare dreapta."
 
 #. IDS_COLDESC_MTIMEC
-#: Merge.rc:5118
+#: Merge.rc:5117
 msgid "Middle side creation time."
 msgstr "Timp creare mijloc."
 
 #. IDS_COLDESC_NEWER
-#: Merge.rc:5119
+#: Merge.rc:5118
 msgid "Tells which side has newer modification date."
 msgstr "Raportează care parte are o dată a modificării mai recentă."
 
 #. IDS_COLDESC_LVERSION
-#: Merge.rc:5120
+#: Merge.rc:5119
 msgid "Left side file version, only for some file types."
 msgstr "Versiune fișier stânga, numai pentru unele tipuri de fișiere."
 
 #. IDS_COLDESC_RVERSION
-#: Merge.rc:5121
+#: Merge.rc:5120
 msgid "Right side file version, only for some file types."
 msgstr "Versiune fișier dreapta, numai pentru unele tipuri de fișiere."
 
 #. IDS_COLDESC_MVERSION
-#: Merge.rc:5126
+#: Merge.rc:5125
 msgid "Middle side file version, only for some file types."
 msgstr "Versiune fișier mijloc, numai pentru unele tipuri de fișiere."
 
 #. IDS_COLDESC_RESULT_ABBR
-#: Merge.rc:5127
+#: Merge.rc:5126
 msgid "Short comparison result."
 msgstr "Rezultat comparare pe scurt."
 
 #. IDS_COLDESC_LATTRIBUTES
-#: Merge.rc:5128
+#: Merge.rc:5127
 msgid "Left side attributes."
 msgstr "Atribute partea stângă."
 
 #. IDS_COLDESC_RATTRIBUTES
-#: Merge.rc:5129
+#: Merge.rc:5128
 msgid "Right side attributes."
 msgstr "Atribute partea dreaptă."
 
 #. IDS_COLDESC_MATTRIBUTES
-#: Merge.rc:5130
+#: Merge.rc:5129
 msgid "Middle side attributes."
 msgstr "Atribute mijloc."
 
 #. IDS_COLDESC_LEOL_TYPE
-#: Merge.rc:5131
+#: Merge.rc:5130
 msgid "Left side file EOL type."
 msgstr "Tip EOL fișier partea stângă."
 
 #. IDS_COLDESC_REOL_TYPE
-#: Merge.rc:5132
+#: Merge.rc:5131
 msgid "Right side file EOL type."
 msgstr "Tip EOL fișier partea dreaptă."
 
 #. IDS_COLDESC_MEOL_TYPE
-#: Merge.rc:5133
+#: Merge.rc:5132
 msgid "Middle side file EOL type."
 msgstr "Tip EOL fișier mijloc."
 
 #. IDS_COLDESC_LENCODING
-#: Merge.rc:5139
+#: Merge.rc:5138
 msgid "Left side encoding."
 msgstr "Set de caractere partea stângă."
 
 #. IDS_COLDESC_RENCODING
-#: Merge.rc:5140
+#: Merge.rc:5139
 msgid "Right side encoding."
 msgstr "Set de caractere partea dreaptă."
 
 #. IDS_COLDESC_MENCODING
-#: Merge.rc:5141
+#: Merge.rc:5140
 msgid "Middle side encoding."
 msgstr "Set de caractere mijloc."
 
 #. IDS_COLDESC_NIDIFFS
-#: Merge.rc:5142
+#: Merge.rc:5141
 msgid "Number of ignored differences in file. Ignored and cannot be merged."
 msgstr ""
 "Număr de diferențe ignorate în fișier. Aceste diferențe sunt ignorate de "
 "WinMerge și nu pot fi fuzionate."
 
 #. IDS_COLDESC_NSDIFFS
-#: Merge.rc:5143
+#: Merge.rc:5142
 msgid "Number of differences in file (excluding ignored)."
 msgstr ""
 "Număr de diferențe în fișier. Acest număr nu include diferențele ignorate."
 
 #. IDS_COLDESC_BINARY
-#: Merge.rc:5144
+#: Merge.rc:5143
 msgid "Shows an asterisk (*) if the file is binary."
 msgstr "Afișează un asterisc (*) dacă fișierul este binar."
 
 #. IDS_COLDESC_UNPACKER
-#: Merge.rc:5145
+#: Merge.rc:5144
 msgid "Unpacker plugin name or pipeline."
 msgstr "Nume sau lanț plugin dezarhivator."
 
 #. IDS_COLDESC_PREDIFFER
-#: Merge.rc:5146
+#: Merge.rc:5145
 msgid "Prediffer plugin name or pipeline."
 msgstr "Nume sau lanț plugin prediferențiator."
 
 #. IDS_DIRECTORY_REPORT_TITLE
-#: Merge.rc:5152
+#: Merge.rc:5151
 #, c-format
 msgid "Compare %1 with %2"
 msgstr "Compară %1 cu %2"
 
 #. IDS_DIRECTORY_REPORT_TITLE3
-#: Merge.rc:5153
+#: Merge.rc:5152
 #, c-format
 msgid "Compare %1 with %2 and %3"
 msgstr "Compară %1 cu %2 și %3"
 
 #. IDS_REPORT_COMMALIST
-#: Merge.rc:5154
+#: Merge.rc:5153
 msgid "Comma-separated list"
 msgstr "Listă separată-prin-virgule"
 
 #. IDS_REPORT_TABLIST
-#: Merge.rc:5155
+#: Merge.rc:5154
 msgid "Tab-separated list"
 msgstr "Listă separată-prin-tab-uri"
 
 #. IDS_REPORT_SIMPLEHTML
-#: Merge.rc:5156
+#: Merge.rc:5155
 msgid "Simple HTML"
 msgstr "HTML simplu"
 
 #. IDS_REPORT_SIMPLEXML
-#: Merge.rc:5157
+#: Merge.rc:5156
 msgid "Simple XML"
 msgstr "XML simplu"
 
-#: Merge.rc:5159
+#: Merge.rc:5158
 msgid "Report file already exists. Overwrite?"
 msgstr "Fișierul raport există deja. Doriți să suprascrieți fișierul existent?"
 
 #. IDS_REPORT_ERROR
-#: Merge.rc:5164
+#: Merge.rc:5163
 #, c-format
 msgid ""
 "Error creating the report:\n"
@@ -7211,52 +7206,52 @@ msgstr ""
 "%1"
 
 #. IDS_REPORT_SUCCESS
-#: Merge.rc:5165
+#: Merge.rc:5164
 msgid "Report created successfully."
 msgstr "Raportul a fost creat cu succes."
 
 #. IDS_SYNCPOINT_LASTBLOCK
-#: Merge.rc:5171
+#: Merge.rc:5170
 msgid "Cannot add a synchronization point at this line."
 msgstr "Nu se poate adăuga un punct de sincronizare la acest rând."
 
 #. IDS_FILE_TO_ITSELF
-#: Merge.rc:5177
+#: Merge.rc:5176
 msgid "Same file is opened in both panes."
 msgstr "Același fișier este deschis în ambele panouri."
 
 #. IDS_FILESSAME
-#: Merge.rc:5178
+#: Merge.rc:5177
 msgid "Selected files are identical."
 msgstr "Fișierele selectate sunt identice."
 
 #. IDS_FILESSAME_CURCFG
-#: Merge.rc:5179
+#: Merge.rc:5178
 msgid "Selected files are identical (with current settings).\r\nChecking binary identity..."
 msgstr ""
 
 #. IDS_FILESSAME_BINERROR
-#: Merge.rc:5180
+#: Merge.rc:5179
 msgid "Selected files are identical (with current settings).\r\nBut binary comparison failed."
 msgstr ""
 
 #. IDS_FILESSAME_BINSAME
-#: Merge.rc:5181
+#: Merge.rc:5180
 msgid "Selected files are identical (binary match)."
 msgstr ""
 
 #. IDS_FILESSAME_BINDIFF
-#: Merge.rc:5182
+#: Merge.rc:5181
 msgid "Selected files are identical (with current settings).\r\nBut differ at the binary level."
 msgstr ""
 
 #. IDS_FILEERROR
-#: Merge.rc:5183
+#: Merge.rc:5182
 msgid "An error occurred while comparing files."
 msgstr "A fost întâlnită o eroare în timpul comparării fișierelor."
 
 #. IDS_TEMP_FILEERROR
-#: Merge.rc:5184
+#: Merge.rc:5183
 msgid ""
 "Could not create temporary files. Check your temporary path settings."
 msgstr ""
@@ -7264,7 +7259,7 @@ msgstr ""
 "locația temporară."
 
 #. IDS_SUGGEST_IGNOREEOL
-#: Merge.rc:5185
+#: Merge.rc:5184
 msgid "Files use different EOL.\n\nTreat all EOL as equivalent?\n\nSet 'Ignore EOL differences (Windows/Unix/Mac)' in Compare section of Options."
 msgstr ""
 "Aceste fișiere folosesc caractere de sfârșit de rând (EOL) diferite.\n"
@@ -7278,17 +7273,17 @@ msgstr ""
 "opțiuni (disponibilă sub meniul Editare/Opțiuni)."
 
 #. IDS_INVALID_DIRECTORY
-#: Merge.rc:5186
+#: Merge.rc:5185
 msgid "Selected folder is invalid."
 msgstr "Directorul selectat este invalid."
 
 #. IDS_CANNOT_OPEN_BINARYFILE
-#: Merge.rc:5187
+#: Merge.rc:5186
 msgid "Cannot open a binary file in Editor."
 msgstr "Nu se poate deschide în editor un fișier binar."
 
 #. IDS_CREATE_PAIR_FOLDER
-#: Merge.rc:5188
+#: Merge.rc:5187
 #, c-format
 msgid "Create matching folder:\n%1\non the other side and open?"
 msgstr ""
@@ -7299,42 +7294,42 @@ msgstr ""
 "în partea cealaltă și să deschideți ambele directoare?"
 
 #. IDS_CONFIRM_COPY_ALL_DIFFS
-#: Merge.rc:5189
+#: Merge.rc:5188
 msgid "Copy all differences to other file?"
 msgstr ""
 "Sunteți sigur că doriți să copiați toate diferențele în celelalt fișier?"
 
 #. IDS_MOVE_TO_NEXTFILE
-#: Merge.rc:5194
+#: Merge.rc:5193
 msgid "Move to next file?"
 msgstr "Doriți să treceți la fișierul următor?"
 
 #. IDS_MOVE_TO_PREVFILE
-#: Merge.rc:5195
+#: Merge.rc:5194
 msgid "Move to previous file?"
 msgstr "Doriți să treceți la fișierul precedent?"
 
 #. IDS_MOVE_TO_NEXTPAGE
-#: Merge.rc:5196
+#: Merge.rc:5195
 msgid "Move to next page?"
 msgstr "Doriți să treceți la pagina următoare?"
 
 #. IDS_MOVE_TO_PREVPAGE
-#: Merge.rc:5197
+#: Merge.rc:5196
 msgid "Move to previous page?"
 msgstr "Doriți să treceți la pagina precedentă?"
 
 #. IDS_MOVE_TO_FIRSTFILE
-#: Merge.rc:5198
+#: Merge.rc:5197
 msgid "Move to first file?"
 msgstr "Doriți să treceți la primul fișier?"
 
 #. IDS_MOVE_TO_LASTFILE
-#: Merge.rc:5199
+#: Merge.rc:5198
 msgid "Move to last file?"
 msgstr "Doriți să treceți la ultimul fișier?"
 
-#: Merge.rc:5206
+#: Merge.rc:5205
 #, c-format
 msgid "Different codepages: left (cp%d), right (cp%d).\nDisplay in codepage (better display) or default Windows codepage (safer merging)?\n(Recommended: default Windows codepage)"
 msgstr ""
@@ -7345,53 +7340,53 @@ msgstr ""
 "Doriți tratarea ambelor fișiere ca și cum ar fi în pagina de codare "
 "implicită din Windows (recomandat)?"
 
-#: Merge.rc:5208
+#: Merge.rc:5207
 msgid "Information lost due to encoding errors: both files"
 msgstr "Pierdere de informație datorită erorilor de codificare: ambele fișiere"
 
-#: Merge.rc:5210
+#: Merge.rc:5209
 msgid "Information lost due to encoding errors: first file"
 msgstr "Pierdere de informație datorită erorilor de codificare: fișierul 1"
 
-#: Merge.rc:5212
+#: Merge.rc:5211
 msgid "Information lost due to encoding errors: second file"
 msgstr "Pierdere de informație datorită erorilor de codificare: fișierul 2"
 
-#: Merge.rc:5214
+#: Merge.rc:5213
 msgid "Information lost due to encoding errors: third file"
 msgstr "Pierdere de informație datorită erorilor de codificare: fișierul 3"
 
 #. IDS_LINEDIFF_NODIFF
-#: Merge.rc:5220
+#: Merge.rc:5219
 msgid "No difference"
 msgstr "Nicio diferență"
 
 #. IDS_LINEDIFF_NODIFF_CAPTION
-#: Merge.rc:5221
+#: Merge.rc:5220
 msgid "Line difference"
 msgstr "Diferență din rând"
 
 #. IDS_NUM_REPLACED
-#: Merge.rc:5227
+#: Merge.rc:5226
 #, c-format
 msgid "Replaced %1 string(s)."
 msgstr "S-a(u) înlocuit %1 șir(uri)."
 
 #. IDS_EDIT_TEXT_NOT_FOUND
-#: Merge.rc:5228
+#: Merge.rc:5227
 #, c-format
 msgid "Cannot find string \"%s\"."
 msgstr "Nu s-a găsit șirul \"%s\"."
 
 #. IDS_MERGE_MODE
-#: Merge.rc:5234
+#: Merge.rc:5233
 msgid "Entering Merge Mode. Press F9 to turn off."
 msgstr ""
 "Intrați acum în modul fuziune. Dacă doriți să ieșiți din modul fuziune, "
 "apăsați tasta F9."
 
 #. IDS_AUTO_MERGE
-#: Merge.rc:5240
+#: Merge.rc:5239
 #, c-format
 msgid ""
 "Automatic merges: %1\n"
@@ -7401,89 +7396,89 @@ msgstr ""
 "Număr conflicte nerezolvate: %2"
 
 #. IDS_CODEPAGE_MERGED
-#: Merge.rc:5241
+#: Merge.rc:5240
 msgid "Codepage change merged."
 msgstr "Modificarea paginii de codare a fost fuzionată."
 
 #. IDS_CODEPAGE_CONFLICT
-#: Merge.rc:5242
+#: Merge.rc:5241
 msgid "Codepage changes are conflicting."
 msgstr "Modificările paginii de codare sunt în conflict."
 
 #. IDS_EOL_MERGED
-#: Merge.rc:5243
+#: Merge.rc:5242
 msgid "EOL change merged."
 msgstr "Modificarea EOL a fost fuzionată."
 
 #. IDS_EOL_CONFLICT
-#: Merge.rc:5244
+#: Merge.rc:5243
 msgid "EOL changes are conflicting."
 msgstr "Modificările EOL sunt în conflict."
 
 #. IDS_LOCBAR_CAPTION
-#: Merge.rc:5250
+#: Merge.rc:5249
 msgid "Location Pane"
 msgstr "Panou locație"
 
 #. IDS_DIFFBAR_CAPTION
-#: Merge.rc:5251
+#: Merge.rc:5250
 msgid "Diff Pane"
 msgstr "Panou diferențe"
 
 #. IDS_DIFF_SUCCEEDED
-#: Merge.rc:5258
+#: Merge.rc:5257
 msgid "Patch file written."
 msgstr "Fișierul petic a fost scris cu succes."
 
 #. IDS_DIFF_FILEOVERWRITE
-#: Merge.rc:5259
+#: Merge.rc:5258
 msgid "Patch file already exists. Overwrite?"
 msgstr "Fișierul petic deja există. Doriți suprascrierea lui?"
 
 #. IDS_DIFF_SELECTEDFILES
-#: Merge.rc:5260
+#: Merge.rc:5259
 #, c-format
 msgid "[%1 files selected]"
 msgstr "[%1 fișier(e) selectat(e)]"
 
 #. IDS_DIFF_NORMAL
-#: Merge.rc:5261
+#: Merge.rc:5260
 msgid "Normal"
 msgstr "Normal"
 
 #. IDS_DIFF_CONTEXT
-#: Merge.rc:5262
+#: Merge.rc:5261
 msgid "Context"
 msgstr "Context"
 
 #. IDS_DIFF_UNIFIED
-#: Merge.rc:5263
+#: Merge.rc:5262
 msgid "Unified"
 msgstr "Unificat"
 
 #. IDS_FILEWRITE_ERROR
-#: Merge.rc:5265
+#: Merge.rc:5264
 #, c-format
 msgid "Could not write to file %1."
 msgstr "Nu s-a reușit scrierea în fișierul %1."
 
 #. IDS_PATH_NOT_ABSOLUTE
-#: Merge.rc:5266
+#: Merge.rc:5265
 #, c-format
 msgid "Output path is not absolute: %1"
 msgstr "Calea destinație specificată nu este o cale absolută: %1"
 
 #. IDS_MUST_SPECIFY_OUTPUT
-#: Merge.rc:5267
+#: Merge.rc:5266
 msgid "Specify an output file."
 msgstr "Specificați un fișier destinație."
 
-#: Merge.rc:5269
+#: Merge.rc:5268
 msgid "Cannot create patch from binary files."
 msgstr "Nu s-a reușit crearea unui fișier petic din fișiere binare."
 
 #. IDS_SAVEFILES_FORPATCH
-#: Merge.rc:5270
+#: Merge.rc:5269
 msgid ""
 "Save all files first.\n"
 "\n"
@@ -7494,22 +7489,22 @@ msgstr ""
 "Crearea unui petic necesită ca fișierele să nu aibă modificări nesalvate."
 
 #. IDS_FOLDER_NOTEXIST
-#: Merge.rc:5271
+#: Merge.rc:5270
 msgid "Folder does not exist."
 msgstr "Directorul nu există."
 
 #. IDS_ARCHIVE_SUCCEEDED
-#: Merge.rc:5277
+#: Merge.rc:5276
 msgid "Archive file written."
 msgstr ""
 
 #. IDS_ARCHIVE_SAVEFILES
-#: Merge.rc:5278
+#: Merge.rc:5277
 msgid "Save all files first.\n\nCreating an archive requires no unsaved changes."
 msgstr ""
 
 #. IDS_NO_ZIP_SUPPORT
-#: Merge.rc:5283
+#: Merge.rc:5282
 msgid "Archive support not enabled.\n7-Zip and/or Merge7z*.dll not found.\nSee manual for archive support."
 msgstr ""
 "Suportul de dezarhivare nu este activat.\n"
@@ -7519,37 +7514,37 @@ msgstr ""
 "și despre cum să-l activați."
 
 #. IDS_OPT_EXPORT_CAPTION
-#: Merge.rc:5284
+#: Merge.rc:5283
 msgid "Select file for export"
 msgstr "Selectați fișierul pentru export"
 
 #. IDS_OPT_IMPORT_CAPTION
-#: Merge.rc:5285
+#: Merge.rc:5284
 msgid "Select file for import"
 msgstr "Selectați fișierul pentru import"
 
 #. IDS_OPT_IMPORT_DONE
-#: Merge.rc:5286
+#: Merge.rc:5285
 msgid "Options imported from file."
 msgstr "Opțiuni importate din fișier."
 
 #. IDS_OPT_EXPORT_DONE
-#: Merge.rc:5287
+#: Merge.rc:5286
 msgid "Options exported to file."
 msgstr "Opțiuni exportate către fișier."
 
 #. IDS_OPT_IMPORT_ERR
-#: Merge.rc:5288
+#: Merge.rc:5287
 msgid "Failed to import options from file."
 msgstr "A eșuat importul opțiunilor din fișier."
 
 #. IDS_OPT_EXPORT_ERR
-#: Merge.rc:5289
+#: Merge.rc:5288
 msgid "Failed to write options to file."
 msgstr "A eșuat scrierea opțiunilor către fișier."
 
 #. IDS_CLOSEALL_WINDOWS
-#: Merge.rc:5290
+#: Merge.rc:5289
 msgid ""
 "Close multiple compare windows?\n"
 "\n"
@@ -7560,34 +7555,34 @@ msgstr ""
 "Doriți să continuați?"
 
 #. IDS_EOL_BIN
-#: Merge.rc:5300
+#: Merge.rc:5299
 msgctxt "EOL Type"
 msgid "Binary"
 msgstr "Binar"
 
 #. IDS_MARKER_COLOR_FMT
-#: Merge.rc:5305
+#: Merge.rc:5304
 #, c-format
 msgid "Marker Color %d"
 msgstr "Culoare marcator %d"
 
 #. IDS_MARKER_NEW_PATTERN
-#: Merge.rc:5306
+#: Merge.rc:5305
 msgid "New Pattern"
 msgstr "Model nou"
 
 #. IDS_PLUGINSLIST_TYPE
-#: Merge.rc:5312
+#: Merge.rc:5311
 msgid "Type"
 msgstr "Tip"
 
 #. IDS_PLUGINS_TYPE_EDITSCRIPT
-#: Merge.rc:5316
+#: Merge.rc:5315
 msgid "Editor script"
 msgstr "Script editor"
 
 #. ID_SELECTLINEDIFF
-#: Merge.rc:5322
+#: Merge.rc:5321
 msgid ""
 "\n"
 "Difference in Current Line (F4)"
@@ -7596,7 +7591,7 @@ msgstr ""
 "Diferențe în rândul curent (F4)"
 
 #. ID_OPTIONS
-#: Merge.rc:5323
+#: Merge.rc:5322
 msgid ""
 "\n"
 "Options"
@@ -7605,7 +7600,7 @@ msgstr ""
 "Opțiuni"
 
 #. ID_REFRESH
-#: Merge.rc:5324
+#: Merge.rc:5323
 msgid ""
 "\n"
 "Refresh (F5)"
@@ -7614,7 +7609,7 @@ msgstr ""
 "Reîmprospătare (F5)"
 
 #. ID_PREVDIFF
-#: Merge.rc:5330
+#: Merge.rc:5329
 msgid ""
 "\n"
 "Previous Difference (Alt+Up)"
@@ -7623,7 +7618,7 @@ msgstr ""
 "Diferența precedentă (Alt+Up)"
 
 #. ID_NEXTDIFF
-#: Merge.rc:5331
+#: Merge.rc:5330
 msgid ""
 "\n"
 "Next Difference (Alt+Down)"
@@ -7632,7 +7627,7 @@ msgstr ""
 "Diferența următoare (Alt+Down)"
 
 #. ID_PREVCONFLICT
-#: Merge.rc:5332
+#: Merge.rc:5331
 msgid ""
 "\n"
 "Previous Conflict (Alt+Shift+Up)"
@@ -7641,7 +7636,7 @@ msgstr ""
 "Conflictul precedent (Alt+Shift+Up)"
 
 #. ID_NEXTCONFLICT
-#: Merge.rc:5333
+#: Merge.rc:5332
 msgid ""
 "\n"
 "Next Conflict (Alt+Shift+Down)"
@@ -7650,7 +7645,7 @@ msgstr ""
 "Conflictul următor (Alt+Shift+Down)"
 
 #. ID_FIRSTDIFF
-#: Merge.rc:5338
+#: Merge.rc:5337
 msgid ""
 "\n"
 "First Difference (Alt+Home)"
@@ -7659,7 +7654,7 @@ msgstr ""
 "Prima diferență (Alt+Home)"
 
 #. ID_CURDIFF
-#: Merge.rc:5339
+#: Merge.rc:5338
 msgid ""
 "\n"
 "Current Difference (Alt+Enter)"
@@ -7668,7 +7663,7 @@ msgstr ""
 "Diferența curentă (Alt+Enter)"
 
 #. ID_LASTDIFF
-#: Merge.rc:5340
+#: Merge.rc:5339
 msgid ""
 "\n"
 "Last Difference (Alt+End)"
@@ -7677,7 +7672,7 @@ msgstr ""
 "Ultima diferență (Alt+End)"
 
 #. ID_L2R
-#: Merge.rc:5341
+#: Merge.rc:5340
 msgid ""
 "\n"
 "Copy to Right (Alt+Right)"
@@ -7686,7 +7681,7 @@ msgstr ""
 "Copiază în dreapta (Alt+Right)"
 
 #. ID_R2L
-#: Merge.rc:5342
+#: Merge.rc:5341
 msgid ""
 "\n"
 "Copy to Left (Alt+Left)"
@@ -7695,7 +7690,7 @@ msgstr ""
 "Copiază în stânga (Alt+Right)"
 
 #. ID_L2RNEXT
-#: Merge.rc:5343
+#: Merge.rc:5342
 msgid ""
 "\n"
 "Copy to Right and Advance (Ctrl+Alt+Right)"
@@ -7704,7 +7699,7 @@ msgstr ""
 "Copiază în dreapta și avansează (Ctrl+Alt+Right)"
 
 #. ID_R2LNEXT
-#: Merge.rc:5344
+#: Merge.rc:5343
 msgid ""
 "\n"
 "Copy to Left and Advance (Ctrl+Alt+Left)"
@@ -7713,7 +7708,7 @@ msgstr ""
 "Copiază în stânga și avansează (Ctrl+Alt+Left)"
 
 #. ID_ALL_RIGHT
-#: Merge.rc:5345
+#: Merge.rc:5344
 msgid ""
 "\n"
 "Copy All to Right"
@@ -7722,7 +7717,7 @@ msgstr ""
 "Copiază tot la dreapta"
 
 #. ID_ALL_LEFT
-#: Merge.rc:5346
+#: Merge.rc:5345
 msgid ""
 "\n"
 "Copy All to Left"
@@ -7731,7 +7726,7 @@ msgstr ""
 "Copiază tot la stânga"
 
 #. ID_AUTO_MERGE
-#: Merge.rc:5347
+#: Merge.rc:5346
 msgid ""
 "\n"
 "Auto Merge (Ctrl+Alt+M)"
@@ -7740,7 +7735,7 @@ msgstr ""
 "Fuzionează automat (Ctrl+Alt+M)"
 
 #. ID_FIRSTFILE
-#: Merge.rc:5348
+#: Merge.rc:5347
 msgid ""
 "\n"
 "First File"
@@ -7749,7 +7744,7 @@ msgstr ""
 "Primul fișier"
 
 #. ID_NEXTFILE
-#: Merge.rc:5349
+#: Merge.rc:5348
 msgid ""
 "\n"
 "Next File (Ctrl+F8)"
@@ -7758,7 +7753,7 @@ msgstr ""
 "Fișierul următor (Ctrl+F8)"
 
 #. ID_LASTFILE
-#: Merge.rc:5350
+#: Merge.rc:5349
 msgid ""
 "\n"
 "Last File"
@@ -7767,7 +7762,7 @@ msgstr ""
 "Ultimul fișier"
 
 #. ID_PREVFILE
-#: Merge.rc:5351
+#: Merge.rc:5350
 msgid ""
 "\n"
 "Previous File (Ctrl+F7)"
@@ -7776,143 +7771,143 @@ msgstr ""
 "Fișierul precedent (Ctrl+F7)"
 
 #. IDS_UNPACK_AUTO
-#: Merge.rc:5358
+#: Merge.rc:5357
 msgid "Adapted unpacker applied to both files (one needs extension)."
 msgstr ""
 "Dezarhivatorul potrivit este aplicat la ambele fișiere (este suficient ca "
 "doar un fișier să conțină extensie)."
 
 #. IDS_NO_PREDIFFER
-#: Merge.rc:5359
+#: Merge.rc:5358
 msgid "No Prediffer (Normal)"
 msgstr "Nu folosi prediferențiatorul (normal)"
 
 #. IDS_SUGGESTED_PLUGINS
-#: Merge.rc:5360
+#: Merge.rc:5359
 msgid "Suggested Plugins"
 msgstr "Plugin-uri sugerate"
 
 #. IDS_NOT_SUGGESTED_PLUGINS
-#: Merge.rc:5361
+#: Merge.rc:5360
 msgid "All Plugins"
 msgstr "Toate plugin-urile"
 
 #. IDS_PRIVATEBUILD_FMT
-#: Merge.rc:5367
+#: Merge.rc:5366
 #, c-format
 msgid "Private Build: %1"
 msgstr "Număr de asamblare privat: %1"
 
 #. IDS_ALLRIGHTS_RESERVED
-#: Merge.rc:5368
+#: Merge.rc:5367
 msgid " - All rights reserved."
 msgstr ""
 
 #. IDS_TITLE_PLUGINS_SETTINGS
-#: Merge.rc:5374
+#: Merge.rc:5373
 msgid "Plugin Settings"
 msgstr "Setări pentru plugin-uri"
 
 #. IDS_NO_SCT_SCRIPTS
-#: Merge.rc:5376
+#: Merge.rc:5375
 msgid "WSH not found - .sct scripts disabled"
 msgstr "Nu s-a găsit WSH - scripturile .sct sunt dezactivate"
 
 #. IDS_LOCBAR_GOTOLINE_FMT
-#: Merge.rc:5384
+#: Merge.rc:5383
 #, c-format
 msgid "G&o to Line %1"
 msgstr "&Mergi la rândul %1"
 
 #. IDS_GOTO_MOVED_LINE
-#: Merge.rc:5390
+#: Merge.rc:5389
 msgid "Go to Moved Line\tCtrl+Shift+G"
 msgstr "Mergi la rândul mutat\tCtrl+Shift+G"
 
 #. IDS_AUTOCOMPLETE_DISABLED
-#: Merge.rc:5396
+#: Merge.rc:5395
 msgctxt "Options dialog|General|Open dialog Auto completion"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_AUTOCOMPLETE_FILE_SYS
-#: Merge.rc:5397
+#: Merge.rc:5396
 msgid "From file system"
 msgstr "Din sistemul de fișiere"
 
 #. IDS_AUTOCOMPLETE_MRU
-#: Merge.rc:5398
+#: Merge.rc:5397
 msgid "From Most Recently Used list"
 msgstr "Din lista de recent utilizate"
 
 #. IDS_COLORSCHEME_PLAIN
-#: Merge.rc:5404
+#: Merge.rc:5403
 msgid "No Highlighting"
 msgstr "Fără evidențiere"
 
 #. IDS_COLORSCHEME_PO
-#: Merge.rc:5439
+#: Merge.rc:5438
 msgid "Portable Object"
 msgstr "Portable Object"
 
 #. IDS_COLORSCHEME_RSRC
-#: Merge.rc:5444
+#: Merge.rc:5443
 msgid "Resources"
 msgstr "Resurse"
 
 #. IDS_COLORSCHEME_SH
-#: Merge.rc:5448
+#: Merge.rc:5447
 msgid "Shell"
 msgstr "Shell"
 
 #. IDS_CLOSE_LEFT_TABS
-#: Merge.rc:5469
+#: Merge.rc:5468
 msgid "Close &Left Tabs"
 msgstr "Închide filele din stânga"
 
 #. IDS_CLOSE_RIGHT_TABS
-#: Merge.rc:5470
+#: Merge.rc:5469
 msgid "Close R&ight Tabs"
 msgstr "Închide filele din dreapta"
 
 #. IDS_CLOSE_OTHER_TABS
-#: Merge.rc:5471
+#: Merge.rc:5470
 msgid "Close &Other Tabs"
 msgstr "Închide celelalte file"
 
 #. IDS_TABBAR_AUTO_MAXWIDTH
-#: Merge.rc:5472
+#: Merge.rc:5471
 msgid "Enable &Auto Max Width"
 msgstr "Activează mărime maximă &automatp"
 
 #. IDS_WEBPAGE_MENU
-#: Merge.rc:5482
+#: Merge.rc:5481
 msgid "We&bpage"
 msgstr "Pagină &web"
 
 #. IDS_VIEW_WRAP_TEXT
-#: Merge.rc:5487
+#: Merge.rc:5486
 msgid "W&rap Text"
 msgstr "Înfășoa&ră textul"
 
 #. IDS_NOTINSTALLED
-#: Merge.rc:5492
+#: Merge.rc:5491
 msgid "%1 is not installed."
 msgstr "%1 nu este instalat."
 
 #. IDS_CREATE_FOLDER
-#: Merge.rc:5497
+#: Merge.rc:5496
 #, c-format
 msgid "%1 does not exist. Create it?"
 msgstr "%1 nu există. Doriți să-l creați?"
 
 #. IDS_CREATE_FOLDER_ERROR
-#: Merge.rc:5498
+#: Merge.rc:5497
 msgid "Failed to create folder."
 msgstr "Eroare creare director."
 
 #. IDC_EXT_EDITOR_PATH
-#: Merge.rc:5503
+#: Merge.rc:5502
 msgid ""
 "Parameters:\n"
 "$file: Current file path\n"
@@ -7923,912 +7918,912 @@ msgstr ""
 "$linenum: Numărul rândului unde se află cursorul"
 
 #. IDS_DIFF_ALGORITHM_DEFAULT
-#: Merge.rc:5508
+#: Merge.rc:5507
 msgid "default"
 msgstr "implicit"
 
 #. IDS_DIFF_ALGORITHM_MINIMAL
-#: Merge.rc:5509
+#: Merge.rc:5508
 msgid "minimal"
 msgstr "minimal"
 
 #. IDS_DIFF_ALGORITHM_PATIENCE
-#: Merge.rc:5510
+#: Merge.rc:5509
 msgid "patience"
 msgstr "patience"
 
 #. IDS_DIFF_ALGORITHM_HISTOGRAM
-#: Merge.rc:5511
+#: Merge.rc:5510
 msgid "histogram"
 msgstr "histogram"
 
 #. IDS_DIFF_ALGORITHM_NONE
-#: Merge.rc:5512
+#: Merge.rc:5511
 msgid "none"
 msgstr "niciunul"
 
 #. IDS_RENDERING_MODE_GDI
-#: Merge.rc:5517
+#: Merge.rc:5516
 msgid "GDI"
 msgstr "GDI"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_DEFAULT
-#: Merge.rc:5518
+#: Merge.rc:5517
 msgid "DirectWrite Default"
 msgstr "DirectWrite implicit"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_ALIASED
-#: Merge.rc:5519
+#: Merge.rc:5518
 msgid "DirectWrite Aliased"
 msgstr "DirectWrite aliasat"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_GDI_CLASSIC
-#: Merge.rc:5520
+#: Merge.rc:5519
 msgid "DirectWrite GDI Classic"
 msgstr "DirectWrite GDI clasic"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_GDI_NATURAL
-#: Merge.rc:5521
+#: Merge.rc:5520
 msgid "DirectWrite GDI Natural"
 msgstr "DirectWrite GDI natural"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_NATURAL
-#: Merge.rc:5522
+#: Merge.rc:5521
 msgid "DirectWrite Natural"
 msgstr "DirectWrite natural"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_NATURAL_SYMMETRIC
-#: Merge.rc:5523
+#: Merge.rc:5522
 msgid "DirectWrite Natural Symmetric"
 msgstr "DirectWrite natural simetric"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_DISABLED
-#: Merge.rc:5528
+#: Merge.rc:5527
 msgctxt "Options dialog|General|Close windows with Esc"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_1
-#: Merge.rc:5529
+#: Merge.rc:5528
 msgid "MDI child window or main window"
 msgstr "Fereastră copil MDI sau fereastră principală"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_2
-#: Merge.rc:5530
+#: Merge.rc:5529
 msgid "MDI child window only"
 msgstr "Doar fereastră copil MDI"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_3
-#: Merge.rc:5531
+#: Merge.rc:5530
 msgid "Close main window if only one MDI child window"
 msgstr "Închide fereastra principală dacă există doar o fereastră copil MDI"
 
 #. IDS_DIFF_GROUP
-#: Merge.rc:5536
+#: Merge.rc:5535
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Diff"
 msgstr "Diferență"
 
 #. IDS_DIFF_HIGHLIGHT
-#: Merge.rc:5537
+#: Merge.rc:5536
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Highlight"
 msgstr "Evidențiere"
 
 #. IDS_DIFF_BLINK
-#: Merge.rc:5538
+#: Merge.rc:5537
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Blink"
 msgstr "Clipire"
 
 #. IDS_DIFF_BLOCKSIZE
-#: Merge.rc:5539
+#: Merge.rc:5538
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Block Size"
 msgstr "Mărime bloc"
 
 #. IDS_DIFF_BLOCKALPHA
-#: Merge.rc:5540
+#: Merge.rc:5539
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Block Alpha"
 msgstr "Alpha bloc"
 
 #. IDS_DIFF_CDTHRESHOLD
-#: Merge.rc:5541
+#: Merge.rc:5540
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "CD Threshold"
 msgstr "Prag CD"
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION
-#: Merge.rc:5542
+#: Merge.rc:5541
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Ins/Del Detection"
 msgstr "Detectare taste Ins/Del"
 
 #. IDS_OVERLAY_MODE_NONE
-#: Merge.rc:5543 Merge.rc:5548
+#: Merge.rc:5542 Merge.rc:5547
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "None"
 msgstr "Nimic"
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION_VERTICAL
-#: Merge.rc:5544
+#: Merge.rc:5543
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Vertical"
 msgstr "Vertical"
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION_HORIZONTAL
-#: Merge.rc:5545
+#: Merge.rc:5544
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Horizontal"
 msgstr "Horizontal"
 
 #. IDS_OVERLAY_GROUP
-#: Merge.rc:5546
+#: Merge.rc:5545
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Overlay"
 msgstr "Suprapunere"
 
 #. IDS_OVERLAY_ALPHA
-#: Merge.rc:5547
+#: Merge.rc:5546
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha"
 msgstr "Alpha"
 
 #. IDS_OVERLAY_MODE_XOR
-#: Merge.rc:5549
+#: Merge.rc:5548
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "XOR"
 msgstr "XOR"
 
 #. IDS_OVERLAY_MODE_ALPHA
-#: Merge.rc:5550
+#: Merge.rc:5549
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha Blend"
 msgstr "Amestec Alpha"
 
 #. IDS_OVERLAY_MODE_ALPHA_ANIMATION
-#: Merge.rc:5551
+#: Merge.rc:5550
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha Animation"
 msgstr "Animație Alpha"
 
 #. IDS_ZOOM
-#: Merge.rc:5552
+#: Merge.rc:5551
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Zoom"
 msgstr "Mărire"
 
 #. IDS_PAGE
-#: Merge.rc:5553
+#: Merge.rc:5552
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Page:"
 msgstr "Pagina:"
 
 #. IDS_IMGCMP_STATUS_PT_RGBA_FMT
-#: Merge.rc:5554
+#: Merge.rc:5553
 #, c-format
 msgid "Pt: (%d, %d)  RGBA: (%d, %d, %d, %d)  "
 msgstr "Pt: (%d, %d)  RGBA: (%d, %d, %d, %d)  "
 
 #. IDS_IMGCMP_STATUS_DIST1_FMT
-#: Merge.rc:5555
+#: Merge.rc:5554
 #, c-format
 msgid "Dist: %g  "
 msgstr "Dist: %g  "
 
 #. IDS_IMGCMP_STATUS_DIST2_FMT
-#: Merge.rc:5556
+#: Merge.rc:5555
 #, c-format
 msgid "Dist: %g, %g  "
 msgstr "Dist: %g, %g  "
 
 #. IDS_IMGCMP_STATUS_PAGE_ZOOM_SIZE_BPP_FMT
-#: Merge.rc:5557
+#: Merge.rc:5556
 #, c-format
 msgid "Page: %d/%d  Zoom: %d%%  %dx%dpx  %dbpp  "
 msgstr "Pagină: %d/%d  Zoom: %d%%  %dx%dpx  %dbpp  "
 
 #. IDS_IMGCMP_STATUS_RC_FMT
-#: Merge.rc:5558
+#: Merge.rc:5557
 #, c-format
 msgid "Rc: (%d, %d)  "
 msgstr "Rc: (%d, %d)  "
 
 #. IDS_IMGCMP_STATUS_FLIPPED_FMT
-#: Merge.rc:5559
+#: Merge.rc:5558
 #, c-format
 msgid "Flipped: %s  "
 msgstr "Reflectat: %s  "
 
 #. IDS_IMGCMP_STATUS_ROTATED_FMT
-#: Merge.rc:5560
+#: Merge.rc:5559
 #, c-format
 msgid "Rotated: %d  "
 msgstr "Rotit: %d  "
 
 #. IDS_IMGCMP_REPORT_ALLPAGES
-#: Merge.rc:5561
+#: Merge.rc:5560
 msgid "All pages"
 msgstr "Toate paginile"
 
 #. IDS_IGNSUB_STR1
-#: Merge.rc:5566
+#: Merge.rc:5565
 msgid "<Edit here>"
 msgstr "<Editează aici>"
 
 #. IDS_IGNSUB_STR2
-#: Merge.rc:5567
+#: Merge.rc:5566
 msgid "No differences found to select"
 msgstr "Nu au fost găsite diferențe de selectat"
 
 #. IDS_IGNSUB_STR3
-#: Merge.rc:5568
+#: Merge.rc:5567
 msgid "No differences found to add as substitution filter"
 msgstr "Nu au fost găsite diferențe de adăugat ca filtru de substituție"
 
 #. IDS_IGNSUB_STR4
-#: Merge.rc:5569
+#: Merge.rc:5568
 msgid "The pair is already in the Substitution Filters list"
 msgstr "Perechea se află deja în lista filtrelor de substituție"
 
 #. IDS_IGNSUB_STR5
-#: Merge.rc:5570
+#: Merge.rc:5569
 msgid "Add this change to Substitution Filters?"
 msgstr "Adaug această modificare la filtrele de substituție?"
 
 #. IDS_OCRRESULT_TEXTONLY
-#: Merge.rc:5575
+#: Merge.rc:5574
 msgid "Text only"
 msgstr "Doar text"
 
 #. IDS_OCRRESULT_POS_LINE
-#: Merge.rc:5576
+#: Merge.rc:5575
 msgid "Line-by-line position and text"
 msgstr "Poziție și text rând cu rând"
 
 #. IDS_OCRRESULT_POS_WORD
-#: Merge.rc:5577
+#: Merge.rc:5576
 msgid "Word-by-word position and text"
 msgstr "Poziție și text cuvânt cu cuvânt"
 
 #. IDS_USERDATAFOLDER_APPDATA
-#: Merge.rc:5582
+#: Merge.rc:5581
 msgid "AppData (Roaming) folder"
 msgstr ""
 
 #. IDS_USERDATAFOLDER_INSTALL
-#: Merge.rc:5583
+#: Merge.rc:5582
 msgid "Install folder"
 msgstr "Directorul de instalare"
 
 #. IDS_USERDATAFOLDER_DOCUMENTS
-#: Merge.rc:5584
+#: Merge.rc:5583
 msgid "Documents folder"
 msgstr ""
 
 #. IDS_SINGLEINSTANCE_DISABLED
-#: Merge.rc:5589
+#: Merge.rc:5588
 msgctxt "Options dialog|General|Single instance mode"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_SINGLEINSTANCE_STR1
-#: Merge.rc:5590
+#: Merge.rc:5589
 msgid "Allow only one instance to run"
 msgstr "Permite rularea unei singure instanțe"
 
 #. IDS_CLIPBOARD_HISTORY
-#: Merge.rc:5591
+#: Merge.rc:5590
 msgid "Clipboard &History"
 msgstr ""
 
 #. IDS_SINGLEINSTANCE_STR2
-#: Merge.rc:5592
+#: Merge.rc:5591
 msgid "Allow only one instance; wait for termination"
 msgstr ""
 "Permite rularea unei singure instanțe și așteaptă ca instanța să se termine"
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_DISABLED
-#: Merge.rc:5597
+#: Merge.rc:5596
 msgctxt "Options dialog|General|Auto-reload modified files"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_STR1
-#: Merge.rc:5598
+#: Merge.rc:5597
 msgid "Only on window activated"
 msgstr "Doar în fereastră activată"
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_STR2
-#: Merge.rc:5599
+#: Merge.rc:5598
 msgid "Immediately"
 msgstr "Imediat"
 
 #. IDS_PLUGIN_ALL
-#: Merge.rc:5604
+#: Merge.rc:5603
 msgid "Al&l"
 msgstr "Tot"
 
 #. IDS_PLUGIN_OTHERS
-#: Merge.rc:5605
+#: Merge.rc:5604
 msgid "&Others"
 msgstr "Altele"
 
-#: Merge.rc:5607
+#: Merge.rc:5606
 #, c-format
 msgid "Missing plugin name in pipeline: %1"
 msgstr "Numele fișierului plugin lipsește în lanțul de plugin-uri: %1"
 
-#: Merge.rc:5609
+#: Merge.rc:5608
 #, c-format
 msgid "Missing quote in plugin pipeline: %1"
 msgstr "Ghilimele lipsă în lanțul de plugin-uri: %1"
 
 #. IDS_PLUGIN_NAME_ALREADY_EXISTS
-#: Merge.rc:5610
+#: Merge.rc:5609
 #, c-format
 msgid "Plugin name '%1' already exists."
 msgstr ""
 
 #. IDS_PLUGIN_TITLE1
-#: Merge.rc:5611
+#: Merge.rc:5610
 msgid "Specify plugin arguments"
 msgstr "Specificați argumente plugin"
 
-#: Merge.rc:5613
+#: Merge.rc:5612
 #, c-format
 msgid "Plugin not found or invalid: %1"
 msgstr "Plugin inexistent sau invalid: %1"
 
 #. IDS_PLUGIN_NOT_UNPACK
-#: Merge.rc:5614
+#: Merge.rc:5613
 #, c-format
 msgid "'%1' is not an unpacker plugin"
 msgstr "'%1' nu este plugin dezarhivator"
 
 #. IDS_PLUGIN_NOT_PREDIFF
-#: Merge.rc:5615
+#: Merge.rc:5614
 #, c-format
 msgid "'%1' is not a prediffer plugin"
 msgstr "'%1' nu este plugin prediferențiator"
 
-#: Merge.rc:5617
+#: Merge.rc:5616
 #, c-format
 msgid "Error prediffing '%1' with '%2'. Prediffing disabled."
 msgstr ""
 
 #. IDS_PLUGIN_CIRCULAR_REFERENCE
-#: Merge.rc:5618
+#: Merge.rc:5617
 #, c-format
 msgid "Circular reference in plugin pipeline: %1"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE1
-#: Merge.rc:5619
+#: Merge.rc:5618
 msgid "URL Handler"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE2
-#: Merge.rc:5620
+#: Merge.rc:5619
 msgid "File Unpacker"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE3
-#: Merge.rc:5621
+#: Merge.rc:5620
 msgid "File or Folder Unpacker"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE5
-#: Merge.rc:5623
+#: Merge.rc:5622
 msgid "Alias for Unpacker"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE6
-#: Merge.rc:5624
+#: Merge.rc:5623
 msgid "Alias for Prediffer"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE7
-#: Merge.rc:5625
+#: Merge.rc:5624
 msgid "Alias for Editor script"
 msgstr ""
 
 #. IDS_PLUGIN_ALIAS_DESC
-#: Merge.rc:5626
+#: Merge.rc:5625
 #, c-format
 msgid "Alias for plugin pipeline '%1'"
 msgstr ""
 
 #. IDS_PLUGIN_NEW_DESC
-#: Merge.rc:5627
+#: Merge.rc:5626
 msgid "New plugin description"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_ALL
-#: Merge.rc:5628
+#: Merge.rc:5627
 msgid "All"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_1ST
-#: Merge.rc:5629
+#: Merge.rc:5628
 msgid "1st"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_2ND
-#: Merge.rc:5630
+#: Merge.rc:5629
 msgid "2nd"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_3RD
-#: Merge.rc:5631
+#: Merge.rc:5630
 msgid "3rd"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_1ST_2ND
-#: Merge.rc:5632
+#: Merge.rc:5631
 msgid "1st and 2nd"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_1ST_3RD
-#: Merge.rc:5633
+#: Merge.rc:5632
 msgid "1st and 3rd"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_2ND_3RD
-#: Merge.rc:5634
+#: Merge.rc:5633
 msgid "2nd and 3rd"
 msgstr ""
 
 #. IDS_PLUGIN_CTRL_CLICK
-#: Merge.rc:5635
+#: Merge.rc:5634
 msgid "(Ctrl+Click to add to pipeline)"
 msgstr ""
 
 #. IDS_FILTER_APPLIED
-#: Merge.rc:5640
+#: Merge.rc:5639
 msgid "Filter applied"
 msgstr "Filtru aplicat"
 
 #. IDS_FILTERMENU_COMPARE
-#: Merge.rc:5645
+#: Merge.rc:5644
 #, c-format
 msgid "Compare %1"
 msgstr ""
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN2
-#: Merge.rc:5647
+#: Merge.rc:5646
 msgid "&Filter by This Column..."
 msgstr ""
 
 #. IDS_CLIPBOARDHISTORY_TIME
-#: Merge.rc:5652
+#: Merge.rc:5651
 #, c-format
 msgid "Clipboard at %s"
 msgstr "Clipboard la %s"
 
 #. IDS_CLIPBOARDHISTORY_DISABLED
-#: Merge.rc:5653
+#: Merge.rc:5652
 msgid "Clipboard history disabled.\r\nEnable: Windows logo key + V, then Turn on."
 msgstr ""
 "Istoricul clipboard-ului este deactivat.\r\n"
 "Pentru a activa istoricul clipboard-ului, apăsați tasta logo Windows + V, "
 "apoi apăsați butonul Porniți."
 
-#: Merge.rc:5655
+#: Merge.rc:5654
 msgid "This system does not support clipboard history."
 msgstr "Acest sistem nu suportă istoricul clipboard-ului."
 
-#: Merge.rc:5657
+#: Merge.rc:5656
 msgid "32-bit WinMerge does not support Clipboard Compare"
 msgstr "Versiunea pe 32 biți WinMerge nu suportă Comparare clipboard"
 
 #. IDS_WEBVIEW2_RUNTIME_NOT_INSTALLED
-#: Merge.rc:5662
+#: Merge.rc:5661
 msgid "WebView2 runtime not installed. Download it?"
 msgstr "Runtime-ul WebView2 nu este instalat. Doriți să-l descărcați?"
 
 #. IDS_JUMPLIST_NEW_TEXT_COMPARE
-#: Merge.rc:5667
+#: Merge.rc:5666
 msgid "New Text Compare"
 msgstr "Comparare text nouă"
 
 #. IDS_JUMPLIST_NEW_TABLE_COMPARE
-#: Merge.rc:5668
+#: Merge.rc:5667
 msgid "New Table Compare"
 msgstr "Comparare tabel nouă"
 
 #. IDS_JUMPLIST_NEW_BINARY_COMPARE
-#: Merge.rc:5669
+#: Merge.rc:5668
 msgid "New Binary Compare"
 msgstr "Comparare binară nouă"
 
 #. IDS_JUMPLIST_NEW_IMAGE_COMPARE
-#: Merge.rc:5670
+#: Merge.rc:5669
 msgid "New Image Compare"
 msgstr "Comparare imagine nouă"
 
 #. IDS_JUMPLIST_NEW_WEBPAGE_COMPARE
-#: Merge.rc:5671
+#: Merge.rc:5670
 msgid "New Webpage Compare"
 msgstr "Comparare pagină web nouă"
 
 #. IDS_JUMPLIST_NEW_FOLDER_COMPARE
-#: Merge.rc:5672
+#: Merge.rc:5671
 msgid "New Folder Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_CLIPBOARD_COMPARE
-#: Merge.rc:5673
+#: Merge.rc:5672
 msgid "Clipboard Compare"
 msgstr "Comparare clipboard"
 
 #. IDS_PREVIEWBAR_PRINT
-#: Merge.rc:5678
+#: Merge.rc:5677
 msgid "&Print..."
 msgstr ""
 
 #. IDS_PREVIEWBAR_PREVPAGE
-#: Merge.rc:5680
+#: Merge.rc:5679
 msgid "Pre&v Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_TWOPAGE
-#: Merge.rc:5681
+#: Merge.rc:5680
 msgid "&Two Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_ONEPAGE
-#: Merge.rc:5682
+#: Merge.rc:5681
 msgid "&One Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_ZOOMIN
-#: Merge.rc:5683
+#: Merge.rc:5682
 msgid "Zoom &In"
 msgstr ""
 
 #. IDS_PREVIEWBAR_ZOOMOUT
-#: Merge.rc:5684
+#: Merge.rc:5683
 msgid "Zoom &Out"
 msgstr ""
 
 #. IDS_WEBPAGE_COMPARING
-#: Merge.rc:5690
+#: Merge.rc:5689
 msgid "Comparing..."
 msgstr ""
 
 #. IDS_WEBPAGE_ZOOM
-#: Merge.rc:5691
+#: Merge.rc:5690
 msgid "Zoom:"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_DIFFHUNK
-#: Merge.rc:5696
+#: Merge.rc:5695
 msgid "Diff hunk"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_INLINE
-#: Merge.rc:5697
+#: Merge.rc:5696
 msgid "Inline diff"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_LINE
-#: Merge.rc:5698
+#: Merge.rc:5697
 msgid "Line"
 msgstr ""
 
-#: Merge.rc:5699
+#: Merge.rc:5698
 msgid "Character"
 msgstr ""
 
 #. ID_MICE_PREVDIFF
-#: Merge.rc:5704
+#: Merge.rc:5703
 msgid "\nPrevious Difference (Alt+Up)\n(Right Button+Wheel Up)\n(Alt+Wheel Up)"
 msgstr ""
 
 #. ID_MICE_NEXTDIFF
-#: Merge.rc:5705
+#: Merge.rc:5704
 msgid "\nNext Difference (Alt+Down)\n(Right Button+Wheel Down)\n(Alt+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_L2R
-#: Merge.rc:5706
+#: Merge.rc:5705
 msgid "\nCopy to Right (Alt+Right)\n(Right Button+Wheel Right)\n(Alt+Wheel Right)\n(Alt+Shift+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_R2L
-#: Merge.rc:5707
+#: Merge.rc:5706
 msgid "\nCopy to Left (Alt+Left)\n(Right Button+Wheel Left)\n(Alt+Wheel Left)\n(Alt+Shift+Wheel Up)"
 msgstr ""
 
 #. ID_MICE_L2RNEXT
-#: Merge.rc:5708
+#: Merge.rc:5707
 msgid "\nCopy to Right and Advance (Ctrl+Alt+Right)\n(Ctrl+Alt+Wheel Right)\n(Ctrl+Alt+Shift+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_R2LNEXT
-#: Merge.rc:5709
+#: Merge.rc:5708
 msgid "\nCopy to Left and Advance (Ctrl+Alt+Left)\n(Ctrl+Alt+Wheel Left)\n(Ctrl+Alt+Shift+Wheel Up)"
 msgstr ""
 
 #. IDS_LOG_COMPARING_2
-#: Merge.rc:5719
+#: Merge.rc:5718
 #, c-format
 msgid "Comparing %1 with %2"
 msgstr ""
 
 #. IDS_LOG_COMPARING_3
-#: Merge.rc:5720
+#: Merge.rc:5719
 #, c-format
 msgid "Comparing %1 with %2 and %3"
 msgstr ""
 
 #. IDS_LOG_COMPARE_COMPLETED
-#: Merge.rc:5721
+#: Merge.rc:5720
 msgid "Comparison completed"
 msgstr ""
 
 #. IDS_LOG_COMPARE_ERROR_2
-#: Merge.rc:5722
+#: Merge.rc:5721
 #, c-format
 msgid "Failed to compare %1 with %2: "
 msgstr ""
 
 #. IDS_LOG_COMPARE_ERROR_3
-#: Merge.rc:5723
+#: Merge.rc:5722
 #, c-format
 msgid "Failed to compare %1 with %2 and %3: "
 msgstr ""
 
 #. IDS_LOG_FILE_SAVED
-#: Merge.rc:5724
+#: Merge.rc:5723
 msgid "File saved"
 msgstr ""
 
 #. IDS_LOG_COPYING_FILES
-#: Merge.rc:5725
+#: Merge.rc:5724
 msgid "Copying files..."
 msgstr ""
 
 #. IDS_LOG_MOVING_FILES
-#: Merge.rc:5726
+#: Merge.rc:5725
 msgid "Moving files..."
 msgstr ""
 
 #. IDS_LOG_DELETING_FILES
-#: Merge.rc:5727
+#: Merge.rc:5726
 msgid "Deleting files..."
 msgstr ""
 
 #. IDS_LOG_RECYCLEBIN
-#: Merge.rc:5728
+#: Merge.rc:5727
 msgid "Recycle Bin"
 msgstr ""
 
 #. IDS_LOG_PERMANENTLY_DELETED
-#: Merge.rc:5729
+#: Merge.rc:5728
 msgid "Permanently deleted"
 msgstr ""
 
 #. IDS_LOG_FILEOPERATION_COMPLETED
-#: Merge.rc:5730
+#: Merge.rc:5729
 msgid "File operation completed successfully"
 msgstr ""
 
 #. IDS_LOG_FILEOPERATION_CANCELED
-#: Merge.rc:5731
+#: Merge.rc:5730
 msgid "File operation canceled"
 msgstr ""
 
 #. IDS_FILTER_ERROR_NO_ERROR
-#: Merge.rc:5736
+#: Merge.rc:5735
 msgid "No error"
 msgstr ""
 
 #. IDS_FILTER_ERROR_EMPTY_EXPRESSION
-#: Merge.rc:5737
+#: Merge.rc:5736
 msgid "Filter expression is empty"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNKNOWN_CHAR
-#: Merge.rc:5738
+#: Merge.rc:5737
 msgid "Unknown character in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNTERMINATED_STRING
-#: Merge.rc:5739
+#: Merge.rc:5738
 msgid "Unterminated string literal"
 msgstr ""
 
 #. IDS_FILTER_ERROR_SYNTAX_ERROR
-#: Merge.rc:5740
+#: Merge.rc:5739
 msgid "Syntax error in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_PARSE_FAILURE
-#: Merge.rc:5741
+#: Merge.rc:5740
 msgid "Failed to parse filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_LITERAL
-#: Merge.rc:5742
+#: Merge.rc:5741
 msgid "Invalid literal value"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_REGULAR_EXPRESSION
-#: Merge.rc:5743
+#: Merge.rc:5742
 msgid "Invalid regular expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNDEFINED_IDENTIFIER
-#: Merge.rc:5744
+#: Merge.rc:5743
 msgid "Undefined identifier"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_ARGUMENT_COUNT
-#: Merge.rc:5745
+#: Merge.rc:5744
 msgid "Invalid number of arguments"
 msgstr ""
 
 #. IDS_FILTER_ERROR_FILTER_NAME_NOT_FOUND
-#: Merge.rc:5746
+#: Merge.rc:5745
 msgid "Filter name not found"
 msgstr ""
 
 #. IDS_FILTER_ERROR_DIVIDE_BY_ZERO
-#: Merge.rc:5747
+#: Merge.rc:5746
 msgid "Division by zero in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNKNOWN_ERROR
-#: Merge.rc:5748
+#: Merge.rc:5747
 msgid "Unknown error"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_PROPERTY_NAME
-#: Merge.rc:5749
+#: Merge.rc:5748
 msgid "Invalid property name"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_DIRECTIVE
-#: Merge.rc:5750
+#: Merge.rc:5749
 msgid "Invalid directive"
 msgstr ""
 
 #. IDS_FILTER_OP_EQUALS
-#: Merge.rc:5755
+#: Merge.rc:5754
 msgid "Equals"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_EQUALS
-#: Merge.rc:5756
+#: Merge.rc:5755
 msgid "Does not equal"
 msgstr ""
 
 #. IDS_FILTER_OP_LESS_THAN
-#: Merge.rc:5757
+#: Merge.rc:5756
 msgid "Less than"
 msgstr ""
 
 #. IDS_FILTER_OP_LESS_EQUAL
-#: Merge.rc:5758
+#: Merge.rc:5757
 msgid "Less than or equal to"
 msgstr ""
 
 #. IDS_FILTER_OP_GREATER_EQUAL
-#: Merge.rc:5759
+#: Merge.rc:5758
 msgid "Greater than or equal to"
 msgstr ""
 
 #. IDS_FILTER_OP_GREATER_THAN
-#: Merge.rc:5760
+#: Merge.rc:5759
 msgid "Greater than"
 msgstr ""
 
 #. IDS_FILTER_OP_BETWEEN
-#: Merge.rc:5761
+#: Merge.rc:5760
 msgid "Between"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_BETWEEN
-#: Merge.rc:5762
+#: Merge.rc:5761
 msgid "Not Between"
 msgstr ""
 
 #. IDS_FILTER_OP_CONTAINS
-#: Merge.rc:5763
+#: Merge.rc:5762
 msgid "Contains"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_CONTAINS
-#: Merge.rc:5764
+#: Merge.rc:5763
 msgid "Not Contains"
 msgstr ""
 
 #. IDS_FILTER_OP_RECONTAINS
-#: Merge.rc:5765
+#: Merge.rc:5764
 msgid "Contains (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_RECONTAINS
-#: Merge.rc:5766
+#: Merge.rc:5765
 msgid "Not Contains (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_LIKE
-#: Merge.rc:5767
+#: Merge.rc:5766
 msgid "Match (wildcard)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_LIKE
-#: Merge.rc:5768
+#: Merge.rc:5767
 msgid "Not match (wildcard)"
 msgstr ""
 
 #. IDS_FILTER_OP_MATCHES
-#: Merge.rc:5769
+#: Merge.rc:5768
 msgid "Match (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_MATCHES
-#: Merge.rc:5770
+#: Merge.rc:5769
 msgid "Not match (regex)"
 msgstr ""
 
 #. IDS_COLORMODE_LIGHT
-#: Merge.rc:5775
+#: Merge.rc:5774
 msgid "Light"
 msgstr ""
 
 #. IDS_COLORMODE_DARK
-#: Merge.rc:5776
+#: Merge.rc:5775
 msgid "Dark"
 msgstr ""
 
 #. IDS_COLORMODE_FOLLOWSYSTEM
-#: Merge.rc:5777
+#: Merge.rc:5776
 msgid "Follow system"
 msgstr ""
 
 #. IDS_EXAMPLE
-#: Merge.rc:5782
+#: Merge.rc:5781
 #, c-format
 msgid "e.g. %1"
 msgstr ""
 
 #. IDS_DETECTED_PREVIOUS_CRASH
-#: Merge.rc:5787
+#: Merge.rc:5786
 msgid "WinMerge detected a previous crash. Please report this if possible."
 msgstr ""
 
 #. IDS_REGEX_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5792
+#: Merge.rc:5791
 msgid "# Regex replacement list\r\n# Format: regex<TAB>replacement\r\n# Backreferences like $1, $2 are supported\r\n\r\n(\\d{4})-(\\d{2})-(\\d{2})\t$1_$2_$3\r\n"
 msgstr ""
 
 #. IDS_STRING_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5793
+#: Merge.rc:5792
 msgid "# Replacement list\r\n# Format: search<TAB>replacement\r\n# Lines starting with # are ignored\r\n\r\nfrom1\tto1\r\nfrom2\tto2\r\n"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_ONLY
-#: Merge.rc:5798
+#: Merge.rc:5797
 msgid "Built-in only"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_FIRST
-#: Merge.rc:5799
+#: Merge.rc:5798
 msgid "Built-in first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_FIRST
-#: Merge.rc:5800
+#: Merge.rc:5799
 msgid "Tree-sitter first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_ONLY
-#: Merge.rc:5801
+#: Merge.rc:5800
 msgid "Tree-sitter only"
 msgstr ""
 

--- a/Translations/WinMerge/Russian.po
+++ b/Translations/WinMerge/Russian.po
@@ -25,7 +25,7 @@ msgstr ""
 "X-Poedit-Country: RUSSIAN FEDERATION\n"
 
 #. LANGUAGE, SUBLANGUAGE
-#: Merge.rc:26 Merge.rc:59 Merge.rc:5818
+#: Merge.rc:26 Merge.rc:59 Merge.rc:5817
 msgid "LANG_ENGLISH, SUBLANG_ENGLISH_US"
 msgstr "LANG_RUSSIAN, SUBLANG_DEFAULT"
 
@@ -167,7 +167,7 @@ msgstr "&Скрипты"
 #. IDS_NO_EDIT_SCRIPTS
 #: Merge.rc:127 Merge.rc:352 Merge.rc:463 Merge.rc:673 Merge.rc:678
 #: Merge.rc:887 Merge.rc:899 Merge.rc:906 Merge.rc:963 Merge.rc:1210
-#: Merge.rc:5375
+#: Merge.rc:5374
 msgid "< Empty >"
 msgstr "< Пусто >"
 
@@ -232,7 +232,7 @@ msgid "Auto-Fit All Columns"
 msgstr "Автоширина столбцов"
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN
-#: Merge.rc:153 Merge.rc:5646
+#: Merge.rc:153 Merge.rc:5645
 msgid "&Filter by This Column"
 msgstr "Фильтр по этому столбцу"
 
@@ -293,7 +293,7 @@ msgid "&Previous Page"
 msgstr "Предыдущая страница"
 
 #. IDS_PREVIEWBAR_NEXTPAGE
-#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5679
+#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5678
 msgid "&Next Page"
 msgstr "Следующая страница"
 
@@ -544,7 +544,7 @@ msgstr "Двоичный"
 #. IDS_IMAGE_MENU
 #: Merge.rc:329 Merge.rc:338 Merge.rc:432 Merge.rc:441 Merge.rc:609
 #: Merge.rc:618 Merge.rc:670 Merge.rc:960 Merge.rc:1187 Merge.rc:1200
-#: Merge.rc:5477
+#: Merge.rc:5476
 msgid "&Image"
 msgstr "Изображение"
 
@@ -666,7 +666,7 @@ msgid "&Huge"
 msgstr "&Огромные значки"
 
 #. IDS_VIEW_MENU_BAR
-#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5714
+#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5713
 msgid "Men&u Bar"
 msgstr "Панель меню"
 
@@ -1321,7 +1321,7 @@ msgid "Lo&cation Pane"
 msgstr "Панель управления"
 
 #. IDS_OUTPUTBAR_CAPTION
-#: Merge.rc:782 Merge.rc:5252
+#: Merge.rc:782 Merge.rc:5251
 msgid "Output Pane"
 msgstr "Панель вывода"
 
@@ -1584,55 +1584,55 @@ msgid "Co&mpare As"
 msgstr "Сравнить как"
 
 #. IDS_COPY_LEFT_TO_MIDDLE2
-#: Merge.rc:968 Merge.rc:980 Merge.rc:4852
+#: Merge.rc:968 Merge.rc:980 Merge.rc:4851
 #, c-format
 msgid "Left to Middle (%1 of %2)"
 msgstr "Слева в центр (%1 из %2)"
 
 #. IDS_COPY_LEFT_TO_RIGHT2
-#: Merge.rc:969 Merge.rc:981 Merge.rc:4851
+#: Merge.rc:969 Merge.rc:981 Merge.rc:4850
 #, c-format
 msgid "Left to Right (%1 of %2)"
 msgstr "Слева направо (%1 из %2)"
 
 #. IDS_MOVE_LEFT_TO2
-#: Merge.rc:970 Merge.rc:982 Merge.rc:1045 Merge.rc:4863 Merge.rc:4892
+#: Merge.rc:970 Merge.rc:982 Merge.rc:1045 Merge.rc:4862 Merge.rc:4891
 #, c-format
 msgid "Left to... (%1 of %2)"
 msgstr "Слева... (%1 из %2)"
 
 #. IDS_COPY_MIDDLE_TO_LEFT2
-#: Merge.rc:971 Merge.rc:983 Merge.rc:4849
+#: Merge.rc:971 Merge.rc:983 Merge.rc:4848
 #, c-format
 msgid "Middle to Left (%1 of %2)"
 msgstr "Из центра налево (%1 из %2)"
 
 #. IDS_COPY_MIDDLE_TO_RIGHT2
-#: Merge.rc:972 Merge.rc:984 Merge.rc:4850
+#: Merge.rc:972 Merge.rc:984 Merge.rc:4849
 #, c-format
 msgid "Middle to Right (%1 of %2)"
 msgstr "Из центра направо (%1 из %2)"
 
 #. IDS_MOVE_MIDDLE_TO2
-#: Merge.rc:973 Merge.rc:985 Merge.rc:1046 Merge.rc:4864 Merge.rc:4893
+#: Merge.rc:973 Merge.rc:985 Merge.rc:1046 Merge.rc:4863 Merge.rc:4892
 #, c-format
 msgid "Middle to... (%1 of %2)"
 msgstr "Из центра... (%1 из %2)"
 
 #. IDS_COPY_RIGHT_TO_MIDDLE2
-#: Merge.rc:974 Merge.rc:986 Merge.rc:4848
+#: Merge.rc:974 Merge.rc:986 Merge.rc:4847
 #, c-format
 msgid "Right to Middle (%1 of %2)"
 msgstr "Справа в центр (%1 из %2)"
 
 #. IDS_COPY_RIGHT_TO_LEFT2
-#: Merge.rc:975 Merge.rc:987 Merge.rc:4847
+#: Merge.rc:975 Merge.rc:987 Merge.rc:4846
 #, c-format
 msgid "Right to Left (%1 of %2)"
 msgstr "Справа налево (%1 из %2)"
 
 #. IDS_MOVE_RIGHT_TO2
-#: Merge.rc:976 Merge.rc:988 Merge.rc:1047 Merge.rc:4865 Merge.rc:4894
+#: Merge.rc:976 Merge.rc:988 Merge.rc:1047 Merge.rc:4864 Merge.rc:4893
 #, c-format
 msgid "Right to... (%1 of %2)"
 msgstr "Справа... (%1 из %2)"
@@ -1688,31 +1688,31 @@ msgid "Cop&y Paths"
 msgstr "Копировать пути"
 
 #. IDS_DEL_LEFT_FMT2
-#: Merge.rc:1026 Merge.rc:1035 Merge.rc:4880
+#: Merge.rc:1026 Merge.rc:1035 Merge.rc:4879
 #, c-format
 msgid "Left (%1 of %2)"
 msgstr "Слева (%1 из %2)"
 
 #. IDS_DEL_MIDDLE_FMT2
-#: Merge.rc:1027 Merge.rc:1036 Merge.rc:4881
+#: Merge.rc:1027 Merge.rc:1036 Merge.rc:4880
 #, c-format
 msgid "Middle (%1 of %2)"
 msgstr "В центре (%1 из %2)"
 
 #. IDS_DEL_RIGHT_FMT2
-#: Merge.rc:1028 Merge.rc:1037 Merge.rc:4882
+#: Merge.rc:1028 Merge.rc:1037 Merge.rc:4881
 #, c-format
 msgid "Right (%1 of %2)"
 msgstr "Справа (%1 из %2)"
 
 #. IDS_DEL_BOTH_FMT2
-#: Merge.rc:1029 Merge.rc:1038 Merge.rc:4883
+#: Merge.rc:1029 Merge.rc:1038 Merge.rc:4882
 #, c-format
 msgid "Both (%1 of %2)"
 msgstr "Оба (%1 из %2)"
 
 #. IDS_DEL_ALL_FMT2
-#: Merge.rc:1030 Merge.rc:1039 Merge.rc:4888
+#: Merge.rc:1030 Merge.rc:1039 Merge.rc:4887
 #, c-format
 msgid "All (%1 of %2)"
 msgstr "Все (%1 из %2)"
@@ -1738,19 +1738,19 @@ msgid "&Zip"
 msgstr "&Заархивировать"
 
 #. IDS_COPY_BOTH_TO2
-#: Merge.rc:1048 Merge.rc:4866
+#: Merge.rc:1048 Merge.rc:4865
 #, c-format
 msgid "Both to... (%1 of %2)"
 msgstr "Оба на... (%1 из %2)"
 
 #. IDS_COPY_ALL_TO2
-#: Merge.rc:1049 Merge.rc:4867
+#: Merge.rc:1049 Merge.rc:4866
 #, c-format
 msgid "All to... (%1 of %2)"
 msgstr "Все на... (%1 из %2)"
 
 #. IDS_COPY_DIFFERENCES_TO2
-#: Merge.rc:1050 Merge.rc:4868
+#: Merge.rc:1050 Merge.rc:4867
 #, c-format
 msgid "Differences to... (%1 of %2)"
 msgstr "Отличия на... (%1 из %2)"
@@ -1817,12 +1817,12 @@ msgstr "Параметры распаковщика"
 
 #. IDS_USERCHOICE_NONE
 #: Merge.rc:1088 Merge.rc:1094 Merge.rc:1836 Merge.rc:1840 Merge.rc:2031
-#: Merge.rc:2035 Merge.rc:5377
+#: Merge.rc:2035 Merge.rc:5376
 msgid "<None>"
 msgstr "<Нет>"
 
 #. IDS_USERCHOICE_AUTOMATIC
-#: Merge.rc:1089 Merge.rc:1095 Merge.rc:5378
+#: Merge.rc:1089 Merge.rc:1095 Merge.rc:5377
 msgid "<Automatic>"
 msgstr "<Автоматически>"
 
@@ -2752,12 +2752,12 @@ msgid "Text files only"
 msgstr "Только текстовые файлы"
 
 #. IDS_EOL_NONE
-#: Merge.rc:1667 Merge.rc:1918 Merge.rc:5304
+#: Merge.rc:1667 Merge.rc:1918 Merge.rc:5303
 msgid "None"
 msgstr "Нет"
 
 #. IDS_EOL_MIXED
-#: Merge.rc:1668 Merge.rc:5299
+#: Merge.rc:1668 Merge.rc:5298
 msgid "Mixed"
 msgstr "Смешанный"
 
@@ -3029,13 +3029,13 @@ msgstr "Состояния строки"
 
 #. IDS_DIFFERENT
 #: Merge.rc:1904 Merge.rc:1988 Merge.rc:2866 Merge.rc:3036 Merge.rc:3077
-#: Merge.rc:5058
+#: Merge.rc:5057
 msgid "Different"
 msgstr "Отличаются"
 
 #. IDS_IDENTICAL
 #: Merge.rc:1905 Merge.rc:1989 Merge.rc:2865 Merge.rc:3055 Merge.rc:3116
-#: Merge.rc:5048
+#: Merge.rc:5047
 msgid "Identical"
 msgstr "Идентичные"
 
@@ -3055,7 +3055,7 @@ msgid "Missing"
 msgstr "Отсутствует"
 
 #. IDS_MOVED
-#: Merge.rc:1910 Merge.rc:5076
+#: Merge.rc:1910 Merge.rc:5075
 msgid "Moved"
 msgstr "Перемещено"
 
@@ -3791,7 +3791,7 @@ msgid "&Use custom system colors"
 msgstr "Использовать настраиваемые системные цвета"
 
 #. IDS_PRPCAT_SYSTEM
-#: Merge.rc:2565 Merge.rc:4559 Merge.rc:4560 Merge.rc:5007
+#: Merge.rc:2565 Merge.rc:4559 Merge.rc:4560 Merge.rc:5006
 msgid "System"
 msgstr "Система"
 
@@ -4191,7 +4191,7 @@ msgid "Items compared:"
 msgstr "Обработано:"
 
 #. IDS_PREVIEWBAR_CLOSE
-#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5685
+#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5684
 msgid "&Close"
 msgstr "&Закрыть"
 
@@ -4806,7 +4806,7 @@ msgid "A&ppend timestamp"
 msgstr "Добавить дату"
 
 #. IDS_CONFIRM_COPY_CAPTION
-#: Merge.rc:3214 Merge.rc:4915
+#: Merge.rc:3214 Merge.rc:4914
 msgid "Confirm Copy"
 msgstr "Подтверждения"
 
@@ -5043,7 +5043,7 @@ msgid "&Character Set..."
 msgstr "Набор символов..."
 
 #. IDS_PRPCAT_IMAGE
-#: Merge.rc:3351 Merge.rc:4574 Merge.rc:5015
+#: Merge.rc:3351 Merge.rc:4574 Merge.rc:5014
 msgid "Image"
 msgstr "Изображение"
 
@@ -5388,7 +5388,7 @@ msgid "Project"
 msgstr "Проект"
 
 #. IDS_COLHDR_NSDIFFS
-#: Merge.rc:4566 Merge.rc:4990
+#: Merge.rc:4566 Merge.rc:4989
 msgid "Differences"
 msgstr "Отличия"
 
@@ -5530,12 +5530,12 @@ msgid "File Type"
 msgstr "Тип файла"
 
 #. IDS_COLHDR_EXTENSION
-#: Merge.rc:4653 Merge.rc:4947
+#: Merge.rc:4653 Merge.rc:4946
 msgid "Extension"
 msgstr "Расширение"
 
 #. IDS_PRPCAT_MESSAGE
-#: Merge.rc:4659 Merge.rc:5019
+#: Merge.rc:4659 Merge.rc:5018
 msgid "Message"
 msgstr "Сообщение"
 
@@ -5575,7 +5575,7 @@ msgid "Hidden Items"
 msgstr "Скрытые элементы"
 
 #. IDS_PLUGINSLIST_NAME
-#: Merge.rc:4680 Merge.rc:5311
+#: Merge.rc:4680 Merge.rc:5310
 msgid "Name"
 msgstr "Имя"
 
@@ -5595,7 +5595,7 @@ msgid "[F] "
 msgstr "[F] "
 
 #. IDS_PLUGINSLIST_DESC
-#: Merge.rc:4684 Merge.rc:5313
+#: Merge.rc:4684 Merge.rc:5312
 msgid "Description"
 msgstr "Описание"
 
@@ -5721,2734 +5721,2729 @@ msgstr "Стр: %s  Стб: %d/%d  Симв: %d/%d"
 msgid "  Sel: %d | %d"
 msgstr " Выбр: %d | %d"
 
-#. IDS_MERGEMODE_MERGING
-#: Merge.rc:4734
-msgid "Merge"
-msgstr "Объединение"
-
 #. IDS_DIFF_NUMBER_STATUS_FMT
-#: Merge.rc:4735
+#: Merge.rc:4734
 #, c-format
 msgid "Difference %1 of %2"
 msgstr "Отличие %1 из %2"
 
 #. IDS_NO_DIFF_SEL_FMT
-#: Merge.rc:4736
+#: Merge.rc:4735
 #, c-format
 msgid "%1 Differences Found"
 msgstr "Найдено отличий %1"
 
 #. IDS_1_DIFF_FOUND
-#: Merge.rc:4737
+#: Merge.rc:4736
 msgid "1 Difference Found"
 msgstr "Найдено всего одно отличие"
 
 #. IDS_NO_ERR_SEL_FMT
-#: Merge.rc:4738
+#: Merge.rc:4737
 #, c-format
 msgid "%1 Errors Found"
 msgstr "Найдено ошибок %1"
 
 #. IDS_1_ERR_FOUND
-#: Merge.rc:4739
+#: Merge.rc:4738
 msgid "1 Error Found"
 msgstr "Найдена 1 ошибка"
 
 #. IDS_STATUSBAR_READONLY, Abbreviation from "Read Only"
-#: Merge.rc:4740
+#: Merge.rc:4739
 msgid "RO"
 msgstr "RO"
 
 #. IDS_DIRVIEW_STATUS_FMT_FOCUS
-#: Merge.rc:4746
+#: Merge.rc:4745
 #, c-format
 msgid "Item %1 of %2"
 msgstr "Элемент %1 из %2"
 
 #. IDS_DIRVIEW_STATUS_FMT_NOFOCUS
-#: Merge.rc:4747
+#: Merge.rc:4746
 #, c-format
 msgid "Items: %1"
 msgstr "Элементов: %1"
 
 #. IDS_DIRVIEW_STATUS_COMPARING
-#: Merge.rc:4748
+#: Merge.rc:4747
 msgid "Comparing items..."
 msgstr "Идет сравнение..."
 
 #. IDS_ITEMS_PER_SEC
-#: Merge.rc:4749
+#: Merge.rc:4748
 #, c-format
 msgid "%.1f[items/sec]"
 msgstr "%.1f[элементов/сек]"
 
 #. IDS_ERROR_INCOMPARABLE
-#: Merge.rc:4755
+#: Merge.rc:4754
 msgid "Select two existing folders/files to compare."
 msgstr "Выберите для сравнения 2 существующих папки или файла."
 
 #. IDS_DIRSEL_TAG
-#: Merge.rc:4756
+#: Merge.rc:4755
 msgid "Folder Selection"
 msgstr "Выбор папки"
 
 #. IDS_OPEN_FILESDIRS
-#: Merge.rc:4757
+#: Merge.rc:4756
 msgid "Select two (or three) folders/files to compare."
 msgstr "Выберите для сравнения 2 (или 3) папки или файла."
 
 #. IDS_OPEN_LEFTINVALID
-#: Merge.rc:4758
+#: Merge.rc:4757
 msgid "Left (1st) path is invalid!"
 msgstr "Путь слева (1-й) указан неверно!"
 
 #. IDS_OPEN_MIDDLEINVALID
-#: Merge.rc:4759
+#: Merge.rc:4758
 msgid "Middle (2nd) path is invalid!"
 msgstr "Путь в центре (2-й) указан неверно!"
 
 #. IDS_OPEN_RIGHTINVALID2
-#: Merge.rc:4760
+#: Merge.rc:4759
 msgid "Right (2nd) path is invalid!"
 msgstr "Путь справа (2-й) указан неверно!"
 
 #. IDS_OPEN_RIGHTINVALID3
-#: Merge.rc:4761
+#: Merge.rc:4760
 msgid "Right (3rd) path is invalid!"
 msgstr "Путь справа (3-й) указан неверно!"
 
 #. IDS_OPEN_BOTHINVALID
-#: Merge.rc:4762
+#: Merge.rc:4761
 msgid "Both paths are invalid!"
 msgstr "Оба пути указаны неверно!"
 
-#: Merge.rc:4764
+#: Merge.rc:4763
 msgid "Left (1st) and Middle (2nd) paths are invalid!"
 msgstr "Пути слева (1-й) и в центре (2-й) указаны неверно!"
 
 #. IDS_OPEN_LEFTRIGHTINVALID
-#: Merge.rc:4765
+#: Merge.rc:4764
 msgid "Left (1st) and Right (3rd) paths are invalid!"
 msgstr "Пути слева (1-й) и справа (3-й) указаны неверно!"
 
-#: Merge.rc:4767
+#: Merge.rc:4766
 msgid "Middle (2nd) and Right (3rd) paths are invalid!"
 msgstr "Пути в центре (2-й) и справа (3-й) указаны неверно!"
 
 #. IDS_OPEN_ALLINVALID
-#: Merge.rc:4768
+#: Merge.rc:4767
 msgid "All paths are invalid!"
 msgstr "Все пути указаны неверно!"
 
 #. IDS_OPEN_UNPACKERDISABLED
-#: Merge.rc:4769
+#: Merge.rc:4768
 msgid "Only enabled for file comparisons"
 msgstr "Включено только для сравнения файлов"
 
 #. IDS_OPEN_MISMATCH
-#: Merge.rc:4770
+#: Merge.rc:4769
 msgid "Cannot compare file and folder!"
 msgstr "Не удается сравнить файл и папку!"
 
 #. IDS_ERROR_FILE_NOT_FOUND
-#: Merge.rc:4776
+#: Merge.rc:4775
 #, c-format
 msgid "File not found: %1"
 msgstr "Файл не найден: %1"
 
 #. IDS_ERROR_FOLDER_NOT_FOUND
-#: Merge.rc:4777
+#: Merge.rc:4776
 #, c-format
 msgid "Folder not found: %1"
 msgstr "Папка не найдена: %1"
 
 #. IDS_ERROR_FILE_NOT_UNPACKED
-#: Merge.rc:4778
+#: Merge.rc:4777
 #, c-format
 msgid "File not unpacked: %1"
 msgstr "Файл не распакован: %1"
 
 #. IDS_ERROR_FILEOPEN
-#: Merge.rc:4779
+#: Merge.rc:4778
 #, c-format
 msgid "Cannot open file\n%1\n\n%2"
 msgstr "Не удается открыть файл\n%1\n\n%2"
 
 #. IDS_ERROR_CONF_RESOLVE
-#: Merge.rc:4780
+#: Merge.rc:4779
 msgid "Failed to parse conflict file."
 msgstr "Сбой разбора файла конфликтов."
 
 #. IDS_NOT_CONFLICT_FILE
-#: Merge.rc:4781
+#: Merge.rc:4780
 #, c-format
 msgid "The file\n%1\nis not a conflict file."
 msgstr "Файл\n%1\nне является файлом конфликтов."
 
 #. IDS_COMPARE_LARGE_FILES
-#: Merge.rc:4782
+#: Merge.rc:4781
 msgid "Comparing large files requires significant memory.\nShow only comparison results (not file contents)?"
 msgstr "Вы собираетесь сравнить очень большие файлы.\nОтображение содержимого этих файлов требует много памяти.\nХотите увидеть только результаты сравнения, а не содержимое файлов?\n\n"
 
 #. IDS_SAVE_AS_TITLE
-#: Merge.rc:4788
+#: Merge.rc:4787
 msgid "Save As"
 msgstr "Сохранить как"
 
 #. IDS_SAVE_FMT
-#: Merge.rc:4789
+#: Merge.rc:4788
 #, c-format
 msgid "Save changes to %1?"
 msgstr "Сохранить изменения в %1?"
 
 #. IDS_SAVEREADONLY_FMT
-#: Merge.rc:4790
+#: Merge.rc:4789
 #, c-format
 msgid "%1 is read-only. Override? Or 'No' to save as new filename?"
 msgstr "%1 помечен как только для чтения. Перезаписать файл только для чтения? (ответив Нет можно сохранить файл с другим именем)"
 
 #. IDS_ERROR_BACKUP
-#: Merge.rc:4791
+#: Merge.rc:4790
 msgid "Error backing up file"
 msgstr "Ошибка создания резервной копии"
 
-#: Merge.rc:4793
+#: Merge.rc:4792
 #, c-format
 msgid "Unable to backup original file:\n%1\n\nContinue anyway?"
 msgstr "Не удается создать копию исходного файла:\n%1\n\nПродолжить в любом случае?"
 
 #. IDS_FILESAVE_FAILED
-#: Merge.rc:4794
+#: Merge.rc:4793
 #, c-format
 msgid "Saving file failed.\n%1\n%2\n\t- Use different filename (OK)\n\t- Abort (Cancel)?"
 msgstr "Сбой сохранения файла.\n%1\n%2\nХотите:\n\t- использовать другое имя файла (Нажмите OK)\n\t-отменить текущую операцию (Нажмите Отмена)?"
 
-#: Merge.rc:4796
+#: Merge.rc:4795
 #, c-format
 msgid "Plugin '%2' cannot pack changes to left file into '%1'.\n\nOriginal unchanged. Save unpacked version?"
 msgstr "Плагин '%2' не может упаковать ваши изменения из левого файла обратно в '%1'.\n\nИсходный файл не будет изменен.\n\nСохранить распакованную версию в другой файл?"
 
-#: Merge.rc:4798
+#: Merge.rc:4797
 #, c-format
 msgid "Plugin '%2' cannot pack changes to middle file into '%1'.\n\nOriginal unchanged. Save unpacked version?"
 msgstr "Плагин '%2' не может упаковать ваши изменения из центрального файла обратно в '%1'.\n\nИсходный файл не будет изменен.\n\nСохранить распакованную версию в другой файл?"
 
-#: Merge.rc:4800
+#: Merge.rc:4799
 #, c-format
 msgid "Plugin '%2' cannot pack changes to right file into '%1'.\n\nOriginal unchanged. Save unpacked version?"
 msgstr "Плагин '%2' не может упаковать ваши изменения из правого файла обратно в '%1'.\n\nИсходный файл не будет изменен.\n\nСохранить распакованную версию в другой файл?"
 
 #. IDS_FILECHANGED_ONDISK
-#: Merge.rc:4801
+#: Merge.rc:4800
 #, c-format
 msgid "Another application updated\n%1\nsince WinMerge loaded it.\n\nOverwrite?"
 msgstr "Другое приложение обновило файл\n%1\nуже загруженный в WinMerge .\n\nПерезаписать измененный файл?"
 
 #. IDS_SAVEREADONLY_MULTI
-#: Merge.rc:4802
+#: Merge.rc:4801
 #, c-format
 msgid "%1\nis read-only. Override?"
 msgstr "%1\nпомечен как только для чтения. Перезаписать файл только для чтения?"
 
 #. IDS_FILECHANGED_RESCAN
-#: Merge.rc:4803
+#: Merge.rc:4802
 #, c-format
 msgid "Another application updated\n%1\nsince last scan.\n\nReload?"
 msgstr "Другое приложение обновило файл\n%1\nуже проверенный WinMerge.\n\nПерезагрузить файл?"
 
 #. IDS_SAVE_LEFT_AS
-#: Merge.rc:4804
+#: Merge.rc:4803
 msgid "Save Left File As"
 msgstr "Сохранить файл слева как"
 
 #. IDS_SAVE_MIDDLE_AS
-#: Merge.rc:4805
+#: Merge.rc:4804
 msgid "Save Middle File As"
 msgstr "Сохранить файл в центре как"
 
 #. IDS_SAVE_RIGHT_AS
-#: Merge.rc:4806
+#: Merge.rc:4805
 msgid "Save Right File As"
 msgstr "Сохранить файл справа как"
 
 #. IDS_FILE_DISAPPEARED
-#: Merge.rc:4811
+#: Merge.rc:4810
 #, c-format
 msgid "File\n%1\nnot found. Save a copy to continue."
 msgstr "Файл\n%1\nутрачен. Для продолжения сохраните копию файла."
 
 #. IDS_VIEWS_OUTOFSYNC
-#: Merge.rc:4817
+#: Merge.rc:4816
 msgid "Cannot merge unsynched documents.\n\nRefresh before continuing."
 msgstr "Не удается объединить отличия, если документы не синхронизированы.\n\nОбновите документы, прежде чем продолжить."
 
 #. IDS_BREAK_ON_WHITESPACE
-#: Merge.rc:4822
+#: Merge.rc:4821
 msgid "Break at whitespace"
 msgstr "Разбивать по пробельным символам"
 
 #. IDS_BREAK_ON_PUNCTUATION
-#: Merge.rc:4823
+#: Merge.rc:4822
 msgid "Break at whitespace or punctuation"
 msgstr "Разбивать по пробельным символам и знакам пунктуации"
 
 #. IDS_L2M
-#: Merge.rc:4829
+#: Merge.rc:4828
 msgid "Copy to &Middle\tAlt+Right"
 msgstr "Копировать в центр\tAlt+Right"
 
 #. IDS_R2M
-#: Merge.rc:4830
+#: Merge.rc:4829
 msgid "Copy to &Middle\tAlt+Left"
 msgstr "Копировать в центр\tAlt+Left"
 
 #. IDS_COPY_FROM_MIDDLE_R
-#: Merge.rc:4831
+#: Merge.rc:4830
 msgid "Copy from Middle\tAlt+Shift+Right"
 msgstr "Копировать из центра\tAlt+Shift+Right"
 
 #. IDS_COPY_FROM_MIDDLE_L
-#: Merge.rc:4832
+#: Merge.rc:4831
 msgid "Copy from Middle\tAlt+Shift+Left"
 msgstr "Копировать из центра\tAlt+Shift+Left"
 
 #. IDS_L2MNEXT
-#: Merge.rc:4833
+#: Merge.rc:4832
 msgid "Copy to Middle and Advance\tCtrl+Alt+Right"
 msgstr "Копировать в центр и перейти\tCtrl+Alt+Right"
 
 #. IDS_R2MNEXT
-#: Merge.rc:4834
+#: Merge.rc:4833
 msgid "Copy to Middle and Advance\tCtrl+Alt+Left"
 msgstr "Копировать в центр и перейти\tCtrl+Alt+Left"
 
 #. IDS_ALL_MIDDLE
-#: Merge.rc:4835
+#: Merge.rc:4834
 msgid "Copy All to Middle"
 msgstr "Копировать все в центр"
 
 #. IDS_COPY_RIGHT_TO_LEFT
-#: Merge.rc:4841
+#: Merge.rc:4840
 #, c-format
 msgid "Right to Left (%1)"
 msgstr "Справа налево (%1)"
 
 #. IDS_COPY_RIGHT_TO_MIDDLE
-#: Merge.rc:4842
+#: Merge.rc:4841
 #, c-format
 msgid "Right to Middle (%1)"
 msgstr "Справа в центр (%1)"
 
 #. IDS_COPY_MIDDLE_TO_LEFT
-#: Merge.rc:4843
+#: Merge.rc:4842
 #, c-format
 msgid "Middle to Left (%1)"
 msgstr "Из центра налево (%1)"
 
 #. IDS_COPY_MIDDLE_TO_RIGHT
-#: Merge.rc:4844
+#: Merge.rc:4843
 #, c-format
 msgid "Middle to Right (%1)"
 msgstr "Из центра направо (%1)"
 
 #. IDS_COPY_LEFT_TO_RIGHT
-#: Merge.rc:4845
+#: Merge.rc:4844
 #, c-format
 msgid "Left to Right (%1)"
 msgstr "Слева направо (%1)"
 
 #. IDS_COPY_LEFT_TO_MIDDLE
-#: Merge.rc:4846
+#: Merge.rc:4845
 #, c-format
 msgid "Left to Middle (%1)"
 msgstr "Слева в центр (%1)"
 
 #. IDS_MOVE_LEFT_TO
-#: Merge.rc:4857 Merge.rc:4889
+#: Merge.rc:4856 Merge.rc:4888
 #, c-format
 msgid "Left to... (%1)"
 msgstr "Слева... (%1)"
 
 #. IDS_MOVE_MIDDLE_TO
-#: Merge.rc:4858 Merge.rc:4890
+#: Merge.rc:4857 Merge.rc:4889
 #, c-format
 msgid "Middle to... (%1)"
 msgstr "Из центра... (%1)"
 
 #. IDS_MOVE_RIGHT_TO
-#: Merge.rc:4859 Merge.rc:4891
+#: Merge.rc:4858 Merge.rc:4890
 #, c-format
 msgid "Right to... (%1)"
 msgstr "Справа... (%1)"
 
 #. IDS_COPY_BOTH_TO
-#: Merge.rc:4860
+#: Merge.rc:4859
 #, c-format
 msgid "Both to... (%1)"
 msgstr "Оба... (%1)"
 
 #. IDS_COPY_ALL_TO
-#: Merge.rc:4861
+#: Merge.rc:4860
 #, c-format
 msgid "All to... (%1)"
 msgstr "Все... (%1)"
 
 #. IDS_COPY_DIFFERENCES_TO
-#: Merge.rc:4862
+#: Merge.rc:4861
 #, c-format
 msgid "Differences to... (%1)"
 msgstr "Отличия... (%1)"
 
 #. IDS_ONLYDIFFITEMS_CONFIRM
-#: Merge.rc:4869
+#: Merge.rc:4868
 msgid "Some selected items are identical or skipped.\nProcess only items with differences?"
 msgstr "Некоторые выбранные элементы идентичны или пропущены.\nОбработать только элементы с отличиями?"
 
 #. IDS_DEL_LEFT_FMT
-#: Merge.rc:4875
+#: Merge.rc:4874
 #, c-format
 msgid "Left (%1)"
 msgstr "Слева (%1)"
 
 #. IDS_DEL_MIDDLE_FMT
-#: Merge.rc:4876
+#: Merge.rc:4875
 #, c-format
 msgid "Middle (%1)"
 msgstr "Из центра (%1)"
 
 #. IDS_DEL_RIGHT_FMT
-#: Merge.rc:4877
+#: Merge.rc:4876
 #, c-format
 msgid "Right (%1)"
 msgstr "Справа (%1)"
 
 #. IDS_DEL_BOTH_FMT
-#: Merge.rc:4878
+#: Merge.rc:4877
 #, c-format
 msgid "Both (%1)"
 msgstr "Оба (%1)"
 
 #. IDS_DEL_ALL_FMT
-#: Merge.rc:4879
+#: Merge.rc:4878
 #, c-format
 msgid "All (%1)"
 msgstr "Все (%1)"
 
 #. IDS_SELECT_DEST_LEFT
-#: Merge.rc:4895
+#: Merge.rc:4894
 msgid "Left Side - Select Destination Folder:"
 msgstr "Слева - выбор папки назначения:"
 
 #. IDS_SELECT_DEST_MIDDLE
-#: Merge.rc:4896
+#: Merge.rc:4895
 msgid "Middle Side - Select Destination Folder:"
 msgstr "В центре - выбор папки назначения:"
 
 #. IDS_SELECT_DEST_RIGHT
-#: Merge.rc:4897
+#: Merge.rc:4896
 msgid "Right Side - Select Destination Folder:"
 msgstr "Справа - выбор папки назначения:"
 
 #. IDS_FILES_AFFECTED_FMT
-#: Merge.rc:4898
+#: Merge.rc:4897
 #, c-format
 msgid "(%1 Files Affected)"
 msgstr "(%1 файлов обработано)"
 
 #. IDS_FILES_AFFECTED_FMT2
-#: Merge.rc:4899
+#: Merge.rc:4898
 #, c-format
 msgid "(%1 of %2 Files Affected)"
 msgstr "(%1 из %2 файлов обработано)"
 
 #. IDS_CONFIRM_DELETE_SINGLE
-#: Merge.rc:4905
+#: Merge.rc:4904
 #, c-format
 msgid "Are you sure you want to delete\n\n%1 ?"
 msgstr "Хотите удалить\n\n%1 ?"
 
 #. IDS_CONFIRM_SINGLE_COPY
-#: Merge.rc:4906
+#: Merge.rc:4905
 msgid "Are you sure you want to copy?"
 msgstr "Хотите копировать?"
 
 #. IDS_CONFIRM_MULTIPLE_COPY
-#: Merge.rc:4907
+#: Merge.rc:4906
 #, c-format
 msgid "Are you sure you want to copy %d items?"
 msgstr "Хотите копировать %d элементов?"
 
 #. IDS_DIRCMP_NOTSYNC
-#: Merge.rc:4908
+#: Merge.rc:4907
 #, c-format
 msgid "Operation aborted!\n\nFolder contents changed, path\n%1\nnot found.\n\nRefresh the compare."
 msgstr "Операция прервана!\n\nСодержимое папки изменено, путь\n%1\nне был найден.\n\nОбновите сравнение."
 
 #. IDS_CONFIRM_SINGLE_MOVE
-#: Merge.rc:4913
+#: Merge.rc:4912
 msgid "Are you sure you want to move?"
 msgstr "Хотите переместить?"
 
 #. IDS_CONFIRM_MULTIPLE_MOVE
-#: Merge.rc:4914
+#: Merge.rc:4913
 #, c-format
 msgid "Are you sure you want to move %d items?"
 msgstr "Хотите переместить %d элементов?"
 
 #. IDS_CONFIRM_MOVE_CAPTION
-#: Merge.rc:4916
+#: Merge.rc:4915
 msgid "Confirm Move"
 msgstr "Подтвердите перемещение"
 
-#: Merge.rc:4918
+#: Merge.rc:4917
 msgid "Close the folder comparison window?"
 msgstr "Закрыть окно сравнения папок?"
 
-#: Merge.rc:4920
+#: Merge.rc:4919
 msgid "Close the folder comparison window, which took a long time?"
 msgstr "Закрыть окно сравнения папок, занявшее много времени на выполнение?"
 
 #. IDS_ERROR_INVALID_DIR_FILE_NAME
-#: Merge.rc:4921
+#: Merge.rc:4920
 msgid "The file or folder name is invalid."
 msgstr "Неверное имя файла или папки."
 
 #. IDS_ERROR_EXECUTE_FILE
-#: Merge.rc:4927
+#: Merge.rc:4926
 #, c-format
 msgid "Failed to execute external editor: %1"
 msgstr "Не удается запустить внешний редактор: %1"
 
 #. IDS_UNKNOWN_ARCHIVE_FORMAT
-#: Merge.rc:4933
+#: Merge.rc:4932
 msgid "Unknown archive format"
 msgstr "Неизвестный формат архива"
 
-#: Merge.rc:4935
+#: Merge.rc:4934
 msgid "Failed to extract archive.\nCompare as text file?"
 msgstr "Не удалось извлечь архивные файлы.\nВы хотите сравнить архивные файлы как текстовые файлы?"
 
 #. IDS_COLHDR_FILENAME
-#: Merge.rc:4941
+#: Merge.rc:4940
 msgid "Filename"
 msgstr "Имя файла"
 
 #. IDS_COLHDR_DIR
-#: Merge.rc:4942
+#: Merge.rc:4941
 msgctxt "DirView|ColumnHeader"
 msgid "Folder"
 msgstr "Папка"
 
 #. IDS_COLHDR_RESULT
-#: Merge.rc:4943
+#: Merge.rc:4942
 msgid "Comparison Result"
 msgstr "Результат сравнения"
 
 #. IDS_COLHDR_LTIMEM
-#: Merge.rc:4944
+#: Merge.rc:4943
 msgid "Left Date"
 msgstr "Дата слева"
 
 #. IDS_COLHDR_RTIMEM
-#: Merge.rc:4945
+#: Merge.rc:4944
 msgid "Right Date"
 msgstr "Дата справа"
 
 #. IDS_COLHDR_MTIMEM
-#: Merge.rc:4946
+#: Merge.rc:4945
 msgid "Middle Date"
 msgstr "Дата в центре"
 
 #. IDS_COLHDR_LSIZE
-#: Merge.rc:4948
+#: Merge.rc:4947
 msgid "Left Size"
 msgstr "Размер слева"
 
 #. IDS_COLHDR_RSIZE
-#: Merge.rc:4949
+#: Merge.rc:4948
 msgid "Right Size"
 msgstr "Размер справа"
 
 #. IDS_COLHDR_MSIZE
-#: Merge.rc:4954
+#: Merge.rc:4953
 msgid "Middle Size"
 msgstr "Размер в центре"
 
 #. IDS_COLHDR_RSIZE_SHORT
-#: Merge.rc:4955
+#: Merge.rc:4954
 msgid "Right Size (Short)"
 msgstr "Размер справа (сокр.)"
 
 #. IDS_COLHDR_LSIZE_SHORT
-#: Merge.rc:4956
+#: Merge.rc:4955
 msgid "Left Size (Short)"
 msgstr "Размер слева (сокр.)"
 
 #. IDS_COLHDR_MSIZE_SHORT
-#: Merge.rc:4957
+#: Merge.rc:4956
 msgid "Middle Size (Short)"
 msgstr "Размер в центре (сокр.)"
 
 #. IDS_COLHDR_LTIMEC
-#: Merge.rc:4963
+#: Merge.rc:4962
 msgid "Left Creation Time"
 msgstr "Время создания слева"
 
 #. IDS_COLHDR_RTIMEC
-#: Merge.rc:4964
+#: Merge.rc:4963
 msgid "Right Creation Time"
 msgstr "Время создания справа"
 
 #. IDS_COLHDR_MTIMEC
-#: Merge.rc:4965
+#: Merge.rc:4964
 msgid "Middle Creation Time"
 msgstr "Время создания в центре"
 
 #. IDS_COLHDR_NEWER
-#: Merge.rc:4966
+#: Merge.rc:4965
 msgid "Newer File"
 msgstr "Более новый файл"
 
 #. IDS_COLHDR_LVERSION
-#: Merge.rc:4967
+#: Merge.rc:4966
 msgid "Left File Version"
 msgstr "Версия файла слева"
 
 #. IDS_COLHDR_RVERSION
-#: Merge.rc:4968
+#: Merge.rc:4967
 msgid "Right File Version"
 msgstr "Версия файла справа"
 
 #. IDS_COLHDR_MVERSION
-#: Merge.rc:4969
+#: Merge.rc:4968
 msgid "Middle File Version"
 msgstr "Версия файла в центре"
 
 #. IDS_COLHDR_RESULT_ABBR
-#: Merge.rc:4970
+#: Merge.rc:4969
 msgid "Short Result"
 msgstr "Упрощенный результат"
 
 #. IDS_COLHDR_LATTRIBUTES
-#: Merge.rc:4971
+#: Merge.rc:4970
 msgid "Left Attributes"
 msgstr "Атрибуты слева"
 
 #. IDS_COLHDR_RATTRIBUTES
-#: Merge.rc:4972
+#: Merge.rc:4971
 msgid "Right Attributes"
 msgstr "Атрибуты справа"
 
 #. IDS_COLHDR_MATTRIBUTES
-#: Merge.rc:4973
+#: Merge.rc:4972
 msgid "Middle Attributes"
 msgstr "Атрибуты в центре"
 
 #. IDS_COLHDR_LEOL_TYPE
-#: Merge.rc:4978
+#: Merge.rc:4977
 msgid "Left EOL"
 msgstr "EOL слева"
 
 #. IDS_COLHDR_MEOL_TYPE
-#: Merge.rc:4979
+#: Merge.rc:4978
 msgid "Middle EOL"
 msgstr "EOL в центре"
 
 #. IDS_COLHDR_REOL_TYPE
-#: Merge.rc:4980
+#: Merge.rc:4979
 msgid "Right EOL"
 msgstr "EOL справа"
 
 #. IDS_COLHDR_LENCODING
-#: Merge.rc:4986
+#: Merge.rc:4985
 msgid "Left Encoding"
 msgstr "Кодировка слева"
 
 #. IDS_COLHDR_RENCODING
-#: Merge.rc:4987
+#: Merge.rc:4986
 msgid "Right Encoding"
 msgstr "Кодировка справа"
 
 #. IDS_COLHDR_MENCODING
-#: Merge.rc:4988
+#: Merge.rc:4987
 msgid "Middle Encoding"
 msgstr "Кодировка в центре"
 
 #. IDS_COLHDR_NIDIFFS
-#: Merge.rc:4989
+#: Merge.rc:4988
 msgid "Ignored Diff"
 msgstr "Игнор. отличия"
 
 #. IDS_COLHDR_BINARY
-#: Merge.rc:4991
+#: Merge.rc:4990
 msgctxt "DirView|ColumnHeader"
 msgid "Binary"
 msgstr "Двоичный"
 
 #. IDS_PLUGINS_TYPE_UNPACKER
-#: Merge.rc:4992 Merge.rc:5314
+#: Merge.rc:4991 Merge.rc:5313
 msgid "Unpacker"
 msgstr "Распаковщик"
 
 #. IDS_PLUGIN_TYPE4
-#: Merge.rc:4993 Merge.rc:5315 Merge.rc:5622
+#: Merge.rc:4992 Merge.rc:5314 Merge.rc:5621
 msgid "Prediffer"
 msgstr "Предсравнение"
 
 #. IDS_COLHDR_LEFT
-#: Merge.rc:4994
+#: Merge.rc:4993
 msgid "Left"
 msgstr "Слева"
 
 #. IDS_COLHDR_MIDDLE
-#: Merge.rc:4995
+#: Merge.rc:4994
 msgid "Middle"
 msgstr "В центре"
 
 #. IDS_COLHDR_RIGHT
-#: Merge.rc:4996
+#: Merge.rc:4995
 msgid "Right"
 msgstr "Справа"
 
 #. IDS_COLHDR_DIFF
-#: Merge.rc:4997
+#: Merge.rc:4996
 msgid "Diff"
 msgstr "Отличия"
 
 #. IDS_COLHDR_LEFT_DUPLICATE
-#: Merge.rc:4998
+#: Merge.rc:4997
 msgid "Left Duplicate Count"
 msgstr "Кол-во дублей слева"
 
 #. IDS_COLHDR_RIGHT_DUPLICATE
-#: Merge.rc:4999
+#: Merge.rc:4998
 msgid "Right Duplicate Count"
 msgstr "Кол-во дублей справа"
 
 #. IDS_COLHDR_MIDDLE_DUPLICATE
-#: Merge.rc:5000
+#: Merge.rc:4999
 msgid "Middle Duplicate Count"
 msgstr "Кол-во дублей в центре"
 
 #. IDS_COLHDR_MOVE
-#: Merge.rc:5001
+#: Merge.rc:5000
 msgid "Move"
 msgstr "Переместить"
 
 #. IDS_PRPCAT_AUDIO
-#: Merge.rc:5008
+#: Merge.rc:5007
 msgid "Audio"
 msgstr "Аудио"
 
 #. IDS_PRPCAT_CALENDAR
-#: Merge.rc:5009
+#: Merge.rc:5008
 msgid "Calendar"
 msgstr "Календарь"
 
 #. IDS_PRPCAT_COMMUNICATION
-#: Merge.rc:5010
+#: Merge.rc:5009
 msgid "Communication"
 msgstr "Коммуникация"
 
 #. IDS_PRPCAT_CONTACT
-#: Merge.rc:5011
+#: Merge.rc:5010
 msgid "Contact"
 msgstr "Контакт"
 
 #. IDS_PRPCAT_DEVICES
-#: Merge.rc:5012
+#: Merge.rc:5011
 msgid "Devices"
 msgstr "Устройства"
 
 #. IDS_PRPCAT_DOCUMENT
-#: Merge.rc:5013
+#: Merge.rc:5012
 msgid "Document"
 msgstr "Документ"
 
 #. IDS_PRPCAT_HOME
-#: Merge.rc:5014
+#: Merge.rc:5013
 msgid "Home"
 msgstr "Домой"
 
 #. IDS_PRPCAT_JOURNAL
-#: Merge.rc:5016
+#: Merge.rc:5015
 msgid "Journal"
 msgstr "Журнал"
 
 #. IDS_PRPCAT_LINK
-#: Merge.rc:5017
+#: Merge.rc:5016
 msgid "Link"
 msgstr "Ссылка"
 
 #. IDS_PRPCAT_MEDIA
-#: Merge.rc:5018
+#: Merge.rc:5017
 msgid "Media"
 msgstr "Медиа"
 
 #. IDS_PRPCAT_MUSIC
-#: Merge.rc:5020
+#: Merge.rc:5019
 msgid "Music"
 msgstr "Музыка"
 
 #. IDS_PRPCAT_NOTE
-#: Merge.rc:5021
+#: Merge.rc:5020
 msgid "Note"
 msgstr "Заметка"
 
 #. IDS_PRPCAT_PHOTO
-#: Merge.rc:5022
+#: Merge.rc:5021
 msgid "Photo"
 msgstr "Фото"
 
 #. IDS_PRPCAT_RECORDEDTV
-#: Merge.rc:5023
+#: Merge.rc:5022
 msgid "RecordedTV"
 msgstr "Записанное ТВ"
 
 #. IDS_PRPCAT_SEARCH
-#: Merge.rc:5024
+#: Merge.rc:5023
 msgid "Search"
 msgstr "Поиск"
 
 #. IDS_PRPCAT_SECURITY
-#: Merge.rc:5025
+#: Merge.rc:5024
 msgid "Security"
 msgstr "Безопасность"
 
 #. IDS_PRPCAT_SOFTWARE
-#: Merge.rc:5026
+#: Merge.rc:5025
 msgid "Software"
 msgstr "ПО"
 
 #. IDS_PRPCAT_TASK
-#: Merge.rc:5027
+#: Merge.rc:5026
 msgid "Task"
 msgstr "Задача"
 
 #. IDS_PRPCAT_VIDEO
-#: Merge.rc:5028
+#: Merge.rc:5027
 msgid "Video"
 msgstr "Видео"
 
 #. IDS_PRPCAT_HASH
-#: Merge.rc:5029
+#: Merge.rc:5028
 msgid "Hash"
 msgstr "Хеш"
 
 #. IDS_CANT_COMPARE_FILES
-#: Merge.rc:5035
+#: Merge.rc:5034
 msgid "Unable to compare files"
 msgstr "Не удается сравнить файлы"
 
 #. IDS_ABORTED_ITEM
-#: Merge.rc:5036
+#: Merge.rc:5035
 msgid "Item aborted"
 msgstr "Сравнение прервано"
 
 #. IDS_FILE_SKIPPED
-#: Merge.rc:5037
+#: Merge.rc:5036
 msgid "File skipped"
 msgstr "Файл пропущен"
 
 #. IDS_DIR_SKIPPED
-#: Merge.rc:5038
+#: Merge.rc:5037
 msgid "Folder skipped"
 msgstr "Папка пропущена"
 
 #. IDS_LEFT_ONLY_IN_FMT
-#: Merge.rc:5039
+#: Merge.rc:5038
 #, c-format
 msgid "Left only: %1"
 msgstr "Только слева: %1"
 
 #. IDS_MIDDLE_ONLY_IN_FMT
-#: Merge.rc:5040
+#: Merge.rc:5039
 #, c-format
 msgid "Middle only: %1"
 msgstr "Только в центре: %1"
 
 #. IDS_RIGHT_ONLY_IN_FMT
-#: Merge.rc:5041
+#: Merge.rc:5040
 #, c-format
 msgid "Right only: %1"
 msgstr "Только справа: %1"
 
 #. IDS_DOES_NOT_EXIST_IN_FMT
-#: Merge.rc:5042
+#: Merge.rc:5041
 #, c-format
 msgid "Does not exist in %1"
 msgstr "Не существует в %1"
 
 #. IDS_BIN_FILES_SAME
-#: Merge.rc:5043
+#: Merge.rc:5042
 msgid "Binary files are identical"
 msgstr "Двоичные файлы идентичны"
 
 #. IDS_BIN_FILES_DIFF
-#: Merge.rc:5049
+#: Merge.rc:5048
 msgid "Binary files are different"
 msgstr "Двоичные файлы отличаются"
 
 #. IDS_FILES_ARE_DIFFERENT
-#: Merge.rc:5050
+#: Merge.rc:5049
 msgid "Files are different"
 msgstr "Файлы отличаются"
 
 #. IDS_FOLDERS_ARE_DIFFERENT
-#: Merge.rc:5051
+#: Merge.rc:5050
 msgid "Folders are different"
 msgstr "Папки отличаются"
 
 #. IDS_LEFTONLY
-#: Merge.rc:5052
+#: Merge.rc:5051
 msgid "Left Only"
 msgstr "Только слева"
 
 #. IDS_RIGHTONLY
-#: Merge.rc:5053
+#: Merge.rc:5052
 msgid "Right Only"
 msgstr "Только справа"
 
 #. IDS_MIDDLEONLY
-#: Merge.rc:5054
+#: Merge.rc:5053
 msgid "Middle Only"
 msgstr "Только в центре"
 
 #. IDS_NOITEMLEFT
-#: Merge.rc:5055
+#: Merge.rc:5054
 msgid "No item in left"
 msgstr "Нет элемента слева"
 
 #. IDS_NOITEMRIGHT
-#: Merge.rc:5056
+#: Merge.rc:5055
 msgid "No item in right"
 msgstr "Нет элемента справа"
 
 #. IDS_NOITEMMIDDLE
-#: Merge.rc:5057
+#: Merge.rc:5056
 msgid "No item in middle"
 msgstr "Нет элемента в центре"
 
 #. IDS_CMPRES_ERROR
-#: Merge.rc:5059
+#: Merge.rc:5058
 msgid "Error"
 msgstr "Ошибка"
 
 #. IDS_TEXT_FILES_SAME
-#: Merge.rc:5060
+#: Merge.rc:5059
 msgid "Text files are identical"
 msgstr "Текстовые файлы идентичны"
 
 #. IDS_LEFTONLY_DIFF
-#: Merge.rc:5061
+#: Merge.rc:5060
 msgid " (Middle and right are identical)"
 msgstr " (В центре и справа идентичны)"
 
 #. IDS_MIDDLEONLY_DIFF
-#: Merge.rc:5062
+#: Merge.rc:5061
 msgid " (Left and right are identical)"
 msgstr " (Слева и справа идентичны)"
 
 #. IDS_RIGHTONLY_DIFF
-#: Merge.rc:5063
+#: Merge.rc:5062
 msgid " (Left and middle are identical)"
 msgstr " (Слева и в центре идентичны)"
 
 #. IDS_PATH_MISMATCH
-#: Merge.rc:5064
+#: Merge.rc:5063
 msgid " (paths differ)"
 msgstr " (пути отличаются)"
 
 #. IDS_TEXT_FILES_DIFF
-#: Merge.rc:5065
+#: Merge.rc:5064
 msgid "Text files are different"
 msgstr "Текстовые файлы отличаются"
 
 #. IDS_IMAGE_FILES_SAME
-#: Merge.rc:5066
+#: Merge.rc:5065
 msgid "Image files are identical"
 msgstr "Файлы изображений идентичны"
 
 #. IDS_IMAGE_FILES_DIFF
-#: Merge.rc:5067
+#: Merge.rc:5066
 msgid "Image files are different"
 msgstr "Файлы изображений отличаются"
 
 #. IDS_EXPR_DIFF
-#: Merge.rc:5068
+#: Merge.rc:5067
 #, c-format
 msgid "Files are different (expr: %1)"
 msgstr "Файлы отличаются (выражение: %1)"
 
 #. IDS_HASH_GROUP
-#: Merge.rc:5069
+#: Merge.rc:5068
 #, c-format
 msgid "Group%d"
 msgstr "Группа%d"
 
 #. IDS_RENAME_MOVE_DETECTION_DISALBED
-#: Merge.rc:5070
+#: Merge.rc:5069
 msgctxt "Options dialog|Compare|Folder|Detect renames and moves"
 msgid "Disabled"
 msgstr "Отключено"
 
 #. IDS_RENAME_MOVE_DETECTION_RENAME
-#: Merge.rc:5071
+#: Merge.rc:5070
 msgid "Detect renames"
 msgstr "Обнаружение переименований"
 
 #. IDS_RENAME_MOVE_DETECTION_RENAME_MOVE
-#: Merge.rc:5072
+#: Merge.rc:5071
 msgid "Detect renames and moves"
 msgstr "Обнаружение переименований и перемещений"
 
 #. IDS_RENAME_MOVE_MERGE_MODE_RENAME
-#: Merge.rc:5073
+#: Merge.rc:5072
 msgid "Merge renames"
 msgstr "Объединение переименований"
 
 #. IDS_RENAME_MOVE_MERGE_MODE_RENAME_MOVE
-#: Merge.rc:5074
+#: Merge.rc:5073
 msgid "Merge renames and moves"
 msgstr "Объединение переименований и перемещений"
 
 #. IDS_RENAMED
-#: Merge.rc:5075
+#: Merge.rc:5074
 msgid "Renamed"
 msgstr "Переименовано"
 
 #. IDS_RENAMED_MOVED
-#: Merge.rc:5077
+#: Merge.rc:5076
 msgid "Renamed/Moved"
 msgstr "Переименовано/Перемещено"
 
 #. IDS_RENAMED_MOVED_ITEMS
-#: Merge.rc:5078
+#: Merge.rc:5077
 #, c-format
 msgid "(%1 items)"
 msgstr "(элементов %1)"
 
 #. IDS_RENAMED_MOVED_RESULT
-#: Merge.rc:5079
+#: Merge.rc:5078
 #, c-format
 msgid "%1 (set %2): "
 msgstr "%1 (набор %2): "
 
 #. IDS_SWITCH_FLAT_MODE
-#: Merge.rc:5080
+#: Merge.rc:5079
 msgid "Some moved items have been merged.\nIn Tree Mode, these items may appear in positions that do not reflect the actual folder structure, which can be confusing.\nSwitch to Flat Mode?"
 msgstr "Некоторые перемещённые элементы были объединены.\nВ режиме дерева эти элементы могут отображаться в позициях, не соответствующих фактической структуре папок, что может вызывать путаницу.\nПереключиться в плоский режим?"
 
 #. IDS_ELAPSED_TIME
-#: Merge.rc:5086
+#: Merge.rc:5085
 #, c-format
 msgid "Elapsed time: %ld ms"
 msgstr "Прошло времени: %ld мс"
 
 #. IDS_STATUS_SELITEM1
-#: Merge.rc:5087
+#: Merge.rc:5086
 msgid "1 item selected"
 msgstr "Выбран 1 элемент"
 
 #. IDS_STATUS_SELITEMS
-#: Merge.rc:5088
+#: Merge.rc:5087
 #, c-format
 msgid "%1 items selected"
 msgstr "Выбрано элементов: %1"
 
 #. IDS_COLDESC_FILENAME
-#: Merge.rc:5094
+#: Merge.rc:5093
 msgid "Filename or folder name."
 msgstr "Имя файла или папки."
 
 #. IDS_COLDESC_DIR
-#: Merge.rc:5095
+#: Merge.rc:5094
 msgid "Subfolder name when subfolders are included."
 msgstr "Имена подпапок, если подпапки включены."
 
 #. IDS_COLDESC_RESULT
-#: Merge.rc:5096
+#: Merge.rc:5095
 msgid "Comparison result, long form."
 msgstr "Результат сравнения, длинная форма."
 
 #. IDS_COLDESC_LTIMEM
-#: Merge.rc:5101
+#: Merge.rc:5100
 msgid "Left side modification date."
 msgstr "Дата изменения слева."
 
 #. IDS_COLDESC_RTIMEM
-#: Merge.rc:5102
+#: Merge.rc:5101
 msgid "Right side modification date."
 msgstr "Дата изменения справа."
 
 #. IDS_COLDESC_MTIMEM
-#: Merge.rc:5103
+#: Merge.rc:5102
 msgid "Middle side modification date."
 msgstr "Дата изменения в центре."
 
 #. IDS_COLDESC_EXTENSION
-#: Merge.rc:5104
+#: Merge.rc:5103
 msgid "File's extension."
 msgstr "Расширение файла."
 
 #. IDS_COLDESC_LSIZE
-#: Merge.rc:5105
+#: Merge.rc:5104
 msgid "Left file size in bytes."
 msgstr "Размер файла слева в байтах."
 
 #. IDS_COLDESC_RSIZE
-#: Merge.rc:5106
+#: Merge.rc:5105
 msgid "Right file size in bytes."
 msgstr "Размер файла справа в байтах."
 
 #. IDS_COLDESC_MSIZE
-#: Merge.rc:5107
+#: Merge.rc:5106
 msgid "Middle file size in bytes."
 msgstr "Размер файла в центре в байтах."
 
 #. IDS_COLDESC_LSIZE_SHORT
-#: Merge.rc:5108
+#: Merge.rc:5107
 msgid "Left file size abbreviated."
 msgstr "Размер файла слева (сокр.)"
 
 #. IDS_COLDESC_RSIZE_SHORT
-#: Merge.rc:5109
+#: Merge.rc:5108
 msgid "Right file size abbreviated."
 msgstr "Размер файла справа (сокр.)"
 
 #. IDS_COLDESC_MSIZE_SHORT
-#: Merge.rc:5110
+#: Merge.rc:5109
 msgid "Middle file size abbreviated."
 msgstr "Размер файла в центре (сокр.)"
 
 #. IDS_COLDESC_LTIMEC
-#: Merge.rc:5116
+#: Merge.rc:5115
 msgid "Left side creation time."
 msgstr "Время создания файла слева."
 
 #. IDS_COLDESC_RTIMEC
-#: Merge.rc:5117
+#: Merge.rc:5116
 msgid "Right side creation time."
 msgstr "Время создания файла справа."
 
 #. IDS_COLDESC_MTIMEC
-#: Merge.rc:5118
+#: Merge.rc:5117
 msgid "Middle side creation time."
 msgstr "Время создания файла в центре."
 
 #. IDS_COLDESC_NEWER
-#: Merge.rc:5119
+#: Merge.rc:5118
 msgid "Tells which side has newer modification date."
 msgstr "Показать на какой из сторон дата изменения файла новее."
 
 #. IDS_COLDESC_LVERSION
-#: Merge.rc:5120
+#: Merge.rc:5119
 msgid "Left side file version, only for some file types."
 msgstr "Версия файла слева, только для некоторых типов файлов."
 
 #. IDS_COLDESC_RVERSION
-#: Merge.rc:5121
+#: Merge.rc:5120
 msgid "Right side file version, only for some file types."
 msgstr "Версия файла справа, только для некоторых типов файлов."
 
 #. IDS_COLDESC_MVERSION
-#: Merge.rc:5126
+#: Merge.rc:5125
 msgid "Middle side file version, only for some file types."
 msgstr "Версия файла в центре, только для некоторых типов файлов."
 
 #. IDS_COLDESC_RESULT_ABBR
-#: Merge.rc:5127
+#: Merge.rc:5126
 msgid "Short comparison result."
 msgstr "Результат быстрого сравнения."
 
 #. IDS_COLDESC_LATTRIBUTES
-#: Merge.rc:5128
+#: Merge.rc:5127
 msgid "Left side attributes."
 msgstr "Атрибуты слева."
 
 #. IDS_COLDESC_RATTRIBUTES
-#: Merge.rc:5129
+#: Merge.rc:5128
 msgid "Right side attributes."
 msgstr "Атрибуты справа."
 
 #. IDS_COLDESC_MATTRIBUTES
-#: Merge.rc:5130
+#: Merge.rc:5129
 msgid "Middle side attributes."
 msgstr "Атрибуты в центре."
 
 #. IDS_COLDESC_LEOL_TYPE
-#: Merge.rc:5131
+#: Merge.rc:5130
 msgid "Left side file EOL type."
 msgstr "Тип EOL для файла слева."
 
 #. IDS_COLDESC_REOL_TYPE
-#: Merge.rc:5132
+#: Merge.rc:5131
 msgid "Right side file EOL type."
 msgstr "Тип EOL для файла справа."
 
 #. IDS_COLDESC_MEOL_TYPE
-#: Merge.rc:5133
+#: Merge.rc:5132
 msgid "Middle side file EOL type."
 msgstr "Тип EOL для файла в центре."
 
 #. IDS_COLDESC_LENCODING
-#: Merge.rc:5139
+#: Merge.rc:5138
 msgid "Left side encoding."
 msgstr "Кодировка слева."
 
 #. IDS_COLDESC_RENCODING
-#: Merge.rc:5140
+#: Merge.rc:5139
 msgid "Right side encoding."
 msgstr "Кодировка справа."
 
 #. IDS_COLDESC_MENCODING
-#: Merge.rc:5141
+#: Merge.rc:5140
 msgid "Middle side encoding."
 msgstr "Кодировка в центре."
 
 #. IDS_COLDESC_NIDIFFS
-#: Merge.rc:5142
+#: Merge.rc:5141
 msgid "Number of ignored differences in file. Ignored and cannot be merged."
 msgstr "Количество проигнорированных отличий в файле. Эти отличия проигнорированы WinMerge и не могут быть обработаны."
 
 #. IDS_COLDESC_NSDIFFS
-#: Merge.rc:5143
+#: Merge.rc:5142
 msgid "Number of differences in file (excluding ignored)."
 msgstr "Количество отличий в файле. Это количество не включает в себя проигнорированные отличия."
 
 #. IDS_COLDESC_BINARY
-#: Merge.rc:5144
+#: Merge.rc:5143
 msgid "Shows an asterisk (*) if the file is binary."
 msgstr "Показать звездочку (*) если файл двоичный."
 
 #. IDS_COLDESC_UNPACKER
-#: Merge.rc:5145
+#: Merge.rc:5144
 msgid "Unpacker plugin name or pipeline."
 msgstr "Имя плагина распаковщика или конвейера."
 
 #. IDS_COLDESC_PREDIFFER
-#: Merge.rc:5146
+#: Merge.rc:5145
 msgid "Prediffer plugin name or pipeline."
 msgstr "Имя плагина предсравнения или конвейера."
 
 #. IDS_DIRECTORY_REPORT_TITLE
-#: Merge.rc:5152
+#: Merge.rc:5151
 #, c-format
 msgid "Compare %1 with %2"
 msgstr "Сравнение %1 с %2"
 
 #. IDS_DIRECTORY_REPORT_TITLE3
-#: Merge.rc:5153
+#: Merge.rc:5152
 #, c-format
 msgid "Compare %1 with %2 and %3"
 msgstr "Сравнить %1 с %2 и %3"
 
 #. IDS_REPORT_COMMALIST
-#: Merge.rc:5154
+#: Merge.rc:5153
 msgid "Comma-separated list"
 msgstr "Список с разделителем Запятая"
 
 #. IDS_REPORT_TABLIST
-#: Merge.rc:5155
+#: Merge.rc:5154
 msgid "Tab-separated list"
 msgstr "Список с разделителем Табуляция"
 
 #. IDS_REPORT_SIMPLEHTML
-#: Merge.rc:5156
+#: Merge.rc:5155
 msgid "Simple HTML"
 msgstr "Простой HTML"
 
 #. IDS_REPORT_SIMPLEXML
-#: Merge.rc:5157
+#: Merge.rc:5156
 msgid "Simple XML"
 msgstr "Простой XML"
 
-#: Merge.rc:5159
+#: Merge.rc:5158
 msgid "Report file already exists. Overwrite?"
 msgstr "Файл отчета уже существует. Перезаписать существующий файл?"
 
 #. IDS_REPORT_ERROR
-#: Merge.rc:5164
+#: Merge.rc:5163
 #, c-format
 msgid "Error creating the report:\n%1"
 msgstr "Ошибка создания отчета:\n%1"
 
 #. IDS_REPORT_SUCCESS
-#: Merge.rc:5165
+#: Merge.rc:5164
 msgid "Report created successfully."
 msgstr "Отчет успешно создан."
 
 #. IDS_SYNCPOINT_LASTBLOCK
-#: Merge.rc:5171
+#: Merge.rc:5170
 msgid "Cannot add a synchronization point at this line."
 msgstr "Невозможно добавить точку синхронизации в этой строке."
 
 #. IDS_FILE_TO_ITSELF
-#: Merge.rc:5177
+#: Merge.rc:5176
 msgid "Same file is opened in both panes."
 msgstr "На обеих панелях открыт один и тот же файл."
 
 #. IDS_FILESSAME
-#: Merge.rc:5178
+#: Merge.rc:5177
 msgid "Selected files are identical."
 msgstr "Выбранные файлы идентичны."
 
 #. IDS_FILESSAME_CURCFG
-#: Merge.rc:5179
+#: Merge.rc:5178
 msgid "Selected files are identical (with current settings).\r\nChecking binary identity..."
 msgstr "Выбранные файлы идентичны (с текущими параметрами).\r\nПроверка идентичности двоичных данных..."
 
 #. IDS_FILESSAME_BINERROR
-#: Merge.rc:5180
+#: Merge.rc:5179
 msgid "Selected files are identical (with current settings).\r\nBut binary comparison failed."
 msgstr "Выбранные файлы идентичны (с текущими параметрами).\Но произошёл сбой двоичного сравнения."
 
 #. IDS_FILESSAME_BINSAME
-#: Merge.rc:5181
+#: Merge.rc:5180
 msgid "Selected files are identical (binary match)."
 msgstr "Выбранные файлы идентичны (двоичное совпадение)."
 
 #. IDS_FILESSAME_BINDIFF
-#: Merge.rc:5182
+#: Merge.rc:5181
 msgid "Selected files are identical (with current settings).\r\nBut differ at the binary level."
 msgstr "Выбранные файлы идентичны (с текущими параметрами).\r\nНо отличаются на двоичном уровне."
 
 #. IDS_FILEERROR
-#: Merge.rc:5183
+#: Merge.rc:5182
 msgid "An error occurred while comparing files."
 msgstr "При сравнении файлов произошла ошибка."
 
 #. IDS_TEMP_FILEERROR
-#: Merge.rc:5184
+#: Merge.rc:5183
 msgid "Could not create temporary files. Check your temporary path settings."
 msgstr "Временные файлы не могут быть созданы. Проверьте параметры путей временных файлов."
 
 #. IDS_SUGGEST_IGNOREEOL
-#: Merge.rc:5185
+#: Merge.rc:5184
 msgid "Files use different EOL.\n\nTreat all EOL as equivalent?\n\nSet 'Ignore EOL differences (Windows/Unix/Mac)' in Compare section of Options."
 msgstr "В файлах используются различные типы конца строки.\n\nСчитать все концы строк в этом сравнении равнозначными?\n\nЕсли Вас не интересуют отличия EOL, установите параметр 'Игнорировать концы строк (Win/Unix/Mac)' на вкладке Сравнение в Настройках."
 
 #. IDS_INVALID_DIRECTORY
-#: Merge.rc:5186
+#: Merge.rc:5185
 msgid "Selected folder is invalid."
 msgstr "Выбранная папка указана неверно."
 
 #. IDS_CANNOT_OPEN_BINARYFILE
-#: Merge.rc:5187
+#: Merge.rc:5186
 msgid "Cannot open a binary file in Editor."
 msgstr "Не удается открыть двоичный файл в редакторе."
 
 #. IDS_CREATE_PAIR_FOLDER
-#: Merge.rc:5188
+#: Merge.rc:5187
 #, c-format
 msgid "Create matching folder:\n%1\non the other side and open?"
 msgstr "Папка существует только на одной стороне и не может быть открыта.\n\nСоздать подходящую папку:\n%1\nна другой стороне и открыть эти папки?"
 
 #. IDS_CONFIRM_COPY_ALL_DIFFS
-#: Merge.rc:5189
+#: Merge.rc:5188
 msgid "Copy all differences to other file?"
 msgstr "Хотите скопировать все отличия в другой файл?"
 
 #. IDS_MOVE_TO_NEXTFILE
-#: Merge.rc:5194
+#: Merge.rc:5193
 msgid "Move to next file?"
 msgstr "Перейти к следующему файлу?"
 
 #. IDS_MOVE_TO_PREVFILE
-#: Merge.rc:5195
+#: Merge.rc:5194
 msgid "Move to previous file?"
 msgstr "Перейти к предыдущему файлу?"
 
 #. IDS_MOVE_TO_NEXTPAGE
-#: Merge.rc:5196
+#: Merge.rc:5195
 msgid "Move to next page?"
 msgstr "Перейти к следующей странице?"
 
 #. IDS_MOVE_TO_PREVPAGE
-#: Merge.rc:5197
+#: Merge.rc:5196
 msgid "Move to previous page?"
 msgstr "Перейти к предыдущей странице?"
 
 #. IDS_MOVE_TO_FIRSTFILE
-#: Merge.rc:5198
+#: Merge.rc:5197
 msgid "Move to first file?"
 msgstr "Перейти к первому файлу?"
 
 #. IDS_MOVE_TO_LASTFILE
-#: Merge.rc:5199
+#: Merge.rc:5198
 msgid "Move to last file?"
 msgstr "Перейти к последнему файлу?"
 
-#: Merge.rc:5206
+#: Merge.rc:5205
 #, c-format
 msgid "Different codepages: left (cp%d), right (cp%d).\nDisplay in codepage (better display) or default Windows codepage (safer merging)?\n(Recommended: default Windows codepage)"
 msgstr "Различные кодировки: слева - (cp%d), справа - (cp%d). \nКаждый из файлов может быть отображен в своей кодировке, но их объединение или копирование может повредить информацию.\nОтобразить оба файла в системной кодировке Windows по умолчанию (рекомендуется)?"
 
-#: Merge.rc:5208
+#: Merge.rc:5207
 msgid "Information lost due to encoding errors: both files"
 msgstr "Информация потеряна из-за ошибочной кодировки: оба файла"
 
-#: Merge.rc:5210
+#: Merge.rc:5209
 msgid "Information lost due to encoding errors: first file"
 msgstr "Информация потеряна из-за ошибочной кодировки: первый файл"
 
-#: Merge.rc:5212
+#: Merge.rc:5211
 msgid "Information lost due to encoding errors: second file"
 msgstr "Информация потеряна из-за ошибочной кодировки: второй файл"
 
-#: Merge.rc:5214
+#: Merge.rc:5213
 msgid "Information lost due to encoding errors: third file"
 msgstr "Информация потеряна из-за ошибочной кодировки: третий файл"
 
 #. IDS_LINEDIFF_NODIFF
-#: Merge.rc:5220
+#: Merge.rc:5219
 msgid "No difference"
 msgstr "Нет отличий"
 
 #. IDS_LINEDIFF_NODIFF_CAPTION
-#: Merge.rc:5221
+#: Merge.rc:5220
 msgid "Line difference"
 msgstr "Строка отличий"
 
 #. IDS_NUM_REPLACED
-#: Merge.rc:5227
+#: Merge.rc:5226
 #, c-format
 msgid "Replaced %1 string(s)."
 msgstr "Заменено строк %1."
 
 #. IDS_EDIT_TEXT_NOT_FOUND
-#: Merge.rc:5228
+#: Merge.rc:5227
 #, c-format
 msgid "Cannot find string \"%s\"."
 msgstr "Не удается найти строку \"%s\"."
 
 #. IDS_MERGE_MODE
-#: Merge.rc:5234
+#: Merge.rc:5233
 msgid "Entering Merge Mode. Press F9 to turn off."
 msgstr "Вы входите в режим объединения. Для отключения режима объединения нажмите клавишу F9."
 
 #. IDS_AUTO_MERGE
-#: Merge.rc:5240
+#: Merge.rc:5239
 #, c-format
 msgid "Automatic merges: %1\nUnresolved conflicts: %2"
 msgstr "Количество автоматически объединяемых изменений: %1\nКоличество неразрешенных конфликтов: %2"
 
 #. IDS_CODEPAGE_MERGED
-#: Merge.rc:5241
+#: Merge.rc:5240
 msgid "Codepage change merged."
 msgstr "Изменение кодовой страницы объединено."
 
 #. IDS_CODEPAGE_CONFLICT
-#: Merge.rc:5242
+#: Merge.rc:5241
 msgid "Codepage changes are conflicting."
 msgstr "Изменения кодовой страницы противоречат друг другу."
 
 #. IDS_EOL_MERGED
-#: Merge.rc:5243
+#: Merge.rc:5242
 msgid "EOL change merged."
 msgstr "Изменение EOL было объединено."
 
 #. IDS_EOL_CONFLICT
-#: Merge.rc:5244
+#: Merge.rc:5243
 msgid "EOL changes are conflicting."
 msgstr "Изменения EOL противоречат друг другу."
 
 #. IDS_LOCBAR_CAPTION
-#: Merge.rc:5250
+#: Merge.rc:5249
 msgid "Location Pane"
 msgstr "Панель управления"
 
 #. IDS_DIFFBAR_CAPTION
-#: Merge.rc:5251
+#: Merge.rc:5250
 msgid "Diff Pane"
 msgstr "Панель сравнения"
 
 #. IDS_DIFF_SUCCEEDED
-#: Merge.rc:5258
+#: Merge.rc:5257
 msgid "Patch file written."
 msgstr "Патч успешно записан."
 
 #. IDS_DIFF_FILEOVERWRITE
-#: Merge.rc:5259
+#: Merge.rc:5258
 msgid "Patch file already exists. Overwrite?"
 msgstr "Патч уже существует. Перезаписать?"
 
 #. IDS_DIFF_SELECTEDFILES
-#: Merge.rc:5260
+#: Merge.rc:5259
 #, c-format
 msgid "[%1 files selected]"
 msgstr "[%1 файлов выбрано]"
 
 #. IDS_DIFF_NORMAL
-#: Merge.rc:5261
+#: Merge.rc:5260
 msgid "Normal"
 msgstr "Нормальный"
 
 #. IDS_DIFF_CONTEXT
-#: Merge.rc:5262
+#: Merge.rc:5261
 msgid "Context"
 msgstr "Контекст"
 
 #. IDS_DIFF_UNIFIED
-#: Merge.rc:5263
+#: Merge.rc:5262
 msgid "Unified"
 msgstr "Унифицированный"
 
 #. IDS_FILEWRITE_ERROR
-#: Merge.rc:5265
+#: Merge.rc:5264
 #, c-format
 msgid "Could not write to file %1."
 msgstr "Не удается записать в файл %1."
 
 #. IDS_PATH_NOT_ABSOLUTE
-#: Merge.rc:5266
+#: Merge.rc:5265
 #, c-format
 msgid "Output path is not absolute: %1"
 msgstr "Указанный путь для вывода не является абсолютным: %1"
 
 #. IDS_MUST_SPECIFY_OUTPUT
-#: Merge.rc:5267
+#: Merge.rc:5266
 msgid "Specify an output file."
 msgstr "Указать выходной файл."
 
-#: Merge.rc:5269
+#: Merge.rc:5268
 msgid "Cannot create patch from binary files."
 msgstr "Не удается создать патч из двоичных файлов."
 
 #. IDS_SAVEFILES_FORPATCH
-#: Merge.rc:5270
+#: Merge.rc:5269
 msgid "Save all files first.\n\nCreating a patch requires no unsaved changes."
 msgstr "Сначала сохраните все файлы.\n\nДля создания патча необходимо, чтобы в файлах не было несохраненных изменений."
 
 #. IDS_FOLDER_NOTEXIST
-#: Merge.rc:5271
+#: Merge.rc:5270
 msgid "Folder does not exist."
 msgstr "Папка не существует."
 
 #. IDS_ARCHIVE_SUCCEEDED
-#: Merge.rc:5277
+#: Merge.rc:5276
 msgid "Archive file written."
 msgstr "Архивный файл записан."
 
 #. IDS_ARCHIVE_SAVEFILES
-#: Merge.rc:5278
+#: Merge.rc:5277
 msgid "Save all files first.\n\nCreating an archive requires no unsaved changes."
 msgstr "Сначала сохраните все файлы.\n\nПри создании архива не должно быть несохранённых изменений."
 
 #. IDS_NO_ZIP_SUPPORT
-#: Merge.rc:5283
+#: Merge.rc:5282
 msgid "Archive support not enabled.\n7-Zip and/or Merge7z*.dll not found.\nSee manual for archive support."
 msgstr "Поддержка архивов не включена.\nНе найдены необходимые компоненты (7-Zip и/или Merge7z*.dll) для поддержки архивов.\nДополнительную информацию о поддержке архивов и ее включении смотрите в руководстве."
 
 #. IDS_OPT_EXPORT_CAPTION
-#: Merge.rc:5284
+#: Merge.rc:5283
 msgid "Select file for export"
 msgstr "Выбрать файл для экспорта"
 
 #. IDS_OPT_IMPORT_CAPTION
-#: Merge.rc:5285
+#: Merge.rc:5284
 msgid "Select file for import"
 msgstr "Выбрать файл для импорта"
 
 #. IDS_OPT_IMPORT_DONE
-#: Merge.rc:5286
+#: Merge.rc:5285
 msgid "Options imported from file."
 msgstr "Настройки, импортируемые из файла."
 
 #. IDS_OPT_EXPORT_DONE
-#: Merge.rc:5287
+#: Merge.rc:5286
 msgid "Options exported to file."
 msgstr "Настройки, экспортируемые в файл."
 
 #. IDS_OPT_IMPORT_ERR
-#: Merge.rc:5288
+#: Merge.rc:5287
 msgid "Failed to import options from file."
 msgstr "Сбой импорта настроек из файла."
 
 #. IDS_OPT_EXPORT_ERR
-#: Merge.rc:5289
+#: Merge.rc:5288
 msgid "Failed to write options to file."
 msgstr "Сбой экспорта настроек в файл."
 
 #. IDS_CLOSEALL_WINDOWS
-#: Merge.rc:5290
+#: Merge.rc:5289
 msgid "Close multiple compare windows?\n\nContinue?"
 msgstr "Вы собираетесь закрыть сразу несколько окон сравнения.\n\nПродолжить?"
 
 #. IDS_EOL_BIN
-#: Merge.rc:5300
+#: Merge.rc:5299
 msgctxt "EOL Type"
 msgid "Binary"
 msgstr "Двоичный"
 
 #. IDS_MARKER_COLOR_FMT
-#: Merge.rc:5305
+#: Merge.rc:5304
 #, c-format
 msgid "Marker Color %d"
 msgstr "Цвет маркера %d"
 
 #. IDS_MARKER_NEW_PATTERN
-#: Merge.rc:5306
+#: Merge.rc:5305
 msgid "New Pattern"
 msgstr "Новый шаблон"
 
 #. IDS_PLUGINSLIST_TYPE
-#: Merge.rc:5312
+#: Merge.rc:5311
 msgid "Type"
 msgstr "Тип"
 
 #. IDS_PLUGINS_TYPE_EDITSCRIPT
-#: Merge.rc:5316
+#: Merge.rc:5315
 msgid "Editor script"
 msgstr "Редактор скриптов"
 
 #. ID_SELECTLINEDIFF
-#: Merge.rc:5322
+#: Merge.rc:5321
 msgid "\nDifference in Current Line (F4)"
 msgstr "\nОтличие в текущей строке (F4)"
 
 #. ID_OPTIONS
-#: Merge.rc:5323
+#: Merge.rc:5322
 msgid "\nOptions"
 msgstr "\nНастройки"
 
 #. ID_REFRESH
-#: Merge.rc:5324
+#: Merge.rc:5323
 msgid "\nRefresh (F5)"
 msgstr "\nОбновить (F5)"
 
 #. ID_PREVDIFF
-#: Merge.rc:5330
+#: Merge.rc:5329
 msgid "\nPrevious Difference (Alt+Up)"
 msgstr "\nПредыдущее отличие (Alt+Up)"
 
 #. ID_NEXTDIFF
-#: Merge.rc:5331
+#: Merge.rc:5330
 msgid "\nNext Difference (Alt+Down)"
 msgstr "\nСледующее отличие (Alt+Down)"
 
 #. ID_PREVCONFLICT
-#: Merge.rc:5332
+#: Merge.rc:5331
 msgid "\nPrevious Conflict (Alt+Shift+Up)"
 msgstr "\nПредыдущий конфликт (Alt+Shift+Up)"
 
 #. ID_NEXTCONFLICT
-#: Merge.rc:5333
+#: Merge.rc:5332
 msgid "\nNext Conflict (Alt+Shift+Down)"
 msgstr "\nСледующий конфликт (Alt+Shift+Down)"
 
 #. ID_FIRSTDIFF
-#: Merge.rc:5338
+#: Merge.rc:5337
 msgid "\nFirst Difference (Alt+Home)"
 msgstr "\nПервое отличие (Alt+Home)"
 
 #. ID_CURDIFF
-#: Merge.rc:5339
+#: Merge.rc:5338
 msgid "\nCurrent Difference (Alt+Enter)"
 msgstr "\nТекущее отличие (Alt+Enter)"
 
 #. ID_LASTDIFF
-#: Merge.rc:5340
+#: Merge.rc:5339
 msgid "\nLast Difference (Alt+End)"
 msgstr "\nПоследнее отличие (Alt+End)"
 
 #. ID_L2R
-#: Merge.rc:5341
+#: Merge.rc:5340
 msgid "\nCopy to Right (Alt+Right)"
 msgstr "\nКопировать направо (Alt+Right)"
 
 #. ID_R2L
-#: Merge.rc:5342
+#: Merge.rc:5341
 msgid "\nCopy to Left (Alt+Left)"
 msgstr "\nКопировать налево (Alt+Left)"
 
 #. ID_L2RNEXT
-#: Merge.rc:5343
+#: Merge.rc:5342
 msgid "\nCopy to Right and Advance (Ctrl+Alt+Right)"
 msgstr "\nКопировать направо и перейти (Ctrl+Alt+Right)"
 
 #. ID_R2LNEXT
-#: Merge.rc:5344
+#: Merge.rc:5343
 msgid "\nCopy to Left and Advance (Ctrl+Alt+Left)"
 msgstr "\nКопировать налево и перейти (Ctrl+Alt+Left)"
 
 #. ID_ALL_RIGHT
-#: Merge.rc:5345
+#: Merge.rc:5344
 msgid "\nCopy All to Right"
 msgstr "\nКопировать все направо"
 
 #. ID_ALL_LEFT
-#: Merge.rc:5346
+#: Merge.rc:5345
 msgid "\nCopy All to Left"
 msgstr "\nКопировать все налево"
 
 #. ID_AUTO_MERGE
-#: Merge.rc:5347
+#: Merge.rc:5346
 msgid "\nAuto Merge (Ctrl+Alt+M)"
 msgstr "\nАвто объединение (Ctrl+Alt+M)"
 
 #. ID_FIRSTFILE
-#: Merge.rc:5348
+#: Merge.rc:5347
 msgid "\nFirst File"
 msgstr "\nПервый файл"
 
 #. ID_NEXTFILE
-#: Merge.rc:5349
+#: Merge.rc:5348
 msgid "\nNext File (Ctrl+F8)"
 msgstr "\nСледующий файл (Ctrl+F8)"
 
 #. ID_LASTFILE
-#: Merge.rc:5350
+#: Merge.rc:5349
 msgid "\nLast File"
 msgstr "\nПоследний файл"
 
 #. ID_PREVFILE
-#: Merge.rc:5351
+#: Merge.rc:5350
 msgid "\nPrevious File (Ctrl+F7)"
 msgstr "\nПредыдущий файл (Ctrl+F7)"
 
 #. IDS_UNPACK_AUTO
-#: Merge.rc:5358
+#: Merge.rc:5357
 msgid "Adapted unpacker applied to both files (one needs extension)."
 msgstr "Автоматический подбор распаковщика (укажите расширение хотя бы у одного из файлов)."
 
 #. IDS_NO_PREDIFFER
-#: Merge.rc:5359
+#: Merge.rc:5358
 msgid "No Prediffer (Normal)"
 msgstr "Без предсравнения (обычно)"
 
 #. IDS_SUGGESTED_PLUGINS
-#: Merge.rc:5360
+#: Merge.rc:5359
 msgid "Suggested Plugins"
 msgstr "Предлагаемые плагины"
 
 #. IDS_NOT_SUGGESTED_PLUGINS
-#: Merge.rc:5361
+#: Merge.rc:5360
 msgid "All Plugins"
 msgstr "Все плагины"
 
 #. IDS_PRIVATEBUILD_FMT
-#: Merge.rc:5367
+#: Merge.rc:5366
 #, c-format
 msgid "Private Build: %1"
 msgstr "Частный билд: %1"
 
 #. IDS_ALLRIGHTS_RESERVED
-#: Merge.rc:5368
+#: Merge.rc:5367
 msgid " - All rights reserved."
 msgstr " - Все права защищены."
 
 #. IDS_TITLE_PLUGINS_SETTINGS
-#: Merge.rc:5374
+#: Merge.rc:5373
 msgid "Plugin Settings"
 msgstr "Параметры плагина"
 
 #. IDS_NO_SCT_SCRIPTS
-#: Merge.rc:5376
+#: Merge.rc:5375
 msgid "WSH not found - .sct scripts disabled"
 msgstr "WSH не найден - .sct скрипты отключены"
 
 #. IDS_LOCBAR_GOTOLINE_FMT
-#: Merge.rc:5384
+#: Merge.rc:5383
 #, c-format
 msgid "G&o to Line %1"
 msgstr "Перейти к строке %1"
 
 #. IDS_GOTO_MOVED_LINE
-#: Merge.rc:5390
+#: Merge.rc:5389
 msgid "Go to Moved Line\tCtrl+Shift+G"
 msgstr "Перейти к перемещенной строке\tCtrl+Shift+G"
 
 #. IDS_AUTOCOMPLETE_DISABLED
-#: Merge.rc:5396
+#: Merge.rc:5395
 msgctxt "Options dialog|General|Open dialog Auto completion"
 msgid "Disabled"
 msgstr "Отключено"
 
 #. IDS_AUTOCOMPLETE_FILE_SYS
-#: Merge.rc:5397
+#: Merge.rc:5396
 msgid "From file system"
 msgstr "Как в файловой системе"
 
 #. IDS_AUTOCOMPLETE_MRU
-#: Merge.rc:5398
+#: Merge.rc:5397
 msgid "From Most Recently Used list"
 msgstr "Как в истории"
 
 #. IDS_COLORSCHEME_PLAIN
-#: Merge.rc:5404
+#: Merge.rc:5403
 msgid "No Highlighting"
 msgstr "Без выделения"
 
 #. IDS_COLORSCHEME_PO
-#: Merge.rc:5439
+#: Merge.rc:5438
 msgid "Portable Object"
 msgstr "Портативный объект"
 
 #. IDS_COLORSCHEME_RSRC
-#: Merge.rc:5444
+#: Merge.rc:5443
 msgid "Resources"
 msgstr "Ресурсы"
 
 #. IDS_COLORSCHEME_SH
-#: Merge.rc:5448
+#: Merge.rc:5447
 msgid "Shell"
 msgstr "Оболочка"
 
 #. IDS_CLOSE_LEFT_TABS
-#: Merge.rc:5469
+#: Merge.rc:5468
 msgid "Close &Left Tabs"
 msgstr "Закрыть вкладки слева"
 
 #. IDS_CLOSE_RIGHT_TABS
-#: Merge.rc:5470
+#: Merge.rc:5469
 msgid "Close R&ight Tabs"
 msgstr "Закрыть вкладки справа"
 
 #. IDS_CLOSE_OTHER_TABS
-#: Merge.rc:5471
+#: Merge.rc:5470
 msgid "Close &Other Tabs"
 msgstr "Закрыть другие вкладки"
 
 #. IDS_TABBAR_AUTO_MAXWIDTH
-#: Merge.rc:5472
+#: Merge.rc:5471
 msgid "Enable &Auto Max Width"
 msgstr "Включить максимальную авто ширину"
 
 #. IDS_WEBPAGE_MENU
-#: Merge.rc:5482
+#: Merge.rc:5481
 msgid "We&bpage"
 msgstr "Веб-страница"
 
 #. IDS_VIEW_WRAP_TEXT
-#: Merge.rc:5487
+#: Merge.rc:5486
 msgid "W&rap Text"
 msgstr "&Перенос строк"
 
 #. IDS_NOTINSTALLED
-#: Merge.rc:5492
+#: Merge.rc:5491
 msgid "%1 is not installed."
 msgstr "%1 не установлен."
 
 #. IDS_CREATE_FOLDER
-#: Merge.rc:5497
+#: Merge.rc:5496
 #, c-format
 msgid "%1 does not exist. Create it?"
 msgstr "%1 не существует. Создать?"
 
 #. IDS_CREATE_FOLDER_ERROR
-#: Merge.rc:5498
+#: Merge.rc:5497
 msgid "Failed to create folder."
 msgstr "Не удалось создать папку."
 
 #. IDC_EXT_EDITOR_PATH
-#: Merge.rc:5503
+#: Merge.rc:5502
 msgid "Parameters:\n$file: Current file path\n$linenum: Current cursor line number"
 msgstr "Можно указать следующие параметры пути:\n$file: Имя пути текущего файла\n$linenum: Номер строки текущей позиции курсора"
 
 #. IDS_DIFF_ALGORITHM_DEFAULT
-#: Merge.rc:5508
+#: Merge.rc:5507
 msgid "default"
 msgstr "по умолчанию"
 
 #. IDS_DIFF_ALGORITHM_MINIMAL
-#: Merge.rc:5509
+#: Merge.rc:5508
 msgid "minimal"
 msgstr "минимально"
 
 #. IDS_DIFF_ALGORITHM_PATIENCE
-#: Merge.rc:5510
+#: Merge.rc:5509
 msgid "patience"
 msgstr "терпеливо"
 
 #. IDS_DIFF_ALGORITHM_HISTOGRAM
-#: Merge.rc:5511
+#: Merge.rc:5510
 msgid "histogram"
 msgstr "гистограмма"
 
 #. IDS_DIFF_ALGORITHM_NONE
-#: Merge.rc:5512
+#: Merge.rc:5511
 msgid "none"
 msgstr "нет"
 
 #. IDS_RENDERING_MODE_GDI
-#: Merge.rc:5517
+#: Merge.rc:5516
 msgid "GDI"
 msgstr "GDI"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_DEFAULT
-#: Merge.rc:5518
+#: Merge.rc:5517
 msgid "DirectWrite Default"
 msgstr "Прямая запись по умолчанию"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_ALIASED
-#: Merge.rc:5519
+#: Merge.rc:5518
 msgid "DirectWrite Aliased"
 msgstr "Прямая запись с псевдонимом"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_GDI_CLASSIC
-#: Merge.rc:5520
+#: Merge.rc:5519
 msgid "DirectWrite GDI Classic"
 msgstr "Прямая запись GDI Classic"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_GDI_NATURAL
-#: Merge.rc:5521
+#: Merge.rc:5520
 msgid "DirectWrite GDI Natural"
 msgstr "Прямая запись GDI Natural"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_NATURAL
-#: Merge.rc:5522
+#: Merge.rc:5521
 msgid "DirectWrite Natural"
 msgstr "Прямая запись Natural"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_NATURAL_SYMMETRIC
-#: Merge.rc:5523
+#: Merge.rc:5522
 msgid "DirectWrite Natural Symmetric"
 msgstr "Прямая запись Natural Symmetric"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_DISABLED
-#: Merge.rc:5528
+#: Merge.rc:5527
 msgctxt "Options dialog|General|Close windows with Esc"
 msgid "Disabled"
 msgstr "Отключено"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_1
-#: Merge.rc:5529
+#: Merge.rc:5528
 msgid "MDI child window or main window"
 msgstr "MDI дочернее окно или главное окно"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_2
-#: Merge.rc:5530
+#: Merge.rc:5529
 msgid "MDI child window only"
 msgstr "MDI дочернее окно только"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_3
-#: Merge.rc:5531
+#: Merge.rc:5530
 msgid "Close main window if only one MDI child window"
 msgstr "Закрыть главное окно, если дочернее окно MDI единственное"
 
 #. IDS_DIFF_GROUP
-#: Merge.rc:5536
+#: Merge.rc:5535
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Diff"
 msgstr "Отличия"
 
 #. IDS_DIFF_HIGHLIGHT
-#: Merge.rc:5537
+#: Merge.rc:5536
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Highlight"
 msgstr "Подсветка"
 
 #. IDS_DIFF_BLINK
-#: Merge.rc:5538
+#: Merge.rc:5537
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Blink"
 msgstr "Мигание"
 
 #. IDS_DIFF_BLOCKSIZE
-#: Merge.rc:5539
+#: Merge.rc:5538
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Block Size"
 msgstr "Размер блока"
 
 #. IDS_DIFF_BLOCKALPHA
-#: Merge.rc:5540
+#: Merge.rc:5539
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Block Alpha"
 msgstr "Прозрачность блока"
 
 #. IDS_DIFF_CDTHRESHOLD
-#: Merge.rc:5541
+#: Merge.rc:5540
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "CD Threshold"
 msgstr "Порог цветоразличения"
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION
-#: Merge.rc:5542
+#: Merge.rc:5541
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Ins/Del Detection"
 msgstr "Обнаружение Ins/Del"
 
 #. IDS_OVERLAY_MODE_NONE
-#: Merge.rc:5543 Merge.rc:5548
+#: Merge.rc:5542 Merge.rc:5547
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "None"
 msgstr "Нет"
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION_VERTICAL
-#: Merge.rc:5544
+#: Merge.rc:5543
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Vertical"
 msgstr "Вертикально"
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION_HORIZONTAL
-#: Merge.rc:5545
+#: Merge.rc:5544
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Horizontal"
 msgstr "Горизонтально"
 
 #. IDS_OVERLAY_GROUP
-#: Merge.rc:5546
+#: Merge.rc:5545
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Overlay"
 msgstr "Наложение"
 
 #. IDS_OVERLAY_ALPHA
-#: Merge.rc:5547
+#: Merge.rc:5546
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha"
 msgstr "Альфа"
 
 #. IDS_OVERLAY_MODE_XOR
-#: Merge.rc:5549
+#: Merge.rc:5548
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "XOR"
 msgstr "XOR"
 
 #. IDS_OVERLAY_MODE_ALPHA
-#: Merge.rc:5550
+#: Merge.rc:5549
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha Blend"
 msgstr "Альфа-смешение"
 
 #. IDS_OVERLAY_MODE_ALPHA_ANIMATION
-#: Merge.rc:5551
+#: Merge.rc:5550
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha Animation"
 msgstr "Альфа-анимация"
 
 #. IDS_ZOOM
-#: Merge.rc:5552
+#: Merge.rc:5551
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Zoom"
 msgstr "Масштаб"
 
 #. IDS_PAGE
-#: Merge.rc:5553
+#: Merge.rc:5552
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Page:"
 msgstr "Страница:"
 
 #. IDS_IMGCMP_STATUS_PT_RGBA_FMT
-#: Merge.rc:5554
+#: Merge.rc:5553
 #, c-format
 msgid "Pt: (%d, %d)  RGBA: (%d, %d, %d, %d)  "
 msgstr "Чс: (%d, %d)  RGBA: (%d, %d, %d, %d)  "
 
 #. IDS_IMGCMP_STATUS_DIST1_FMT
-#: Merge.rc:5555
+#: Merge.rc:5554
 #, c-format
 msgid "Dist: %g  "
 msgstr "Путь: %g  "
 
 #. IDS_IMGCMP_STATUS_DIST2_FMT
-#: Merge.rc:5556
+#: Merge.rc:5555
 #, c-format
 msgid "Dist: %g, %g  "
 msgstr "Путь: %g, %g  "
 
 #. IDS_IMGCMP_STATUS_PAGE_ZOOM_SIZE_BPP_FMT
-#: Merge.rc:5557
+#: Merge.rc:5556
 #, c-format
 msgid "Page: %d/%d  Zoom: %d%%  %dx%dpx  %dbpp  "
 msgstr "Страница: %d/%d  Масштаб: %d%%  %dx%dpx  %dbpp  "
 
 #. IDS_IMGCMP_STATUS_RC_FMT
-#: Merge.rc:5558
+#: Merge.rc:5557
 #, c-format
 msgid "Rc: (%d, %d)  "
 msgstr "Rc: (%d, %d)  "
 
 #. IDS_IMGCMP_STATUS_FLIPPED_FMT
-#: Merge.rc:5559
+#: Merge.rc:5558
 #, c-format
 msgid "Flipped: %s  "
 msgstr "Отражен: %s  "
 
 #. IDS_IMGCMP_STATUS_ROTATED_FMT
-#: Merge.rc:5560
+#: Merge.rc:5559
 #, c-format
 msgid "Rotated: %d  "
 msgstr "Повернут: %d  "
 
 #. IDS_IMGCMP_REPORT_ALLPAGES
-#: Merge.rc:5561
+#: Merge.rc:5560
 msgid "All pages"
 msgstr "Все страницы"
 
 #. IDS_IGNSUB_STR1
-#: Merge.rc:5566
+#: Merge.rc:5565
 msgid "<Edit here>"
 msgstr "<Редактировать здесь>"
 
 #. IDS_IGNSUB_STR2
-#: Merge.rc:5567
+#: Merge.rc:5566
 msgid "No differences found to select"
 msgstr "Не найдено отличий для выбора"
 
 #. IDS_IGNSUB_STR3
-#: Merge.rc:5568
+#: Merge.rc:5567
 msgid "No differences found to add as substitution filter"
 msgstr "Не найдено отличий для добавления в фильтр подмены"
 
 #. IDS_IGNSUB_STR4
-#: Merge.rc:5569
+#: Merge.rc:5568
 msgid "The pair is already in the Substitution Filters list"
 msgstr "Эта пара уже присутствует в списке фильтров подмены"
 
 #. IDS_IGNSUB_STR5
-#: Merge.rc:5570
+#: Merge.rc:5569
 msgid "Add this change to Substitution Filters?"
 msgstr "Добавить это изменение в фильтры подмены?"
 
 #. IDS_OCRRESULT_TEXTONLY
-#: Merge.rc:5575
+#: Merge.rc:5574
 msgid "Text only"
 msgstr "Только текст"
 
 #. IDS_OCRRESULT_POS_LINE
-#: Merge.rc:5576
+#: Merge.rc:5575
 msgid "Line-by-line position and text"
 msgstr "Построчная позиция и текст"
 
 #. IDS_OCRRESULT_POS_WORD
-#: Merge.rc:5577
+#: Merge.rc:5576
 msgid "Word-by-word position and text"
 msgstr "Пословная позиция и текст"
 
 #. IDS_USERDATAFOLDER_APPDATA
-#: Merge.rc:5582
+#: Merge.rc:5581
 msgid "AppData (Roaming) folder"
 msgstr "Папка AppData (Roaming)"
 
 #. IDS_USERDATAFOLDER_INSTALL
-#: Merge.rc:5583
+#: Merge.rc:5582
 msgid "Install folder"
 msgstr "Папка установки"
 
 #. IDS_USERDATAFOLDER_DOCUMENTS
-#: Merge.rc:5584
+#: Merge.rc:5583
 msgid "Documents folder"
 msgstr "Папка Документы"
 
 #. IDS_SINGLEINSTANCE_DISABLED
-#: Merge.rc:5589
+#: Merge.rc:5588
 msgctxt "Options dialog|General|Single instance mode"
 msgid "Disabled"
 msgstr "Отключено"
 
 #. IDS_SINGLEINSTANCE_STR1
-#: Merge.rc:5590
+#: Merge.rc:5589
 msgid "Allow only one instance to run"
 msgstr "Разрешить запуск только одной копии"
 
 #. IDS_CLIPBOARD_HISTORY
-#: Merge.rc:5591
+#: Merge.rc:5590
 msgid "Clipboard &History"
 msgstr "История буфера обмена"
 
 #. IDS_SINGLEINSTANCE_STR2
-#: Merge.rc:5592
+#: Merge.rc:5591
 msgid "Allow only one instance; wait for termination"
 msgstr "Разрешить запуск только одной копии и дожидаться ее завершения"
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_DISABLED
-#: Merge.rc:5597
+#: Merge.rc:5596
 msgctxt "Options dialog|General|Auto-reload modified files"
 msgid "Disabled"
 msgstr "Отключено"
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_STR1
-#: Merge.rc:5598
+#: Merge.rc:5597
 msgid "Only on window activated"
 msgstr "Активно только в окне"
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_STR2
-#: Merge.rc:5599
+#: Merge.rc:5598
 msgid "Immediately"
 msgstr "Незамедлительно"
 
 #. IDS_PLUGIN_ALL
-#: Merge.rc:5604
+#: Merge.rc:5603
 msgid "Al&l"
 msgstr "Все"
 
 #. IDS_PLUGIN_OTHERS
-#: Merge.rc:5605
+#: Merge.rc:5604
 msgid "&Others"
 msgstr "Другое"
 
-#: Merge.rc:5607
+#: Merge.rc:5606
 #, c-format
 msgid "Missing plugin name in pipeline: %1"
 msgstr "Отсутствует имя плагина в конвейере: %1"
 
-#: Merge.rc:5609
+#: Merge.rc:5608
 #, c-format
 msgid "Missing quote in plugin pipeline: %1"
 msgstr "Отсутствует кавычка в конвейере плагинов: %1"
 
 #. IDS_PLUGIN_NAME_ALREADY_EXISTS
-#: Merge.rc:5610
+#: Merge.rc:5609
 #, c-format
 msgid "Plugin name '%1' already exists."
 msgstr "Имя плагина '%1' уже существует."
 
 #. IDS_PLUGIN_TITLE1
-#: Merge.rc:5611
+#: Merge.rc:5610
 msgid "Specify plugin arguments"
 msgstr "Укажите аргументы плагина"
 
-#: Merge.rc:5613
+#: Merge.rc:5612
 #, c-format
 msgid "Plugin not found or invalid: %1"
 msgstr "Плагин не найден или недействителен: %1"
 
 #. IDS_PLUGIN_NOT_UNPACK
-#: Merge.rc:5614
+#: Merge.rc:5613
 #, c-format
 msgid "'%1' is not an unpacker plugin"
 msgstr "'%1' не является плагином распаковщика"
 
 #. IDS_PLUGIN_NOT_PREDIFF
-#: Merge.rc:5615
+#: Merge.rc:5614
 #, c-format
 msgid "'%1' is not a prediffer plugin"
 msgstr "'%1' не является плагином предсравнения"
 
-#: Merge.rc:5617
+#: Merge.rc:5616
 #, c-format
 msgid "Error prediffing '%1' with '%2'. Prediffing disabled."
 msgstr "Ошибка предсравнения '%1' с '%2'. Предсравнение отключено."
 
 #. IDS_PLUGIN_CIRCULAR_REFERENCE
-#: Merge.rc:5618
+#: Merge.rc:5617
 #, c-format
 msgid "Circular reference in plugin pipeline: %1"
 msgstr "Циклическая ссылка в конвейере плагина: %1"
 
 #. IDS_PLUGIN_TYPE1
-#: Merge.rc:5619
+#: Merge.rc:5618
 msgid "URL Handler"
 msgstr "Обработчик URL"
 
 #. IDS_PLUGIN_TYPE2
-#: Merge.rc:5620
+#: Merge.rc:5619
 msgid "File Unpacker"
 msgstr "Распаковщик файлов"
 
 #. IDS_PLUGIN_TYPE3
-#: Merge.rc:5621
+#: Merge.rc:5620
 msgid "File or Folder Unpacker"
 msgstr "Распаковщик файлов или папок"
 
 #. IDS_PLUGIN_TYPE5
-#: Merge.rc:5623
+#: Merge.rc:5622
 msgid "Alias for Unpacker"
 msgstr "Псевдоним для распаковщика"
 
 #. IDS_PLUGIN_TYPE6
-#: Merge.rc:5624
+#: Merge.rc:5623
 msgid "Alias for Prediffer"
 msgstr "Псевдоним для предсравнения"
 
 #. IDS_PLUGIN_TYPE7
-#: Merge.rc:5625
+#: Merge.rc:5624
 msgid "Alias for Editor script"
 msgstr "Псевдоним для редактора скриптов"
 
 #. IDS_PLUGIN_ALIAS_DESC
-#: Merge.rc:5626
+#: Merge.rc:5625
 #, c-format
 msgid "Alias for plugin pipeline '%1'"
 msgstr "Псевдоним для конвейера плагина '%1'"
 
 #. IDS_PLUGIN_NEW_DESC
-#: Merge.rc:5627
+#: Merge.rc:5626
 msgid "New plugin description"
 msgstr "Создать описание плагина"
 
 #. IDS_PLUGIN_TARGETS_ALL
-#: Merge.rc:5628
+#: Merge.rc:5627
 msgid "All"
 msgstr "Все"
 
 #. IDS_PLUGIN_TARGETS_1ST
-#: Merge.rc:5629
+#: Merge.rc:5628
 msgid "1st"
 msgstr "1-й"
 
 #. IDS_PLUGIN_TARGETS_2ND
-#: Merge.rc:5630
+#: Merge.rc:5629
 msgid "2nd"
 msgstr "2-й"
 
 #. IDS_PLUGIN_TARGETS_3RD
-#: Merge.rc:5631
+#: Merge.rc:5630
 msgid "3rd"
 msgstr "3-й"
 
 #. IDS_PLUGIN_TARGETS_1ST_2ND
-#: Merge.rc:5632
+#: Merge.rc:5631
 msgid "1st and 2nd"
 msgstr "1-й и 2-й"
 
 #. IDS_PLUGIN_TARGETS_1ST_3RD
-#: Merge.rc:5633
+#: Merge.rc:5632
 msgid "1st and 3rd"
 msgstr "1-й и 3-й"
 
 #. IDS_PLUGIN_TARGETS_2ND_3RD
-#: Merge.rc:5634
+#: Merge.rc:5633
 msgid "2nd and 3rd"
 msgstr "2-й и 3-й"
 
 #. IDS_PLUGIN_CTRL_CLICK
-#: Merge.rc:5635
+#: Merge.rc:5634
 msgid "(Ctrl+Click to add to pipeline)"
 msgstr ""
 
 #. IDS_FILTER_APPLIED
-#: Merge.rc:5640
+#: Merge.rc:5639
 msgid "Filter applied"
 msgstr "Фильтр применен"
 
 #. IDS_FILTERMENU_COMPARE
-#: Merge.rc:5645
+#: Merge.rc:5644
 #, c-format
 msgid "Compare %1"
 msgstr "Сравнить %1"
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN2
-#: Merge.rc:5647
+#: Merge.rc:5646
 msgid "&Filter by This Column..."
 msgstr "Фильтр по этому столбцу..."
 
 #. IDS_CLIPBOARDHISTORY_TIME
-#: Merge.rc:5652
+#: Merge.rc:5651
 #, c-format
 msgid "Clipboard at %s"
 msgstr "Буфер обмена в %s"
 
 #. IDS_CLIPBOARDHISTORY_DISABLED
-#: Merge.rc:5653
+#: Merge.rc:5652
 msgid "Clipboard history disabled.\r\nEnable: Windows logo key + V, then Turn on."
 msgstr "История буфера обмена отключена.\r\nЧтобы включить историю буфера обмена, нажмите Win+V, а затем кнопку 'включить'."
 
-#: Merge.rc:5655
+#: Merge.rc:5654
 msgid "This system does not support clipboard history."
 msgstr "Эта система не поддерживает историю буфера обмена."
 
-#: Merge.rc:5657
+#: Merge.rc:5656
 msgid "32-bit WinMerge does not support Clipboard Compare"
 msgstr "32-битная версия WinMerge не поддерживает Сравнение буфера обмена"
 
 #. IDS_WEBVIEW2_RUNTIME_NOT_INSTALLED
-#: Merge.rc:5662
+#: Merge.rc:5661
 msgid "WebView2 runtime not installed. Download it?"
 msgstr "Не установлена среда выполнения WebView2. Загрузить?"
 
 #. IDS_JUMPLIST_NEW_TEXT_COMPARE
-#: Merge.rc:5667
+#: Merge.rc:5666
 msgid "New Text Compare"
 msgstr "Создать сравнение текста"
 
 #. IDS_JUMPLIST_NEW_TABLE_COMPARE
-#: Merge.rc:5668
+#: Merge.rc:5667
 msgid "New Table Compare"
 msgstr "Создать сравнение таблиц"
 
 #. IDS_JUMPLIST_NEW_BINARY_COMPARE
-#: Merge.rc:5669
+#: Merge.rc:5668
 msgid "New Binary Compare"
 msgstr "Создать двоичное сравнение"
 
 #. IDS_JUMPLIST_NEW_IMAGE_COMPARE
-#: Merge.rc:5670
+#: Merge.rc:5669
 msgid "New Image Compare"
 msgstr "Создать сравнение изображений"
 
 #. IDS_JUMPLIST_NEW_WEBPAGE_COMPARE
-#: Merge.rc:5671
+#: Merge.rc:5670
 msgid "New Webpage Compare"
 msgstr "Создать сравнение веб-страниц"
 
 #. IDS_JUMPLIST_NEW_FOLDER_COMPARE
-#: Merge.rc:5672
+#: Merge.rc:5671
 msgid "New Folder Compare"
 msgstr "Создать сравнение папок"
 
 #. IDS_JUMPLIST_CLIPBOARD_COMPARE
-#: Merge.rc:5673
+#: Merge.rc:5672
 msgid "Clipboard Compare"
 msgstr "Сравнение буфера обмена"
 
 #. IDS_PREVIEWBAR_PRINT
-#: Merge.rc:5678
+#: Merge.rc:5677
 msgid "&Print..."
 msgstr "Печать..."
 
 #. IDS_PREVIEWBAR_PREVPAGE
-#: Merge.rc:5680
+#: Merge.rc:5679
 msgid "Pre&v Page"
 msgstr "Предыдущая страница"
 
 #. IDS_PREVIEWBAR_TWOPAGE
-#: Merge.rc:5681
+#: Merge.rc:5680
 msgid "&Two Page"
 msgstr "Две страницы"
 
 #. IDS_PREVIEWBAR_ONEPAGE
-#: Merge.rc:5682
+#: Merge.rc:5681
 msgid "&One Page"
 msgstr "Одна страница"
 
 #. IDS_PREVIEWBAR_ZOOMIN
-#: Merge.rc:5683
+#: Merge.rc:5682
 msgid "Zoom &In"
 msgstr "Увеличить"
 
 #. IDS_PREVIEWBAR_ZOOMOUT
-#: Merge.rc:5684
+#: Merge.rc:5683
 msgid "Zoom &Out"
 msgstr "Уменьшить"
 
 #. IDS_WEBPAGE_COMPARING
-#: Merge.rc:5690
+#: Merge.rc:5689
 msgid "Comparing..."
 msgstr "Сравнение..."
 
 #. IDS_WEBPAGE_ZOOM
-#: Merge.rc:5691
+#: Merge.rc:5690
 msgid "Zoom:"
 msgstr "Масштаб:"
 
 #. IDS_COPY_GRANULARITY_DIFFHUNK
-#: Merge.rc:5696
+#: Merge.rc:5695
 msgid "Diff hunk"
 msgstr "Отличающийся кусок"
 
 #. IDS_COPY_GRANULARITY_INLINE
-#: Merge.rc:5697
+#: Merge.rc:5696
 msgid "Inline diff"
 msgstr "Встроенное отличие"
 
 #. IDS_COPY_GRANULARITY_LINE
-#: Merge.rc:5698
+#: Merge.rc:5697
 msgid "Line"
 msgstr "Строка"
 
-#: Merge.rc:5699
+#: Merge.rc:5698
 msgid "Character"
 msgstr "Символ"
 
 #. ID_MICE_PREVDIFF
-#: Merge.rc:5704
+#: Merge.rc:5703
 msgid "\nPrevious Difference (Alt+Up)\n(Right Button+Wheel Up)\n(Alt+Wheel Up)"
 msgstr "\nПредыдущее отличие (Alt+Up)\n(Правая кнопка+Колесо вверх)\n(Alt+Колесо вверх)"
 
 #. ID_MICE_NEXTDIFF
-#: Merge.rc:5705
+#: Merge.rc:5704
 msgid "\nNext Difference (Alt+Down)\n(Right Button+Wheel Down)\n(Alt+Wheel Down)"
 msgstr "\nСледующее отличие (Alt+Down)\n(Правая кнопка+Колесо вниз)\n(Alt+Колесо вниз)"
 
 #. ID_MICE_L2R
-#: Merge.rc:5706
+#: Merge.rc:5705
 msgid "\nCopy to Right (Alt+Right)\n(Right Button+Wheel Right)\n(Alt+Wheel Right)\n(Alt+Shift+Wheel Down)"
 msgstr "\nКопировать направо (Alt+Right)\n(Правая кнопка+Колесо вправо)\n(Alt+Колесо вправо)\n(Alt+Shift+Колесо вниз)"
 
 #. ID_MICE_R2L
-#: Merge.rc:5707
+#: Merge.rc:5706
 msgid "\nCopy to Left (Alt+Left)\n(Right Button+Wheel Left)\n(Alt+Wheel Left)\n(Alt+Shift+Wheel Up)"
 msgstr "\nКопировать налево (Alt+Left)\n(Правая кнопка+Колесо влево)\n(Alt+Колесо влево)\n(Alt+Shift+Колесо вверх)"
 
 #. ID_MICE_L2RNEXT
-#: Merge.rc:5708
+#: Merge.rc:5707
 msgid "\nCopy to Right and Advance (Ctrl+Alt+Right)\n(Ctrl+Alt+Wheel Right)\n(Ctrl+Alt+Shift+Wheel Down)"
 msgstr "\nКопировать направо и перейти (Ctrl+Alt+Right)\n(Ctrl+Alt+Колесо вправо)\n(Ctrl+Alt+Shift+Колесо вниз)"
 
 #. ID_MICE_R2LNEXT
-#: Merge.rc:5709
+#: Merge.rc:5708
 msgid "\nCopy to Left and Advance (Ctrl+Alt+Left)\n(Ctrl+Alt+Wheel Left)\n(Ctrl+Alt+Shift+Wheel Up)"
 msgstr "\nКопировать налево и перейти (Ctrl+Alt+Left)\n(Ctrl+Alt+Колесо влево)\n(Ctrl+Alt+Shift+Колесо вверх)"
 
 #. IDS_LOG_COMPARING_2
-#: Merge.rc:5719
+#: Merge.rc:5718
 #, c-format
 msgid "Comparing %1 with %2"
 msgstr "Сравнение %1 с %2"
 
 #. IDS_LOG_COMPARING_3
-#: Merge.rc:5720
+#: Merge.rc:5719
 #, c-format
 msgid "Comparing %1 with %2 and %3"
 msgstr "Сравнение %1 с %2 и %3"
 
 #. IDS_LOG_COMPARE_COMPLETED
-#: Merge.rc:5721
+#: Merge.rc:5720
 msgid "Comparison completed"
 msgstr "Сравнение завершено"
 
 #. IDS_LOG_COMPARE_ERROR_2
-#: Merge.rc:5722
+#: Merge.rc:5721
 #, c-format
 msgid "Failed to compare %1 with %2: "
 msgstr "Не удалось сравнить %1 с %2: "
 
 #. IDS_LOG_COMPARE_ERROR_3
-#: Merge.rc:5723
+#: Merge.rc:5722
 #, c-format
 msgid "Failed to compare %1 with %2 and %3: "
 msgstr "Не удалось сравнить %1 с %2 и %3: "
 
 #. IDS_LOG_FILE_SAVED
-#: Merge.rc:5724
+#: Merge.rc:5723
 msgid "File saved"
 msgstr "Файл сохранен"
 
 #. IDS_LOG_COPYING_FILES
-#: Merge.rc:5725
+#: Merge.rc:5724
 msgid "Copying files..."
 msgstr "Копирование файлов..."
 
 #. IDS_LOG_MOVING_FILES
-#: Merge.rc:5726
+#: Merge.rc:5725
 msgid "Moving files..."
 msgstr "Перемещение файлов..."
 
 #. IDS_LOG_DELETING_FILES
-#: Merge.rc:5727
+#: Merge.rc:5726
 msgid "Deleting files..."
 msgstr "Удаление файлов..."
 
 #. IDS_LOG_RECYCLEBIN
-#: Merge.rc:5728
+#: Merge.rc:5727
 msgid "Recycle Bin"
 msgstr "Корзина"
 
 #. IDS_LOG_PERMANENTLY_DELETED
-#: Merge.rc:5729
+#: Merge.rc:5728
 msgid "Permanently deleted"
 msgstr "Удалено без возможности восстановления"
 
 #. IDS_LOG_FILEOPERATION_COMPLETED
-#: Merge.rc:5730
+#: Merge.rc:5729
 msgid "File operation completed successfully"
 msgstr "Файловая операция успешно завершена"
 
 #. IDS_LOG_FILEOPERATION_CANCELED
-#: Merge.rc:5731
+#: Merge.rc:5730
 msgid "File operation canceled"
 msgstr "Файловая операция отменена"
 
 #. IDS_FILTER_ERROR_NO_ERROR
-#: Merge.rc:5736
+#: Merge.rc:5735
 msgid "No error"
 msgstr "Ошибок нет"
 
 #. IDS_FILTER_ERROR_EMPTY_EXPRESSION
-#: Merge.rc:5737
+#: Merge.rc:5736
 msgid "Filter expression is empty"
 msgstr "Пустое выражение фильтра"
 
 #. IDS_FILTER_ERROR_UNKNOWN_CHAR
-#: Merge.rc:5738
+#: Merge.rc:5737
 msgid "Unknown character in filter expression"
 msgstr "Неизвестный символ в выражении фильтра"
 
 #. IDS_FILTER_ERROR_UNTERMINATED_STRING
-#: Merge.rc:5739
+#: Merge.rc:5738
 msgid "Unterminated string literal"
 msgstr "Незаконченный литерал"
 
 #. IDS_FILTER_ERROR_SYNTAX_ERROR
-#: Merge.rc:5740
+#: Merge.rc:5739
 msgid "Syntax error in filter expression"
 msgstr "Синтаксическая ошибка в выражении фильтра"
 
 #. IDS_FILTER_ERROR_PARSE_FAILURE
-#: Merge.rc:5741
+#: Merge.rc:5740
 msgid "Failed to parse filter expression"
 msgstr "Не удалось разобрать выражение фильтра"
 
 #. IDS_FILTER_ERROR_INVALID_LITERAL
-#: Merge.rc:5742
+#: Merge.rc:5741
 msgid "Invalid literal value"
 msgstr "Неверное значение литерала"
 
 #. IDS_FILTER_ERROR_INVALID_REGULAR_EXPRESSION
-#: Merge.rc:5743
+#: Merge.rc:5742
 msgid "Invalid regular expression"
 msgstr "Неверное регулярное выражение"
 
 #. IDS_FILTER_ERROR_UNDEFINED_IDENTIFIER
-#: Merge.rc:5744
+#: Merge.rc:5743
 msgid "Undefined identifier"
 msgstr "Неопределенный идентификатор"
 
 #. IDS_FILTER_ERROR_INVALID_ARGUMENT_COUNT
-#: Merge.rc:5745
+#: Merge.rc:5744
 msgid "Invalid number of arguments"
 msgstr "Неверное количество аргументов"
 
 #. IDS_FILTER_ERROR_FILTER_NAME_NOT_FOUND
-#: Merge.rc:5746
+#: Merge.rc:5745
 msgid "Filter name not found"
 msgstr "Не найдено имя фильтра "
 
 #. IDS_FILTER_ERROR_DIVIDE_BY_ZERO
-#: Merge.rc:5747
+#: Merge.rc:5746
 msgid "Division by zero in filter expression"
 msgstr "Деление на ноль в выражении фильтра"
 
 #. IDS_FILTER_ERROR_UNKNOWN_ERROR
-#: Merge.rc:5748
+#: Merge.rc:5747
 msgid "Unknown error"
 msgstr "Неизвестная ошибка"
 
 #. IDS_FILTER_ERROR_INVALID_PROPERTY_NAME
-#: Merge.rc:5749
+#: Merge.rc:5748
 msgid "Invalid property name"
 msgstr "Неверное имя свойства"
 
 #. IDS_FILTER_ERROR_INVALID_DIRECTIVE
-#: Merge.rc:5750
+#: Merge.rc:5749
 msgid "Invalid directive"
 msgstr "Неверная директива"
 
 #. IDS_FILTER_OP_EQUALS
-#: Merge.rc:5755
+#: Merge.rc:5754
 msgid "Equals"
 msgstr "Равно"
 
 #. IDS_FILTER_OP_NOT_EQUALS
-#: Merge.rc:5756
+#: Merge.rc:5755
 msgid "Does not equal"
 msgstr "Не равно"
 
 #. IDS_FILTER_OP_LESS_THAN
-#: Merge.rc:5757
+#: Merge.rc:5756
 msgid "Less than"
 msgstr "Меньше чем"
 
 #. IDS_FILTER_OP_LESS_EQUAL
-#: Merge.rc:5758
+#: Merge.rc:5757
 msgid "Less than or equal to"
 msgstr "Меньше или равно"
 
 #. IDS_FILTER_OP_GREATER_EQUAL
-#: Merge.rc:5759
+#: Merge.rc:5758
 msgid "Greater than or equal to"
 msgstr "Больше или равно"
 
 #. IDS_FILTER_OP_GREATER_THAN
-#: Merge.rc:5760
+#: Merge.rc:5759
 msgid "Greater than"
 msgstr "Больше чем"
 
 #. IDS_FILTER_OP_BETWEEN
-#: Merge.rc:5761
+#: Merge.rc:5760
 msgid "Between"
 msgstr "Между"
 
 #. IDS_FILTER_OP_NOT_BETWEEN
-#: Merge.rc:5762
+#: Merge.rc:5761
 msgid "Not Between"
 msgstr "Не между"
 
 #. IDS_FILTER_OP_CONTAINS
-#: Merge.rc:5763
+#: Merge.rc:5762
 msgid "Contains"
 msgstr "Содержит"
 
 #. IDS_FILTER_OP_NOT_CONTAINS
-#: Merge.rc:5764
+#: Merge.rc:5763
 msgid "Not Contains"
 msgstr "Не содержит"
 
 #. IDS_FILTER_OP_RECONTAINS
-#: Merge.rc:5765
+#: Merge.rc:5764
 msgid "Contains (regex)"
 msgstr "Содержит (regex)"
 
 #. IDS_FILTER_OP_NOT_RECONTAINS
-#: Merge.rc:5766
+#: Merge.rc:5765
 msgid "Not Contains (regex)"
 msgstr "Не содержит (regex)"
 
 #. IDS_FILTER_OP_LIKE
-#: Merge.rc:5767
+#: Merge.rc:5766
 msgid "Match (wildcard)"
 msgstr "Совпадение (маска)"
 
 #. IDS_FILTER_OP_NOT_LIKE
-#: Merge.rc:5768
+#: Merge.rc:5767
 msgid "Not match (wildcard)"
 msgstr "Несовпадение (маска)"
 
 #. IDS_FILTER_OP_MATCHES
-#: Merge.rc:5769
+#: Merge.rc:5768
 msgid "Match (regex)"
 msgstr "Совпадение (regex)"
 
 #. IDS_FILTER_OP_NOT_MATCHES
-#: Merge.rc:5770
+#: Merge.rc:5769
 msgid "Not match (regex)"
 msgstr "Несовпадение (regex)"
 
 #. IDS_COLORMODE_LIGHT
-#: Merge.rc:5775
+#: Merge.rc:5774
 msgid "Light"
 msgstr "Светлый"
 
 #. IDS_COLORMODE_DARK
-#: Merge.rc:5776
+#: Merge.rc:5775
 msgid "Dark"
 msgstr "Тёмный"
 
 #. IDS_COLORMODE_FOLLOWSYSTEM
-#: Merge.rc:5777
+#: Merge.rc:5776
 msgid "Follow system"
 msgstr "Системный"
 
 #. IDS_EXAMPLE
-#: Merge.rc:5782
+#: Merge.rc:5781
 #, c-format
 msgid "e.g. %1"
 msgstr "например, %1"
 
 #. IDS_DETECTED_PREVIOUS_CRASH
-#: Merge.rc:5787
+#: Merge.rc:5786
 msgid "WinMerge detected a previous crash. Please report this if possible."
 msgstr "WinMerge обнаружил предыдущий сбой. Пожалуйста, сообщите о нём, если это возможно."
 
 #. IDS_REGEX_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5792
+#: Merge.rc:5791
 msgid "# Regex replacement list\r\n# Format: regex<TAB>replacement\r\n# Backreferences like $1, $2 are supported\r\n\r\n(\\d{4})-(\\d{2})-(\\d{2})\t$1_$2_$3\r\n"
 msgstr "# Список замены регулярных выражений\r\n# Формат: регулярное выражение<TAB>замена\r\n# Поддерживаются обратные ссылки типа $1, $2\r\n\r\n(\\d{4})-(\\d{2})-(\\d{2})\t$1_$2_$3\r\n"
 
 #. IDS_STRING_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5793
+#: Merge.rc:5792
 msgid "# Replacement list\r\n# Format: search<TAB>replacement\r\n# Lines starting with # are ignored\r\n\r\nfrom1\tto1\r\nfrom2\tto2\r\n"
 msgstr "# Список замены\r\n# Формат: поиск<TAB>замена\r\n# Строки, начинающиеся с #, игнорируются\r\n\r\nот1\tдо1\r\nот2\tдо2\r\n"
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_ONLY
-#: Merge.rc:5798
+#: Merge.rc:5797
 msgid "Built-in only"
 msgstr "Только встроенный"
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_FIRST
-#: Merge.rc:5799
+#: Merge.rc:5798
 msgid "Built-in first"
 msgstr "Сначала встроенный"
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_FIRST
-#: Merge.rc:5800
+#: Merge.rc:5799
 msgid "Tree-sitter first"
 msgstr "Сначала Tree-sitter"
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_ONLY
-#: Merge.rc:5801
+#: Merge.rc:5800
 msgid "Tree-sitter only"
 msgstr "Только Tree-sitter"
 

--- a/Translations/WinMerge/Serbian.po
+++ b/Translations/WinMerge/Serbian.po
@@ -20,7 +20,7 @@ msgstr ""
 "X-Poedit-Basepath: ../../Src/\n"
 
 #. LANGUAGE, SUBLANGUAGE
-#: Merge.rc:26 Merge.rc:59 Merge.rc:5818
+#: Merge.rc:26 Merge.rc:59 Merge.rc:5817
 #, c-format
 msgid "LANG_ENGLISH, SUBLANG_ENGLISH_US"
 msgstr "LANG_SERBIAN, SUBLANG_SERBIAN_CYRILLIC"
@@ -170,7 +170,7 @@ msgstr "&Скрипте "
 #. IDS_NO_EDIT_SCRIPTS
 #: Merge.rc:127 Merge.rc:352 Merge.rc:463 Merge.rc:673 Merge.rc:678
 #: Merge.rc:887 Merge.rc:899 Merge.rc:906 Merge.rc:963 Merge.rc:1210
-#: Merge.rc:5375
+#: Merge.rc:5374
 #, c-format
 msgid "< Empty >"
 msgstr "< Празан >"
@@ -237,7 +237,7 @@ msgid "Auto-Fit All Columns"
 msgstr ""
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN
-#: Merge.rc:153 Merge.rc:5646
+#: Merge.rc:153 Merge.rc:5645
 msgid "&Filter by This Column"
 msgstr ""
 
@@ -303,7 +303,7 @@ msgid "&Previous Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_NEXTPAGE
-#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5679
+#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5678
 #, c-format
 msgid "&Next Page"
 msgstr ""
@@ -570,7 +570,7 @@ msgstr ""
 #. IDS_IMAGE_MENU
 #: Merge.rc:329 Merge.rc:338 Merge.rc:432 Merge.rc:441 Merge.rc:609
 #: Merge.rc:618 Merge.rc:670 Merge.rc:960 Merge.rc:1187 Merge.rc:1200
-#: Merge.rc:5477
+#: Merge.rc:5476
 #, c-format
 msgid "&Image"
 msgstr ""
@@ -708,7 +708,7 @@ msgid "&Huge"
 msgstr ""
 
 #. IDS_VIEW_MENU_BAR
-#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5714
+#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5713
 msgid "Men&u Bar"
 msgstr ""
 
@@ -1471,7 +1471,7 @@ msgid "Lo&cation Pane"
 msgstr "Поло&жај табле"
 
 #. IDS_OUTPUTBAR_CAPTION
-#: Merge.rc:782 Merge.rc:5252
+#: Merge.rc:782 Merge.rc:5251
 msgid "Output Pane"
 msgstr ""
 
@@ -1766,55 +1766,55 @@ msgid "Co&mpare As"
 msgstr ""
 
 #. IDS_COPY_LEFT_TO_MIDDLE2
-#: Merge.rc:968 Merge.rc:980 Merge.rc:4852
+#: Merge.rc:968 Merge.rc:980 Merge.rc:4851
 #, c-format
 msgid "Left to Middle (%1 of %2)"
 msgstr ""
 
 #. IDS_COPY_LEFT_TO_RIGHT2
-#: Merge.rc:969 Merge.rc:981 Merge.rc:4851
+#: Merge.rc:969 Merge.rc:981 Merge.rc:4850
 #, c-format
 msgid "Left to Right (%1 of %2)"
 msgstr "Лева у десно (%1 од %2)"
 
 #. IDS_MOVE_LEFT_TO2
-#: Merge.rc:970 Merge.rc:982 Merge.rc:1045 Merge.rc:4863 Merge.rc:4892
+#: Merge.rc:970 Merge.rc:982 Merge.rc:1045 Merge.rc:4862 Merge.rc:4891
 #, c-format
 msgid "Left to... (%1 of %2)"
 msgstr "Лева у... (%1 од %2)"
 
 #. IDS_COPY_MIDDLE_TO_LEFT2
-#: Merge.rc:971 Merge.rc:983 Merge.rc:4849
+#: Merge.rc:971 Merge.rc:983 Merge.rc:4848
 #, c-format
 msgid "Middle to Left (%1 of %2)"
 msgstr ""
 
 #. IDS_COPY_MIDDLE_TO_RIGHT2
-#: Merge.rc:972 Merge.rc:984 Merge.rc:4850
+#: Merge.rc:972 Merge.rc:984 Merge.rc:4849
 #, c-format
 msgid "Middle to Right (%1 of %2)"
 msgstr ""
 
 #. IDS_MOVE_MIDDLE_TO2
-#: Merge.rc:973 Merge.rc:985 Merge.rc:1046 Merge.rc:4864 Merge.rc:4893
+#: Merge.rc:973 Merge.rc:985 Merge.rc:1046 Merge.rc:4863 Merge.rc:4892
 #, c-format
 msgid "Middle to... (%1 of %2)"
 msgstr ""
 
 #. IDS_COPY_RIGHT_TO_MIDDLE2
-#: Merge.rc:974 Merge.rc:986 Merge.rc:4848
+#: Merge.rc:974 Merge.rc:986 Merge.rc:4847
 #, c-format
 msgid "Right to Middle (%1 of %2)"
 msgstr ""
 
 #. IDS_COPY_RIGHT_TO_LEFT2
-#: Merge.rc:975 Merge.rc:987 Merge.rc:4847
+#: Merge.rc:975 Merge.rc:987 Merge.rc:4846
 #, c-format
 msgid "Right to Left (%1 of %2)"
 msgstr "Десна у лево (%1 од %2)"
 
 #. IDS_MOVE_RIGHT_TO2
-#: Merge.rc:976 Merge.rc:988 Merge.rc:1047 Merge.rc:4865 Merge.rc:4894
+#: Merge.rc:976 Merge.rc:988 Merge.rc:1047 Merge.rc:4864 Merge.rc:4893
 #, c-format
 msgid "Right to... (%1 of %2)"
 msgstr "Десна у... (%1 од %2)"
@@ -1880,31 +1880,31 @@ msgid "Cop&y Paths"
 msgstr "Умножи пута&њу"
 
 #. IDS_DEL_LEFT_FMT2
-#: Merge.rc:1026 Merge.rc:1035 Merge.rc:4880
+#: Merge.rc:1026 Merge.rc:1035 Merge.rc:4879
 #, c-format
 msgid "Left (%1 of %2)"
 msgstr "Лева (%1 од %2)"
 
 #. IDS_DEL_MIDDLE_FMT2
-#: Merge.rc:1027 Merge.rc:1036 Merge.rc:4881
+#: Merge.rc:1027 Merge.rc:1036 Merge.rc:4880
 #, c-format
 msgid "Middle (%1 of %2)"
 msgstr ""
 
 #. IDS_DEL_RIGHT_FMT2
-#: Merge.rc:1028 Merge.rc:1037 Merge.rc:4882
+#: Merge.rc:1028 Merge.rc:1037 Merge.rc:4881
 #, c-format
 msgid "Right (%1 of %2)"
 msgstr "Десна (%1 од %2)"
 
 #. IDS_DEL_BOTH_FMT2
-#: Merge.rc:1029 Merge.rc:1038 Merge.rc:4883
+#: Merge.rc:1029 Merge.rc:1038 Merge.rc:4882
 #, c-format
 msgid "Both (%1 of %2)"
 msgstr "Обе(%1 од %2)"
 
 #. IDS_DEL_ALL_FMT2
-#: Merge.rc:1030 Merge.rc:1039 Merge.rc:4888
+#: Merge.rc:1030 Merge.rc:1039 Merge.rc:4887
 #, c-format
 msgid "All (%1 of %2)"
 msgstr ""
@@ -1933,19 +1933,19 @@ msgid "&Zip"
 msgstr "&Зип"
 
 #. IDS_COPY_BOTH_TO2
-#: Merge.rc:1048 Merge.rc:4866
+#: Merge.rc:1048 Merge.rc:4865
 #, c-format
 msgid "Both to... (%1 of %2)"
 msgstr ""
 
 #. IDS_COPY_ALL_TO2
-#: Merge.rc:1049 Merge.rc:4867
+#: Merge.rc:1049 Merge.rc:4866
 #, c-format
 msgid "All to... (%1 of %2)"
 msgstr ""
 
 #. IDS_COPY_DIFFERENCES_TO2
-#: Merge.rc:1050 Merge.rc:4868
+#: Merge.rc:1050 Merge.rc:4867
 #, c-format
 msgid "Differences to... (%1 of %2)"
 msgstr ""
@@ -2018,13 +2018,13 @@ msgstr ""
 
 #. IDS_USERCHOICE_NONE
 #: Merge.rc:1088 Merge.rc:1094 Merge.rc:1836 Merge.rc:1840 Merge.rc:2031
-#: Merge.rc:2035 Merge.rc:5377
+#: Merge.rc:2035 Merge.rc:5376
 #, c-format
 msgid "<None>"
 msgstr "<Ништа>"
 
 #. IDS_USERCHOICE_AUTOMATIC
-#: Merge.rc:1089 Merge.rc:1095 Merge.rc:5378
+#: Merge.rc:1089 Merge.rc:1095 Merge.rc:5377
 #, c-format
 msgid "<Automatic>"
 msgstr "<Аутоматски>"
@@ -2975,13 +2975,13 @@ msgid "Text files only"
 msgstr ""
 
 #. IDS_EOL_NONE
-#: Merge.rc:1667 Merge.rc:1918 Merge.rc:5304
+#: Merge.rc:1667 Merge.rc:1918 Merge.rc:5303
 #, c-format
 msgid "None"
 msgstr "Ништа"
 
 #. IDS_EOL_MIXED
-#: Merge.rc:1668 Merge.rc:5299
+#: Merge.rc:1668 Merge.rc:5298
 #, c-format
 msgid "Mixed"
 msgstr "Mixed"
@@ -3255,14 +3255,14 @@ msgstr ""
 
 #. IDS_DIFFERENT
 #: Merge.rc:1904 Merge.rc:1988 Merge.rc:2866 Merge.rc:3036 Merge.rc:3077
-#: Merge.rc:5058
+#: Merge.rc:5057
 #, c-format
 msgid "Different"
 msgstr "Разлика"
 
 #. IDS_IDENTICAL
 #: Merge.rc:1905 Merge.rc:1989 Merge.rc:2865 Merge.rc:3055 Merge.rc:3116
-#: Merge.rc:5048
+#: Merge.rc:5047
 #, c-format
 msgid "Identical"
 msgstr "Исте"
@@ -3283,7 +3283,7 @@ msgid "Missing"
 msgstr ""
 
 #. IDS_MOVED
-#: Merge.rc:1910 Merge.rc:5076
+#: Merge.rc:1910 Merge.rc:5075
 msgid "Moved"
 msgstr ""
 
@@ -4100,7 +4100,7 @@ msgid "&Use custom system colors"
 msgstr ""
 
 #. IDS_PRPCAT_SYSTEM
-#: Merge.rc:2565 Merge.rc:4559 Merge.rc:4560 Merge.rc:5007
+#: Merge.rc:2565 Merge.rc:4559 Merge.rc:4560 Merge.rc:5006
 #, c-format
 msgid "System"
 msgstr "Систем"
@@ -4549,7 +4549,7 @@ msgid "Items compared:"
 msgstr "Поређење ставки:"
 
 #. IDS_PREVIEWBAR_CLOSE
-#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5685
+#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5684
 #, c-format
 msgid "&Close"
 msgstr "&Затвори"
@@ -5236,7 +5236,7 @@ msgid "A&ppend timestamp"
 msgstr "До&дај датум/време"
 
 #. IDS_CONFIRM_COPY_CAPTION
-#: Merge.rc:3214 Merge.rc:4915
+#: Merge.rc:3214 Merge.rc:4914
 #, c-format
 msgid "Confirm Copy"
 msgstr "Потврди копирање"
@@ -5497,7 +5497,7 @@ msgid "&Character Set..."
 msgstr ""
 
 #. IDS_PRPCAT_IMAGE
-#: Merge.rc:3351 Merge.rc:4574 Merge.rc:5015
+#: Merge.rc:3351 Merge.rc:4574 Merge.rc:5014
 msgid "Image"
 msgstr ""
 
@@ -5901,7 +5901,7 @@ msgid "Project"
 msgstr ""
 
 #. IDS_COLHDR_NSDIFFS
-#: Merge.rc:4566 Merge.rc:4990
+#: Merge.rc:4566 Merge.rc:4989
 #, c-format
 msgid "Differences"
 msgstr "Разлике"
@@ -6061,13 +6061,13 @@ msgid "File Type"
 msgstr ""
 
 #. IDS_COLHDR_EXTENSION
-#: Merge.rc:4653 Merge.rc:4947
+#: Merge.rc:4653 Merge.rc:4946
 #, c-format
 msgid "Extension"
 msgstr "Наставак"
 
 #. IDS_PRPCAT_MESSAGE
-#: Merge.rc:4659 Merge.rc:5019
+#: Merge.rc:4659 Merge.rc:5018
 msgid "Message"
 msgstr ""
 
@@ -6107,7 +6107,7 @@ msgid "Hidden Items"
 msgstr ""
 
 #. IDS_PLUGINSLIST_NAME
-#: Merge.rc:4680 Merge.rc:5311
+#: Merge.rc:4680 Merge.rc:5310
 #, c-format
 msgid "Name"
 msgstr "Име"
@@ -6131,7 +6131,7 @@ msgid "[F] "
 msgstr "[F]"
 
 #. IDS_PLUGINSLIST_DESC
-#: Merge.rc:4684 Merge.rc:5313
+#: Merge.rc:4684 Merge.rc:5312
 #, c-format
 msgid "Description"
 msgstr "Опис"
@@ -6303,163 +6303,157 @@ msgstr ""
 msgid "  Sel: %d | %d"
 msgstr ""
 
-#. IDS_MERGEMODE_MERGING
-#: Merge.rc:4734
-#, c-format
-msgid "Merge"
-msgstr "Упореди"
-
 #. IDS_DIFF_NUMBER_STATUS_FMT
-#: Merge.rc:4735
+#: Merge.rc:4734
 #, c-format
 msgid "Difference %1 of %2"
 msgstr "Разлике %1 од %2"
 
 #. IDS_NO_DIFF_SEL_FMT
-#: Merge.rc:4736
+#: Merge.rc:4735
 #, c-format
 msgid "%1 Differences Found"
 msgstr "Нађено разлика %1"
 
 #. IDS_1_DIFF_FOUND
-#: Merge.rc:4737
+#: Merge.rc:4736
 #, c-format
 msgid "1 Difference Found"
 msgstr "Нађено разлика 1"
 
 #. IDS_NO_ERR_SEL_FMT
-#: Merge.rc:4738
+#: Merge.rc:4737
 #, c-format
 msgid "%1 Errors Found"
 msgstr ""
 
 #. IDS_1_ERR_FOUND
-#: Merge.rc:4739
+#: Merge.rc:4738
 msgid "1 Error Found"
 msgstr ""
 
 #. IDS_STATUSBAR_READONLY, Abbreviation from "Read Only"
-#: Merge.rc:4740
+#: Merge.rc:4739
 #, c-format
 msgid "RO"
 msgstr "RO"
 
 #. IDS_DIRVIEW_STATUS_FMT_FOCUS
-#: Merge.rc:4746
+#: Merge.rc:4745
 #, c-format
 msgid "Item %1 of %2"
 msgstr "Ставке %1 од %2"
 
 #. IDS_DIRVIEW_STATUS_FMT_NOFOCUS
-#: Merge.rc:4747
+#: Merge.rc:4746
 #, c-format
 msgid "Items: %1"
 msgstr "Ставке: %1"
 
 #. IDS_DIRVIEW_STATUS_COMPARING
-#: Merge.rc:4748
+#: Merge.rc:4747
 #, c-format
 msgid "Comparing items..."
 msgstr "Упоређивање ставки..."
 
 #. IDS_ITEMS_PER_SEC
-#: Merge.rc:4749
+#: Merge.rc:4748
 #, c-format
 msgid "%.1f[items/sec]"
 msgstr ""
 
 #. IDS_ERROR_INCOMPARABLE
-#: Merge.rc:4755
+#: Merge.rc:4754
 msgid "Select two existing folders/files to compare."
 msgstr "Одабери две постојеће датотеке или фасцикле за поређење."
 
 #. IDS_DIRSEL_TAG
-#: Merge.rc:4756
+#: Merge.rc:4755
 #, c-format
 msgid "Folder Selection"
 msgstr "Изабери фасциклу"
 
 #. IDS_OPEN_FILESDIRS
-#: Merge.rc:4757
+#: Merge.rc:4756
 msgid "Select two (or three) folders/files to compare."
 msgstr ""
 
 #. IDS_OPEN_LEFTINVALID
-#: Merge.rc:4758
+#: Merge.rc:4757
 msgid "Left (1st) path is invalid!"
 msgstr ""
 
 #. IDS_OPEN_MIDDLEINVALID
-#: Merge.rc:4759
+#: Merge.rc:4758
 msgid "Middle (2nd) path is invalid!"
 msgstr ""
 
 #. IDS_OPEN_RIGHTINVALID2
-#: Merge.rc:4760
+#: Merge.rc:4759
 msgid "Right (2nd) path is invalid!"
 msgstr ""
 
 #. IDS_OPEN_RIGHTINVALID3
-#: Merge.rc:4761
+#: Merge.rc:4760
 msgid "Right (3rd) path is invalid!"
 msgstr ""
 
 #. IDS_OPEN_BOTHINVALID
-#: Merge.rc:4762
+#: Merge.rc:4761
 #, c-format
 msgid "Both paths are invalid!"
 msgstr "Обе путање су неважеће!"
 
-#: Merge.rc:4764
+#: Merge.rc:4763
 msgid "Left (1st) and Middle (2nd) paths are invalid!"
 msgstr ""
 
 #. IDS_OPEN_LEFTRIGHTINVALID
-#: Merge.rc:4765
+#: Merge.rc:4764
 msgid "Left (1st) and Right (3rd) paths are invalid!"
 msgstr ""
 
-#: Merge.rc:4767
+#: Merge.rc:4766
 msgid "Middle (2nd) and Right (3rd) paths are invalid!"
 msgstr ""
 
 #. IDS_OPEN_ALLINVALID
-#: Merge.rc:4768
+#: Merge.rc:4767
 #, c-format
 msgid "All paths are invalid!"
 msgstr ""
 
 #. IDS_OPEN_UNPACKERDISABLED
-#: Merge.rc:4769
+#: Merge.rc:4768
 msgid "Only enabled for file comparisons"
 msgstr ""
 
 #. IDS_OPEN_MISMATCH
-#: Merge.rc:4770
+#: Merge.rc:4769
 #, c-format
 msgid "Cannot compare file and folder!"
 msgstr "Не могу упоредити датотеку и фасциклу!"
 
 #. IDS_ERROR_FILE_NOT_FOUND
-#: Merge.rc:4776
+#: Merge.rc:4775
 #, c-format
 msgid "File not found: %1"
 msgstr "Датотека није пронађена: %1"
 
 #. IDS_ERROR_FOLDER_NOT_FOUND
-#: Merge.rc:4777
+#: Merge.rc:4776
 #, c-format
 msgid "Folder not found: %1"
 msgstr ""
 
 #. IDS_ERROR_FILE_NOT_UNPACKED
-#: Merge.rc:4778
+#: Merge.rc:4777
 #, c-format
 msgid "File not unpacked: %1"
 msgstr "Датотека није распакована: %1"
 
 #. IDS_ERROR_FILEOPEN
-#: Merge.rc:4779
+#: Merge.rc:4778
 #, c-format
 msgid ""
 "Cannot open file\n"
@@ -6473,13 +6467,13 @@ msgstr ""
 "%2"
 
 #. IDS_ERROR_CONF_RESOLVE
-#: Merge.rc:4780
+#: Merge.rc:4779
 #, c-format
 msgid "Failed to parse conflict file."
 msgstr "Не могу рашчланити проблематичну датотеку"
 
 #. IDS_NOT_CONFLICT_FILE
-#: Merge.rc:4781
+#: Merge.rc:4780
 #, c-format
 msgid "The file\n%1\nis not a conflict file."
 msgstr ""
@@ -6488,35 +6482,35 @@ msgstr ""
 "није проблематична"
 
 #. IDS_COMPARE_LARGE_FILES
-#: Merge.rc:4782
+#: Merge.rc:4781
 msgid "Comparing large files requires significant memory.\nShow only comparison results (not file contents)?"
 msgstr ""
 
 #. IDS_SAVE_AS_TITLE
-#: Merge.rc:4788
+#: Merge.rc:4787
 #, c-format
 msgid "Save As"
 msgstr "Сачувај као"
 
 #. IDS_SAVE_FMT
-#: Merge.rc:4789
+#: Merge.rc:4788
 #, c-format
 msgid "Save changes to %1?"
 msgstr "Сачувај измене %1? "
 
 #. IDS_SAVEREADONLY_FMT
-#: Merge.rc:4790
+#: Merge.rc:4789
 #, c-format
 msgid "%1 is read-only. Override? Or 'No' to save as new filename?"
 msgstr "%1 је означена само за читање. Желите ли да је поништите? (Не, сачувана је под новим именом)"
 
 #. IDS_ERROR_BACKUP
-#: Merge.rc:4791
+#: Merge.rc:4790
 #, c-format
 msgid "Error backing up file"
 msgstr "Грешка при прављењу резервне датотеке"
 
-#: Merge.rc:4793
+#: Merge.rc:4792
 #, c-format
 msgid ""
 "Unable to backup original file:\n"
@@ -6530,7 +6524,7 @@ msgstr ""
 "Наставитe?"
 
 #. IDS_FILESAVE_FAILED
-#: Merge.rc:4794
+#: Merge.rc:4793
 #, c-format
 msgid "Saving file failed.\n%1\n%2\n\t- Use different filename (OK)\n\t- Abort (Cancel)?"
 msgstr ""
@@ -6541,7 +6535,7 @@ msgstr ""
 "\t- je запамтите под другим именом, притисните /У реду/\n"
 "\t- или притисните /Изађи/за прекид поступка?"
 
-#: Merge.rc:4796
+#: Merge.rc:4795
 #, c-format
 msgid "Plugin '%2' cannot pack changes to left file into '%1'.\n\nOriginal unchanged. Save unpacked version?"
 msgstr ""
@@ -6551,12 +6545,12 @@ msgstr ""
 "\n"
 "Да ли желите да сачувате нераспаковано издање као датотеку?"
 
-#: Merge.rc:4798
+#: Merge.rc:4797
 #, c-format
 msgid "Plugin '%2' cannot pack changes to middle file into '%1'.\n\nOriginal unchanged. Save unpacked version?"
 msgstr ""
 
-#: Merge.rc:4800
+#: Merge.rc:4799
 #, c-format
 msgid "Plugin '%2' cannot pack changes to right file into '%1'.\n\nOriginal unchanged. Save unpacked version?"
 msgstr ""
@@ -6567,7 +6561,7 @@ msgstr ""
 "Да ли желите да сачувате нераспаковано издање као датотеку?"
 
 #. IDS_FILECHANGED_ONDISK
-#: Merge.rc:4801
+#: Merge.rc:4800
 #, c-format
 msgid ""
 "Another application updated\n"
@@ -6583,7 +6577,7 @@ msgstr ""
 "Замените измењену датотеку?"
 
 #. IDS_SAVEREADONLY_MULTI
-#: Merge.rc:4802
+#: Merge.rc:4801
 #, c-format
 msgid ""
 "%1\n"
@@ -6593,7 +6587,7 @@ msgstr ""
 "је означена само за читање. Желите ли да је замените?"
 
 #. IDS_FILECHANGED_RESCAN
-#: Merge.rc:4803
+#: Merge.rc:4802
 #, c-format
 msgid "Another application updated\n%1\nsince last scan.\n\nReload?"
 msgstr ""
@@ -6602,25 +6596,25 @@ msgstr ""
 "од задњег прегледа WinMerge-а. Желите ли поново учитати датотеку?"
 
 #. IDS_SAVE_LEFT_AS
-#: Merge.rc:4804
+#: Merge.rc:4803
 #, c-format
 msgid "Save Left File As"
 msgstr "Сачувај леву датотеку као"
 
 #. IDS_SAVE_MIDDLE_AS
-#: Merge.rc:4805
+#: Merge.rc:4804
 #, c-format
 msgid "Save Middle File As"
 msgstr ""
 
 #. IDS_SAVE_RIGHT_AS
-#: Merge.rc:4806
+#: Merge.rc:4805
 #, c-format
 msgid "Save Right File As"
 msgstr "Сачувај десну датотеку као"
 
 #. IDS_FILE_DISAPPEARED
-#: Merge.rc:4811
+#: Merge.rc:4810
 #, c-format
 msgid ""
 "File\n"
@@ -6632,7 +6626,7 @@ msgstr ""
 "је нестала. Молимо Вас да сачувате умножену датотеку да бисте наставили."
 
 #. IDS_VIEWS_OUTOFSYNC
-#: Merge.rc:4817
+#: Merge.rc:4816
 #, c-format
 msgid ""
 "Cannot merge unsynched documents.\n"
@@ -6644,191 +6638,191 @@ msgstr ""
 "Освежи документе пре наставка."
 
 #. IDS_BREAK_ON_WHITESPACE
-#: Merge.rc:4822
+#: Merge.rc:4821
 #, c-format
 msgid "Break at whitespace"
 msgstr "Стани на размаку"
 
 #. IDS_BREAK_ON_PUNCTUATION
-#: Merge.rc:4823
+#: Merge.rc:4822
 #, c-format
 msgid "Break at whitespace or punctuation"
 msgstr "Стани на размаку или интерпукцији"
 
 #. IDS_L2M
-#: Merge.rc:4829
+#: Merge.rc:4828
 msgid "Copy to &Middle\tAlt+Right"
 msgstr ""
 
 #. IDS_R2M
-#: Merge.rc:4830
+#: Merge.rc:4829
 msgid "Copy to &Middle\tAlt+Left"
 msgstr ""
 
 #. IDS_COPY_FROM_MIDDLE_R
-#: Merge.rc:4831
+#: Merge.rc:4830
 msgid "Copy from Middle\tAlt+Shift+Right"
 msgstr ""
 
 #. IDS_COPY_FROM_MIDDLE_L
-#: Merge.rc:4832
+#: Merge.rc:4831
 msgid "Copy from Middle\tAlt+Shift+Left"
 msgstr ""
 
 #. IDS_L2MNEXT
-#: Merge.rc:4833
+#: Merge.rc:4832
 msgid "Copy to Middle and Advance\tCtrl+Alt+Right"
 msgstr ""
 
 #. IDS_R2MNEXT
-#: Merge.rc:4834
+#: Merge.rc:4833
 msgid "Copy to Middle and Advance\tCtrl+Alt+Left"
 msgstr ""
 
 #. IDS_ALL_MIDDLE
-#: Merge.rc:4835
+#: Merge.rc:4834
 msgid "Copy All to Middle"
 msgstr ""
 
 #. IDS_COPY_RIGHT_TO_LEFT
-#: Merge.rc:4841
+#: Merge.rc:4840
 #, c-format
 msgid "Right to Left (%1)"
 msgstr "Десна у лево (%1)"
 
 #. IDS_COPY_RIGHT_TO_MIDDLE
-#: Merge.rc:4842
+#: Merge.rc:4841
 #, c-format
 msgid "Right to Middle (%1)"
 msgstr ""
 
 #. IDS_COPY_MIDDLE_TO_LEFT
-#: Merge.rc:4843
+#: Merge.rc:4842
 #, c-format
 msgid "Middle to Left (%1)"
 msgstr ""
 
 #. IDS_COPY_MIDDLE_TO_RIGHT
-#: Merge.rc:4844
+#: Merge.rc:4843
 #, c-format
 msgid "Middle to Right (%1)"
 msgstr ""
 
 #. IDS_COPY_LEFT_TO_RIGHT
-#: Merge.rc:4845
+#: Merge.rc:4844
 #, c-format
 msgid "Left to Right (%1)"
 msgstr "Лева у десно (%1)"
 
 #. IDS_COPY_LEFT_TO_MIDDLE
-#: Merge.rc:4846
+#: Merge.rc:4845
 #, c-format
 msgid "Left to Middle (%1)"
 msgstr ""
 
 #. IDS_MOVE_LEFT_TO
-#: Merge.rc:4857 Merge.rc:4889
+#: Merge.rc:4856 Merge.rc:4888
 #, c-format
 msgid "Left to... (%1)"
 msgstr "Лева у... (%1)"
 
 #. IDS_MOVE_MIDDLE_TO
-#: Merge.rc:4858 Merge.rc:4890
+#: Merge.rc:4857 Merge.rc:4889
 #, c-format
 msgid "Middle to... (%1)"
 msgstr ""
 
 #. IDS_MOVE_RIGHT_TO
-#: Merge.rc:4859 Merge.rc:4891
+#: Merge.rc:4858 Merge.rc:4890
 #, c-format
 msgid "Right to... (%1)"
 msgstr "Десна у... (%1)"
 
 #. IDS_COPY_BOTH_TO
-#: Merge.rc:4860
+#: Merge.rc:4859
 #, c-format
 msgid "Both to... (%1)"
 msgstr ""
 
 #. IDS_COPY_ALL_TO
-#: Merge.rc:4861
+#: Merge.rc:4860
 #, c-format
 msgid "All to... (%1)"
 msgstr ""
 
 #. IDS_COPY_DIFFERENCES_TO
-#: Merge.rc:4862
+#: Merge.rc:4861
 #, c-format
 msgid "Differences to... (%1)"
 msgstr ""
 
 #. IDS_ONLYDIFFITEMS_CONFIRM
-#: Merge.rc:4869
+#: Merge.rc:4868
 msgid "Some selected items are identical or skipped.\nProcess only items with differences?"
 msgstr ""
 
 #. IDS_DEL_LEFT_FMT
-#: Merge.rc:4875
+#: Merge.rc:4874
 #, c-format
 msgid "Left (%1)"
 msgstr "Лева (%1)"
 
 #. IDS_DEL_MIDDLE_FMT
-#: Merge.rc:4876
+#: Merge.rc:4875
 #, c-format
 msgid "Middle (%1)"
 msgstr ""
 
 #. IDS_DEL_RIGHT_FMT
-#: Merge.rc:4877
+#: Merge.rc:4876
 #, c-format
 msgid "Right (%1)"
 msgstr "Десна (%1)"
 
 #. IDS_DEL_BOTH_FMT
-#: Merge.rc:4878
+#: Merge.rc:4877
 #, c-format
 msgid "Both (%1)"
 msgstr "Обе (%1)"
 
 #. IDS_DEL_ALL_FMT
-#: Merge.rc:4879
+#: Merge.rc:4878
 #, c-format
 msgid "All (%1)"
 msgstr ""
 
 #. IDS_SELECT_DEST_LEFT
-#: Merge.rc:4895
+#: Merge.rc:4894
 #, c-format
 msgid "Left Side - Select Destination Folder:"
 msgstr "Лева страна - одабери фасциклу одредишта:"
 
 #. IDS_SELECT_DEST_MIDDLE
-#: Merge.rc:4896
+#: Merge.rc:4895
 #, c-format
 msgid "Middle Side - Select Destination Folder:"
 msgstr ""
 
 #. IDS_SELECT_DEST_RIGHT
-#: Merge.rc:4897
+#: Merge.rc:4896
 #, c-format
 msgid "Right Side - Select Destination Folder:"
 msgstr "Десна страна - одабери фасциклу одредишта:"
 
 #. IDS_FILES_AFFECTED_FMT
-#: Merge.rc:4898
+#: Merge.rc:4897
 #, c-format
 msgid "(%1 Files Affected)"
 msgstr "(%1 усмерених датотека)"
 
 #. IDS_FILES_AFFECTED_FMT2
-#: Merge.rc:4899
+#: Merge.rc:4898
 #, c-format
 msgid "(%1 of %2 Files Affected)"
 msgstr "(%1 од %2 усмерених датотека)"
 
 #. IDS_CONFIRM_DELETE_SINGLE
-#: Merge.rc:4905
+#: Merge.rc:4904
 #, c-format
 msgid ""
 "Are you sure you want to delete\n"
@@ -6840,18 +6834,18 @@ msgstr ""
 "%1 ?"
 
 #. IDS_CONFIRM_SINGLE_COPY
-#: Merge.rc:4906
+#: Merge.rc:4905
 msgid "Are you sure you want to copy?"
 msgstr "Да ли сте сигурни да желите да умножите?"
 
 #. IDS_CONFIRM_MULTIPLE_COPY
-#: Merge.rc:4907
+#: Merge.rc:4906
 #, c-format
 msgid "Are you sure you want to copy %d items?"
 msgstr "Да ли сте сигурни да желите да умножите %d ставки?"
 
 #. IDS_DIRCMP_NOTSYNC
-#: Merge.rc:4908
+#: Merge.rc:4907
 #, c-format
 msgid ""
 "Operation aborted!\n"
@@ -6871,873 +6865,873 @@ msgstr ""
 "Молим, освежите поређење."
 
 #. IDS_CONFIRM_SINGLE_MOVE
-#: Merge.rc:4913
+#: Merge.rc:4912
 msgid "Are you sure you want to move?"
 msgstr "Да ли сте сигурни да желите да је преместите?"
 
 #. IDS_CONFIRM_MULTIPLE_MOVE
-#: Merge.rc:4914
+#: Merge.rc:4913
 #, c-format
 msgid "Are you sure you want to move %d items?"
 msgstr "Да ли сте сигурни да желите да преместите %d ставки?"
 
 #. IDS_CONFIRM_MOVE_CAPTION
-#: Merge.rc:4916
+#: Merge.rc:4915
 #, c-format
 msgid "Confirm Move"
 msgstr "Потврди премештај"
 
-#: Merge.rc:4918
+#: Merge.rc:4917
 #, c-format
 msgid "Close the folder comparison window?"
 msgstr ""
 
-#: Merge.rc:4920
+#: Merge.rc:4919
 msgid "Close the folder comparison window, which took a long time?"
 msgstr ""
 
 #. IDS_ERROR_INVALID_DIR_FILE_NAME
-#: Merge.rc:4921
+#: Merge.rc:4920
 msgid "The file or folder name is invalid."
 msgstr ""
 
 #. IDS_ERROR_EXECUTE_FILE
-#: Merge.rc:4927
+#: Merge.rc:4926
 #, c-format
 msgid "Failed to execute external editor: %1"
 msgstr "Није успело покретање другог уређивача: %1"
 
 #. IDS_UNKNOWN_ARCHIVE_FORMAT
-#: Merge.rc:4933
+#: Merge.rc:4932
 #, c-format
 msgid "Unknown archive format"
 msgstr "Непознат облик архиве"
 
-#: Merge.rc:4935
+#: Merge.rc:4934
 msgid "Failed to extract archive.\nCompare as text file?"
 msgstr ""
 
 #. IDS_COLHDR_FILENAME
-#: Merge.rc:4941
+#: Merge.rc:4940
 #, c-format
 msgid "Filename"
 msgstr "Име датотеке"
 
 #. IDS_COLHDR_DIR
-#: Merge.rc:4942
+#: Merge.rc:4941
 msgctxt "DirView|ColumnHeader"
 msgid "Folder"
 msgstr "Фасцикла"
 
 #. IDS_COLHDR_RESULT
-#: Merge.rc:4943
+#: Merge.rc:4942
 #, c-format
 msgid "Comparison Result"
 msgstr "Резултат поређења"
 
 #. IDS_COLHDR_LTIMEM
-#: Merge.rc:4944
+#: Merge.rc:4943
 #, c-format
 msgid "Left Date"
 msgstr "Датум лево"
 
 #. IDS_COLHDR_RTIMEM
-#: Merge.rc:4945
+#: Merge.rc:4944
 #, c-format
 msgid "Right Date"
 msgstr "Датум десно"
 
 #. IDS_COLHDR_MTIMEM
-#: Merge.rc:4946
+#: Merge.rc:4945
 #, c-format
 msgid "Middle Date"
 msgstr ""
 
 #. IDS_COLHDR_LSIZE
-#: Merge.rc:4948
+#: Merge.rc:4947
 #, c-format
 msgid "Left Size"
 msgstr "Величина лево"
 
 #. IDS_COLHDR_RSIZE
-#: Merge.rc:4949
+#: Merge.rc:4948
 #, c-format
 msgid "Right Size"
 msgstr "Величина десно"
 
 #. IDS_COLHDR_MSIZE
-#: Merge.rc:4954
+#: Merge.rc:4953
 #, c-format
 msgid "Middle Size"
 msgstr ""
 
 #. IDS_COLHDR_RSIZE_SHORT
-#: Merge.rc:4955
+#: Merge.rc:4954
 #, c-format
 msgid "Right Size (Short)"
 msgstr "Величина десно (скраћено)"
 
 #. IDS_COLHDR_LSIZE_SHORT
-#: Merge.rc:4956
+#: Merge.rc:4955
 #, c-format
 msgid "Left Size (Short)"
 msgstr "Величина лево (скраћено)"
 
 #. IDS_COLHDR_MSIZE_SHORT
-#: Merge.rc:4957
+#: Merge.rc:4956
 #, c-format
 msgid "Middle Size (Short)"
 msgstr ""
 
 #. IDS_COLHDR_LTIMEC
-#: Merge.rc:4963
+#: Merge.rc:4962
 #, c-format
 msgid "Left Creation Time"
 msgstr "Време стварања леве"
 
 #. IDS_COLHDR_RTIMEC
-#: Merge.rc:4964
+#: Merge.rc:4963
 #, c-format
 msgid "Right Creation Time"
 msgstr "Време стварања десне"
 
 #. IDS_COLHDR_MTIMEC
-#: Merge.rc:4965
+#: Merge.rc:4964
 #, c-format
 msgid "Middle Creation Time"
 msgstr ""
 
 #. IDS_COLHDR_NEWER
-#: Merge.rc:4966
+#: Merge.rc:4965
 #, c-format
 msgid "Newer File"
 msgstr "Новија датотека"
 
 #. IDS_COLHDR_LVERSION
-#: Merge.rc:4967
+#: Merge.rc:4966
 #, c-format
 msgid "Left File Version"
 msgstr "Издање леве датотеке"
 
 #. IDS_COLHDR_RVERSION
-#: Merge.rc:4968
+#: Merge.rc:4967
 #, c-format
 msgid "Right File Version"
 msgstr "Издање десне датотеке"
 
 #. IDS_COLHDR_MVERSION
-#: Merge.rc:4969
+#: Merge.rc:4968
 #, c-format
 msgid "Middle File Version"
 msgstr ""
 
 #. IDS_COLHDR_RESULT_ABBR
-#: Merge.rc:4970
+#: Merge.rc:4969
 #, c-format
 msgid "Short Result"
 msgstr "Скраћени исход"
 
 #. IDS_COLHDR_LATTRIBUTES
-#: Merge.rc:4971
+#: Merge.rc:4970
 #, c-format
 msgid "Left Attributes"
 msgstr "Особине леве"
 
 #. IDS_COLHDR_RATTRIBUTES
-#: Merge.rc:4972
+#: Merge.rc:4971
 #, c-format
 msgid "Right Attributes"
 msgstr "Особине десне"
 
 #. IDS_COLHDR_MATTRIBUTES
-#: Merge.rc:4973
+#: Merge.rc:4972
 #, c-format
 msgid "Middle Attributes"
 msgstr ""
 
 #. IDS_COLHDR_LEOL_TYPE
-#: Merge.rc:4978
+#: Merge.rc:4977
 #, c-format
 msgid "Left EOL"
 msgstr "Завршетак реда леве датотеке"
 
 #. IDS_COLHDR_MEOL_TYPE
-#: Merge.rc:4979
+#: Merge.rc:4978
 #, c-format
 msgid "Middle EOL"
 msgstr ""
 
 #. IDS_COLHDR_REOL_TYPE
-#: Merge.rc:4980
+#: Merge.rc:4979
 #, c-format
 msgid "Right EOL"
 msgstr "Завршетак реда десне датотеке"
 
 #. IDS_COLHDR_LENCODING
-#: Merge.rc:4986
+#: Merge.rc:4985
 #, c-format
 msgid "Left Encoding"
 msgstr "Кодирање леве"
 
 #. IDS_COLHDR_RENCODING
-#: Merge.rc:4987
+#: Merge.rc:4986
 #, c-format
 msgid "Right Encoding"
 msgstr "Кодирање десне"
 
 #. IDS_COLHDR_MENCODING
-#: Merge.rc:4988
+#: Merge.rc:4987
 #, c-format
 msgid "Middle Encoding"
 msgstr ""
 
 #. IDS_COLHDR_NIDIFFS
-#: Merge.rc:4989
+#: Merge.rc:4988
 msgid "Ignored Diff"
 msgstr "Занемари разлике"
 
 #. IDS_COLHDR_BINARY
-#: Merge.rc:4991
+#: Merge.rc:4990
 msgctxt "DirView|ColumnHeader"
 msgid "Binary"
 msgstr "Бинарни"
 
 #. IDS_PLUGINS_TYPE_UNPACKER
-#: Merge.rc:4992 Merge.rc:5314
+#: Merge.rc:4991 Merge.rc:5313
 #, c-format
 msgid "Unpacker"
 msgstr "Распакивање"
 
 #. IDS_PLUGIN_TYPE4
-#: Merge.rc:4993 Merge.rc:5315 Merge.rc:5622
+#: Merge.rc:4992 Merge.rc:5314 Merge.rc:5621
 #, c-format
 msgid "Prediffer"
 msgstr "Дефинисано поређење"
 
 #. IDS_COLHDR_LEFT
-#: Merge.rc:4994
+#: Merge.rc:4993
 msgid "Left"
 msgstr ""
 
 #. IDS_COLHDR_MIDDLE
-#: Merge.rc:4995
+#: Merge.rc:4994
 msgid "Middle"
 msgstr ""
 
 #. IDS_COLHDR_RIGHT
-#: Merge.rc:4996
+#: Merge.rc:4995
 msgid "Right"
 msgstr ""
 
 #. IDS_COLHDR_DIFF
-#: Merge.rc:4997
+#: Merge.rc:4996
 msgid "Diff"
 msgstr ""
 
 #. IDS_COLHDR_LEFT_DUPLICATE
-#: Merge.rc:4998
+#: Merge.rc:4997
 msgid "Left Duplicate Count"
 msgstr ""
 
 #. IDS_COLHDR_RIGHT_DUPLICATE
-#: Merge.rc:4999
+#: Merge.rc:4998
 msgid "Right Duplicate Count"
 msgstr ""
 
 #. IDS_COLHDR_MIDDLE_DUPLICATE
-#: Merge.rc:5000
+#: Merge.rc:4999
 msgid "Middle Duplicate Count"
 msgstr ""
 
 #. IDS_COLHDR_MOVE
-#: Merge.rc:5001
+#: Merge.rc:5000
 msgid "Move"
 msgstr ""
 
 #. IDS_PRPCAT_AUDIO
-#: Merge.rc:5008
+#: Merge.rc:5007
 msgid "Audio"
 msgstr ""
 
 #. IDS_PRPCAT_CALENDAR
-#: Merge.rc:5009
+#: Merge.rc:5008
 msgid "Calendar"
 msgstr ""
 
 #. IDS_PRPCAT_COMMUNICATION
-#: Merge.rc:5010
+#: Merge.rc:5009
 msgid "Communication"
 msgstr ""
 
 #. IDS_PRPCAT_CONTACT
-#: Merge.rc:5011
+#: Merge.rc:5010
 msgid "Contact"
 msgstr ""
 
 #. IDS_PRPCAT_DEVICES
-#: Merge.rc:5012
+#: Merge.rc:5011
 msgid "Devices"
 msgstr ""
 
 #. IDS_PRPCAT_DOCUMENT
-#: Merge.rc:5013
+#: Merge.rc:5012
 msgid "Document"
 msgstr ""
 
 #. IDS_PRPCAT_HOME
-#: Merge.rc:5014
+#: Merge.rc:5013
 msgid "Home"
 msgstr ""
 
 #. IDS_PRPCAT_JOURNAL
-#: Merge.rc:5016
+#: Merge.rc:5015
 msgid "Journal"
 msgstr ""
 
 #. IDS_PRPCAT_LINK
-#: Merge.rc:5017
+#: Merge.rc:5016
 msgid "Link"
 msgstr ""
 
 #. IDS_PRPCAT_MEDIA
-#: Merge.rc:5018
+#: Merge.rc:5017
 msgid "Media"
 msgstr ""
 
 #. IDS_PRPCAT_MUSIC
-#: Merge.rc:5020
+#: Merge.rc:5019
 msgid "Music"
 msgstr ""
 
 #. IDS_PRPCAT_NOTE
-#: Merge.rc:5021
+#: Merge.rc:5020
 msgid "Note"
 msgstr ""
 
 #. IDS_PRPCAT_PHOTO
-#: Merge.rc:5022
+#: Merge.rc:5021
 msgid "Photo"
 msgstr ""
 
 #. IDS_PRPCAT_RECORDEDTV
-#: Merge.rc:5023
+#: Merge.rc:5022
 msgid "RecordedTV"
 msgstr ""
 
 #. IDS_PRPCAT_SEARCH
-#: Merge.rc:5024
+#: Merge.rc:5023
 msgid "Search"
 msgstr ""
 
 #. IDS_PRPCAT_SECURITY
-#: Merge.rc:5025
+#: Merge.rc:5024
 msgid "Security"
 msgstr ""
 
 #. IDS_PRPCAT_SOFTWARE
-#: Merge.rc:5026
+#: Merge.rc:5025
 msgid "Software"
 msgstr ""
 
 #. IDS_PRPCAT_TASK
-#: Merge.rc:5027
+#: Merge.rc:5026
 msgid "Task"
 msgstr ""
 
 #. IDS_PRPCAT_VIDEO
-#: Merge.rc:5028
+#: Merge.rc:5027
 msgid "Video"
 msgstr ""
 
 #. IDS_PRPCAT_HASH
-#: Merge.rc:5029
+#: Merge.rc:5028
 msgid "Hash"
 msgstr ""
 
 #. IDS_CANT_COMPARE_FILES
-#: Merge.rc:5035
+#: Merge.rc:5034
 #, c-format
 msgid "Unable to compare files"
 msgstr "Не могу упоредити датотеке"
 
 #. IDS_ABORTED_ITEM
-#: Merge.rc:5036
+#: Merge.rc:5035
 #, c-format
 msgid "Item aborted"
 msgstr "Одбачена ставка"
 
 #. IDS_FILE_SKIPPED
-#: Merge.rc:5037
+#: Merge.rc:5036
 #, c-format
 msgid "File skipped"
 msgstr "Изостављена датотека"
 
 #. IDS_DIR_SKIPPED
-#: Merge.rc:5038
+#: Merge.rc:5037
 #, c-format
 msgid "Folder skipped"
 msgstr "Изостављена фасцикла"
 
 #. IDS_LEFT_ONLY_IN_FMT
-#: Merge.rc:5039
+#: Merge.rc:5038
 #, c-format
 msgid "Left only: %1"
 msgstr "Само лева: %1"
 
 #. IDS_MIDDLE_ONLY_IN_FMT
-#: Merge.rc:5040
+#: Merge.rc:5039
 #, c-format
 msgid "Middle only: %1"
 msgstr ""
 
 #. IDS_RIGHT_ONLY_IN_FMT
-#: Merge.rc:5041
+#: Merge.rc:5040
 #, c-format
 msgid "Right only: %1"
 msgstr "Само десна: %"
 
 #. IDS_DOES_NOT_EXIST_IN_FMT
-#: Merge.rc:5042
+#: Merge.rc:5041
 #, c-format
 msgid "Does not exist in %1"
 msgstr ""
 
 #. IDS_BIN_FILES_SAME
-#: Merge.rc:5043
+#: Merge.rc:5042
 #, c-format
 msgid "Binary files are identical"
 msgstr "Бинарне датотеке су исте"
 
 #. IDS_BIN_FILES_DIFF
-#: Merge.rc:5049
+#: Merge.rc:5048
 #, c-format
 msgid "Binary files are different"
 msgstr "Бинарне датотеке су различите"
 
 #. IDS_FILES_ARE_DIFFERENT
-#: Merge.rc:5050
+#: Merge.rc:5049
 #, c-format
 msgid "Files are different"
 msgstr "Датотеке су различите"
 
 #. IDS_FOLDERS_ARE_DIFFERENT
-#: Merge.rc:5051
+#: Merge.rc:5050
 #, c-format
 msgid "Folders are different"
 msgstr "Фасцикле су различите"
 
 #. IDS_LEFTONLY
-#: Merge.rc:5052
+#: Merge.rc:5051
 #, c-format
 msgid "Left Only"
 msgstr "Само лева"
 
 #. IDS_RIGHTONLY
-#: Merge.rc:5053
+#: Merge.rc:5052
 #, c-format
 msgid "Right Only"
 msgstr "Само десна"
 
 #. IDS_MIDDLEONLY
-#: Merge.rc:5054
+#: Merge.rc:5053
 #, c-format
 msgid "Middle Only"
 msgstr ""
 
 #. IDS_NOITEMLEFT
-#: Merge.rc:5055
+#: Merge.rc:5054
 #, c-format
 msgid "No item in left"
 msgstr ""
 
 #. IDS_NOITEMRIGHT
-#: Merge.rc:5056
+#: Merge.rc:5055
 #, c-format
 msgid "No item in right"
 msgstr ""
 
 #. IDS_NOITEMMIDDLE
-#: Merge.rc:5057
+#: Merge.rc:5056
 #, c-format
 msgid "No item in middle"
 msgstr ""
 
 #. IDS_CMPRES_ERROR
-#: Merge.rc:5059
+#: Merge.rc:5058
 #, c-format
 msgid "Error"
 msgstr "Грешка"
 
 #. IDS_TEXT_FILES_SAME
-#: Merge.rc:5060
+#: Merge.rc:5059
 #, c-format
 msgid "Text files are identical"
 msgstr "Текстови датотека су исти"
 
 #. IDS_LEFTONLY_DIFF
-#: Merge.rc:5061
+#: Merge.rc:5060
 msgid " (Middle and right are identical)"
 msgstr ""
 
 #. IDS_MIDDLEONLY_DIFF
-#: Merge.rc:5062
+#: Merge.rc:5061
 msgid " (Left and right are identical)"
 msgstr ""
 
 #. IDS_RIGHTONLY_DIFF
-#: Merge.rc:5063
+#: Merge.rc:5062
 msgid " (Left and middle are identical)"
 msgstr ""
 
 #. IDS_PATH_MISMATCH
-#: Merge.rc:5064
+#: Merge.rc:5063
 msgid " (paths differ)"
 msgstr ""
 
 #. IDS_TEXT_FILES_DIFF
-#: Merge.rc:5065
+#: Merge.rc:5064
 #, c-format
 msgid "Text files are different"
 msgstr "Текстови датотека су различити"
 
 #. IDS_IMAGE_FILES_SAME
-#: Merge.rc:5066
+#: Merge.rc:5065
 msgid "Image files are identical"
 msgstr ""
 
 #. IDS_IMAGE_FILES_DIFF
-#: Merge.rc:5067
+#: Merge.rc:5066
 msgid "Image files are different"
 msgstr ""
 
 #. IDS_EXPR_DIFF
-#: Merge.rc:5068
+#: Merge.rc:5067
 #, c-format
 msgid "Files are different (expr: %1)"
 msgstr ""
 
 #. IDS_HASH_GROUP
-#: Merge.rc:5069
+#: Merge.rc:5068
 #, c-format
 msgid "Group%d"
 msgstr ""
 
 #. IDS_RENAME_MOVE_DETECTION_DISALBED
-#: Merge.rc:5070
+#: Merge.rc:5069
 msgctxt "Options dialog|Compare|Folder|Detect renames and moves"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_RENAME_MOVE_DETECTION_RENAME
-#: Merge.rc:5071
+#: Merge.rc:5070
 msgid "Detect renames"
 msgstr ""
 
 #. IDS_RENAME_MOVE_DETECTION_RENAME_MOVE
-#: Merge.rc:5072
+#: Merge.rc:5071
 msgid "Detect renames and moves"
 msgstr ""
 
 #. IDS_RENAME_MOVE_MERGE_MODE_RENAME
-#: Merge.rc:5073
+#: Merge.rc:5072
 msgid "Merge renames"
 msgstr ""
 
 #. IDS_RENAME_MOVE_MERGE_MODE_RENAME_MOVE
-#: Merge.rc:5074
+#: Merge.rc:5073
 msgid "Merge renames and moves"
 msgstr ""
 
 #. IDS_RENAMED
-#: Merge.rc:5075
+#: Merge.rc:5074
 msgid "Renamed"
 msgstr ""
 
 #. IDS_RENAMED_MOVED
-#: Merge.rc:5077
+#: Merge.rc:5076
 msgid "Renamed/Moved"
 msgstr ""
 
 #. IDS_RENAMED_MOVED_ITEMS
-#: Merge.rc:5078
+#: Merge.rc:5077
 #, c-format
 msgid "(%1 items)"
 msgstr ""
 
 #. IDS_RENAMED_MOVED_RESULT
-#: Merge.rc:5079
+#: Merge.rc:5078
 #, c-format
 msgid "%1 (set %2): "
 msgstr ""
 
 #. IDS_SWITCH_FLAT_MODE
-#: Merge.rc:5080
+#: Merge.rc:5079
 msgid "Some moved items have been merged.\nIn Tree Mode, these items may appear in positions that do not reflect the actual folder structure, which can be confusing.\nSwitch to Flat Mode?"
 msgstr ""
 
 #. IDS_ELAPSED_TIME
-#: Merge.rc:5086
+#: Merge.rc:5085
 #, c-format
 msgid "Elapsed time: %ld ms"
 msgstr "Протекло време: %ld ms"
 
 #. IDS_STATUS_SELITEM1
-#: Merge.rc:5087
+#: Merge.rc:5086
 #, c-format
 msgid "1 item selected"
 msgstr "1 ставка је одабрана"
 
 #. IDS_STATUS_SELITEMS
-#: Merge.rc:5088
+#: Merge.rc:5087
 #, c-format
 msgid "%1 items selected"
 msgstr "%1 ставка је одабрана"
 
 #. IDS_COLDESC_FILENAME
-#: Merge.rc:5094
+#: Merge.rc:5093
 #, c-format
 msgid "Filename or folder name."
 msgstr "Име датотеке или фасцикле"
 
 #. IDS_COLDESC_DIR
-#: Merge.rc:5095
+#: Merge.rc:5094
 #, c-format
 msgid "Subfolder name when subfolders are included."
 msgstr "Име потфасцикле кад су потфасцикле укључене"
 
 #. IDS_COLDESC_RESULT
-#: Merge.rc:5096
+#: Merge.rc:5095
 #, c-format
 msgid "Comparison result, long form."
 msgstr "Изход поређења,дужи облик"
 
 #. IDS_COLDESC_LTIMEM
-#: Merge.rc:5101
+#: Merge.rc:5100
 #, c-format
 msgid "Left side modification date."
 msgstr "Датум промене леве стране"
 
 #. IDS_COLDESC_RTIMEM
-#: Merge.rc:5102
+#: Merge.rc:5101
 #, c-format
 msgid "Right side modification date."
 msgstr "Датум промене десне стране"
 
 #. IDS_COLDESC_MTIMEM
-#: Merge.rc:5103
+#: Merge.rc:5102
 #, c-format
 msgid "Middle side modification date."
 msgstr ""
 
 #. IDS_COLDESC_EXTENSION
-#: Merge.rc:5104
+#: Merge.rc:5103
 #, c-format
 msgid "File's extension."
 msgstr "/Наставак/ датотеке"
 
 #. IDS_COLDESC_LSIZE
-#: Merge.rc:5105
+#: Merge.rc:5104
 #, c-format
 msgid "Left file size in bytes."
 msgstr "Величина леве датотеке у бајтима"
 
 #. IDS_COLDESC_RSIZE
-#: Merge.rc:5106
+#: Merge.rc:5105
 #, c-format
 msgid "Right file size in bytes."
 msgstr "Величина десне датотеке у бајтима"
 
 #. IDS_COLDESC_MSIZE
-#: Merge.rc:5107
+#: Merge.rc:5106
 #, c-format
 msgid "Middle file size in bytes."
 msgstr ""
 
 #. IDS_COLDESC_LSIZE_SHORT
-#: Merge.rc:5108
+#: Merge.rc:5107
 #, c-format
 msgid "Left file size abbreviated."
 msgstr "Скраћена лева датотека"
 
 #. IDS_COLDESC_RSIZE_SHORT
-#: Merge.rc:5109
+#: Merge.rc:5108
 #, c-format
 msgid "Right file size abbreviated."
 msgstr "Скраћена десна датотека"
 
 #. IDS_COLDESC_MSIZE_SHORT
-#: Merge.rc:5110
+#: Merge.rc:5109
 #, c-format
 msgid "Middle file size abbreviated."
 msgstr ""
 
 #. IDS_COLDESC_LTIMEC
-#: Merge.rc:5116
+#: Merge.rc:5115
 #, c-format
 msgid "Left side creation time."
 msgstr "Време стварања леве стране"
 
 #. IDS_COLDESC_RTIMEC
-#: Merge.rc:5117
+#: Merge.rc:5116
 #, c-format
 msgid "Right side creation time."
 msgstr "Време стварања десне стране"
 
 #. IDS_COLDESC_MTIMEC
-#: Merge.rc:5118
+#: Merge.rc:5117
 #, c-format
 msgid "Middle side creation time."
 msgstr ""
 
 #. IDS_COLDESC_NEWER
-#: Merge.rc:5119
+#: Merge.rc:5118
 #, c-format
 msgid "Tells which side has newer modification date."
 msgstr "Која страна има новији датум промене"
 
 #. IDS_COLDESC_LVERSION
-#: Merge.rc:5120
+#: Merge.rc:5119
 msgid "Left side file version, only for some file types."
 msgstr "Издање на левој страни је само за неке врсте датотеке"
 
 #. IDS_COLDESC_RVERSION
-#: Merge.rc:5121
+#: Merge.rc:5120
 msgid "Right side file version, only for some file types."
 msgstr "Издање на десној страни је само за неке врсте датотеке"
 
 #. IDS_COLDESC_MVERSION
-#: Merge.rc:5126
+#: Merge.rc:5125
 msgid "Middle side file version, only for some file types."
 msgstr ""
 
 #. IDS_COLDESC_RESULT_ABBR
-#: Merge.rc:5127
+#: Merge.rc:5126
 #, c-format
 msgid "Short comparison result."
 msgstr "Краћи резултат поређења"
 
 #. IDS_COLDESC_LATTRIBUTES
-#: Merge.rc:5128
+#: Merge.rc:5127
 #, c-format
 msgid "Left side attributes."
 msgstr "Особине леве стране"
 
 #. IDS_COLDESC_RATTRIBUTES
-#: Merge.rc:5129
+#: Merge.rc:5128
 #, c-format
 msgid "Right side attributes."
 msgstr "Особине десне стране"
 
 #. IDS_COLDESC_MATTRIBUTES
-#: Merge.rc:5130
+#: Merge.rc:5129
 #, c-format
 msgid "Middle side attributes."
 msgstr ""
 
 #. IDS_COLDESC_LEOL_TYPE
-#: Merge.rc:5131
+#: Merge.rc:5130
 msgid "Left side file EOL type."
 msgstr "Начин завршетка реда леве датотеке."
 
 #. IDS_COLDESC_REOL_TYPE
-#: Merge.rc:5132
+#: Merge.rc:5131
 msgid "Right side file EOL type."
 msgstr "Начин завршетка реда десне датотеке."
 
 #. IDS_COLDESC_MEOL_TYPE
-#: Merge.rc:5133
+#: Merge.rc:5132
 msgid "Middle side file EOL type."
 msgstr ""
 
 #. IDS_COLDESC_LENCODING
-#: Merge.rc:5139
+#: Merge.rc:5138
 #, c-format
 msgid "Left side encoding."
 msgstr "Кодирање леве стране"
 
 #. IDS_COLDESC_RENCODING
-#: Merge.rc:5140
+#: Merge.rc:5139
 #, c-format
 msgid "Right side encoding."
 msgstr "Кодирање десне стране"
 
 #. IDS_COLDESC_MENCODING
-#: Merge.rc:5141
+#: Merge.rc:5140
 #, c-format
 msgid "Middle side encoding."
 msgstr ""
 
 #. IDS_COLDESC_NIDIFFS
-#: Merge.rc:5142
+#: Merge.rc:5141
 #, c-format
 msgid "Number of ignored differences in file. Ignored and cannot be merged."
 msgstr "Број занемарених разлика у датотеци. Ове разлике је занемарио WinMerge и не могу бити обједињене."
 
 #. IDS_COLDESC_NSDIFFS
-#: Merge.rc:5143
+#: Merge.rc:5142
 #, c-format
 msgid "Number of differences in file (excluding ignored)."
 msgstr "Број разлика у датотеци. Овај број не укључује занемарене разлике."
 
 #. IDS_COLDESC_BINARY
-#: Merge.rc:5144
+#: Merge.rc:5143
 #, c-format
 msgid "Shows an asterisk (*) if the file is binary."
 msgstr "Приказује звездицу (*), ако је датотека бинарна."
 
 #. IDS_COLDESC_UNPACKER
-#: Merge.rc:5145
+#: Merge.rc:5144
 msgid "Unpacker plugin name or pipeline."
 msgstr ""
 
 #. IDS_COLDESC_PREDIFFER
-#: Merge.rc:5146
+#: Merge.rc:5145
 msgid "Prediffer plugin name or pipeline."
 msgstr ""
 
 #. IDS_DIRECTORY_REPORT_TITLE
-#: Merge.rc:5152
+#: Merge.rc:5151
 #, c-format
 msgid "Compare %1 with %2"
 msgstr "Упореди %1 са %2"
 
 #. IDS_DIRECTORY_REPORT_TITLE3
-#: Merge.rc:5153
+#: Merge.rc:5152
 #, c-format
 msgid "Compare %1 with %2 and %3"
 msgstr ""
 
 #. IDS_REPORT_COMMALIST
-#: Merge.rc:5154
+#: Merge.rc:5153
 #, c-format
 msgid "Comma-separated list"
 msgstr "Списак је одвојен зарезом"
 
 #. IDS_REPORT_TABLIST
-#: Merge.rc:5155
+#: Merge.rc:5154
 #, c-format
 msgid "Tab-separated list"
 msgstr "Списак је одвојен језичком"
 
 #. IDS_REPORT_SIMPLEHTML
-#: Merge.rc:5156
+#: Merge.rc:5155
 #, c-format
 msgid "Simple HTML"
 msgstr "Једноставни HTML"
 
 #. IDS_REPORT_SIMPLEXML
-#: Merge.rc:5157
+#: Merge.rc:5156
 #, c-format
 msgid "Simple XML"
 msgstr "Једноставни XML"
 
-#: Merge.rc:5159
+#: Merge.rc:5158
 #, c-format
 msgid "Report file already exists. Overwrite?"
 msgstr "Датотека извештаја већ постоји. Да ли желите заменити постојећу датотеку?"
 
 #. IDS_REPORT_ERROR
-#: Merge.rc:5164
+#: Merge.rc:5163
 #, c-format
 msgid ""
 "Error creating the report:\n"
@@ -7747,62 +7741,62 @@ msgstr ""
 "%1"
 
 #. IDS_REPORT_SUCCESS
-#: Merge.rc:5165
+#: Merge.rc:5164
 #, c-format
 msgid "Report created successfully."
 msgstr "Извештај је успешно направљен."
 
 #. IDS_SYNCPOINT_LASTBLOCK
-#: Merge.rc:5171
+#: Merge.rc:5170
 msgid "Cannot add a synchronization point at this line."
 msgstr ""
 
 #. IDS_FILE_TO_ITSELF
-#: Merge.rc:5177
+#: Merge.rc:5176
 #, c-format
 msgid "Same file is opened in both panes."
 msgstr "Иста датотека је отворена у обе табле."
 
 #. IDS_FILESSAME
-#: Merge.rc:5178
+#: Merge.rc:5177
 #, c-format
 msgid "Selected files are identical."
 msgstr "Изабране датотеке су исте."
 
 #. IDS_FILESSAME_CURCFG
-#: Merge.rc:5179
+#: Merge.rc:5178
 msgid "Selected files are identical (with current settings).\r\nChecking binary identity..."
 msgstr ""
 
 #. IDS_FILESSAME_BINERROR
-#: Merge.rc:5180
+#: Merge.rc:5179
 msgid "Selected files are identical (with current settings).\r\nBut binary comparison failed."
 msgstr ""
 
 #. IDS_FILESSAME_BINSAME
-#: Merge.rc:5181
+#: Merge.rc:5180
 msgid "Selected files are identical (binary match)."
 msgstr ""
 
 #. IDS_FILESSAME_BINDIFF
-#: Merge.rc:5182
+#: Merge.rc:5181
 msgid "Selected files are identical (with current settings).\r\nBut differ at the binary level."
 msgstr ""
 
 #. IDS_FILEERROR
-#: Merge.rc:5183
+#: Merge.rc:5182
 #, c-format
 msgid "An error occurred while comparing files."
 msgstr "Дошло је до грешке при поређењу."
 
 #. IDS_TEMP_FILEERROR
-#: Merge.rc:5184
+#: Merge.rc:5183
 #, c-format
 msgid "Could not create temporary files. Check your temporary path settings."
 msgstr "Привремена датотека не може бити створена. Проверите и подесите привремену путању."
 
 #. IDS_SUGGEST_IGNOREEOL
-#: Merge.rc:5185
+#: Merge.rc:5184
 msgid "Files use different EOL.\n\nTreat all EOL as equivalent?\n\nSet 'Ignore EOL differences (Windows/Unix/Mac)' in Compare section of Options."
 msgstr ""
 "Ове датотеке се разликују према преласку у други ред.\n"
@@ -7812,19 +7806,19 @@ msgstr ""
 "Напомена:Желите ли увек задржати различите преласка у други ред, одаберите 'Занемари разлике ознака завршетка реда (Windows/Unix/Mac)' у дијалошкој картици поређење прозора (Уређивање/Поставке)."
 
 #. IDS_INVALID_DIRECTORY
-#: Merge.rc:5186
+#: Merge.rc:5185
 #, c-format
 msgid "Selected folder is invalid."
 msgstr "Одабрана фасцикла је неупотребљива."
 
 #. IDS_CANNOT_OPEN_BINARYFILE
-#: Merge.rc:5187
+#: Merge.rc:5186
 #, c-format
 msgid "Cannot open a binary file in Editor."
 msgstr "Не могу отворити бинарну датотеку у уређивачу."
 
 #. IDS_CREATE_PAIR_FOLDER
-#: Merge.rc:5188
+#: Merge.rc:5187
 #, c-format
 msgid "Create matching folder:\n%1\non the other side and open?"
 msgstr ""
@@ -7835,196 +7829,196 @@ msgstr ""
 "на другој страни и отворити је?"
 
 #. IDS_CONFIRM_COPY_ALL_DIFFS
-#: Merge.rc:5189
+#: Merge.rc:5188
 msgid "Copy all differences to other file?"
 msgstr ""
 
 #. IDS_MOVE_TO_NEXTFILE
-#: Merge.rc:5194
+#: Merge.rc:5193
 #, c-format
 msgid "Move to next file?"
 msgstr ""
 
 #. IDS_MOVE_TO_PREVFILE
-#: Merge.rc:5195
+#: Merge.rc:5194
 #, c-format
 msgid "Move to previous file?"
 msgstr ""
 
 #. IDS_MOVE_TO_NEXTPAGE
-#: Merge.rc:5196
+#: Merge.rc:5195
 #, c-format
 msgid "Move to next page?"
 msgstr ""
 
 #. IDS_MOVE_TO_PREVPAGE
-#: Merge.rc:5197
+#: Merge.rc:5196
 #, c-format
 msgid "Move to previous page?"
 msgstr ""
 
 #. IDS_MOVE_TO_FIRSTFILE
-#: Merge.rc:5198
+#: Merge.rc:5197
 msgid "Move to first file?"
 msgstr ""
 
 #. IDS_MOVE_TO_LASTFILE
-#: Merge.rc:5199
+#: Merge.rc:5198
 msgid "Move to last file?"
 msgstr ""
 
-#: Merge.rc:5206
+#: Merge.rc:5205
 #, c-format
 msgid "Different codepages: left (cp%d), right (cp%d).\nDisplay in codepage (better display) or default Windows codepage (safer merging)?\n(Recommended: default Windows codepage)"
 msgstr ""
 
-#: Merge.rc:5208
+#: Merge.rc:5207
 #, c-format
 msgid "Information lost due to encoding errors: both files"
 msgstr "Подаци су изгубљени због грешке при кодирању: обе датотеке"
 
-#: Merge.rc:5210
+#: Merge.rc:5209
 #, c-format
 msgid "Information lost due to encoding errors: first file"
 msgstr ""
 
-#: Merge.rc:5212
+#: Merge.rc:5211
 #, c-format
 msgid "Information lost due to encoding errors: second file"
 msgstr ""
 
-#: Merge.rc:5214
+#: Merge.rc:5213
 #, c-format
 msgid "Information lost due to encoding errors: third file"
 msgstr ""
 
 #. IDS_LINEDIFF_NODIFF
-#: Merge.rc:5220
+#: Merge.rc:5219
 #, c-format
 msgid "No difference"
 msgstr "Нема разлике"
 
 #. IDS_LINEDIFF_NODIFF_CAPTION
-#: Merge.rc:5221
+#: Merge.rc:5220
 #, c-format
 msgid "Line difference"
 msgstr "Различити ред"
 
 #. IDS_NUM_REPLACED
-#: Merge.rc:5227
+#: Merge.rc:5226
 #, c-format
 msgid "Replaced %1 string(s)."
 msgstr "Замењен %1 појам(а)"
 
 #. IDS_EDIT_TEXT_NOT_FOUND
-#: Merge.rc:5228
+#: Merge.rc:5227
 #, c-format
 msgid "Cannot find string \"%s\"."
 msgstr "Не могу наћи појам \"%s\"."
 
 #. IDS_MERGE_MODE
-#: Merge.rc:5234
+#: Merge.rc:5233
 msgid "Entering Merge Mode. Press F9 to turn off."
 msgstr ""
 
 #. IDS_AUTO_MERGE
-#: Merge.rc:5240
+#: Merge.rc:5239
 #, c-format
 msgid "Automatic merges: %1\nUnresolved conflicts: %2"
 msgstr ""
 
 #. IDS_CODEPAGE_MERGED
-#: Merge.rc:5241
+#: Merge.rc:5240
 msgid "Codepage change merged."
 msgstr ""
 
 #. IDS_CODEPAGE_CONFLICT
-#: Merge.rc:5242
+#: Merge.rc:5241
 msgid "Codepage changes are conflicting."
 msgstr ""
 
 #. IDS_EOL_MERGED
-#: Merge.rc:5243
+#: Merge.rc:5242
 msgid "EOL change merged."
 msgstr ""
 
 #. IDS_EOL_CONFLICT
-#: Merge.rc:5244
+#: Merge.rc:5243
 msgid "EOL changes are conflicting."
 msgstr ""
 
 #. IDS_LOCBAR_CAPTION
-#: Merge.rc:5250
+#: Merge.rc:5249
 #, c-format
 msgid "Location Pane"
 msgstr "Положај табли"
 
 #. IDS_DIFFBAR_CAPTION
-#: Merge.rc:5251
+#: Merge.rc:5250
 #, c-format
 msgid "Diff Pane"
 msgstr "Различите табле"
 
 #. IDS_DIFF_SUCCEEDED
-#: Merge.rc:5258
+#: Merge.rc:5257
 #, c-format
 msgid "Patch file written."
 msgstr "Датотека разлика је успешно сачувана."
 
 #. IDS_DIFF_FILEOVERWRITE
-#: Merge.rc:5259
+#: Merge.rc:5258
 #, c-format
 msgid "Patch file already exists. Overwrite?"
 msgstr "Датотека разлика већ постоји. Да ли желите да je замените?"
 
 #. IDS_DIFF_SELECTEDFILES
-#: Merge.rc:5260
+#: Merge.rc:5259
 #, c-format
 msgid "[%1 files selected]"
 msgstr "[%1 одабрана датотека"
 
 #. IDS_DIFF_NORMAL
-#: Merge.rc:5261
+#: Merge.rc:5260
 #, c-format
 msgid "Normal"
 msgstr "Уобичајен"
 
 #. IDS_DIFF_CONTEXT
-#: Merge.rc:5262
+#: Merge.rc:5261
 #, c-format
 msgid "Context"
 msgstr "У оквиру"
 
 #. IDS_DIFF_UNIFIED
-#: Merge.rc:5263
+#: Merge.rc:5262
 #, c-format
 msgid "Unified"
 msgstr "Обједињен"
 
 #. IDS_FILEWRITE_ERROR
-#: Merge.rc:5265
+#: Merge.rc:5264
 #, c-format
 msgid "Could not write to file %1."
 msgstr "Не могу сачувати у датотеци %1"
 
 #. IDS_PATH_NOT_ABSOLUTE
-#: Merge.rc:5266
+#: Merge.rc:5265
 #, c-format
 msgid "Output path is not absolute: %1"
 msgstr "Наведена излазна путања није потпуна путања: %1"
 
 #. IDS_MUST_SPECIFY_OUTPUT
-#: Merge.rc:5267
+#: Merge.rc:5266
 msgid "Specify an output file."
 msgstr "Одредите излазну датотеку."
 
-#: Merge.rc:5269
+#: Merge.rc:5268
 #, c-format
 msgid "Cannot create patch from binary files."
 msgstr "Не може створити датотеку разлика из бинарних датотека"
 
 #. IDS_SAVEFILES_FORPATCH
-#: Merge.rc:5270
+#: Merge.rc:5269
 #, c-format
 msgid ""
 "Save all files first.\n"
@@ -8036,23 +8030,23 @@ msgstr ""
 "Стварање датотеке разлика захтева да постоје промене које нису сачуване у датотекама"
 
 #. IDS_FOLDER_NOTEXIST
-#: Merge.rc:5271
+#: Merge.rc:5270
 #, c-format
 msgid "Folder does not exist."
 msgstr "Фасцикла не постоји"
 
 #. IDS_ARCHIVE_SUCCEEDED
-#: Merge.rc:5277
+#: Merge.rc:5276
 msgid "Archive file written."
 msgstr ""
 
 #. IDS_ARCHIVE_SAVEFILES
-#: Merge.rc:5278
+#: Merge.rc:5277
 msgid "Save all files first.\n\nCreating an archive requires no unsaved changes."
 msgstr ""
 
 #. IDS_NO_ZIP_SUPPORT
-#: Merge.rc:5283
+#: Merge.rc:5282
 msgid "Archive support not enabled.\n7-Zip and/or Merge7z*.dll not found.\nSee manual for archive support."
 msgstr ""
 "Рад са архивама је онемогућен.\n"
@@ -8060,43 +8054,43 @@ msgstr ""
 "Погледајте упутство како омогућити рад са архивама"
 
 #. IDS_OPT_EXPORT_CAPTION
-#: Merge.rc:5284
+#: Merge.rc:5283
 #, c-format
 msgid "Select file for export"
 msgstr "Одабери датотеку за извоз"
 
 #. IDS_OPT_IMPORT_CAPTION
-#: Merge.rc:5285
+#: Merge.rc:5284
 #, c-format
 msgid "Select file for import"
 msgstr "Одабери датотеку за увоз"
 
 #. IDS_OPT_IMPORT_DONE
-#: Merge.rc:5286
+#: Merge.rc:5285
 #, c-format
 msgid "Options imported from file."
 msgstr "Увоз поставки у датотеку"
 
 #. IDS_OPT_EXPORT_DONE
-#: Merge.rc:5287
+#: Merge.rc:5286
 #, c-format
 msgid "Options exported to file."
 msgstr "Извоз поставки у датотеку"
 
 #. IDS_OPT_IMPORT_ERR
-#: Merge.rc:5288
+#: Merge.rc:5287
 #, c-format
 msgid "Failed to import options from file."
 msgstr "Није успео да увезе поставке из датотеке"
 
 #. IDS_OPT_EXPORT_ERR
-#: Merge.rc:5289
+#: Merge.rc:5288
 #, c-format
 msgid "Failed to write options to file."
 msgstr "Није успео да запамти поставке у датотеци"
 
 #. IDS_CLOSEALL_WINDOWS
-#: Merge.rc:5290
+#: Merge.rc:5289
 #, c-format
 msgid ""
 "Close multiple compare windows?\n"
@@ -8108,1209 +8102,1209 @@ msgstr ""
 "Да ли желите наставити?"
 
 #. IDS_EOL_BIN
-#: Merge.rc:5300
+#: Merge.rc:5299
 msgctxt "EOL Type"
 msgid "Binary"
 msgstr "Бинарни"
 
 #. IDS_MARKER_COLOR_FMT
-#: Merge.rc:5305
+#: Merge.rc:5304
 #, c-format
 msgid "Marker Color %d"
 msgstr ""
 
 #. IDS_MARKER_NEW_PATTERN
-#: Merge.rc:5306
+#: Merge.rc:5305
 msgid "New Pattern"
 msgstr ""
 
 #. IDS_PLUGINSLIST_TYPE
-#: Merge.rc:5312
+#: Merge.rc:5311
 #, c-format
 msgid "Type"
 msgstr "Врста"
 
 #. IDS_PLUGINS_TYPE_EDITSCRIPT
-#: Merge.rc:5316
+#: Merge.rc:5315
 #, c-format
 msgid "Editor script"
 msgstr "Уређивач рукописа"
 
 #. ID_SELECTLINEDIFF
-#: Merge.rc:5322
+#: Merge.rc:5321
 #, c-format
 msgid "\nDifference in Current Line (F4)"
 msgstr ""
 
 #. ID_OPTIONS
-#: Merge.rc:5323
+#: Merge.rc:5322
 #, c-format
 msgid "\nOptions"
 msgstr ""
 
 #. ID_REFRESH
-#: Merge.rc:5324
+#: Merge.rc:5323
 #, c-format
 msgid "\nRefresh (F5)"
 msgstr ""
 
 #. ID_PREVDIFF
-#: Merge.rc:5330
+#: Merge.rc:5329
 #, c-format
 msgid "\nPrevious Difference (Alt+Up)"
 msgstr ""
 
 #. ID_NEXTDIFF
-#: Merge.rc:5331
+#: Merge.rc:5330
 #, c-format
 msgid "\nNext Difference (Alt+Down)"
 msgstr ""
 
 #. ID_PREVCONFLICT
-#: Merge.rc:5332
+#: Merge.rc:5331
 #, c-format
 msgid "\nPrevious Conflict (Alt+Shift+Up)"
 msgstr ""
 
 #. ID_NEXTCONFLICT
-#: Merge.rc:5333
+#: Merge.rc:5332
 #, c-format
 msgid "\nNext Conflict (Alt+Shift+Down)"
 msgstr ""
 
 #. ID_FIRSTDIFF
-#: Merge.rc:5338
+#: Merge.rc:5337
 #, c-format
 msgid "\nFirst Difference (Alt+Home)"
 msgstr ""
 
 #. ID_CURDIFF
-#: Merge.rc:5339
+#: Merge.rc:5338
 #, c-format
 msgid "\nCurrent Difference (Alt+Enter)"
 msgstr ""
 
 #. ID_LASTDIFF
-#: Merge.rc:5340
+#: Merge.rc:5339
 #, c-format
 msgid "\nLast Difference (Alt+End)"
 msgstr ""
 
 #. ID_L2R
-#: Merge.rc:5341
+#: Merge.rc:5340
 msgid "\nCopy to Right (Alt+Right)"
 msgstr ""
 
 #. ID_R2L
-#: Merge.rc:5342
+#: Merge.rc:5341
 msgid "\nCopy to Left (Alt+Left)"
 msgstr ""
 
 #. ID_L2RNEXT
-#: Merge.rc:5343
+#: Merge.rc:5342
 msgid "\nCopy to Right and Advance (Ctrl+Alt+Right)"
 msgstr ""
 
 #. ID_R2LNEXT
-#: Merge.rc:5344
+#: Merge.rc:5343
 msgid "\nCopy to Left and Advance (Ctrl+Alt+Left)"
 msgstr ""
 
 #. ID_ALL_RIGHT
-#: Merge.rc:5345
+#: Merge.rc:5344
 msgid "\nCopy All to Right"
 msgstr "\nУмножи све у десно"
 
 #. ID_ALL_LEFT
-#: Merge.rc:5346
+#: Merge.rc:5345
 msgid "\nCopy All to Left"
 msgstr "\nУмножи све у лево"
 
 #. ID_AUTO_MERGE
-#: Merge.rc:5347
+#: Merge.rc:5346
 #, c-format
 msgid "\nAuto Merge (Ctrl+Alt+M)"
 msgstr ""
 
 #. ID_FIRSTFILE
-#: Merge.rc:5348
+#: Merge.rc:5347
 msgid "\nFirst File"
 msgstr ""
 
 #. ID_NEXTFILE
-#: Merge.rc:5349
+#: Merge.rc:5348
 msgid "\nNext File (Ctrl+F8)"
 msgstr ""
 
 #. ID_LASTFILE
-#: Merge.rc:5350
+#: Merge.rc:5349
 msgid "\nLast File"
 msgstr ""
 
 #. ID_PREVFILE
-#: Merge.rc:5351
+#: Merge.rc:5350
 msgid "\nPrevious File (Ctrl+F7)"
 msgstr ""
 
 #. IDS_UNPACK_AUTO
-#: Merge.rc:5358
+#: Merge.rc:5357
 msgid "Adapted unpacker applied to both files (one needs extension)."
 msgstr "Прилагођено распакивање ће се користити за обе датотеке (једна датотека треба наставак)."
 
 #. IDS_NO_PREDIFFER
-#: Merge.rc:5359
+#: Merge.rc:5358
 #, c-format
 msgid "No Prediffer (Normal)"
 msgstr "Нема дефинисаног поређења (уобичајено)"
 
 #. IDS_SUGGESTED_PLUGINS
-#: Merge.rc:5360
+#: Merge.rc:5359
 #, c-format
 msgid "Suggested Plugins"
 msgstr "Препоручени додаци"
 
 #. IDS_NOT_SUGGESTED_PLUGINS
-#: Merge.rc:5361
+#: Merge.rc:5360
 msgid "All Plugins"
 msgstr ""
 
 #. IDS_PRIVATEBUILD_FMT
-#: Merge.rc:5367
+#: Merge.rc:5366
 #, c-format
 msgid "Private Build: %1"
 msgstr "Лична израда: %1"
 
 #. IDS_ALLRIGHTS_RESERVED
-#: Merge.rc:5368
+#: Merge.rc:5367
 msgid " - All rights reserved."
 msgstr ""
 
 #. IDS_TITLE_PLUGINS_SETTINGS
-#: Merge.rc:5374
+#: Merge.rc:5373
 #, c-format
 msgid "Plugin Settings"
 msgstr "Подешавања додатака"
 
 #. IDS_NO_SCT_SCRIPTS
-#: Merge.rc:5376
+#: Merge.rc:5375
 #, c-format
 msgid "WSH not found - .sct scripts disabled"
 msgstr "WSH није нађен - .sct скрипте су онемогућене"
 
 #. IDS_LOCBAR_GOTOLINE_FMT
-#: Merge.rc:5384
+#: Merge.rc:5383
 #, c-format
 msgid "G&o to Line %1"
 msgstr "И&ди на ред %1"
 
 #. IDS_GOTO_MOVED_LINE
-#: Merge.rc:5390
+#: Merge.rc:5389
 msgid "Go to Moved Line\tCtrl+Shift+G"
 msgstr ""
 
 #. IDS_AUTOCOMPLETE_DISABLED
-#: Merge.rc:5396
+#: Merge.rc:5395
 msgctxt "Options dialog|General|Open dialog Auto completion"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_AUTOCOMPLETE_FILE_SYS
-#: Merge.rc:5397
+#: Merge.rc:5396
 #, c-format
 msgid "From file system"
 msgstr "Од система"
 
 #. IDS_AUTOCOMPLETE_MRU
-#: Merge.rc:5398
+#: Merge.rc:5397
 #, c-format
 msgid "From Most Recently Used list"
 msgstr "Из MRU списка"
 
 #. IDS_COLORSCHEME_PLAIN
-#: Merge.rc:5404
+#: Merge.rc:5403
 #, c-format
 msgid "No Highlighting"
 msgstr "Није означено"
 
 #. IDS_COLORSCHEME_PO
-#: Merge.rc:5439
+#: Merge.rc:5438
 #, c-format
 msgid "Portable Object"
 msgstr "Преносни објекат"
 
 #. IDS_COLORSCHEME_RSRC
-#: Merge.rc:5444
+#: Merge.rc:5443
 #, c-format
 msgid "Resources"
 msgstr "Resources"
 
 #. IDS_COLORSCHEME_SH
-#: Merge.rc:5448
+#: Merge.rc:5447
 #, c-format
 msgid "Shell"
 msgstr "Shell"
 
 #. IDS_CLOSE_LEFT_TABS
-#: Merge.rc:5469
+#: Merge.rc:5468
 #, c-format
 msgid "Close &Left Tabs"
 msgstr ""
 
 #. IDS_CLOSE_RIGHT_TABS
-#: Merge.rc:5470
+#: Merge.rc:5469
 #, c-format
 msgid "Close R&ight Tabs"
 msgstr ""
 
 #. IDS_CLOSE_OTHER_TABS
-#: Merge.rc:5471
+#: Merge.rc:5470
 #, c-format
 msgid "Close &Other Tabs"
 msgstr ""
 
 #. IDS_TABBAR_AUTO_MAXWIDTH
-#: Merge.rc:5472
+#: Merge.rc:5471
 #, c-format
 msgid "Enable &Auto Max Width"
 msgstr ""
 
 #. IDS_WEBPAGE_MENU
-#: Merge.rc:5482
+#: Merge.rc:5481
 msgid "We&bpage"
 msgstr ""
 
 #. IDS_VIEW_WRAP_TEXT
-#: Merge.rc:5487
+#: Merge.rc:5486
 msgid "W&rap Text"
 msgstr ""
 
 #. IDS_NOTINSTALLED
-#: Merge.rc:5492
+#: Merge.rc:5491
 msgid "%1 is not installed."
 msgstr ""
 
 #. IDS_CREATE_FOLDER
-#: Merge.rc:5497
+#: Merge.rc:5496
 #, c-format
 msgid "%1 does not exist. Create it?"
 msgstr ""
 
 #. IDS_CREATE_FOLDER_ERROR
-#: Merge.rc:5498
+#: Merge.rc:5497
 #, c-format
 msgid "Failed to create folder."
 msgstr ""
 
 #. IDC_EXT_EDITOR_PATH
-#: Merge.rc:5503
+#: Merge.rc:5502
 #, c-format
 msgid "Parameters:\n$file: Current file path\n$linenum: Current cursor line number"
 msgstr ""
 
 #. IDS_DIFF_ALGORITHM_DEFAULT
-#: Merge.rc:5508
+#: Merge.rc:5507
 msgid "default"
 msgstr ""
 
 #. IDS_DIFF_ALGORITHM_MINIMAL
-#: Merge.rc:5509
+#: Merge.rc:5508
 msgid "minimal"
 msgstr ""
 
 #. IDS_DIFF_ALGORITHM_PATIENCE
-#: Merge.rc:5510
+#: Merge.rc:5509
 msgid "patience"
 msgstr ""
 
 #. IDS_DIFF_ALGORITHM_HISTOGRAM
-#: Merge.rc:5511
+#: Merge.rc:5510
 msgid "histogram"
 msgstr ""
 
 #. IDS_DIFF_ALGORITHM_NONE
-#: Merge.rc:5512
+#: Merge.rc:5511
 msgid "none"
 msgstr ""
 
 #. IDS_RENDERING_MODE_GDI
-#: Merge.rc:5517
+#: Merge.rc:5516
 msgid "GDI"
 msgstr ""
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_DEFAULT
-#: Merge.rc:5518
+#: Merge.rc:5517
 msgid "DirectWrite Default"
 msgstr ""
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_ALIASED
-#: Merge.rc:5519
+#: Merge.rc:5518
 msgid "DirectWrite Aliased"
 msgstr ""
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_GDI_CLASSIC
-#: Merge.rc:5520
+#: Merge.rc:5519
 msgid "DirectWrite GDI Classic"
 msgstr ""
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_GDI_NATURAL
-#: Merge.rc:5521
+#: Merge.rc:5520
 msgid "DirectWrite GDI Natural"
 msgstr ""
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_NATURAL
-#: Merge.rc:5522
+#: Merge.rc:5521
 msgid "DirectWrite Natural"
 msgstr ""
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_NATURAL_SYMMETRIC
-#: Merge.rc:5523
+#: Merge.rc:5522
 msgid "DirectWrite Natural Symmetric"
 msgstr ""
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_DISABLED
-#: Merge.rc:5528
+#: Merge.rc:5527
 msgctxt "Options dialog|General|Close windows with Esc"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_1
-#: Merge.rc:5529
+#: Merge.rc:5528
 msgid "MDI child window or main window"
 msgstr ""
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_2
-#: Merge.rc:5530
+#: Merge.rc:5529
 msgid "MDI child window only"
 msgstr ""
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_3
-#: Merge.rc:5531
+#: Merge.rc:5530
 msgid "Close main window if only one MDI child window"
 msgstr ""
 
 #. IDS_DIFF_GROUP
-#: Merge.rc:5536
+#: Merge.rc:5535
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Diff"
 msgstr ""
 
 #. IDS_DIFF_HIGHLIGHT
-#: Merge.rc:5537
+#: Merge.rc:5536
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Highlight"
 msgstr ""
 
 #. IDS_DIFF_BLINK
-#: Merge.rc:5538
+#: Merge.rc:5537
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Blink"
 msgstr ""
 
 #. IDS_DIFF_BLOCKSIZE
-#: Merge.rc:5539
+#: Merge.rc:5538
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Block Size"
 msgstr ""
 
 #. IDS_DIFF_BLOCKALPHA
-#: Merge.rc:5540
+#: Merge.rc:5539
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Block Alpha"
 msgstr ""
 
 #. IDS_DIFF_CDTHRESHOLD
-#: Merge.rc:5541
+#: Merge.rc:5540
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "CD Threshold"
 msgstr ""
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION
-#: Merge.rc:5542
+#: Merge.rc:5541
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Ins/Del Detection"
 msgstr ""
 
 #. IDS_OVERLAY_MODE_NONE
-#: Merge.rc:5543 Merge.rc:5548
+#: Merge.rc:5542 Merge.rc:5547
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "None"
 msgstr ""
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION_VERTICAL
-#: Merge.rc:5544
+#: Merge.rc:5543
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Vertical"
 msgstr ""
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION_HORIZONTAL
-#: Merge.rc:5545
+#: Merge.rc:5544
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Horizontal"
 msgstr ""
 
 #. IDS_OVERLAY_GROUP
-#: Merge.rc:5546
+#: Merge.rc:5545
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Overlay"
 msgstr ""
 
 #. IDS_OVERLAY_ALPHA
-#: Merge.rc:5547
+#: Merge.rc:5546
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha"
 msgstr ""
 
 #. IDS_OVERLAY_MODE_XOR
-#: Merge.rc:5549
+#: Merge.rc:5548
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "XOR"
 msgstr ""
 
 #. IDS_OVERLAY_MODE_ALPHA
-#: Merge.rc:5550
+#: Merge.rc:5549
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha Blend"
 msgstr ""
 
 #. IDS_OVERLAY_MODE_ALPHA_ANIMATION
-#: Merge.rc:5551
+#: Merge.rc:5550
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha Animation"
 msgstr ""
 
 #. IDS_ZOOM
-#: Merge.rc:5552
+#: Merge.rc:5551
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Zoom"
 msgstr ""
 
 #. IDS_PAGE
-#: Merge.rc:5553
+#: Merge.rc:5552
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Page:"
 msgstr ""
 
 #. IDS_IMGCMP_STATUS_PT_RGBA_FMT
-#: Merge.rc:5554
+#: Merge.rc:5553
 #, c-format
 msgid "Pt: (%d, %d)  RGBA: (%d, %d, %d, %d)  "
 msgstr ""
 
 #. IDS_IMGCMP_STATUS_DIST1_FMT
-#: Merge.rc:5555
+#: Merge.rc:5554
 #, c-format
 msgid "Dist: %g  "
 msgstr ""
 
 #. IDS_IMGCMP_STATUS_DIST2_FMT
-#: Merge.rc:5556
+#: Merge.rc:5555
 #, c-format
 msgid "Dist: %g, %g  "
 msgstr ""
 
 #. IDS_IMGCMP_STATUS_PAGE_ZOOM_SIZE_BPP_FMT
-#: Merge.rc:5557
+#: Merge.rc:5556
 #, c-format
 msgid "Page: %d/%d  Zoom: %d%%  %dx%dpx  %dbpp  "
 msgstr ""
 
 #. IDS_IMGCMP_STATUS_RC_FMT
-#: Merge.rc:5558
+#: Merge.rc:5557
 #, c-format
 msgid "Rc: (%d, %d)  "
 msgstr ""
 
 #. IDS_IMGCMP_STATUS_FLIPPED_FMT
-#: Merge.rc:5559
+#: Merge.rc:5558
 #, c-format
 msgid "Flipped: %s  "
 msgstr ""
 
 #. IDS_IMGCMP_STATUS_ROTATED_FMT
-#: Merge.rc:5560
+#: Merge.rc:5559
 #, c-format
 msgid "Rotated: %d  "
 msgstr ""
 
 #. IDS_IMGCMP_REPORT_ALLPAGES
-#: Merge.rc:5561
+#: Merge.rc:5560
 msgid "All pages"
 msgstr ""
 
 #. IDS_IGNSUB_STR1
-#: Merge.rc:5566
+#: Merge.rc:5565
 msgid "<Edit here>"
 msgstr ""
 
 #. IDS_IGNSUB_STR2
-#: Merge.rc:5567
+#: Merge.rc:5566
 msgid "No differences found to select"
 msgstr ""
 
 #. IDS_IGNSUB_STR3
-#: Merge.rc:5568
+#: Merge.rc:5567
 msgid "No differences found to add as substitution filter"
 msgstr ""
 
 #. IDS_IGNSUB_STR4
-#: Merge.rc:5569
+#: Merge.rc:5568
 msgid "The pair is already in the Substitution Filters list"
 msgstr ""
 
 #. IDS_IGNSUB_STR5
-#: Merge.rc:5570
+#: Merge.rc:5569
 msgid "Add this change to Substitution Filters?"
 msgstr ""
 
 #. IDS_OCRRESULT_TEXTONLY
-#: Merge.rc:5575
+#: Merge.rc:5574
 msgid "Text only"
 msgstr ""
 
 #. IDS_OCRRESULT_POS_LINE
-#: Merge.rc:5576
+#: Merge.rc:5575
 msgid "Line-by-line position and text"
 msgstr ""
 
 #. IDS_OCRRESULT_POS_WORD
-#: Merge.rc:5577
+#: Merge.rc:5576
 msgid "Word-by-word position and text"
 msgstr ""
 
 #. IDS_USERDATAFOLDER_APPDATA
-#: Merge.rc:5582
+#: Merge.rc:5581
 msgid "AppData (Roaming) folder"
 msgstr ""
 
 #. IDS_USERDATAFOLDER_INSTALL
-#: Merge.rc:5583
+#: Merge.rc:5582
 msgid "Install folder"
 msgstr ""
 
 #. IDS_USERDATAFOLDER_DOCUMENTS
-#: Merge.rc:5584
+#: Merge.rc:5583
 msgid "Documents folder"
 msgstr ""
 
 #. IDS_SINGLEINSTANCE_DISABLED
-#: Merge.rc:5589
+#: Merge.rc:5588
 msgctxt "Options dialog|General|Single instance mode"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_SINGLEINSTANCE_STR1
-#: Merge.rc:5590
+#: Merge.rc:5589
 #, c-format
 msgid "Allow only one instance to run"
 msgstr "Дозволи само једну покренуту надлежност"
 
 #. IDS_CLIPBOARD_HISTORY
-#: Merge.rc:5591
+#: Merge.rc:5590
 msgid "Clipboard &History"
 msgstr ""
 
 #. IDS_SINGLEINSTANCE_STR2
-#: Merge.rc:5592
+#: Merge.rc:5591
 msgid "Allow only one instance; wait for termination"
 msgstr ""
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_DISABLED
-#: Merge.rc:5597
+#: Merge.rc:5596
 msgctxt "Options dialog|General|Auto-reload modified files"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_STR1
-#: Merge.rc:5598
+#: Merge.rc:5597
 msgid "Only on window activated"
 msgstr ""
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_STR2
-#: Merge.rc:5599
+#: Merge.rc:5598
 msgid "Immediately"
 msgstr ""
 
 #. IDS_PLUGIN_ALL
-#: Merge.rc:5604
+#: Merge.rc:5603
 msgid "Al&l"
 msgstr ""
 
 #. IDS_PLUGIN_OTHERS
-#: Merge.rc:5605
+#: Merge.rc:5604
 msgid "&Others"
 msgstr ""
 
-#: Merge.rc:5607
+#: Merge.rc:5606
 #, c-format
 msgid "Missing plugin name in pipeline: %1"
 msgstr ""
 
-#: Merge.rc:5609
+#: Merge.rc:5608
 #, c-format
 msgid "Missing quote in plugin pipeline: %1"
 msgstr ""
 
 #. IDS_PLUGIN_NAME_ALREADY_EXISTS
-#: Merge.rc:5610
+#: Merge.rc:5609
 #, c-format
 msgid "Plugin name '%1' already exists."
 msgstr ""
 
 #. IDS_PLUGIN_TITLE1
-#: Merge.rc:5611
+#: Merge.rc:5610
 msgid "Specify plugin arguments"
 msgstr ""
 
-#: Merge.rc:5613
+#: Merge.rc:5612
 #, c-format
 msgid "Plugin not found or invalid: %1"
 msgstr ""
 
 #. IDS_PLUGIN_NOT_UNPACK
-#: Merge.rc:5614
+#: Merge.rc:5613
 #, c-format
 msgid "'%1' is not an unpacker plugin"
 msgstr ""
 
 #. IDS_PLUGIN_NOT_PREDIFF
-#: Merge.rc:5615
+#: Merge.rc:5614
 #, c-format
 msgid "'%1' is not a prediffer plugin"
 msgstr ""
 
-#: Merge.rc:5617
+#: Merge.rc:5616
 #, c-format
 msgid "Error prediffing '%1' with '%2'. Prediffing disabled."
 msgstr ""
 
 #. IDS_PLUGIN_CIRCULAR_REFERENCE
-#: Merge.rc:5618
+#: Merge.rc:5617
 #, c-format
 msgid "Circular reference in plugin pipeline: %1"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE1
-#: Merge.rc:5619
+#: Merge.rc:5618
 msgid "URL Handler"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE2
-#: Merge.rc:5620
+#: Merge.rc:5619
 msgid "File Unpacker"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE3
-#: Merge.rc:5621
+#: Merge.rc:5620
 msgid "File or Folder Unpacker"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE5
-#: Merge.rc:5623
+#: Merge.rc:5622
 msgid "Alias for Unpacker"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE6
-#: Merge.rc:5624
+#: Merge.rc:5623
 msgid "Alias for Prediffer"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE7
-#: Merge.rc:5625
+#: Merge.rc:5624
 msgid "Alias for Editor script"
 msgstr ""
 
 #. IDS_PLUGIN_ALIAS_DESC
-#: Merge.rc:5626
+#: Merge.rc:5625
 #, c-format
 msgid "Alias for plugin pipeline '%1'"
 msgstr ""
 
 #. IDS_PLUGIN_NEW_DESC
-#: Merge.rc:5627
+#: Merge.rc:5626
 msgid "New plugin description"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_ALL
-#: Merge.rc:5628
+#: Merge.rc:5627
 msgid "All"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_1ST
-#: Merge.rc:5629
+#: Merge.rc:5628
 msgid "1st"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_2ND
-#: Merge.rc:5630
+#: Merge.rc:5629
 msgid "2nd"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_3RD
-#: Merge.rc:5631
+#: Merge.rc:5630
 msgid "3rd"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_1ST_2ND
-#: Merge.rc:5632
+#: Merge.rc:5631
 msgid "1st and 2nd"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_1ST_3RD
-#: Merge.rc:5633
+#: Merge.rc:5632
 msgid "1st and 3rd"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_2ND_3RD
-#: Merge.rc:5634
+#: Merge.rc:5633
 msgid "2nd and 3rd"
 msgstr ""
 
 #. IDS_PLUGIN_CTRL_CLICK
-#: Merge.rc:5635
+#: Merge.rc:5634
 msgid "(Ctrl+Click to add to pipeline)"
 msgstr ""
 
 #. IDS_FILTER_APPLIED
-#: Merge.rc:5640
+#: Merge.rc:5639
 msgid "Filter applied"
 msgstr ""
 
 #. IDS_FILTERMENU_COMPARE
-#: Merge.rc:5645
+#: Merge.rc:5644
 #, c-format
 msgid "Compare %1"
 msgstr ""
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN2
-#: Merge.rc:5647
+#: Merge.rc:5646
 msgid "&Filter by This Column..."
 msgstr ""
 
 #. IDS_CLIPBOARDHISTORY_TIME
-#: Merge.rc:5652
+#: Merge.rc:5651
 #, c-format
 msgid "Clipboard at %s"
 msgstr ""
 
 #. IDS_CLIPBOARDHISTORY_DISABLED
-#: Merge.rc:5653
+#: Merge.rc:5652
 msgid "Clipboard history disabled.\r\nEnable: Windows logo key + V, then Turn on."
 msgstr ""
 
-#: Merge.rc:5655
+#: Merge.rc:5654
 msgid "This system does not support clipboard history."
 msgstr ""
 
-#: Merge.rc:5657
+#: Merge.rc:5656
 msgid "32-bit WinMerge does not support Clipboard Compare"
 msgstr ""
 
 #. IDS_WEBVIEW2_RUNTIME_NOT_INSTALLED
-#: Merge.rc:5662
+#: Merge.rc:5661
 msgid "WebView2 runtime not installed. Download it?"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_TEXT_COMPARE
-#: Merge.rc:5667
+#: Merge.rc:5666
 msgid "New Text Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_TABLE_COMPARE
-#: Merge.rc:5668
+#: Merge.rc:5667
 msgid "New Table Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_BINARY_COMPARE
-#: Merge.rc:5669
+#: Merge.rc:5668
 msgid "New Binary Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_IMAGE_COMPARE
-#: Merge.rc:5670
+#: Merge.rc:5669
 msgid "New Image Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_WEBPAGE_COMPARE
-#: Merge.rc:5671
+#: Merge.rc:5670
 msgid "New Webpage Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_FOLDER_COMPARE
-#: Merge.rc:5672
+#: Merge.rc:5671
 msgid "New Folder Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_CLIPBOARD_COMPARE
-#: Merge.rc:5673
+#: Merge.rc:5672
 msgid "Clipboard Compare"
 msgstr ""
 
 #. IDS_PREVIEWBAR_PRINT
-#: Merge.rc:5678
+#: Merge.rc:5677
 msgid "&Print..."
 msgstr ""
 
 #. IDS_PREVIEWBAR_PREVPAGE
-#: Merge.rc:5680
+#: Merge.rc:5679
 msgid "Pre&v Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_TWOPAGE
-#: Merge.rc:5681
+#: Merge.rc:5680
 msgid "&Two Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_ONEPAGE
-#: Merge.rc:5682
+#: Merge.rc:5681
 msgid "&One Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_ZOOMIN
-#: Merge.rc:5683
+#: Merge.rc:5682
 msgid "Zoom &In"
 msgstr ""
 
 #. IDS_PREVIEWBAR_ZOOMOUT
-#: Merge.rc:5684
+#: Merge.rc:5683
 msgid "Zoom &Out"
 msgstr ""
 
 #. IDS_WEBPAGE_COMPARING
-#: Merge.rc:5690
+#: Merge.rc:5689
 msgid "Comparing..."
 msgstr ""
 
 #. IDS_WEBPAGE_ZOOM
-#: Merge.rc:5691
+#: Merge.rc:5690
 msgid "Zoom:"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_DIFFHUNK
-#: Merge.rc:5696
+#: Merge.rc:5695
 msgid "Diff hunk"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_INLINE
-#: Merge.rc:5697
+#: Merge.rc:5696
 msgid "Inline diff"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_LINE
-#: Merge.rc:5698
+#: Merge.rc:5697
 msgid "Line"
 msgstr ""
 
-#: Merge.rc:5699
+#: Merge.rc:5698
 msgid "Character"
 msgstr ""
 
 #. ID_MICE_PREVDIFF
-#: Merge.rc:5704
+#: Merge.rc:5703
 msgid "\nPrevious Difference (Alt+Up)\n(Right Button+Wheel Up)\n(Alt+Wheel Up)"
 msgstr ""
 
 #. ID_MICE_NEXTDIFF
-#: Merge.rc:5705
+#: Merge.rc:5704
 msgid "\nNext Difference (Alt+Down)\n(Right Button+Wheel Down)\n(Alt+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_L2R
-#: Merge.rc:5706
+#: Merge.rc:5705
 msgid "\nCopy to Right (Alt+Right)\n(Right Button+Wheel Right)\n(Alt+Wheel Right)\n(Alt+Shift+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_R2L
-#: Merge.rc:5707
+#: Merge.rc:5706
 msgid "\nCopy to Left (Alt+Left)\n(Right Button+Wheel Left)\n(Alt+Wheel Left)\n(Alt+Shift+Wheel Up)"
 msgstr ""
 
 #. ID_MICE_L2RNEXT
-#: Merge.rc:5708
+#: Merge.rc:5707
 msgid "\nCopy to Right and Advance (Ctrl+Alt+Right)\n(Ctrl+Alt+Wheel Right)\n(Ctrl+Alt+Shift+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_R2LNEXT
-#: Merge.rc:5709
+#: Merge.rc:5708
 msgid "\nCopy to Left and Advance (Ctrl+Alt+Left)\n(Ctrl+Alt+Wheel Left)\n(Ctrl+Alt+Shift+Wheel Up)"
 msgstr ""
 
 #. IDS_LOG_COMPARING_2
-#: Merge.rc:5719
+#: Merge.rc:5718
 #, c-format
 msgid "Comparing %1 with %2"
 msgstr ""
 
 #. IDS_LOG_COMPARING_3
-#: Merge.rc:5720
+#: Merge.rc:5719
 #, c-format
 msgid "Comparing %1 with %2 and %3"
 msgstr ""
 
 #. IDS_LOG_COMPARE_COMPLETED
-#: Merge.rc:5721
+#: Merge.rc:5720
 msgid "Comparison completed"
 msgstr ""
 
 #. IDS_LOG_COMPARE_ERROR_2
-#: Merge.rc:5722
+#: Merge.rc:5721
 #, c-format
 msgid "Failed to compare %1 with %2: "
 msgstr ""
 
 #. IDS_LOG_COMPARE_ERROR_3
-#: Merge.rc:5723
+#: Merge.rc:5722
 #, c-format
 msgid "Failed to compare %1 with %2 and %3: "
 msgstr ""
 
 #. IDS_LOG_FILE_SAVED
-#: Merge.rc:5724
+#: Merge.rc:5723
 msgid "File saved"
 msgstr ""
 
 #. IDS_LOG_COPYING_FILES
-#: Merge.rc:5725
+#: Merge.rc:5724
 msgid "Copying files..."
 msgstr ""
 
 #. IDS_LOG_MOVING_FILES
-#: Merge.rc:5726
+#: Merge.rc:5725
 msgid "Moving files..."
 msgstr ""
 
 #. IDS_LOG_DELETING_FILES
-#: Merge.rc:5727
+#: Merge.rc:5726
 msgid "Deleting files..."
 msgstr ""
 
 #. IDS_LOG_RECYCLEBIN
-#: Merge.rc:5728
+#: Merge.rc:5727
 msgid "Recycle Bin"
 msgstr ""
 
 #. IDS_LOG_PERMANENTLY_DELETED
-#: Merge.rc:5729
+#: Merge.rc:5728
 msgid "Permanently deleted"
 msgstr ""
 
 #. IDS_LOG_FILEOPERATION_COMPLETED
-#: Merge.rc:5730
+#: Merge.rc:5729
 msgid "File operation completed successfully"
 msgstr ""
 
 #. IDS_LOG_FILEOPERATION_CANCELED
-#: Merge.rc:5731
+#: Merge.rc:5730
 msgid "File operation canceled"
 msgstr ""
 
 #. IDS_FILTER_ERROR_NO_ERROR
-#: Merge.rc:5736
+#: Merge.rc:5735
 msgid "No error"
 msgstr ""
 
 #. IDS_FILTER_ERROR_EMPTY_EXPRESSION
-#: Merge.rc:5737
+#: Merge.rc:5736
 msgid "Filter expression is empty"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNKNOWN_CHAR
-#: Merge.rc:5738
+#: Merge.rc:5737
 msgid "Unknown character in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNTERMINATED_STRING
-#: Merge.rc:5739
+#: Merge.rc:5738
 msgid "Unterminated string literal"
 msgstr ""
 
 #. IDS_FILTER_ERROR_SYNTAX_ERROR
-#: Merge.rc:5740
+#: Merge.rc:5739
 msgid "Syntax error in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_PARSE_FAILURE
-#: Merge.rc:5741
+#: Merge.rc:5740
 msgid "Failed to parse filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_LITERAL
-#: Merge.rc:5742
+#: Merge.rc:5741
 msgid "Invalid literal value"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_REGULAR_EXPRESSION
-#: Merge.rc:5743
+#: Merge.rc:5742
 msgid "Invalid regular expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNDEFINED_IDENTIFIER
-#: Merge.rc:5744
+#: Merge.rc:5743
 msgid "Undefined identifier"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_ARGUMENT_COUNT
-#: Merge.rc:5745
+#: Merge.rc:5744
 msgid "Invalid number of arguments"
 msgstr ""
 
 #. IDS_FILTER_ERROR_FILTER_NAME_NOT_FOUND
-#: Merge.rc:5746
+#: Merge.rc:5745
 msgid "Filter name not found"
 msgstr ""
 
 #. IDS_FILTER_ERROR_DIVIDE_BY_ZERO
-#: Merge.rc:5747
+#: Merge.rc:5746
 msgid "Division by zero in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNKNOWN_ERROR
-#: Merge.rc:5748
+#: Merge.rc:5747
 msgid "Unknown error"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_PROPERTY_NAME
-#: Merge.rc:5749
+#: Merge.rc:5748
 msgid "Invalid property name"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_DIRECTIVE
-#: Merge.rc:5750
+#: Merge.rc:5749
 msgid "Invalid directive"
 msgstr ""
 
 #. IDS_FILTER_OP_EQUALS
-#: Merge.rc:5755
+#: Merge.rc:5754
 msgid "Equals"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_EQUALS
-#: Merge.rc:5756
+#: Merge.rc:5755
 msgid "Does not equal"
 msgstr ""
 
 #. IDS_FILTER_OP_LESS_THAN
-#: Merge.rc:5757
+#: Merge.rc:5756
 msgid "Less than"
 msgstr ""
 
 #. IDS_FILTER_OP_LESS_EQUAL
-#: Merge.rc:5758
+#: Merge.rc:5757
 msgid "Less than or equal to"
 msgstr ""
 
 #. IDS_FILTER_OP_GREATER_EQUAL
-#: Merge.rc:5759
+#: Merge.rc:5758
 msgid "Greater than or equal to"
 msgstr ""
 
 #. IDS_FILTER_OP_GREATER_THAN
-#: Merge.rc:5760
+#: Merge.rc:5759
 msgid "Greater than"
 msgstr ""
 
 #. IDS_FILTER_OP_BETWEEN
-#: Merge.rc:5761
+#: Merge.rc:5760
 msgid "Between"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_BETWEEN
-#: Merge.rc:5762
+#: Merge.rc:5761
 msgid "Not Between"
 msgstr ""
 
 #. IDS_FILTER_OP_CONTAINS
-#: Merge.rc:5763
+#: Merge.rc:5762
 msgid "Contains"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_CONTAINS
-#: Merge.rc:5764
+#: Merge.rc:5763
 msgid "Not Contains"
 msgstr ""
 
 #. IDS_FILTER_OP_RECONTAINS
-#: Merge.rc:5765
+#: Merge.rc:5764
 msgid "Contains (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_RECONTAINS
-#: Merge.rc:5766
+#: Merge.rc:5765
 msgid "Not Contains (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_LIKE
-#: Merge.rc:5767
+#: Merge.rc:5766
 msgid "Match (wildcard)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_LIKE
-#: Merge.rc:5768
+#: Merge.rc:5767
 msgid "Not match (wildcard)"
 msgstr ""
 
 #. IDS_FILTER_OP_MATCHES
-#: Merge.rc:5769
+#: Merge.rc:5768
 msgid "Match (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_MATCHES
-#: Merge.rc:5770
+#: Merge.rc:5769
 msgid "Not match (regex)"
 msgstr ""
 
 #. IDS_COLORMODE_LIGHT
-#: Merge.rc:5775
+#: Merge.rc:5774
 msgid "Light"
 msgstr ""
 
 #. IDS_COLORMODE_DARK
-#: Merge.rc:5776
+#: Merge.rc:5775
 msgid "Dark"
 msgstr ""
 
 #. IDS_COLORMODE_FOLLOWSYSTEM
-#: Merge.rc:5777
+#: Merge.rc:5776
 msgid "Follow system"
 msgstr ""
 
 #. IDS_EXAMPLE
-#: Merge.rc:5782
+#: Merge.rc:5781
 #, c-format
 msgid "e.g. %1"
 msgstr ""
 
 #. IDS_DETECTED_PREVIOUS_CRASH
-#: Merge.rc:5787
+#: Merge.rc:5786
 msgid "WinMerge detected a previous crash. Please report this if possible."
 msgstr ""
 
 #. IDS_REGEX_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5792
+#: Merge.rc:5791
 msgid "# Regex replacement list\r\n# Format: regex<TAB>replacement\r\n# Backreferences like $1, $2 are supported\r\n\r\n(\\d{4})-(\\d{2})-(\\d{2})\t$1_$2_$3\r\n"
 msgstr ""
 
 #. IDS_STRING_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5793
+#: Merge.rc:5792
 msgid "# Replacement list\r\n# Format: search<TAB>replacement\r\n# Lines starting with # are ignored\r\n\r\nfrom1\tto1\r\nfrom2\tto2\r\n"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_ONLY
-#: Merge.rc:5798
+#: Merge.rc:5797
 msgid "Built-in only"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_FIRST
-#: Merge.rc:5799
+#: Merge.rc:5798
 msgid "Built-in first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_FIRST
-#: Merge.rc:5800
+#: Merge.rc:5799
 msgid "Tree-sitter first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_ONLY
-#: Merge.rc:5801
+#: Merge.rc:5800
 msgid "Tree-sitter only"
 msgstr ""
 

--- a/Translations/WinMerge/Sinhala.po
+++ b/Translations/WinMerge/Sinhala.po
@@ -21,7 +21,7 @@ msgstr ""
 "X-Poedit-Country: SRI LANKA\n"
 
 #. LANGUAGE, SUBLANGUAGE
-#: Merge.rc:26 Merge.rc:59 Merge.rc:5818
+#: Merge.rc:26 Merge.rc:59 Merge.rc:5817
 #, c-format
 msgid "LANG_ENGLISH, SUBLANG_ENGLISH_US"
 msgstr "LANG_SINHALESE, SUBLANG_DEFAULT"
@@ -171,7 +171,7 @@ msgstr "&Scripts"
 #. IDS_NO_EDIT_SCRIPTS
 #: Merge.rc:127 Merge.rc:352 Merge.rc:463 Merge.rc:673 Merge.rc:678
 #: Merge.rc:887 Merge.rc:899 Merge.rc:906 Merge.rc:963 Merge.rc:1210
-#: Merge.rc:5375
+#: Merge.rc:5374
 #, c-format
 msgid "< Empty >"
 msgstr "< හිස් >"
@@ -238,7 +238,7 @@ msgid "Auto-Fit All Columns"
 msgstr ""
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN
-#: Merge.rc:153 Merge.rc:5646
+#: Merge.rc:153 Merge.rc:5645
 msgid "&Filter by This Column"
 msgstr ""
 
@@ -304,7 +304,7 @@ msgid "&Previous Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_NEXTPAGE
-#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5679
+#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5678
 #, c-format
 msgid "&Next Page"
 msgstr ""
@@ -572,7 +572,7 @@ msgstr ""
 #. IDS_IMAGE_MENU
 #: Merge.rc:329 Merge.rc:338 Merge.rc:432 Merge.rc:441 Merge.rc:609
 #: Merge.rc:618 Merge.rc:670 Merge.rc:960 Merge.rc:1187 Merge.rc:1200
-#: Merge.rc:5477
+#: Merge.rc:5476
 #, c-format
 msgid "&Image"
 msgstr ""
@@ -710,7 +710,7 @@ msgid "&Huge"
 msgstr ""
 
 #. IDS_VIEW_MENU_BAR
-#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5714
+#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5713
 msgid "Men&u Bar"
 msgstr ""
 
@@ -1473,7 +1473,7 @@ msgid "Lo&cation Pane"
 msgstr "Lo&cation Pane"
 
 #. IDS_OUTPUTBAR_CAPTION
-#: Merge.rc:782 Merge.rc:5252
+#: Merge.rc:782 Merge.rc:5251
 msgid "Output Pane"
 msgstr ""
 
@@ -1769,55 +1769,55 @@ msgid "Co&mpare As"
 msgstr ""
 
 #. IDS_COPY_LEFT_TO_MIDDLE2
-#: Merge.rc:968 Merge.rc:980 Merge.rc:4852
+#: Merge.rc:968 Merge.rc:980 Merge.rc:4851
 #, c-format
 msgid "Left to Middle (%1 of %2)"
 msgstr ""
 
 #. IDS_COPY_LEFT_TO_RIGHT2
-#: Merge.rc:969 Merge.rc:981 Merge.rc:4851
+#: Merge.rc:969 Merge.rc:981 Merge.rc:4850
 #, c-format
 msgid "Left to Right (%1 of %2)"
 msgstr "වමේ සිට දකුණට (%1 de %2)"
 
 #. IDS_MOVE_LEFT_TO2
-#: Merge.rc:970 Merge.rc:982 Merge.rc:1045 Merge.rc:4863 Merge.rc:4892
+#: Merge.rc:970 Merge.rc:982 Merge.rc:1045 Merge.rc:4862 Merge.rc:4891
 #, c-format
 msgid "Left to... (%1 of %2)"
 msgstr "වම ට... (%1 de %2)"
 
 #. IDS_COPY_MIDDLE_TO_LEFT2
-#: Merge.rc:971 Merge.rc:983 Merge.rc:4849
+#: Merge.rc:971 Merge.rc:983 Merge.rc:4848
 #, c-format
 msgid "Middle to Left (%1 of %2)"
 msgstr ""
 
 #. IDS_COPY_MIDDLE_TO_RIGHT2
-#: Merge.rc:972 Merge.rc:984 Merge.rc:4850
+#: Merge.rc:972 Merge.rc:984 Merge.rc:4849
 #, c-format
 msgid "Middle to Right (%1 of %2)"
 msgstr ""
 
 #. IDS_MOVE_MIDDLE_TO2
-#: Merge.rc:973 Merge.rc:985 Merge.rc:1046 Merge.rc:4864 Merge.rc:4893
+#: Merge.rc:973 Merge.rc:985 Merge.rc:1046 Merge.rc:4863 Merge.rc:4892
 #, c-format
 msgid "Middle to... (%1 of %2)"
 msgstr ""
 
 #. IDS_COPY_RIGHT_TO_MIDDLE2
-#: Merge.rc:974 Merge.rc:986 Merge.rc:4848
+#: Merge.rc:974 Merge.rc:986 Merge.rc:4847
 #, c-format
 msgid "Right to Middle (%1 of %2)"
 msgstr ""
 
 #. IDS_COPY_RIGHT_TO_LEFT2
-#: Merge.rc:975 Merge.rc:987 Merge.rc:4847
+#: Merge.rc:975 Merge.rc:987 Merge.rc:4846
 #, c-format
 msgid "Right to Left (%1 of %2)"
 msgstr "දකුණේ සිට වමට (%1 de %2)"
 
 #. IDS_MOVE_RIGHT_TO2
-#: Merge.rc:976 Merge.rc:988 Merge.rc:1047 Merge.rc:4865 Merge.rc:4894
+#: Merge.rc:976 Merge.rc:988 Merge.rc:1047 Merge.rc:4864 Merge.rc:4893
 #, c-format
 msgid "Right to... (%1 of %2)"
 msgstr "දකුණ ට ... (%1 de %2)"
@@ -1883,31 +1883,31 @@ msgid "Cop&y Paths"
 msgstr "Copier le c&hemin complet"
 
 #. IDS_DEL_LEFT_FMT2
-#: Merge.rc:1026 Merge.rc:1035 Merge.rc:4880
+#: Merge.rc:1026 Merge.rc:1035 Merge.rc:4879
 #, c-format
 msgid "Left (%1 of %2)"
 msgstr "වම (%1 de %2)"
 
 #. IDS_DEL_MIDDLE_FMT2
-#: Merge.rc:1027 Merge.rc:1036 Merge.rc:4881
+#: Merge.rc:1027 Merge.rc:1036 Merge.rc:4880
 #, c-format
 msgid "Middle (%1 of %2)"
 msgstr ""
 
 #. IDS_DEL_RIGHT_FMT2
-#: Merge.rc:1028 Merge.rc:1037 Merge.rc:4882
+#: Merge.rc:1028 Merge.rc:1037 Merge.rc:4881
 #, c-format
 msgid "Right (%1 of %2)"
 msgstr "දකුණ (%1 de %2)"
 
 #. IDS_DEL_BOTH_FMT2
-#: Merge.rc:1029 Merge.rc:1038 Merge.rc:4883
+#: Merge.rc:1029 Merge.rc:1038 Merge.rc:4882
 #, c-format
 msgid "Both (%1 of %2)"
 msgstr "දෙකම (%1 de %2)"
 
 #. IDS_DEL_ALL_FMT2
-#: Merge.rc:1030 Merge.rc:1039 Merge.rc:4888
+#: Merge.rc:1030 Merge.rc:1039 Merge.rc:4887
 #, c-format
 msgid "All (%1 of %2)"
 msgstr ""
@@ -1936,19 +1936,19 @@ msgid "&Zip"
 msgstr "&Zip"
 
 #. IDS_COPY_BOTH_TO2
-#: Merge.rc:1048 Merge.rc:4866
+#: Merge.rc:1048 Merge.rc:4865
 #, c-format
 msgid "Both to... (%1 of %2)"
 msgstr ""
 
 #. IDS_COPY_ALL_TO2
-#: Merge.rc:1049 Merge.rc:4867
+#: Merge.rc:1049 Merge.rc:4866
 #, c-format
 msgid "All to... (%1 of %2)"
 msgstr ""
 
 #. IDS_COPY_DIFFERENCES_TO2
-#: Merge.rc:1050 Merge.rc:4868
+#: Merge.rc:1050 Merge.rc:4867
 #, c-format
 msgid "Differences to... (%1 of %2)"
 msgstr ""
@@ -2021,13 +2021,13 @@ msgstr ""
 
 #. IDS_USERCHOICE_NONE
 #: Merge.rc:1088 Merge.rc:1094 Merge.rc:1836 Merge.rc:1840 Merge.rc:2031
-#: Merge.rc:2035 Merge.rc:5377
+#: Merge.rc:2035 Merge.rc:5376
 #, c-format
 msgid "<None>"
 msgstr "<None>"
 
 #. IDS_USERCHOICE_AUTOMATIC
-#: Merge.rc:1089 Merge.rc:1095 Merge.rc:5378
+#: Merge.rc:1089 Merge.rc:1095 Merge.rc:5377
 #, c-format
 msgid "<Automatic>"
 msgstr "<Automatic>"
@@ -2979,13 +2979,13 @@ msgid "Text files only"
 msgstr ""
 
 #. IDS_EOL_NONE
-#: Merge.rc:1667 Merge.rc:1918 Merge.rc:5304
+#: Merge.rc:1667 Merge.rc:1918 Merge.rc:5303
 #, c-format
 msgid "None"
 msgstr "None"
 
 #. IDS_EOL_MIXED
-#: Merge.rc:1668 Merge.rc:5299
+#: Merge.rc:1668 Merge.rc:5298
 #, c-format
 msgid "Mixed"
 msgstr "Mixed"
@@ -3259,14 +3259,14 @@ msgstr ""
 
 #. IDS_DIFFERENT
 #: Merge.rc:1904 Merge.rc:1988 Merge.rc:2866 Merge.rc:3036 Merge.rc:3077
-#: Merge.rc:5058
+#: Merge.rc:5057
 #, c-format
 msgid "Different"
 msgstr "වෙනස්"
 
 #. IDS_IDENTICAL
 #: Merge.rc:1905 Merge.rc:1989 Merge.rc:2865 Merge.rc:3055 Merge.rc:3116
-#: Merge.rc:5048
+#: Merge.rc:5047
 #, c-format
 msgid "Identical"
 msgstr "සර්වසම"
@@ -3287,7 +3287,7 @@ msgid "Missing"
 msgstr ""
 
 #. IDS_MOVED
-#: Merge.rc:1910 Merge.rc:5076
+#: Merge.rc:1910 Merge.rc:5075
 msgid "Moved"
 msgstr ""
 
@@ -4115,7 +4115,7 @@ msgid "&Use custom system colors"
 msgstr ""
 
 #. IDS_PRPCAT_SYSTEM
-#: Merge.rc:2565 Merge.rc:4559 Merge.rc:4560 Merge.rc:5007
+#: Merge.rc:2565 Merge.rc:4559 Merge.rc:4560 Merge.rc:5006
 #, c-format
 msgid "System"
 msgstr "පද්ධතිය"
@@ -4566,7 +4566,7 @@ msgid "Items compared:"
 msgstr "සැසඳූ අයිතම:"
 
 #. IDS_PREVIEWBAR_CLOSE
-#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5685
+#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5684
 #, c-format
 msgid "&Close"
 msgstr "වසන්න"
@@ -5251,7 +5251,7 @@ msgid "A&ppend timestamp"
 msgstr "A&ppend timestamp"
 
 #. IDS_CONFIRM_COPY_CAPTION
-#: Merge.rc:3214 Merge.rc:4915
+#: Merge.rc:3214 Merge.rc:4914
 #, c-format
 msgid "Confirm Copy"
 msgstr "පිටපත ස්ථිර් කිරීම"
@@ -5512,7 +5512,7 @@ msgid "&Character Set..."
 msgstr ""
 
 #. IDS_PRPCAT_IMAGE
-#: Merge.rc:3351 Merge.rc:4574 Merge.rc:5015
+#: Merge.rc:3351 Merge.rc:4574 Merge.rc:5014
 msgid "Image"
 msgstr ""
 
@@ -5916,7 +5916,7 @@ msgid "Project"
 msgstr ""
 
 #. IDS_COLHDR_NSDIFFS
-#: Merge.rc:4566 Merge.rc:4990
+#: Merge.rc:4566 Merge.rc:4989
 #, c-format
 msgid "Differences"
 msgstr "වෙනස්කම්"
@@ -6076,13 +6076,13 @@ msgid "File Type"
 msgstr ""
 
 #. IDS_COLHDR_EXTENSION
-#: Merge.rc:4653 Merge.rc:4947
+#: Merge.rc:4653 Merge.rc:4946
 #, c-format
 msgid "Extension"
 msgstr "දිගුව"
 
 #. IDS_PRPCAT_MESSAGE
-#: Merge.rc:4659 Merge.rc:5019
+#: Merge.rc:4659 Merge.rc:5018
 msgid "Message"
 msgstr ""
 
@@ -6122,7 +6122,7 @@ msgid "Hidden Items"
 msgstr ""
 
 #. IDS_PLUGINSLIST_NAME
-#: Merge.rc:4680 Merge.rc:5311
+#: Merge.rc:4680 Merge.rc:5310
 #, c-format
 msgid "Name"
 msgstr "නම"
@@ -6146,7 +6146,7 @@ msgid "[F] "
 msgstr "[F] "
 
 #. IDS_PLUGINSLIST_DESC
-#: Merge.rc:4684 Merge.rc:5313
+#: Merge.rc:4684 Merge.rc:5312
 #, c-format
 msgid "Description"
 msgstr "විස්තරය"
@@ -6315,171 +6315,165 @@ msgstr "Ln: %s  Col: %d/%d  Ch: %d/%d"
 msgid "  Sel: %d | %d"
 msgstr ""
 
-#. IDS_MERGEMODE_MERGING
-#: Merge.rc:4734
-#, c-format
-msgid "Merge"
-msgstr "මුසු කරන්න"
-
 #. IDS_DIFF_NUMBER_STATUS_FMT
-#: Merge.rc:4735
+#: Merge.rc:4734
 #, c-format
 msgid "Difference %1 of %2"
 msgstr "වෙනස  %1 ගෙන්  %2"
 
 #. IDS_NO_DIFF_SEL_FMT
-#: Merge.rc:4736
+#: Merge.rc:4735
 #, c-format
 msgid "%1 Differences Found"
 msgstr "%1 වෙනස්කම් සොයාගත්තා"
 
 #. IDS_1_DIFF_FOUND
-#: Merge.rc:4737
+#: Merge.rc:4736
 #, c-format
 msgid "1 Difference Found"
 msgstr "1 වෙනස්කම සොයා ගත්තා"
 
 #. IDS_NO_ERR_SEL_FMT
-#: Merge.rc:4738
+#: Merge.rc:4737
 #, c-format
 msgid "%1 Errors Found"
 msgstr ""
 
 #. IDS_1_ERR_FOUND
-#: Merge.rc:4739
+#: Merge.rc:4738
 msgid "1 Error Found"
 msgstr ""
 
 #. IDS_STATUSBAR_READONLY, Abbreviation from "Read Only"
-#: Merge.rc:4740
+#: Merge.rc:4739
 #, c-format
 msgid "RO"
 msgstr "RO"
 
 #. IDS_DIRVIEW_STATUS_FMT_FOCUS
-#: Merge.rc:4746
+#: Merge.rc:4745
 #, c-format
 msgid "Item %1 of %2"
 msgstr "අයිතමය %1 ගෙන් %2"
 
 #. IDS_DIRVIEW_STATUS_FMT_NOFOCUS
-#: Merge.rc:4747
+#: Merge.rc:4746
 #, c-format
 msgid "Items: %1"
 msgstr "අයිතම : %1"
 
 #. IDS_DIRVIEW_STATUS_COMPARING
-#: Merge.rc:4748
+#: Merge.rc:4747
 #, c-format
 msgid "Comparing items..."
 msgstr "අයිතම සැසඳීම..."
 
 #. IDS_ITEMS_PER_SEC
-#: Merge.rc:4749
+#: Merge.rc:4748
 #, c-format
 msgid "%.1f[items/sec]"
 msgstr ""
 
 #. IDS_ERROR_INCOMPARABLE
-#: Merge.rc:4755
+#: Merge.rc:4754
 msgid "Select two existing folders/files to compare."
 msgstr "සංසන්දනය කිරීම සඳහා පවතින ෆෝල්ඩර හෝ ලිපිගොනු දෙකක් තෝරන්න !"
 
 #. IDS_DIRSEL_TAG
-#: Merge.rc:4756
+#: Merge.rc:4755
 #, c-format
 msgid "Folder Selection"
 msgstr "ෆෝල්ඩර තේරීම"
 
 #. IDS_OPEN_FILESDIRS
-#: Merge.rc:4757
+#: Merge.rc:4756
 #, c-format
 msgid "Select two (or three) folders/files to compare."
 msgstr ""
 
 #. IDS_OPEN_LEFTINVALID
-#: Merge.rc:4758
+#: Merge.rc:4757
 #, c-format
 msgid "Left (1st) path is invalid!"
 msgstr ""
 
 #. IDS_OPEN_MIDDLEINVALID
-#: Merge.rc:4759
+#: Merge.rc:4758
 #, c-format
 msgid "Middle (2nd) path is invalid!"
 msgstr ""
 
 #. IDS_OPEN_RIGHTINVALID2
-#: Merge.rc:4760
+#: Merge.rc:4759
 #, c-format
 msgid "Right (2nd) path is invalid!"
 msgstr ""
 
 #. IDS_OPEN_RIGHTINVALID3
-#: Merge.rc:4761
+#: Merge.rc:4760
 #, c-format
 msgid "Right (3rd) path is invalid!"
 msgstr ""
 
 #. IDS_OPEN_BOTHINVALID
-#: Merge.rc:4762
+#: Merge.rc:4761
 #, c-format
 msgid "Both paths are invalid!"
 msgstr "පෙත් දෙකම අවලංගුය !"
 
-#: Merge.rc:4764
+#: Merge.rc:4763
 #, c-format
 msgid "Left (1st) and Middle (2nd) paths are invalid!"
 msgstr ""
 
 #. IDS_OPEN_LEFTRIGHTINVALID
-#: Merge.rc:4765
+#: Merge.rc:4764
 #, c-format
 msgid "Left (1st) and Right (3rd) paths are invalid!"
 msgstr ""
 
-#: Merge.rc:4767
+#: Merge.rc:4766
 #, c-format
 msgid "Middle (2nd) and Right (3rd) paths are invalid!"
 msgstr ""
 
 #. IDS_OPEN_ALLINVALID
-#: Merge.rc:4768
+#: Merge.rc:4767
 #, c-format
 msgid "All paths are invalid!"
 msgstr ""
 
 #. IDS_OPEN_UNPACKERDISABLED
-#: Merge.rc:4769
+#: Merge.rc:4768
 msgid "Only enabled for file comparisons"
 msgstr ""
 
 #. IDS_OPEN_MISMATCH
-#: Merge.rc:4770
+#: Merge.rc:4769
 #, c-format
 msgid "Cannot compare file and folder!"
 msgstr "ලිපිගොනුවක් සහ ෆෝල්ඩරයක් සංසන්දනය කල නොහැකිය !"
 
 #. IDS_ERROR_FILE_NOT_FOUND
-#: Merge.rc:4776
+#: Merge.rc:4775
 #, c-format
 msgid "File not found: %1"
 msgstr "ලිපිගොනුව සොයාගෙන නැත: %1 "
 
 #. IDS_ERROR_FOLDER_NOT_FOUND
-#: Merge.rc:4777
+#: Merge.rc:4776
 #, c-format
 msgid "Folder not found: %1"
 msgstr ""
 
 #. IDS_ERROR_FILE_NOT_UNPACKED
-#: Merge.rc:4778
+#: Merge.rc:4777
 #, c-format
 msgid "File not unpacked: %1"
 msgstr "ලිපිගොනුව ගලවා නැත : %1"
 
 #. IDS_ERROR_FILEOPEN
-#: Merge.rc:4779
+#: Merge.rc:4778
 #, c-format
 msgid ""
 "Cannot open file\n"
@@ -6493,13 +6487,13 @@ msgstr ""
 "%2"
 
 #. IDS_ERROR_CONF_RESOLVE
-#: Merge.rc:4780
+#: Merge.rc:4779
 #, c-format
 msgid "Failed to parse conflict file."
 msgstr "ලිපිගොනුව ව්‍යාකරණ විග්‍රහය හා ගැටීමට අසමත්ය."
 
 #. IDS_NOT_CONFLICT_FILE
-#: Merge.rc:4781
+#: Merge.rc:4780
 #, c-format
 msgid "The file\n%1\nis not a conflict file."
 msgstr ""
@@ -6508,35 +6502,35 @@ msgstr ""
 "ගැටුම ලිපිගොනුව නොවේ."
 
 #. IDS_COMPARE_LARGE_FILES
-#: Merge.rc:4782
+#: Merge.rc:4781
 msgid "Comparing large files requires significant memory.\nShow only comparison results (not file contents)?"
 msgstr ""
 
 #. IDS_SAVE_AS_TITLE
-#: Merge.rc:4788
+#: Merge.rc:4787
 #, c-format
 msgid "Save As"
 msgstr "මෙසේ සුරකින්න"
 
 #. IDS_SAVE_FMT
-#: Merge.rc:4789
+#: Merge.rc:4788
 #, c-format
 msgid "Save changes to %1?"
 msgstr "වෙනස් කිරීම් සුරකින්න %1 ?"
 
 #. IDS_SAVEREADONLY_FMT
-#: Merge.rc:4790
+#: Merge.rc:4789
 #, c-format
 msgid "%1 is read-only. Override? Or 'No' to save as new filename?"
 msgstr ""
 
 #. IDS_ERROR_BACKUP
-#: Merge.rc:4791
+#: Merge.rc:4790
 #, fuzzy, c-format
 msgid "Error backing up file"
 msgstr "Erreur lors du backup du fichier"
 
-#: Merge.rc:4793
+#: Merge.rc:4792
 #, c-format
 msgid ""
 "Unable to backup original file:\n"
@@ -6550,7 +6544,7 @@ msgstr ""
 "කෙසේ හෝ කරයිද?"
 
 #. IDS_FILESAVE_FAILED
-#: Merge.rc:4794
+#: Merge.rc:4793
 #, c-format
 msgid "Saving file failed.\n%1\n%2\n\t- Use different filename (OK)\n\t- Abort (Cancel)?"
 msgstr ""
@@ -6561,7 +6555,7 @@ msgstr ""
 "\t- වෙනස් නමක් ගොනුවට භාවිතා කිරීමට(Press OK)\n"
 "\t- දැන් ක්‍රියත්මක වන ක්‍රියාව නැවත් වීමට?  (Press Cancel)?"
 
-#: Merge.rc:4796
+#: Merge.rc:4795
 #, c-format
 msgid "Plugin '%2' cannot pack changes to left file into '%1'.\n\nOriginal unchanged. Save unpacked version?"
 msgstr ""
@@ -6571,12 +6565,12 @@ msgstr ""
 "\n"
 "Do you want to save the unpacked version to another file?"
 
-#: Merge.rc:4798
+#: Merge.rc:4797
 #, c-format
 msgid "Plugin '%2' cannot pack changes to middle file into '%1'.\n\nOriginal unchanged. Save unpacked version?"
 msgstr ""
 
-#: Merge.rc:4800
+#: Merge.rc:4799
 #, c-format
 msgid "Plugin '%2' cannot pack changes to right file into '%1'.\n\nOriginal unchanged. Save unpacked version?"
 msgstr ""
@@ -6587,7 +6581,7 @@ msgstr ""
 "Do you want to save the unpacked version to another file?"
 
 #. IDS_FILECHANGED_ONDISK
-#: Merge.rc:4801
+#: Merge.rc:4800
 #, c-format
 msgid ""
 "Another application updated\n"
@@ -6603,7 +6597,7 @@ msgstr ""
 "Overwrite?"
 
 #. IDS_SAVEREADONLY_MULTI
-#: Merge.rc:4802
+#: Merge.rc:4801
 #, c-format
 msgid ""
 "%1\n"
@@ -6613,7 +6607,7 @@ msgstr ""
 "is read-only. Override?"
 
 #. IDS_FILECHANGED_RESCAN
-#: Merge.rc:4803
+#: Merge.rc:4802
 #, c-format
 msgid "Another application updated\n%1\nsince last scan.\n\nReload?"
 msgstr ""
@@ -6624,25 +6618,25 @@ msgstr ""
 "Reload?"
 
 #. IDS_SAVE_LEFT_AS
-#: Merge.rc:4804
+#: Merge.rc:4803
 #, c-format
 msgid "Save Left File As"
 msgstr "වම්  පස ගොනුව මෙලස සුරක්ෂිත කරන්න"
 
 #. IDS_SAVE_MIDDLE_AS
-#: Merge.rc:4805
+#: Merge.rc:4804
 #, c-format
 msgid "Save Middle File As"
 msgstr ""
 
 #. IDS_SAVE_RIGHT_AS
-#: Merge.rc:4806
+#: Merge.rc:4805
 #, c-format
 msgid "Save Right File As"
 msgstr "දකුණු පස ගොනුව මෙලස සුරක්ෂිත කරන්න"
 
 #. IDS_FILE_DISAPPEARED
-#: Merge.rc:4811
+#: Merge.rc:4810
 #, c-format
 msgid ""
 "File\n"
@@ -6654,7 +6648,7 @@ msgstr ""
 "නොපෙනී ගොස් ඇත.ඉදිරියට යෑමට අනුපිටපතක් සුරක්ෂිත කරන්න."
 
 #. IDS_VIEWS_OUTOFSYNC
-#: Merge.rc:4817
+#: Merge.rc:4816
 #, c-format
 msgid ""
 "Cannot merge unsynched documents.\n"
@@ -6666,189 +6660,189 @@ msgstr ""
 "Refresh before continuing."
 
 #. IDS_BREAK_ON_WHITESPACE
-#: Merge.rc:4822
+#: Merge.rc:4821
 msgid "Break at whitespace"
 msgstr "Break at whitespace"
 
 #. IDS_BREAK_ON_PUNCTUATION
-#: Merge.rc:4823
+#: Merge.rc:4822
 msgid "Break at whitespace or punctuation"
 msgstr "Break at whitespace or punctuation"
 
 #. IDS_L2M
-#: Merge.rc:4829
+#: Merge.rc:4828
 msgid "Copy to &Middle\tAlt+Right"
 msgstr ""
 
 #. IDS_R2M
-#: Merge.rc:4830
+#: Merge.rc:4829
 msgid "Copy to &Middle\tAlt+Left"
 msgstr ""
 
 #. IDS_COPY_FROM_MIDDLE_R
-#: Merge.rc:4831
+#: Merge.rc:4830
 msgid "Copy from Middle\tAlt+Shift+Right"
 msgstr ""
 
 #. IDS_COPY_FROM_MIDDLE_L
-#: Merge.rc:4832
+#: Merge.rc:4831
 msgid "Copy from Middle\tAlt+Shift+Left"
 msgstr ""
 
 #. IDS_L2MNEXT
-#: Merge.rc:4833
+#: Merge.rc:4832
 msgid "Copy to Middle and Advance\tCtrl+Alt+Right"
 msgstr ""
 
 #. IDS_R2MNEXT
-#: Merge.rc:4834
+#: Merge.rc:4833
 msgid "Copy to Middle and Advance\tCtrl+Alt+Left"
 msgstr ""
 
 #. IDS_ALL_MIDDLE
-#: Merge.rc:4835
+#: Merge.rc:4834
 msgid "Copy All to Middle"
 msgstr ""
 
 #. IDS_COPY_RIGHT_TO_LEFT
-#: Merge.rc:4841
+#: Merge.rc:4840
 #, c-format
 msgid "Right to Left (%1)"
 msgstr "දකුණේ සිට වමට  (%1)"
 
 #. IDS_COPY_RIGHT_TO_MIDDLE
-#: Merge.rc:4842
+#: Merge.rc:4841
 #, c-format
 msgid "Right to Middle (%1)"
 msgstr ""
 
 #. IDS_COPY_MIDDLE_TO_LEFT
-#: Merge.rc:4843
+#: Merge.rc:4842
 #, c-format
 msgid "Middle to Left (%1)"
 msgstr ""
 
 #. IDS_COPY_MIDDLE_TO_RIGHT
-#: Merge.rc:4844
+#: Merge.rc:4843
 #, c-format
 msgid "Middle to Right (%1)"
 msgstr ""
 
 #. IDS_COPY_LEFT_TO_RIGHT
-#: Merge.rc:4845
+#: Merge.rc:4844
 #, c-format
 msgid "Left to Right (%1)"
 msgstr "වමේ සිට දකුණට  (%1)"
 
 #. IDS_COPY_LEFT_TO_MIDDLE
-#: Merge.rc:4846
+#: Merge.rc:4845
 #, c-format
 msgid "Left to Middle (%1)"
 msgstr ""
 
 #. IDS_MOVE_LEFT_TO
-#: Merge.rc:4857 Merge.rc:4889
+#: Merge.rc:4856 Merge.rc:4888
 #, c-format
 msgid "Left to... (%1)"
 msgstr "වම ට.... (%1)"
 
 #. IDS_MOVE_MIDDLE_TO
-#: Merge.rc:4858 Merge.rc:4890
+#: Merge.rc:4857 Merge.rc:4889
 #, c-format
 msgid "Middle to... (%1)"
 msgstr ""
 
 #. IDS_MOVE_RIGHT_TO
-#: Merge.rc:4859 Merge.rc:4891
+#: Merge.rc:4858 Merge.rc:4890
 #, c-format
 msgid "Right to... (%1)"
 msgstr "දකුණ ට... (%1)"
 
 #. IDS_COPY_BOTH_TO
-#: Merge.rc:4860
+#: Merge.rc:4859
 #, c-format
 msgid "Both to... (%1)"
 msgstr ""
 
 #. IDS_COPY_ALL_TO
-#: Merge.rc:4861
+#: Merge.rc:4860
 #, c-format
 msgid "All to... (%1)"
 msgstr ""
 
 #. IDS_COPY_DIFFERENCES_TO
-#: Merge.rc:4862
+#: Merge.rc:4861
 #, c-format
 msgid "Differences to... (%1)"
 msgstr ""
 
 #. IDS_ONLYDIFFITEMS_CONFIRM
-#: Merge.rc:4869
+#: Merge.rc:4868
 msgid "Some selected items are identical or skipped.\nProcess only items with differences?"
 msgstr ""
 
 #. IDS_DEL_LEFT_FMT
-#: Merge.rc:4875
+#: Merge.rc:4874
 #, c-format
 msgid "Left (%1)"
 msgstr "වම (%1)"
 
 #. IDS_DEL_MIDDLE_FMT
-#: Merge.rc:4876
+#: Merge.rc:4875
 #, c-format
 msgid "Middle (%1)"
 msgstr ""
 
 #. IDS_DEL_RIGHT_FMT
-#: Merge.rc:4877
+#: Merge.rc:4876
 #, c-format
 msgid "Right (%1)"
 msgstr "දකුණ  (%1)"
 
 #. IDS_DEL_BOTH_FMT
-#: Merge.rc:4878
+#: Merge.rc:4877
 #, c-format
 msgid "Both (%1)"
 msgstr "දෙකම (%1)"
 
 #. IDS_DEL_ALL_FMT
-#: Merge.rc:4879
+#: Merge.rc:4878
 #, c-format
 msgid "All (%1)"
 msgstr ""
 
 #. IDS_SELECT_DEST_LEFT
-#: Merge.rc:4895
+#: Merge.rc:4894
 #, c-format
 msgid "Left Side - Select Destination Folder:"
 msgstr "Left Side - Select Destination Folder:"
 
 #. IDS_SELECT_DEST_MIDDLE
-#: Merge.rc:4896
+#: Merge.rc:4895
 #, c-format
 msgid "Middle Side - Select Destination Folder:"
 msgstr ""
 
 #. IDS_SELECT_DEST_RIGHT
-#: Merge.rc:4897
+#: Merge.rc:4896
 #, c-format
 msgid "Right Side - Select Destination Folder:"
 msgstr "Right Side - Select Destination Folder:"
 
 #. IDS_FILES_AFFECTED_FMT
-#: Merge.rc:4898
+#: Merge.rc:4897
 #, c-format
 msgid "(%1 Files Affected)"
 msgstr "(%1 Files Affected)"
 
 #. IDS_FILES_AFFECTED_FMT2
-#: Merge.rc:4899
+#: Merge.rc:4898
 #, c-format
 msgid "(%1 of %2 Files Affected)"
 msgstr "(%1 of %2 Files Affected)"
 
 #. IDS_CONFIRM_DELETE_SINGLE
-#: Merge.rc:4905
+#: Merge.rc:4904
 #, c-format
 msgid ""
 "Are you sure you want to delete\n"
@@ -6860,18 +6854,18 @@ msgstr ""
 "%1 ?"
 
 #. IDS_CONFIRM_SINGLE_COPY
-#: Merge.rc:4906
+#: Merge.rc:4905
 msgid "Are you sure you want to copy?"
 msgstr ""
 
 #. IDS_CONFIRM_MULTIPLE_COPY
-#: Merge.rc:4907
+#: Merge.rc:4906
 #, c-format
 msgid "Are you sure you want to copy %d items?"
 msgstr ""
 
 #. IDS_DIRCMP_NOTSYNC
-#: Merge.rc:4908
+#: Merge.rc:4907
 #, c-format
 msgid ""
 "Operation aborted!\n"
@@ -6891,873 +6885,873 @@ msgstr ""
 "Refresh the compare."
 
 #. IDS_CONFIRM_SINGLE_MOVE
-#: Merge.rc:4913
+#: Merge.rc:4912
 msgid "Are you sure you want to move?"
 msgstr ""
 
 #. IDS_CONFIRM_MULTIPLE_MOVE
-#: Merge.rc:4914
+#: Merge.rc:4913
 #, c-format
 msgid "Are you sure you want to move %d items?"
 msgstr ""
 
 #. IDS_CONFIRM_MOVE_CAPTION
-#: Merge.rc:4916
+#: Merge.rc:4915
 #, c-format
 msgid "Confirm Move"
 msgstr "ගෙන යෑම තහවුරු කරන්න"
 
-#: Merge.rc:4918
+#: Merge.rc:4917
 #, c-format
 msgid "Close the folder comparison window?"
 msgstr ""
 
-#: Merge.rc:4920
+#: Merge.rc:4919
 msgid "Close the folder comparison window, which took a long time?"
 msgstr ""
 
 #. IDS_ERROR_INVALID_DIR_FILE_NAME
-#: Merge.rc:4921
+#: Merge.rc:4920
 msgid "The file or folder name is invalid."
 msgstr ""
 
 #. IDS_ERROR_EXECUTE_FILE
-#: Merge.rc:4927
+#: Merge.rc:4926
 #, c-format
 msgid "Failed to execute external editor: %1"
 msgstr "Failed to execute external editor: %1"
 
 #. IDS_UNKNOWN_ARCHIVE_FORMAT
-#: Merge.rc:4933
+#: Merge.rc:4932
 #, c-format
 msgid "Unknown archive format"
 msgstr "Unknown archive format"
 
-#: Merge.rc:4935
+#: Merge.rc:4934
 msgid "Failed to extract archive.\nCompare as text file?"
 msgstr ""
 
 #. IDS_COLHDR_FILENAME
-#: Merge.rc:4941
+#: Merge.rc:4940
 #, c-format
 msgid "Filename"
 msgstr "ලිපිගොනුවේ නම"
 
 #. IDS_COLHDR_DIR
-#: Merge.rc:4942
+#: Merge.rc:4941
 msgctxt "DirView|ColumnHeader"
 msgid "Folder"
 msgstr "ෆෝල්ඩර"
 
 #. IDS_COLHDR_RESULT
-#: Merge.rc:4943
+#: Merge.rc:4942
 #, c-format
 msgid "Comparison Result"
 msgstr "සංසන්දන ප්‍රතිඵල"
 
 #. IDS_COLHDR_LTIMEM
-#: Merge.rc:4944
+#: Merge.rc:4943
 #, c-format
 msgid "Left Date"
 msgstr "වම් දිනය"
 
 #. IDS_COLHDR_RTIMEM
-#: Merge.rc:4945
+#: Merge.rc:4944
 #, c-format
 msgid "Right Date"
 msgstr "දකුණු දිනය"
 
 #. IDS_COLHDR_MTIMEM
-#: Merge.rc:4946
+#: Merge.rc:4945
 #, c-format
 msgid "Middle Date"
 msgstr ""
 
 #. IDS_COLHDR_LSIZE
-#: Merge.rc:4948
+#: Merge.rc:4947
 #, c-format
 msgid "Left Size"
 msgstr "වම් ප්‍රමාණය"
 
 #. IDS_COLHDR_RSIZE
-#: Merge.rc:4949
+#: Merge.rc:4948
 #, c-format
 msgid "Right Size"
 msgstr "දකුණු ප්‍රමාණය"
 
 #. IDS_COLHDR_MSIZE
-#: Merge.rc:4954
+#: Merge.rc:4953
 #, c-format
 msgid "Middle Size"
 msgstr ""
 
 #. IDS_COLHDR_RSIZE_SHORT
-#: Merge.rc:4955
+#: Merge.rc:4954
 #, c-format
 msgid "Right Size (Short)"
 msgstr "දකුණු ප්‍රමාණය(කෙටි)"
 
 #. IDS_COLHDR_LSIZE_SHORT
-#: Merge.rc:4956
+#: Merge.rc:4955
 #, c-format
 msgid "Left Size (Short)"
 msgstr "වම් ප්‍රමාණය (කෙටි)"
 
 #. IDS_COLHDR_MSIZE_SHORT
-#: Merge.rc:4957
+#: Merge.rc:4956
 #, c-format
 msgid "Middle Size (Short)"
 msgstr ""
 
 #. IDS_COLHDR_LTIMEC
-#: Merge.rc:4963
+#: Merge.rc:4962
 #, c-format
 msgid "Left Creation Time"
 msgstr "වම් නිර්මාණකරන වේලාව"
 
 #. IDS_COLHDR_RTIMEC
-#: Merge.rc:4964
+#: Merge.rc:4963
 #, c-format
 msgid "Right Creation Time"
 msgstr "දකුණු නිර්මාණකරන වේලාව"
 
 #. IDS_COLHDR_MTIMEC
-#: Merge.rc:4965
+#: Merge.rc:4964
 #, c-format
 msgid "Middle Creation Time"
 msgstr ""
 
 #. IDS_COLHDR_NEWER
-#: Merge.rc:4966
+#: Merge.rc:4965
 #, c-format
 msgid "Newer File"
 msgstr "අළුත්ම ගොනුව"
 
 #. IDS_COLHDR_LVERSION
-#: Merge.rc:4967
+#: Merge.rc:4966
 #, c-format
 msgid "Left File Version"
 msgstr "වම් ලිපිගොනු අනුවාදය"
 
 #. IDS_COLHDR_RVERSION
-#: Merge.rc:4968
+#: Merge.rc:4967
 #, c-format
 msgid "Right File Version"
 msgstr "දකුණු ලිපිගොනු අනුවාදය"
 
 #. IDS_COLHDR_MVERSION
-#: Merge.rc:4969
+#: Merge.rc:4968
 #, c-format
 msgid "Middle File Version"
 msgstr ""
 
 #. IDS_COLHDR_RESULT_ABBR
-#: Merge.rc:4970
+#: Merge.rc:4969
 #, c-format
 msgid "Short Result"
 msgstr "කෙටි ප්‍රතිඵලය"
 
 #. IDS_COLHDR_LATTRIBUTES
-#: Merge.rc:4971
+#: Merge.rc:4970
 #, c-format
 msgid "Left Attributes"
 msgstr "වම් උපලක්ෂණ"
 
 #. IDS_COLHDR_RATTRIBUTES
-#: Merge.rc:4972
+#: Merge.rc:4971
 #, c-format
 msgid "Right Attributes"
 msgstr "දකුණු උපලක්ෂණ"
 
 #. IDS_COLHDR_MATTRIBUTES
-#: Merge.rc:4973
+#: Merge.rc:4972
 #, c-format
 msgid "Middle Attributes"
 msgstr ""
 
 #. IDS_COLHDR_LEOL_TYPE
-#: Merge.rc:4978
+#: Merge.rc:4977
 #, c-format
 msgid "Left EOL"
 msgstr "වම් EOL"
 
 #. IDS_COLHDR_MEOL_TYPE
-#: Merge.rc:4979
+#: Merge.rc:4978
 #, c-format
 msgid "Middle EOL"
 msgstr ""
 
 #. IDS_COLHDR_REOL_TYPE
-#: Merge.rc:4980
+#: Merge.rc:4979
 #, c-format
 msgid "Right EOL"
 msgstr "දකුණු EOL"
 
 #. IDS_COLHDR_LENCODING
-#: Merge.rc:4986
+#: Merge.rc:4985
 #, c-format
 msgid "Left Encoding"
 msgstr "වම් කේතනය"
 
 #. IDS_COLHDR_RENCODING
-#: Merge.rc:4987
+#: Merge.rc:4986
 #, c-format
 msgid "Right Encoding"
 msgstr "දකුණු කේතනය"
 
 #. IDS_COLHDR_MENCODING
-#: Merge.rc:4988
+#: Merge.rc:4987
 #, c-format
 msgid "Middle Encoding"
 msgstr ""
 
 #. IDS_COLHDR_NIDIFFS
-#: Merge.rc:4989
+#: Merge.rc:4988
 msgid "Ignored Diff"
 msgstr "වෙනස්කම් නොසලකා හැරියා"
 
 #. IDS_COLHDR_BINARY
-#: Merge.rc:4991
+#: Merge.rc:4990
 msgctxt "DirView|ColumnHeader"
 msgid "Binary"
 msgstr "ද්වීමය "
 
 #. IDS_PLUGINS_TYPE_UNPACKER
-#: Merge.rc:4992 Merge.rc:5314
+#: Merge.rc:4991 Merge.rc:5313
 #, fuzzy, c-format
 msgid "Unpacker"
 msgstr "Unpacker"
 
 #. IDS_PLUGIN_TYPE4
-#: Merge.rc:4993 Merge.rc:5315 Merge.rc:5622
+#: Merge.rc:4992 Merge.rc:5314 Merge.rc:5621
 #, fuzzy, c-format
 msgid "Prediffer"
 msgstr "Prediffer"
 
 #. IDS_COLHDR_LEFT
-#: Merge.rc:4994
+#: Merge.rc:4993
 msgid "Left"
 msgstr ""
 
 #. IDS_COLHDR_MIDDLE
-#: Merge.rc:4995
+#: Merge.rc:4994
 msgid "Middle"
 msgstr ""
 
 #. IDS_COLHDR_RIGHT
-#: Merge.rc:4996
+#: Merge.rc:4995
 msgid "Right"
 msgstr ""
 
 #. IDS_COLHDR_DIFF
-#: Merge.rc:4997
+#: Merge.rc:4996
 msgid "Diff"
 msgstr ""
 
 #. IDS_COLHDR_LEFT_DUPLICATE
-#: Merge.rc:4998
+#: Merge.rc:4997
 msgid "Left Duplicate Count"
 msgstr ""
 
 #. IDS_COLHDR_RIGHT_DUPLICATE
-#: Merge.rc:4999
+#: Merge.rc:4998
 msgid "Right Duplicate Count"
 msgstr ""
 
 #. IDS_COLHDR_MIDDLE_DUPLICATE
-#: Merge.rc:5000
+#: Merge.rc:4999
 msgid "Middle Duplicate Count"
 msgstr ""
 
 #. IDS_COLHDR_MOVE
-#: Merge.rc:5001
+#: Merge.rc:5000
 msgid "Move"
 msgstr ""
 
 #. IDS_PRPCAT_AUDIO
-#: Merge.rc:5008
+#: Merge.rc:5007
 msgid "Audio"
 msgstr ""
 
 #. IDS_PRPCAT_CALENDAR
-#: Merge.rc:5009
+#: Merge.rc:5008
 msgid "Calendar"
 msgstr ""
 
 #. IDS_PRPCAT_COMMUNICATION
-#: Merge.rc:5010
+#: Merge.rc:5009
 msgid "Communication"
 msgstr ""
 
 #. IDS_PRPCAT_CONTACT
-#: Merge.rc:5011
+#: Merge.rc:5010
 msgid "Contact"
 msgstr ""
 
 #. IDS_PRPCAT_DEVICES
-#: Merge.rc:5012
+#: Merge.rc:5011
 msgid "Devices"
 msgstr ""
 
 #. IDS_PRPCAT_DOCUMENT
-#: Merge.rc:5013
+#: Merge.rc:5012
 msgid "Document"
 msgstr ""
 
 #. IDS_PRPCAT_HOME
-#: Merge.rc:5014
+#: Merge.rc:5013
 msgid "Home"
 msgstr ""
 
 #. IDS_PRPCAT_JOURNAL
-#: Merge.rc:5016
+#: Merge.rc:5015
 msgid "Journal"
 msgstr ""
 
 #. IDS_PRPCAT_LINK
-#: Merge.rc:5017
+#: Merge.rc:5016
 msgid "Link"
 msgstr ""
 
 #. IDS_PRPCAT_MEDIA
-#: Merge.rc:5018
+#: Merge.rc:5017
 msgid "Media"
 msgstr ""
 
 #. IDS_PRPCAT_MUSIC
-#: Merge.rc:5020
+#: Merge.rc:5019
 msgid "Music"
 msgstr ""
 
 #. IDS_PRPCAT_NOTE
-#: Merge.rc:5021
+#: Merge.rc:5020
 msgid "Note"
 msgstr ""
 
 #. IDS_PRPCAT_PHOTO
-#: Merge.rc:5022
+#: Merge.rc:5021
 msgid "Photo"
 msgstr ""
 
 #. IDS_PRPCAT_RECORDEDTV
-#: Merge.rc:5023
+#: Merge.rc:5022
 msgid "RecordedTV"
 msgstr ""
 
 #. IDS_PRPCAT_SEARCH
-#: Merge.rc:5024
+#: Merge.rc:5023
 msgid "Search"
 msgstr ""
 
 #. IDS_PRPCAT_SECURITY
-#: Merge.rc:5025
+#: Merge.rc:5024
 msgid "Security"
 msgstr ""
 
 #. IDS_PRPCAT_SOFTWARE
-#: Merge.rc:5026
+#: Merge.rc:5025
 msgid "Software"
 msgstr ""
 
 #. IDS_PRPCAT_TASK
-#: Merge.rc:5027
+#: Merge.rc:5026
 msgid "Task"
 msgstr ""
 
 #. IDS_PRPCAT_VIDEO
-#: Merge.rc:5028
+#: Merge.rc:5027
 msgid "Video"
 msgstr ""
 
 #. IDS_PRPCAT_HASH
-#: Merge.rc:5029
+#: Merge.rc:5028
 msgid "Hash"
 msgstr ""
 
 #. IDS_CANT_COMPARE_FILES
-#: Merge.rc:5035
+#: Merge.rc:5034
 #, c-format
 msgid "Unable to compare files"
 msgstr "ලිපිගොනු සංසන්දනය කිරීමට නොහැකිය"
 
 #. IDS_ABORTED_ITEM
-#: Merge.rc:5036
+#: Merge.rc:5035
 #, c-format
 msgid "Item aborted"
 msgstr "අයිතම අසාර්ථක විය "
 
 #. IDS_FILE_SKIPPED
-#: Merge.rc:5037
+#: Merge.rc:5036
 #, c-format
 msgid "File skipped"
 msgstr "ලිපිගොනු මඟහැරියා"
 
 #. IDS_DIR_SKIPPED
-#: Merge.rc:5038
+#: Merge.rc:5037
 #, c-format
 msgid "Folder skipped"
 msgstr "ෆෝල්ඩර මඟහැරියා"
 
 #. IDS_LEFT_ONLY_IN_FMT
-#: Merge.rc:5039
+#: Merge.rc:5038
 #, c-format
 msgid "Left only: %1"
 msgstr "වම පමණක්: %1"
 
 #. IDS_MIDDLE_ONLY_IN_FMT
-#: Merge.rc:5040
+#: Merge.rc:5039
 #, c-format
 msgid "Middle only: %1"
 msgstr ""
 
 #. IDS_RIGHT_ONLY_IN_FMT
-#: Merge.rc:5041
+#: Merge.rc:5040
 #, c-format
 msgid "Right only: %1"
 msgstr "දකුණ පමණක්: %1"
 
 #. IDS_DOES_NOT_EXIST_IN_FMT
-#: Merge.rc:5042
+#: Merge.rc:5041
 #, c-format
 msgid "Does not exist in %1"
 msgstr ""
 
 #. IDS_BIN_FILES_SAME
-#: Merge.rc:5043
+#: Merge.rc:5042
 #, c-format
 msgid "Binary files are identical"
 msgstr "ද්වීමය ලිපිගොනු සර්වසමයි"
 
 #. IDS_BIN_FILES_DIFF
-#: Merge.rc:5049
+#: Merge.rc:5048
 #, c-format
 msgid "Binary files are different"
 msgstr "ද්වීමය ලිපිගොනු වෙනස්"
 
 #. IDS_FILES_ARE_DIFFERENT
-#: Merge.rc:5050
+#: Merge.rc:5049
 #, c-format
 msgid "Files are different"
 msgstr "ලිපිගොනු වෙනස්"
 
 #. IDS_FOLDERS_ARE_DIFFERENT
-#: Merge.rc:5051
+#: Merge.rc:5050
 #, c-format
 msgid "Folders are different"
 msgstr "ෆෝල්ඩර වෙනස්"
 
 #. IDS_LEFTONLY
-#: Merge.rc:5052
+#: Merge.rc:5051
 #, c-format
 msgid "Left Only"
 msgstr "වම පමණක්"
 
 #. IDS_RIGHTONLY
-#: Merge.rc:5053
+#: Merge.rc:5052
 #, c-format
 msgid "Right Only"
 msgstr "දකුණ පමණක්"
 
 #. IDS_MIDDLEONLY
-#: Merge.rc:5054
+#: Merge.rc:5053
 #, c-format
 msgid "Middle Only"
 msgstr ""
 
 #. IDS_NOITEMLEFT
-#: Merge.rc:5055
+#: Merge.rc:5054
 #, c-format
 msgid "No item in left"
 msgstr ""
 
 #. IDS_NOITEMRIGHT
-#: Merge.rc:5056
+#: Merge.rc:5055
 #, c-format
 msgid "No item in right"
 msgstr ""
 
 #. IDS_NOITEMMIDDLE
-#: Merge.rc:5057
+#: Merge.rc:5056
 #, c-format
 msgid "No item in middle"
 msgstr ""
 
 #. IDS_CMPRES_ERROR
-#: Merge.rc:5059
+#: Merge.rc:5058
 #, c-format
 msgid "Error"
 msgstr "වැරදි"
 
 #. IDS_TEXT_FILES_SAME
-#: Merge.rc:5060
+#: Merge.rc:5059
 #, c-format
 msgid "Text files are identical"
 msgstr "Text files are identical"
 
 #. IDS_LEFTONLY_DIFF
-#: Merge.rc:5061
+#: Merge.rc:5060
 msgid " (Middle and right are identical)"
 msgstr ""
 
 #. IDS_MIDDLEONLY_DIFF
-#: Merge.rc:5062
+#: Merge.rc:5061
 msgid " (Left and right are identical)"
 msgstr ""
 
 #. IDS_RIGHTONLY_DIFF
-#: Merge.rc:5063
+#: Merge.rc:5062
 msgid " (Left and middle are identical)"
 msgstr ""
 
 #. IDS_PATH_MISMATCH
-#: Merge.rc:5064
+#: Merge.rc:5063
 msgid " (paths differ)"
 msgstr ""
 
 #. IDS_TEXT_FILES_DIFF
-#: Merge.rc:5065
+#: Merge.rc:5064
 #, c-format
 msgid "Text files are different"
 msgstr "Text files are different"
 
 #. IDS_IMAGE_FILES_SAME
-#: Merge.rc:5066
+#: Merge.rc:5065
 msgid "Image files are identical"
 msgstr ""
 
 #. IDS_IMAGE_FILES_DIFF
-#: Merge.rc:5067
+#: Merge.rc:5066
 msgid "Image files are different"
 msgstr ""
 
 #. IDS_EXPR_DIFF
-#: Merge.rc:5068
+#: Merge.rc:5067
 #, c-format
 msgid "Files are different (expr: %1)"
 msgstr ""
 
 #. IDS_HASH_GROUP
-#: Merge.rc:5069
+#: Merge.rc:5068
 #, c-format
 msgid "Group%d"
 msgstr ""
 
 #. IDS_RENAME_MOVE_DETECTION_DISALBED
-#: Merge.rc:5070
+#: Merge.rc:5069
 msgctxt "Options dialog|Compare|Folder|Detect renames and moves"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_RENAME_MOVE_DETECTION_RENAME
-#: Merge.rc:5071
+#: Merge.rc:5070
 msgid "Detect renames"
 msgstr ""
 
 #. IDS_RENAME_MOVE_DETECTION_RENAME_MOVE
-#: Merge.rc:5072
+#: Merge.rc:5071
 msgid "Detect renames and moves"
 msgstr ""
 
 #. IDS_RENAME_MOVE_MERGE_MODE_RENAME
-#: Merge.rc:5073
+#: Merge.rc:5072
 msgid "Merge renames"
 msgstr ""
 
 #. IDS_RENAME_MOVE_MERGE_MODE_RENAME_MOVE
-#: Merge.rc:5074
+#: Merge.rc:5073
 msgid "Merge renames and moves"
 msgstr ""
 
 #. IDS_RENAMED
-#: Merge.rc:5075
+#: Merge.rc:5074
 msgid "Renamed"
 msgstr ""
 
 #. IDS_RENAMED_MOVED
-#: Merge.rc:5077
+#: Merge.rc:5076
 msgid "Renamed/Moved"
 msgstr ""
 
 #. IDS_RENAMED_MOVED_ITEMS
-#: Merge.rc:5078
+#: Merge.rc:5077
 #, c-format
 msgid "(%1 items)"
 msgstr ""
 
 #. IDS_RENAMED_MOVED_RESULT
-#: Merge.rc:5079
+#: Merge.rc:5078
 #, c-format
 msgid "%1 (set %2): "
 msgstr ""
 
 #. IDS_SWITCH_FLAT_MODE
-#: Merge.rc:5080
+#: Merge.rc:5079
 msgid "Some moved items have been merged.\nIn Tree Mode, these items may appear in positions that do not reflect the actual folder structure, which can be confusing.\nSwitch to Flat Mode?"
 msgstr ""
 
 #. IDS_ELAPSED_TIME
-#: Merge.rc:5086
+#: Merge.rc:5085
 #, c-format
 msgid "Elapsed time: %ld ms"
 msgstr "Elapsed time: %ld ms"
 
 #. IDS_STATUS_SELITEM1
-#: Merge.rc:5087
+#: Merge.rc:5086
 #, c-format
 msgid "1 item selected"
 msgstr "1 item selected"
 
 #. IDS_STATUS_SELITEMS
-#: Merge.rc:5088
+#: Merge.rc:5087
 #, c-format
 msgid "%1 items selected"
 msgstr "%1 items selected"
 
 #. IDS_COLDESC_FILENAME
-#: Merge.rc:5094
+#: Merge.rc:5093
 #, c-format
 msgid "Filename or folder name."
 msgstr "Filename or folder name."
 
 #. IDS_COLDESC_DIR
-#: Merge.rc:5095
+#: Merge.rc:5094
 #, c-format
 msgid "Subfolder name when subfolders are included."
 msgstr "Subfolder name when subfolders are included."
 
 #. IDS_COLDESC_RESULT
-#: Merge.rc:5096
+#: Merge.rc:5095
 #, c-format
 msgid "Comparison result, long form."
 msgstr "Comparison result, long form."
 
 #. IDS_COLDESC_LTIMEM
-#: Merge.rc:5101
+#: Merge.rc:5100
 #, c-format
 msgid "Left side modification date."
 msgstr "Left side modification date."
 
 #. IDS_COLDESC_RTIMEM
-#: Merge.rc:5102
+#: Merge.rc:5101
 #, c-format
 msgid "Right side modification date."
 msgstr "Right side modification date."
 
 #. IDS_COLDESC_MTIMEM
-#: Merge.rc:5103
+#: Merge.rc:5102
 #, c-format
 msgid "Middle side modification date."
 msgstr ""
 
 #. IDS_COLDESC_EXTENSION
-#: Merge.rc:5104
+#: Merge.rc:5103
 #, c-format
 msgid "File's extension."
 msgstr "File's extension."
 
 #. IDS_COLDESC_LSIZE
-#: Merge.rc:5105
+#: Merge.rc:5104
 #, c-format
 msgid "Left file size in bytes."
 msgstr "Left file size in bytes."
 
 #. IDS_COLDESC_RSIZE
-#: Merge.rc:5106
+#: Merge.rc:5105
 #, c-format
 msgid "Right file size in bytes."
 msgstr "Right file size in bytes."
 
 #. IDS_COLDESC_MSIZE
-#: Merge.rc:5107
+#: Merge.rc:5106
 #, c-format
 msgid "Middle file size in bytes."
 msgstr ""
 
 #. IDS_COLDESC_LSIZE_SHORT
-#: Merge.rc:5108
+#: Merge.rc:5107
 #, c-format
 msgid "Left file size abbreviated."
 msgstr "Left file size abbreviated."
 
 #. IDS_COLDESC_RSIZE_SHORT
-#: Merge.rc:5109
+#: Merge.rc:5108
 #, c-format
 msgid "Right file size abbreviated."
 msgstr "Right file size abbreviated."
 
 #. IDS_COLDESC_MSIZE_SHORT
-#: Merge.rc:5110
+#: Merge.rc:5109
 #, c-format
 msgid "Middle file size abbreviated."
 msgstr ""
 
 #. IDS_COLDESC_LTIMEC
-#: Merge.rc:5116
+#: Merge.rc:5115
 #, c-format
 msgid "Left side creation time."
 msgstr "Left side creation time."
 
 #. IDS_COLDESC_RTIMEC
-#: Merge.rc:5117
+#: Merge.rc:5116
 #, c-format
 msgid "Right side creation time."
 msgstr "Right side creation time."
 
 #. IDS_COLDESC_MTIMEC
-#: Merge.rc:5118
+#: Merge.rc:5117
 #, c-format
 msgid "Middle side creation time."
 msgstr ""
 
 #. IDS_COLDESC_NEWER
-#: Merge.rc:5119
+#: Merge.rc:5118
 #, c-format
 msgid "Tells which side has newer modification date."
 msgstr "Tells which side has newer modification date."
 
 #. IDS_COLDESC_LVERSION
-#: Merge.rc:5120
+#: Merge.rc:5119
 msgid "Left side file version, only for some file types."
 msgstr ""
 
 #. IDS_COLDESC_RVERSION
-#: Merge.rc:5121
+#: Merge.rc:5120
 msgid "Right side file version, only for some file types."
 msgstr ""
 
 #. IDS_COLDESC_MVERSION
-#: Merge.rc:5126
+#: Merge.rc:5125
 msgid "Middle side file version, only for some file types."
 msgstr ""
 
 #. IDS_COLDESC_RESULT_ABBR
-#: Merge.rc:5127
+#: Merge.rc:5126
 #, c-format
 msgid "Short comparison result."
 msgstr "Short comparison result."
 
 #. IDS_COLDESC_LATTRIBUTES
-#: Merge.rc:5128
+#: Merge.rc:5127
 #, c-format
 msgid "Left side attributes."
 msgstr "Left side attributes."
 
 #. IDS_COLDESC_RATTRIBUTES
-#: Merge.rc:5129
+#: Merge.rc:5128
 #, c-format
 msgid "Right side attributes."
 msgstr "Right side attributes."
 
 #. IDS_COLDESC_MATTRIBUTES
-#: Merge.rc:5130
+#: Merge.rc:5129
 #, c-format
 msgid "Middle side attributes."
 msgstr ""
 
 #. IDS_COLDESC_LEOL_TYPE
-#: Merge.rc:5131
+#: Merge.rc:5130
 msgid "Left side file EOL type."
 msgstr "Left side file EOL type."
 
 #. IDS_COLDESC_REOL_TYPE
-#: Merge.rc:5132
+#: Merge.rc:5131
 msgid "Right side file EOL type."
 msgstr "Right side file EOL type."
 
 #. IDS_COLDESC_MEOL_TYPE
-#: Merge.rc:5133
+#: Merge.rc:5132
 msgid "Middle side file EOL type."
 msgstr ""
 
 #. IDS_COLDESC_LENCODING
-#: Merge.rc:5139
+#: Merge.rc:5138
 #, c-format
 msgid "Left side encoding."
 msgstr "Left side encoding."
 
 #. IDS_COLDESC_RENCODING
-#: Merge.rc:5140
+#: Merge.rc:5139
 #, c-format
 msgid "Right side encoding."
 msgstr "Right side encoding."
 
 #. IDS_COLDESC_MENCODING
-#: Merge.rc:5141
+#: Merge.rc:5140
 #, c-format
 msgid "Middle side encoding."
 msgstr ""
 
 #. IDS_COLDESC_NIDIFFS
-#: Merge.rc:5142
+#: Merge.rc:5141
 #, c-format
 msgid "Number of ignored differences in file. Ignored and cannot be merged."
 msgstr "Number of ignored differences in file. Ignored and cannot be merged."
 
 #. IDS_COLDESC_NSDIFFS
-#: Merge.rc:5143
+#: Merge.rc:5142
 #, c-format
 msgid "Number of differences in file (excluding ignored)."
 msgstr "Number of differences in file (excluding ignored)."
 
 #. IDS_COLDESC_BINARY
-#: Merge.rc:5144
+#: Merge.rc:5143
 #, c-format
 msgid "Shows an asterisk (*) if the file is binary."
 msgstr "Shows an asterisk (*) if the file is binary."
 
 #. IDS_COLDESC_UNPACKER
-#: Merge.rc:5145
+#: Merge.rc:5144
 msgid "Unpacker plugin name or pipeline."
 msgstr ""
 
 #. IDS_COLDESC_PREDIFFER
-#: Merge.rc:5146
+#: Merge.rc:5145
 msgid "Prediffer plugin name or pipeline."
 msgstr ""
 
 #. IDS_DIRECTORY_REPORT_TITLE
-#: Merge.rc:5152
+#: Merge.rc:5151
 #, c-format
 msgid "Compare %1 with %2"
 msgstr "Compare %1 with %2"
 
 #. IDS_DIRECTORY_REPORT_TITLE3
-#: Merge.rc:5153
+#: Merge.rc:5152
 #, c-format
 msgid "Compare %1 with %2 and %3"
 msgstr ""
 
 #. IDS_REPORT_COMMALIST
-#: Merge.rc:5154
+#: Merge.rc:5153
 #, c-format
 msgid "Comma-separated list"
 msgstr "Comma-separated list"
 
 #. IDS_REPORT_TABLIST
-#: Merge.rc:5155
+#: Merge.rc:5154
 #, c-format
 msgid "Tab-separated list"
 msgstr "Tab-separated list"
 
 #. IDS_REPORT_SIMPLEHTML
-#: Merge.rc:5156
+#: Merge.rc:5155
 #, c-format
 msgid "Simple HTML"
 msgstr "Simple HTML"
 
 #. IDS_REPORT_SIMPLEXML
-#: Merge.rc:5157
+#: Merge.rc:5156
 #, c-format
 msgid "Simple XML"
 msgstr "Simple XML"
 
-#: Merge.rc:5159
+#: Merge.rc:5158
 #, c-format
 msgid "Report file already exists. Overwrite?"
 msgstr "Report file already exists. Overwrite?"
 
 #. IDS_REPORT_ERROR
-#: Merge.rc:5164
+#: Merge.rc:5163
 #, c-format
 msgid ""
 "Error creating the report:\n"
@@ -7767,79 +7761,79 @@ msgstr ""
 "%1"
 
 #. IDS_REPORT_SUCCESS
-#: Merge.rc:5165
+#: Merge.rc:5164
 #, c-format
 msgid "Report created successfully."
 msgstr "Report created successfully."
 
 #. IDS_SYNCPOINT_LASTBLOCK
-#: Merge.rc:5171
+#: Merge.rc:5170
 msgid "Cannot add a synchronization point at this line."
 msgstr ""
 
 #. IDS_FILE_TO_ITSELF
-#: Merge.rc:5177
+#: Merge.rc:5176
 #, c-format
 msgid "Same file is opened in both panes."
 msgstr "Same file is opened in both panes."
 
 #. IDS_FILESSAME
-#: Merge.rc:5178
+#: Merge.rc:5177
 #, c-format
 msgid "Selected files are identical."
 msgstr "Selected files are identical."
 
 #. IDS_FILESSAME_CURCFG
-#: Merge.rc:5179
+#: Merge.rc:5178
 msgid "Selected files are identical (with current settings).\r\nChecking binary identity..."
 msgstr ""
 
 #. IDS_FILESSAME_BINERROR
-#: Merge.rc:5180
+#: Merge.rc:5179
 msgid "Selected files are identical (with current settings).\r\nBut binary comparison failed."
 msgstr ""
 
 #. IDS_FILESSAME_BINSAME
-#: Merge.rc:5181
+#: Merge.rc:5180
 msgid "Selected files are identical (binary match)."
 msgstr ""
 
 #. IDS_FILESSAME_BINDIFF
-#: Merge.rc:5182
+#: Merge.rc:5181
 msgid "Selected files are identical (with current settings).\r\nBut differ at the binary level."
 msgstr ""
 
 #. IDS_FILEERROR
-#: Merge.rc:5183
+#: Merge.rc:5182
 #, c-format
 msgid "An error occurred while comparing files."
 msgstr "An error occurred while comparing files."
 
 #. IDS_TEMP_FILEERROR
-#: Merge.rc:5184
+#: Merge.rc:5183
 #, c-format
 msgid "Could not create temporary files. Check your temporary path settings."
 msgstr "Could not create temporary files. Check your temporary path settings."
 
 #. IDS_SUGGEST_IGNOREEOL
-#: Merge.rc:5185
+#: Merge.rc:5184
 msgid "Files use different EOL.\n\nTreat all EOL as equivalent?\n\nSet 'Ignore EOL differences (Windows/Unix/Mac)' in Compare section of Options."
 msgstr ""
 
 #. IDS_INVALID_DIRECTORY
-#: Merge.rc:5186
+#: Merge.rc:5185
 #, c-format
 msgid "Selected folder is invalid."
 msgstr "Le répertoire sélectionné est invalide."
 
 #. IDS_CANNOT_OPEN_BINARYFILE
-#: Merge.rc:5187
+#: Merge.rc:5186
 #, c-format
 msgid "Cannot open a binary file in Editor."
 msgstr "Ne peut ouvrir un fichier binaire avec l'éditeur."
 
 #. IDS_CREATE_PAIR_FOLDER
-#: Merge.rc:5188
+#: Merge.rc:5187
 #, c-format
 msgid "Create matching folder:\n%1\non the other side and open?"
 msgstr ""
@@ -7850,45 +7844,45 @@ msgstr ""
 "à l'autre côté et ouvrir ces répertoires"
 
 #. IDS_CONFIRM_COPY_ALL_DIFFS
-#: Merge.rc:5189
+#: Merge.rc:5188
 msgid "Copy all differences to other file?"
 msgstr ""
 
 #. IDS_MOVE_TO_NEXTFILE
-#: Merge.rc:5194
+#: Merge.rc:5193
 #, c-format
 msgid "Move to next file?"
 msgstr ""
 
 #. IDS_MOVE_TO_PREVFILE
-#: Merge.rc:5195
+#: Merge.rc:5194
 #, c-format
 msgid "Move to previous file?"
 msgstr ""
 
 #. IDS_MOVE_TO_NEXTPAGE
-#: Merge.rc:5196
+#: Merge.rc:5195
 #, c-format
 msgid "Move to next page?"
 msgstr ""
 
 #. IDS_MOVE_TO_PREVPAGE
-#: Merge.rc:5197
+#: Merge.rc:5196
 #, c-format
 msgid "Move to previous page?"
 msgstr ""
 
 #. IDS_MOVE_TO_FIRSTFILE
-#: Merge.rc:5198
+#: Merge.rc:5197
 msgid "Move to first file?"
 msgstr ""
 
 #. IDS_MOVE_TO_LASTFILE
-#: Merge.rc:5199
+#: Merge.rc:5198
 msgid "Move to last file?"
 msgstr ""
 
-#: Merge.rc:5206
+#: Merge.rc:5205
 #, c-format
 msgid "Different codepages: left (cp%d), right (cp%d).\nDisplay in codepage (better display) or default Windows codepage (safer merging)?\n(Recommended: default Windows codepage)"
 msgstr ""
@@ -7896,153 +7890,153 @@ msgstr ""
 "L'affichage est ainsi meilleurs cependant les copie/fusion seront dangeureuses.\n"
 "Désirez-vous traiter les deux fichiers avec la page de code windows par défaut (recommandé)?"
 
-#: Merge.rc:5208
+#: Merge.rc:5207
 #, c-format
 msgid "Information lost due to encoding errors: both files"
 msgstr "Information lost due to encoding errors: both files"
 
-#: Merge.rc:5210
+#: Merge.rc:5209
 #, c-format
 msgid "Information lost due to encoding errors: first file"
 msgstr ""
 
-#: Merge.rc:5212
+#: Merge.rc:5211
 #, c-format
 msgid "Information lost due to encoding errors: second file"
 msgstr ""
 
-#: Merge.rc:5214
+#: Merge.rc:5213
 #, c-format
 msgid "Information lost due to encoding errors: third file"
 msgstr ""
 
 #. IDS_LINEDIFF_NODIFF
-#: Merge.rc:5220
+#: Merge.rc:5219
 #, c-format
 msgid "No difference"
 msgstr "No difference"
 
 #. IDS_LINEDIFF_NODIFF_CAPTION
-#: Merge.rc:5221
+#: Merge.rc:5220
 #, c-format
 msgid "Line difference"
 msgstr "Line difference"
 
 #. IDS_NUM_REPLACED
-#: Merge.rc:5227
+#: Merge.rc:5226
 #, c-format
 msgid "Replaced %1 string(s)."
 msgstr "Replaced %1 string(s)."
 
 #. IDS_EDIT_TEXT_NOT_FOUND
-#: Merge.rc:5228
+#: Merge.rc:5227
 #, c-format
 msgid "Cannot find string \"%s\"."
 msgstr ""
 
 #. IDS_MERGE_MODE
-#: Merge.rc:5234
+#: Merge.rc:5233
 msgid "Entering Merge Mode. Press F9 to turn off."
 msgstr ""
 
 #. IDS_AUTO_MERGE
-#: Merge.rc:5240
+#: Merge.rc:5239
 #, c-format
 msgid "Automatic merges: %1\nUnresolved conflicts: %2"
 msgstr ""
 
 #. IDS_CODEPAGE_MERGED
-#: Merge.rc:5241
+#: Merge.rc:5240
 msgid "Codepage change merged."
 msgstr ""
 
 #. IDS_CODEPAGE_CONFLICT
-#: Merge.rc:5242
+#: Merge.rc:5241
 msgid "Codepage changes are conflicting."
 msgstr ""
 
 #. IDS_EOL_MERGED
-#: Merge.rc:5243
+#: Merge.rc:5242
 msgid "EOL change merged."
 msgstr ""
 
 #. IDS_EOL_CONFLICT
-#: Merge.rc:5244
+#: Merge.rc:5243
 msgid "EOL changes are conflicting."
 msgstr ""
 
 #. IDS_LOCBAR_CAPTION
-#: Merge.rc:5250
+#: Merge.rc:5249
 #, c-format
 msgid "Location Pane"
 msgstr "Location Pane"
 
 #. IDS_DIFFBAR_CAPTION
-#: Merge.rc:5251
+#: Merge.rc:5250
 #, c-format
 msgid "Diff Pane"
 msgstr "Diff Pane"
 
 #. IDS_DIFF_SUCCEEDED
-#: Merge.rc:5258
+#: Merge.rc:5257
 #, c-format
 msgid "Patch file written."
 msgstr "Patch file written."
 
 #. IDS_DIFF_FILEOVERWRITE
-#: Merge.rc:5259
+#: Merge.rc:5258
 #, c-format
 msgid "Patch file already exists. Overwrite?"
 msgstr "Patch file already exists. Overwrite?"
 
 #. IDS_DIFF_SELECTEDFILES
-#: Merge.rc:5260
+#: Merge.rc:5259
 #, c-format
 msgid "[%1 files selected]"
 msgstr "[%1 files selected]"
 
 #. IDS_DIFF_NORMAL
-#: Merge.rc:5261
+#: Merge.rc:5260
 #, c-format
 msgid "Normal"
 msgstr "Normal"
 
 #. IDS_DIFF_CONTEXT
-#: Merge.rc:5262
+#: Merge.rc:5261
 #, c-format
 msgid "Context"
 msgstr "Context"
 
 #. IDS_DIFF_UNIFIED
-#: Merge.rc:5263
+#: Merge.rc:5262
 #, c-format
 msgid "Unified"
 msgstr "Unified"
 
 #. IDS_FILEWRITE_ERROR
-#: Merge.rc:5265
+#: Merge.rc:5264
 #, c-format
 msgid "Could not write to file %1."
 msgstr "Could not write to file %1."
 
 #. IDS_PATH_NOT_ABSOLUTE
-#: Merge.rc:5266
+#: Merge.rc:5265
 #, c-format
 msgid "Output path is not absolute: %1"
 msgstr "Output path is not absolute: %1"
 
 #. IDS_MUST_SPECIFY_OUTPUT
-#: Merge.rc:5267
+#: Merge.rc:5266
 msgid "Specify an output file."
 msgstr ""
 
-#: Merge.rc:5269
+#: Merge.rc:5268
 #, c-format
 msgid "Cannot create patch from binary files."
 msgstr "Cannot create patch from binary files."
 
 #. IDS_SAVEFILES_FORPATCH
-#: Merge.rc:5270
+#: Merge.rc:5269
 #, c-format
 msgid ""
 "Save all files first.\n"
@@ -8054,7 +8048,7 @@ msgstr ""
 "Creating a patch requires no unsaved changes."
 
 #. IDS_FOLDER_NOTEXIST
-#: Merge.rc:5271
+#: Merge.rc:5270
 #, c-format
 msgid "Folder does not exist."
 msgstr ""
@@ -8063,17 +8057,17 @@ msgstr ""
 "Creating a patch requires no unsaved changes."
 
 #. IDS_ARCHIVE_SUCCEEDED
-#: Merge.rc:5277
+#: Merge.rc:5276
 msgid "Archive file written."
 msgstr ""
 
 #. IDS_ARCHIVE_SAVEFILES
-#: Merge.rc:5278
+#: Merge.rc:5277
 msgid "Save all files first.\n\nCreating an archive requires no unsaved changes."
 msgstr ""
 
 #. IDS_NO_ZIP_SUPPORT
-#: Merge.rc:5283
+#: Merge.rc:5282
 msgid "Archive support not enabled.\n7-Zip and/or Merge7z*.dll not found.\nSee manual for archive support."
 msgstr ""
 "Archive support not enabled.\n"
@@ -8081,43 +8075,43 @@ msgstr ""
 "See manual for archive support."
 
 #. IDS_OPT_EXPORT_CAPTION
-#: Merge.rc:5284
+#: Merge.rc:5283
 #, c-format
 msgid "Select file for export"
 msgstr "Select file for export"
 
 #. IDS_OPT_IMPORT_CAPTION
-#: Merge.rc:5285
+#: Merge.rc:5284
 #, c-format
 msgid "Select file for import"
 msgstr "Select file for import"
 
 #. IDS_OPT_IMPORT_DONE
-#: Merge.rc:5286
+#: Merge.rc:5285
 #, c-format
 msgid "Options imported from file."
 msgstr "Options imported from file."
 
 #. IDS_OPT_EXPORT_DONE
-#: Merge.rc:5287
+#: Merge.rc:5286
 #, c-format
 msgid "Options exported to file."
 msgstr "Options exported to file."
 
 #. IDS_OPT_IMPORT_ERR
-#: Merge.rc:5288
+#: Merge.rc:5287
 #, c-format
 msgid "Failed to import options from file."
 msgstr "Failed to import options from file."
 
 #. IDS_OPT_EXPORT_ERR
-#: Merge.rc:5289
+#: Merge.rc:5288
 #, c-format
 msgid "Failed to write options to file."
 msgstr "Failed to write options to file."
 
 #. IDS_CLOSEALL_WINDOWS
-#: Merge.rc:5290
+#: Merge.rc:5289
 #, c-format
 msgid ""
 "Close multiple compare windows?\n"
@@ -8129,116 +8123,116 @@ msgstr ""
 "Continue?"
 
 #. IDS_EOL_BIN
-#: Merge.rc:5300
+#: Merge.rc:5299
 msgctxt "EOL Type"
 msgid "Binary"
 msgstr ""
 
 #. IDS_MARKER_COLOR_FMT
-#: Merge.rc:5305
+#: Merge.rc:5304
 #, c-format
 msgid "Marker Color %d"
 msgstr ""
 
 #. IDS_MARKER_NEW_PATTERN
-#: Merge.rc:5306
+#: Merge.rc:5305
 msgid "New Pattern"
 msgstr ""
 
 #. IDS_PLUGINSLIST_TYPE
-#: Merge.rc:5312
+#: Merge.rc:5311
 #, c-format
 msgid "Type"
 msgstr "Type"
 
 #. IDS_PLUGINS_TYPE_EDITSCRIPT
-#: Merge.rc:5316
+#: Merge.rc:5315
 #, c-format
 msgid "Editor script"
 msgstr "Editor script"
 
 #. ID_SELECTLINEDIFF
-#: Merge.rc:5322
+#: Merge.rc:5321
 #, c-format
 msgid "\nDifference in Current Line (F4)"
 msgstr ""
 
 #. ID_OPTIONS
-#: Merge.rc:5323
+#: Merge.rc:5322
 #, c-format
 msgid "\nOptions"
 msgstr ""
 
 #. ID_REFRESH
-#: Merge.rc:5324
+#: Merge.rc:5323
 #, c-format
 msgid "\nRefresh (F5)"
 msgstr ""
 
 #. ID_PREVDIFF
-#: Merge.rc:5330
+#: Merge.rc:5329
 #, c-format
 msgid "\nPrevious Difference (Alt+Up)"
 msgstr ""
 
 #. ID_NEXTDIFF
-#: Merge.rc:5331
+#: Merge.rc:5330
 #, c-format
 msgid "\nNext Difference (Alt+Down)"
 msgstr ""
 
 #. ID_PREVCONFLICT
-#: Merge.rc:5332
+#: Merge.rc:5331
 #, c-format
 msgid "\nPrevious Conflict (Alt+Shift+Up)"
 msgstr ""
 
 #. ID_NEXTCONFLICT
-#: Merge.rc:5333
+#: Merge.rc:5332
 #, c-format
 msgid "\nNext Conflict (Alt+Shift+Down)"
 msgstr ""
 
 #. ID_FIRSTDIFF
-#: Merge.rc:5338
+#: Merge.rc:5337
 #, c-format
 msgid "\nFirst Difference (Alt+Home)"
 msgstr ""
 
 #. ID_CURDIFF
-#: Merge.rc:5339
+#: Merge.rc:5338
 #, c-format
 msgid "\nCurrent Difference (Alt+Enter)"
 msgstr ""
 
 #. ID_LASTDIFF
-#: Merge.rc:5340
+#: Merge.rc:5339
 #, c-format
 msgid "\nLast Difference (Alt+End)"
 msgstr ""
 
 #. ID_L2R
-#: Merge.rc:5341
+#: Merge.rc:5340
 msgid "\nCopy to Right (Alt+Right)"
 msgstr ""
 
 #. ID_R2L
-#: Merge.rc:5342
+#: Merge.rc:5341
 msgid "\nCopy to Left (Alt+Left)"
 msgstr ""
 
 #. ID_L2RNEXT
-#: Merge.rc:5343
+#: Merge.rc:5342
 msgid "\nCopy to Right and Advance (Ctrl+Alt+Right)"
 msgstr ""
 
 #. ID_R2LNEXT
-#: Merge.rc:5344
+#: Merge.rc:5343
 msgid "\nCopy to Left and Advance (Ctrl+Alt+Left)"
 msgstr ""
 
 #. ID_ALL_RIGHT
-#: Merge.rc:5345
+#: Merge.rc:5344
 msgid ""
 "\n"
 "Copy All to Right"
@@ -8247,7 +8241,7 @@ msgstr ""
 "සියල්ල දකුණු පසට කොපිකරන්"
 
 #. ID_ALL_LEFT
-#: Merge.rc:5346
+#: Merge.rc:5345
 msgid ""
 "\n"
 "Copy All to Left"
@@ -8256,1090 +8250,1090 @@ msgstr ""
 "සියල්ල වම් පසට කොපිකරන්න"
 
 #. ID_AUTO_MERGE
-#: Merge.rc:5347
+#: Merge.rc:5346
 #, c-format
 msgid "\nAuto Merge (Ctrl+Alt+M)"
 msgstr ""
 
 #. ID_FIRSTFILE
-#: Merge.rc:5348
+#: Merge.rc:5347
 msgid "\nFirst File"
 msgstr ""
 
 #. ID_NEXTFILE
-#: Merge.rc:5349
+#: Merge.rc:5348
 msgid "\nNext File (Ctrl+F8)"
 msgstr ""
 
 #. ID_LASTFILE
-#: Merge.rc:5350
+#: Merge.rc:5349
 msgid "\nLast File"
 msgstr ""
 
 #. ID_PREVFILE
-#: Merge.rc:5351
+#: Merge.rc:5350
 msgid "\nPrevious File (Ctrl+F7)"
 msgstr ""
 
 #. IDS_UNPACK_AUTO
-#: Merge.rc:5358
+#: Merge.rc:5357
 msgid "Adapted unpacker applied to both files (one needs extension)."
 msgstr ""
 
 #. IDS_NO_PREDIFFER
-#: Merge.rc:5359
+#: Merge.rc:5358
 #, c-format
 msgid "No Prediffer (Normal)"
 msgstr "No Prediffer (Normal)"
 
 #. IDS_SUGGESTED_PLUGINS
-#: Merge.rc:5360
+#: Merge.rc:5359
 #, c-format
 msgid "Suggested Plugins"
 msgstr "Suggested Plugins"
 
 #. IDS_NOT_SUGGESTED_PLUGINS
-#: Merge.rc:5361
+#: Merge.rc:5360
 msgid "All Plugins"
 msgstr ""
 
 #. IDS_PRIVATEBUILD_FMT
-#: Merge.rc:5367
+#: Merge.rc:5366
 #, c-format
 msgid "Private Build: %1"
 msgstr "Private Build: %1"
 
 #. IDS_ALLRIGHTS_RESERVED
-#: Merge.rc:5368
+#: Merge.rc:5367
 msgid " - All rights reserved."
 msgstr ""
 
 #. IDS_TITLE_PLUGINS_SETTINGS
-#: Merge.rc:5374
+#: Merge.rc:5373
 #, c-format
 msgid "Plugin Settings"
 msgstr "Plugin Settings"
 
 #. IDS_NO_SCT_SCRIPTS
-#: Merge.rc:5376
+#: Merge.rc:5375
 #, c-format
 msgid "WSH not found - .sct scripts disabled"
 msgstr "WSH not found - .sct scripts disabled"
 
 #. IDS_LOCBAR_GOTOLINE_FMT
-#: Merge.rc:5384
+#: Merge.rc:5383
 #, c-format
 msgid "G&o to Line %1"
 msgstr "G&o to Line %1"
 
 #. IDS_GOTO_MOVED_LINE
-#: Merge.rc:5390
+#: Merge.rc:5389
 msgid "Go to Moved Line\tCtrl+Shift+G"
 msgstr ""
 
 #. IDS_AUTOCOMPLETE_DISABLED
-#: Merge.rc:5396
+#: Merge.rc:5395
 msgctxt "Options dialog|General|Open dialog Auto completion"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_AUTOCOMPLETE_FILE_SYS
-#: Merge.rc:5397
+#: Merge.rc:5396
 #, c-format
 msgid "From file system"
 msgstr "From file system"
 
 #. IDS_AUTOCOMPLETE_MRU
-#: Merge.rc:5398
+#: Merge.rc:5397
 #, c-format
 msgid "From Most Recently Used list"
 msgstr "From Most Recently Used list"
 
 #. IDS_COLORSCHEME_PLAIN
-#: Merge.rc:5404
+#: Merge.rc:5403
 #, c-format
 msgid "No Highlighting"
 msgstr "No Highlighting"
 
 #. IDS_COLORSCHEME_PO
-#: Merge.rc:5439
+#: Merge.rc:5438
 #, c-format
 msgid "Portable Object"
 msgstr "Portable Object"
 
 #. IDS_COLORSCHEME_RSRC
-#: Merge.rc:5444
+#: Merge.rc:5443
 #, c-format
 msgid "Resources"
 msgstr "Resources"
 
 #. IDS_COLORSCHEME_SH
-#: Merge.rc:5448
+#: Merge.rc:5447
 #, c-format
 msgid "Shell"
 msgstr "Shell"
 
 #. IDS_CLOSE_LEFT_TABS
-#: Merge.rc:5469
+#: Merge.rc:5468
 #, c-format
 msgid "Close &Left Tabs"
 msgstr ""
 
 #. IDS_CLOSE_RIGHT_TABS
-#: Merge.rc:5470
+#: Merge.rc:5469
 #, c-format
 msgid "Close R&ight Tabs"
 msgstr ""
 
 #. IDS_CLOSE_OTHER_TABS
-#: Merge.rc:5471
+#: Merge.rc:5470
 #, c-format
 msgid "Close &Other Tabs"
 msgstr ""
 
 #. IDS_TABBAR_AUTO_MAXWIDTH
-#: Merge.rc:5472
+#: Merge.rc:5471
 #, c-format
 msgid "Enable &Auto Max Width"
 msgstr ""
 
 #. IDS_WEBPAGE_MENU
-#: Merge.rc:5482
+#: Merge.rc:5481
 msgid "We&bpage"
 msgstr ""
 
 #. IDS_VIEW_WRAP_TEXT
-#: Merge.rc:5487
+#: Merge.rc:5486
 msgid "W&rap Text"
 msgstr ""
 
 #. IDS_NOTINSTALLED
-#: Merge.rc:5492
+#: Merge.rc:5491
 msgid "%1 is not installed."
 msgstr ""
 
 #. IDS_CREATE_FOLDER
-#: Merge.rc:5497
+#: Merge.rc:5496
 #, c-format
 msgid "%1 does not exist. Create it?"
 msgstr ""
 
 #. IDS_CREATE_FOLDER_ERROR
-#: Merge.rc:5498
+#: Merge.rc:5497
 #, c-format
 msgid "Failed to create folder."
 msgstr ""
 
 #. IDC_EXT_EDITOR_PATH
-#: Merge.rc:5503
+#: Merge.rc:5502
 #, c-format
 msgid "Parameters:\n$file: Current file path\n$linenum: Current cursor line number"
 msgstr ""
 
 #. IDS_DIFF_ALGORITHM_DEFAULT
-#: Merge.rc:5508
+#: Merge.rc:5507
 msgid "default"
 msgstr ""
 
 #. IDS_DIFF_ALGORITHM_MINIMAL
-#: Merge.rc:5509
+#: Merge.rc:5508
 msgid "minimal"
 msgstr ""
 
 #. IDS_DIFF_ALGORITHM_PATIENCE
-#: Merge.rc:5510
+#: Merge.rc:5509
 msgid "patience"
 msgstr ""
 
 #. IDS_DIFF_ALGORITHM_HISTOGRAM
-#: Merge.rc:5511
+#: Merge.rc:5510
 msgid "histogram"
 msgstr ""
 
 #. IDS_DIFF_ALGORITHM_NONE
-#: Merge.rc:5512
+#: Merge.rc:5511
 msgid "none"
 msgstr ""
 
 #. IDS_RENDERING_MODE_GDI
-#: Merge.rc:5517
+#: Merge.rc:5516
 msgid "GDI"
 msgstr ""
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_DEFAULT
-#: Merge.rc:5518
+#: Merge.rc:5517
 msgid "DirectWrite Default"
 msgstr ""
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_ALIASED
-#: Merge.rc:5519
+#: Merge.rc:5518
 msgid "DirectWrite Aliased"
 msgstr ""
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_GDI_CLASSIC
-#: Merge.rc:5520
+#: Merge.rc:5519
 msgid "DirectWrite GDI Classic"
 msgstr ""
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_GDI_NATURAL
-#: Merge.rc:5521
+#: Merge.rc:5520
 msgid "DirectWrite GDI Natural"
 msgstr ""
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_NATURAL
-#: Merge.rc:5522
+#: Merge.rc:5521
 msgid "DirectWrite Natural"
 msgstr ""
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_NATURAL_SYMMETRIC
-#: Merge.rc:5523
+#: Merge.rc:5522
 msgid "DirectWrite Natural Symmetric"
 msgstr ""
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_DISABLED
-#: Merge.rc:5528
+#: Merge.rc:5527
 msgctxt "Options dialog|General|Close windows with Esc"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_1
-#: Merge.rc:5529
+#: Merge.rc:5528
 msgid "MDI child window or main window"
 msgstr ""
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_2
-#: Merge.rc:5530
+#: Merge.rc:5529
 msgid "MDI child window only"
 msgstr ""
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_3
-#: Merge.rc:5531
+#: Merge.rc:5530
 msgid "Close main window if only one MDI child window"
 msgstr ""
 
 #. IDS_DIFF_GROUP
-#: Merge.rc:5536
+#: Merge.rc:5535
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Diff"
 msgstr ""
 
 #. IDS_DIFF_HIGHLIGHT
-#: Merge.rc:5537
+#: Merge.rc:5536
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Highlight"
 msgstr ""
 
 #. IDS_DIFF_BLINK
-#: Merge.rc:5538
+#: Merge.rc:5537
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Blink"
 msgstr ""
 
 #. IDS_DIFF_BLOCKSIZE
-#: Merge.rc:5539
+#: Merge.rc:5538
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Block Size"
 msgstr ""
 
 #. IDS_DIFF_BLOCKALPHA
-#: Merge.rc:5540
+#: Merge.rc:5539
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Block Alpha"
 msgstr ""
 
 #. IDS_DIFF_CDTHRESHOLD
-#: Merge.rc:5541
+#: Merge.rc:5540
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "CD Threshold"
 msgstr ""
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION
-#: Merge.rc:5542
+#: Merge.rc:5541
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Ins/Del Detection"
 msgstr ""
 
 #. IDS_OVERLAY_MODE_NONE
-#: Merge.rc:5543 Merge.rc:5548
+#: Merge.rc:5542 Merge.rc:5547
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "None"
 msgstr ""
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION_VERTICAL
-#: Merge.rc:5544
+#: Merge.rc:5543
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Vertical"
 msgstr ""
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION_HORIZONTAL
-#: Merge.rc:5545
+#: Merge.rc:5544
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Horizontal"
 msgstr ""
 
 #. IDS_OVERLAY_GROUP
-#: Merge.rc:5546
+#: Merge.rc:5545
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Overlay"
 msgstr ""
 
 #. IDS_OVERLAY_ALPHA
-#: Merge.rc:5547
+#: Merge.rc:5546
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha"
 msgstr ""
 
 #. IDS_OVERLAY_MODE_XOR
-#: Merge.rc:5549
+#: Merge.rc:5548
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "XOR"
 msgstr ""
 
 #. IDS_OVERLAY_MODE_ALPHA
-#: Merge.rc:5550
+#: Merge.rc:5549
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha Blend"
 msgstr ""
 
 #. IDS_OVERLAY_MODE_ALPHA_ANIMATION
-#: Merge.rc:5551
+#: Merge.rc:5550
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha Animation"
 msgstr ""
 
 #. IDS_ZOOM
-#: Merge.rc:5552
+#: Merge.rc:5551
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Zoom"
 msgstr ""
 
 #. IDS_PAGE
-#: Merge.rc:5553
+#: Merge.rc:5552
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Page:"
 msgstr ""
 
 #. IDS_IMGCMP_STATUS_PT_RGBA_FMT
-#: Merge.rc:5554
+#: Merge.rc:5553
 #, c-format
 msgid "Pt: (%d, %d)  RGBA: (%d, %d, %d, %d)  "
 msgstr ""
 
 #. IDS_IMGCMP_STATUS_DIST1_FMT
-#: Merge.rc:5555
+#: Merge.rc:5554
 #, c-format
 msgid "Dist: %g  "
 msgstr ""
 
 #. IDS_IMGCMP_STATUS_DIST2_FMT
-#: Merge.rc:5556
+#: Merge.rc:5555
 #, c-format
 msgid "Dist: %g, %g  "
 msgstr ""
 
 #. IDS_IMGCMP_STATUS_PAGE_ZOOM_SIZE_BPP_FMT
-#: Merge.rc:5557
+#: Merge.rc:5556
 #, c-format
 msgid "Page: %d/%d  Zoom: %d%%  %dx%dpx  %dbpp  "
 msgstr ""
 
 #. IDS_IMGCMP_STATUS_RC_FMT
-#: Merge.rc:5558
+#: Merge.rc:5557
 #, c-format
 msgid "Rc: (%d, %d)  "
 msgstr ""
 
 #. IDS_IMGCMP_STATUS_FLIPPED_FMT
-#: Merge.rc:5559
+#: Merge.rc:5558
 #, c-format
 msgid "Flipped: %s  "
 msgstr ""
 
 #. IDS_IMGCMP_STATUS_ROTATED_FMT
-#: Merge.rc:5560
+#: Merge.rc:5559
 #, c-format
 msgid "Rotated: %d  "
 msgstr ""
 
 #. IDS_IMGCMP_REPORT_ALLPAGES
-#: Merge.rc:5561
+#: Merge.rc:5560
 msgid "All pages"
 msgstr ""
 
 #. IDS_IGNSUB_STR1
-#: Merge.rc:5566
+#: Merge.rc:5565
 msgid "<Edit here>"
 msgstr ""
 
 #. IDS_IGNSUB_STR2
-#: Merge.rc:5567
+#: Merge.rc:5566
 msgid "No differences found to select"
 msgstr ""
 
 #. IDS_IGNSUB_STR3
-#: Merge.rc:5568
+#: Merge.rc:5567
 msgid "No differences found to add as substitution filter"
 msgstr ""
 
 #. IDS_IGNSUB_STR4
-#: Merge.rc:5569
+#: Merge.rc:5568
 msgid "The pair is already in the Substitution Filters list"
 msgstr ""
 
 #. IDS_IGNSUB_STR5
-#: Merge.rc:5570
+#: Merge.rc:5569
 msgid "Add this change to Substitution Filters?"
 msgstr ""
 
 #. IDS_OCRRESULT_TEXTONLY
-#: Merge.rc:5575
+#: Merge.rc:5574
 msgid "Text only"
 msgstr ""
 
 #. IDS_OCRRESULT_POS_LINE
-#: Merge.rc:5576
+#: Merge.rc:5575
 msgid "Line-by-line position and text"
 msgstr ""
 
 #. IDS_OCRRESULT_POS_WORD
-#: Merge.rc:5577
+#: Merge.rc:5576
 msgid "Word-by-word position and text"
 msgstr ""
 
 #. IDS_USERDATAFOLDER_APPDATA
-#: Merge.rc:5582
+#: Merge.rc:5581
 msgid "AppData (Roaming) folder"
 msgstr ""
 
 #. IDS_USERDATAFOLDER_INSTALL
-#: Merge.rc:5583
+#: Merge.rc:5582
 msgid "Install folder"
 msgstr ""
 
 #. IDS_USERDATAFOLDER_DOCUMENTS
-#: Merge.rc:5584
+#: Merge.rc:5583
 msgid "Documents folder"
 msgstr ""
 
 #. IDS_SINGLEINSTANCE_DISABLED
-#: Merge.rc:5589
+#: Merge.rc:5588
 msgctxt "Options dialog|General|Single instance mode"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_SINGLEINSTANCE_STR1
-#: Merge.rc:5590
+#: Merge.rc:5589
 #, c-format
 msgid "Allow only one instance to run"
 msgstr "එක් දෘෂ්ටාන්තයක් පමණක් සිදු වීමට ඉඩ හරින්න"
 
 #. IDS_CLIPBOARD_HISTORY
-#: Merge.rc:5591
+#: Merge.rc:5590
 msgid "Clipboard &History"
 msgstr ""
 
 #. IDS_SINGLEINSTANCE_STR2
-#: Merge.rc:5592
+#: Merge.rc:5591
 msgid "Allow only one instance; wait for termination"
 msgstr ""
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_DISABLED
-#: Merge.rc:5597
+#: Merge.rc:5596
 msgctxt "Options dialog|General|Auto-reload modified files"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_STR1
-#: Merge.rc:5598
+#: Merge.rc:5597
 msgid "Only on window activated"
 msgstr ""
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_STR2
-#: Merge.rc:5599
+#: Merge.rc:5598
 msgid "Immediately"
 msgstr ""
 
 #. IDS_PLUGIN_ALL
-#: Merge.rc:5604
+#: Merge.rc:5603
 msgid "Al&l"
 msgstr ""
 
 #. IDS_PLUGIN_OTHERS
-#: Merge.rc:5605
+#: Merge.rc:5604
 msgid "&Others"
 msgstr ""
 
-#: Merge.rc:5607
+#: Merge.rc:5606
 #, c-format
 msgid "Missing plugin name in pipeline: %1"
 msgstr ""
 
-#: Merge.rc:5609
+#: Merge.rc:5608
 #, c-format
 msgid "Missing quote in plugin pipeline: %1"
 msgstr ""
 
 #. IDS_PLUGIN_NAME_ALREADY_EXISTS
-#: Merge.rc:5610
+#: Merge.rc:5609
 #, c-format
 msgid "Plugin name '%1' already exists."
 msgstr ""
 
 #. IDS_PLUGIN_TITLE1
-#: Merge.rc:5611
+#: Merge.rc:5610
 msgid "Specify plugin arguments"
 msgstr ""
 
-#: Merge.rc:5613
+#: Merge.rc:5612
 #, c-format
 msgid "Plugin not found or invalid: %1"
 msgstr ""
 
 #. IDS_PLUGIN_NOT_UNPACK
-#: Merge.rc:5614
+#: Merge.rc:5613
 #, c-format
 msgid "'%1' is not an unpacker plugin"
 msgstr ""
 
 #. IDS_PLUGIN_NOT_PREDIFF
-#: Merge.rc:5615
+#: Merge.rc:5614
 #, c-format
 msgid "'%1' is not a prediffer plugin"
 msgstr ""
 
-#: Merge.rc:5617
+#: Merge.rc:5616
 #, c-format
 msgid "Error prediffing '%1' with '%2'. Prediffing disabled."
 msgstr ""
 
 #. IDS_PLUGIN_CIRCULAR_REFERENCE
-#: Merge.rc:5618
+#: Merge.rc:5617
 #, c-format
 msgid "Circular reference in plugin pipeline: %1"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE1
-#: Merge.rc:5619
+#: Merge.rc:5618
 msgid "URL Handler"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE2
-#: Merge.rc:5620
+#: Merge.rc:5619
 msgid "File Unpacker"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE3
-#: Merge.rc:5621
+#: Merge.rc:5620
 msgid "File or Folder Unpacker"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE5
-#: Merge.rc:5623
+#: Merge.rc:5622
 msgid "Alias for Unpacker"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE6
-#: Merge.rc:5624
+#: Merge.rc:5623
 msgid "Alias for Prediffer"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE7
-#: Merge.rc:5625
+#: Merge.rc:5624
 msgid "Alias for Editor script"
 msgstr ""
 
 #. IDS_PLUGIN_ALIAS_DESC
-#: Merge.rc:5626
+#: Merge.rc:5625
 #, c-format
 msgid "Alias for plugin pipeline '%1'"
 msgstr ""
 
 #. IDS_PLUGIN_NEW_DESC
-#: Merge.rc:5627
+#: Merge.rc:5626
 msgid "New plugin description"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_ALL
-#: Merge.rc:5628
+#: Merge.rc:5627
 msgid "All"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_1ST
-#: Merge.rc:5629
+#: Merge.rc:5628
 msgid "1st"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_2ND
-#: Merge.rc:5630
+#: Merge.rc:5629
 msgid "2nd"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_3RD
-#: Merge.rc:5631
+#: Merge.rc:5630
 msgid "3rd"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_1ST_2ND
-#: Merge.rc:5632
+#: Merge.rc:5631
 msgid "1st and 2nd"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_1ST_3RD
-#: Merge.rc:5633
+#: Merge.rc:5632
 msgid "1st and 3rd"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_2ND_3RD
-#: Merge.rc:5634
+#: Merge.rc:5633
 msgid "2nd and 3rd"
 msgstr ""
 
 #. IDS_PLUGIN_CTRL_CLICK
-#: Merge.rc:5635
+#: Merge.rc:5634
 msgid "(Ctrl+Click to add to pipeline)"
 msgstr ""
 
 #. IDS_FILTER_APPLIED
-#: Merge.rc:5640
+#: Merge.rc:5639
 msgid "Filter applied"
 msgstr ""
 
 #. IDS_FILTERMENU_COMPARE
-#: Merge.rc:5645
+#: Merge.rc:5644
 #, c-format
 msgid "Compare %1"
 msgstr ""
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN2
-#: Merge.rc:5647
+#: Merge.rc:5646
 msgid "&Filter by This Column..."
 msgstr ""
 
 #. IDS_CLIPBOARDHISTORY_TIME
-#: Merge.rc:5652
+#: Merge.rc:5651
 #, c-format
 msgid "Clipboard at %s"
 msgstr ""
 
 #. IDS_CLIPBOARDHISTORY_DISABLED
-#: Merge.rc:5653
+#: Merge.rc:5652
 msgid "Clipboard history disabled.\r\nEnable: Windows logo key + V, then Turn on."
 msgstr ""
 
-#: Merge.rc:5655
+#: Merge.rc:5654
 msgid "This system does not support clipboard history."
 msgstr ""
 
-#: Merge.rc:5657
+#: Merge.rc:5656
 msgid "32-bit WinMerge does not support Clipboard Compare"
 msgstr ""
 
 #. IDS_WEBVIEW2_RUNTIME_NOT_INSTALLED
-#: Merge.rc:5662
+#: Merge.rc:5661
 msgid "WebView2 runtime not installed. Download it?"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_TEXT_COMPARE
-#: Merge.rc:5667
+#: Merge.rc:5666
 msgid "New Text Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_TABLE_COMPARE
-#: Merge.rc:5668
+#: Merge.rc:5667
 msgid "New Table Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_BINARY_COMPARE
-#: Merge.rc:5669
+#: Merge.rc:5668
 msgid "New Binary Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_IMAGE_COMPARE
-#: Merge.rc:5670
+#: Merge.rc:5669
 msgid "New Image Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_WEBPAGE_COMPARE
-#: Merge.rc:5671
+#: Merge.rc:5670
 msgid "New Webpage Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_FOLDER_COMPARE
-#: Merge.rc:5672
+#: Merge.rc:5671
 msgid "New Folder Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_CLIPBOARD_COMPARE
-#: Merge.rc:5673
+#: Merge.rc:5672
 msgid "Clipboard Compare"
 msgstr ""
 
 #. IDS_PREVIEWBAR_PRINT
-#: Merge.rc:5678
+#: Merge.rc:5677
 msgid "&Print..."
 msgstr ""
 
 #. IDS_PREVIEWBAR_PREVPAGE
-#: Merge.rc:5680
+#: Merge.rc:5679
 msgid "Pre&v Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_TWOPAGE
-#: Merge.rc:5681
+#: Merge.rc:5680
 msgid "&Two Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_ONEPAGE
-#: Merge.rc:5682
+#: Merge.rc:5681
 msgid "&One Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_ZOOMIN
-#: Merge.rc:5683
+#: Merge.rc:5682
 msgid "Zoom &In"
 msgstr ""
 
 #. IDS_PREVIEWBAR_ZOOMOUT
-#: Merge.rc:5684
+#: Merge.rc:5683
 msgid "Zoom &Out"
 msgstr ""
 
 #. IDS_WEBPAGE_COMPARING
-#: Merge.rc:5690
+#: Merge.rc:5689
 msgid "Comparing..."
 msgstr ""
 
 #. IDS_WEBPAGE_ZOOM
-#: Merge.rc:5691
+#: Merge.rc:5690
 msgid "Zoom:"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_DIFFHUNK
-#: Merge.rc:5696
+#: Merge.rc:5695
 msgid "Diff hunk"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_INLINE
-#: Merge.rc:5697
+#: Merge.rc:5696
 msgid "Inline diff"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_LINE
-#: Merge.rc:5698
+#: Merge.rc:5697
 msgid "Line"
 msgstr ""
 
-#: Merge.rc:5699
+#: Merge.rc:5698
 msgid "Character"
 msgstr ""
 
 #. ID_MICE_PREVDIFF
-#: Merge.rc:5704
+#: Merge.rc:5703
 msgid "\nPrevious Difference (Alt+Up)\n(Right Button+Wheel Up)\n(Alt+Wheel Up)"
 msgstr ""
 
 #. ID_MICE_NEXTDIFF
-#: Merge.rc:5705
+#: Merge.rc:5704
 msgid "\nNext Difference (Alt+Down)\n(Right Button+Wheel Down)\n(Alt+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_L2R
-#: Merge.rc:5706
+#: Merge.rc:5705
 msgid "\nCopy to Right (Alt+Right)\n(Right Button+Wheel Right)\n(Alt+Wheel Right)\n(Alt+Shift+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_R2L
-#: Merge.rc:5707
+#: Merge.rc:5706
 msgid "\nCopy to Left (Alt+Left)\n(Right Button+Wheel Left)\n(Alt+Wheel Left)\n(Alt+Shift+Wheel Up)"
 msgstr ""
 
 #. ID_MICE_L2RNEXT
-#: Merge.rc:5708
+#: Merge.rc:5707
 msgid "\nCopy to Right and Advance (Ctrl+Alt+Right)\n(Ctrl+Alt+Wheel Right)\n(Ctrl+Alt+Shift+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_R2LNEXT
-#: Merge.rc:5709
+#: Merge.rc:5708
 msgid "\nCopy to Left and Advance (Ctrl+Alt+Left)\n(Ctrl+Alt+Wheel Left)\n(Ctrl+Alt+Shift+Wheel Up)"
 msgstr ""
 
 #. IDS_LOG_COMPARING_2
-#: Merge.rc:5719
+#: Merge.rc:5718
 #, c-format
 msgid "Comparing %1 with %2"
 msgstr ""
 
 #. IDS_LOG_COMPARING_3
-#: Merge.rc:5720
+#: Merge.rc:5719
 #, c-format
 msgid "Comparing %1 with %2 and %3"
 msgstr ""
 
 #. IDS_LOG_COMPARE_COMPLETED
-#: Merge.rc:5721
+#: Merge.rc:5720
 msgid "Comparison completed"
 msgstr ""
 
 #. IDS_LOG_COMPARE_ERROR_2
-#: Merge.rc:5722
+#: Merge.rc:5721
 #, c-format
 msgid "Failed to compare %1 with %2: "
 msgstr ""
 
 #. IDS_LOG_COMPARE_ERROR_3
-#: Merge.rc:5723
+#: Merge.rc:5722
 #, c-format
 msgid "Failed to compare %1 with %2 and %3: "
 msgstr ""
 
 #. IDS_LOG_FILE_SAVED
-#: Merge.rc:5724
+#: Merge.rc:5723
 msgid "File saved"
 msgstr ""
 
 #. IDS_LOG_COPYING_FILES
-#: Merge.rc:5725
+#: Merge.rc:5724
 msgid "Copying files..."
 msgstr ""
 
 #. IDS_LOG_MOVING_FILES
-#: Merge.rc:5726
+#: Merge.rc:5725
 msgid "Moving files..."
 msgstr ""
 
 #. IDS_LOG_DELETING_FILES
-#: Merge.rc:5727
+#: Merge.rc:5726
 msgid "Deleting files..."
 msgstr ""
 
 #. IDS_LOG_RECYCLEBIN
-#: Merge.rc:5728
+#: Merge.rc:5727
 msgid "Recycle Bin"
 msgstr ""
 
 #. IDS_LOG_PERMANENTLY_DELETED
-#: Merge.rc:5729
+#: Merge.rc:5728
 msgid "Permanently deleted"
 msgstr ""
 
 #. IDS_LOG_FILEOPERATION_COMPLETED
-#: Merge.rc:5730
+#: Merge.rc:5729
 msgid "File operation completed successfully"
 msgstr ""
 
 #. IDS_LOG_FILEOPERATION_CANCELED
-#: Merge.rc:5731
+#: Merge.rc:5730
 msgid "File operation canceled"
 msgstr ""
 
 #. IDS_FILTER_ERROR_NO_ERROR
-#: Merge.rc:5736
+#: Merge.rc:5735
 msgid "No error"
 msgstr ""
 
 #. IDS_FILTER_ERROR_EMPTY_EXPRESSION
-#: Merge.rc:5737
+#: Merge.rc:5736
 msgid "Filter expression is empty"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNKNOWN_CHAR
-#: Merge.rc:5738
+#: Merge.rc:5737
 msgid "Unknown character in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNTERMINATED_STRING
-#: Merge.rc:5739
+#: Merge.rc:5738
 msgid "Unterminated string literal"
 msgstr ""
 
 #. IDS_FILTER_ERROR_SYNTAX_ERROR
-#: Merge.rc:5740
+#: Merge.rc:5739
 msgid "Syntax error in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_PARSE_FAILURE
-#: Merge.rc:5741
+#: Merge.rc:5740
 msgid "Failed to parse filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_LITERAL
-#: Merge.rc:5742
+#: Merge.rc:5741
 msgid "Invalid literal value"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_REGULAR_EXPRESSION
-#: Merge.rc:5743
+#: Merge.rc:5742
 msgid "Invalid regular expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNDEFINED_IDENTIFIER
-#: Merge.rc:5744
+#: Merge.rc:5743
 msgid "Undefined identifier"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_ARGUMENT_COUNT
-#: Merge.rc:5745
+#: Merge.rc:5744
 msgid "Invalid number of arguments"
 msgstr ""
 
 #. IDS_FILTER_ERROR_FILTER_NAME_NOT_FOUND
-#: Merge.rc:5746
+#: Merge.rc:5745
 msgid "Filter name not found"
 msgstr ""
 
 #. IDS_FILTER_ERROR_DIVIDE_BY_ZERO
-#: Merge.rc:5747
+#: Merge.rc:5746
 msgid "Division by zero in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNKNOWN_ERROR
-#: Merge.rc:5748
+#: Merge.rc:5747
 msgid "Unknown error"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_PROPERTY_NAME
-#: Merge.rc:5749
+#: Merge.rc:5748
 msgid "Invalid property name"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_DIRECTIVE
-#: Merge.rc:5750
+#: Merge.rc:5749
 msgid "Invalid directive"
 msgstr ""
 
 #. IDS_FILTER_OP_EQUALS
-#: Merge.rc:5755
+#: Merge.rc:5754
 msgid "Equals"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_EQUALS
-#: Merge.rc:5756
+#: Merge.rc:5755
 msgid "Does not equal"
 msgstr ""
 
 #. IDS_FILTER_OP_LESS_THAN
-#: Merge.rc:5757
+#: Merge.rc:5756
 msgid "Less than"
 msgstr ""
 
 #. IDS_FILTER_OP_LESS_EQUAL
-#: Merge.rc:5758
+#: Merge.rc:5757
 msgid "Less than or equal to"
 msgstr ""
 
 #. IDS_FILTER_OP_GREATER_EQUAL
-#: Merge.rc:5759
+#: Merge.rc:5758
 msgid "Greater than or equal to"
 msgstr ""
 
 #. IDS_FILTER_OP_GREATER_THAN
-#: Merge.rc:5760
+#: Merge.rc:5759
 msgid "Greater than"
 msgstr ""
 
 #. IDS_FILTER_OP_BETWEEN
-#: Merge.rc:5761
+#: Merge.rc:5760
 msgid "Between"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_BETWEEN
-#: Merge.rc:5762
+#: Merge.rc:5761
 msgid "Not Between"
 msgstr ""
 
 #. IDS_FILTER_OP_CONTAINS
-#: Merge.rc:5763
+#: Merge.rc:5762
 msgid "Contains"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_CONTAINS
-#: Merge.rc:5764
+#: Merge.rc:5763
 msgid "Not Contains"
 msgstr ""
 
 #. IDS_FILTER_OP_RECONTAINS
-#: Merge.rc:5765
+#: Merge.rc:5764
 msgid "Contains (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_RECONTAINS
-#: Merge.rc:5766
+#: Merge.rc:5765
 msgid "Not Contains (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_LIKE
-#: Merge.rc:5767
+#: Merge.rc:5766
 msgid "Match (wildcard)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_LIKE
-#: Merge.rc:5768
+#: Merge.rc:5767
 msgid "Not match (wildcard)"
 msgstr ""
 
 #. IDS_FILTER_OP_MATCHES
-#: Merge.rc:5769
+#: Merge.rc:5768
 msgid "Match (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_MATCHES
-#: Merge.rc:5770
+#: Merge.rc:5769
 msgid "Not match (regex)"
 msgstr ""
 
 #. IDS_COLORMODE_LIGHT
-#: Merge.rc:5775
+#: Merge.rc:5774
 msgid "Light"
 msgstr ""
 
 #. IDS_COLORMODE_DARK
-#: Merge.rc:5776
+#: Merge.rc:5775
 msgid "Dark"
 msgstr ""
 
 #. IDS_COLORMODE_FOLLOWSYSTEM
-#: Merge.rc:5777
+#: Merge.rc:5776
 msgid "Follow system"
 msgstr ""
 
 #. IDS_EXAMPLE
-#: Merge.rc:5782
+#: Merge.rc:5781
 #, c-format
 msgid "e.g. %1"
 msgstr ""
 
 #. IDS_DETECTED_PREVIOUS_CRASH
-#: Merge.rc:5787
+#: Merge.rc:5786
 msgid "WinMerge detected a previous crash. Please report this if possible."
 msgstr ""
 
 #. IDS_REGEX_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5792
+#: Merge.rc:5791
 msgid "# Regex replacement list\r\n# Format: regex<TAB>replacement\r\n# Backreferences like $1, $2 are supported\r\n\r\n(\\d{4})-(\\d{2})-(\\d{2})\t$1_$2_$3\r\n"
 msgstr ""
 
 #. IDS_STRING_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5793
+#: Merge.rc:5792
 msgid "# Replacement list\r\n# Format: search<TAB>replacement\r\n# Lines starting with # are ignored\r\n\r\nfrom1\tto1\r\nfrom2\tto2\r\n"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_ONLY
-#: Merge.rc:5798
+#: Merge.rc:5797
 msgid "Built-in only"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_FIRST
-#: Merge.rc:5799
+#: Merge.rc:5798
 msgid "Built-in first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_FIRST
-#: Merge.rc:5800
+#: Merge.rc:5799
 msgid "Tree-sitter first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_ONLY
-#: Merge.rc:5801
+#: Merge.rc:5800
 msgid "Tree-sitter only"
 msgstr ""
 

--- a/Translations/WinMerge/Slovak.po
+++ b/Translations/WinMerge/Slovak.po
@@ -23,7 +23,7 @@ msgstr ""
 "X-Generator: Poedit 3.0.1\n"
 
 #. LANGUAGE, SUBLANGUAGE
-#: Merge.rc:26 Merge.rc:59 Merge.rc:5818
+#: Merge.rc:26 Merge.rc:59 Merge.rc:5817
 msgid "LANG_ENGLISH, SUBLANG_ENGLISH_US"
 msgstr "LANG_SLOVAK, SUBLANG_DEFAULT"
 
@@ -165,7 +165,7 @@ msgstr "&Skripty"
 #. IDS_NO_EDIT_SCRIPTS
 #: Merge.rc:127 Merge.rc:352 Merge.rc:463 Merge.rc:673 Merge.rc:678
 #: Merge.rc:887 Merge.rc:899 Merge.rc:906 Merge.rc:963 Merge.rc:1210
-#: Merge.rc:5375
+#: Merge.rc:5374
 msgid "< Empty >"
 msgstr "< Prázdne >"
 
@@ -230,7 +230,7 @@ msgid "Auto-Fit All Columns"
 msgstr ""
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN
-#: Merge.rc:153 Merge.rc:5646
+#: Merge.rc:153 Merge.rc:5645
 msgid "&Filter by This Column"
 msgstr ""
 
@@ -291,7 +291,7 @@ msgid "&Previous Page"
 msgstr "&Predošlá stránka"
 
 #. IDS_PREVIEWBAR_NEXTPAGE
-#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5679
+#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5678
 msgid "&Next Page"
 msgstr "Ď&alšia stránka"
 
@@ -542,7 +542,7 @@ msgstr "&Binárne"
 #. IDS_IMAGE_MENU
 #: Merge.rc:329 Merge.rc:338 Merge.rc:432 Merge.rc:441 Merge.rc:609
 #: Merge.rc:618 Merge.rc:670 Merge.rc:960 Merge.rc:1187 Merge.rc:1200
-#: Merge.rc:5477
+#: Merge.rc:5476
 msgid "&Image"
 msgstr "&Obrázok"
 
@@ -664,7 +664,7 @@ msgid "&Huge"
 msgstr "&Obrovská"
 
 #. IDS_VIEW_MENU_BAR
-#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5714
+#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5713
 msgid "Men&u Bar"
 msgstr ""
 
@@ -1319,7 +1319,7 @@ msgid "Lo&cation Pane"
 msgstr "Panel &polohy"
 
 #. IDS_OUTPUTBAR_CAPTION
-#: Merge.rc:782 Merge.rc:5252
+#: Merge.rc:782 Merge.rc:5251
 msgid "Output Pane"
 msgstr ""
 
@@ -1582,55 +1582,55 @@ msgid "Co&mpare As"
 msgstr "Po&rovnať ako"
 
 #. IDS_COPY_LEFT_TO_MIDDLE2
-#: Merge.rc:968 Merge.rc:980 Merge.rc:4852
+#: Merge.rc:968 Merge.rc:980 Merge.rc:4851
 #, c-format
 msgid "Left to Middle (%1 of %2)"
 msgstr "Ľavý do stredu (%1 z %2)"
 
 #. IDS_COPY_LEFT_TO_RIGHT2
-#: Merge.rc:969 Merge.rc:981 Merge.rc:4851
+#: Merge.rc:969 Merge.rc:981 Merge.rc:4850
 #, c-format
 msgid "Left to Right (%1 of %2)"
 msgstr "Ľavý vpravo (%1 z %2)"
 
 #. IDS_MOVE_LEFT_TO2
-#: Merge.rc:970 Merge.rc:982 Merge.rc:1045 Merge.rc:4863 Merge.rc:4892
+#: Merge.rc:970 Merge.rc:982 Merge.rc:1045 Merge.rc:4862 Merge.rc:4891
 #, c-format
 msgid "Left to... (%1 of %2)"
 msgstr "Ľavý do... (%1 z %2)"
 
 #. IDS_COPY_MIDDLE_TO_LEFT2
-#: Merge.rc:971 Merge.rc:983 Merge.rc:4849
+#: Merge.rc:971 Merge.rc:983 Merge.rc:4848
 #, c-format
 msgid "Middle to Left (%1 of %2)"
 msgstr "Stredný vľavo (%1 z %2)"
 
 #. IDS_COPY_MIDDLE_TO_RIGHT2
-#: Merge.rc:972 Merge.rc:984 Merge.rc:4850
+#: Merge.rc:972 Merge.rc:984 Merge.rc:4849
 #, c-format
 msgid "Middle to Right (%1 of %2)"
 msgstr "Stredný vpravo (%1 z %2)"
 
 #. IDS_MOVE_MIDDLE_TO2
-#: Merge.rc:973 Merge.rc:985 Merge.rc:1046 Merge.rc:4864 Merge.rc:4893
+#: Merge.rc:973 Merge.rc:985 Merge.rc:1046 Merge.rc:4863 Merge.rc:4892
 #, c-format
 msgid "Middle to... (%1 of %2)"
 msgstr "Stredný do... (%1 z %2)"
 
 #. IDS_COPY_RIGHT_TO_MIDDLE2
-#: Merge.rc:974 Merge.rc:986 Merge.rc:4848
+#: Merge.rc:974 Merge.rc:986 Merge.rc:4847
 #, c-format
 msgid "Right to Middle (%1 of %2)"
 msgstr "Pravý do stredu (%1 z %2)"
 
 #. IDS_COPY_RIGHT_TO_LEFT2
-#: Merge.rc:975 Merge.rc:987 Merge.rc:4847
+#: Merge.rc:975 Merge.rc:987 Merge.rc:4846
 #, c-format
 msgid "Right to Left (%1 of %2)"
 msgstr "Pravý vľavo (%1 z %2)"
 
 #. IDS_MOVE_RIGHT_TO2
-#: Merge.rc:976 Merge.rc:988 Merge.rc:1047 Merge.rc:4865 Merge.rc:4894
+#: Merge.rc:976 Merge.rc:988 Merge.rc:1047 Merge.rc:4864 Merge.rc:4893
 #, c-format
 msgid "Right to... (%1 of %2)"
 msgstr "Pravý do... (%1 z %2)"
@@ -1686,31 +1686,31 @@ msgid "Cop&y Paths"
 msgstr "Kopírovať názvy &ciest"
 
 #. IDS_DEL_LEFT_FMT2
-#: Merge.rc:1026 Merge.rc:1035 Merge.rc:4880
+#: Merge.rc:1026 Merge.rc:1035 Merge.rc:4879
 #, c-format
 msgid "Left (%1 of %2)"
 msgstr "Ľavý (%1 z %2)"
 
 #. IDS_DEL_MIDDLE_FMT2
-#: Merge.rc:1027 Merge.rc:1036 Merge.rc:4881
+#: Merge.rc:1027 Merge.rc:1036 Merge.rc:4880
 #, c-format
 msgid "Middle (%1 of %2)"
 msgstr "Stredný (%1 z %2)"
 
 #. IDS_DEL_RIGHT_FMT2
-#: Merge.rc:1028 Merge.rc:1037 Merge.rc:4882
+#: Merge.rc:1028 Merge.rc:1037 Merge.rc:4881
 #, c-format
 msgid "Right (%1 of %2)"
 msgstr "Pravý (%1 z %2)"
 
 #. IDS_DEL_BOTH_FMT2
-#: Merge.rc:1029 Merge.rc:1038 Merge.rc:4883
+#: Merge.rc:1029 Merge.rc:1038 Merge.rc:4882
 #, c-format
 msgid "Both (%1 of %2)"
 msgstr "Oba (%1 z %2)"
 
 #. IDS_DEL_ALL_FMT2
-#: Merge.rc:1030 Merge.rc:1039 Merge.rc:4888
+#: Merge.rc:1030 Merge.rc:1039 Merge.rc:4887
 #, c-format
 msgid "All (%1 of %2)"
 msgstr "Všetky (%1 z %2)"
@@ -1736,19 +1736,19 @@ msgid "&Zip"
 msgstr "&Zbaliť ZIP"
 
 #. IDS_COPY_BOTH_TO2
-#: Merge.rc:1048 Merge.rc:4866
+#: Merge.rc:1048 Merge.rc:4865
 #, c-format
 msgid "Both to... (%1 of %2)"
 msgstr "Oba do... (%1 z %2)"
 
 #. IDS_COPY_ALL_TO2
-#: Merge.rc:1049 Merge.rc:4867
+#: Merge.rc:1049 Merge.rc:4866
 #, c-format
 msgid "All to... (%1 of %2)"
 msgstr "Všetky do... (%1 z %2)"
 
 #. IDS_COPY_DIFFERENCES_TO2
-#: Merge.rc:1050 Merge.rc:4868
+#: Merge.rc:1050 Merge.rc:4867
 #, c-format
 msgid "Differences to... (%1 of %2)"
 msgstr "Rozdiely do... (%1 z %2)"
@@ -1815,12 +1815,12 @@ msgstr "Nastavenia rozbaľovača"
 
 #. IDS_USERCHOICE_NONE
 #: Merge.rc:1088 Merge.rc:1094 Merge.rc:1836 Merge.rc:1840 Merge.rc:2031
-#: Merge.rc:2035 Merge.rc:5377
+#: Merge.rc:2035 Merge.rc:5376
 msgid "<None>"
 msgstr "<Žiadny>"
 
 #. IDS_USERCHOICE_AUTOMATIC
-#: Merge.rc:1089 Merge.rc:1095 Merge.rc:5378
+#: Merge.rc:1089 Merge.rc:1095 Merge.rc:5377
 msgid "<Automatic>"
 msgstr "<Automatické>"
 
@@ -2750,12 +2750,12 @@ msgid "Text files only"
 msgstr ""
 
 #. IDS_EOL_NONE
-#: Merge.rc:1667 Merge.rc:1918 Merge.rc:5304
+#: Merge.rc:1667 Merge.rc:1918 Merge.rc:5303
 msgid "None"
 msgstr "Žiadny"
 
 #. IDS_EOL_MIXED
-#: Merge.rc:1668 Merge.rc:5299
+#: Merge.rc:1668 Merge.rc:5298
 msgid "Mixed"
 msgstr "Zmiešaný"
 
@@ -3027,13 +3027,13 @@ msgstr ""
 
 #. IDS_DIFFERENT
 #: Merge.rc:1904 Merge.rc:1988 Merge.rc:2866 Merge.rc:3036 Merge.rc:3077
-#: Merge.rc:5058
+#: Merge.rc:5057
 msgid "Different"
 msgstr "Rozdielne"
 
 #. IDS_IDENTICAL
 #: Merge.rc:1905 Merge.rc:1989 Merge.rc:2865 Merge.rc:3055 Merge.rc:3116
-#: Merge.rc:5048
+#: Merge.rc:5047
 msgid "Identical"
 msgstr "Identické"
 
@@ -3053,7 +3053,7 @@ msgid "Missing"
 msgstr ""
 
 #. IDS_MOVED
-#: Merge.rc:1910 Merge.rc:5076
+#: Merge.rc:1910 Merge.rc:5075
 msgid "Moved"
 msgstr ""
 
@@ -3789,7 +3789,7 @@ msgid "&Use custom system colors"
 msgstr ""
 
 #. IDS_PRPCAT_SYSTEM
-#: Merge.rc:2565 Merge.rc:4559 Merge.rc:4560 Merge.rc:5007
+#: Merge.rc:2565 Merge.rc:4559 Merge.rc:4560 Merge.rc:5006
 msgid "System"
 msgstr "Systém"
 
@@ -4189,7 +4189,7 @@ msgid "Items compared:"
 msgstr "Porovnané položky:"
 
 #. IDS_PREVIEWBAR_CLOSE
-#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5685
+#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5684
 msgid "&Close"
 msgstr "&Zatvoriť"
 
@@ -4812,7 +4812,7 @@ msgid "A&ppend timestamp"
 msgstr "P&ripojiť časovú pečiatku"
 
 #. IDS_CONFIRM_COPY_CAPTION
-#: Merge.rc:3214 Merge.rc:4915
+#: Merge.rc:3214 Merge.rc:4914
 msgid "Confirm Copy"
 msgstr "Potvrdiť kopírovanie"
 
@@ -5049,7 +5049,7 @@ msgid "&Character Set..."
 msgstr "&Znaková sústava..."
 
 #. IDS_PRPCAT_IMAGE
-#: Merge.rc:3351 Merge.rc:4574 Merge.rc:5015
+#: Merge.rc:3351 Merge.rc:4574 Merge.rc:5014
 msgid "Image"
 msgstr "Obrázok"
 
@@ -5442,7 +5442,7 @@ msgid "Project"
 msgstr "Premietnuť"
 
 #. IDS_COLHDR_NSDIFFS
-#: Merge.rc:4566 Merge.rc:4990
+#: Merge.rc:4566 Merge.rc:4989
 msgid "Differences"
 msgstr "Rozdiely"
 
@@ -5587,12 +5587,12 @@ msgid "File Type"
 msgstr "Typ súboru"
 
 #. IDS_COLHDR_EXTENSION
-#: Merge.rc:4653 Merge.rc:4947
+#: Merge.rc:4653 Merge.rc:4946
 msgid "Extension"
 msgstr "Prípona"
 
 #. IDS_PRPCAT_MESSAGE
-#: Merge.rc:4659 Merge.rc:5019
+#: Merge.rc:4659 Merge.rc:5018
 msgid "Message"
 msgstr "Správa"
 
@@ -5632,7 +5632,7 @@ msgid "Hidden Items"
 msgstr ""
 
 #. IDS_PLUGINSLIST_NAME
-#: Merge.rc:4680 Merge.rc:5311
+#: Merge.rc:4680 Merge.rc:5310
 msgid "Name"
 msgstr "Názov"
 
@@ -5652,7 +5652,7 @@ msgid "[F] "
 msgstr "[F] "
 
 #. IDS_PLUGINSLIST_DESC
-#: Merge.rc:4684 Merge.rc:5313
+#: Merge.rc:4684 Merge.rc:5312
 msgid "Description"
 msgstr "Popis"
 
@@ -5816,155 +5816,150 @@ msgstr "Riad: %s  Stĺ: %d/%d  Zn: %d/%d"
 msgid "  Sel: %d | %d"
 msgstr "  Vyb: %d | %d"
 
-#. IDS_MERGEMODE_MERGING
-#: Merge.rc:4734
-msgid "Merge"
-msgstr "Zlúčiť"
-
 #. IDS_DIFF_NUMBER_STATUS_FMT
-#: Merge.rc:4735
+#: Merge.rc:4734
 #, c-format
 msgid "Difference %1 of %2"
 msgstr "Rozdiel %1 z %2"
 
 #. IDS_NO_DIFF_SEL_FMT
-#: Merge.rc:4736
+#: Merge.rc:4735
 #, c-format
 msgid "%1 Differences Found"
 msgstr "nájdených %1 rozdielov"
 
 #. IDS_1_DIFF_FOUND
-#: Merge.rc:4737
+#: Merge.rc:4736
 msgid "1 Difference Found"
 msgstr "nájdený jeden rozdiel"
 
 #. IDS_NO_ERR_SEL_FMT
-#: Merge.rc:4738
+#: Merge.rc:4737
 #, c-format
 msgid "%1 Errors Found"
 msgstr ""
 
 #. IDS_1_ERR_FOUND
-#: Merge.rc:4739
+#: Merge.rc:4738
 msgid "1 Error Found"
 msgstr ""
 
 #. IDS_STATUSBAR_READONLY, Abbreviation from "Read Only"
-#: Merge.rc:4740
+#: Merge.rc:4739
 msgid "RO"
 msgstr "RO"
 
 #. IDS_DIRVIEW_STATUS_FMT_FOCUS
-#: Merge.rc:4746
+#: Merge.rc:4745
 #, c-format
 msgid "Item %1 of %2"
 msgstr "Položka %1 of %2"
 
 #. IDS_DIRVIEW_STATUS_FMT_NOFOCUS
-#: Merge.rc:4747
+#: Merge.rc:4746
 #, c-format
 msgid "Items: %1"
 msgstr "Položky: %1"
 
 #. IDS_DIRVIEW_STATUS_COMPARING
-#: Merge.rc:4748
+#: Merge.rc:4747
 msgid "Comparing items..."
 msgstr "Porovnávanie položiek..."
 
 #. IDS_ITEMS_PER_SEC
-#: Merge.rc:4749
+#: Merge.rc:4748
 #, c-format
 msgid "%.1f[items/sec]"
 msgstr ""
 
 #. IDS_ERROR_INCOMPARABLE
-#: Merge.rc:4755
+#: Merge.rc:4754
 msgid "Select two existing folders/files to compare."
 msgstr "Vyberte dva existujúce priečinky alebo súbory na porovnanie."
 
 #. IDS_DIRSEL_TAG
-#: Merge.rc:4756
+#: Merge.rc:4755
 msgid "Folder Selection"
 msgstr "Výber priečinka"
 
 #. IDS_OPEN_FILESDIRS
-#: Merge.rc:4757
+#: Merge.rc:4756
 msgid "Select two (or three) folders/files to compare."
 msgstr "Vyberte dva (alebo tri) priečinky alebo dva (alebo tri) súbory na porovnanie."
 
 #. IDS_OPEN_LEFTINVALID
-#: Merge.rc:4758
+#: Merge.rc:4757
 msgid "Left (1st) path is invalid!"
 msgstr "Ľavá (1.) cesta je neplatná!"
 
 #. IDS_OPEN_MIDDLEINVALID
-#: Merge.rc:4759
+#: Merge.rc:4758
 msgid "Middle (2nd) path is invalid!"
 msgstr "Stredná (2.) cesta je neplatná!"
 
 #. IDS_OPEN_RIGHTINVALID2
-#: Merge.rc:4760
+#: Merge.rc:4759
 msgid "Right (2nd) path is invalid!"
 msgstr "Pravá (2.) cesta je neplatná!"
 
 #. IDS_OPEN_RIGHTINVALID3
-#: Merge.rc:4761
+#: Merge.rc:4760
 msgid "Right (3rd) path is invalid!"
 msgstr "Pravá (3.) cesta je neplatná!"
 
 #. IDS_OPEN_BOTHINVALID
-#: Merge.rc:4762
+#: Merge.rc:4761
 msgid "Both paths are invalid!"
 msgstr "Obe cesty sú neplatné!"
 
-#: Merge.rc:4764
+#: Merge.rc:4763
 msgid "Left (1st) and Middle (2nd) paths are invalid!"
 msgstr "Ľavá (1.) a stredná (2.) cesta sú neplatné!"
 
 #. IDS_OPEN_LEFTRIGHTINVALID
-#: Merge.rc:4765
+#: Merge.rc:4764
 msgid "Left (1st) and Right (3rd) paths are invalid!"
 msgstr "Ľavá (1.) a pravá (3.) cesta sú neplatné!"
 
-#: Merge.rc:4767
+#: Merge.rc:4766
 msgid "Middle (2nd) and Right (3rd) paths are invalid!"
 msgstr "Stredná (2.) a pravá (3.) cesta sú neplatné!"
 
 #. IDS_OPEN_ALLINVALID
-#: Merge.rc:4768
+#: Merge.rc:4767
 msgid "All paths are invalid!"
 msgstr "Všetky cesty sú neplatné!"
 
 #. IDS_OPEN_UNPACKERDISABLED
-#: Merge.rc:4769
+#: Merge.rc:4768
 msgid "Only enabled for file comparisons"
 msgstr "Povolené iba na porovnanie súborov"
 
 #. IDS_OPEN_MISMATCH
-#: Merge.rc:4770
+#: Merge.rc:4769
 msgid "Cannot compare file and folder!"
 msgstr "Nemožno porovnať súbor a priečinok!"
 
 #. IDS_ERROR_FILE_NOT_FOUND
-#: Merge.rc:4776
+#: Merge.rc:4775
 #, c-format
 msgid "File not found: %1"
 msgstr "Súbor nenájdený: %1"
 
 #. IDS_ERROR_FOLDER_NOT_FOUND
-#: Merge.rc:4777
+#: Merge.rc:4776
 #, c-format
 msgid "Folder not found: %1"
 msgstr ""
 
 #. IDS_ERROR_FILE_NOT_UNPACKED
-#: Merge.rc:4778
+#: Merge.rc:4777
 #, c-format
 msgid "File not unpacked: %1"
 msgstr "Súbor nerozbalený: %1"
 
 #. IDS_ERROR_FILEOPEN
-#: Merge.rc:4779
+#: Merge.rc:4778
 #, c-format
 msgid ""
 "Cannot open file\n"
@@ -5978,12 +5973,12 @@ msgstr ""
 "%2"
 
 #. IDS_ERROR_CONF_RESOLVE
-#: Merge.rc:4780
+#: Merge.rc:4779
 msgid "Failed to parse conflict file."
 msgstr "Nepodarilo sa spracovať súbor konfliktov."
 
 #. IDS_NOT_CONFLICT_FILE
-#: Merge.rc:4781
+#: Merge.rc:4780
 #, c-format
 msgid "The file\n%1\nis not a conflict file."
 msgstr ""
@@ -5992,7 +5987,7 @@ msgstr ""
 "nie je súbor konfliktov."
 
 #. IDS_COMPARE_LARGE_FILES
-#: Merge.rc:4782
+#: Merge.rc:4781
 msgid "Comparing large files requires significant memory.\nShow only comparison results (not file contents)?"
 msgstr ""
 "Chystáte sa porovnať veľmi veľké súbory.\n"
@@ -6001,28 +5996,28 @@ msgstr ""
 "\n"
 
 #. IDS_SAVE_AS_TITLE
-#: Merge.rc:4788
+#: Merge.rc:4787
 msgid "Save As"
 msgstr "Uložiť ako"
 
 #. IDS_SAVE_FMT
-#: Merge.rc:4789
+#: Merge.rc:4788
 #, c-format
 msgid "Save changes to %1?"
 msgstr "Uložiť zmeny do %1?"
 
 #. IDS_SAVEREADONLY_FMT
-#: Merge.rc:4790
+#: Merge.rc:4789
 #, c-format
 msgid "%1 is read-only. Override? Or 'No' to save as new filename?"
 msgstr "%1 je označený iba na čítanie. Prajete si prepísať súbor iba na čítanie? (Nie, ak chcete uložiť ako nový názov súboru.)"
 
 #. IDS_ERROR_BACKUP
-#: Merge.rc:4791
+#: Merge.rc:4790
 msgid "Error backing up file"
 msgstr "Chyba pri zálohovaní súboru"
 
-#: Merge.rc:4793
+#: Merge.rc:4792
 #, c-format
 msgid ""
 "Unable to backup original file:\n"
@@ -6036,7 +6031,7 @@ msgstr ""
 "Pokračovať napriek tomu?"
 
 #. IDS_FILESAVE_FAILED
-#: Merge.rc:4794
+#: Merge.rc:4793
 #, c-format
 msgid "Saving file failed.\n%1\n%2\n\t- Use different filename (OK)\n\t- Abort (Cancel)?"
 msgstr ""
@@ -6047,7 +6042,7 @@ msgstr ""
 "- použiť iný názov súboru (stlačte tlačidlo OK)\n"
 "- prerušiť aktuálnu operáciu (stlačte Zrušiť)?"
 
-#: Merge.rc:4796
+#: Merge.rc:4795
 #, c-format
 msgid "Plugin '%2' cannot pack changes to left file into '%1'.\n\nOriginal unchanged. Save unpacked version?"
 msgstr ""
@@ -6057,7 +6052,7 @@ msgstr ""
 "\n"
 "Želáte si uložiť rozbalenú verziu do iného súboru?"
 
-#: Merge.rc:4798
+#: Merge.rc:4797
 #, c-format
 msgid "Plugin '%2' cannot pack changes to middle file into '%1'.\n\nOriginal unchanged. Save unpacked version?"
 msgstr ""
@@ -6067,7 +6062,7 @@ msgstr ""
 "\n"
 "Chcete rozbalenú verziu uložiť do iného súboru?"
 
-#: Merge.rc:4800
+#: Merge.rc:4799
 #, c-format
 msgid "Plugin '%2' cannot pack changes to right file into '%1'.\n\nOriginal unchanged. Save unpacked version?"
 msgstr ""
@@ -6078,7 +6073,7 @@ msgstr ""
 "Želáte si uložiť rozbalenú verziu do iného súboru?"
 
 #. IDS_FILECHANGED_ONDISK
-#: Merge.rc:4801
+#: Merge.rc:4800
 #, c-format
 msgid ""
 "Another application updated\n"
@@ -6094,7 +6089,7 @@ msgstr ""
 "Prepísať zmenený súbor?"
 
 #. IDS_SAVEREADONLY_MULTI
-#: Merge.rc:4802
+#: Merge.rc:4801
 #, c-format
 msgid ""
 "%1\n"
@@ -6104,7 +6099,7 @@ msgstr ""
 "je označený len na čítanie. Želáte si prepísať položku len na čítanie?"
 
 #. IDS_FILECHANGED_RESCAN
-#: Merge.rc:4803
+#: Merge.rc:4802
 #, c-format
 msgid "Another application updated\n%1\nsince last scan.\n\nReload?"
 msgstr ""
@@ -6115,22 +6110,22 @@ msgstr ""
 "Chcete znovu načítať súbor?"
 
 #. IDS_SAVE_LEFT_AS
-#: Merge.rc:4804
+#: Merge.rc:4803
 msgid "Save Left File As"
 msgstr "Uložiť ľavý súbor ako"
 
 #. IDS_SAVE_MIDDLE_AS
-#: Merge.rc:4805
+#: Merge.rc:4804
 msgid "Save Middle File As"
 msgstr "Uložiť stredný súbor ako"
 
 #. IDS_SAVE_RIGHT_AS
-#: Merge.rc:4806
+#: Merge.rc:4805
 msgid "Save Right File As"
 msgstr "Uložiť pravý súbor ako"
 
 #. IDS_FILE_DISAPPEARED
-#: Merge.rc:4811
+#: Merge.rc:4810
 #, c-format
 msgid ""
 "File\n"
@@ -6142,7 +6137,7 @@ msgstr ""
 "sa stratil. Pokračujte, prosím, uložením kópie súboru."
 
 #. IDS_VIEWS_OUTOFSYNC
-#: Merge.rc:4817
+#: Merge.rc:4816
 msgid ""
 "Cannot merge unsynched documents.\n"
 "\n"
@@ -6153,186 +6148,186 @@ msgstr ""
 "Obnovte dokumenty, než budete pokračovať."
 
 #. IDS_BREAK_ON_WHITESPACE
-#: Merge.rc:4822
+#: Merge.rc:4821
 msgid "Break at whitespace"
 msgstr "Prerušiť na netlačiteľnom znaku"
 
 #. IDS_BREAK_ON_PUNCTUATION
-#: Merge.rc:4823
+#: Merge.rc:4822
 msgid "Break at whitespace or punctuation"
 msgstr "Prerušiť na netlačiteľnom znaku alebo vetnej diakritike"
 
 #. IDS_L2M
-#: Merge.rc:4829
+#: Merge.rc:4828
 msgid "Copy to &Middle\tAlt+Right"
 msgstr "Kopírovať do &stredného\tAlt+→"
 
 #. IDS_R2M
-#: Merge.rc:4830
+#: Merge.rc:4829
 msgid "Copy to &Middle\tAlt+Left"
 msgstr "Kopírovať do &stredného\tAlt+←"
 
 #. IDS_COPY_FROM_MIDDLE_R
-#: Merge.rc:4831
+#: Merge.rc:4830
 msgid "Copy from Middle\tAlt+Shift+Right"
 msgstr "Kopírovať zo stredného\tAlt+Shift+→"
 
 #. IDS_COPY_FROM_MIDDLE_L
-#: Merge.rc:4832
+#: Merge.rc:4831
 msgid "Copy from Middle\tAlt+Shift+Left"
 msgstr "Kopírovať zo stredného Alt+Shift+←"
 
 #. IDS_L2MNEXT
-#: Merge.rc:4833
+#: Merge.rc:4832
 msgid "Copy to Middle and Advance\tCtrl+Alt+Right"
 msgstr "Kopírovať do stredného a posunúť\tCtrl+Alt+→"
 
 #. IDS_R2MNEXT
-#: Merge.rc:4834
+#: Merge.rc:4833
 msgid "Copy to Middle and Advance\tCtrl+Alt+Left"
 msgstr "Kopírovať do stredného a posunúť\tCtrl+Alt+←"
 
 #. IDS_ALL_MIDDLE
-#: Merge.rc:4835
+#: Merge.rc:4834
 msgid "Copy All to Middle"
 msgstr "Kopírovať všetko do stredu"
 
 #. IDS_COPY_RIGHT_TO_LEFT
-#: Merge.rc:4841
+#: Merge.rc:4840
 #, c-format
 msgid "Right to Left (%1)"
 msgstr "Z pravého do ľavého (%1)"
 
 #. IDS_COPY_RIGHT_TO_MIDDLE
-#: Merge.rc:4842
+#: Merge.rc:4841
 #, c-format
 msgid "Right to Middle (%1)"
 msgstr "Z pravého do stredného (%1)"
 
 #. IDS_COPY_MIDDLE_TO_LEFT
-#: Merge.rc:4843
+#: Merge.rc:4842
 #, c-format
 msgid "Middle to Left (%1)"
 msgstr "Zo stredného do ľavého (% 1)"
 
 #. IDS_COPY_MIDDLE_TO_RIGHT
-#: Merge.rc:4844
+#: Merge.rc:4843
 #, c-format
 msgid "Middle to Right (%1)"
 msgstr "Zo stredného do pravého (% 1)"
 
 #. IDS_COPY_LEFT_TO_RIGHT
-#: Merge.rc:4845
+#: Merge.rc:4844
 #, c-format
 msgid "Left to Right (%1)"
 msgstr "Z ľavého do pravého (%1)"
 
 #. IDS_COPY_LEFT_TO_MIDDLE
-#: Merge.rc:4846
+#: Merge.rc:4845
 #, c-format
 msgid "Left to Middle (%1)"
 msgstr "Z ľavého do stredého (%1)"
 
 #. IDS_MOVE_LEFT_TO
-#: Merge.rc:4857 Merge.rc:4889
+#: Merge.rc:4856 Merge.rc:4888
 #, c-format
 msgid "Left to... (%1)"
 msgstr "Z ľavého do... (%1)"
 
 #. IDS_MOVE_MIDDLE_TO
-#: Merge.rc:4858 Merge.rc:4890
+#: Merge.rc:4857 Merge.rc:4889
 #, c-format
 msgid "Middle to... (%1)"
 msgstr "Zo stredného do... (%1)"
 
 #. IDS_MOVE_RIGHT_TO
-#: Merge.rc:4859 Merge.rc:4891
+#: Merge.rc:4858 Merge.rc:4890
 #, c-format
 msgid "Right to... (%1)"
 msgstr "Z pravého do... (%1)"
 
 #. IDS_COPY_BOTH_TO
-#: Merge.rc:4860
+#: Merge.rc:4859
 #, c-format
 msgid "Both to... (%1)"
 msgstr "Z oboch do... (%1)"
 
 #. IDS_COPY_ALL_TO
-#: Merge.rc:4861
+#: Merge.rc:4860
 #, c-format
 msgid "All to... (%1)"
 msgstr "Všetky do... (%1)"
 
 #. IDS_COPY_DIFFERENCES_TO
-#: Merge.rc:4862
+#: Merge.rc:4861
 #, c-format
 msgid "Differences to... (%1)"
 msgstr "Rozdiely do... (%1)"
 
 #. IDS_ONLYDIFFITEMS_CONFIRM
-#: Merge.rc:4869
+#: Merge.rc:4868
 msgid "Some selected items are identical or skipped.\nProcess only items with differences?"
 msgstr ""
 
 #. IDS_DEL_LEFT_FMT
-#: Merge.rc:4875
+#: Merge.rc:4874
 #, c-format
 msgid "Left (%1)"
 msgstr "Ľavého (%1)"
 
 #. IDS_DEL_MIDDLE_FMT
-#: Merge.rc:4876
+#: Merge.rc:4875
 #, c-format
 msgid "Middle (%1)"
 msgstr "Stredného (%1)"
 
 #. IDS_DEL_RIGHT_FMT
-#: Merge.rc:4877
+#: Merge.rc:4876
 #, c-format
 msgid "Right (%1)"
 msgstr "Pravého (%1)"
 
 #. IDS_DEL_BOTH_FMT
-#: Merge.rc:4878
+#: Merge.rc:4877
 #, c-format
 msgid "Both (%1)"
 msgstr "Oboch (%1)"
 
 #. IDS_DEL_ALL_FMT
-#: Merge.rc:4879
+#: Merge.rc:4878
 #, c-format
 msgid "All (%1)"
 msgstr "Všetkých (%1)"
 
 #. IDS_SELECT_DEST_LEFT
-#: Merge.rc:4895
+#: Merge.rc:4894
 msgid "Left Side - Select Destination Folder:"
 msgstr "Ľavá strana - vyberte cieľový priečinok:"
 
 #. IDS_SELECT_DEST_MIDDLE
-#: Merge.rc:4896
+#: Merge.rc:4895
 msgid "Middle Side - Select Destination Folder:"
 msgstr "Stredný - vyberte cieľový priečinok:"
 
 #. IDS_SELECT_DEST_RIGHT
-#: Merge.rc:4897
+#: Merge.rc:4896
 msgid "Right Side - Select Destination Folder:"
 msgstr "Pravá strana - vyberte cieľový priečinok:"
 
 #. IDS_FILES_AFFECTED_FMT
-#: Merge.rc:4898
+#: Merge.rc:4897
 #, c-format
 msgid "(%1 Files Affected)"
 msgstr "(%1 ovplyvnených súborov)"
 
 #. IDS_FILES_AFFECTED_FMT2
-#: Merge.rc:4899
+#: Merge.rc:4898
 #, c-format
 msgid "(%1 of %2 Files Affected)"
 msgstr "(%1 ovplyvnených súborov z %2)"
 
 #. IDS_CONFIRM_DELETE_SINGLE
-#: Merge.rc:4905
+#: Merge.rc:4904
 #, c-format
 msgid ""
 "Are you sure you want to delete\n"
@@ -6344,18 +6339,18 @@ msgstr ""
 "%1 ?"
 
 #. IDS_CONFIRM_SINGLE_COPY
-#: Merge.rc:4906
+#: Merge.rc:4905
 msgid "Are you sure you want to copy?"
 msgstr "Naozaj chcete kopírovať?"
 
 #. IDS_CONFIRM_MULTIPLE_COPY
-#: Merge.rc:4907
+#: Merge.rc:4906
 #, c-format
 msgid "Are you sure you want to copy %d items?"
 msgstr "Naozaj chcete skopírovať %d položky?"
 
 #. IDS_DIRCMP_NOTSYNC
-#: Merge.rc:4908
+#: Merge.rc:4907
 #, c-format
 msgid ""
 "Operation aborted!\n"
@@ -6375,790 +6370,790 @@ msgstr ""
 "Obnovte, prosím, porovnanie."
 
 #. IDS_CONFIRM_SINGLE_MOVE
-#: Merge.rc:4913
+#: Merge.rc:4912
 msgid "Are you sure you want to move?"
 msgstr "Naozaj chcete presunúť?"
 
 #. IDS_CONFIRM_MULTIPLE_MOVE
-#: Merge.rc:4914
+#: Merge.rc:4913
 #, c-format
 msgid "Are you sure you want to move %d items?"
 msgstr "Naozaj chcete presunúť %d položiek?"
 
 #. IDS_CONFIRM_MOVE_CAPTION
-#: Merge.rc:4916
+#: Merge.rc:4915
 msgid "Confirm Move"
 msgstr "Potvrdiť presun"
 
-#: Merge.rc:4918
+#: Merge.rc:4917
 msgid "Close the folder comparison window?"
 msgstr "Chystáte sa zavrieť okno s porovnaním priečinkov. Naozaj chcete zavrieť okno?"
 
-#: Merge.rc:4920
+#: Merge.rc:4919
 msgid "Close the folder comparison window, which took a long time?"
 msgstr ""
 
 #. IDS_ERROR_INVALID_DIR_FILE_NAME
-#: Merge.rc:4921
+#: Merge.rc:4920
 msgid "The file or folder name is invalid."
 msgstr ""
 
 #. IDS_ERROR_EXECUTE_FILE
-#: Merge.rc:4927
+#: Merge.rc:4926
 #, c-format
 msgid "Failed to execute external editor: %1"
 msgstr "Nepodarilo sa spustiť externý editor: %1"
 
 #. IDS_UNKNOWN_ARCHIVE_FORMAT
-#: Merge.rc:4933
+#: Merge.rc:4932
 msgid "Unknown archive format"
 msgstr "Neznámy formát archívu"
 
-#: Merge.rc:4935
+#: Merge.rc:4934
 msgid "Failed to extract archive.\nCompare as text file?"
 msgstr ""
 
 #. IDS_COLHDR_FILENAME
-#: Merge.rc:4941
+#: Merge.rc:4940
 msgid "Filename"
 msgstr "Názov súboru"
 
 #. IDS_COLHDR_DIR
-#: Merge.rc:4942
+#: Merge.rc:4941
 msgctxt "DirView|ColumnHeader"
 msgid "Folder"
 msgstr "Priečinok"
 
 #. IDS_COLHDR_RESULT
-#: Merge.rc:4943
+#: Merge.rc:4942
 msgid "Comparison Result"
 msgstr "Výsledok porovnania"
 
 #. IDS_COLHDR_LTIMEM
-#: Merge.rc:4944
+#: Merge.rc:4943
 msgid "Left Date"
 msgstr "Dátum ľavého"
 
 #. IDS_COLHDR_RTIMEM
-#: Merge.rc:4945
+#: Merge.rc:4944
 msgid "Right Date"
 msgstr "Dátum pravého"
 
 #. IDS_COLHDR_MTIMEM
-#: Merge.rc:4946
+#: Merge.rc:4945
 msgid "Middle Date"
 msgstr "Dátum stredného"
 
 #. IDS_COLHDR_LSIZE
-#: Merge.rc:4948
+#: Merge.rc:4947
 msgid "Left Size"
 msgstr "Veľkosť ľavého"
 
 #. IDS_COLHDR_RSIZE
-#: Merge.rc:4949
+#: Merge.rc:4948
 msgid "Right Size"
 msgstr "Veľkosť pravého"
 
 #. IDS_COLHDR_MSIZE
-#: Merge.rc:4954
+#: Merge.rc:4953
 msgid "Middle Size"
 msgstr "Veľkosť stredného"
 
 #. IDS_COLHDR_RSIZE_SHORT
-#: Merge.rc:4955
+#: Merge.rc:4954
 msgid "Right Size (Short)"
 msgstr "Veľkosť pravého (krátka)"
 
 #. IDS_COLHDR_LSIZE_SHORT
-#: Merge.rc:4956
+#: Merge.rc:4955
 msgid "Left Size (Short)"
 msgstr "Veľkosť ľavého (krátka)"
 
 #. IDS_COLHDR_MSIZE_SHORT
-#: Merge.rc:4957
+#: Merge.rc:4956
 msgid "Middle Size (Short)"
 msgstr "Veľkosť stredného (krátka)"
 
 #. IDS_COLHDR_LTIMEC
-#: Merge.rc:4963
+#: Merge.rc:4962
 msgid "Left Creation Time"
 msgstr "Čas vzniku ľavého"
 
 #. IDS_COLHDR_RTIMEC
-#: Merge.rc:4964
+#: Merge.rc:4963
 msgid "Right Creation Time"
 msgstr "Čas vzniku pravého"
 
 #. IDS_COLHDR_MTIMEC
-#: Merge.rc:4965
+#: Merge.rc:4964
 msgid "Middle Creation Time"
 msgstr "Čas vzniku stredného"
 
 #. IDS_COLHDR_NEWER
-#: Merge.rc:4966
+#: Merge.rc:4965
 msgid "Newer File"
 msgstr "Novší súbor"
 
 #. IDS_COLHDR_LVERSION
-#: Merge.rc:4967
+#: Merge.rc:4966
 msgid "Left File Version"
 msgstr "Verzia ľavého súboru"
 
 #. IDS_COLHDR_RVERSION
-#: Merge.rc:4968
+#: Merge.rc:4967
 msgid "Right File Version"
 msgstr "Verzia pravého súboru"
 
 #. IDS_COLHDR_MVERSION
-#: Merge.rc:4969
+#: Merge.rc:4968
 msgid "Middle File Version"
 msgstr "Verzia stredného súboru"
 
 #. IDS_COLHDR_RESULT_ABBR
-#: Merge.rc:4970
+#: Merge.rc:4969
 msgid "Short Result"
 msgstr "Krátky výsledok"
 
 #. IDS_COLHDR_LATTRIBUTES
-#: Merge.rc:4971
+#: Merge.rc:4970
 msgid "Left Attributes"
 msgstr "Atribúty ľavého"
 
 #. IDS_COLHDR_RATTRIBUTES
-#: Merge.rc:4972
+#: Merge.rc:4971
 msgid "Right Attributes"
 msgstr "Atribúty pravého"
 
 #. IDS_COLHDR_MATTRIBUTES
-#: Merge.rc:4973
+#: Merge.rc:4972
 msgid "Middle Attributes"
 msgstr "Atribúty stredného"
 
 #. IDS_COLHDR_LEOL_TYPE
-#: Merge.rc:4978
+#: Merge.rc:4977
 msgid "Left EOL"
 msgstr "Znak konca riadku ľavého"
 
 #. IDS_COLHDR_MEOL_TYPE
-#: Merge.rc:4979
+#: Merge.rc:4978
 msgid "Middle EOL"
 msgstr "Znak konca riadku stredného"
 
 #. IDS_COLHDR_REOL_TYPE
-#: Merge.rc:4980
+#: Merge.rc:4979
 msgid "Right EOL"
 msgstr "Znak konca riadku pravého"
 
 #. IDS_COLHDR_LENCODING
-#: Merge.rc:4986
+#: Merge.rc:4985
 msgid "Left Encoding"
 msgstr "Kódovanie ľavého"
 
 #. IDS_COLHDR_RENCODING
-#: Merge.rc:4987
+#: Merge.rc:4986
 msgid "Right Encoding"
 msgstr "Kódovanie pravého"
 
 #. IDS_COLHDR_MENCODING
-#: Merge.rc:4988
+#: Merge.rc:4987
 msgid "Middle Encoding"
 msgstr "Kódovanie stredného"
 
 #. IDS_COLHDR_NIDIFFS
-#: Merge.rc:4989
+#: Merge.rc:4988
 msgid "Ignored Diff"
 msgstr "Ignorovaný rozdiel"
 
 #. IDS_COLHDR_BINARY
-#: Merge.rc:4991
+#: Merge.rc:4990
 msgctxt "DirView|ColumnHeader"
 msgid "Binary"
 msgstr "Binárny"
 
 #. IDS_PLUGINS_TYPE_UNPACKER
-#: Merge.rc:4992 Merge.rc:5314
+#: Merge.rc:4991 Merge.rc:5313
 msgid "Unpacker"
 msgstr "Rozbaľovač"
 
 #. IDS_PLUGIN_TYPE4
-#: Merge.rc:4993 Merge.rc:5315 Merge.rc:5622
+#: Merge.rc:4992 Merge.rc:5314 Merge.rc:5621
 msgid "Prediffer"
 msgstr "Predbežný spracovateľ rozdielov"
 
 #. IDS_COLHDR_LEFT
-#: Merge.rc:4994
+#: Merge.rc:4993
 msgid "Left"
 msgstr "←"
 
 #. IDS_COLHDR_MIDDLE
-#: Merge.rc:4995
+#: Merge.rc:4994
 msgid "Middle"
 msgstr "Stred"
 
 #. IDS_COLHDR_RIGHT
-#: Merge.rc:4996
+#: Merge.rc:4995
 msgid "Right"
 msgstr "→"
 
 #. IDS_COLHDR_DIFF
-#: Merge.rc:4997
+#: Merge.rc:4996
 msgid "Diff"
 msgstr "Rozdiel"
 
 #. IDS_COLHDR_LEFT_DUPLICATE
-#: Merge.rc:4998
+#: Merge.rc:4997
 msgid "Left Duplicate Count"
 msgstr "Počet vytvorených kópií vľavo"
 
 #. IDS_COLHDR_RIGHT_DUPLICATE
-#: Merge.rc:4999
+#: Merge.rc:4998
 msgid "Right Duplicate Count"
 msgstr "Počet vytvorených kópií vpravo"
 
 #. IDS_COLHDR_MIDDLE_DUPLICATE
-#: Merge.rc:5000
+#: Merge.rc:4999
 msgid "Middle Duplicate Count"
 msgstr "Počet vytvorených kópií v strede"
 
 #. IDS_COLHDR_MOVE
-#: Merge.rc:5001
+#: Merge.rc:5000
 msgid "Move"
 msgstr "Presunúť"
 
 #. IDS_PRPCAT_AUDIO
-#: Merge.rc:5008
+#: Merge.rc:5007
 msgid "Audio"
 msgstr "Audio"
 
 #. IDS_PRPCAT_CALENDAR
-#: Merge.rc:5009
+#: Merge.rc:5008
 msgid "Calendar"
 msgstr "Kalendár"
 
 #. IDS_PRPCAT_COMMUNICATION
-#: Merge.rc:5010
+#: Merge.rc:5009
 msgid "Communication"
 msgstr "Komunikácia"
 
 #. IDS_PRPCAT_CONTACT
-#: Merge.rc:5011
+#: Merge.rc:5010
 msgid "Contact"
 msgstr "Kontakt"
 
 #. IDS_PRPCAT_DEVICES
-#: Merge.rc:5012
+#: Merge.rc:5011
 msgid "Devices"
 msgstr "Zariadenia"
 
 #. IDS_PRPCAT_DOCUMENT
-#: Merge.rc:5013
+#: Merge.rc:5012
 msgid "Document"
 msgstr "Dokument"
 
 #. IDS_PRPCAT_HOME
-#: Merge.rc:5014
+#: Merge.rc:5013
 msgid "Home"
 msgstr "Domov"
 
 #. IDS_PRPCAT_JOURNAL
-#: Merge.rc:5016
+#: Merge.rc:5015
 msgid "Journal"
 msgstr "Denník"
 
 #. IDS_PRPCAT_LINK
-#: Merge.rc:5017
+#: Merge.rc:5016
 msgid "Link"
 msgstr "Odkaz"
 
 #. IDS_PRPCAT_MEDIA
-#: Merge.rc:5018
+#: Merge.rc:5017
 msgid "Media"
 msgstr "Média"
 
 #. IDS_PRPCAT_MUSIC
-#: Merge.rc:5020
+#: Merge.rc:5019
 msgid "Music"
 msgstr "Hudba"
 
 #. IDS_PRPCAT_NOTE
-#: Merge.rc:5021
+#: Merge.rc:5020
 msgid "Note"
 msgstr "Poznámka"
 
 #. IDS_PRPCAT_PHOTO
-#: Merge.rc:5022
+#: Merge.rc:5021
 msgid "Photo"
 msgstr "Fotografia"
 
 #. IDS_PRPCAT_RECORDEDTV
-#: Merge.rc:5023
+#: Merge.rc:5022
 msgid "RecordedTV"
 msgstr "Prehrávaná TV"
 
 #. IDS_PRPCAT_SEARCH
-#: Merge.rc:5024
+#: Merge.rc:5023
 msgid "Search"
 msgstr "Hľadať"
 
 #. IDS_PRPCAT_SECURITY
-#: Merge.rc:5025
+#: Merge.rc:5024
 msgid "Security"
 msgstr "Ochrana"
 
 #. IDS_PRPCAT_SOFTWARE
-#: Merge.rc:5026
+#: Merge.rc:5025
 msgid "Software"
 msgstr "Softvér"
 
 #. IDS_PRPCAT_TASK
-#: Merge.rc:5027
+#: Merge.rc:5026
 msgid "Task"
 msgstr "Úloha"
 
 #. IDS_PRPCAT_VIDEO
-#: Merge.rc:5028
+#: Merge.rc:5027
 msgid "Video"
 msgstr "Video"
 
 #. IDS_PRPCAT_HASH
-#: Merge.rc:5029
+#: Merge.rc:5028
 msgid "Hash"
 msgstr "Haš súčet"
 
 #. IDS_CANT_COMPARE_FILES
-#: Merge.rc:5035
+#: Merge.rc:5034
 msgid "Unable to compare files"
 msgstr "Nemožno porovnať súbory"
 
 #. IDS_ABORTED_ITEM
-#: Merge.rc:5036
+#: Merge.rc:5035
 msgid "Item aborted"
 msgstr "Položka zrušená"
 
 #. IDS_FILE_SKIPPED
-#: Merge.rc:5037
+#: Merge.rc:5036
 msgid "File skipped"
 msgstr "Súbor preskočený"
 
 #. IDS_DIR_SKIPPED
-#: Merge.rc:5038
+#: Merge.rc:5037
 msgid "Folder skipped"
 msgstr "Priečinok preskočený"
 
 #. IDS_LEFT_ONLY_IN_FMT
-#: Merge.rc:5039
+#: Merge.rc:5038
 #, c-format
 msgid "Left only: %1"
 msgstr "Iba ľavý: %1"
 
 #. IDS_MIDDLE_ONLY_IN_FMT
-#: Merge.rc:5040
+#: Merge.rc:5039
 #, c-format
 msgid "Middle only: %1"
 msgstr "Iba stredný: %1"
 
 #. IDS_RIGHT_ONLY_IN_FMT
-#: Merge.rc:5041
+#: Merge.rc:5040
 #, c-format
 msgid "Right only: %1"
 msgstr "Iba pravý: %1"
 
 #. IDS_DOES_NOT_EXIST_IN_FMT
-#: Merge.rc:5042
+#: Merge.rc:5041
 #, c-format
 msgid "Does not exist in %1"
 msgstr "Neexistuje v %1"
 
 #. IDS_BIN_FILES_SAME
-#: Merge.rc:5043
+#: Merge.rc:5042
 msgid "Binary files are identical"
 msgstr "Binárne súbory sú identické"
 
 #. IDS_BIN_FILES_DIFF
-#: Merge.rc:5049
+#: Merge.rc:5048
 msgid "Binary files are different"
 msgstr "Binárne súbory sú rozdielne"
 
 #. IDS_FILES_ARE_DIFFERENT
-#: Merge.rc:5050
+#: Merge.rc:5049
 msgid "Files are different"
 msgstr "Súbory sú rozdielne"
 
 #. IDS_FOLDERS_ARE_DIFFERENT
-#: Merge.rc:5051
+#: Merge.rc:5050
 msgid "Folders are different"
 msgstr "Priečinky sú rozdielne"
 
 #. IDS_LEFTONLY
-#: Merge.rc:5052
+#: Merge.rc:5051
 msgid "Left Only"
 msgstr "Len ľavý"
 
 #. IDS_RIGHTONLY
-#: Merge.rc:5053
+#: Merge.rc:5052
 msgid "Right Only"
 msgstr "Len pravý"
 
 #. IDS_MIDDLEONLY
-#: Merge.rc:5054
+#: Merge.rc:5053
 msgid "Middle Only"
 msgstr "Len stredný"
 
 #. IDS_NOITEMLEFT
-#: Merge.rc:5055
+#: Merge.rc:5054
 msgid "No item in left"
 msgstr "Žiadna položka vľavo"
 
 #. IDS_NOITEMRIGHT
-#: Merge.rc:5056
+#: Merge.rc:5055
 msgid "No item in right"
 msgstr "Žiadna položka vpravo"
 
 #. IDS_NOITEMMIDDLE
-#: Merge.rc:5057
+#: Merge.rc:5056
 msgid "No item in middle"
 msgstr "Žiadna položka v strede"
 
 #. IDS_CMPRES_ERROR
-#: Merge.rc:5059
+#: Merge.rc:5058
 msgid "Error"
 msgstr "Chyba"
 
 #. IDS_TEXT_FILES_SAME
-#: Merge.rc:5060
+#: Merge.rc:5059
 msgid "Text files are identical"
 msgstr "Textové súbory sú identické"
 
 #. IDS_LEFTONLY_DIFF
-#: Merge.rc:5061
+#: Merge.rc:5060
 msgid " (Middle and right are identical)"
 msgstr " (Stredný a pravý sú identické)"
 
 #. IDS_MIDDLEONLY_DIFF
-#: Merge.rc:5062
+#: Merge.rc:5061
 msgid " (Left and right are identical)"
 msgstr " (Ľavý a pravý sú identické)"
 
 #. IDS_RIGHTONLY_DIFF
-#: Merge.rc:5063
+#: Merge.rc:5062
 msgid " (Left and middle are identical)"
 msgstr " (Ľavý a stredný sú identické)"
 
 #. IDS_PATH_MISMATCH
-#: Merge.rc:5064
+#: Merge.rc:5063
 msgid " (paths differ)"
 msgstr ""
 
 #. IDS_TEXT_FILES_DIFF
-#: Merge.rc:5065
+#: Merge.rc:5064
 msgid "Text files are different"
 msgstr "Textové súbory sú rozdielne"
 
 #. IDS_IMAGE_FILES_SAME
-#: Merge.rc:5066
+#: Merge.rc:5065
 msgid "Image files are identical"
 msgstr "Súbory obrázkov sú identické"
 
 #. IDS_IMAGE_FILES_DIFF
-#: Merge.rc:5067
+#: Merge.rc:5066
 msgid "Image files are different"
 msgstr "Súbory obrázkov sú rozdielne"
 
 #. IDS_EXPR_DIFF
-#: Merge.rc:5068
+#: Merge.rc:5067
 #, c-format
 msgid "Files are different (expr: %1)"
 msgstr ""
 
 #. IDS_HASH_GROUP
-#: Merge.rc:5069
+#: Merge.rc:5068
 #, c-format
 msgid "Group%d"
 msgstr "Skupina%d"
 
 #. IDS_RENAME_MOVE_DETECTION_DISALBED
-#: Merge.rc:5070
+#: Merge.rc:5069
 msgctxt "Options dialog|Compare|Folder|Detect renames and moves"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_RENAME_MOVE_DETECTION_RENAME
-#: Merge.rc:5071
+#: Merge.rc:5070
 msgid "Detect renames"
 msgstr ""
 
 #. IDS_RENAME_MOVE_DETECTION_RENAME_MOVE
-#: Merge.rc:5072
+#: Merge.rc:5071
 msgid "Detect renames and moves"
 msgstr ""
 
 #. IDS_RENAME_MOVE_MERGE_MODE_RENAME
-#: Merge.rc:5073
+#: Merge.rc:5072
 msgid "Merge renames"
 msgstr ""
 
 #. IDS_RENAME_MOVE_MERGE_MODE_RENAME_MOVE
-#: Merge.rc:5074
+#: Merge.rc:5073
 msgid "Merge renames and moves"
 msgstr ""
 
 #. IDS_RENAMED
-#: Merge.rc:5075
+#: Merge.rc:5074
 msgid "Renamed"
 msgstr ""
 
 #. IDS_RENAMED_MOVED
-#: Merge.rc:5077
+#: Merge.rc:5076
 msgid "Renamed/Moved"
 msgstr ""
 
 #. IDS_RENAMED_MOVED_ITEMS
-#: Merge.rc:5078
+#: Merge.rc:5077
 #, c-format
 msgid "(%1 items)"
 msgstr ""
 
 #. IDS_RENAMED_MOVED_RESULT
-#: Merge.rc:5079
+#: Merge.rc:5078
 #, c-format
 msgid "%1 (set %2): "
 msgstr ""
 
 #. IDS_SWITCH_FLAT_MODE
-#: Merge.rc:5080
+#: Merge.rc:5079
 msgid "Some moved items have been merged.\nIn Tree Mode, these items may appear in positions that do not reflect the actual folder structure, which can be confusing.\nSwitch to Flat Mode?"
 msgstr ""
 
 #. IDS_ELAPSED_TIME
-#: Merge.rc:5086
+#: Merge.rc:5085
 #, c-format
 msgid "Elapsed time: %ld ms"
 msgstr "Uplynulý čas: %ld ms"
 
 #. IDS_STATUS_SELITEM1
-#: Merge.rc:5087
+#: Merge.rc:5086
 msgid "1 item selected"
 msgstr "1 vybraná položka"
 
 #. IDS_STATUS_SELITEMS
-#: Merge.rc:5088
+#: Merge.rc:5087
 #, c-format
 msgid "%1 items selected"
 msgstr "%1 vybraných položiek"
 
 #. IDS_COLDESC_FILENAME
-#: Merge.rc:5094
+#: Merge.rc:5093
 msgid "Filename or folder name."
 msgstr "Názov súboru alebo priečinka."
 
 #. IDS_COLDESC_DIR
-#: Merge.rc:5095
+#: Merge.rc:5094
 msgid "Subfolder name when subfolders are included."
 msgstr "Názov podpriečinka, keď obsahuje aj podpriečinky."
 
 #. IDS_COLDESC_RESULT
-#: Merge.rc:5096
+#: Merge.rc:5095
 msgid "Comparison result, long form."
 msgstr "Výsledok porovnania, dlhá forma."
 
 #. IDS_COLDESC_LTIMEM
-#: Merge.rc:5101
+#: Merge.rc:5100
 msgid "Left side modification date."
 msgstr "Dátum poslednej zmeny ľavého."
 
 #. IDS_COLDESC_RTIMEM
-#: Merge.rc:5102
+#: Merge.rc:5101
 msgid "Right side modification date."
 msgstr "Dátum poslednej zmeny pravého."
 
 #. IDS_COLDESC_MTIMEM
-#: Merge.rc:5103
+#: Merge.rc:5102
 msgid "Middle side modification date."
 msgstr "Dátum poslednej zmeny stredného."
 
 #. IDS_COLDESC_EXTENSION
-#: Merge.rc:5104
+#: Merge.rc:5103
 msgid "File's extension."
 msgstr "Prípona súboru."
 
 #. IDS_COLDESC_LSIZE
-#: Merge.rc:5105
+#: Merge.rc:5104
 msgid "Left file size in bytes."
 msgstr "Veľkosť ľavého súboru v bajtoch."
 
 #. IDS_COLDESC_RSIZE
-#: Merge.rc:5106
+#: Merge.rc:5105
 msgid "Right file size in bytes."
 msgstr "Veľkosť pravého súboru v bajtoch."
 
 #. IDS_COLDESC_MSIZE
-#: Merge.rc:5107
+#: Merge.rc:5106
 msgid "Middle file size in bytes."
 msgstr "Veľkosť stredného súboru v bajtoch."
 
 #. IDS_COLDESC_LSIZE_SHORT
-#: Merge.rc:5108
+#: Merge.rc:5107
 msgid "Left file size abbreviated."
 msgstr "Veľkosť ľavého súboru skrátená."
 
 #. IDS_COLDESC_RSIZE_SHORT
-#: Merge.rc:5109
+#: Merge.rc:5108
 msgid "Right file size abbreviated."
 msgstr "Veľkosť pravého súboru skrátená."
 
 #. IDS_COLDESC_MSIZE_SHORT
-#: Merge.rc:5110
+#: Merge.rc:5109
 msgid "Middle file size abbreviated."
 msgstr "Veľkosť streného súboru skrátená."
 
 #. IDS_COLDESC_LTIMEC
-#: Merge.rc:5116
+#: Merge.rc:5115
 msgid "Left side creation time."
 msgstr "Dátum vytvorenia ľavého."
 
 #. IDS_COLDESC_RTIMEC
-#: Merge.rc:5117
+#: Merge.rc:5116
 msgid "Right side creation time."
 msgstr "Dátum vytvorenia na pravého."
 
 #. IDS_COLDESC_MTIMEC
-#: Merge.rc:5118
+#: Merge.rc:5117
 msgid "Middle side creation time."
 msgstr "Dátum vytvorenia na stredného."
 
 #. IDS_COLDESC_NEWER
-#: Merge.rc:5119
+#: Merge.rc:5118
 msgid "Tells which side has newer modification date."
 msgstr "Hovorí, na ktorej strane je novší dátum zmeny."
 
 #. IDS_COLDESC_LVERSION
-#: Merge.rc:5120
+#: Merge.rc:5119
 msgid "Left side file version, only for some file types."
 msgstr "Verzia súboru ľavého, iba pre niektoré typy súborov."
 
 #. IDS_COLDESC_RVERSION
-#: Merge.rc:5121
+#: Merge.rc:5120
 msgid "Right side file version, only for some file types."
 msgstr "Verzia súboru pravého, iba pre niektoré typy súborov."
 
 #. IDS_COLDESC_MVERSION
-#: Merge.rc:5126
+#: Merge.rc:5125
 msgid "Middle side file version, only for some file types."
 msgstr "Verzia súboru stredného, iba pre niektoré typy súborov."
 
 #. IDS_COLDESC_RESULT_ABBR
-#: Merge.rc:5127
+#: Merge.rc:5126
 msgid "Short comparison result."
 msgstr "Krátky výsledok porovnania."
 
 #. IDS_COLDESC_LATTRIBUTES
-#: Merge.rc:5128
+#: Merge.rc:5127
 msgid "Left side attributes."
 msgstr "Atribúty ľavého."
 
 #. IDS_COLDESC_RATTRIBUTES
-#: Merge.rc:5129
+#: Merge.rc:5128
 msgid "Right side attributes."
 msgstr "Atribúty pravého."
 
 #. IDS_COLDESC_MATTRIBUTES
-#: Merge.rc:5130
+#: Merge.rc:5129
 msgid "Middle side attributes."
 msgstr "Atribúty stredného."
 
 #. IDS_COLDESC_LEOL_TYPE
-#: Merge.rc:5131
+#: Merge.rc:5130
 msgid "Left side file EOL type."
 msgstr "Typ znaku zakončenia riadka ľavého súboru."
 
 #. IDS_COLDESC_REOL_TYPE
-#: Merge.rc:5132
+#: Merge.rc:5131
 msgid "Right side file EOL type."
 msgstr "Typ znaku zakončenia riadka pravého súboru."
 
 #. IDS_COLDESC_MEOL_TYPE
-#: Merge.rc:5133
+#: Merge.rc:5132
 msgid "Middle side file EOL type."
 msgstr "Typ znaku zakončenia riadka stredného súboru."
 
 #. IDS_COLDESC_LENCODING
-#: Merge.rc:5139
+#: Merge.rc:5138
 msgid "Left side encoding."
 msgstr "Kódovanie ľavého."
 
 #. IDS_COLDESC_RENCODING
-#: Merge.rc:5140
+#: Merge.rc:5139
 msgid "Right side encoding."
 msgstr "Kódovanie pravého."
 
 #. IDS_COLDESC_MENCODING
-#: Merge.rc:5141
+#: Merge.rc:5140
 msgid "Middle side encoding."
 msgstr "Kódovanie stredného."
 
 #. IDS_COLDESC_NIDIFFS
-#: Merge.rc:5142
+#: Merge.rc:5141
 msgid "Number of ignored differences in file. Ignored and cannot be merged."
 msgstr "Počet ignorovaných rozdielov v súbore. Tieto rozdiely WinMerge ignoruje a nemožno ich zlúčiť."
 
 #. IDS_COLDESC_NSDIFFS
-#: Merge.rc:5143
+#: Merge.rc:5142
 msgid "Number of differences in file (excluding ignored)."
 msgstr "Počet rozdielov v súbore. V tomto čísle nie sú zahrnuté ignorované rozdiely."
 
 #. IDS_COLDESC_BINARY
-#: Merge.rc:5144
+#: Merge.rc:5143
 msgid "Shows an asterisk (*) if the file is binary."
 msgstr "Zobrazí hviezdičku (*) ak je súbor binárny."
 
 #. IDS_COLDESC_UNPACKER
-#: Merge.rc:5145
+#: Merge.rc:5144
 msgid "Unpacker plugin name or pipeline."
 msgstr "Názov rozšírenia rozbaľovača alebo potrubia."
 
 #. IDS_COLDESC_PREDIFFER
-#: Merge.rc:5146
+#: Merge.rc:5145
 msgid "Prediffer plugin name or pipeline."
 msgstr "Názov rozšírenia predbežného spracovateľa rozdielov alebo potrubia."
 
 #. IDS_DIRECTORY_REPORT_TITLE
-#: Merge.rc:5152
+#: Merge.rc:5151
 #, c-format
 msgid "Compare %1 with %2"
 msgstr "Porovnať %1 s %2"
 
 #. IDS_DIRECTORY_REPORT_TITLE3
-#: Merge.rc:5153
+#: Merge.rc:5152
 #, c-format
 msgid "Compare %1 with %2 and %3"
 msgstr ""
 
 #. IDS_REPORT_COMMALIST
-#: Merge.rc:5154
+#: Merge.rc:5153
 msgid "Comma-separated list"
 msgstr "Zoznam oddelený čiarkami"
 
 #. IDS_REPORT_TABLIST
-#: Merge.rc:5155
+#: Merge.rc:5154
 msgid "Tab-separated list"
 msgstr "Zoznam oddelený tabulátormi"
 
 #. IDS_REPORT_SIMPLEHTML
-#: Merge.rc:5156
+#: Merge.rc:5155
 msgid "Simple HTML"
 msgstr "Jednoduché HTML"
 
 #. IDS_REPORT_SIMPLEXML
-#: Merge.rc:5157
+#: Merge.rc:5156
 msgid "Simple XML"
 msgstr "Jednoduché XML"
 
-#: Merge.rc:5159
+#: Merge.rc:5158
 msgid "Report file already exists. Overwrite?"
 msgstr "Súbor so správou už existuje. Chcete prepísať existujúci súbor?"
 
 #. IDS_REPORT_ERROR
-#: Merge.rc:5164
+#: Merge.rc:5163
 #, c-format
 msgid ""
 "Error creating the report:\n"
@@ -7168,57 +7163,57 @@ msgstr ""
 "%1"
 
 #. IDS_REPORT_SUCCESS
-#: Merge.rc:5165
+#: Merge.rc:5164
 msgid "Report created successfully."
 msgstr "Správa bola úspešne vytvorená."
 
 #. IDS_SYNCPOINT_LASTBLOCK
-#: Merge.rc:5171
+#: Merge.rc:5170
 msgid "Cannot add a synchronization point at this line."
 msgstr "Na tento riadok nemožno pridať synchronizačný bod."
 
 #. IDS_FILE_TO_ITSELF
-#: Merge.rc:5177
+#: Merge.rc:5176
 msgid "Same file is opened in both panes."
 msgstr "Na oboch paneloch sa otvorí rovnaký súbor."
 
 #. IDS_FILESSAME
-#: Merge.rc:5178
+#: Merge.rc:5177
 msgid "Selected files are identical."
 msgstr "Vybraté súbory sú identické."
 
 #. IDS_FILESSAME_CURCFG
-#: Merge.rc:5179
+#: Merge.rc:5178
 msgid "Selected files are identical (with current settings).\r\nChecking binary identity..."
 msgstr ""
 
 #. IDS_FILESSAME_BINERROR
-#: Merge.rc:5180
+#: Merge.rc:5179
 msgid "Selected files are identical (with current settings).\r\nBut binary comparison failed."
 msgstr ""
 
 #. IDS_FILESSAME_BINSAME
-#: Merge.rc:5181
+#: Merge.rc:5180
 msgid "Selected files are identical (binary match)."
 msgstr ""
 
 #. IDS_FILESSAME_BINDIFF
-#: Merge.rc:5182
+#: Merge.rc:5181
 msgid "Selected files are identical (with current settings).\r\nBut differ at the binary level."
 msgstr ""
 
 #. IDS_FILEERROR
-#: Merge.rc:5183
+#: Merge.rc:5182
 msgid "An error occurred while comparing files."
 msgstr "Počas porovnávania sa vyskytla chyba."
 
 #. IDS_TEMP_FILEERROR
-#: Merge.rc:5184
+#: Merge.rc:5183
 msgid "Could not create temporary files. Check your temporary path settings."
 msgstr "Dočasné súbory sa nepodarilo vytvoriť. Skontrolujte dočasné nastavenia cesty."
 
 #. IDS_SUGGEST_IGNOREEOL
-#: Merge.rc:5185
+#: Merge.rc:5184
 msgid "Files use different EOL.\n\nTreat all EOL as equivalent?\n\nSet 'Ignore EOL differences (Windows/Unix/Mac)' in Compare section of Options."
 msgstr ""
 "Tieto súbory používajú rôzne typy návratov vozíka.\n"
@@ -7228,17 +7223,17 @@ msgstr ""
 "Poznámka: Ak chcete vždy zaobchádzať so všetkými typmi návratov vozíka ako s ekvivalentnými, nastavte možnosť „Ignorovať rozdiely návratov vozíka (Windows/Unix/Mac)“ na karte Porovnať v dialógovom okne možností (k dispozícii v časti Upraviť/Možnosti)."
 
 #. IDS_INVALID_DIRECTORY
-#: Merge.rc:5186
+#: Merge.rc:5185
 msgid "Selected folder is invalid."
 msgstr "Vybraný priečinok je neplatný."
 
 #. IDS_CANNOT_OPEN_BINARYFILE
-#: Merge.rc:5187
+#: Merge.rc:5186
 msgid "Cannot open a binary file in Editor."
 msgstr "Nemožno otvoriť binárny súbor v editore."
 
 #. IDS_CREATE_PAIR_FOLDER
-#: Merge.rc:5188
+#: Merge.rc:5187
 #, c-format
 msgid "Create matching folder:\n%1\non the other side and open?"
 msgstr ""
@@ -7249,41 +7244,41 @@ msgstr ""
 "na druhej strane a otvoriť tieto priečinky?"
 
 #. IDS_CONFIRM_COPY_ALL_DIFFS
-#: Merge.rc:5189
+#: Merge.rc:5188
 msgid "Copy all differences to other file?"
 msgstr ""
 
 #. IDS_MOVE_TO_NEXTFILE
-#: Merge.rc:5194
+#: Merge.rc:5193
 msgid "Move to next file?"
 msgstr "Chcete prejsť na nasledujúci súbor?"
 
 #. IDS_MOVE_TO_PREVFILE
-#: Merge.rc:5195
+#: Merge.rc:5194
 msgid "Move to previous file?"
 msgstr "Chcete prejsť na predošlý súbor?"
 
 #. IDS_MOVE_TO_NEXTPAGE
-#: Merge.rc:5196
+#: Merge.rc:5195
 msgid "Move to next page?"
 msgstr "Chcete prejsť na ďalšiu stránku?"
 
 #. IDS_MOVE_TO_PREVPAGE
-#: Merge.rc:5197
+#: Merge.rc:5196
 msgid "Move to previous page?"
 msgstr "Chcete prejsť na predošlú stránku?"
 
 #. IDS_MOVE_TO_FIRSTFILE
-#: Merge.rc:5198
+#: Merge.rc:5197
 msgid "Move to first file?"
 msgstr "Chcete prejsť na prvý súbor?"
 
 #. IDS_MOVE_TO_LASTFILE
-#: Merge.rc:5199
+#: Merge.rc:5198
 msgid "Move to last file?"
 msgstr "Chcete prejsť na posledný súbor?"
 
-#: Merge.rc:5206
+#: Merge.rc:5205
 #, c-format
 msgid "Different codepages: left (cp%d), right (cp%d).\nDisplay in codepage (better display) or default Windows codepage (safer merging)?\n(Recommended: default Windows codepage)"
 msgstr ""
@@ -7291,51 +7286,51 @@ msgstr ""
 "Zobrazenie každého súboru na jeho kódovej stránke zabezpečí lepšie zobrazenie, ale zlúčenie/kopírovanie bude nebezpečné.\n"
 "Prajete si, aby sa s obidvomi súbormi zaobchádzalo ako s predvolenou kódovou stránkou systému Windows (odporúčané)?"
 
-#: Merge.rc:5208
+#: Merge.rc:5207
 msgid "Information lost due to encoding errors: both files"
 msgstr "Informácie sa stratili kvôli chybám v kódovaní: oba súbory"
 
-#: Merge.rc:5210
+#: Merge.rc:5209
 msgid "Information lost due to encoding errors: first file"
 msgstr "Informácie stratené v dôsledku chýb kódovania: prvý súbor"
 
-#: Merge.rc:5212
+#: Merge.rc:5211
 msgid "Information lost due to encoding errors: second file"
 msgstr "Informácie stratené v dôsledku chýb kódovania: druhý súbor"
 
-#: Merge.rc:5214
+#: Merge.rc:5213
 msgid "Information lost due to encoding errors: third file"
 msgstr "Informácie stratené v dôsledku chýb kódovania: tretí súbor"
 
 #. IDS_LINEDIFF_NODIFF
-#: Merge.rc:5220
+#: Merge.rc:5219
 msgid "No difference"
 msgstr "Bez rozdielu"
 
 #. IDS_LINEDIFF_NODIFF_CAPTION
-#: Merge.rc:5221
+#: Merge.rc:5220
 msgid "Line difference"
 msgstr "Rozdiely v riadkoch"
 
 #. IDS_NUM_REPLACED
-#: Merge.rc:5227
+#: Merge.rc:5226
 #, c-format
 msgid "Replaced %1 string(s)."
 msgstr "Nahradených %1 reťazcov."
 
 #. IDS_EDIT_TEXT_NOT_FOUND
-#: Merge.rc:5228
+#: Merge.rc:5227
 #, c-format
 msgid "Cannot find string \"%s\"."
 msgstr "Nemožno nájsť reťazec „%s“."
 
 #. IDS_MERGE_MODE
-#: Merge.rc:5234
+#: Merge.rc:5233
 msgid "Entering Merge Mode. Press F9 to turn off."
 msgstr "Teraz vstupujete do režimu zlúčenia. Ak chcete vypnúť režim zlúčenia, stlačte kláves F9."
 
 #. IDS_AUTO_MERGE
-#: Merge.rc:5240
+#: Merge.rc:5239
 #, c-format
 msgid ""
 "Automatic merges: %1\n"
@@ -7345,89 +7340,89 @@ msgstr ""
 "Počet nevyriešených konfliktov: %2"
 
 #. IDS_CODEPAGE_MERGED
-#: Merge.rc:5241
+#: Merge.rc:5240
 msgid "Codepage change merged."
 msgstr "Zmena kódovej stránky bola zlúčená."
 
 #. IDS_CODEPAGE_CONFLICT
-#: Merge.rc:5242
+#: Merge.rc:5241
 msgid "Codepage changes are conflicting."
 msgstr "Zmeny kódovej stránky sú konfliktné."
 
 #. IDS_EOL_MERGED
-#: Merge.rc:5243
+#: Merge.rc:5242
 msgid "EOL change merged."
 msgstr "Zmena znaku EOL bola zlúčená."
 
 #. IDS_EOL_CONFLICT
-#: Merge.rc:5244
+#: Merge.rc:5243
 msgid "EOL changes are conflicting."
 msgstr "Zmeny znakov EOL sú protichodné."
 
 #. IDS_LOCBAR_CAPTION
-#: Merge.rc:5250
+#: Merge.rc:5249
 msgid "Location Pane"
 msgstr "Panel polohy"
 
 #. IDS_DIFFBAR_CAPTION
-#: Merge.rc:5251
+#: Merge.rc:5250
 msgid "Diff Pane"
 msgstr "Panel rozdielu"
 
 #. IDS_DIFF_SUCCEEDED
-#: Merge.rc:5258
+#: Merge.rc:5257
 msgid "Patch file written."
 msgstr "Súbor so záplatou bol úspešne zapísaný."
 
 #. IDS_DIFF_FILEOVERWRITE
-#: Merge.rc:5259
+#: Merge.rc:5258
 msgid "Patch file already exists. Overwrite?"
 msgstr "Súbor so záplatou už existuje. Chcete ho prepísať?"
 
 #. IDS_DIFF_SELECTEDFILES
-#: Merge.rc:5260
+#: Merge.rc:5259
 #, c-format
 msgid "[%1 files selected]"
 msgstr "[vybrané %1 súbory]"
 
 #. IDS_DIFF_NORMAL
-#: Merge.rc:5261
+#: Merge.rc:5260
 msgid "Normal"
 msgstr "Normálny"
 
 #. IDS_DIFF_CONTEXT
-#: Merge.rc:5262
+#: Merge.rc:5261
 msgid "Context"
 msgstr "Kontextový"
 
 #. IDS_DIFF_UNIFIED
-#: Merge.rc:5263
+#: Merge.rc:5262
 msgid "Unified"
 msgstr "Zjednotený"
 
 #. IDS_FILEWRITE_ERROR
-#: Merge.rc:5265
+#: Merge.rc:5264
 #, c-format
 msgid "Could not write to file %1."
 msgstr "Nepodarilo sa zapísať do súboru %1."
 
 #. IDS_PATH_NOT_ABSOLUTE
-#: Merge.rc:5266
+#: Merge.rc:5265
 #, c-format
 msgid "Output path is not absolute: %1"
 msgstr "Zadaná výstupná cesta nie je absolútna cesta: %1"
 
 #. IDS_MUST_SPECIFY_OUTPUT
-#: Merge.rc:5267
+#: Merge.rc:5266
 msgid "Specify an output file."
 msgstr "Zadajte výstupný súbor."
 
-#: Merge.rc:5269
+#: Merge.rc:5268
 msgid "Cannot create patch from binary files."
 msgstr "Nemožno vytvoriť súbor so záplatou z binárnych súborov."
 
 #. IDS_SAVEFILES_FORPATCH
-#: Merge.rc:5270
+#: Merge.rc:5269
 msgid ""
 "Save all files first.\n"
 "\n"
@@ -7438,22 +7433,22 @@ msgstr ""
 "Vytvorenie záplaty vyžaduje, aby v súboroch neboli žiadne neuložené zmeny."
 
 #. IDS_FOLDER_NOTEXIST
-#: Merge.rc:5271
+#: Merge.rc:5270
 msgid "Folder does not exist."
 msgstr "Priečinok neexistuje."
 
 #. IDS_ARCHIVE_SUCCEEDED
-#: Merge.rc:5277
+#: Merge.rc:5276
 msgid "Archive file written."
 msgstr ""
 
 #. IDS_ARCHIVE_SAVEFILES
-#: Merge.rc:5278
+#: Merge.rc:5277
 msgid "Save all files first.\n\nCreating an archive requires no unsaved changes."
 msgstr ""
 
 #. IDS_NO_ZIP_SUPPORT
-#: Merge.rc:5283
+#: Merge.rc:5282
 msgid ""
 "Archive support not enabled.\n"
 "7-Zip and/or Merge7z*.dll not found.\n"
@@ -7464,37 +7459,37 @@ msgstr ""
 "V príručke nájdete ďalšie informácie o podpore archívov a o tom, ako ich povoliť."
 
 #. IDS_OPT_EXPORT_CAPTION
-#: Merge.rc:5284
+#: Merge.rc:5283
 msgid "Select file for export"
 msgstr "Vyberte súbor pre export"
 
 #. IDS_OPT_IMPORT_CAPTION
-#: Merge.rc:5285
+#: Merge.rc:5284
 msgid "Select file for import"
 msgstr "Vyberte súbor pre import"
 
 #. IDS_OPT_IMPORT_DONE
-#: Merge.rc:5286
+#: Merge.rc:5285
 msgid "Options imported from file."
 msgstr "Možnosti importované zo súboru."
 
 #. IDS_OPT_EXPORT_DONE
-#: Merge.rc:5287
+#: Merge.rc:5286
 msgid "Options exported to file."
 msgstr "Možnosti exportované do súboru."
 
 #. IDS_OPT_IMPORT_ERR
-#: Merge.rc:5288
+#: Merge.rc:5287
 msgid "Failed to import options from file."
 msgstr "Nepodarilo sa importovať nastavenia zo súboru."
 
 #. IDS_OPT_EXPORT_ERR
-#: Merge.rc:5289
+#: Merge.rc:5288
 msgid "Failed to write options to file."
 msgstr "Nepodarilo sa zapísať nastavenia do súboru."
 
 #. IDS_CLOSEALL_WINDOWS
-#: Merge.rc:5290
+#: Merge.rc:5289
 msgid ""
 "Close multiple compare windows?\n"
 "\n"
@@ -7505,34 +7500,34 @@ msgstr ""
 "Chcete pokračovať?"
 
 #. IDS_EOL_BIN
-#: Merge.rc:5300
+#: Merge.rc:5299
 msgctxt "EOL Type"
 msgid "Binary"
 msgstr "Binárny"
 
 #. IDS_MARKER_COLOR_FMT
-#: Merge.rc:5305
+#: Merge.rc:5304
 #, c-format
 msgid "Marker Color %d"
 msgstr "Farba značky %d"
 
 #. IDS_MARKER_NEW_PATTERN
-#: Merge.rc:5306
+#: Merge.rc:5305
 msgid "New Pattern"
 msgstr "Nový vzor"
 
 #. IDS_PLUGINSLIST_TYPE
-#: Merge.rc:5312
+#: Merge.rc:5311
 msgid "Type"
 msgstr "Typ"
 
 #. IDS_PLUGINS_TYPE_EDITSCRIPT
-#: Merge.rc:5316
+#: Merge.rc:5315
 msgid "Editor script"
 msgstr "Skript editora"
 
 #. ID_SELECTLINEDIFF
-#: Merge.rc:5322
+#: Merge.rc:5321
 msgid ""
 "\n"
 "Difference in Current Line (F4)"
@@ -7541,7 +7536,7 @@ msgstr ""
 "Rozdiel v aktuálnom riadku (F4)"
 
 #. ID_OPTIONS
-#: Merge.rc:5323
+#: Merge.rc:5322
 msgid ""
 "\n"
 "Options"
@@ -7550,7 +7545,7 @@ msgstr ""
 "Možnosti"
 
 #. ID_REFRESH
-#: Merge.rc:5324
+#: Merge.rc:5323
 msgid ""
 "\n"
 "Refresh (F5)"
@@ -7559,7 +7554,7 @@ msgstr ""
 "Obnoviť (F5)"
 
 #. ID_PREVDIFF
-#: Merge.rc:5330
+#: Merge.rc:5329
 msgid ""
 "\n"
 "Previous Difference (Alt+Up)"
@@ -7568,7 +7563,7 @@ msgstr ""
 "Predchádzajúci rozdiel (Alt+↑)"
 
 #. ID_NEXTDIFF
-#: Merge.rc:5331
+#: Merge.rc:5330
 msgid ""
 "\n"
 "Next Difference (Alt+Down)"
@@ -7577,7 +7572,7 @@ msgstr ""
 "Ďalší rozdiel (Alt+­↓)"
 
 #. ID_PREVCONFLICT
-#: Merge.rc:5332
+#: Merge.rc:5331
 msgid ""
 "\n"
 "Previous Conflict (Alt+Shift+Up)"
@@ -7586,7 +7581,7 @@ msgstr ""
 "Predošlý konflikt (Alt+Shift+↑)"
 
 #. ID_NEXTCONFLICT
-#: Merge.rc:5333
+#: Merge.rc:5332
 msgid ""
 "\n"
 "Next Conflict (Alt+Shift+Down)"
@@ -7595,7 +7590,7 @@ msgstr ""
 "Ďalší konflikt (Alt+Shift+↓)"
 
 #. ID_FIRSTDIFF
-#: Merge.rc:5338
+#: Merge.rc:5337
 msgid ""
 "\n"
 "First Difference (Alt+Home)"
@@ -7604,7 +7599,7 @@ msgstr ""
 "Prvý rozdiel (Alt+Home)"
 
 #. ID_CURDIFF
-#: Merge.rc:5339
+#: Merge.rc:5338
 msgid ""
 "\n"
 "Current Difference (Alt+Enter)"
@@ -7613,7 +7608,7 @@ msgstr ""
 "Aktuálny rozdiel (Alt+Enter)"
 
 #. ID_LASTDIFF
-#: Merge.rc:5340
+#: Merge.rc:5339
 msgid ""
 "\n"
 "Last Difference (Alt+End)"
@@ -7622,45 +7617,45 @@ msgstr ""
 "Posledný rozdiel (Alt+End)"
 
 #. ID_L2R
-#: Merge.rc:5341
+#: Merge.rc:5340
 msgid "\nCopy to Right (Alt+Right)"
 msgstr ""
 "\n"
 "Kopírovať vpravo (Alt+→)"
 
 #. ID_R2L
-#: Merge.rc:5342
+#: Merge.rc:5341
 msgid "\nCopy to Left (Alt+Left)"
 msgstr ""
 "\n"
 "Kopírovať doľava (Alt+←)"
 
 #. ID_L2RNEXT
-#: Merge.rc:5343
+#: Merge.rc:5342
 msgid "\nCopy to Right and Advance (Ctrl+Alt+Right)"
 msgstr ""
 "\n"
 "Kopírovať vpravo a dopredu (Ctrl+Alt+→)"
 
 #. ID_R2LNEXT
-#: Merge.rc:5344
+#: Merge.rc:5343
 msgid "\nCopy to Left and Advance (Ctrl+Alt+Left)"
 msgstr ""
 "\n"
 "Kopírovať vľavo a dopredu (Ctrl+Alt+←)"
 
 #. ID_ALL_RIGHT
-#: Merge.rc:5345
+#: Merge.rc:5344
 msgid "\nCopy All to Right"
 msgstr "\nKopírovať všetko vpravo"
 
 #. ID_ALL_LEFT
-#: Merge.rc:5346
+#: Merge.rc:5345
 msgid "\nCopy All to Left"
 msgstr "\nKopírovať všetko vľavo"
 
 #. ID_AUTO_MERGE
-#: Merge.rc:5347
+#: Merge.rc:5346
 msgid ""
 "\n"
 "Auto Merge (Ctrl+Alt+M)"
@@ -7669,7 +7664,7 @@ msgstr ""
 "Automatické zlúčenie (Ctrl+Alt+M)"
 
 #. ID_FIRSTFILE
-#: Merge.rc:5348
+#: Merge.rc:5347
 msgid ""
 "\n"
 "First File"
@@ -7678,7 +7673,7 @@ msgstr ""
 "Prvý súbor"
 
 #. ID_NEXTFILE
-#: Merge.rc:5349
+#: Merge.rc:5348
 msgid ""
 "\n"
 "Next File (Ctrl+F8)"
@@ -7687,7 +7682,7 @@ msgstr ""
 "Ďalší súbor (Ctrl+F8)"
 
 #. ID_LASTFILE
-#: Merge.rc:5350
+#: Merge.rc:5349
 msgid ""
 "\n"
 "Last File"
@@ -7696,7 +7691,7 @@ msgstr ""
 "Posledný súbor"
 
 #. ID_PREVFILE
-#: Merge.rc:5351
+#: Merge.rc:5350
 msgid ""
 "\n"
 "Previous File (Ctrl+F7)"
@@ -7705,141 +7700,141 @@ msgstr ""
 "Predošlý súbor (Ctrl+F7)"
 
 #. IDS_UNPACK_AUTO
-#: Merge.rc:5358
+#: Merge.rc:5357
 msgid "Adapted unpacker applied to both files (one needs extension)."
 msgstr "Rozbaľovač sa použije na oba súbory (pri jednom súbore stačí prípona)"
 
 #. IDS_NO_PREDIFFER
-#: Merge.rc:5359
+#: Merge.rc:5358
 msgid "No Prediffer (Normal)"
 msgstr "Bez predspracovania rozdielov (bežné)"
 
 #. IDS_SUGGESTED_PLUGINS
-#: Merge.rc:5360
+#: Merge.rc:5359
 msgid "Suggested Plugins"
 msgstr "Odporúčané rozšírenia"
 
 #. IDS_NOT_SUGGESTED_PLUGINS
-#: Merge.rc:5361
+#: Merge.rc:5360
 msgid "All Plugins"
 msgstr "Všetky rozšírenia"
 
 #. IDS_PRIVATEBUILD_FMT
-#: Merge.rc:5367
+#: Merge.rc:5366
 #, c-format
 msgid "Private Build: %1"
 msgstr "Súkromná zostava: %1"
 
 #. IDS_ALLRIGHTS_RESERVED
-#: Merge.rc:5368
+#: Merge.rc:5367
 msgid " - All rights reserved."
 msgstr ""
 
 #. IDS_TITLE_PLUGINS_SETTINGS
-#: Merge.rc:5374
+#: Merge.rc:5373
 msgid "Plugin Settings"
 msgstr "Nastavenia rozšírení"
 
 #. IDS_NO_SCT_SCRIPTS
-#: Merge.rc:5376
+#: Merge.rc:5375
 msgid "WSH not found - .sct scripts disabled"
 msgstr "WSH nenájdené - .sct skripty sú zakázané"
 
 #. IDS_LOCBAR_GOTOLINE_FMT
-#: Merge.rc:5384
+#: Merge.rc:5383
 #, c-format
 msgid "G&o to Line %1"
 msgstr "Ch&oď na riadok %1"
 
 #. IDS_GOTO_MOVED_LINE
-#: Merge.rc:5390
+#: Merge.rc:5389
 msgid "Go to Moved Line\tCtrl+Shift+G"
 msgstr "Prejsť na presunutý riadok\tCtrl+Shift+G"
 
 #. IDS_AUTOCOMPLETE_DISABLED
-#: Merge.rc:5396
+#: Merge.rc:5395
 msgctxt "Options dialog|General|Open dialog Auto completion"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_AUTOCOMPLETE_FILE_SYS
-#: Merge.rc:5397
+#: Merge.rc:5396
 msgid "From file system"
 msgstr "Zo súborového systému"
 
 #. IDS_AUTOCOMPLETE_MRU
-#: Merge.rc:5398
+#: Merge.rc:5397
 msgid "From Most Recently Used list"
 msgstr "Zo zoznamu nedávno otvorených"
 
 #. IDS_COLORSCHEME_PLAIN
-#: Merge.rc:5404
+#: Merge.rc:5403
 msgid "No Highlighting"
 msgstr "Bez zvýrazňovania"
 
 #. IDS_COLORSCHEME_PO
-#: Merge.rc:5439
+#: Merge.rc:5438
 msgid "Portable Object"
 msgstr "Prenosný objekt"
 
 #. IDS_COLORSCHEME_RSRC
-#: Merge.rc:5444
+#: Merge.rc:5443
 msgid "Resources"
 msgstr "Zdroje"
 
 #. IDS_COLORSCHEME_SH
-#: Merge.rc:5448
+#: Merge.rc:5447
 msgid "Shell"
 msgstr "Vzhľad prostredia"
 
 #. IDS_CLOSE_LEFT_TABS
-#: Merge.rc:5469
+#: Merge.rc:5468
 msgid "Close &Left Tabs"
 msgstr "Zavrieť karty vľ&avo"
 
 #. IDS_CLOSE_RIGHT_TABS
-#: Merge.rc:5470
+#: Merge.rc:5469
 msgid "Close R&ight Tabs"
 msgstr "Zavrieť karty v&pravo"
 
 #. IDS_CLOSE_OTHER_TABS
-#: Merge.rc:5471
+#: Merge.rc:5470
 msgid "Close &Other Tabs"
 msgstr "Zavrieť ďa&lšie karty"
 
 #. IDS_TABBAR_AUTO_MAXWIDTH
-#: Merge.rc:5472
+#: Merge.rc:5471
 msgid "Enable &Auto Max Width"
 msgstr "Povoliť &automaticky maximalizovať šírku"
 
 #. IDS_WEBPAGE_MENU
-#: Merge.rc:5482
+#: Merge.rc:5481
 msgid "We&bpage"
 msgstr ""
 
 #. IDS_VIEW_WRAP_TEXT
-#: Merge.rc:5487
+#: Merge.rc:5486
 msgid "W&rap Text"
 msgstr ""
 
 #. IDS_NOTINSTALLED
-#: Merge.rc:5492
+#: Merge.rc:5491
 msgid "%1 is not installed."
 msgstr "%1 nie je nainštalovaný."
 
 #. IDS_CREATE_FOLDER
-#: Merge.rc:5497
+#: Merge.rc:5496
 #, c-format
 msgid "%1 does not exist. Create it?"
 msgstr "%1 neexistuje. Chcete ho vytvoriť?"
 
 #. IDS_CREATE_FOLDER_ERROR
-#: Merge.rc:5498
+#: Merge.rc:5497
 msgid "Failed to create folder."
 msgstr "Priečinok sa nepodarilo vytvoriť."
 
 #. IDC_EXT_EDITOR_PATH
-#: Merge.rc:5503
+#: Merge.rc:5502
 msgid ""
 "Parameters:\n"
 "$file: Current file path\n"
@@ -7850,491 +7845,491 @@ msgstr ""
 "$ linenum: Číslo riadku aktuálnej polohy kurzora"
 
 #. IDS_DIFF_ALGORITHM_DEFAULT
-#: Merge.rc:5508
+#: Merge.rc:5507
 msgid "default"
 msgstr "pôvodné"
 
 #. IDS_DIFF_ALGORITHM_MINIMAL
-#: Merge.rc:5509
+#: Merge.rc:5508
 msgid "minimal"
 msgstr "minimálne"
 
 #. IDS_DIFF_ALGORITHM_PATIENCE
-#: Merge.rc:5510
+#: Merge.rc:5509
 msgid "patience"
 msgstr "trpezlivosť"
 
 #. IDS_DIFF_ALGORITHM_HISTOGRAM
-#: Merge.rc:5511
+#: Merge.rc:5510
 msgid "histogram"
 msgstr "histogram"
 
 #. IDS_DIFF_ALGORITHM_NONE
-#: Merge.rc:5512
+#: Merge.rc:5511
 msgid "none"
 msgstr ""
 
 #. IDS_RENDERING_MODE_GDI
-#: Merge.rc:5517
+#: Merge.rc:5516
 msgid "GDI"
 msgstr "GDI"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_DEFAULT
-#: Merge.rc:5518
+#: Merge.rc:5517
 msgid "DirectWrite Default"
 msgstr "DirectWrite Default"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_ALIASED
-#: Merge.rc:5519
+#: Merge.rc:5518
 msgid "DirectWrite Aliased"
 msgstr "DirectWrite Aliased"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_GDI_CLASSIC
-#: Merge.rc:5520
+#: Merge.rc:5519
 msgid "DirectWrite GDI Classic"
 msgstr "DirectWrite GDI Classic"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_GDI_NATURAL
-#: Merge.rc:5521
+#: Merge.rc:5520
 msgid "DirectWrite GDI Natural"
 msgstr "DirectWrite GDI Natural"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_NATURAL
-#: Merge.rc:5522
+#: Merge.rc:5521
 msgid "DirectWrite Natural"
 msgstr "DirectWrite Natural"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_NATURAL_SYMMETRIC
-#: Merge.rc:5523
+#: Merge.rc:5522
 msgid "DirectWrite Natural Symmetric"
 msgstr "DirectWrite Natural Symmetric"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_DISABLED
-#: Merge.rc:5528
+#: Merge.rc:5527
 msgctxt "Options dialog|General|Close windows with Esc"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_1
-#: Merge.rc:5529
+#: Merge.rc:5528
 msgid "MDI child window or main window"
 msgstr "MDI okno potomka alebo hlavné okno"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_2
-#: Merge.rc:5530
+#: Merge.rc:5529
 msgid "MDI child window only"
 msgstr "Iba MDI okno potomka"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_3
-#: Merge.rc:5531
+#: Merge.rc:5530
 msgid "Close main window if only one MDI child window"
 msgstr "Zatvorí hlavné okno, ak existuje len jedno okno potomka MDI"
 
 #. IDS_DIFF_GROUP
-#: Merge.rc:5536
+#: Merge.rc:5535
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Diff"
 msgstr "Rozdiel"
 
 #. IDS_DIFF_HIGHLIGHT
-#: Merge.rc:5537
+#: Merge.rc:5536
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Highlight"
 msgstr "Zvýrazniť"
 
 #. IDS_DIFF_BLINK
-#: Merge.rc:5538
+#: Merge.rc:5537
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Blink"
 msgstr "Blikať"
 
 #. IDS_DIFF_BLOCKSIZE
-#: Merge.rc:5539
+#: Merge.rc:5538
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Block Size"
 msgstr "Veľkosť bloku"
 
 #. IDS_DIFF_BLOCKALPHA
-#: Merge.rc:5540
+#: Merge.rc:5539
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Block Alpha"
 msgstr "Blokovať alfa"
 
 #. IDS_DIFF_CDTHRESHOLD
-#: Merge.rc:5541
+#: Merge.rc:5540
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "CD Threshold"
 msgstr "Prahová hodnota CD"
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION
-#: Merge.rc:5542
+#: Merge.rc:5541
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Ins/Del Detection"
 msgstr "Detekcia Insert/Delete"
 
 #. IDS_OVERLAY_MODE_NONE
-#: Merge.rc:5543 Merge.rc:5548
+#: Merge.rc:5542 Merge.rc:5547
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "None"
 msgstr "Žiadny"
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION_VERTICAL
-#: Merge.rc:5544
+#: Merge.rc:5543
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Vertical"
 msgstr "Vertikálna"
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION_HORIZONTAL
-#: Merge.rc:5545
+#: Merge.rc:5544
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Horizontal"
 msgstr "Horizontálna"
 
 #. IDS_OVERLAY_GROUP
-#: Merge.rc:5546
+#: Merge.rc:5545
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Overlay"
 msgstr "Prekrytie"
 
 #. IDS_OVERLAY_ALPHA
-#: Merge.rc:5547
+#: Merge.rc:5546
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha"
 msgstr "Alfa"
 
 #. IDS_OVERLAY_MODE_XOR
-#: Merge.rc:5549
+#: Merge.rc:5548
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "XOR"
 msgstr "XOR"
 
 #. IDS_OVERLAY_MODE_ALPHA
-#: Merge.rc:5550
+#: Merge.rc:5549
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha Blend"
 msgstr "Alfa zmiešavanie"
 
 #. IDS_OVERLAY_MODE_ALPHA_ANIMATION
-#: Merge.rc:5551
+#: Merge.rc:5550
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha Animation"
 msgstr "Alfa animácia"
 
 #. IDS_ZOOM
-#: Merge.rc:5552
+#: Merge.rc:5551
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Zoom"
 msgstr "Priblíženie"
 
 #. IDS_PAGE
-#: Merge.rc:5553
+#: Merge.rc:5552
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Page:"
 msgstr "Stránka:"
 
 #. IDS_IMGCMP_STATUS_PT_RGBA_FMT
-#: Merge.rc:5554
+#: Merge.rc:5553
 #, c-format
 msgid "Pt: (%d, %d)  RGBA: (%d, %d, %d, %d)  "
 msgstr "Pt: (%d, %d)  RGBA: (%d, %d, %d, %d)  "
 
 #. IDS_IMGCMP_STATUS_DIST1_FMT
-#: Merge.rc:5555
+#: Merge.rc:5554
 #, c-format
 msgid "Dist: %g  "
 msgstr "Vzdialenosť: %g  "
 
 #. IDS_IMGCMP_STATUS_DIST2_FMT
-#: Merge.rc:5556
+#: Merge.rc:5555
 #, c-format
 msgid "Dist: %g, %g  "
 msgstr "Vzdialenosť: %g, %g  "
 
 #. IDS_IMGCMP_STATUS_PAGE_ZOOM_SIZE_BPP_FMT
-#: Merge.rc:5557
+#: Merge.rc:5556
 #, c-format
 msgid "Page: %d/%d  Zoom: %d%%  %dx%dpx  %dbpp  "
 msgstr "Stránka: %d/%d  Priblíženie: %d%%  %dx%dpx  %dbpp  "
 
 #. IDS_IMGCMP_STATUS_RC_FMT
-#: Merge.rc:5558
+#: Merge.rc:5557
 #, c-format
 msgid "Rc: (%d, %d)  "
 msgstr "Rc: (%d, %d)  "
 
 #. IDS_IMGCMP_STATUS_FLIPPED_FMT
-#: Merge.rc:5559
+#: Merge.rc:5558
 #, c-format
 msgid "Flipped: %s  "
 msgstr "Preklopené: %s  "
 
 #. IDS_IMGCMP_STATUS_ROTATED_FMT
-#: Merge.rc:5560
+#: Merge.rc:5559
 #, c-format
 msgid "Rotated: %d  "
 msgstr "Otočené: %d  "
 
 #. IDS_IMGCMP_REPORT_ALLPAGES
-#: Merge.rc:5561
+#: Merge.rc:5560
 msgid "All pages"
 msgstr "Všetky stránky"
 
 #. IDS_IGNSUB_STR1
-#: Merge.rc:5566
+#: Merge.rc:5565
 msgid "<Edit here>"
 msgstr "<Upraviť tu>"
 
 #. IDS_IGNSUB_STR2
-#: Merge.rc:5567
+#: Merge.rc:5566
 msgid "No differences found to select"
 msgstr "Neboli nájdené žiadne rozdiely"
 
 #. IDS_IGNSUB_STR3
-#: Merge.rc:5568
+#: Merge.rc:5567
 msgid "No differences found to add as substitution filter"
 msgstr "Nenašli sa žiadne rozdiely, ktoré by sa dali pridať ako filter nahradenia"
 
 #. IDS_IGNSUB_STR4
-#: Merge.rc:5569
+#: Merge.rc:5568
 msgid "The pair is already in the Substitution Filters list"
 msgstr "Táto dvojica sa už nachádza v zozname filtrov nahradenia"
 
 #. IDS_IGNSUB_STR5
-#: Merge.rc:5570
+#: Merge.rc:5569
 msgid "Add this change to Substitution Filters?"
 msgstr "Pridať túto zmenu do položky Filtre nahradenia?"
 
 #. IDS_OCRRESULT_TEXTONLY
-#: Merge.rc:5575
+#: Merge.rc:5574
 msgid "Text only"
 msgstr "Len text"
 
 #. IDS_OCRRESULT_POS_LINE
-#: Merge.rc:5576
+#: Merge.rc:5575
 msgid "Line-by-line position and text"
 msgstr "Pozícia po riadkoch a text"
 
 #. IDS_OCRRESULT_POS_WORD
-#: Merge.rc:5577
+#: Merge.rc:5576
 msgid "Word-by-word position and text"
 msgstr "Pozícia a text po slovách"
 
 #. IDS_USERDATAFOLDER_APPDATA
-#: Merge.rc:5582
+#: Merge.rc:5581
 msgid "AppData (Roaming) folder"
 msgstr ""
 
 #. IDS_USERDATAFOLDER_INSTALL
-#: Merge.rc:5583
+#: Merge.rc:5582
 msgid "Install folder"
 msgstr ""
 
 #. IDS_USERDATAFOLDER_DOCUMENTS
-#: Merge.rc:5584
+#: Merge.rc:5583
 msgid "Documents folder"
 msgstr ""
 
 #. IDS_SINGLEINSTANCE_DISABLED
-#: Merge.rc:5589
+#: Merge.rc:5588
 msgctxt "Options dialog|General|Single instance mode"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_SINGLEINSTANCE_STR1
-#: Merge.rc:5590
+#: Merge.rc:5589
 msgid "Allow only one instance to run"
 msgstr "Povoliť spustenie iba jednej inštancie"
 
 #. IDS_CLIPBOARD_HISTORY
-#: Merge.rc:5591
+#: Merge.rc:5590
 msgid "Clipboard &History"
 msgstr ""
 
 #. IDS_SINGLEINSTANCE_STR2
-#: Merge.rc:5592
+#: Merge.rc:5591
 msgid "Allow only one instance; wait for termination"
 msgstr "Povolí spustenie iba jednej inštancie a počká, kým sa inštancia ukončí"
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_DISABLED
-#: Merge.rc:5597
+#: Merge.rc:5596
 msgctxt "Options dialog|General|Auto-reload modified files"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_STR1
-#: Merge.rc:5598
+#: Merge.rc:5597
 msgid "Only on window activated"
 msgstr ""
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_STR2
-#: Merge.rc:5599
+#: Merge.rc:5598
 msgid "Immediately"
 msgstr ""
 
 #. IDS_PLUGIN_ALL
-#: Merge.rc:5604
+#: Merge.rc:5603
 msgid "Al&l"
 msgstr "Al&l"
 
 #. IDS_PLUGIN_OTHERS
-#: Merge.rc:5605
+#: Merge.rc:5604
 msgid "&Others"
 msgstr "&Ostatné"
 
-#: Merge.rc:5607
+#: Merge.rc:5606
 #, c-format
 msgid "Missing plugin name in pipeline: %1"
 msgstr "Chýbajúci názov rozšírenia v potrubí rozšírení: %1"
 
-#: Merge.rc:5609
+#: Merge.rc:5608
 #, c-format
 msgid "Missing quote in plugin pipeline: %1"
 msgstr "Chýbajúca úvodzovka v rozšírení: %1"
 
 #. IDS_PLUGIN_NAME_ALREADY_EXISTS
-#: Merge.rc:5610
+#: Merge.rc:5609
 #, c-format
 msgid "Plugin name '%1' already exists."
 msgstr ""
 
 #. IDS_PLUGIN_TITLE1
-#: Merge.rc:5611
+#: Merge.rc:5610
 msgid "Specify plugin arguments"
 msgstr "Určenie argumentov rozšírenia"
 
-#: Merge.rc:5613
+#: Merge.rc:5612
 #, c-format
 msgid "Plugin not found or invalid: %1"
 msgstr ""
 
 #. IDS_PLUGIN_NOT_UNPACK
-#: Merge.rc:5614
+#: Merge.rc:5613
 #, c-format
 msgid "'%1' is not an unpacker plugin"
 msgstr ""
 
 #. IDS_PLUGIN_NOT_PREDIFF
-#: Merge.rc:5615
+#: Merge.rc:5614
 #, c-format
 msgid "'%1' is not a prediffer plugin"
 msgstr ""
 
-#: Merge.rc:5617
+#: Merge.rc:5616
 #, c-format
 msgid "Error prediffing '%1' with '%2'. Prediffing disabled."
 msgstr ""
 
 #. IDS_PLUGIN_CIRCULAR_REFERENCE
-#: Merge.rc:5618
+#: Merge.rc:5617
 #, c-format
 msgid "Circular reference in plugin pipeline: %1"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE1
-#: Merge.rc:5619
+#: Merge.rc:5618
 msgid "URL Handler"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE2
-#: Merge.rc:5620
+#: Merge.rc:5619
 msgid "File Unpacker"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE3
-#: Merge.rc:5621
+#: Merge.rc:5620
 msgid "File or Folder Unpacker"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE5
-#: Merge.rc:5623
+#: Merge.rc:5622
 msgid "Alias for Unpacker"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE6
-#: Merge.rc:5624
+#: Merge.rc:5623
 msgid "Alias for Prediffer"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE7
-#: Merge.rc:5625
+#: Merge.rc:5624
 msgid "Alias for Editor script"
 msgstr ""
 
 #. IDS_PLUGIN_ALIAS_DESC
-#: Merge.rc:5626
+#: Merge.rc:5625
 #, c-format
 msgid "Alias for plugin pipeline '%1'"
 msgstr ""
 
 #. IDS_PLUGIN_NEW_DESC
-#: Merge.rc:5627
+#: Merge.rc:5626
 msgid "New plugin description"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_ALL
-#: Merge.rc:5628
+#: Merge.rc:5627
 msgid "All"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_1ST
-#: Merge.rc:5629
+#: Merge.rc:5628
 msgid "1st"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_2ND
-#: Merge.rc:5630
+#: Merge.rc:5629
 msgid "2nd"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_3RD
-#: Merge.rc:5631
+#: Merge.rc:5630
 msgid "3rd"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_1ST_2ND
-#: Merge.rc:5632
+#: Merge.rc:5631
 msgid "1st and 2nd"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_1ST_3RD
-#: Merge.rc:5633
+#: Merge.rc:5632
 msgid "1st and 3rd"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_2ND_3RD
-#: Merge.rc:5634
+#: Merge.rc:5633
 msgid "2nd and 3rd"
 msgstr ""
 
 #. IDS_PLUGIN_CTRL_CLICK
-#: Merge.rc:5635
+#: Merge.rc:5634
 msgid "(Ctrl+Click to add to pipeline)"
 msgstr ""
 
 #. IDS_FILTER_APPLIED
-#: Merge.rc:5640
+#: Merge.rc:5639
 msgid "Filter applied"
 msgstr "Použitý filter"
 
 #. IDS_FILTERMENU_COMPARE
-#: Merge.rc:5645
+#: Merge.rc:5644
 #, c-format
 msgid "Compare %1"
 msgstr ""
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN2
-#: Merge.rc:5647
+#: Merge.rc:5646
 msgid "&Filter by This Column..."
 msgstr ""
 
 #. IDS_CLIPBOARDHISTORY_TIME
-#: Merge.rc:5652
+#: Merge.rc:5651
 #, c-format
 msgid "Clipboard at %s"
 msgstr "Schránka na %s"
 
 #. IDS_CLIPBOARDHISTORY_DISABLED
-#: Merge.rc:5653
+#: Merge.rc:5652
 msgid ""
 "Clipboard history disabled.\r\n"
 "Enable: Windows logo key + V, then Turn on."
@@ -8342,420 +8337,420 @@ msgstr ""
 "História schránky je vypnutá.\r\n"
 "Ak chcete zapnúť históriu schránky, stlačte kláves s logom Windows + V a potom kliknite na tlačidlo Zapnúť."
 
-#: Merge.rc:5655
+#: Merge.rc:5654
 msgid "This system does not support clipboard history."
 msgstr "Tento systém nepodporuje históriu schránky."
 
-#: Merge.rc:5657
+#: Merge.rc:5656
 msgid "32-bit WinMerge does not support Clipboard Compare"
 msgstr "32-bitová verzia WinMerge nepodporuje porovnávanie schránky"
 
 #. IDS_WEBVIEW2_RUNTIME_NOT_INSTALLED
-#: Merge.rc:5662
+#: Merge.rc:5661
 msgid "WebView2 runtime not installed. Download it?"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_TEXT_COMPARE
-#: Merge.rc:5667
+#: Merge.rc:5666
 msgid "New Text Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_TABLE_COMPARE
-#: Merge.rc:5668
+#: Merge.rc:5667
 msgid "New Table Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_BINARY_COMPARE
-#: Merge.rc:5669
+#: Merge.rc:5668
 msgid "New Binary Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_IMAGE_COMPARE
-#: Merge.rc:5670
+#: Merge.rc:5669
 msgid "New Image Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_WEBPAGE_COMPARE
-#: Merge.rc:5671
+#: Merge.rc:5670
 msgid "New Webpage Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_NEW_FOLDER_COMPARE
-#: Merge.rc:5672
+#: Merge.rc:5671
 msgid "New Folder Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_CLIPBOARD_COMPARE
-#: Merge.rc:5673
+#: Merge.rc:5672
 msgid "Clipboard Compare"
 msgstr ""
 
 #. IDS_PREVIEWBAR_PRINT
-#: Merge.rc:5678
+#: Merge.rc:5677
 msgid "&Print..."
 msgstr ""
 
 #. IDS_PREVIEWBAR_PREVPAGE
-#: Merge.rc:5680
+#: Merge.rc:5679
 msgid "Pre&v Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_TWOPAGE
-#: Merge.rc:5681
+#: Merge.rc:5680
 msgid "&Two Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_ONEPAGE
-#: Merge.rc:5682
+#: Merge.rc:5681
 msgid "&One Page"
 msgstr ""
 
 #. IDS_PREVIEWBAR_ZOOMIN
-#: Merge.rc:5683
+#: Merge.rc:5682
 msgid "Zoom &In"
 msgstr ""
 
 #. IDS_PREVIEWBAR_ZOOMOUT
-#: Merge.rc:5684
+#: Merge.rc:5683
 msgid "Zoom &Out"
 msgstr ""
 
 #. IDS_WEBPAGE_COMPARING
-#: Merge.rc:5690
+#: Merge.rc:5689
 msgid "Comparing..."
 msgstr ""
 
 #. IDS_WEBPAGE_ZOOM
-#: Merge.rc:5691
+#: Merge.rc:5690
 msgid "Zoom:"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_DIFFHUNK
-#: Merge.rc:5696
+#: Merge.rc:5695
 msgid "Diff hunk"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_INLINE
-#: Merge.rc:5697
+#: Merge.rc:5696
 msgid "Inline diff"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_LINE
-#: Merge.rc:5698
+#: Merge.rc:5697
 msgid "Line"
 msgstr ""
 
-#: Merge.rc:5699
+#: Merge.rc:5698
 msgid "Character"
 msgstr ""
 
 #. ID_MICE_PREVDIFF
-#: Merge.rc:5704
+#: Merge.rc:5703
 msgid "\nPrevious Difference (Alt+Up)\n(Right Button+Wheel Up)\n(Alt+Wheel Up)"
 msgstr ""
 
 #. ID_MICE_NEXTDIFF
-#: Merge.rc:5705
+#: Merge.rc:5704
 msgid "\nNext Difference (Alt+Down)\n(Right Button+Wheel Down)\n(Alt+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_L2R
-#: Merge.rc:5706
+#: Merge.rc:5705
 msgid "\nCopy to Right (Alt+Right)\n(Right Button+Wheel Right)\n(Alt+Wheel Right)\n(Alt+Shift+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_R2L
-#: Merge.rc:5707
+#: Merge.rc:5706
 msgid "\nCopy to Left (Alt+Left)\n(Right Button+Wheel Left)\n(Alt+Wheel Left)\n(Alt+Shift+Wheel Up)"
 msgstr ""
 
 #. ID_MICE_L2RNEXT
-#: Merge.rc:5708
+#: Merge.rc:5707
 msgid "\nCopy to Right and Advance (Ctrl+Alt+Right)\n(Ctrl+Alt+Wheel Right)\n(Ctrl+Alt+Shift+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_R2LNEXT
-#: Merge.rc:5709
+#: Merge.rc:5708
 msgid "\nCopy to Left and Advance (Ctrl+Alt+Left)\n(Ctrl+Alt+Wheel Left)\n(Ctrl+Alt+Shift+Wheel Up)"
 msgstr ""
 
 #. IDS_LOG_COMPARING_2
-#: Merge.rc:5719
+#: Merge.rc:5718
 #, c-format
 msgid "Comparing %1 with %2"
 msgstr ""
 
 #. IDS_LOG_COMPARING_3
-#: Merge.rc:5720
+#: Merge.rc:5719
 #, c-format
 msgid "Comparing %1 with %2 and %3"
 msgstr ""
 
 #. IDS_LOG_COMPARE_COMPLETED
-#: Merge.rc:5721
+#: Merge.rc:5720
 msgid "Comparison completed"
 msgstr ""
 
 #. IDS_LOG_COMPARE_ERROR_2
-#: Merge.rc:5722
+#: Merge.rc:5721
 #, c-format
 msgid "Failed to compare %1 with %2: "
 msgstr ""
 
 #. IDS_LOG_COMPARE_ERROR_3
-#: Merge.rc:5723
+#: Merge.rc:5722
 #, c-format
 msgid "Failed to compare %1 with %2 and %3: "
 msgstr ""
 
 #. IDS_LOG_FILE_SAVED
-#: Merge.rc:5724
+#: Merge.rc:5723
 msgid "File saved"
 msgstr ""
 
 #. IDS_LOG_COPYING_FILES
-#: Merge.rc:5725
+#: Merge.rc:5724
 msgid "Copying files..."
 msgstr ""
 
 #. IDS_LOG_MOVING_FILES
-#: Merge.rc:5726
+#: Merge.rc:5725
 msgid "Moving files..."
 msgstr ""
 
 #. IDS_LOG_DELETING_FILES
-#: Merge.rc:5727
+#: Merge.rc:5726
 msgid "Deleting files..."
 msgstr ""
 
 #. IDS_LOG_RECYCLEBIN
-#: Merge.rc:5728
+#: Merge.rc:5727
 msgid "Recycle Bin"
 msgstr ""
 
 #. IDS_LOG_PERMANENTLY_DELETED
-#: Merge.rc:5729
+#: Merge.rc:5728
 msgid "Permanently deleted"
 msgstr ""
 
 #. IDS_LOG_FILEOPERATION_COMPLETED
-#: Merge.rc:5730
+#: Merge.rc:5729
 msgid "File operation completed successfully"
 msgstr ""
 
 #. IDS_LOG_FILEOPERATION_CANCELED
-#: Merge.rc:5731
+#: Merge.rc:5730
 msgid "File operation canceled"
 msgstr ""
 
 #. IDS_FILTER_ERROR_NO_ERROR
-#: Merge.rc:5736
+#: Merge.rc:5735
 msgid "No error"
 msgstr ""
 
 #. IDS_FILTER_ERROR_EMPTY_EXPRESSION
-#: Merge.rc:5737
+#: Merge.rc:5736
 msgid "Filter expression is empty"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNKNOWN_CHAR
-#: Merge.rc:5738
+#: Merge.rc:5737
 msgid "Unknown character in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNTERMINATED_STRING
-#: Merge.rc:5739
+#: Merge.rc:5738
 msgid "Unterminated string literal"
 msgstr ""
 
 #. IDS_FILTER_ERROR_SYNTAX_ERROR
-#: Merge.rc:5740
+#: Merge.rc:5739
 msgid "Syntax error in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_PARSE_FAILURE
-#: Merge.rc:5741
+#: Merge.rc:5740
 msgid "Failed to parse filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_LITERAL
-#: Merge.rc:5742
+#: Merge.rc:5741
 msgid "Invalid literal value"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_REGULAR_EXPRESSION
-#: Merge.rc:5743
+#: Merge.rc:5742
 msgid "Invalid regular expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNDEFINED_IDENTIFIER
-#: Merge.rc:5744
+#: Merge.rc:5743
 msgid "Undefined identifier"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_ARGUMENT_COUNT
-#: Merge.rc:5745
+#: Merge.rc:5744
 msgid "Invalid number of arguments"
 msgstr ""
 
 #. IDS_FILTER_ERROR_FILTER_NAME_NOT_FOUND
-#: Merge.rc:5746
+#: Merge.rc:5745
 msgid "Filter name not found"
 msgstr ""
 
 #. IDS_FILTER_ERROR_DIVIDE_BY_ZERO
-#: Merge.rc:5747
+#: Merge.rc:5746
 msgid "Division by zero in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNKNOWN_ERROR
-#: Merge.rc:5748
+#: Merge.rc:5747
 msgid "Unknown error"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_PROPERTY_NAME
-#: Merge.rc:5749
+#: Merge.rc:5748
 msgid "Invalid property name"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_DIRECTIVE
-#: Merge.rc:5750
+#: Merge.rc:5749
 msgid "Invalid directive"
 msgstr ""
 
 #. IDS_FILTER_OP_EQUALS
-#: Merge.rc:5755
+#: Merge.rc:5754
 msgid "Equals"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_EQUALS
-#: Merge.rc:5756
+#: Merge.rc:5755
 msgid "Does not equal"
 msgstr ""
 
 #. IDS_FILTER_OP_LESS_THAN
-#: Merge.rc:5757
+#: Merge.rc:5756
 msgid "Less than"
 msgstr ""
 
 #. IDS_FILTER_OP_LESS_EQUAL
-#: Merge.rc:5758
+#: Merge.rc:5757
 msgid "Less than or equal to"
 msgstr ""
 
 #. IDS_FILTER_OP_GREATER_EQUAL
-#: Merge.rc:5759
+#: Merge.rc:5758
 msgid "Greater than or equal to"
 msgstr ""
 
 #. IDS_FILTER_OP_GREATER_THAN
-#: Merge.rc:5760
+#: Merge.rc:5759
 msgid "Greater than"
 msgstr ""
 
 #. IDS_FILTER_OP_BETWEEN
-#: Merge.rc:5761
+#: Merge.rc:5760
 msgid "Between"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_BETWEEN
-#: Merge.rc:5762
+#: Merge.rc:5761
 msgid "Not Between"
 msgstr ""
 
 #. IDS_FILTER_OP_CONTAINS
-#: Merge.rc:5763
+#: Merge.rc:5762
 msgid "Contains"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_CONTAINS
-#: Merge.rc:5764
+#: Merge.rc:5763
 msgid "Not Contains"
 msgstr ""
 
 #. IDS_FILTER_OP_RECONTAINS
-#: Merge.rc:5765
+#: Merge.rc:5764
 msgid "Contains (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_RECONTAINS
-#: Merge.rc:5766
+#: Merge.rc:5765
 msgid "Not Contains (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_LIKE
-#: Merge.rc:5767
+#: Merge.rc:5766
 msgid "Match (wildcard)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_LIKE
-#: Merge.rc:5768
+#: Merge.rc:5767
 msgid "Not match (wildcard)"
 msgstr ""
 
 #. IDS_FILTER_OP_MATCHES
-#: Merge.rc:5769
+#: Merge.rc:5768
 msgid "Match (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_MATCHES
-#: Merge.rc:5770
+#: Merge.rc:5769
 msgid "Not match (regex)"
 msgstr ""
 
 #. IDS_COLORMODE_LIGHT
-#: Merge.rc:5775
+#: Merge.rc:5774
 msgid "Light"
 msgstr ""
 
 #. IDS_COLORMODE_DARK
-#: Merge.rc:5776
+#: Merge.rc:5775
 msgid "Dark"
 msgstr ""
 
 #. IDS_COLORMODE_FOLLOWSYSTEM
-#: Merge.rc:5777
+#: Merge.rc:5776
 msgid "Follow system"
 msgstr ""
 
 #. IDS_EXAMPLE
-#: Merge.rc:5782
+#: Merge.rc:5781
 #, c-format
 msgid "e.g. %1"
 msgstr ""
 
 #. IDS_DETECTED_PREVIOUS_CRASH
-#: Merge.rc:5787
+#: Merge.rc:5786
 msgid "WinMerge detected a previous crash. Please report this if possible."
 msgstr ""
 
 #. IDS_REGEX_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5792
+#: Merge.rc:5791
 msgid "# Regex replacement list\r\n# Format: regex<TAB>replacement\r\n# Backreferences like $1, $2 are supported\r\n\r\n(\\d{4})-(\\d{2})-(\\d{2})\t$1_$2_$3\r\n"
 msgstr ""
 
 #. IDS_STRING_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5793
+#: Merge.rc:5792
 msgid "# Replacement list\r\n# Format: search<TAB>replacement\r\n# Lines starting with # are ignored\r\n\r\nfrom1\tto1\r\nfrom2\tto2\r\n"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_ONLY
-#: Merge.rc:5798
+#: Merge.rc:5797
 msgid "Built-in only"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_FIRST
-#: Merge.rc:5799
+#: Merge.rc:5798
 msgid "Built-in first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_FIRST
-#: Merge.rc:5800
+#: Merge.rc:5799
 msgid "Tree-sitter first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_ONLY
-#: Merge.rc:5801
+#: Merge.rc:5800
 msgid "Tree-sitter only"
 msgstr ""
 

--- a/Translations/WinMerge/Slovenian.po
+++ b/Translations/WinMerge/Slovenian.po
@@ -23,7 +23,7 @@ msgstr ""
 "X-Generator: Poedit 3.4.2\n"
 
 #. LANGUAGE, SUBLANGUAGE
-#: Merge.rc:26 Merge.rc:59 Merge.rc:5818
+#: Merge.rc:26 Merge.rc:59 Merge.rc:5817
 msgid "LANG_ENGLISH, SUBLANG_ENGLISH_US"
 msgstr "LANG_SLOVENIAN, SUBLANG_SLOVENIAN"
 
@@ -165,7 +165,7 @@ msgstr "&Skripti"
 #. IDS_NO_EDIT_SCRIPTS
 #: Merge.rc:127 Merge.rc:352 Merge.rc:463 Merge.rc:673 Merge.rc:678
 #: Merge.rc:887 Merge.rc:899 Merge.rc:906 Merge.rc:963 Merge.rc:1210
-#: Merge.rc:5375
+#: Merge.rc:5374
 msgid "< Empty >"
 msgstr "< Prazno >"
 
@@ -230,7 +230,7 @@ msgid "Auto-Fit All Columns"
 msgstr "Samodejno prilagodi vse stolpce"
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN
-#: Merge.rc:153 Merge.rc:5646
+#: Merge.rc:153 Merge.rc:5645
 msgid "&Filter by This Column"
 msgstr ""
 
@@ -291,7 +291,7 @@ msgid "&Previous Page"
 msgstr "&Prejšnja stran"
 
 #. IDS_PREVIEWBAR_NEXTPAGE
-#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5679
+#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5678
 msgid "&Next Page"
 msgstr "&Naslednja stran"
 
@@ -542,7 +542,7 @@ msgstr "&Dvojiško"
 #. IDS_IMAGE_MENU
 #: Merge.rc:329 Merge.rc:338 Merge.rc:432 Merge.rc:441 Merge.rc:609
 #: Merge.rc:618 Merge.rc:670 Merge.rc:960 Merge.rc:1187 Merge.rc:1200
-#: Merge.rc:5477
+#: Merge.rc:5476
 msgid "&Image"
 msgstr "S&lika"
 
@@ -664,7 +664,7 @@ msgid "&Huge"
 msgstr "O&gromne"
 
 #. IDS_VIEW_MENU_BAR
-#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5714
+#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5713
 msgid "Men&u Bar"
 msgstr ""
 
@@ -1319,7 +1319,7 @@ msgid "Lo&cation Pane"
 msgstr "Podokno loka&cije"
 
 #. IDS_OUTPUTBAR_CAPTION
-#: Merge.rc:782 Merge.rc:5252
+#: Merge.rc:782 Merge.rc:5251
 msgid "Output Pane"
 msgstr ""
 
@@ -1582,55 +1582,55 @@ msgid "Co&mpare As"
 msgstr "Pri&merjaj kot"
 
 #. IDS_COPY_LEFT_TO_MIDDLE2
-#: Merge.rc:968 Merge.rc:980 Merge.rc:4852
+#: Merge.rc:968 Merge.rc:980 Merge.rc:4851
 #, c-format
 msgid "Left to Middle (%1 of %2)"
 msgstr "Iz leve v srednjo (%1 od %2)"
 
 #. IDS_COPY_LEFT_TO_RIGHT2
-#: Merge.rc:969 Merge.rc:981 Merge.rc:4851
+#: Merge.rc:969 Merge.rc:981 Merge.rc:4850
 #, c-format
 msgid "Left to Right (%1 of %2)"
 msgstr "Z leve proti desni (%1 od %2)"
 
 #. IDS_MOVE_LEFT_TO2
-#: Merge.rc:970 Merge.rc:982 Merge.rc:1045 Merge.rc:4863 Merge.rc:4892
+#: Merge.rc:970 Merge.rc:982 Merge.rc:1045 Merge.rc:4862 Merge.rc:4891
 #, c-format
 msgid "Left to... (%1 of %2)"
 msgstr "Levo v... (%1 od%2)"
 
 #. IDS_COPY_MIDDLE_TO_LEFT2
-#: Merge.rc:971 Merge.rc:983 Merge.rc:4849
+#: Merge.rc:971 Merge.rc:983 Merge.rc:4848
 #, c-format
 msgid "Middle to Left (%1 of %2)"
 msgstr "Iz srednje v levo (%1 od %2)"
 
 #. IDS_COPY_MIDDLE_TO_RIGHT2
-#: Merge.rc:972 Merge.rc:984 Merge.rc:4850
+#: Merge.rc:972 Merge.rc:984 Merge.rc:4849
 #, c-format
 msgid "Middle to Right (%1 of %2)"
 msgstr "Iz srednje v desno (%1 od %2)"
 
 #. IDS_MOVE_MIDDLE_TO2
-#: Merge.rc:973 Merge.rc:985 Merge.rc:1046 Merge.rc:4864 Merge.rc:4893
+#: Merge.rc:973 Merge.rc:985 Merge.rc:1046 Merge.rc:4863 Merge.rc:4892
 #, c-format
 msgid "Middle to... (%1 of %2)"
 msgstr "Srednjo v... (%1 od %2)"
 
 #. IDS_COPY_RIGHT_TO_MIDDLE2
-#: Merge.rc:974 Merge.rc:986 Merge.rc:4848
+#: Merge.rc:974 Merge.rc:986 Merge.rc:4847
 #, c-format
 msgid "Right to Middle (%1 of %2)"
 msgstr "Iz desne v srednjo (%1 od %2)"
 
 #. IDS_COPY_RIGHT_TO_LEFT2
-#: Merge.rc:975 Merge.rc:987 Merge.rc:4847
+#: Merge.rc:975 Merge.rc:987 Merge.rc:4846
 #, c-format
 msgid "Right to Left (%1 of %2)"
 msgstr "Z desne proti levi (%1 od %2)"
 
 #. IDS_MOVE_RIGHT_TO2
-#: Merge.rc:976 Merge.rc:988 Merge.rc:1047 Merge.rc:4865 Merge.rc:4894
+#: Merge.rc:976 Merge.rc:988 Merge.rc:1047 Merge.rc:4864 Merge.rc:4893
 #, c-format
 msgid "Right to... (%1 of %2)"
 msgstr "Desno v... (%1 od%2)"
@@ -1686,31 +1686,31 @@ msgid "Cop&y Paths"
 msgstr "Kopiraj &imena poti"
 
 #. IDS_DEL_LEFT_FMT2
-#: Merge.rc:1026 Merge.rc:1035 Merge.rc:4880
+#: Merge.rc:1026 Merge.rc:1035 Merge.rc:4879
 #, c-format
 msgid "Left (%1 of %2)"
 msgstr "Leva (%1 od %2)"
 
 #. IDS_DEL_MIDDLE_FMT2
-#: Merge.rc:1027 Merge.rc:1036 Merge.rc:4881
+#: Merge.rc:1027 Merge.rc:1036 Merge.rc:4880
 #, c-format
 msgid "Middle (%1 of %2)"
 msgstr "Srednja (%1 od %2)"
 
 #. IDS_DEL_RIGHT_FMT2
-#: Merge.rc:1028 Merge.rc:1037 Merge.rc:4882
+#: Merge.rc:1028 Merge.rc:1037 Merge.rc:4881
 #, c-format
 msgid "Right (%1 of %2)"
 msgstr "Desna (%1 od %2)"
 
 #. IDS_DEL_BOTH_FMT2
-#: Merge.rc:1029 Merge.rc:1038 Merge.rc:4883
+#: Merge.rc:1029 Merge.rc:1038 Merge.rc:4882
 #, c-format
 msgid "Both (%1 of %2)"
 msgstr "Obe (%1 od %2)"
 
 #. IDS_DEL_ALL_FMT2
-#: Merge.rc:1030 Merge.rc:1039 Merge.rc:4888
+#: Merge.rc:1030 Merge.rc:1039 Merge.rc:4887
 #, c-format
 msgid "All (%1 of %2)"
 msgstr "Vse (%1 od %2)"
@@ -1736,19 +1736,19 @@ msgid "&Zip"
 msgstr "Arhiv &Zip"
 
 #. IDS_COPY_BOTH_TO2
-#: Merge.rc:1048 Merge.rc:4866
+#: Merge.rc:1048 Merge.rc:4865
 #, c-format
 msgid "Both to... (%1 of %2)"
 msgstr "Obe v... (%1 od %2)"
 
 #. IDS_COPY_ALL_TO2
-#: Merge.rc:1049 Merge.rc:4867
+#: Merge.rc:1049 Merge.rc:4866
 #, c-format
 msgid "All to... (%1 of %2)"
 msgstr "Vse v... (%1 od %2)"
 
 #. IDS_COPY_DIFFERENCES_TO2
-#: Merge.rc:1050 Merge.rc:4868
+#: Merge.rc:1050 Merge.rc:4867
 #, c-format
 msgid "Differences to... (%1 of %2)"
 msgstr "Razlike v... (%1 od %2)"
@@ -1815,12 +1815,12 @@ msgstr "Nastavitve razpakovalca"
 
 #. IDS_USERCHOICE_NONE
 #: Merge.rc:1088 Merge.rc:1094 Merge.rc:1836 Merge.rc:1840 Merge.rc:2031
-#: Merge.rc:2035 Merge.rc:5377
+#: Merge.rc:2035 Merge.rc:5376
 msgid "<None>"
 msgstr "<Brez>"
 
 #. IDS_USERCHOICE_AUTOMATIC
-#: Merge.rc:1089 Merge.rc:1095 Merge.rc:5378
+#: Merge.rc:1089 Merge.rc:1095 Merge.rc:5377
 msgid "<Automatic>"
 msgstr "<Samodejno>"
 
@@ -2750,12 +2750,12 @@ msgid "Text files only"
 msgstr ""
 
 #. IDS_EOL_NONE
-#: Merge.rc:1667 Merge.rc:1918 Merge.rc:5304
+#: Merge.rc:1667 Merge.rc:1918 Merge.rc:5303
 msgid "None"
 msgstr "Brez"
 
 #. IDS_EOL_MIXED
-#: Merge.rc:1668 Merge.rc:5299
+#: Merge.rc:1668 Merge.rc:5298
 msgid "Mixed"
 msgstr "Mešano"
 
@@ -3027,13 +3027,13 @@ msgstr ""
 
 #. IDS_DIFFERENT
 #: Merge.rc:1904 Merge.rc:1988 Merge.rc:2866 Merge.rc:3036 Merge.rc:3077
-#: Merge.rc:5058
+#: Merge.rc:5057
 msgid "Different"
 msgstr "Razlika"
 
 #. IDS_IDENTICAL
 #: Merge.rc:1905 Merge.rc:1989 Merge.rc:2865 Merge.rc:3055 Merge.rc:3116
-#: Merge.rc:5048
+#: Merge.rc:5047
 msgid "Identical"
 msgstr "Enako"
 
@@ -3053,7 +3053,7 @@ msgid "Missing"
 msgstr ""
 
 #. IDS_MOVED
-#: Merge.rc:1910 Merge.rc:5076
+#: Merge.rc:1910 Merge.rc:5075
 msgid "Moved"
 msgstr ""
 
@@ -3789,7 +3789,7 @@ msgid "&Use custom system colors"
 msgstr ""
 
 #. IDS_PRPCAT_SYSTEM
-#: Merge.rc:2565 Merge.rc:4559 Merge.rc:4560 Merge.rc:5007
+#: Merge.rc:2565 Merge.rc:4559 Merge.rc:4560 Merge.rc:5006
 msgid "System"
 msgstr "Sistem"
 
@@ -4189,7 +4189,7 @@ msgid "Items compared:"
 msgstr "Primerjanih vnosov:"
 
 #. IDS_PREVIEWBAR_CLOSE
-#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5685
+#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5684
 msgid "&Close"
 msgstr "&Zapri"
 
@@ -4812,7 +4812,7 @@ msgid "A&ppend timestamp"
 msgstr "Dodaj ča&sovni žig"
 
 #. IDS_CONFIRM_COPY_CAPTION
-#: Merge.rc:3214 Merge.rc:4915
+#: Merge.rc:3214 Merge.rc:4914
 msgid "Confirm Copy"
 msgstr "Potrdi kopiranje"
 
@@ -5049,7 +5049,7 @@ msgid "&Character Set..."
 msgstr "Nabor z&nakov..."
 
 #. IDS_PRPCAT_IMAGE
-#: Merge.rc:3351 Merge.rc:4574 Merge.rc:5015
+#: Merge.rc:3351 Merge.rc:4574 Merge.rc:5014
 msgid "Image"
 msgstr "Slika"
 
@@ -5442,7 +5442,7 @@ msgid "Project"
 msgstr "Projekt"
 
 #. IDS_COLHDR_NSDIFFS
-#: Merge.rc:4566 Merge.rc:4990
+#: Merge.rc:4566 Merge.rc:4989
 msgid "Differences"
 msgstr "Razlike"
 
@@ -5587,12 +5587,12 @@ msgid "File Type"
 msgstr "Vrsta datoteke"
 
 #. IDS_COLHDR_EXTENSION
-#: Merge.rc:4653 Merge.rc:4947
+#: Merge.rc:4653 Merge.rc:4946
 msgid "Extension"
 msgstr "Končnica"
 
 #. IDS_PRPCAT_MESSAGE
-#: Merge.rc:4659 Merge.rc:5019
+#: Merge.rc:4659 Merge.rc:5018
 msgid "Message"
 msgstr "Sporočilo"
 
@@ -5632,7 +5632,7 @@ msgid "Hidden Items"
 msgstr "Skriti vnosi"
 
 #. IDS_PLUGINSLIST_NAME
-#: Merge.rc:4680 Merge.rc:5311
+#: Merge.rc:4680 Merge.rc:5310
 msgid "Name"
 msgstr "Ime"
 
@@ -5652,7 +5652,7 @@ msgid "[F] "
 msgstr "[F] "
 
 #. IDS_PLUGINSLIST_DESC
-#: Merge.rc:4684 Merge.rc:5313
+#: Merge.rc:4684 Merge.rc:5312
 msgid "Description"
 msgstr "Opis"
 
@@ -5819,155 +5819,150 @@ msgstr "Vr: %s  St: %d/%d  Zn: %d/%d"
 msgid "  Sel: %d | %d"
 msgstr "  Izb: %d | %d"
 
-#. IDS_MERGEMODE_MERGING
-#: Merge.rc:4734
-msgid "Merge"
-msgstr "Združi"
-
 #. IDS_DIFF_NUMBER_STATUS_FMT
-#: Merge.rc:4735
+#: Merge.rc:4734
 #, c-format
 msgid "Difference %1 of %2"
 msgstr "Razlika %1 od %2"
 
 #. IDS_NO_DIFF_SEL_FMT
-#: Merge.rc:4736
+#: Merge.rc:4735
 #, c-format
 msgid "%1 Differences Found"
 msgstr "%1 najdenih razlik"
 
 #. IDS_1_DIFF_FOUND
-#: Merge.rc:4737
+#: Merge.rc:4736
 msgid "1 Difference Found"
 msgstr "1 najdena razlika"
 
 #. IDS_NO_ERR_SEL_FMT
-#: Merge.rc:4738
+#: Merge.rc:4737
 #, c-format
 msgid "%1 Errors Found"
 msgstr ""
 
 #. IDS_1_ERR_FOUND
-#: Merge.rc:4739
+#: Merge.rc:4738
 msgid "1 Error Found"
 msgstr ""
 
 #. IDS_STATUSBAR_READONLY, Abbreviation from "Read Only"
-#: Merge.rc:4740
+#: Merge.rc:4739
 msgid "RO"
 msgstr "SZB"
 
 #. IDS_DIRVIEW_STATUS_FMT_FOCUS
-#: Merge.rc:4746
+#: Merge.rc:4745
 #, c-format
 msgid "Item %1 of %2"
 msgstr "Vnos %1 od %2"
 
 #. IDS_DIRVIEW_STATUS_FMT_NOFOCUS
-#: Merge.rc:4747
+#: Merge.rc:4746
 #, c-format
 msgid "Items: %1"
 msgstr "Vnosov: %1"
 
 #. IDS_DIRVIEW_STATUS_COMPARING
-#: Merge.rc:4748
+#: Merge.rc:4747
 msgid "Comparing items..."
 msgstr "Primerjava vnosov..."
 
 #. IDS_ITEMS_PER_SEC
-#: Merge.rc:4749
+#: Merge.rc:4748
 #, c-format
 msgid "%.1f[items/sec]"
 msgstr "%.1f[vnosov/sek.]"
 
 #. IDS_ERROR_INCOMPARABLE
-#: Merge.rc:4755
+#: Merge.rc:4754
 msgid "Select two existing folders/files to compare."
 msgstr "Za primerjavo izberite dve obstoječi mapi ali datoteki."
 
 #. IDS_DIRSEL_TAG
-#: Merge.rc:4756
+#: Merge.rc:4755
 msgid "Folder Selection"
 msgstr "Izbira map"
 
 #. IDS_OPEN_FILESDIRS
-#: Merge.rc:4757
+#: Merge.rc:4756
 msgid "Select two (or three) folders/files to compare."
 msgstr "Za primerjavo izberite dve (ali tri) mape ali dve (ali tri) datoteke."
 
 #. IDS_OPEN_LEFTINVALID
-#: Merge.rc:4758
+#: Merge.rc:4757
 msgid "Left (1st) path is invalid!"
 msgstr "Leva (prva) pot je neveljavna!"
 
 #. IDS_OPEN_MIDDLEINVALID
-#: Merge.rc:4759
+#: Merge.rc:4758
 msgid "Middle (2nd) path is invalid!"
 msgstr "Srednja (druga) pot je neveljavna!"
 
 #. IDS_OPEN_RIGHTINVALID2
-#: Merge.rc:4760
+#: Merge.rc:4759
 msgid "Right (2nd) path is invalid!"
 msgstr "Desna (druga) pot je neveljavna!"
 
 #. IDS_OPEN_RIGHTINVALID3
-#: Merge.rc:4761
+#: Merge.rc:4760
 msgid "Right (3rd) path is invalid!"
 msgstr "Desna (tretja) pot je neveljavna!"
 
 #. IDS_OPEN_BOTHINVALID
-#: Merge.rc:4762
+#: Merge.rc:4761
 msgid "Both paths are invalid!"
 msgstr "Obe poti sta neveljavni!"
 
-#: Merge.rc:4764
+#: Merge.rc:4763
 msgid "Left (1st) and Middle (2nd) paths are invalid!"
 msgstr "Leva (prva) in srednja (druga) pot sta neveljavni!"
 
 #. IDS_OPEN_LEFTRIGHTINVALID
-#: Merge.rc:4765
+#: Merge.rc:4764
 msgid "Left (1st) and Right (3rd) paths are invalid!"
 msgstr "Leva (prva) in desna (tretja) pot sta neveljavni!"
 
-#: Merge.rc:4767
+#: Merge.rc:4766
 msgid "Middle (2nd) and Right (3rd) paths are invalid!"
 msgstr "Srednja (druga) in desna (tretja) pot sta neveljavni!"
 
 #. IDS_OPEN_ALLINVALID
-#: Merge.rc:4768
+#: Merge.rc:4767
 msgid "All paths are invalid!"
 msgstr "Vse poti so neveljavne!"
 
 #. IDS_OPEN_UNPACKERDISABLED
-#: Merge.rc:4769
+#: Merge.rc:4768
 msgid "Only enabled for file comparisons"
 msgstr "Omogočeno je le za primerjave datotek"
 
 #. IDS_OPEN_MISMATCH
-#: Merge.rc:4770
+#: Merge.rc:4769
 msgid "Cannot compare file and folder!"
 msgstr "Ni mogoče primerjati datoteke in mape!"
 
 #. IDS_ERROR_FILE_NOT_FOUND
-#: Merge.rc:4776
+#: Merge.rc:4775
 #, c-format
 msgid "File not found: %1"
 msgstr "Datoteka ni bila najdena: %1"
 
 #. IDS_ERROR_FOLDER_NOT_FOUND
-#: Merge.rc:4777
+#: Merge.rc:4776
 #, c-format
 msgid "Folder not found: %1"
 msgstr ""
 
 #. IDS_ERROR_FILE_NOT_UNPACKED
-#: Merge.rc:4778
+#: Merge.rc:4777
 #, c-format
 msgid "File not unpacked: %1"
 msgstr "Datoteka ni razpakirana: %1"
 
 #. IDS_ERROR_FILEOPEN
-#: Merge.rc:4779
+#: Merge.rc:4778
 #, c-format
 msgid ""
 "Cannot open file\n"
@@ -5981,12 +5976,12 @@ msgstr ""
 "%2"
 
 #. IDS_ERROR_CONF_RESOLVE
-#: Merge.rc:4780
+#: Merge.rc:4779
 msgid "Failed to parse conflict file."
 msgstr "Ni uspela razčlenitev datoteke v sporu."
 
 #. IDS_NOT_CONFLICT_FILE
-#: Merge.rc:4781
+#: Merge.rc:4780
 #, c-format
 msgid "The file\n%1\nis not a conflict file."
 msgstr ""
@@ -5995,7 +5990,7 @@ msgstr ""
 "ni datoteka v sporu."
 
 #. IDS_COMPARE_LARGE_FILES
-#: Merge.rc:4782
+#: Merge.rc:4781
 msgid "Comparing large files requires significant memory.\nShow only comparison results (not file contents)?"
 msgstr ""
 "Primerjate zelo velike datoteke.\n"
@@ -6004,28 +5999,28 @@ msgstr ""
 "\n"
 
 #. IDS_SAVE_AS_TITLE
-#: Merge.rc:4788
+#: Merge.rc:4787
 msgid "Save As"
 msgstr "Shrani kot"
 
 #. IDS_SAVE_FMT
-#: Merge.rc:4789
+#: Merge.rc:4788
 #, c-format
 msgid "Save changes to %1?"
 msgstr "Želite shraniti spremembe v %1?"
 
 #. IDS_SAVEREADONLY_FMT
-#: Merge.rc:4790
+#: Merge.rc:4789
 #, c-format
 msgid "%1 is read-only. Override? Or 'No' to save as new filename?"
 msgstr "%1 je označena Samo-za- branje. Ali želite preglasiti datoteko Samo-za- branje? ('Ne', za shranjevanje pod novim imenom)"
 
 #. IDS_ERROR_BACKUP
-#: Merge.rc:4791
+#: Merge.rc:4790
 msgid "Error backing up file"
 msgstr "Napaka pri varnostnem kopiranju datoteke"
 
-#: Merge.rc:4793
+#: Merge.rc:4792
 #, c-format
 msgid ""
 "Unable to backup original file:\n"
@@ -6039,7 +6034,7 @@ msgstr ""
 "Želite vseeno nadaljevati?"
 
 #. IDS_FILESAVE_FAILED
-#: Merge.rc:4794
+#: Merge.rc:4793
 #, c-format
 msgid "Saving file failed.\n%1\n%2\n\t- Use different filename (OK)\n\t- Abort (Cancel)?"
 msgstr ""
@@ -6050,7 +6045,7 @@ msgstr ""
 "\t- uporabiti drugačno ime datoteke (Pritisnite 'Vredu')\n"
 "\t- prekiniti trenutno operacijo (Pritisnite 'Prekliči')?"
 
-#: Merge.rc:4796
+#: Merge.rc:4795
 #, c-format
 msgid "Plugin '%2' cannot pack changes to left file into '%1'.\n\nOriginal unchanged. Save unpacked version?"
 msgstr ""
@@ -6060,7 +6055,7 @@ msgstr ""
 "\n"
 "Ali želite shraniti nepakirano različico v drugo datoteko?"
 
-#: Merge.rc:4798
+#: Merge.rc:4797
 #, c-format
 msgid "Plugin '%2' cannot pack changes to middle file into '%1'.\n\nOriginal unchanged. Save unpacked version?"
 msgstr ""
@@ -6070,7 +6065,7 @@ msgstr ""
 "\n"
 "Ali želite razpakirano različico shraniti v drugo datoteko?"
 
-#: Merge.rc:4800
+#: Merge.rc:4799
 #, c-format
 msgid "Plugin '%2' cannot pack changes to right file into '%1'.\n\nOriginal unchanged. Save unpacked version?"
 msgstr ""
@@ -6081,7 +6076,7 @@ msgstr ""
 "Ali želite shraniti nepakirano različico v drugo datoteko?"
 
 #. IDS_FILECHANGED_ONDISK
-#: Merge.rc:4801
+#: Merge.rc:4800
 #, c-format
 msgid ""
 "Another application updated\n"
@@ -6097,7 +6092,7 @@ msgstr ""
 "Želite prepisati spremenjeno datoteko?"
 
 #. IDS_SAVEREADONLY_MULTI
-#: Merge.rc:4802
+#: Merge.rc:4801
 #, c-format
 msgid ""
 "%1\n"
@@ -6107,7 +6102,7 @@ msgstr ""
 "je označena 'samo-za-branje'. Ali želite preglasiti vnos 'samo-za-branje'?"
 
 #. IDS_FILECHANGED_RESCAN
-#: Merge.rc:4803
+#: Merge.rc:4802
 #, c-format
 msgid "Another application updated\n%1\nsince last scan.\n\nReload?"
 msgstr ""
@@ -6117,22 +6112,22 @@ msgstr ""
 "Ali želite znova naložiti datoteko?"
 
 #. IDS_SAVE_LEFT_AS
-#: Merge.rc:4804
+#: Merge.rc:4803
 msgid "Save Left File As"
 msgstr "Shrani levo datoteko kot"
 
 #. IDS_SAVE_MIDDLE_AS
-#: Merge.rc:4805
+#: Merge.rc:4804
 msgid "Save Middle File As"
 msgstr "Shrani srednjo datoteko kot"
 
 #. IDS_SAVE_RIGHT_AS
-#: Merge.rc:4806
+#: Merge.rc:4805
 msgid "Save Right File As"
 msgstr "Shrani desno datoteko kot"
 
 #. IDS_FILE_DISAPPEARED
-#: Merge.rc:4811
+#: Merge.rc:4810
 #, c-format
 msgid ""
 "File\n"
@@ -6144,7 +6139,7 @@ msgstr ""
 "je izginila. Za nadaljevanje shranite kopijo datoteke."
 
 #. IDS_VIEWS_OUTOFSYNC
-#: Merge.rc:4817
+#: Merge.rc:4816
 msgid ""
 "Cannot merge unsynched documents.\n"
 "\n"
@@ -6155,186 +6150,186 @@ msgstr ""
 "Osvežite dokumente pred nadaljevanjem."
 
 #. IDS_BREAK_ON_WHITESPACE
-#: Merge.rc:4822
+#: Merge.rc:4821
 msgid "Break at whitespace"
 msgstr "Prelom na praznem znaku"
 
 #. IDS_BREAK_ON_PUNCTUATION
-#: Merge.rc:4823
+#: Merge.rc:4822
 msgid "Break at whitespace or punctuation"
 msgstr "Prelom na praznem znaku ali ločilu"
 
 #. IDS_L2M
-#: Merge.rc:4829
+#: Merge.rc:4828
 msgid "Copy to &Middle\tAlt+Right"
 msgstr "Kopiraj v s%rednjo\tAlt+Desno"
 
 #. IDS_R2M
-#: Merge.rc:4830
+#: Merge.rc:4829
 msgid "Copy to &Middle\tAlt+Left"
 msgstr "Kopiraj v s%rednjo\tAlt+Levo"
 
 #. IDS_COPY_FROM_MIDDLE_R
-#: Merge.rc:4831
+#: Merge.rc:4830
 msgid "Copy from Middle\tAlt+Shift+Right"
 msgstr "Kopiraj iz srednje\tAlt+Shift+Desno"
 
 #. IDS_COPY_FROM_MIDDLE_L
-#: Merge.rc:4832
+#: Merge.rc:4831
 msgid "Copy from Middle\tAlt+Shift+Left"
 msgstr "Kopiraj iz srednje\tAlt+Shift+Levo"
 
 #. IDS_L2MNEXT
-#: Merge.rc:4833
+#: Merge.rc:4832
 msgid "Copy to Middle and Advance\tCtrl+Alt+Right"
 msgstr "Kopiraj v sredino in naprej\tCtrl+Alt+Desno"
 
 #. IDS_R2MNEXT
-#: Merge.rc:4834
+#: Merge.rc:4833
 msgid "Copy to Middle and Advance\tCtrl+Alt+Left"
 msgstr "Kopiraj v srednjo in naprej\tCtrl+Alt+Levo"
 
 #. IDS_ALL_MIDDLE
-#: Merge.rc:4835
+#: Merge.rc:4834
 msgid "Copy All to Middle"
 msgstr "Kopiraj vse v srednjo"
 
 #. IDS_COPY_RIGHT_TO_LEFT
-#: Merge.rc:4841
+#: Merge.rc:4840
 #, c-format
 msgid "Right to Left (%1)"
 msgstr "Z desne proti levi (%1)"
 
 #. IDS_COPY_RIGHT_TO_MIDDLE
-#: Merge.rc:4842
+#: Merge.rc:4841
 #, c-format
 msgid "Right to Middle (%1)"
 msgstr "Iz desne v srednjo (%1)"
 
 #. IDS_COPY_MIDDLE_TO_LEFT
-#: Merge.rc:4843
+#: Merge.rc:4842
 #, c-format
 msgid "Middle to Left (%1)"
 msgstr "Iz srednje v levo (%1)"
 
 #. IDS_COPY_MIDDLE_TO_RIGHT
-#: Merge.rc:4844
+#: Merge.rc:4843
 #, c-format
 msgid "Middle to Right (%1)"
 msgstr "Iz srednje v desno (%1 od %2)"
 
 #. IDS_COPY_LEFT_TO_RIGHT
-#: Merge.rc:4845
+#: Merge.rc:4844
 #, c-format
 msgid "Left to Right (%1)"
 msgstr "Z leve proti desni (%1)"
 
 #. IDS_COPY_LEFT_TO_MIDDLE
-#: Merge.rc:4846
+#: Merge.rc:4845
 #, c-format
 msgid "Left to Middle (%1)"
 msgstr "Iz leve v srednjo (%1)"
 
 #. IDS_MOVE_LEFT_TO
-#: Merge.rc:4857 Merge.rc:4889
+#: Merge.rc:4856 Merge.rc:4888
 #, c-format
 msgid "Left to... (%1)"
 msgstr "Leva do... (%1)"
 
 #. IDS_MOVE_MIDDLE_TO
-#: Merge.rc:4858 Merge.rc:4890
+#: Merge.rc:4857 Merge.rc:4889
 #, c-format
 msgid "Middle to... (%1)"
 msgstr "Srednjo v.... (%1)"
 
 #. IDS_MOVE_RIGHT_TO
-#: Merge.rc:4859 Merge.rc:4891
+#: Merge.rc:4858 Merge.rc:4890
 #, c-format
 msgid "Right to... (%1)"
 msgstr "Desno v... (%1)"
 
 #. IDS_COPY_BOTH_TO
-#: Merge.rc:4860
+#: Merge.rc:4859
 #, c-format
 msgid "Both to... (%1)"
 msgstr "Obe v... (%1)"
 
 #. IDS_COPY_ALL_TO
-#: Merge.rc:4861
+#: Merge.rc:4860
 #, c-format
 msgid "All to... (%1)"
 msgstr "Vse v... (%1)"
 
 #. IDS_COPY_DIFFERENCES_TO
-#: Merge.rc:4862
+#: Merge.rc:4861
 #, c-format
 msgid "Differences to... (%1)"
 msgstr "Razlike v... (%1)"
 
 #. IDS_ONLYDIFFITEMS_CONFIRM
-#: Merge.rc:4869
+#: Merge.rc:4868
 msgid "Some selected items are identical or skipped.\nProcess only items with differences?"
 msgstr ""
 
 #. IDS_DEL_LEFT_FMT
-#: Merge.rc:4875
+#: Merge.rc:4874
 #, c-format
 msgid "Left (%1)"
 msgstr "Leva (%1)"
 
 #. IDS_DEL_MIDDLE_FMT
-#: Merge.rc:4876
+#: Merge.rc:4875
 #, c-format
 msgid "Middle (%1)"
 msgstr "Srednja (%1)"
 
 #. IDS_DEL_RIGHT_FMT
-#: Merge.rc:4877
+#: Merge.rc:4876
 #, c-format
 msgid "Right (%1)"
 msgstr "Desna (%1)"
 
 #. IDS_DEL_BOTH_FMT
-#: Merge.rc:4878
+#: Merge.rc:4877
 #, c-format
 msgid "Both (%1)"
 msgstr "Obe (%1)"
 
 #. IDS_DEL_ALL_FMT
-#: Merge.rc:4879
+#: Merge.rc:4878
 #, c-format
 msgid "All (%1)"
 msgstr "Vse (%1)"
 
 #. IDS_SELECT_DEST_LEFT
-#: Merge.rc:4895
+#: Merge.rc:4894
 msgid "Left Side - Select Destination Folder:"
 msgstr "Leva stran - izberite ciljno mapo:"
 
 #. IDS_SELECT_DEST_MIDDLE
-#: Merge.rc:4896
+#: Merge.rc:4895
 msgid "Middle Side - Select Destination Folder:"
 msgstr "Srednje okno - izberite ciljno mapo:"
 
 #. IDS_SELECT_DEST_RIGHT
-#: Merge.rc:4897
+#: Merge.rc:4896
 msgid "Right Side - Select Destination Folder:"
 msgstr "Desna stran - izberite ciljno mapo:"
 
 #. IDS_FILES_AFFECTED_FMT
-#: Merge.rc:4898
+#: Merge.rc:4897
 #, c-format
 msgid "(%1 Files Affected)"
 msgstr "(%1 vpletenih datotek)"
 
 #. IDS_FILES_AFFECTED_FMT2
-#: Merge.rc:4899
+#: Merge.rc:4898
 #, c-format
 msgid "(%1 of %2 Files Affected)"
 msgstr "(%1 od %2 vpletenih datotek)"
 
 #. IDS_CONFIRM_DELETE_SINGLE
-#: Merge.rc:4905
+#: Merge.rc:4904
 #, c-format
 msgid ""
 "Are you sure you want to delete\n"
@@ -6346,18 +6341,18 @@ msgstr ""
 "%1 ?"
 
 #. IDS_CONFIRM_SINGLE_COPY
-#: Merge.rc:4906
+#: Merge.rc:4905
 msgid "Are you sure you want to copy?"
 msgstr "Ali ste prepričani, da želite kopirati?"
 
 #. IDS_CONFIRM_MULTIPLE_COPY
-#: Merge.rc:4907
+#: Merge.rc:4906
 #, c-format
 msgid "Are you sure you want to copy %d items?"
 msgstr "Ali ste prepričani, da želite kopirati %d vnosov?"
 
 #. IDS_DIRCMP_NOTSYNC
-#: Merge.rc:4908
+#: Merge.rc:4907
 #, c-format
 msgid ""
 "Operation aborted!\n"
@@ -6377,46 +6372,46 @@ msgstr ""
 "Osvežite primerjavo."
 
 #. IDS_CONFIRM_SINGLE_MOVE
-#: Merge.rc:4913
+#: Merge.rc:4912
 msgid "Are you sure you want to move?"
 msgstr "Ali ste prepričani, da želite premakniti?"
 
 #. IDS_CONFIRM_MULTIPLE_MOVE
-#: Merge.rc:4914
+#: Merge.rc:4913
 #, c-format
 msgid "Are you sure you want to move %d items?"
 msgstr "Ali ste prepričani, da želite premakniti: %d vnosov?"
 
 #. IDS_CONFIRM_MOVE_CAPTION
-#: Merge.rc:4916
+#: Merge.rc:4915
 msgid "Confirm Move"
 msgstr "Potrdi premik"
 
-#: Merge.rc:4918
+#: Merge.rc:4917
 msgid "Close the folder comparison window?"
 msgstr "Zaklenili boste okno za primerjavo map. Ali ste prepričani, da želite zapreti okno?"
 
-#: Merge.rc:4920
+#: Merge.rc:4919
 msgid "Close the folder comparison window, which took a long time?"
 msgstr "Zaprli boste primerjalno okno map, ki je vzelo precej časa. Ali ste prepričani, da želite zapreti okno?"
 
 #. IDS_ERROR_INVALID_DIR_FILE_NAME
-#: Merge.rc:4921
+#: Merge.rc:4920
 msgid "The file or folder name is invalid."
 msgstr "Ime datoteke ali mape ni veljavno."
 
 #. IDS_ERROR_EXECUTE_FILE
-#: Merge.rc:4927
+#: Merge.rc:4926
 #, c-format
 msgid "Failed to execute external editor: %1"
 msgstr "Ni bilo mogoče zagnati zunanjega urejevalnika: %1"
 
 #. IDS_UNKNOWN_ARCHIVE_FORMAT
-#: Merge.rc:4933
+#: Merge.rc:4932
 msgid "Unknown archive format"
 msgstr "Neznan format arhiva"
 
-#: Merge.rc:4935
+#: Merge.rc:4934
 msgid ""
 "Failed to extract archive.\n"
 "Compare as text file?"
@@ -6425,746 +6420,746 @@ msgstr ""
 "Ali želite primerjati arhivske datoteke kot besedilne datoteke?"
 
 #. IDS_COLHDR_FILENAME
-#: Merge.rc:4941
+#: Merge.rc:4940
 msgid "Filename"
 msgstr "Ime datoteke"
 
 #. IDS_COLHDR_DIR
-#: Merge.rc:4942
+#: Merge.rc:4941
 msgctxt "DirView|ColumnHeader"
 msgid "Folder"
 msgstr "Mapa"
 
 #. IDS_COLHDR_RESULT
-#: Merge.rc:4943
+#: Merge.rc:4942
 msgid "Comparison Result"
 msgstr "Rezultat primerjave"
 
 #. IDS_COLHDR_LTIMEM
-#: Merge.rc:4944
+#: Merge.rc:4943
 msgid "Left Date"
 msgstr "Levi datum"
 
 #. IDS_COLHDR_RTIMEM
-#: Merge.rc:4945
+#: Merge.rc:4944
 msgid "Right Date"
 msgstr "Datum desne"
 
 #. IDS_COLHDR_MTIMEM
-#: Merge.rc:4946
+#: Merge.rc:4945
 msgid "Middle Date"
 msgstr "Datum srednje"
 
 #. IDS_COLHDR_LSIZE
-#: Merge.rc:4948
+#: Merge.rc:4947
 msgid "Left Size"
 msgstr "Leva velikost"
 
 #. IDS_COLHDR_RSIZE
-#: Merge.rc:4949
+#: Merge.rc:4948
 msgid "Right Size"
 msgstr "Velikost desne"
 
 #. IDS_COLHDR_MSIZE
-#: Merge.rc:4954
+#: Merge.rc:4953
 msgid "Middle Size"
 msgstr "Velikost srednje"
 
 #. IDS_COLHDR_RSIZE_SHORT
-#: Merge.rc:4955
+#: Merge.rc:4954
 msgid "Right Size (Short)"
 msgstr "Velikost desne (kratko)"
 
 #. IDS_COLHDR_LSIZE_SHORT
-#: Merge.rc:4956
+#: Merge.rc:4955
 msgid "Left Size (Short)"
 msgstr "Leva velikost (kratko)"
 
 #. IDS_COLHDR_MSIZE_SHORT
-#: Merge.rc:4957
+#: Merge.rc:4956
 msgid "Middle Size (Short)"
 msgstr "Velikost srednje (Kratko)"
 
 #. IDS_COLHDR_LTIMEC
-#: Merge.rc:4963
+#: Merge.rc:4962
 msgid "Left Creation Time"
 msgstr "Čas ustvarjanja leve"
 
 #. IDS_COLHDR_RTIMEC
-#: Merge.rc:4964
+#: Merge.rc:4963
 msgid "Right Creation Time"
 msgstr "Čas ustvarjanja desne"
 
 #. IDS_COLHDR_MTIMEC
-#: Merge.rc:4965
+#: Merge.rc:4964
 msgid "Middle Creation Time"
 msgstr "Čas ustvarjanja srednje"
 
 #. IDS_COLHDR_NEWER
-#: Merge.rc:4966
+#: Merge.rc:4965
 msgid "Newer File"
 msgstr "Novejša datoteka"
 
 #. IDS_COLHDR_LVERSION
-#: Merge.rc:4967
+#: Merge.rc:4966
 msgid "Left File Version"
 msgstr "Različica leve datoteke"
 
 #. IDS_COLHDR_RVERSION
-#: Merge.rc:4968
+#: Merge.rc:4967
 msgid "Right File Version"
 msgstr "Različica desne datoteke"
 
 #. IDS_COLHDR_MVERSION
-#: Merge.rc:4969
+#: Merge.rc:4968
 msgid "Middle File Version"
 msgstr "Različica srednje datoteke"
 
 #. IDS_COLHDR_RESULT_ABBR
-#: Merge.rc:4970
+#: Merge.rc:4969
 msgid "Short Result"
 msgstr "Kratek rezultat"
 
 #. IDS_COLHDR_LATTRIBUTES
-#: Merge.rc:4971
+#: Merge.rc:4970
 msgid "Left Attributes"
 msgstr "Levi atributi"
 
 #. IDS_COLHDR_RATTRIBUTES
-#: Merge.rc:4972
+#: Merge.rc:4971
 msgid "Right Attributes"
 msgstr "Atributi desne"
 
 #. IDS_COLHDR_MATTRIBUTES
-#: Merge.rc:4973
+#: Merge.rc:4972
 msgid "Middle Attributes"
 msgstr "Atributi srednje"
 
 #. IDS_COLHDR_LEOL_TYPE
-#: Merge.rc:4978
+#: Merge.rc:4977
 msgid "Left EOL"
 msgstr "Konci vrstic v levi"
 
 #. IDS_COLHDR_MEOL_TYPE
-#: Merge.rc:4979
+#: Merge.rc:4978
 msgid "Middle EOL"
 msgstr "Konci vrstic v srednji"
 
 #. IDS_COLHDR_REOL_TYPE
-#: Merge.rc:4980
+#: Merge.rc:4979
 msgid "Right EOL"
 msgstr "Konci vrstic v desni"
 
 #. IDS_COLHDR_LENCODING
-#: Merge.rc:4986
+#: Merge.rc:4985
 msgid "Left Encoding"
 msgstr "Kodiranje leve"
 
 #. IDS_COLHDR_RENCODING
-#: Merge.rc:4987
+#: Merge.rc:4986
 msgid "Right Encoding"
 msgstr "Kodiranje desne"
 
 #. IDS_COLHDR_MENCODING
-#: Merge.rc:4988
+#: Merge.rc:4987
 msgid "Middle Encoding"
 msgstr "Kodiranje srednje"
 
 #. IDS_COLHDR_NIDIFFS
-#: Merge.rc:4989
+#: Merge.rc:4988
 msgid "Ignored Diff"
 msgstr "Prezrte razlike"
 
 #. IDS_COLHDR_BINARY
-#: Merge.rc:4991
+#: Merge.rc:4990
 msgctxt "DirView|ColumnHeader"
 msgid "Binary"
 msgstr "Dvojiško"
 
 #. IDS_PLUGINS_TYPE_UNPACKER
-#: Merge.rc:4992 Merge.rc:5314
+#: Merge.rc:4991 Merge.rc:5313
 msgid "Unpacker"
 msgstr "Razpakovalec"
 
 #. IDS_PLUGIN_TYPE4
-#: Merge.rc:4993 Merge.rc:5315 Merge.rc:5622
+#: Merge.rc:4992 Merge.rc:5314 Merge.rc:5621
 msgid "Prediffer"
 msgstr "Predpregled razlik"
 
 #. IDS_COLHDR_LEFT
-#: Merge.rc:4994
+#: Merge.rc:4993
 msgid "Left"
 msgstr "Levo"
 
 #. IDS_COLHDR_MIDDLE
-#: Merge.rc:4995
+#: Merge.rc:4994
 msgid "Middle"
 msgstr "Sredina"
 
 #. IDS_COLHDR_RIGHT
-#: Merge.rc:4996
+#: Merge.rc:4995
 msgid "Right"
 msgstr "Desno"
 
 #. IDS_COLHDR_DIFF
-#: Merge.rc:4997
+#: Merge.rc:4996
 msgid "Diff"
 msgstr "Razlika"
 
 #. IDS_COLHDR_LEFT_DUPLICATE
-#: Merge.rc:4998
+#: Merge.rc:4997
 msgid "Left Duplicate Count"
 msgstr "Število levih dvojnikov"
 
 #. IDS_COLHDR_RIGHT_DUPLICATE
-#: Merge.rc:4999
+#: Merge.rc:4998
 msgid "Right Duplicate Count"
 msgstr "Število desnih dvojnikov"
 
 #. IDS_COLHDR_MIDDLE_DUPLICATE
-#: Merge.rc:5000
+#: Merge.rc:4999
 msgid "Middle Duplicate Count"
 msgstr "Število srednjih dvojnikov"
 
 #. IDS_COLHDR_MOVE
-#: Merge.rc:5001
+#: Merge.rc:5000
 msgid "Move"
 msgstr "Premakni"
 
 #. IDS_PRPCAT_AUDIO
-#: Merge.rc:5008
+#: Merge.rc:5007
 msgid "Audio"
 msgstr "Samodejno"
 
 #. IDS_PRPCAT_CALENDAR
-#: Merge.rc:5009
+#: Merge.rc:5008
 msgid "Calendar"
 msgstr "Koledar"
 
 #. IDS_PRPCAT_COMMUNICATION
-#: Merge.rc:5010
+#: Merge.rc:5009
 msgid "Communication"
 msgstr "Komunikacija"
 
 #. IDS_PRPCAT_CONTACT
-#: Merge.rc:5011
+#: Merge.rc:5010
 msgid "Contact"
 msgstr "Stik"
 
 #. IDS_PRPCAT_DEVICES
-#: Merge.rc:5012
+#: Merge.rc:5011
 msgid "Devices"
 msgstr "Naprave"
 
 #. IDS_PRPCAT_DOCUMENT
-#: Merge.rc:5013
+#: Merge.rc:5012
 msgid "Document"
 msgstr "Dokument"
 
 #. IDS_PRPCAT_HOME
-#: Merge.rc:5014
+#: Merge.rc:5013
 msgid "Home"
 msgstr "Domov"
 
 #. IDS_PRPCAT_JOURNAL
-#: Merge.rc:5016
+#: Merge.rc:5015
 msgid "Journal"
 msgstr "Žurnal"
 
 #. IDS_PRPCAT_LINK
-#: Merge.rc:5017
+#: Merge.rc:5016
 msgid "Link"
 msgstr "Poveži"
 
 #. IDS_PRPCAT_MEDIA
-#: Merge.rc:5018
+#: Merge.rc:5017
 msgid "Media"
 msgstr "Medij"
 
 #. IDS_PRPCAT_MUSIC
-#: Merge.rc:5020
+#: Merge.rc:5019
 msgid "Music"
 msgstr "Glasba"
 
 #. IDS_PRPCAT_NOTE
-#: Merge.rc:5021
+#: Merge.rc:5020
 msgid "Note"
 msgstr "Opomba"
 
 #. IDS_PRPCAT_PHOTO
-#: Merge.rc:5022
+#: Merge.rc:5021
 msgid "Photo"
 msgstr "Fotografija"
 
 #. IDS_PRPCAT_RECORDEDTV
-#: Merge.rc:5023
+#: Merge.rc:5022
 msgid "RecordedTV"
 msgstr "Posneta TV"
 
 #. IDS_PRPCAT_SEARCH
-#: Merge.rc:5024
+#: Merge.rc:5023
 msgid "Search"
 msgstr "Poišči"
 
 #. IDS_PRPCAT_SECURITY
-#: Merge.rc:5025
+#: Merge.rc:5024
 msgid "Security"
 msgstr "Varnost"
 
 #. IDS_PRPCAT_SOFTWARE
-#: Merge.rc:5026
+#: Merge.rc:5025
 msgid "Software"
 msgstr "Program"
 
 #. IDS_PRPCAT_TASK
-#: Merge.rc:5027
+#: Merge.rc:5026
 msgid "Task"
 msgstr "Opravilo"
 
 #. IDS_PRPCAT_VIDEO
-#: Merge.rc:5028
+#: Merge.rc:5027
 msgid "Video"
 msgstr "Videoposnetek"
 
 #. IDS_PRPCAT_HASH
-#: Merge.rc:5029
+#: Merge.rc:5028
 msgid "Hash"
 msgstr "Hash"
 
 #. IDS_CANT_COMPARE_FILES
-#: Merge.rc:5035
+#: Merge.rc:5034
 msgid "Unable to compare files"
 msgstr "Datotek ni mogoče primerjati"
 
 #. IDS_ABORTED_ITEM
-#: Merge.rc:5036
+#: Merge.rc:5035
 msgid "Item aborted"
 msgstr "Prekinjen vnos"
 
 #. IDS_FILE_SKIPPED
-#: Merge.rc:5037
+#: Merge.rc:5036
 msgid "File skipped"
 msgstr "Preskočena datoteka"
 
 #. IDS_DIR_SKIPPED
-#: Merge.rc:5038
+#: Merge.rc:5037
 msgid "Folder skipped"
 msgstr "Preskočena mapa"
 
 #. IDS_LEFT_ONLY_IN_FMT
-#: Merge.rc:5039
+#: Merge.rc:5038
 #, c-format
 msgid "Left only: %1"
 msgstr "Samo leva: %1"
 
 #. IDS_MIDDLE_ONLY_IN_FMT
-#: Merge.rc:5040
+#: Merge.rc:5039
 #, c-format
 msgid "Middle only: %1"
 msgstr "Samo srednja: %1"
 
 #. IDS_RIGHT_ONLY_IN_FMT
-#: Merge.rc:5041
+#: Merge.rc:5040
 #, c-format
 msgid "Right only: %1"
 msgstr "Samo desna: %1"
 
 #. IDS_DOES_NOT_EXIST_IN_FMT
-#: Merge.rc:5042
+#: Merge.rc:5041
 #, c-format
 msgid "Does not exist in %1"
 msgstr "Ne obstaja v %1"
 
 #. IDS_BIN_FILES_SAME
-#: Merge.rc:5043
+#: Merge.rc:5042
 msgid "Binary files are identical"
 msgstr "Dvojiški datoteki sta enaki"
 
 #. IDS_BIN_FILES_DIFF
-#: Merge.rc:5049
+#: Merge.rc:5048
 msgid "Binary files are different"
 msgstr "Dvojiški datoteki sta različni"
 
 #. IDS_FILES_ARE_DIFFERENT
-#: Merge.rc:5050
+#: Merge.rc:5049
 msgid "Files are different"
 msgstr "Datoteke so različne"
 
 #. IDS_FOLDERS_ARE_DIFFERENT
-#: Merge.rc:5051
+#: Merge.rc:5050
 msgid "Folders are different"
 msgstr "Mapi sta različni"
 
 #. IDS_LEFTONLY
-#: Merge.rc:5052
+#: Merge.rc:5051
 msgid "Left Only"
 msgstr "Samo leva"
 
 #. IDS_RIGHTONLY
-#: Merge.rc:5053
+#: Merge.rc:5052
 msgid "Right Only"
 msgstr "Samo desna"
 
 #. IDS_MIDDLEONLY
-#: Merge.rc:5054
+#: Merge.rc:5053
 msgid "Middle Only"
 msgstr "Samo srednja"
 
 #. IDS_NOITEMLEFT
-#: Merge.rc:5055
+#: Merge.rc:5054
 msgid "No item in left"
 msgstr "Noben vnos v levi"
 
 #. IDS_NOITEMRIGHT
-#: Merge.rc:5056
+#: Merge.rc:5055
 msgid "No item in right"
 msgstr "Noben vnos v desni"
 
 #. IDS_NOITEMMIDDLE
-#: Merge.rc:5057
+#: Merge.rc:5056
 msgid "No item in middle"
 msgstr "Noben vnos v srednji"
 
 #. IDS_CMPRES_ERROR
-#: Merge.rc:5059
+#: Merge.rc:5058
 msgid "Error"
 msgstr "Napaka"
 
 #. IDS_TEXT_FILES_SAME
-#: Merge.rc:5060
+#: Merge.rc:5059
 msgid "Text files are identical"
 msgstr "Besedilne datoteke so enake"
 
 #. IDS_LEFTONLY_DIFF
-#: Merge.rc:5061
+#: Merge.rc:5060
 msgid " (Middle and right are identical)"
 msgstr " (Srednja in desna sta enaki)"
 
 #. IDS_MIDDLEONLY_DIFF
-#: Merge.rc:5062
+#: Merge.rc:5061
 msgid " (Left and right are identical)"
 msgstr " (Leva in desno sta enaki)"
 
 #. IDS_RIGHTONLY_DIFF
-#: Merge.rc:5063
+#: Merge.rc:5062
 msgid " (Left and middle are identical)"
 msgstr " (Leva in srednja sta enaki)"
 
 #. IDS_PATH_MISMATCH
-#: Merge.rc:5064
+#: Merge.rc:5063
 msgid " (paths differ)"
 msgstr ""
 
 #. IDS_TEXT_FILES_DIFF
-#: Merge.rc:5065
+#: Merge.rc:5064
 msgid "Text files are different"
 msgstr "Besedilne datoteke so različne"
 
 #. IDS_IMAGE_FILES_SAME
-#: Merge.rc:5066
+#: Merge.rc:5065
 msgid "Image files are identical"
 msgstr "Slikovne datoteke so enake"
 
 #. IDS_IMAGE_FILES_DIFF
-#: Merge.rc:5067
+#: Merge.rc:5066
 msgid "Image files are different"
 msgstr "Slikovne datoteke so različne"
 
 #. IDS_EXPR_DIFF
-#: Merge.rc:5068
+#: Merge.rc:5067
 #, c-format
 msgid "Files are different (expr: %1)"
 msgstr ""
 
 #. IDS_HASH_GROUP
-#: Merge.rc:5069
+#: Merge.rc:5068
 #, c-format
 msgid "Group%d"
 msgstr "Skupina %d"
 
 #. IDS_RENAME_MOVE_DETECTION_DISALBED
-#: Merge.rc:5070
+#: Merge.rc:5069
 msgctxt "Options dialog|Compare|Folder|Detect renames and moves"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_RENAME_MOVE_DETECTION_RENAME
-#: Merge.rc:5071
+#: Merge.rc:5070
 msgid "Detect renames"
 msgstr ""
 
 #. IDS_RENAME_MOVE_DETECTION_RENAME_MOVE
-#: Merge.rc:5072
+#: Merge.rc:5071
 msgid "Detect renames and moves"
 msgstr ""
 
 #. IDS_RENAME_MOVE_MERGE_MODE_RENAME
-#: Merge.rc:5073
+#: Merge.rc:5072
 msgid "Merge renames"
 msgstr ""
 
 #. IDS_RENAME_MOVE_MERGE_MODE_RENAME_MOVE
-#: Merge.rc:5074
+#: Merge.rc:5073
 msgid "Merge renames and moves"
 msgstr ""
 
 #. IDS_RENAMED
-#: Merge.rc:5075
+#: Merge.rc:5074
 msgid "Renamed"
 msgstr ""
 
 #. IDS_RENAMED_MOVED
-#: Merge.rc:5077
+#: Merge.rc:5076
 msgid "Renamed/Moved"
 msgstr ""
 
 #. IDS_RENAMED_MOVED_ITEMS
-#: Merge.rc:5078
+#: Merge.rc:5077
 #, c-format
 msgid "(%1 items)"
 msgstr ""
 
 #. IDS_RENAMED_MOVED_RESULT
-#: Merge.rc:5079
+#: Merge.rc:5078
 #, c-format
 msgid "%1 (set %2): "
 msgstr ""
 
 #. IDS_SWITCH_FLAT_MODE
-#: Merge.rc:5080
+#: Merge.rc:5079
 msgid "Some moved items have been merged.\nIn Tree Mode, these items may appear in positions that do not reflect the actual folder structure, which can be confusing.\nSwitch to Flat Mode?"
 msgstr ""
 
 #. IDS_ELAPSED_TIME
-#: Merge.rc:5086
+#: Merge.rc:5085
 #, c-format
 msgid "Elapsed time: %ld ms"
 msgstr "Potekel čas: %ld ms"
 
 #. IDS_STATUS_SELITEM1
-#: Merge.rc:5087
+#: Merge.rc:5086
 msgid "1 item selected"
 msgstr "1 izbran vnos"
 
 #. IDS_STATUS_SELITEMS
-#: Merge.rc:5088
+#: Merge.rc:5087
 #, c-format
 msgid "%1 items selected"
 msgstr "%1 označenih predmetov"
 
 #. IDS_COLDESC_FILENAME
-#: Merge.rc:5094
+#: Merge.rc:5093
 msgid "Filename or folder name."
 msgstr "Ime datoteke ali mape."
 
 #. IDS_COLDESC_DIR
-#: Merge.rc:5095
+#: Merge.rc:5094
 msgid "Subfolder name when subfolders are included."
 msgstr "Imena podmap, ko so vključene podmape."
 
 #. IDS_COLDESC_RESULT
-#: Merge.rc:5096
+#: Merge.rc:5095
 msgid "Comparison result, long form."
 msgstr "Rezultat primerjave, dolga oblika."
 
 #. IDS_COLDESC_LTIMEM
-#: Merge.rc:5101
+#: Merge.rc:5100
 msgid "Left side modification date."
 msgstr "Čas spremembe na levi strani."
 
 #. IDS_COLDESC_RTIMEM
-#: Merge.rc:5102
+#: Merge.rc:5101
 msgid "Right side modification date."
 msgstr "Čas spremembe na desni strani."
 
 #. IDS_COLDESC_MTIMEM
-#: Merge.rc:5103
+#: Merge.rc:5102
 msgid "Middle side modification date."
 msgstr "Datum ustvarjanja na sredini."
 
 #. IDS_COLDESC_EXTENSION
-#: Merge.rc:5104
+#: Merge.rc:5103
 msgid "File's extension."
 msgstr "Končnica datoteke."
 
 #. IDS_COLDESC_LSIZE
-#: Merge.rc:5105
+#: Merge.rc:5104
 msgid "Left file size in bytes."
 msgstr "Velikost leve datoteke v bajtih."
 
 #. IDS_COLDESC_RSIZE
-#: Merge.rc:5106
+#: Merge.rc:5105
 msgid "Right file size in bytes."
 msgstr "Velikost desne datoteke v bajtih."
 
 #. IDS_COLDESC_MSIZE
-#: Merge.rc:5107
+#: Merge.rc:5106
 msgid "Middle file size in bytes."
 msgstr "Velikost srednje datoteke v bajtih."
 
 #. IDS_COLDESC_LSIZE_SHORT
-#: Merge.rc:5108
+#: Merge.rc:5107
 msgid "Left file size abbreviated."
 msgstr "Skrajšana velikost leve datoteke."
 
 #. IDS_COLDESC_RSIZE_SHORT
-#: Merge.rc:5109
+#: Merge.rc:5108
 msgid "Right file size abbreviated."
 msgstr "Skrajšana velikost desne datoteke."
 
 #. IDS_COLDESC_MSIZE_SHORT
-#: Merge.rc:5110
+#: Merge.rc:5109
 msgid "Middle file size abbreviated."
 msgstr "Velikost srednje datoteke je skrajšana."
 
 #. IDS_COLDESC_LTIMEC
-#: Merge.rc:5116
+#: Merge.rc:5115
 msgid "Left side creation time."
 msgstr "Čas ustvarjanja na levi strani."
 
 #. IDS_COLDESC_RTIMEC
-#: Merge.rc:5117
+#: Merge.rc:5116
 msgid "Right side creation time."
 msgstr "Čas ustvarjanja na desni strani."
 
 #. IDS_COLDESC_MTIMEC
-#: Merge.rc:5118
+#: Merge.rc:5117
 msgid "Middle side creation time."
 msgstr "Čas ustvarjanja na sredini."
 
 #. IDS_COLDESC_NEWER
-#: Merge.rc:5119
+#: Merge.rc:5118
 msgid "Tells which side has newer modification date."
 msgstr "Pove, katera stran ima novejši datum spremembe."
 
 #. IDS_COLDESC_LVERSION
-#: Merge.rc:5120
+#: Merge.rc:5119
 msgid "Left side file version, only for some file types."
 msgstr "Različica leve datoteke, le za nekatere vrste datotek."
 
 #. IDS_COLDESC_RVERSION
-#: Merge.rc:5121
+#: Merge.rc:5120
 msgid "Right side file version, only for some file types."
 msgstr "Različica desne datoteke, le za nekatere vrste datotek."
 
 #. IDS_COLDESC_MVERSION
-#: Merge.rc:5126
+#: Merge.rc:5125
 msgid "Middle side file version, only for some file types."
 msgstr "Različica srednje datoteke, le za nekatere vrste datotek."
 
 #. IDS_COLDESC_RESULT_ABBR
-#: Merge.rc:5127
+#: Merge.rc:5126
 msgid "Short comparison result."
 msgstr "Rezultat kratke primerjave."
 
 #. IDS_COLDESC_LATTRIBUTES
-#: Merge.rc:5128
+#: Merge.rc:5127
 msgid "Left side attributes."
 msgstr "Atributi leve strani."
 
 #. IDS_COLDESC_RATTRIBUTES
-#: Merge.rc:5129
+#: Merge.rc:5128
 msgid "Right side attributes."
 msgstr "Atributi desne strani."
 
 #. IDS_COLDESC_MATTRIBUTES
-#: Merge.rc:5130
+#: Merge.rc:5129
 msgid "Middle side attributes."
 msgstr "Atributi srednje."
 
 #. IDS_COLDESC_LEOL_TYPE
-#: Merge.rc:5131
+#: Merge.rc:5130
 msgid "Left side file EOL type."
 msgstr "Vrsta znakov koncev vrstic v levi datoteki."
 
 #. IDS_COLDESC_REOL_TYPE
-#: Merge.rc:5132
+#: Merge.rc:5131
 msgid "Right side file EOL type."
 msgstr "Vrsta znakov koncev vrstic v desni datoteki."
 
 #. IDS_COLDESC_MEOL_TYPE
-#: Merge.rc:5133
+#: Merge.rc:5132
 msgid "Middle side file EOL type."
 msgstr "Vrsta znakov koncev vrstic v srednji datoteki."
 
 #. IDS_COLDESC_LENCODING
-#: Merge.rc:5139
+#: Merge.rc:5138
 msgid "Left side encoding."
 msgstr "Kodna stran leve strani."
 
 #. IDS_COLDESC_RENCODING
-#: Merge.rc:5140
+#: Merge.rc:5139
 msgid "Right side encoding."
 msgstr "Kodna stran desne strani."
 
 #. IDS_COLDESC_MENCODING
-#: Merge.rc:5141
+#: Merge.rc:5140
 msgid "Middle side encoding."
 msgstr "Kodiranje v sredini."
 
 #. IDS_COLDESC_NIDIFFS
-#: Merge.rc:5142
+#: Merge.rc:5141
 msgid "Number of ignored differences in file. Ignored and cannot be merged."
 msgstr "Število prezrtih razlik v datoteki. Te razlike je WinMerge prezrl in jih ni mogoče združiti."
 
 #. IDS_COLDESC_NSDIFFS
-#: Merge.rc:5143
+#: Merge.rc:5142
 msgid "Number of differences in file (excluding ignored)."
 msgstr "Število razlik v datoteki. Ta številka ne vsebuje prezrtih razlik."
 
 #. IDS_COLDESC_BINARY
-#: Merge.rc:5144
+#: Merge.rc:5143
 msgid "Shows an asterisk (*) if the file is binary."
 msgstr "Prikaže zvezdico (*), če je datoteka dvojiška."
 
 #. IDS_COLDESC_UNPACKER
-#: Merge.rc:5145
+#: Merge.rc:5144
 msgid "Unpacker plugin name or pipeline."
 msgstr "Ime vtičnika razpakovalca ali cevovod."
 
 #. IDS_COLDESC_PREDIFFER
-#: Merge.rc:5146
+#: Merge.rc:5145
 msgid "Prediffer plugin name or pipeline."
 msgstr "Ime vtičnika predrazlikovalca ali cevovod."
 
 #. IDS_DIRECTORY_REPORT_TITLE
-#: Merge.rc:5152
+#: Merge.rc:5151
 #, c-format
 msgid "Compare %1 with %2"
 msgstr "Primerjaj %1 z %2"
 
 #. IDS_DIRECTORY_REPORT_TITLE3
-#: Merge.rc:5153
+#: Merge.rc:5152
 #, c-format
 msgid "Compare %1 with %2 and %3"
 msgstr "Primerjaj %1 z %2 in %3"
 
 #. IDS_REPORT_COMMALIST
-#: Merge.rc:5154
+#: Merge.rc:5153
 msgid "Comma-separated list"
 msgstr "Seznam, ločen z vejicami"
 
 #. IDS_REPORT_TABLIST
-#: Merge.rc:5155
+#: Merge.rc:5154
 msgid "Tab-separated list"
 msgstr "Seznam, ločen s tabulatorji"
 
 #. IDS_REPORT_SIMPLEHTML
-#: Merge.rc:5156
+#: Merge.rc:5155
 msgid "Simple HTML"
 msgstr "Enostavni HTML"
 
 #. IDS_REPORT_SIMPLEXML
-#: Merge.rc:5157
+#: Merge.rc:5156
 msgid "Simple XML"
 msgstr "Enostavni XML"
 
-#: Merge.rc:5159
+#: Merge.rc:5158
 msgid "Report file already exists. Overwrite?"
 msgstr "Datoteka poročila že obstaja. Ali jo želite prepisati?"
 
 #. IDS_REPORT_ERROR
-#: Merge.rc:5164
+#: Merge.rc:5163
 #, c-format
 msgid ""
 "Error creating the report:\n"
@@ -7174,57 +7169,57 @@ msgstr ""
 "%1"
 
 #. IDS_REPORT_SUCCESS
-#: Merge.rc:5165
+#: Merge.rc:5164
 msgid "Report created successfully."
 msgstr "Poročilo je bilo uspešno izdelano."
 
 #. IDS_SYNCPOINT_LASTBLOCK
-#: Merge.rc:5171
+#: Merge.rc:5170
 msgid "Cannot add a synchronization point at this line."
 msgstr "V tej vrstici ni mogoče dodati točke sinhronizacije."
 
 #. IDS_FILE_TO_ITSELF
-#: Merge.rc:5177
+#: Merge.rc:5176
 msgid "Same file is opened in both panes."
 msgstr "Ista datoteka je odprta v obeh podoknih."
 
 #. IDS_FILESSAME
-#: Merge.rc:5178
+#: Merge.rc:5177
 msgid "Selected files are identical."
 msgstr "Izbrani datoteki sta enaki."
 
 #. IDS_FILESSAME_CURCFG
-#: Merge.rc:5179
+#: Merge.rc:5178
 msgid "Selected files are identical (with current settings).\r\nChecking binary identity..."
 msgstr ""
 
 #. IDS_FILESSAME_BINERROR
-#: Merge.rc:5180
+#: Merge.rc:5179
 msgid "Selected files are identical (with current settings).\r\nBut binary comparison failed."
 msgstr ""
 
 #. IDS_FILESSAME_BINSAME
-#: Merge.rc:5181
+#: Merge.rc:5180
 msgid "Selected files are identical (binary match)."
 msgstr ""
 
 #. IDS_FILESSAME_BINDIFF
-#: Merge.rc:5182
+#: Merge.rc:5181
 msgid "Selected files are identical (with current settings).\r\nBut differ at the binary level."
 msgstr ""
 
 #. IDS_FILEERROR
-#: Merge.rc:5183
+#: Merge.rc:5182
 msgid "An error occurred while comparing files."
 msgstr "Prišlo je do napake med primerjavo datotek."
 
 #. IDS_TEMP_FILEERROR
-#: Merge.rc:5184
+#: Merge.rc:5183
 msgid "Could not create temporary files. Check your temporary path settings."
 msgstr "Začasnih datotek ni bilo mogoče ustvariti. Preverite nastavitve začasne poti (PATH)."
 
 #. IDS_SUGGEST_IGNOREEOL
-#: Merge.rc:5185
+#: Merge.rc:5184
 msgid "Files use different EOL.\n\nTreat all EOL as equivalent?\n\nSet 'Ignore EOL differences (Windows/Unix/Mac)' in Compare section of Options."
 msgstr ""
 "Ti datoteki imata različno vrsto znakov za konec vrstic.\n"
@@ -7234,17 +7229,17 @@ msgstr ""
 "Opomba: Če jih želite vedno obravnavati kot enaki, nastavite možnost 'Prezri različnost vrste znakov za koncev vrstic' na zavihku 'Primerjava' pogovornega okna 'Nastavitve' (dostopen pod Urejanje/Možnosti)."
 
 #. IDS_INVALID_DIRECTORY
-#: Merge.rc:5186
+#: Merge.rc:5185
 msgid "Selected folder is invalid."
 msgstr "Izbrana mapa ni veljavna."
 
 #. IDS_CANNOT_OPEN_BINARYFILE
-#: Merge.rc:5187
+#: Merge.rc:5186
 msgid "Cannot open a binary file in Editor."
 msgstr "V urejevalniku ni mogoče odpreti dvojiške datoteke."
 
 #. IDS_CREATE_PAIR_FOLDER
-#: Merge.rc:5188
+#: Merge.rc:5187
 #, c-format
 msgid "Create matching folder:\n%1\non the other side and open?"
 msgstr ""
@@ -7256,41 +7251,41 @@ msgstr ""
 "na drugi strani in jo odpreti?"
 
 #. IDS_CONFIRM_COPY_ALL_DIFFS
-#: Merge.rc:5189
+#: Merge.rc:5188
 msgid "Copy all differences to other file?"
 msgstr "Ali ste prepričani, da želite kopirati vse razlike v drugo datoteko?"
 
 #. IDS_MOVE_TO_NEXTFILE
-#: Merge.rc:5194
+#: Merge.rc:5193
 msgid "Move to next file?"
 msgstr "Ali se želite premakniti na naslednjo datoteko?"
 
 #. IDS_MOVE_TO_PREVFILE
-#: Merge.rc:5195
+#: Merge.rc:5194
 msgid "Move to previous file?"
 msgstr "Ali se želite premakniti na prejšnjo datoteko?"
 
 #. IDS_MOVE_TO_NEXTPAGE
-#: Merge.rc:5196
+#: Merge.rc:5195
 msgid "Move to next page?"
 msgstr "Ali se želite premakniti na naslednjo stran?"
 
 #. IDS_MOVE_TO_PREVPAGE
-#: Merge.rc:5197
+#: Merge.rc:5196
 msgid "Move to previous page?"
 msgstr "Ali se želite premakniti na prejšnjo stran?"
 
 #. IDS_MOVE_TO_FIRSTFILE
-#: Merge.rc:5198
+#: Merge.rc:5197
 msgid "Move to first file?"
 msgstr "Ali se želite premakniti v prvo datoteko?"
 
 #. IDS_MOVE_TO_LASTFILE
-#: Merge.rc:5199
+#: Merge.rc:5198
 msgid "Move to last file?"
 msgstr "Ali se želite premakniti na zadnjo datoteko?"
 
-#: Merge.rc:5206
+#: Merge.rc:5205
 #, c-format
 msgid "Different codepages: left (cp%d), right (cp%d).\nDisplay in codepage (better display) or default Windows codepage (safer merging)?\n(Recommended: default Windows codepage)"
 msgstr ""
@@ -7298,51 +7293,51 @@ msgstr ""
 "Prikaz vsake datoteke v svoji kodni strani bo omogočil boljši prikaz, vendar bo nevarno združevanje/kopiranje.\n"
 "Ali želite obe datoteke obravnavati v privzeti kodni strani sistema Windows (priporočeno)?"
 
-#: Merge.rc:5208
+#: Merge.rc:5207
 msgid "Information lost due to encoding errors: both files"
 msgstr "Izgubljeni podatki pri kodiranju: obe datoteki"
 
-#: Merge.rc:5210
+#: Merge.rc:5209
 msgid "Information lost due to encoding errors: first file"
 msgstr "Izgubljeni podatki zaradi napak pri kodiranju: prva datoteka"
 
-#: Merge.rc:5212
+#: Merge.rc:5211
 msgid "Information lost due to encoding errors: second file"
 msgstr "Izgubljeni podatki zaradi napak pri kodiranju: druga datoteka"
 
-#: Merge.rc:5214
+#: Merge.rc:5213
 msgid "Information lost due to encoding errors: third file"
 msgstr "Izgubljeni podatki zaradi napak pri kodiranju: tretja datoteka"
 
 #. IDS_LINEDIFF_NODIFF
-#: Merge.rc:5220
+#: Merge.rc:5219
 msgid "No difference"
 msgstr "Ni razlik"
 
 #. IDS_LINEDIFF_NODIFF_CAPTION
-#: Merge.rc:5221
+#: Merge.rc:5220
 msgid "Line difference"
 msgstr "Razlika v vrstici"
 
 #. IDS_NUM_REPLACED
-#: Merge.rc:5227
+#: Merge.rc:5226
 #, c-format
 msgid "Replaced %1 string(s)."
 msgstr "Zamenjano %1 nizov."
 
 #. IDS_EDIT_TEXT_NOT_FOUND
-#: Merge.rc:5228
+#: Merge.rc:5227
 #, c-format
 msgid "Cannot find string \"%s\"."
 msgstr "Ni mogoče najti niza \"%s\"."
 
 #. IDS_MERGE_MODE
-#: Merge.rc:5234
+#: Merge.rc:5233
 msgid "Entering Merge Mode. Press F9 to turn off."
 msgstr "Zdaj vstopate v združevalni način. Če želite izklopiti združevalni način, pritisnite tipko F9."
 
 #. IDS_AUTO_MERGE
-#: Merge.rc:5240
+#: Merge.rc:5239
 #, c-format
 msgid ""
 "Automatic merges: %1\n"
@@ -7352,89 +7347,89 @@ msgstr ""
 "Število nerešenih sporov: %2"
 
 #. IDS_CODEPAGE_MERGED
-#: Merge.rc:5241
+#: Merge.rc:5240
 msgid "Codepage change merged."
 msgstr "Sprememba kodne strani je bila združena."
 
 #. IDS_CODEPAGE_CONFLICT
-#: Merge.rc:5242
+#: Merge.rc:5241
 msgid "Codepage changes are conflicting."
 msgstr "Spremembe kodne strani so v sporu."
 
 #. IDS_EOL_MERGED
-#: Merge.rc:5243
+#: Merge.rc:5242
 msgid "EOL change merged."
 msgstr "Sprememba konca vrstice (EOL) je bila združena."
 
 #. IDS_EOL_CONFLICT
-#: Merge.rc:5244
+#: Merge.rc:5243
 msgid "EOL changes are conflicting."
 msgstr "Spremembe koncev vrstic (EOL) so v sporu."
 
 #. IDS_LOCBAR_CAPTION
-#: Merge.rc:5250
+#: Merge.rc:5249
 msgid "Location Pane"
 msgstr "Podokno lokacije"
 
 #. IDS_DIFFBAR_CAPTION
-#: Merge.rc:5251
+#: Merge.rc:5250
 msgid "Diff Pane"
 msgstr "Podokno razlik"
 
 #. IDS_DIFF_SUCCEEDED
-#: Merge.rc:5258
+#: Merge.rc:5257
 msgid "Patch file written."
 msgstr "Datoteka popravka je bila uspešno zapisana."
 
 #. IDS_DIFF_FILEOVERWRITE
-#: Merge.rc:5259
+#: Merge.rc:5258
 msgid "Patch file already exists. Overwrite?"
 msgstr "Datoteka s popravki že obstaja. Ali jo želite prepisati?"
 
 #. IDS_DIFF_SELECTEDFILES
-#: Merge.rc:5260
+#: Merge.rc:5259
 #, c-format
 msgid "[%1 files selected]"
 msgstr "[%1 izbranih datotek]"
 
 #. IDS_DIFF_NORMAL
-#: Merge.rc:5261
+#: Merge.rc:5260
 msgid "Normal"
 msgstr "Običajno"
 
 #. IDS_DIFF_CONTEXT
-#: Merge.rc:5262
+#: Merge.rc:5261
 msgid "Context"
 msgstr "Skladnost"
 
 #. IDS_DIFF_UNIFIED
-#: Merge.rc:5263
+#: Merge.rc:5262
 msgid "Unified"
 msgstr "Poenoteno"
 
 #. IDS_FILEWRITE_ERROR
-#: Merge.rc:5265
+#: Merge.rc:5264
 #, c-format
 msgid "Could not write to file %1."
 msgstr "Ni mogoče pisati v datoteko %1."
 
 #. IDS_PATH_NOT_ABSOLUTE
-#: Merge.rc:5266
+#: Merge.rc:5265
 #, c-format
 msgid "Output path is not absolute: %1"
 msgstr "Navedena izhodna pot ni absolutna pot: %1"
 
 #. IDS_MUST_SPECIFY_OUTPUT
-#: Merge.rc:5267
+#: Merge.rc:5266
 msgid "Specify an output file."
 msgstr "Določite izhodno datoteko."
 
-#: Merge.rc:5269
+#: Merge.rc:5268
 msgid "Cannot create patch from binary files."
 msgstr "Iz dvojiških datotek ni mogoče ustvariti datoteke s popravki."
 
 #. IDS_SAVEFILES_FORPATCH
-#: Merge.rc:5270
+#: Merge.rc:5269
 msgid ""
 "Save all files first.\n"
 "\n"
@@ -7445,22 +7440,22 @@ msgstr ""
 "Ustvarjanje datoteke s popravki zahteva, da v datoteki ni ne shranjenih sprememb."
 
 #. IDS_FOLDER_NOTEXIST
-#: Merge.rc:5271
+#: Merge.rc:5270
 msgid "Folder does not exist."
 msgstr "Mapa ne obstaja."
 
 #. IDS_ARCHIVE_SUCCEEDED
-#: Merge.rc:5277
+#: Merge.rc:5276
 msgid "Archive file written."
 msgstr ""
 
 #. IDS_ARCHIVE_SAVEFILES
-#: Merge.rc:5278
+#: Merge.rc:5277
 msgid "Save all files first.\n\nCreating an archive requires no unsaved changes."
 msgstr ""
 
 #. IDS_NO_ZIP_SUPPORT
-#: Merge.rc:5283
+#: Merge.rc:5282
 msgid ""
 "Archive support not enabled.\n"
 "7-Zip and/or Merge7z*.dll not found.\n"
@@ -7471,37 +7466,37 @@ msgstr ""
 "Za več informacij o podpori za arhiviranje in kako jo omogočiti si oglejte priročnik."
 
 #. IDS_OPT_EXPORT_CAPTION
-#: Merge.rc:5284
+#: Merge.rc:5283
 msgid "Select file for export"
 msgstr "Izberite datoteko za izvoz"
 
 #. IDS_OPT_IMPORT_CAPTION
-#: Merge.rc:5285
+#: Merge.rc:5284
 msgid "Select file for import"
 msgstr "Izberite datoteko za uvoz"
 
 #. IDS_OPT_IMPORT_DONE
-#: Merge.rc:5286
+#: Merge.rc:5285
 msgid "Options imported from file."
 msgstr "Možnosti so uvožene iz datoteke."
 
 #. IDS_OPT_EXPORT_DONE
-#: Merge.rc:5287
+#: Merge.rc:5286
 msgid "Options exported to file."
 msgstr "Možnosti so izvožene v datoteko."
 
 #. IDS_OPT_IMPORT_ERR
-#: Merge.rc:5288
+#: Merge.rc:5287
 msgid "Failed to import options from file."
 msgstr "Ni uspel uvoz možnosti iz datoteke."
 
 #. IDS_OPT_EXPORT_ERR
-#: Merge.rc:5289
+#: Merge.rc:5288
 msgid "Failed to write options to file."
 msgstr "Ni uspelo izvažanje možnosti v datoteko."
 
 #. IDS_CLOSEALL_WINDOWS
-#: Merge.rc:5290
+#: Merge.rc:5289
 msgid ""
 "Close multiple compare windows?\n"
 "\n"
@@ -7512,34 +7507,34 @@ msgstr ""
 "Ali želite nadaljevati?"
 
 #. IDS_EOL_BIN
-#: Merge.rc:5300
+#: Merge.rc:5299
 msgctxt "EOL Type"
 msgid "Binary"
 msgstr "Dvojiško"
 
 #. IDS_MARKER_COLOR_FMT
-#: Merge.rc:5305
+#: Merge.rc:5304
 #, c-format
 msgid "Marker Color %d"
 msgstr "Barva označevalca %d"
 
 #. IDS_MARKER_NEW_PATTERN
-#: Merge.rc:5306
+#: Merge.rc:5305
 msgid "New Pattern"
 msgstr "Nov vzorec"
 
 #. IDS_PLUGINSLIST_TYPE
-#: Merge.rc:5312
+#: Merge.rc:5311
 msgid "Type"
 msgstr "Vrsta"
 
 #. IDS_PLUGINS_TYPE_EDITSCRIPT
-#: Merge.rc:5316
+#: Merge.rc:5315
 msgid "Editor script"
 msgstr "Urejevalnik skriptov"
 
 #. ID_SELECTLINEDIFF
-#: Merge.rc:5322
+#: Merge.rc:5321
 msgid ""
 "\n"
 "Difference in Current Line (F4)"
@@ -7548,7 +7543,7 @@ msgstr ""
 "Razlika v trenutni vrstici (F4)"
 
 #. ID_OPTIONS
-#: Merge.rc:5323
+#: Merge.rc:5322
 msgid ""
 "\n"
 "Options"
@@ -7557,7 +7552,7 @@ msgstr ""
 "Možnosti"
 
 #. ID_REFRESH
-#: Merge.rc:5324
+#: Merge.rc:5323
 msgid ""
 "\n"
 "Refresh (F5)"
@@ -7566,7 +7561,7 @@ msgstr ""
 "Osveži (F5)"
 
 #. ID_PREVDIFF
-#: Merge.rc:5330
+#: Merge.rc:5329
 msgid ""
 "\n"
 "Previous Difference (Alt+Up)"
@@ -7575,7 +7570,7 @@ msgstr ""
 "Prejšnja razlika (Alt+Up)"
 
 #. ID_NEXTDIFF
-#: Merge.rc:5331
+#: Merge.rc:5330
 msgid ""
 "\n"
 "Next Difference (Alt+Down)"
@@ -7584,7 +7579,7 @@ msgstr ""
 "Naslednja razlika (Alt+Down)"
 
 #. ID_PREVCONFLICT
-#: Merge.rc:5332
+#: Merge.rc:5331
 msgid ""
 "\n"
 "Previous Conflict (Alt+Shift+Up)"
@@ -7593,7 +7588,7 @@ msgstr ""
 "Prejšnji spor (Alt+Shift+Up)"
 
 #. ID_NEXTCONFLICT
-#: Merge.rc:5333
+#: Merge.rc:5332
 msgid ""
 "\n"
 "Next Conflict (Alt+Shift+Down)"
@@ -7602,7 +7597,7 @@ msgstr ""
 "Naslednji spor (Alt+Shift+Down)"
 
 #. ID_FIRSTDIFF
-#: Merge.rc:5338
+#: Merge.rc:5337
 msgid ""
 "\n"
 "First Difference (Alt+Home)"
@@ -7611,7 +7606,7 @@ msgstr ""
 "Prva razlika (Alt+Home)"
 
 #. ID_CURDIFF
-#: Merge.rc:5339
+#: Merge.rc:5338
 msgid ""
 "\n"
 "Current Difference (Alt+Enter)"
@@ -7620,7 +7615,7 @@ msgstr ""
 "Trenutna razlika (Alt+Enter)"
 
 #. ID_LASTDIFF
-#: Merge.rc:5340
+#: Merge.rc:5339
 msgid ""
 "\n"
 "Last Difference (Alt+End)"
@@ -7629,7 +7624,7 @@ msgstr ""
 "Zadnja razlika (Alt+End)"
 
 #. ID_L2R
-#: Merge.rc:5341
+#: Merge.rc:5340
 msgid ""
 "\n"
 "Copy to Right (Alt+Right)"
@@ -7638,7 +7633,7 @@ msgstr ""
 "Kopiraj desno (Alt+Desno)"
 
 #. ID_R2L
-#: Merge.rc:5342
+#: Merge.rc:5341
 msgid ""
 "\n"
 "Copy to Left (Alt+Left)"
@@ -7647,7 +7642,7 @@ msgstr ""
 "Kopiraj levo (Alt+Levo)"
 
 #. ID_L2RNEXT
-#: Merge.rc:5343
+#: Merge.rc:5342
 msgid ""
 "\n"
 "Copy to Right and Advance (Ctrl+Alt+Right)"
@@ -7656,7 +7651,7 @@ msgstr ""
 "Kopiraj desno in naprej (Ctrl+Alt+Desno)"
 
 #. ID_R2LNEXT
-#: Merge.rc:5344
+#: Merge.rc:5343
 msgid ""
 "\n"
 "Copy to Left and Advance (Ctrl+Alt+Left)"
@@ -7665,7 +7660,7 @@ msgstr ""
 "Kopiraj levo in naprej (Ctrl+Alt+Levo)"
 
 #. ID_ALL_RIGHT
-#: Merge.rc:5345
+#: Merge.rc:5344
 msgid ""
 "\n"
 "Copy All to Right"
@@ -7674,7 +7669,7 @@ msgstr ""
 "Kopiraj vse v desno"
 
 #. ID_ALL_LEFT
-#: Merge.rc:5346
+#: Merge.rc:5345
 msgid ""
 "\n"
 "Copy All to Left"
@@ -7683,7 +7678,7 @@ msgstr ""
 "Kopiraj vse v levo"
 
 #. ID_AUTO_MERGE
-#: Merge.rc:5347
+#: Merge.rc:5346
 msgid ""
 "\n"
 "Auto Merge (Ctrl+Alt+M)"
@@ -7692,7 +7687,7 @@ msgstr ""
 "Samodejno združi (Ctrl+Alt+M)"
 
 #. ID_FIRSTFILE
-#: Merge.rc:5348
+#: Merge.rc:5347
 msgid ""
 "\n"
 "First File"
@@ -7701,7 +7696,7 @@ msgstr ""
 "Prva datoteka"
 
 #. ID_NEXTFILE
-#: Merge.rc:5349
+#: Merge.rc:5348
 msgid ""
 "\n"
 "Next File (Ctrl+F8)"
@@ -7710,7 +7705,7 @@ msgstr ""
 "Naslednja datoteka (Ctrl+F8)"
 
 #. ID_LASTFILE
-#: Merge.rc:5350
+#: Merge.rc:5349
 msgid ""
 "\n"
 "Last File"
@@ -7719,7 +7714,7 @@ msgstr ""
 "Zadnja datoteka"
 
 #. ID_PREVFILE
-#: Merge.rc:5351
+#: Merge.rc:5350
 msgid ""
 "\n"
 "Previous File (Ctrl+F7)"
@@ -7728,141 +7723,141 @@ msgstr ""
 "Prejšnja datoteka (Ctrl+F7)"
 
 #. IDS_UNPACK_AUTO
-#: Merge.rc:5358
+#: Merge.rc:5357
 msgid "Adapted unpacker applied to both files (one needs extension)."
 msgstr "Prilagojen razpakovalec se uporablja za obe datoteki (samo ena datoteka potrebuje končnico)."
 
 #. IDS_NO_PREDIFFER
-#: Merge.rc:5359
+#: Merge.rc:5358
 msgid "No Prediffer (Normal)"
 msgstr "Brez predpregleda razlik (običajno)"
 
 #. IDS_SUGGESTED_PLUGINS
-#: Merge.rc:5360
+#: Merge.rc:5359
 msgid "Suggested Plugins"
 msgstr "Priporočeni vtičniki"
 
 #. IDS_NOT_SUGGESTED_PLUGINS
-#: Merge.rc:5361
+#: Merge.rc:5360
 msgid "All Plugins"
 msgstr "Vsi vtičniki"
 
 #. IDS_PRIVATEBUILD_FMT
-#: Merge.rc:5367
+#: Merge.rc:5366
 #, c-format
 msgid "Private Build: %1"
 msgstr "Zasebna gradnja:%1"
 
 #. IDS_ALLRIGHTS_RESERVED
-#: Merge.rc:5368
+#: Merge.rc:5367
 msgid " - All rights reserved."
 msgstr ""
 
 #. IDS_TITLE_PLUGINS_SETTINGS
-#: Merge.rc:5374
+#: Merge.rc:5373
 msgid "Plugin Settings"
 msgstr "Nastavitve vtičnika"
 
 #. IDS_NO_SCT_SCRIPTS
-#: Merge.rc:5376
+#: Merge.rc:5375
 msgid "WSH not found - .sct scripts disabled"
 msgstr "WSH ni najden - skripti '.sct' so onemogočeni"
 
 #. IDS_LOCBAR_GOTOLINE_FMT
-#: Merge.rc:5384
+#: Merge.rc:5383
 #, c-format
 msgid "G&o to Line %1"
 msgstr "Pojdi &na vrstico %1"
 
 #. IDS_GOTO_MOVED_LINE
-#: Merge.rc:5390
+#: Merge.rc:5389
 msgid "Go to Moved Line\tCtrl+Shift+G"
 msgstr "Pojdi na premaknjeno vrstico\tCtrl+Shift+G"
 
 #. IDS_AUTOCOMPLETE_DISABLED
-#: Merge.rc:5396
+#: Merge.rc:5395
 msgctxt "Options dialog|General|Open dialog Auto completion"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_AUTOCOMPLETE_FILE_SYS
-#: Merge.rc:5397
+#: Merge.rc:5396
 msgid "From file system"
 msgstr "Iz datotečnega sistema"
 
 #. IDS_AUTOCOMPLETE_MRU
-#: Merge.rc:5398
+#: Merge.rc:5397
 msgid "From Most Recently Used list"
 msgstr "Iz seznama nedavnih (MRU)"
 
 #. IDS_COLORSCHEME_PLAIN
-#: Merge.rc:5404
+#: Merge.rc:5403
 msgid "No Highlighting"
 msgstr "Brez označevanja"
 
 #. IDS_COLORSCHEME_PO
-#: Merge.rc:5439
+#: Merge.rc:5438
 msgid "Portable Object"
 msgstr "Prenosni predmet"
 
 #. IDS_COLORSCHEME_RSRC
-#: Merge.rc:5444
+#: Merge.rc:5443
 msgid "Resources"
 msgstr "Viri"
 
 #. IDS_COLORSCHEME_SH
-#: Merge.rc:5448
+#: Merge.rc:5447
 msgid "Shell"
 msgstr "Lupina"
 
 #. IDS_CLOSE_LEFT_TABS
-#: Merge.rc:5469
+#: Merge.rc:5468
 msgid "Close &Left Tabs"
 msgstr "Zapri &leve zavihke"
 
 #. IDS_CLOSE_RIGHT_TABS
-#: Merge.rc:5470
+#: Merge.rc:5469
 msgid "Close R&ight Tabs"
 msgstr "Zapri &desne zavihke"
 
 #. IDS_CLOSE_OTHER_TABS
-#: Merge.rc:5471
+#: Merge.rc:5470
 msgid "Close &Other Tabs"
 msgstr "Zapri d&ruge zavihke"
 
 #. IDS_TABBAR_AUTO_MAXWIDTH
-#: Merge.rc:5472
+#: Merge.rc:5471
 msgid "Enable &Auto Max Width"
 msgstr "Omogoči sa&modejno največjo širino"
 
 #. IDS_WEBPAGE_MENU
-#: Merge.rc:5482
+#: Merge.rc:5481
 msgid "We&bpage"
 msgstr "&Spletna stran"
 
 #. IDS_VIEW_WRAP_TEXT
-#: Merge.rc:5487
+#: Merge.rc:5486
 msgid "W&rap Text"
 msgstr "Pre&lom besedila"
 
 #. IDS_NOTINSTALLED
-#: Merge.rc:5492
+#: Merge.rc:5491
 msgid "%1 is not installed."
 msgstr "%1 ni nameščen."
 
 #. IDS_CREATE_FOLDER
-#: Merge.rc:5497
+#: Merge.rc:5496
 #, c-format
 msgid "%1 does not exist. Create it?"
 msgstr "%1 ne obstaja. Ali jo želite ustvariti?"
 
 #. IDS_CREATE_FOLDER_ERROR
-#: Merge.rc:5498
+#: Merge.rc:5497
 msgid "Failed to create folder."
 msgstr "Ni bilo mogoče ustvariti mape."
 
 #. IDC_EXT_EDITOR_PATH
-#: Merge.rc:5503
+#: Merge.rc:5502
 msgid ""
 "Parameters:\n"
 "$file: Current file path\n"
@@ -7873,491 +7868,491 @@ msgstr ""
 "$linenum: številka vrstice trenutnega položaja kazalca"
 
 #. IDS_DIFF_ALGORITHM_DEFAULT
-#: Merge.rc:5508
+#: Merge.rc:5507
 msgid "default"
 msgstr "privzeto"
 
 #. IDS_DIFF_ALGORITHM_MINIMAL
-#: Merge.rc:5509
+#: Merge.rc:5508
 msgid "minimal"
 msgstr "najmanj"
 
 #. IDS_DIFF_ALGORITHM_PATIENCE
-#: Merge.rc:5510
+#: Merge.rc:5509
 msgid "patience"
 msgstr "potrpežljivo"
 
 #. IDS_DIFF_ALGORITHM_HISTOGRAM
-#: Merge.rc:5511
+#: Merge.rc:5510
 msgid "histogram"
 msgstr "histogram"
 
 #. IDS_DIFF_ALGORITHM_NONE
-#: Merge.rc:5512
+#: Merge.rc:5511
 msgid "none"
 msgstr "brez"
 
 #. IDS_RENDERING_MODE_GDI
-#: Merge.rc:5517
+#: Merge.rc:5516
 msgid "GDI"
 msgstr "GDI"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_DEFAULT
-#: Merge.rc:5518
+#: Merge.rc:5517
 msgid "DirectWrite Default"
 msgstr "Privzeti DirectWrite"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_ALIASED
-#: Merge.rc:5519
+#: Merge.rc:5518
 msgid "DirectWrite Aliased"
 msgstr "Kratko DirectWrite"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_GDI_CLASSIC
-#: Merge.rc:5520
+#: Merge.rc:5519
 msgid "DirectWrite GDI Classic"
 msgstr "Klasičen DirectWrite GDI"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_GDI_NATURAL
-#: Merge.rc:5521
+#: Merge.rc:5520
 msgid "DirectWrite GDI Natural"
 msgstr "Naravni DirectWrite GDI"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_NATURAL
-#: Merge.rc:5522
+#: Merge.rc:5521
 msgid "DirectWrite Natural"
 msgstr "Naravni DirectWrite"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_NATURAL_SYMMETRIC
-#: Merge.rc:5523
+#: Merge.rc:5522
 msgid "DirectWrite Natural Symmetric"
 msgstr "Naravno simetričen DirectWrite"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_DISABLED
-#: Merge.rc:5528
+#: Merge.rc:5527
 msgctxt "Options dialog|General|Close windows with Esc"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_1
-#: Merge.rc:5529
+#: Merge.rc:5528
 msgid "MDI child window or main window"
 msgstr "Podrejeno ali glavno okno MDI"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_2
-#: Merge.rc:5530
+#: Merge.rc:5529
 msgid "MDI child window only"
 msgstr "Le podrejeno okno MDI"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_3
-#: Merge.rc:5531
+#: Merge.rc:5530
 msgid "Close main window if only one MDI child window"
 msgstr "Zapri glavno okno, če je samo eno podrejeno okno MDI"
 
 #. IDS_DIFF_GROUP
-#: Merge.rc:5536
+#: Merge.rc:5535
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Diff"
 msgstr "Razlika"
 
 #. IDS_DIFF_HIGHLIGHT
-#: Merge.rc:5537
+#: Merge.rc:5536
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Highlight"
 msgstr "Označi"
 
 #. IDS_DIFF_BLINK
-#: Merge.rc:5538
+#: Merge.rc:5537
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Blink"
 msgstr "Utripaj"
 
 #. IDS_DIFF_BLOCKSIZE
-#: Merge.rc:5539
+#: Merge.rc:5538
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Block Size"
 msgstr "Velikost bloka"
 
 #. IDS_DIFF_BLOCKALPHA
-#: Merge.rc:5540
+#: Merge.rc:5539
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Block Alpha"
 msgstr "Blok Alfa"
 
 #. IDS_DIFF_CDTHRESHOLD
-#: Merge.rc:5541
+#: Merge.rc:5540
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "CD Threshold"
 msgstr "Prag CD"
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION
-#: Merge.rc:5542
+#: Merge.rc:5541
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Ins/Del Detection"
 msgstr "Zaznavanje Ins/Del"
 
 #. IDS_OVERLAY_MODE_NONE
-#: Merge.rc:5543 Merge.rc:5548
+#: Merge.rc:5542 Merge.rc:5547
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "None"
 msgstr "Brez"
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION_VERTICAL
-#: Merge.rc:5544
+#: Merge.rc:5543
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Vertical"
 msgstr "Navpično"
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION_HORIZONTAL
-#: Merge.rc:5545
+#: Merge.rc:5544
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Horizontal"
 msgstr "Vodoravno"
 
 #. IDS_OVERLAY_GROUP
-#: Merge.rc:5546
+#: Merge.rc:5545
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Overlay"
 msgstr "Prekrivanje"
 
 #. IDS_OVERLAY_ALPHA
-#: Merge.rc:5547
+#: Merge.rc:5546
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha"
 msgstr "Alfa"
 
 #. IDS_OVERLAY_MODE_XOR
-#: Merge.rc:5549
+#: Merge.rc:5548
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "XOR"
 msgstr "XOR"
 
 #. IDS_OVERLAY_MODE_ALPHA
-#: Merge.rc:5550
+#: Merge.rc:5549
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha Blend"
 msgstr "Alfa mešanje"
 
 #. IDS_OVERLAY_MODE_ALPHA_ANIMATION
-#: Merge.rc:5551
+#: Merge.rc:5550
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha Animation"
 msgstr "Alfa animacija"
 
 #. IDS_ZOOM
-#: Merge.rc:5552
+#: Merge.rc:5551
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Zoom"
 msgstr "Povečava"
 
 #. IDS_PAGE
-#: Merge.rc:5553
+#: Merge.rc:5552
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Page:"
 msgstr "Stran:"
 
 #. IDS_IMGCMP_STATUS_PT_RGBA_FMT
-#: Merge.rc:5554
+#: Merge.rc:5553
 #, c-format
 msgid "Pt: (%d, %d)  RGBA: (%d, %d, %d, %d)  "
 msgstr "Tč: (%d, %d)  RGBA: (%d, %d, %d, %d)  "
 
 #. IDS_IMGCMP_STATUS_DIST1_FMT
-#: Merge.rc:5555
+#: Merge.rc:5554
 #, c-format
 msgid "Dist: %g  "
 msgstr "Razdalja: %g  "
 
 #. IDS_IMGCMP_STATUS_DIST2_FMT
-#: Merge.rc:5556
+#: Merge.rc:5555
 #, c-format
 msgid "Dist: %g, %g  "
 msgstr "Razdalja: %g, %g  "
 
 #. IDS_IMGCMP_STATUS_PAGE_ZOOM_SIZE_BPP_FMT
-#: Merge.rc:5557
+#: Merge.rc:5556
 #, c-format
 msgid "Page: %d/%d  Zoom: %d%%  %dx%dpx  %dbpp  "
 msgstr "Stran: %d/%d  Povečava: %d%%  %dx%dpx  %dbpp  "
 
 #. IDS_IMGCMP_STATUS_RC_FMT
-#: Merge.rc:5558
+#: Merge.rc:5557
 #, c-format
 msgid "Rc: (%d, %d)  "
 msgstr "Zapis: (%d, %d)  "
 
 #. IDS_IMGCMP_STATUS_FLIPPED_FMT
-#: Merge.rc:5559
+#: Merge.rc:5558
 #, c-format
 msgid "Flipped: %s  "
 msgstr "Zasukano: %s  "
 
 #. IDS_IMGCMP_STATUS_ROTATED_FMT
-#: Merge.rc:5560
+#: Merge.rc:5559
 #, c-format
 msgid "Rotated: %d  "
 msgstr "Obrnjeno: %d  "
 
 #. IDS_IMGCMP_REPORT_ALLPAGES
-#: Merge.rc:5561
+#: Merge.rc:5560
 msgid "All pages"
 msgstr "Vse strani"
 
 #. IDS_IGNSUB_STR1
-#: Merge.rc:5566
+#: Merge.rc:5565
 msgid "<Edit here>"
 msgstr "<Uredi tukaj>"
 
 #. IDS_IGNSUB_STR2
-#: Merge.rc:5567
+#: Merge.rc:5566
 msgid "No differences found to select"
 msgstr "Ni najdenih nobenih razlik za izbiro"
 
 #. IDS_IGNSUB_STR3
-#: Merge.rc:5568
+#: Merge.rc:5567
 msgid "No differences found to add as substitution filter"
 msgstr "Ni najdenih razlik za dodajanje kot Nadomestni filter"
 
 #. IDS_IGNSUB_STR4
-#: Merge.rc:5569
+#: Merge.rc:5568
 msgid "The pair is already in the Substitution Filters list"
 msgstr "Par je že prisoten na seznamu nadomestnih filtrov"
 
 #. IDS_IGNSUB_STR5
-#: Merge.rc:5570
+#: Merge.rc:5569
 msgid "Add this change to Substitution Filters?"
 msgstr "Dodam to spremembo med Nadomestne filtre?"
 
 #. IDS_OCRRESULT_TEXTONLY
-#: Merge.rc:5575
+#: Merge.rc:5574
 msgid "Text only"
 msgstr "Samo besedilo"
 
 #. IDS_OCRRESULT_POS_LINE
-#: Merge.rc:5576
+#: Merge.rc:5575
 msgid "Line-by-line position and text"
 msgstr "Položaj vrstico po vrstico in besedilo"
 
 #. IDS_OCRRESULT_POS_WORD
-#: Merge.rc:5577
+#: Merge.rc:5576
 msgid "Word-by-word position and text"
 msgstr "Položaj besedo po besedo in besedilo"
 
 #. IDS_USERDATAFOLDER_APPDATA
-#: Merge.rc:5582
+#: Merge.rc:5581
 msgid "AppData (Roaming) folder"
 msgstr ""
 
 #. IDS_USERDATAFOLDER_INSTALL
-#: Merge.rc:5583
+#: Merge.rc:5582
 msgid "Install folder"
 msgstr "Namestitvena mapa"
 
 #. IDS_USERDATAFOLDER_DOCUMENTS
-#: Merge.rc:5584
+#: Merge.rc:5583
 msgid "Documents folder"
 msgstr ""
 
 #. IDS_SINGLEINSTANCE_DISABLED
-#: Merge.rc:5589
+#: Merge.rc:5588
 msgctxt "Options dialog|General|Single instance mode"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_SINGLEINSTANCE_STR1
-#: Merge.rc:5590
+#: Merge.rc:5589
 msgid "Allow only one instance to run"
 msgstr "Dovoli zagon samo enega primerka programa"
 
 #. IDS_CLIPBOARD_HISTORY
-#: Merge.rc:5591
+#: Merge.rc:5590
 msgid "Clipboard &History"
 msgstr ""
 
 #. IDS_SINGLEINSTANCE_STR2
-#: Merge.rc:5592
+#: Merge.rc:5591
 msgid "Allow only one instance; wait for termination"
 msgstr "Dovoli zagon le enega primerka, in počakaj, da se primerek dokonča"
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_DISABLED
-#: Merge.rc:5597
+#: Merge.rc:5596
 msgctxt "Options dialog|General|Auto-reload modified files"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_STR1
-#: Merge.rc:5598
+#: Merge.rc:5597
 msgid "Only on window activated"
 msgstr "Aktivirano samo na oknu"
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_STR2
-#: Merge.rc:5599
+#: Merge.rc:5598
 msgid "Immediately"
 msgstr "Takoj"
 
 #. IDS_PLUGIN_ALL
-#: Merge.rc:5604
+#: Merge.rc:5603
 msgid "Al&l"
 msgstr "V&se"
 
 #. IDS_PLUGIN_OTHERS
-#: Merge.rc:5605
+#: Merge.rc:5604
 msgid "&Others"
 msgstr "&Drugo"
 
-#: Merge.rc:5607
+#: Merge.rc:5606
 #, c-format
 msgid "Missing plugin name in pipeline: %1"
 msgstr "Manjkajoče ime vtičnika v cevovodu vtičnika:%1"
 
-#: Merge.rc:5609
+#: Merge.rc:5608
 #, c-format
 msgid "Missing quote in plugin pipeline: %1"
 msgstr "Manjka narekovaj v cevovodu vtičnika: %1"
 
 #. IDS_PLUGIN_NAME_ALREADY_EXISTS
-#: Merge.rc:5610
+#: Merge.rc:5609
 #, c-format
 msgid "Plugin name '%1' already exists."
 msgstr ""
 
 #. IDS_PLUGIN_TITLE1
-#: Merge.rc:5611
+#: Merge.rc:5610
 msgid "Specify plugin arguments"
 msgstr "Določi argumente vtičnika"
 
-#: Merge.rc:5613
+#: Merge.rc:5612
 #, c-format
 msgid "Plugin not found or invalid: %1"
 msgstr "Vtičnika ni bilo mogoče najti ali je neveljaven: %1"
 
 #. IDS_PLUGIN_NOT_UNPACK
-#: Merge.rc:5614
+#: Merge.rc:5613
 #, c-format
 msgid "'%1' is not an unpacker plugin"
 msgstr "'%1' ni vtičnik razpakirnika"
 
 #. IDS_PLUGIN_NOT_PREDIFF
-#: Merge.rc:5615
+#: Merge.rc:5614
 #, c-format
 msgid "'%1' is not a prediffer plugin"
 msgstr "'%1' ni vtičnik preddifereja"
 
-#: Merge.rc:5617
+#: Merge.rc:5616
 #, c-format
 msgid "Error prediffing '%1' with '%2'. Prediffing disabled."
 msgstr "Med preddifiranjem datoteke '%1' z vtičnikom '%2' je prišlo do napake. Prednastavitev se ne uporablja več."
 
 #. IDS_PLUGIN_CIRCULAR_REFERENCE
-#: Merge.rc:5618
+#: Merge.rc:5617
 #, c-format
 msgid "Circular reference in plugin pipeline: %1"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE1
-#: Merge.rc:5619
+#: Merge.rc:5618
 msgid "URL Handler"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE2
-#: Merge.rc:5620
+#: Merge.rc:5619
 msgid "File Unpacker"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE3
-#: Merge.rc:5621
+#: Merge.rc:5620
 msgid "File or Folder Unpacker"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE5
-#: Merge.rc:5623
+#: Merge.rc:5622
 msgid "Alias for Unpacker"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE6
-#: Merge.rc:5624
+#: Merge.rc:5623
 msgid "Alias for Prediffer"
 msgstr ""
 
 #. IDS_PLUGIN_TYPE7
-#: Merge.rc:5625
+#: Merge.rc:5624
 msgid "Alias for Editor script"
 msgstr ""
 
 #. IDS_PLUGIN_ALIAS_DESC
-#: Merge.rc:5626
+#: Merge.rc:5625
 #, c-format
 msgid "Alias for plugin pipeline '%1'"
 msgstr ""
 
 #. IDS_PLUGIN_NEW_DESC
-#: Merge.rc:5627
+#: Merge.rc:5626
 msgid "New plugin description"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_ALL
-#: Merge.rc:5628
+#: Merge.rc:5627
 msgid "All"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_1ST
-#: Merge.rc:5629
+#: Merge.rc:5628
 msgid "1st"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_2ND
-#: Merge.rc:5630
+#: Merge.rc:5629
 msgid "2nd"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_3RD
-#: Merge.rc:5631
+#: Merge.rc:5630
 msgid "3rd"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_1ST_2ND
-#: Merge.rc:5632
+#: Merge.rc:5631
 msgid "1st and 2nd"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_1ST_3RD
-#: Merge.rc:5633
+#: Merge.rc:5632
 msgid "1st and 3rd"
 msgstr ""
 
 #. IDS_PLUGIN_TARGETS_2ND_3RD
-#: Merge.rc:5634
+#: Merge.rc:5633
 msgid "2nd and 3rd"
 msgstr ""
 
 #. IDS_PLUGIN_CTRL_CLICK
-#: Merge.rc:5635
+#: Merge.rc:5634
 msgid "(Ctrl+Click to add to pipeline)"
 msgstr ""
 
 #. IDS_FILTER_APPLIED
-#: Merge.rc:5640
+#: Merge.rc:5639
 msgid "Filter applied"
 msgstr "Filter je uporabljen"
 
 #. IDS_FILTERMENU_COMPARE
-#: Merge.rc:5645
+#: Merge.rc:5644
 #, c-format
 msgid "Compare %1"
 msgstr ""
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN2
-#: Merge.rc:5647
+#: Merge.rc:5646
 msgid "&Filter by This Column..."
 msgstr ""
 
 #. IDS_CLIPBOARDHISTORY_TIME
-#: Merge.rc:5652
+#: Merge.rc:5651
 #, c-format
 msgid "Clipboard at %s"
 msgstr "Odložišče na %s"
 
 #. IDS_CLIPBOARDHISTORY_DISABLED
-#: Merge.rc:5653
+#: Merge.rc:5652
 msgid ""
 "Clipboard history disabled.\r\n"
 "Enable: Windows logo key + V, then Turn on."
@@ -8365,420 +8360,420 @@ msgstr ""
 "Zgodovina odložišča je onemogočena.\r\n"
 "Za omogočanje zgodovine odložišča, pritisnite tipko z logotipom Windows + V in nato kliknite gumb Vklopi."
 
-#: Merge.rc:5655
+#: Merge.rc:5654
 msgid "This system does not support clipboard history."
 msgstr "Ta sistem ne podpira zgodovine odložišča."
 
-#: Merge.rc:5657
+#: Merge.rc:5656
 msgid "32-bit WinMerge does not support Clipboard Compare"
 msgstr "32-bitna različica WinMerge ne podpira primerjave odložišča"
 
 #. IDS_WEBVIEW2_RUNTIME_NOT_INSTALLED
-#: Merge.rc:5662
+#: Merge.rc:5661
 msgid "WebView2 runtime not installed. Download it?"
 msgstr "Izvajalski čas WebView2 ni nameščen. Ali ga želite prenesti?"
 
 #. IDS_JUMPLIST_NEW_TEXT_COMPARE
-#: Merge.rc:5667
+#: Merge.rc:5666
 msgid "New Text Compare"
 msgstr "Primerjava novega besedila"
 
 #. IDS_JUMPLIST_NEW_TABLE_COMPARE
-#: Merge.rc:5668
+#: Merge.rc:5667
 msgid "New Table Compare"
 msgstr "Primerjava nove tabele"
 
 #. IDS_JUMPLIST_NEW_BINARY_COMPARE
-#: Merge.rc:5669
+#: Merge.rc:5668
 msgid "New Binary Compare"
 msgstr "Primerjava nove dvojiške"
 
 #. IDS_JUMPLIST_NEW_IMAGE_COMPARE
-#: Merge.rc:5670
+#: Merge.rc:5669
 msgid "New Image Compare"
 msgstr "Primerjava nove slike"
 
 #. IDS_JUMPLIST_NEW_WEBPAGE_COMPARE
-#: Merge.rc:5671
+#: Merge.rc:5670
 msgid "New Webpage Compare"
 msgstr "Primerjava nove spletne strani"
 
 #. IDS_JUMPLIST_NEW_FOLDER_COMPARE
-#: Merge.rc:5672
+#: Merge.rc:5671
 msgid "New Folder Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_CLIPBOARD_COMPARE
-#: Merge.rc:5673
+#: Merge.rc:5672
 msgid "Clipboard Compare"
 msgstr "Primerjava odložišča"
 
 #. IDS_PREVIEWBAR_PRINT
-#: Merge.rc:5678
+#: Merge.rc:5677
 msgid "&Print..."
 msgstr "Na&tisni..."
 
 #. IDS_PREVIEWBAR_PREVPAGE
-#: Merge.rc:5680
+#: Merge.rc:5679
 msgid "Pre&v Page"
 msgstr "Pre&jšnja stran"
 
 #. IDS_PREVIEWBAR_TWOPAGE
-#: Merge.rc:5681
+#: Merge.rc:5680
 msgid "&Two Page"
 msgstr "&Dve strani"
 
 #. IDS_PREVIEWBAR_ONEPAGE
-#: Merge.rc:5682
+#: Merge.rc:5681
 msgid "&One Page"
 msgstr "&Ena stran"
 
 #. IDS_PREVIEWBAR_ZOOMIN
-#: Merge.rc:5683
+#: Merge.rc:5682
 msgid "Zoom &In"
 msgstr "Po&večaj"
 
 #. IDS_PREVIEWBAR_ZOOMOUT
-#: Merge.rc:5684
+#: Merge.rc:5683
 msgid "Zoom &Out"
 msgstr "Pom&njšaj"
 
 #. IDS_WEBPAGE_COMPARING
-#: Merge.rc:5690
+#: Merge.rc:5689
 msgid "Comparing..."
 msgstr "Primerjanje..."
 
 #. IDS_WEBPAGE_ZOOM
-#: Merge.rc:5691
+#: Merge.rc:5690
 msgid "Zoom:"
 msgstr "Povečava:"
 
 #. IDS_COPY_GRANULARITY_DIFFHUNK
-#: Merge.rc:5696
+#: Merge.rc:5695
 msgid "Diff hunk"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_INLINE
-#: Merge.rc:5697
+#: Merge.rc:5696
 msgid "Inline diff"
 msgstr ""
 
 #. IDS_COPY_GRANULARITY_LINE
-#: Merge.rc:5698
+#: Merge.rc:5697
 msgid "Line"
 msgstr ""
 
-#: Merge.rc:5699
+#: Merge.rc:5698
 msgid "Character"
 msgstr ""
 
 #. ID_MICE_PREVDIFF
-#: Merge.rc:5704
+#: Merge.rc:5703
 msgid "\nPrevious Difference (Alt+Up)\n(Right Button+Wheel Up)\n(Alt+Wheel Up)"
 msgstr ""
 
 #. ID_MICE_NEXTDIFF
-#: Merge.rc:5705
+#: Merge.rc:5704
 msgid "\nNext Difference (Alt+Down)\n(Right Button+Wheel Down)\n(Alt+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_L2R
-#: Merge.rc:5706
+#: Merge.rc:5705
 msgid "\nCopy to Right (Alt+Right)\n(Right Button+Wheel Right)\n(Alt+Wheel Right)\n(Alt+Shift+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_R2L
-#: Merge.rc:5707
+#: Merge.rc:5706
 msgid "\nCopy to Left (Alt+Left)\n(Right Button+Wheel Left)\n(Alt+Wheel Left)\n(Alt+Shift+Wheel Up)"
 msgstr ""
 
 #. ID_MICE_L2RNEXT
-#: Merge.rc:5708
+#: Merge.rc:5707
 msgid "\nCopy to Right and Advance (Ctrl+Alt+Right)\n(Ctrl+Alt+Wheel Right)\n(Ctrl+Alt+Shift+Wheel Down)"
 msgstr ""
 
 #. ID_MICE_R2LNEXT
-#: Merge.rc:5709
+#: Merge.rc:5708
 msgid "\nCopy to Left and Advance (Ctrl+Alt+Left)\n(Ctrl+Alt+Wheel Left)\n(Ctrl+Alt+Shift+Wheel Up)"
 msgstr ""
 
 #. IDS_LOG_COMPARING_2
-#: Merge.rc:5719
+#: Merge.rc:5718
 #, c-format
 msgid "Comparing %1 with %2"
 msgstr ""
 
 #. IDS_LOG_COMPARING_3
-#: Merge.rc:5720
+#: Merge.rc:5719
 #, c-format
 msgid "Comparing %1 with %2 and %3"
 msgstr ""
 
 #. IDS_LOG_COMPARE_COMPLETED
-#: Merge.rc:5721
+#: Merge.rc:5720
 msgid "Comparison completed"
 msgstr ""
 
 #. IDS_LOG_COMPARE_ERROR_2
-#: Merge.rc:5722
+#: Merge.rc:5721
 #, c-format
 msgid "Failed to compare %1 with %2: "
 msgstr ""
 
 #. IDS_LOG_COMPARE_ERROR_3
-#: Merge.rc:5723
+#: Merge.rc:5722
 #, c-format
 msgid "Failed to compare %1 with %2 and %3: "
 msgstr ""
 
 #. IDS_LOG_FILE_SAVED
-#: Merge.rc:5724
+#: Merge.rc:5723
 msgid "File saved"
 msgstr ""
 
 #. IDS_LOG_COPYING_FILES
-#: Merge.rc:5725
+#: Merge.rc:5724
 msgid "Copying files..."
 msgstr ""
 
 #. IDS_LOG_MOVING_FILES
-#: Merge.rc:5726
+#: Merge.rc:5725
 msgid "Moving files..."
 msgstr ""
 
 #. IDS_LOG_DELETING_FILES
-#: Merge.rc:5727
+#: Merge.rc:5726
 msgid "Deleting files..."
 msgstr ""
 
 #. IDS_LOG_RECYCLEBIN
-#: Merge.rc:5728
+#: Merge.rc:5727
 msgid "Recycle Bin"
 msgstr ""
 
 #. IDS_LOG_PERMANENTLY_DELETED
-#: Merge.rc:5729
+#: Merge.rc:5728
 msgid "Permanently deleted"
 msgstr ""
 
 #. IDS_LOG_FILEOPERATION_COMPLETED
-#: Merge.rc:5730
+#: Merge.rc:5729
 msgid "File operation completed successfully"
 msgstr ""
 
 #. IDS_LOG_FILEOPERATION_CANCELED
-#: Merge.rc:5731
+#: Merge.rc:5730
 msgid "File operation canceled"
 msgstr ""
 
 #. IDS_FILTER_ERROR_NO_ERROR
-#: Merge.rc:5736
+#: Merge.rc:5735
 msgid "No error"
 msgstr ""
 
 #. IDS_FILTER_ERROR_EMPTY_EXPRESSION
-#: Merge.rc:5737
+#: Merge.rc:5736
 msgid "Filter expression is empty"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNKNOWN_CHAR
-#: Merge.rc:5738
+#: Merge.rc:5737
 msgid "Unknown character in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNTERMINATED_STRING
-#: Merge.rc:5739
+#: Merge.rc:5738
 msgid "Unterminated string literal"
 msgstr ""
 
 #. IDS_FILTER_ERROR_SYNTAX_ERROR
-#: Merge.rc:5740
+#: Merge.rc:5739
 msgid "Syntax error in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_PARSE_FAILURE
-#: Merge.rc:5741
+#: Merge.rc:5740
 msgid "Failed to parse filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_LITERAL
-#: Merge.rc:5742
+#: Merge.rc:5741
 msgid "Invalid literal value"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_REGULAR_EXPRESSION
-#: Merge.rc:5743
+#: Merge.rc:5742
 msgid "Invalid regular expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNDEFINED_IDENTIFIER
-#: Merge.rc:5744
+#: Merge.rc:5743
 msgid "Undefined identifier"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_ARGUMENT_COUNT
-#: Merge.rc:5745
+#: Merge.rc:5744
 msgid "Invalid number of arguments"
 msgstr ""
 
 #. IDS_FILTER_ERROR_FILTER_NAME_NOT_FOUND
-#: Merge.rc:5746
+#: Merge.rc:5745
 msgid "Filter name not found"
 msgstr ""
 
 #. IDS_FILTER_ERROR_DIVIDE_BY_ZERO
-#: Merge.rc:5747
+#: Merge.rc:5746
 msgid "Division by zero in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNKNOWN_ERROR
-#: Merge.rc:5748
+#: Merge.rc:5747
 msgid "Unknown error"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_PROPERTY_NAME
-#: Merge.rc:5749
+#: Merge.rc:5748
 msgid "Invalid property name"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_DIRECTIVE
-#: Merge.rc:5750
+#: Merge.rc:5749
 msgid "Invalid directive"
 msgstr ""
 
 #. IDS_FILTER_OP_EQUALS
-#: Merge.rc:5755
+#: Merge.rc:5754
 msgid "Equals"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_EQUALS
-#: Merge.rc:5756
+#: Merge.rc:5755
 msgid "Does not equal"
 msgstr ""
 
 #. IDS_FILTER_OP_LESS_THAN
-#: Merge.rc:5757
+#: Merge.rc:5756
 msgid "Less than"
 msgstr ""
 
 #. IDS_FILTER_OP_LESS_EQUAL
-#: Merge.rc:5758
+#: Merge.rc:5757
 msgid "Less than or equal to"
 msgstr ""
 
 #. IDS_FILTER_OP_GREATER_EQUAL
-#: Merge.rc:5759
+#: Merge.rc:5758
 msgid "Greater than or equal to"
 msgstr ""
 
 #. IDS_FILTER_OP_GREATER_THAN
-#: Merge.rc:5760
+#: Merge.rc:5759
 msgid "Greater than"
 msgstr ""
 
 #. IDS_FILTER_OP_BETWEEN
-#: Merge.rc:5761
+#: Merge.rc:5760
 msgid "Between"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_BETWEEN
-#: Merge.rc:5762
+#: Merge.rc:5761
 msgid "Not Between"
 msgstr ""
 
 #. IDS_FILTER_OP_CONTAINS
-#: Merge.rc:5763
+#: Merge.rc:5762
 msgid "Contains"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_CONTAINS
-#: Merge.rc:5764
+#: Merge.rc:5763
 msgid "Not Contains"
 msgstr ""
 
 #. IDS_FILTER_OP_RECONTAINS
-#: Merge.rc:5765
+#: Merge.rc:5764
 msgid "Contains (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_RECONTAINS
-#: Merge.rc:5766
+#: Merge.rc:5765
 msgid "Not Contains (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_LIKE
-#: Merge.rc:5767
+#: Merge.rc:5766
 msgid "Match (wildcard)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_LIKE
-#: Merge.rc:5768
+#: Merge.rc:5767
 msgid "Not match (wildcard)"
 msgstr ""
 
 #. IDS_FILTER_OP_MATCHES
-#: Merge.rc:5769
+#: Merge.rc:5768
 msgid "Match (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_MATCHES
-#: Merge.rc:5770
+#: Merge.rc:5769
 msgid "Not match (regex)"
 msgstr ""
 
 #. IDS_COLORMODE_LIGHT
-#: Merge.rc:5775
+#: Merge.rc:5774
 msgid "Light"
 msgstr ""
 
 #. IDS_COLORMODE_DARK
-#: Merge.rc:5776
+#: Merge.rc:5775
 msgid "Dark"
 msgstr ""
 
 #. IDS_COLORMODE_FOLLOWSYSTEM
-#: Merge.rc:5777
+#: Merge.rc:5776
 msgid "Follow system"
 msgstr ""
 
 #. IDS_EXAMPLE
-#: Merge.rc:5782
+#: Merge.rc:5781
 #, c-format
 msgid "e.g. %1"
 msgstr ""
 
 #. IDS_DETECTED_PREVIOUS_CRASH
-#: Merge.rc:5787
+#: Merge.rc:5786
 msgid "WinMerge detected a previous crash. Please report this if possible."
 msgstr ""
 
 #. IDS_REGEX_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5792
+#: Merge.rc:5791
 msgid "# Regex replacement list\r\n# Format: regex<TAB>replacement\r\n# Backreferences like $1, $2 are supported\r\n\r\n(\\d{4})-(\\d{2})-(\\d{2})\t$1_$2_$3\r\n"
 msgstr ""
 
 #. IDS_STRING_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5793
+#: Merge.rc:5792
 msgid "# Replacement list\r\n# Format: search<TAB>replacement\r\n# Lines starting with # are ignored\r\n\r\nfrom1\tto1\r\nfrom2\tto2\r\n"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_ONLY
-#: Merge.rc:5798
+#: Merge.rc:5797
 msgid "Built-in only"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_FIRST
-#: Merge.rc:5799
+#: Merge.rc:5798
 msgid "Built-in first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_FIRST
-#: Merge.rc:5800
+#: Merge.rc:5799
 msgid "Tree-sitter first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_ONLY
-#: Merge.rc:5801
+#: Merge.rc:5800
 msgid "Tree-sitter only"
 msgstr ""
 

--- a/Translations/WinMerge/Spanish.po
+++ b/Translations/WinMerge/Spanish.po
@@ -26,7 +26,7 @@ msgstr ""
 "X-Generator: Poedit 3.9\n"
 
 #. LANGUAGE, SUBLANGUAGE
-#: Merge.rc:26 Merge.rc:59 Merge.rc:5818
+#: Merge.rc:26 Merge.rc:59 Merge.rc:5817
 msgid "LANG_ENGLISH, SUBLANG_ENGLISH_US"
 msgstr "LANG_SPANISH, SUBLANG_SPANISH_MODERN"
 
@@ -168,7 +168,7 @@ msgstr "&Secuencias de comandos"
 #. IDS_NO_EDIT_SCRIPTS
 #: Merge.rc:127 Merge.rc:352 Merge.rc:463 Merge.rc:673 Merge.rc:678
 #: Merge.rc:887 Merge.rc:899 Merge.rc:906 Merge.rc:963 Merge.rc:1210
-#: Merge.rc:5375
+#: Merge.rc:5374
 msgid "< Empty >"
 msgstr "< Vacío >"
 
@@ -233,7 +233,7 @@ msgid "Auto-Fit All Columns"
 msgstr "Autoajustar todas las columnas"
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN
-#: Merge.rc:153 Merge.rc:5646
+#: Merge.rc:153 Merge.rc:5645
 msgid "&Filter by This Column"
 msgstr "&Filtrar por esta columna"
 
@@ -294,7 +294,7 @@ msgid "&Previous Page"
 msgstr "&Página anterior"
 
 #. IDS_PREVIEWBAR_NEXTPAGE
-#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5679
+#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5678
 msgid "&Next Page"
 msgstr "Pági&na siguiente"
 
@@ -545,7 +545,7 @@ msgstr "&Binario"
 #. IDS_IMAGE_MENU
 #: Merge.rc:329 Merge.rc:338 Merge.rc:432 Merge.rc:441 Merge.rc:609
 #: Merge.rc:618 Merge.rc:670 Merge.rc:960 Merge.rc:1187 Merge.rc:1200
-#: Merge.rc:5477
+#: Merge.rc:5476
 msgid "&Image"
 msgstr "&Imagen"
 
@@ -667,7 +667,7 @@ msgid "&Huge"
 msgstr "&Enorme"
 
 #. IDS_VIEW_MENU_BAR
-#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5714
+#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5713
 msgid "Men&u Bar"
 msgstr "Barra de men&ús"
 
@@ -1322,7 +1322,7 @@ msgid "Lo&cation Pane"
 msgstr "Panel de lo&calización"
 
 #. IDS_OUTPUTBAR_CAPTION
-#: Merge.rc:782 Merge.rc:5252
+#: Merge.rc:782 Merge.rc:5251
 msgid "Output Pane"
 msgstr "Panel de salida"
 
@@ -1585,55 +1585,55 @@ msgid "Co&mpare As"
 msgstr "Co&mparar como"
 
 #. IDS_COPY_LEFT_TO_MIDDLE2
-#: Merge.rc:968 Merge.rc:980 Merge.rc:4852
+#: Merge.rc:968 Merge.rc:980 Merge.rc:4851
 #, c-format
 msgid "Left to Middle (%1 of %2)"
 msgstr "Izquierdo al central (%1 de %2)"
 
 #. IDS_COPY_LEFT_TO_RIGHT2
-#: Merge.rc:969 Merge.rc:981 Merge.rc:4851
+#: Merge.rc:969 Merge.rc:981 Merge.rc:4850
 #, c-format
 msgid "Left to Right (%1 of %2)"
 msgstr "Izquierdo al derecho (%1 de %2)"
 
 #. IDS_MOVE_LEFT_TO2
-#: Merge.rc:970 Merge.rc:982 Merge.rc:1045 Merge.rc:4863 Merge.rc:4892
+#: Merge.rc:970 Merge.rc:982 Merge.rc:1045 Merge.rc:4862 Merge.rc:4891
 #, c-format
 msgid "Left to... (%1 of %2)"
 msgstr "Izquierdo a... (%1 de %2)"
 
 #. IDS_COPY_MIDDLE_TO_LEFT2
-#: Merge.rc:971 Merge.rc:983 Merge.rc:4849
+#: Merge.rc:971 Merge.rc:983 Merge.rc:4848
 #, c-format
 msgid "Middle to Left (%1 of %2)"
 msgstr "Central al izquierdo (%1 de %2)"
 
 #. IDS_COPY_MIDDLE_TO_RIGHT2
-#: Merge.rc:972 Merge.rc:984 Merge.rc:4850
+#: Merge.rc:972 Merge.rc:984 Merge.rc:4849
 #, c-format
 msgid "Middle to Right (%1 of %2)"
 msgstr "Central al derecho (%1 de %2)"
 
 #. IDS_MOVE_MIDDLE_TO2
-#: Merge.rc:973 Merge.rc:985 Merge.rc:1046 Merge.rc:4864 Merge.rc:4893
+#: Merge.rc:973 Merge.rc:985 Merge.rc:1046 Merge.rc:4863 Merge.rc:4892
 #, c-format
 msgid "Middle to... (%1 of %2)"
 msgstr "Central a... (%1 de %2)"
 
 #. IDS_COPY_RIGHT_TO_MIDDLE2
-#: Merge.rc:974 Merge.rc:986 Merge.rc:4848
+#: Merge.rc:974 Merge.rc:986 Merge.rc:4847
 #, c-format
 msgid "Right to Middle (%1 of %2)"
 msgstr "Derecho al central (%1 de %2)"
 
 #. IDS_COPY_RIGHT_TO_LEFT2
-#: Merge.rc:975 Merge.rc:987 Merge.rc:4847
+#: Merge.rc:975 Merge.rc:987 Merge.rc:4846
 #, c-format
 msgid "Right to Left (%1 of %2)"
 msgstr "Derecho al izquierdo (%1 de %2)"
 
 #. IDS_MOVE_RIGHT_TO2
-#: Merge.rc:976 Merge.rc:988 Merge.rc:1047 Merge.rc:4865 Merge.rc:4894
+#: Merge.rc:976 Merge.rc:988 Merge.rc:1047 Merge.rc:4864 Merge.rc:4893
 #, c-format
 msgid "Right to... (%1 of %2)"
 msgstr "Derecho a... (%1 de %2)"
@@ -1689,31 +1689,31 @@ msgid "Cop&y Paths"
 msgstr "Copiar nombres de &rutas"
 
 #. IDS_DEL_LEFT_FMT2
-#: Merge.rc:1026 Merge.rc:1035 Merge.rc:4880
+#: Merge.rc:1026 Merge.rc:1035 Merge.rc:4879
 #, c-format
 msgid "Left (%1 of %2)"
 msgstr "Izquierdo (%1 de %2)"
 
 #. IDS_DEL_MIDDLE_FMT2
-#: Merge.rc:1027 Merge.rc:1036 Merge.rc:4881
+#: Merge.rc:1027 Merge.rc:1036 Merge.rc:4880
 #, c-format
 msgid "Middle (%1 of %2)"
 msgstr "Central (%1 de %2)"
 
 #. IDS_DEL_RIGHT_FMT2
-#: Merge.rc:1028 Merge.rc:1037 Merge.rc:4882
+#: Merge.rc:1028 Merge.rc:1037 Merge.rc:4881
 #, c-format
 msgid "Right (%1 of %2)"
 msgstr "Derecho (%1 de %2)"
 
 #. IDS_DEL_BOTH_FMT2
-#: Merge.rc:1029 Merge.rc:1038 Merge.rc:4883
+#: Merge.rc:1029 Merge.rc:1038 Merge.rc:4882
 #, c-format
 msgid "Both (%1 of %2)"
 msgstr "Ambos (%1 de %2)"
 
 #. IDS_DEL_ALL_FMT2
-#: Merge.rc:1030 Merge.rc:1039 Merge.rc:4888
+#: Merge.rc:1030 Merge.rc:1039 Merge.rc:4887
 #, c-format
 msgid "All (%1 of %2)"
 msgstr "Todo (%1 de %2)"
@@ -1739,19 +1739,19 @@ msgid "&Zip"
 msgstr "&Zip"
 
 #. IDS_COPY_BOTH_TO2
-#: Merge.rc:1048 Merge.rc:4866
+#: Merge.rc:1048 Merge.rc:4865
 #, c-format
 msgid "Both to... (%1 of %2)"
 msgstr "Ambos a... (% 1 de% 2)"
 
 #. IDS_COPY_ALL_TO2
-#: Merge.rc:1049 Merge.rc:4867
+#: Merge.rc:1049 Merge.rc:4866
 #, c-format
 msgid "All to... (%1 of %2)"
 msgstr "Todo a... (%1 de %2)"
 
 #. IDS_COPY_DIFFERENCES_TO2
-#: Merge.rc:1050 Merge.rc:4868
+#: Merge.rc:1050 Merge.rc:4867
 #, c-format
 msgid "Differences to... (%1 of %2)"
 msgstr "Diferencias a... (%1 de %2)"
@@ -1818,12 +1818,12 @@ msgstr "Opciones del descompresor"
 
 #. IDS_USERCHOICE_NONE
 #: Merge.rc:1088 Merge.rc:1094 Merge.rc:1836 Merge.rc:1840 Merge.rc:2031
-#: Merge.rc:2035 Merge.rc:5377
+#: Merge.rc:2035 Merge.rc:5376
 msgid "<None>"
 msgstr "<Ninguno>"
 
 #. IDS_USERCHOICE_AUTOMATIC
-#: Merge.rc:1089 Merge.rc:1095 Merge.rc:5378
+#: Merge.rc:1089 Merge.rc:1095 Merge.rc:5377
 msgid "<Automatic>"
 msgstr "<Automático>"
 
@@ -2753,12 +2753,12 @@ msgid "Text files only"
 msgstr "Solo archivos de texto"
 
 #. IDS_EOL_NONE
-#: Merge.rc:1667 Merge.rc:1918 Merge.rc:5304
+#: Merge.rc:1667 Merge.rc:1918 Merge.rc:5303
 msgid "None"
 msgstr "Ninguno"
 
 #. IDS_EOL_MIXED
-#: Merge.rc:1668 Merge.rc:5299
+#: Merge.rc:1668 Merge.rc:5298
 msgid "Mixed"
 msgstr "Mezclado"
 
@@ -3030,13 +3030,13 @@ msgstr "E&stado de la línea"
 
 #. IDS_DIFFERENT
 #: Merge.rc:1904 Merge.rc:1988 Merge.rc:2866 Merge.rc:3036 Merge.rc:3077
-#: Merge.rc:5058
+#: Merge.rc:5057
 msgid "Different"
 msgstr "Diferente"
 
 #. IDS_IDENTICAL
 #: Merge.rc:1905 Merge.rc:1989 Merge.rc:2865 Merge.rc:3055 Merge.rc:3116
-#: Merge.rc:5048
+#: Merge.rc:5047
 msgid "Identical"
 msgstr "Igual"
 
@@ -3056,7 +3056,7 @@ msgid "Missing"
 msgstr "Falta"
 
 #. IDS_MOVED
-#: Merge.rc:1910 Merge.rc:5076
+#: Merge.rc:1910 Merge.rc:5075
 msgid "Moved"
 msgstr "Desplazado"
 
@@ -3792,7 +3792,7 @@ msgid "&Use custom system colors"
 msgstr "&Usar colores personalizados del sistema"
 
 #. IDS_PRPCAT_SYSTEM
-#: Merge.rc:2565 Merge.rc:4559 Merge.rc:4560 Merge.rc:5007
+#: Merge.rc:2565 Merge.rc:4559 Merge.rc:4560 Merge.rc:5006
 msgid "System"
 msgstr "Sistema"
 
@@ -4192,7 +4192,7 @@ msgid "Items compared:"
 msgstr "Elementos comparados:"
 
 #. IDS_PREVIEWBAR_CLOSE
-#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5685
+#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5684
 msgid "&Close"
 msgstr "&Cerrar"
 
@@ -4815,7 +4815,7 @@ msgid "A&ppend timestamp"
 msgstr "Añadir &fecha y hora"
 
 #. IDS_CONFIRM_COPY_CAPTION
-#: Merge.rc:3214 Merge.rc:4915
+#: Merge.rc:3214 Merge.rc:4914
 msgid "Confirm Copy"
 msgstr "Confirmar copia"
 
@@ -5052,7 +5052,7 @@ msgid "&Character Set..."
 msgstr "&Conjunto de caracteres..."
 
 #. IDS_PRPCAT_IMAGE
-#: Merge.rc:3351 Merge.rc:4574 Merge.rc:5015
+#: Merge.rc:3351 Merge.rc:4574 Merge.rc:5014
 msgid "Image"
 msgstr "Imagen"
 
@@ -5457,7 +5457,7 @@ msgid "Project"
 msgstr "Proyecto"
 
 #. IDS_COLHDR_NSDIFFS
-#: Merge.rc:4566 Merge.rc:4990
+#: Merge.rc:4566 Merge.rc:4989
 msgid "Differences"
 msgstr "Diferencias"
 
@@ -5602,12 +5602,12 @@ msgid "File Type"
 msgstr "Tipo de archivo"
 
 #. IDS_COLHDR_EXTENSION
-#: Merge.rc:4653 Merge.rc:4947
+#: Merge.rc:4653 Merge.rc:4946
 msgid "Extension"
 msgstr "Extensión"
 
 #. IDS_PRPCAT_MESSAGE
-#: Merge.rc:4659 Merge.rc:5019
+#: Merge.rc:4659 Merge.rc:5018
 msgid "Message"
 msgstr "Mensaje"
 
@@ -5647,7 +5647,7 @@ msgid "Hidden Items"
 msgstr "Elementos ocultos"
 
 #. IDS_PLUGINSLIST_NAME
-#: Merge.rc:4680 Merge.rc:5311
+#: Merge.rc:4680 Merge.rc:5310
 msgid "Name"
 msgstr "Nombre"
 
@@ -5667,7 +5667,7 @@ msgid "[F] "
 msgstr "[F] "
 
 #. IDS_PLUGINSLIST_DESC
-#: Merge.rc:4684 Merge.rc:5313
+#: Merge.rc:4684 Merge.rc:5312
 msgid "Description"
 msgstr "Descripción"
 
@@ -5835,155 +5835,150 @@ msgstr "Línea: %s  Columna: %d/%d  Carácter: %d/%d"
 msgid "  Sel: %d | %d"
 msgstr "  Selec: %d | %d"
 
-#. IDS_MERGEMODE_MERGING
-#: Merge.rc:4734
-msgid "Merge"
-msgstr "Combinar"
-
 #. IDS_DIFF_NUMBER_STATUS_FMT
-#: Merge.rc:4735
+#: Merge.rc:4734
 #, c-format
 msgid "Difference %1 of %2"
 msgstr "Diferencia %1 de %2"
 
 #. IDS_NO_DIFF_SEL_FMT
-#: Merge.rc:4736
+#: Merge.rc:4735
 #, c-format
 msgid "%1 Differences Found"
 msgstr "%1 diferencias encontradas"
 
 #. IDS_1_DIFF_FOUND
-#: Merge.rc:4737
+#: Merge.rc:4736
 msgid "1 Difference Found"
 msgstr "1 diferencia encontrada"
 
 #. IDS_NO_ERR_SEL_FMT
-#: Merge.rc:4738
+#: Merge.rc:4737
 #, c-format
 msgid "%1 Errors Found"
 msgstr "%1 errores encontrados"
 
 #. IDS_1_ERR_FOUND
-#: Merge.rc:4739
+#: Merge.rc:4738
 msgid "1 Error Found"
 msgstr "1 error encontrado"
 
 #. IDS_STATUSBAR_READONLY, Abbreviation from "Read Only"
-#: Merge.rc:4740
+#: Merge.rc:4739
 msgid "RO"
 msgstr "SL"
 
 #. IDS_DIRVIEW_STATUS_FMT_FOCUS
-#: Merge.rc:4746
+#: Merge.rc:4745
 #, c-format
 msgid "Item %1 of %2"
 msgstr "Elemento %1 de %2"
 
 #. IDS_DIRVIEW_STATUS_FMT_NOFOCUS
-#: Merge.rc:4747
+#: Merge.rc:4746
 #, c-format
 msgid "Items: %1"
 msgstr "Elementos: %1"
 
 #. IDS_DIRVIEW_STATUS_COMPARING
-#: Merge.rc:4748
+#: Merge.rc:4747
 msgid "Comparing items..."
 msgstr "Comparando elementos..."
 
 #. IDS_ITEMS_PER_SEC
-#: Merge.rc:4749
+#: Merge.rc:4748
 #, c-format
 msgid "%.1f[items/sec]"
 msgstr "%.1f[elementos/seg]"
 
 #. IDS_ERROR_INCOMPARABLE
-#: Merge.rc:4755
+#: Merge.rc:4754
 msgid "Select two existing folders/files to compare."
 msgstr "Seleccione dos carpetas o archivos para comparar."
 
 #. IDS_DIRSEL_TAG
-#: Merge.rc:4756
+#: Merge.rc:4755
 msgid "Folder Selection"
 msgstr "Selección de carpeta"
 
 #. IDS_OPEN_FILESDIRS
-#: Merge.rc:4757
+#: Merge.rc:4756
 msgid "Select two (or three) folders/files to compare."
 msgstr "Seleccionar dos (o tres) carpetas o dos (o tres) archivos para comparar."
 
 #. IDS_OPEN_LEFTINVALID
-#: Merge.rc:4758
+#: Merge.rc:4757
 msgid "Left (1st) path is invalid!"
 msgstr "¡La ruta del izquierdo (1º) no es válida!"
 
 #. IDS_OPEN_MIDDLEINVALID
-#: Merge.rc:4759
+#: Merge.rc:4758
 msgid "Middle (2nd) path is invalid!"
 msgstr "¡La ruta del central (2º) no es válida!"
 
 #. IDS_OPEN_RIGHTINVALID2
-#: Merge.rc:4760
+#: Merge.rc:4759
 msgid "Right (2nd) path is invalid!"
 msgstr "¡La ruta del derecho (2º) no es válida!"
 
 #. IDS_OPEN_RIGHTINVALID3
-#: Merge.rc:4761
+#: Merge.rc:4760
 msgid "Right (3rd) path is invalid!"
 msgstr "¡La ruta del derecho (3º) no es válida!"
 
 #. IDS_OPEN_BOTHINVALID
-#: Merge.rc:4762
+#: Merge.rc:4761
 msgid "Both paths are invalid!"
 msgstr "¡Ninguna ruta es válida!"
 
-#: Merge.rc:4764
+#: Merge.rc:4763
 msgid "Left (1st) and Middle (2nd) paths are invalid!"
 msgstr "¡Las rutas del izquierdo (1º) y central (2º) no son válidas!"
 
 #. IDS_OPEN_LEFTRIGHTINVALID
-#: Merge.rc:4765
+#: Merge.rc:4764
 msgid "Left (1st) and Right (3rd) paths are invalid!"
 msgstr "¡Las rutas del izquierdo (1º) y derecho (3º) no son válidas!"
 
-#: Merge.rc:4767
+#: Merge.rc:4766
 msgid "Middle (2nd) and Right (3rd) paths are invalid!"
 msgstr "¡Las rutas del central (2º) y derecho (3º) no son válidas!"
 
 #. IDS_OPEN_ALLINVALID
-#: Merge.rc:4768
+#: Merge.rc:4767
 msgid "All paths are invalid!"
 msgstr "¡Ninguna ruta es válida!"
 
 #. IDS_OPEN_UNPACKERDISABLED
-#: Merge.rc:4769
+#: Merge.rc:4768
 msgid "Only enabled for file comparisons"
 msgstr "Activar solo para comparar archivos"
 
 #. IDS_OPEN_MISMATCH
-#: Merge.rc:4770
+#: Merge.rc:4769
 msgid "Cannot compare file and folder!"
 msgstr "¡No se puede comparar un archivo con una carpeta!"
 
 #. IDS_ERROR_FILE_NOT_FOUND
-#: Merge.rc:4776
+#: Merge.rc:4775
 #, c-format
 msgid "File not found: %1"
 msgstr "Archivo no encontrado: %1"
 
 #. IDS_ERROR_FOLDER_NOT_FOUND
-#: Merge.rc:4777
+#: Merge.rc:4776
 #, c-format
 msgid "Folder not found: %1"
 msgstr "Carpeta no encontrada: %1"
 
 #. IDS_ERROR_FILE_NOT_UNPACKED
-#: Merge.rc:4778
+#: Merge.rc:4777
 #, c-format
 msgid "File not unpacked: %1"
 msgstr "Archivo no descomprimido: %1"
 
 #. IDS_ERROR_FILEOPEN
-#: Merge.rc:4779
+#: Merge.rc:4778
 #, c-format
 msgid ""
 "Cannot open file\n"
@@ -5997,12 +5992,12 @@ msgstr ""
 "%2"
 
 #. IDS_ERROR_CONF_RESOLVE
-#: Merge.rc:4780
+#: Merge.rc:4779
 msgid "Failed to parse conflict file."
 msgstr "Error al analizar el archivo de conflictos."
 
 #. IDS_NOT_CONFLICT_FILE
-#: Merge.rc:4781
+#: Merge.rc:4780
 #, c-format
 msgid ""
 "The file\n"
@@ -6014,7 +6009,7 @@ msgstr ""
 "no es conflictivo."
 
 #. IDS_COMPARE_LARGE_FILES
-#: Merge.rc:4782
+#: Merge.rc:4781
 msgid ""
 "Comparing large files requires significant memory.\n"
 "Show only comparison results (not file contents)?"
@@ -6023,28 +6018,28 @@ msgstr ""
 "¿Mostrar solo los resultados de la comparación (sin el contenido de los archivos)?"
 
 #. IDS_SAVE_AS_TITLE
-#: Merge.rc:4788
+#: Merge.rc:4787
 msgid "Save As"
 msgstr "Guardar como"
 
 #. IDS_SAVE_FMT
-#: Merge.rc:4789
+#: Merge.rc:4788
 #, c-format
 msgid "Save changes to %1?"
 msgstr "¿Guardar los cambios en %1?"
 
 #. IDS_SAVEREADONLY_FMT
-#: Merge.rc:4790
+#: Merge.rc:4789
 #, c-format
 msgid "%1 is read-only. Override? Or 'No' to save as new filename?"
 msgstr "%1 está en modo de solo lectura. ¿Desea anular dicho modo? (Seleccione 'No' para guardarlo con un nuevo nombre de archivo)."
 
 #. IDS_ERROR_BACKUP
-#: Merge.rc:4791
+#: Merge.rc:4790
 msgid "Error backing up file"
 msgstr "Error al hacer una copia de seguridad del archivo"
 
-#: Merge.rc:4793
+#: Merge.rc:4792
 #, c-format
 msgid ""
 "Unable to backup original file:\n"
@@ -6058,7 +6053,7 @@ msgstr ""
 "¿Continuar de todas formas?"
 
 #. IDS_FILESAVE_FAILED
-#: Merge.rc:4794
+#: Merge.rc:4793
 #, c-format
 msgid ""
 "Saving file failed.\n"
@@ -6074,7 +6069,7 @@ msgstr ""
 "\t- usar un nombre diferente (Aceptar)\n"
 "\t- cancelar la operación (Cancelar)"
 
-#: Merge.rc:4796
+#: Merge.rc:4795
 #, c-format
 msgid ""
 "Plugin '%2' cannot pack changes to left file into '%1'.\n"
@@ -6087,7 +6082,7 @@ msgstr ""
 "\n"
 "¿Desea guardar la versión sin comprimir en otro archivo?"
 
-#: Merge.rc:4798
+#: Merge.rc:4797
 #, c-format
 msgid ""
 "Plugin '%2' cannot pack changes to middle file into '%1'.\n"
@@ -6100,7 +6095,7 @@ msgstr ""
 "\n"
 "¿Desea guardar la versión sin comprimir en otro archivo?"
 
-#: Merge.rc:4800
+#: Merge.rc:4799
 #, c-format
 msgid ""
 "Plugin '%2' cannot pack changes to right file into '%1'.\n"
@@ -6114,7 +6109,7 @@ msgstr ""
 "¿Desea guardar la versión sin comprimir en otro archivo?"
 
 #. IDS_FILECHANGED_ONDISK
-#: Merge.rc:4801
+#: Merge.rc:4800
 #, c-format
 msgid ""
 "Another application updated\n"
@@ -6130,7 +6125,7 @@ msgstr ""
 "¿Desea sobrescribirlo?"
 
 #. IDS_SAVEREADONLY_MULTI
-#: Merge.rc:4802
+#: Merge.rc:4801
 #, c-format
 msgid ""
 "%1\n"
@@ -6140,7 +6135,7 @@ msgstr ""
 "es de solo lectura. ¿Desea anular esa opción y sobrescribirlo?"
 
 #. IDS_FILECHANGED_RESCAN
-#: Merge.rc:4803
+#: Merge.rc:4802
 #, c-format
 msgid ""
 "Another application updated\n"
@@ -6156,22 +6151,22 @@ msgstr ""
 "¿Desea recargarlo?"
 
 #. IDS_SAVE_LEFT_AS
-#: Merge.rc:4804
+#: Merge.rc:4803
 msgid "Save Left File As"
 msgstr "Guardar archivo izquierdo como"
 
 #. IDS_SAVE_MIDDLE_AS
-#: Merge.rc:4805
+#: Merge.rc:4804
 msgid "Save Middle File As"
 msgstr "Guardar archivo central como"
 
 #. IDS_SAVE_RIGHT_AS
-#: Merge.rc:4806
+#: Merge.rc:4805
 msgid "Save Right File As"
 msgstr "Guardar archivo derecho como"
 
 #. IDS_FILE_DISAPPEARED
-#: Merge.rc:4811
+#: Merge.rc:4810
 #, c-format
 msgid ""
 "File\n"
@@ -6183,7 +6178,7 @@ msgstr ""
 "ha desaparecido. Por favor, guarde una copia para continuar."
 
 #. IDS_VIEWS_OUTOFSYNC
-#: Merge.rc:4817
+#: Merge.rc:4816
 msgid ""
 "Cannot merge unsynched documents.\n"
 "\n"
@@ -6194,186 +6189,186 @@ msgstr ""
 "Actualícelos antes de continuar."
 
 #. IDS_BREAK_ON_WHITESPACE
-#: Merge.rc:4822
+#: Merge.rc:4821
 msgid "Break at whitespace"
 msgstr "Detener en espacio en blanco"
 
 #. IDS_BREAK_ON_PUNCTUATION
-#: Merge.rc:4823
+#: Merge.rc:4822
 msgid "Break at whitespace or punctuation"
 msgstr "Detener en espacio en blanco o puntuación"
 
 #. IDS_L2M
-#: Merge.rc:4829
+#: Merge.rc:4828
 msgid "Copy to &Middle\tAlt+Right"
 msgstr "Copiar al cen&tral\\tAlt+Derecha"
 
 #. IDS_R2M
-#: Merge.rc:4830
+#: Merge.rc:4829
 msgid "Copy to &Middle\tAlt+Left"
 msgstr "Copiar al &central\\tAlt+Izquierda"
 
 #. IDS_COPY_FROM_MIDDLE_R
-#: Merge.rc:4831
+#: Merge.rc:4830
 msgid "Copy from Middle\tAlt+Shift+Right"
 msgstr "Copiar desde el central\\tAlt+Mayús+Derecha"
 
 #. IDS_COPY_FROM_MIDDLE_L
-#: Merge.rc:4832
+#: Merge.rc:4831
 msgid "Copy from Middle\tAlt+Shift+Left"
 msgstr "Copiar desde el central\\tAlt+Mayús+Izquierda"
 
 #. IDS_L2MNEXT
-#: Merge.rc:4833
+#: Merge.rc:4832
 msgid "Copy to Middle and Advance\tCtrl+Alt+Right"
 msgstr "Copiar al central y avanzar\\tCtrl+Alt+Derecha"
 
 #. IDS_R2MNEXT
-#: Merge.rc:4834
+#: Merge.rc:4833
 msgid "Copy to Middle and Advance\tCtrl+Alt+Left"
 msgstr "Copiar al central y avanzar\\tCtrl+Alt+Izquierda"
 
 #. IDS_ALL_MIDDLE
-#: Merge.rc:4835
+#: Merge.rc:4834
 msgid "Copy All to Middle"
 msgstr "Copiar todo en el central"
 
 #. IDS_COPY_RIGHT_TO_LEFT
-#: Merge.rc:4841
+#: Merge.rc:4840
 #, c-format
 msgid "Right to Left (%1)"
 msgstr "Derecho al izquierdo (%1)"
 
 #. IDS_COPY_RIGHT_TO_MIDDLE
-#: Merge.rc:4842
+#: Merge.rc:4841
 #, c-format
 msgid "Right to Middle (%1)"
 msgstr "Derecho al central (%1)"
 
 #. IDS_COPY_MIDDLE_TO_LEFT
-#: Merge.rc:4843
+#: Merge.rc:4842
 #, c-format
 msgid "Middle to Left (%1)"
 msgstr "Central al izquierdo (%1)"
 
 #. IDS_COPY_MIDDLE_TO_RIGHT
-#: Merge.rc:4844
+#: Merge.rc:4843
 #, c-format
 msgid "Middle to Right (%1)"
 msgstr "Central al derecho (%1)"
 
 #. IDS_COPY_LEFT_TO_RIGHT
-#: Merge.rc:4845
+#: Merge.rc:4844
 #, c-format
 msgid "Left to Right (%1)"
 msgstr "Izquierdo al derecho (%1)"
 
 #. IDS_COPY_LEFT_TO_MIDDLE
-#: Merge.rc:4846
+#: Merge.rc:4845
 #, c-format
 msgid "Left to Middle (%1)"
 msgstr "Izquierdo al central (%1)"
 
 #. IDS_MOVE_LEFT_TO
-#: Merge.rc:4857 Merge.rc:4889
+#: Merge.rc:4856 Merge.rc:4888
 #, c-format
 msgid "Left to... (%1)"
 msgstr "Izquierdo al... (%1)"
 
 #. IDS_MOVE_MIDDLE_TO
-#: Merge.rc:4858 Merge.rc:4890
+#: Merge.rc:4857 Merge.rc:4889
 #, c-format
 msgid "Middle to... (%1)"
 msgstr "Central al... (%1)"
 
 #. IDS_MOVE_RIGHT_TO
-#: Merge.rc:4859 Merge.rc:4891
+#: Merge.rc:4858 Merge.rc:4890
 #, c-format
 msgid "Right to... (%1)"
 msgstr "Derecho al... (%1)"
 
 #. IDS_COPY_BOTH_TO
-#: Merge.rc:4860
+#: Merge.rc:4859
 #, c-format
 msgid "Both to... (%1)"
 msgstr "Ambos a...(%1)"
 
 #. IDS_COPY_ALL_TO
-#: Merge.rc:4861
+#: Merge.rc:4860
 #, c-format
 msgid "All to... (%1)"
 msgstr "Todo a... (%1)"
 
 #. IDS_COPY_DIFFERENCES_TO
-#: Merge.rc:4862
+#: Merge.rc:4861
 #, c-format
 msgid "Differences to... (%1)"
 msgstr "Diferencias a... (%1)"
 
 #. IDS_ONLYDIFFITEMS_CONFIRM
-#: Merge.rc:4869
+#: Merge.rc:4868
 msgid "Some selected items are identical or skipped.\nProcess only items with differences?"
 msgstr ""
 
 #. IDS_DEL_LEFT_FMT
-#: Merge.rc:4875
+#: Merge.rc:4874
 #, c-format
 msgid "Left (%1)"
 msgstr "Izquierdo (%1)"
 
 #. IDS_DEL_MIDDLE_FMT
-#: Merge.rc:4876
+#: Merge.rc:4875
 #, c-format
 msgid "Middle (%1)"
 msgstr "Central (%1)"
 
 #. IDS_DEL_RIGHT_FMT
-#: Merge.rc:4877
+#: Merge.rc:4876
 #, c-format
 msgid "Right (%1)"
 msgstr "Derecho (%1)"
 
 #. IDS_DEL_BOTH_FMT
-#: Merge.rc:4878
+#: Merge.rc:4877
 #, c-format
 msgid "Both (%1)"
 msgstr "Ambos (%1)"
 
 #. IDS_DEL_ALL_FMT
-#: Merge.rc:4879
+#: Merge.rc:4878
 #, c-format
 msgid "All (%1)"
 msgstr "Todo (%1)"
 
 #. IDS_SELECT_DEST_LEFT
-#: Merge.rc:4895
+#: Merge.rc:4894
 msgid "Left Side - Select Destination Folder:"
 msgstr "Izquierdo - Seleccione carpeta de destino:"
 
 #. IDS_SELECT_DEST_MIDDLE
-#: Merge.rc:4896
+#: Merge.rc:4895
 msgid "Middle Side - Select Destination Folder:"
 msgstr "Central - Seleccione carpeta de destino:"
 
 #. IDS_SELECT_DEST_RIGHT
-#: Merge.rc:4897
+#: Merge.rc:4896
 msgid "Right Side - Select Destination Folder:"
 msgstr "Derecho - Seleccione carpeta de destino:"
 
 #. IDS_FILES_AFFECTED_FMT
-#: Merge.rc:4898
+#: Merge.rc:4897
 #, c-format
 msgid "(%1 Files Affected)"
 msgstr "(%1 archivos afectados)"
 
 #. IDS_FILES_AFFECTED_FMT2
-#: Merge.rc:4899
+#: Merge.rc:4898
 #, c-format
 msgid "(%1 of %2 Files Affected)"
 msgstr "(%1 de %2 archivos afectados)"
 
 #. IDS_CONFIRM_DELETE_SINGLE
-#: Merge.rc:4905
+#: Merge.rc:4904
 #, c-format
 msgid ""
 "Are you sure you want to delete\n"
@@ -6385,18 +6380,18 @@ msgstr ""
 "%1?"
 
 #. IDS_CONFIRM_SINGLE_COPY
-#: Merge.rc:4906
+#: Merge.rc:4905
 msgid "Are you sure you want to copy?"
 msgstr "¿Está seguro de que quiere copiar?"
 
 #. IDS_CONFIRM_MULTIPLE_COPY
-#: Merge.rc:4907
+#: Merge.rc:4906
 #, c-format
 msgid "Are you sure you want to copy %d items?"
 msgstr "¿Está seguro de que quiere copiar %d elementos?"
 
 #. IDS_DIRCMP_NOTSYNC
-#: Merge.rc:4908
+#: Merge.rc:4907
 #, c-format
 msgid ""
 "Operation aborted!\n"
@@ -6416,46 +6411,46 @@ msgstr ""
 "Actualice la comparación."
 
 #. IDS_CONFIRM_SINGLE_MOVE
-#: Merge.rc:4913
+#: Merge.rc:4912
 msgid "Are you sure you want to move?"
 msgstr "¿Está seguro de que quiere mover?"
 
 #. IDS_CONFIRM_MULTIPLE_MOVE
-#: Merge.rc:4914
+#: Merge.rc:4913
 #, c-format
 msgid "Are you sure you want to move %d items?"
 msgstr "¿Está seguro de que quiere mover %d elementos?"
 
 #. IDS_CONFIRM_MOVE_CAPTION
-#: Merge.rc:4916
+#: Merge.rc:4915
 msgid "Confirm Move"
 msgstr "Confirmar movimiento"
 
-#: Merge.rc:4918
+#: Merge.rc:4917
 msgid "Close the folder comparison window?"
 msgstr "Va a cerrar la ventana que está comparando carpetas. ¿Seguro que quiere cerrarla?"
 
-#: Merge.rc:4920
+#: Merge.rc:4919
 msgid "Close the folder comparison window, which took a long time?"
 msgstr "Va a cerrar la ventana de comparación de carpetas que necesitó de una gran cantidad de tiempo. ¿Seguro que quiere cerrarla?"
 
 #. IDS_ERROR_INVALID_DIR_FILE_NAME
-#: Merge.rc:4921
+#: Merge.rc:4920
 msgid "The file or folder name is invalid."
 msgstr "El nombre del archivo o carpeta no es válido."
 
 #. IDS_ERROR_EXECUTE_FILE
-#: Merge.rc:4927
+#: Merge.rc:4926
 #, c-format
 msgid "Failed to execute external editor: %1"
 msgstr "Error al ejecutar editor externo %1"
 
 #. IDS_UNKNOWN_ARCHIVE_FORMAT
-#: Merge.rc:4933
+#: Merge.rc:4932
 msgid "Unknown archive format"
 msgstr "Formato de archivo desconocido"
 
-#: Merge.rc:4935
+#: Merge.rc:4934
 msgid ""
 "Failed to extract archive.\n"
 "Compare as text file?"
@@ -6464,513 +6459,513 @@ msgstr ""
 "¿Quiere comparar los ficheros del archivo como ficheros de texto?"
 
 #. IDS_COLHDR_FILENAME
-#: Merge.rc:4941
+#: Merge.rc:4940
 msgid "Filename"
 msgstr "Nombre de archivo"
 
 #. IDS_COLHDR_DIR
-#: Merge.rc:4942
+#: Merge.rc:4941
 msgctxt "DirView|ColumnHeader"
 msgid "Folder"
 msgstr "Carpeta"
 
 #. IDS_COLHDR_RESULT
-#: Merge.rc:4943
+#: Merge.rc:4942
 msgid "Comparison Result"
 msgstr "Resultado de la comparación"
 
 #. IDS_COLHDR_LTIMEM
-#: Merge.rc:4944
+#: Merge.rc:4943
 msgid "Left Date"
 msgstr "Fecha del izquierdo"
 
 #. IDS_COLHDR_RTIMEM
-#: Merge.rc:4945
+#: Merge.rc:4944
 msgid "Right Date"
 msgstr "Fecha del derecho"
 
 #. IDS_COLHDR_MTIMEM
-#: Merge.rc:4946
+#: Merge.rc:4945
 msgid "Middle Date"
 msgstr "Fecha del central"
 
 #. IDS_COLHDR_LSIZE
-#: Merge.rc:4948
+#: Merge.rc:4947
 msgid "Left Size"
 msgstr "Tamaño del izquierdo"
 
 #. IDS_COLHDR_RSIZE
-#: Merge.rc:4949
+#: Merge.rc:4948
 msgid "Right Size"
 msgstr "Tamaño del derecho"
 
 #. IDS_COLHDR_MSIZE
-#: Merge.rc:4954
+#: Merge.rc:4953
 msgid "Middle Size"
 msgstr "Tamaño del central"
 
 #. IDS_COLHDR_RSIZE_SHORT
-#: Merge.rc:4955
+#: Merge.rc:4954
 msgid "Right Size (Short)"
 msgstr "Tamaño del dcho. (corto)"
 
 #. IDS_COLHDR_LSIZE_SHORT
-#: Merge.rc:4956
+#: Merge.rc:4955
 msgid "Left Size (Short)"
 msgstr "Tamaño del izq. (corto)"
 
 #. IDS_COLHDR_MSIZE_SHORT
-#: Merge.rc:4957
+#: Merge.rc:4956
 msgid "Middle Size (Short)"
 msgstr "Tamaño del central (corto)"
 
 #. IDS_COLHDR_LTIMEC
-#: Merge.rc:4963
+#: Merge.rc:4962
 msgid "Left Creation Time"
 msgstr "Fecha de creación del izquierdo"
 
 #. IDS_COLHDR_RTIMEC
-#: Merge.rc:4964
+#: Merge.rc:4963
 msgid "Right Creation Time"
 msgstr "Fecha de creación del derecho"
 
 #. IDS_COLHDR_MTIMEC
-#: Merge.rc:4965
+#: Merge.rc:4964
 msgid "Middle Creation Time"
 msgstr "Fecha de creación del central"
 
 #. IDS_COLHDR_NEWER
-#: Merge.rc:4966
+#: Merge.rc:4965
 msgid "Newer File"
 msgstr "Archivo más reciente"
 
 #. IDS_COLHDR_LVERSION
-#: Merge.rc:4967
+#: Merge.rc:4966
 msgid "Left File Version"
 msgstr "Versión del archivo izquierdo"
 
 #. IDS_COLHDR_RVERSION
-#: Merge.rc:4968
+#: Merge.rc:4967
 msgid "Right File Version"
 msgstr "Versión del archivo derecho"
 
 #. IDS_COLHDR_MVERSION
-#: Merge.rc:4969
+#: Merge.rc:4968
 msgid "Middle File Version"
 msgstr "Versión del archivo central"
 
 #. IDS_COLHDR_RESULT_ABBR
-#: Merge.rc:4970
+#: Merge.rc:4969
 msgid "Short Result"
 msgstr "Resultado abreviado"
 
 #. IDS_COLHDR_LATTRIBUTES
-#: Merge.rc:4971
+#: Merge.rc:4970
 msgid "Left Attributes"
 msgstr "Atributos del izquierdo"
 
 #. IDS_COLHDR_RATTRIBUTES
-#: Merge.rc:4972
+#: Merge.rc:4971
 msgid "Right Attributes"
 msgstr "Atributos del derecho"
 
 #. IDS_COLHDR_MATTRIBUTES
-#: Merge.rc:4973
+#: Merge.rc:4972
 msgid "Middle Attributes"
 msgstr "Atributos del central"
 
 #. IDS_COLHDR_LEOL_TYPE
-#: Merge.rc:4978
+#: Merge.rc:4977
 msgid "Left EOL"
 msgstr "Fin de línea del izquierdo"
 
 #. IDS_COLHDR_MEOL_TYPE
-#: Merge.rc:4979
+#: Merge.rc:4978
 msgid "Middle EOL"
 msgstr "Fin de línea del central"
 
 #. IDS_COLHDR_REOL_TYPE
-#: Merge.rc:4980
+#: Merge.rc:4979
 msgid "Right EOL"
 msgstr "Fin de línea del derecho"
 
 #. IDS_COLHDR_LENCODING
-#: Merge.rc:4986
+#: Merge.rc:4985
 msgid "Left Encoding"
 msgstr "Codificación del izquierdo"
 
 #. IDS_COLHDR_RENCODING
-#: Merge.rc:4987
+#: Merge.rc:4986
 msgid "Right Encoding"
 msgstr "Codificación del derecho"
 
 #. IDS_COLHDR_MENCODING
-#: Merge.rc:4988
+#: Merge.rc:4987
 msgid "Middle Encoding"
 msgstr "Codificación del central"
 
 #. IDS_COLHDR_NIDIFFS
-#: Merge.rc:4989
+#: Merge.rc:4988
 msgid "Ignored Diff"
 msgstr "Difs. ignoradas"
 
 #. IDS_COLHDR_BINARY
-#: Merge.rc:4991
+#: Merge.rc:4990
 msgctxt "DirView|ColumnHeader"
 msgid "Binary"
 msgstr "Binario"
 
 #. IDS_PLUGINS_TYPE_UNPACKER
-#: Merge.rc:4992 Merge.rc:5314
+#: Merge.rc:4991 Merge.rc:5313
 msgid "Unpacker"
 msgstr "Descompresor"
 
 #. IDS_PLUGIN_TYPE4
-#: Merge.rc:4993 Merge.rc:5315 Merge.rc:5622
+#: Merge.rc:4992 Merge.rc:5314 Merge.rc:5621
 msgid "Prediffer"
 msgstr "Prediferenciación"
 
 #. IDS_COLHDR_LEFT
-#: Merge.rc:4994
+#: Merge.rc:4993
 msgid "Left"
 msgstr "Izquierdo"
 
 #. IDS_COLHDR_MIDDLE
-#: Merge.rc:4995
+#: Merge.rc:4994
 msgid "Middle"
 msgstr "Central"
 
 #. IDS_COLHDR_RIGHT
-#: Merge.rc:4996
+#: Merge.rc:4995
 msgid "Right"
 msgstr "Derecho"
 
 #. IDS_COLHDR_DIFF
-#: Merge.rc:4997
+#: Merge.rc:4996
 msgid "Diff"
 msgstr "Diferencia"
 
 #. IDS_COLHDR_LEFT_DUPLICATE
-#: Merge.rc:4998
+#: Merge.rc:4997
 msgid "Left Duplicate Count"
 msgstr "Contador de duplicados en el izquierdo"
 
 #. IDS_COLHDR_RIGHT_DUPLICATE
-#: Merge.rc:4999
+#: Merge.rc:4998
 msgid "Right Duplicate Count"
 msgstr "Contador de duplicados en el derecho"
 
 #. IDS_COLHDR_MIDDLE_DUPLICATE
-#: Merge.rc:5000
+#: Merge.rc:4999
 msgid "Middle Duplicate Count"
 msgstr "Contador de duplicados en el central"
 
 #. IDS_COLHDR_MOVE
-#: Merge.rc:5001
+#: Merge.rc:5000
 msgid "Move"
 msgstr "Mover"
 
 #. IDS_PRPCAT_AUDIO
-#: Merge.rc:5008
+#: Merge.rc:5007
 msgid "Audio"
 msgstr "Audio"
 
 #. IDS_PRPCAT_CALENDAR
-#: Merge.rc:5009
+#: Merge.rc:5008
 msgid "Calendar"
 msgstr "Calendario"
 
 #. IDS_PRPCAT_COMMUNICATION
-#: Merge.rc:5010
+#: Merge.rc:5009
 msgid "Communication"
 msgstr "Comunicación"
 
 #. IDS_PRPCAT_CONTACT
-#: Merge.rc:5011
+#: Merge.rc:5010
 msgid "Contact"
 msgstr "Contacto"
 
 #. IDS_PRPCAT_DEVICES
-#: Merge.rc:5012
+#: Merge.rc:5011
 msgid "Devices"
 msgstr "Dispositivos"
 
 #. IDS_PRPCAT_DOCUMENT
-#: Merge.rc:5013
+#: Merge.rc:5012
 msgid "Document"
 msgstr "Documento"
 
 #. IDS_PRPCAT_HOME
-#: Merge.rc:5014
+#: Merge.rc:5013
 msgid "Home"
 msgstr "Inicio"
 
 #. IDS_PRPCAT_JOURNAL
-#: Merge.rc:5016
+#: Merge.rc:5015
 msgid "Journal"
 msgstr "Diario"
 
 #. IDS_PRPCAT_LINK
-#: Merge.rc:5017
+#: Merge.rc:5016
 msgid "Link"
 msgstr "Enlace"
 
 #. IDS_PRPCAT_MEDIA
-#: Merge.rc:5018
+#: Merge.rc:5017
 msgid "Media"
 msgstr "Medios"
 
 #. IDS_PRPCAT_MUSIC
-#: Merge.rc:5020
+#: Merge.rc:5019
 msgid "Music"
 msgstr "Música"
 
 #. IDS_PRPCAT_NOTE
-#: Merge.rc:5021
+#: Merge.rc:5020
 msgid "Note"
 msgstr "Nota"
 
 #. IDS_PRPCAT_PHOTO
-#: Merge.rc:5022
+#: Merge.rc:5021
 msgid "Photo"
 msgstr "Fotografía"
 
 #. IDS_PRPCAT_RECORDEDTV
-#: Merge.rc:5023
+#: Merge.rc:5022
 msgid "RecordedTV"
 msgstr "TV grabada"
 
 #. IDS_PRPCAT_SEARCH
-#: Merge.rc:5024
+#: Merge.rc:5023
 msgid "Search"
 msgstr "Buscar"
 
 #. IDS_PRPCAT_SECURITY
-#: Merge.rc:5025
+#: Merge.rc:5024
 msgid "Security"
 msgstr "Seguridad"
 
 #. IDS_PRPCAT_SOFTWARE
-#: Merge.rc:5026
+#: Merge.rc:5025
 msgid "Software"
 msgstr "Software"
 
 #. IDS_PRPCAT_TASK
-#: Merge.rc:5027
+#: Merge.rc:5026
 msgid "Task"
 msgstr "Tarea"
 
 #. IDS_PRPCAT_VIDEO
-#: Merge.rc:5028
+#: Merge.rc:5027
 msgid "Video"
 msgstr "Vídeo"
 
 #. IDS_PRPCAT_HASH
-#: Merge.rc:5029
+#: Merge.rc:5028
 msgid "Hash"
 msgstr "Suma de verificación"
 
 #. IDS_CANT_COMPARE_FILES
-#: Merge.rc:5035
+#: Merge.rc:5034
 msgid "Unable to compare files"
 msgstr "No se pueden comparar los archivos"
 
 #. IDS_ABORTED_ITEM
-#: Merge.rc:5036
+#: Merge.rc:5035
 msgid "Item aborted"
 msgstr "Elemento cancelado"
 
 #. IDS_FILE_SKIPPED
-#: Merge.rc:5037
+#: Merge.rc:5036
 msgid "File skipped"
 msgstr "Archivo omitido"
 
 #. IDS_DIR_SKIPPED
-#: Merge.rc:5038
+#: Merge.rc:5037
 msgid "Folder skipped"
 msgstr "Carpeta omitida"
 
 #. IDS_LEFT_ONLY_IN_FMT
-#: Merge.rc:5039
+#: Merge.rc:5038
 #, c-format
 msgid "Left only: %1"
 msgstr "Solo izquierdo: %1"
 
 #. IDS_MIDDLE_ONLY_IN_FMT
-#: Merge.rc:5040
+#: Merge.rc:5039
 #, c-format
 msgid "Middle only: %1"
 msgstr "Solo central: %1"
 
 #. IDS_RIGHT_ONLY_IN_FMT
-#: Merge.rc:5041
+#: Merge.rc:5040
 #, c-format
 msgid "Right only: %1"
 msgstr "Solo derecho: %1"
 
 #. IDS_DOES_NOT_EXIST_IN_FMT
-#: Merge.rc:5042
+#: Merge.rc:5041
 #, c-format
 msgid "Does not exist in %1"
 msgstr "No existe en %1"
 
 #. IDS_BIN_FILES_SAME
-#: Merge.rc:5043
+#: Merge.rc:5042
 msgid "Binary files are identical"
 msgstr "Los archivos binarios son iguales"
 
 #. IDS_BIN_FILES_DIFF
-#: Merge.rc:5049
+#: Merge.rc:5048
 msgid "Binary files are different"
 msgstr "Los archivos binarios son diferentes"
 
 #. IDS_FILES_ARE_DIFFERENT
-#: Merge.rc:5050
+#: Merge.rc:5049
 msgid "Files are different"
 msgstr "Los archivos son diferentes"
 
 #. IDS_FOLDERS_ARE_DIFFERENT
-#: Merge.rc:5051
+#: Merge.rc:5050
 msgid "Folders are different"
 msgstr "Las carpetas son diferentes"
 
 #. IDS_LEFTONLY
-#: Merge.rc:5052
+#: Merge.rc:5051
 msgid "Left Only"
 msgstr "Solo izquierdo"
 
 #. IDS_RIGHTONLY
-#: Merge.rc:5053
+#: Merge.rc:5052
 msgid "Right Only"
 msgstr "Solo derecho"
 
 #. IDS_MIDDLEONLY
-#: Merge.rc:5054
+#: Merge.rc:5053
 msgid "Middle Only"
 msgstr "Solo central"
 
 #. IDS_NOITEMLEFT
-#: Merge.rc:5055
+#: Merge.rc:5054
 msgid "No item in left"
 msgstr "Izquierdo vacío"
 
 #. IDS_NOITEMRIGHT
-#: Merge.rc:5056
+#: Merge.rc:5055
 msgid "No item in right"
 msgstr "Derecho vacío"
 
 #. IDS_NOITEMMIDDLE
-#: Merge.rc:5057
+#: Merge.rc:5056
 msgid "No item in middle"
 msgstr "Central vacío"
 
 #. IDS_CMPRES_ERROR
-#: Merge.rc:5059
+#: Merge.rc:5058
 msgid "Error"
 msgstr "Error"
 
 #. IDS_TEXT_FILES_SAME
-#: Merge.rc:5060
+#: Merge.rc:5059
 msgid "Text files are identical"
 msgstr "Los archivos de texto son idénticos"
 
 #. IDS_LEFTONLY_DIFF
-#: Merge.rc:5061
+#: Merge.rc:5060
 msgid " (Middle and right are identical)"
 msgstr " (Central y derecho son idénticos)"
 
 #. IDS_MIDDLEONLY_DIFF
-#: Merge.rc:5062
+#: Merge.rc:5061
 msgid " (Left and right are identical)"
 msgstr " (Izquierdo y derecho son idénticos)"
 
 #. IDS_RIGHTONLY_DIFF
-#: Merge.rc:5063
+#: Merge.rc:5062
 msgid " (Left and middle are identical)"
 msgstr " (Izquierdo y central son idénticos)"
 
 #. IDS_PATH_MISMATCH
-#: Merge.rc:5064
+#: Merge.rc:5063
 msgid " (paths differ)"
 msgstr " (las rutas son diferentes)"
 
 #. IDS_TEXT_FILES_DIFF
-#: Merge.rc:5065
+#: Merge.rc:5064
 msgid "Text files are different"
 msgstr "Los archivos de texto son diferentes"
 
 #. IDS_IMAGE_FILES_SAME
-#: Merge.rc:5066
+#: Merge.rc:5065
 msgid "Image files are identical"
 msgstr "Los archivos de imagen son idénticos"
 
 #. IDS_IMAGE_FILES_DIFF
-#: Merge.rc:5067
+#: Merge.rc:5066
 msgid "Image files are different"
 msgstr "Las archivos de imagen son diferentes"
 
 #. IDS_EXPR_DIFF
-#: Merge.rc:5068
+#: Merge.rc:5067
 #, c-format
 msgid "Files are different (expr: %1)"
 msgstr "Los archivos son diferentes (expr: %1)"
 
 #. IDS_HASH_GROUP
-#: Merge.rc:5069
+#: Merge.rc:5068
 #, c-format
 msgid "Group%d"
 msgstr "Grupo %d"
 
 #. IDS_RENAME_MOVE_DETECTION_DISALBED
-#: Merge.rc:5070
+#: Merge.rc:5069
 msgctxt "Options dialog|Compare|Folder|Detect renames and moves"
 msgid "Disabled"
 msgstr "Desactivado"
 
 #. IDS_RENAME_MOVE_DETECTION_RENAME
-#: Merge.rc:5071
+#: Merge.rc:5070
 msgid "Detect renames"
 msgstr "Detectar renombramientos"
 
 #. IDS_RENAME_MOVE_DETECTION_RENAME_MOVE
-#: Merge.rc:5072
+#: Merge.rc:5071
 msgid "Detect renames and moves"
 msgstr "Detectar renombramientos y desplazamientos"
 
 #. IDS_RENAME_MOVE_MERGE_MODE_RENAME
-#: Merge.rc:5073
+#: Merge.rc:5072
 msgid "Merge renames"
 msgstr "Combinar renombramientos"
 
 #. IDS_RENAME_MOVE_MERGE_MODE_RENAME_MOVE
-#: Merge.rc:5074
+#: Merge.rc:5073
 msgid "Merge renames and moves"
 msgstr "Combinar renombramientos y desplazamientos"
 
 #. IDS_RENAMED
-#: Merge.rc:5075
+#: Merge.rc:5074
 msgid "Renamed"
 msgstr "Renombrado"
 
 #. IDS_RENAMED_MOVED
-#: Merge.rc:5077
+#: Merge.rc:5076
 msgid "Renamed/Moved"
 msgstr "Renombrado/Desplazado"
 
 #. IDS_RENAMED_MOVED_ITEMS
-#: Merge.rc:5078
+#: Merge.rc:5077
 #, c-format
 msgid "(%1 items)"
 msgstr "(%1 elementos)"
 
 #. IDS_RENAMED_MOVED_RESULT
-#: Merge.rc:5079
+#: Merge.rc:5078
 #, c-format
 msgid "%1 (set %2): "
 msgstr "%1 (establecido %2): "
 
 #. IDS_SWITCH_FLAT_MODE
-#: Merge.rc:5080
+#: Merge.rc:5079
 msgid ""
 "Some moved items have been merged.\n"
 "In Tree Mode, these items may appear in positions that do not reflect the actual folder structure, which can be confusing.\n"
@@ -6981,235 +6976,235 @@ msgstr ""
 "¿Quiere cambiar al modo sencillo?"
 
 #. IDS_ELAPSED_TIME
-#: Merge.rc:5086
+#: Merge.rc:5085
 #, c-format
 msgid "Elapsed time: %ld ms"
 msgstr "Tiempo transcurrido: %ld ms"
 
 #. IDS_STATUS_SELITEM1
-#: Merge.rc:5087
+#: Merge.rc:5086
 msgid "1 item selected"
 msgstr "1 elemento seleccionado"
 
 #. IDS_STATUS_SELITEMS
-#: Merge.rc:5088
+#: Merge.rc:5087
 #, c-format
 msgid "%1 items selected"
 msgstr "%1 elementos seleccionados"
 
 #. IDS_COLDESC_FILENAME
-#: Merge.rc:5094
+#: Merge.rc:5093
 msgid "Filename or folder name."
 msgstr "Nombre de archivo o carpeta."
 
 #. IDS_COLDESC_DIR
-#: Merge.rc:5095
+#: Merge.rc:5094
 msgid "Subfolder name when subfolders are included."
 msgstr "Nombre de subcarpeta cuando se incluyen las subcarpetas."
 
 #. IDS_COLDESC_RESULT
-#: Merge.rc:5096
+#: Merge.rc:5095
 msgid "Comparison result, long form."
 msgstr "Resultados de la comparación, formato largo."
 
 #. IDS_COLDESC_LTIMEM
-#: Merge.rc:5101
+#: Merge.rc:5100
 msgid "Left side modification date."
 msgstr "Fecha de modificación del izquierdo."
 
 #. IDS_COLDESC_RTIMEM
-#: Merge.rc:5102
+#: Merge.rc:5101
 msgid "Right side modification date."
 msgstr "Fecha de modificación del derecho."
 
 #. IDS_COLDESC_MTIMEM
-#: Merge.rc:5103
+#: Merge.rc:5102
 msgid "Middle side modification date."
 msgstr "Fecha de modificación del central."
 
 #. IDS_COLDESC_EXTENSION
-#: Merge.rc:5104
+#: Merge.rc:5103
 msgid "File's extension."
 msgstr "Extensión del archivo."
 
 #. IDS_COLDESC_LSIZE
-#: Merge.rc:5105
+#: Merge.rc:5104
 msgid "Left file size in bytes."
 msgstr "Tamaño del archivo izquierdo en bytes."
 
 #. IDS_COLDESC_RSIZE
-#: Merge.rc:5106
+#: Merge.rc:5105
 msgid "Right file size in bytes."
 msgstr "Tamaño del archivo derecho en bytes."
 
 #. IDS_COLDESC_MSIZE
-#: Merge.rc:5107
+#: Merge.rc:5106
 msgid "Middle file size in bytes."
 msgstr "Tamaño del archivo central en bytes."
 
 #. IDS_COLDESC_LSIZE_SHORT
-#: Merge.rc:5108
+#: Merge.rc:5107
 msgid "Left file size abbreviated."
 msgstr "Tamaño abreviado del archivo izquierdo."
 
 #. IDS_COLDESC_RSIZE_SHORT
-#: Merge.rc:5109
+#: Merge.rc:5108
 msgid "Right file size abbreviated."
 msgstr "Tamaño abreviado del archivo derecho."
 
 #. IDS_COLDESC_MSIZE_SHORT
-#: Merge.rc:5110
+#: Merge.rc:5109
 msgid "Middle file size abbreviated."
 msgstr "Tamaño abreviado del archivo central."
 
 #. IDS_COLDESC_LTIMEC
-#: Merge.rc:5116
+#: Merge.rc:5115
 msgid "Left side creation time."
 msgstr "Fecha de creación del izquierdo."
 
 #. IDS_COLDESC_RTIMEC
-#: Merge.rc:5117
+#: Merge.rc:5116
 msgid "Right side creation time."
 msgstr "Fecha de creación del derecho."
 
 #. IDS_COLDESC_MTIMEC
-#: Merge.rc:5118
+#: Merge.rc:5117
 msgid "Middle side creation time."
 msgstr "Fecha de creación del central."
 
 #. IDS_COLDESC_NEWER
-#: Merge.rc:5119
+#: Merge.rc:5118
 msgid "Tells which side has newer modification date."
 msgstr "Indica qué lado tiene la fecha de modificación más reciente."
 
 #. IDS_COLDESC_LVERSION
-#: Merge.rc:5120
+#: Merge.rc:5119
 msgid "Left side file version, only for some file types."
 msgstr "Versión del archivo izquierdo, solo para algunos tipos de archivo."
 
 #. IDS_COLDESC_RVERSION
-#: Merge.rc:5121
+#: Merge.rc:5120
 msgid "Right side file version, only for some file types."
 msgstr "Versión del archivo derecho, solo para algunos tipos de archivo."
 
 #. IDS_COLDESC_MVERSION
-#: Merge.rc:5126
+#: Merge.rc:5125
 msgid "Middle side file version, only for some file types."
 msgstr "Versión del archivo central, solo para algunos tipos de archivo."
 
 #. IDS_COLDESC_RESULT_ABBR
-#: Merge.rc:5127
+#: Merge.rc:5126
 msgid "Short comparison result."
 msgstr "Resultados abreviados de la comparación."
 
 #. IDS_COLDESC_LATTRIBUTES
-#: Merge.rc:5128
+#: Merge.rc:5127
 msgid "Left side attributes."
 msgstr "Atributos del izquierdo."
 
 #. IDS_COLDESC_RATTRIBUTES
-#: Merge.rc:5129
+#: Merge.rc:5128
 msgid "Right side attributes."
 msgstr "Atributos del derecho."
 
 #. IDS_COLDESC_MATTRIBUTES
-#: Merge.rc:5130
+#: Merge.rc:5129
 msgid "Middle side attributes."
 msgstr "Atributos del central."
 
 #. IDS_COLDESC_LEOL_TYPE
-#: Merge.rc:5131
+#: Merge.rc:5130
 msgid "Left side file EOL type."
 msgstr "Tipo de fin de línea del archivo izquierdo."
 
 #. IDS_COLDESC_REOL_TYPE
-#: Merge.rc:5132
+#: Merge.rc:5131
 msgid "Right side file EOL type."
 msgstr "Tipo de fin de línea del archivo derecho."
 
 #. IDS_COLDESC_MEOL_TYPE
-#: Merge.rc:5133
+#: Merge.rc:5132
 msgid "Middle side file EOL type."
 msgstr "Tipo de fin de línea del archivo central."
 
 #. IDS_COLDESC_LENCODING
-#: Merge.rc:5139
+#: Merge.rc:5138
 msgid "Left side encoding."
 msgstr "Codificación del izquierdo."
 
 #. IDS_COLDESC_RENCODING
-#: Merge.rc:5140
+#: Merge.rc:5139
 msgid "Right side encoding."
 msgstr "Codificación del derecho."
 
 #. IDS_COLDESC_MENCODING
-#: Merge.rc:5141
+#: Merge.rc:5140
 msgid "Middle side encoding."
 msgstr "Codificación del central."
 
 #. IDS_COLDESC_NIDIFFS
-#: Merge.rc:5142
+#: Merge.rc:5141
 msgid "Number of ignored differences in file. Ignored and cannot be merged."
 msgstr "Número de diferencias ignoradas en el archivo. Son ignoradas y no se pueden combinar."
 
 #. IDS_COLDESC_NSDIFFS
-#: Merge.rc:5143
+#: Merge.rc:5142
 msgid "Number of differences in file (excluding ignored)."
 msgstr "Número de diferencias en el archivo. No incluye las diferencias ignoradas."
 
 #. IDS_COLDESC_BINARY
-#: Merge.rc:5144
+#: Merge.rc:5143
 msgid "Shows an asterisk (*) if the file is binary."
 msgstr "Muestra un asterisco (*) si el archivo es binario."
 
 #. IDS_COLDESC_UNPACKER
-#: Merge.rc:5145
+#: Merge.rc:5144
 msgid "Unpacker plugin name or pipeline."
 msgstr "Nombre del complemento descompresor o conjunto de procesos."
 
 #. IDS_COLDESC_PREDIFFER
-#: Merge.rc:5146
+#: Merge.rc:5145
 msgid "Prediffer plugin name or pipeline."
 msgstr "Nombre del complemento de prediferenciación o conjunto de procesos."
 
 #. IDS_DIRECTORY_REPORT_TITLE
-#: Merge.rc:5152
+#: Merge.rc:5151
 #, c-format
 msgid "Compare %1 with %2"
 msgstr "Comparar %1 con %2"
 
 #. IDS_DIRECTORY_REPORT_TITLE3
-#: Merge.rc:5153
+#: Merge.rc:5152
 #, c-format
 msgid "Compare %1 with %2 and %3"
 msgstr "Comparar %1 con %2 y con %3"
 
 #. IDS_REPORT_COMMALIST
-#: Merge.rc:5154
+#: Merge.rc:5153
 msgid "Comma-separated list"
 msgstr "Lista separada por comas"
 
 #. IDS_REPORT_TABLIST
-#: Merge.rc:5155
+#: Merge.rc:5154
 msgid "Tab-separated list"
 msgstr "Lista separada por tabulaciones"
 
 #. IDS_REPORT_SIMPLEHTML
-#: Merge.rc:5156
+#: Merge.rc:5155
 msgid "Simple HTML"
 msgstr "HTML simple"
 
 #. IDS_REPORT_SIMPLEXML
-#: Merge.rc:5157
+#: Merge.rc:5156
 msgid "Simple XML"
 msgstr "XML simple"
 
-#: Merge.rc:5159
+#: Merge.rc:5158
 msgid "Report file already exists. Overwrite?"
 msgstr "El archivo de informe ya existe. ¿Desea sobrescribir el archivo?"
 
 #. IDS_REPORT_ERROR
-#: Merge.rc:5164
+#: Merge.rc:5163
 #, c-format
 msgid ""
 "Error creating the report:\n"
@@ -7219,27 +7214,27 @@ msgstr ""
 "%1"
 
 #. IDS_REPORT_SUCCESS
-#: Merge.rc:5165
+#: Merge.rc:5164
 msgid "Report created successfully."
 msgstr "El informe se ha creado correctamente."
 
 #. IDS_SYNCPOINT_LASTBLOCK
-#: Merge.rc:5171
+#: Merge.rc:5170
 msgid "Cannot add a synchronization point at this line."
 msgstr "No se puede añadir un punto de sincronización en esta línea."
 
 #. IDS_FILE_TO_ITSELF
-#: Merge.rc:5177
+#: Merge.rc:5176
 msgid "Same file is opened in both panes."
 msgstr "El mismo archivo está abierto en ambos paneles."
 
 #. IDS_FILESSAME
-#: Merge.rc:5178
+#: Merge.rc:5177
 msgid "Selected files are identical."
 msgstr "Los archivos seleccionados son iguales."
 
 #. IDS_FILESSAME_CURCFG
-#: Merge.rc:5179
+#: Merge.rc:5178
 msgid ""
 "Selected files are identical (with current settings).\r\n"
 "Checking binary identity..."
@@ -7248,7 +7243,7 @@ msgstr ""
 "Comprobando la identidad binaria..."
 
 #. IDS_FILESSAME_BINERROR
-#: Merge.rc:5180
+#: Merge.rc:5179
 msgid ""
 "Selected files are identical (with current settings).\r\n"
 "But binary comparison failed."
@@ -7257,12 +7252,12 @@ msgstr ""
 "Pero la comparación binaria ha fallado."
 
 #. IDS_FILESSAME_BINSAME
-#: Merge.rc:5181
+#: Merge.rc:5180
 msgid "Selected files are identical (binary match)."
 msgstr "Los archivos seleccionados son idénticos (coincidencia binaria)."
 
 #. IDS_FILESSAME_BINDIFF
-#: Merge.rc:5182
+#: Merge.rc:5181
 msgid ""
 "Selected files are identical (with current settings).\r\n"
 "But differ at the binary level."
@@ -7271,17 +7266,17 @@ msgstr ""
 "Pero difieren a nivel binario."
 
 #. IDS_FILEERROR
-#: Merge.rc:5183
+#: Merge.rc:5182
 msgid "An error occurred while comparing files."
 msgstr "Ocurrió un error cuando se estaban comparando los archivos."
 
 #. IDS_TEMP_FILEERROR
-#: Merge.rc:5184
+#: Merge.rc:5183
 msgid "Could not create temporary files. Check your temporary path settings."
 msgstr "No se han podido crear los archivos temporales. Compruebe la ruta para archivos temporales."
 
 #. IDS_SUGGEST_IGNOREEOL
-#: Merge.rc:5185
+#: Merge.rc:5184
 msgid ""
 "Files use different EOL.\n"
 "\n"
@@ -7296,17 +7291,17 @@ msgstr ""
 "Nota: si desea tratar siempre todos los tipos de saltos de línea como equivalentes, seleccione la opción 'Ignorar saltos de línea diferentes (Windows/Unix/Mac)' en la pestaña Comparar del dialogo Opciones... (disponible en Editar/Opciones...)."
 
 #. IDS_INVALID_DIRECTORY
-#: Merge.rc:5186
+#: Merge.rc:5185
 msgid "Selected folder is invalid."
 msgstr "La carpeta seleccionada no es válida."
 
 #. IDS_CANNOT_OPEN_BINARYFILE
-#: Merge.rc:5187
+#: Merge.rc:5186
 msgid "Cannot open a binary file in Editor."
 msgstr "No se puede abrir un archivo binario en el editor."
 
 #. IDS_CREATE_PAIR_FOLDER
-#: Merge.rc:5188
+#: Merge.rc:5187
 #, c-format
 msgid ""
 "Create matching folder:\n"
@@ -7318,41 +7313,41 @@ msgstr ""
 "en el otro lado y abrirla?"
 
 #. IDS_CONFIRM_COPY_ALL_DIFFS
-#: Merge.rc:5189
+#: Merge.rc:5188
 msgid "Copy all differences to other file?"
 msgstr "¿Copiar todas las diferencias al otro archivo?"
 
 #. IDS_MOVE_TO_NEXTFILE
-#: Merge.rc:5194
+#: Merge.rc:5193
 msgid "Move to next file?"
 msgstr "¿Quiere ir al siguiente archivo?"
 
 #. IDS_MOVE_TO_PREVFILE
-#: Merge.rc:5195
+#: Merge.rc:5194
 msgid "Move to previous file?"
 msgstr "¿Quiere volver al archivo anterior?"
 
 #. IDS_MOVE_TO_NEXTPAGE
-#: Merge.rc:5196
+#: Merge.rc:5195
 msgid "Move to next page?"
 msgstr "¿Quiere ir a la siguiente página?"
 
 #. IDS_MOVE_TO_PREVPAGE
-#: Merge.rc:5197
+#: Merge.rc:5196
 msgid "Move to previous page?"
 msgstr "¿Quiere volver a la página anterior?"
 
 #. IDS_MOVE_TO_FIRSTFILE
-#: Merge.rc:5198
+#: Merge.rc:5197
 msgid "Move to first file?"
 msgstr "¿Quiere ir al primer archivo?"
 
 #. IDS_MOVE_TO_LASTFILE
-#: Merge.rc:5199
+#: Merge.rc:5198
 msgid "Move to last file?"
 msgstr "¿Quiere ir al último archivo?"
 
-#: Merge.rc:5206
+#: Merge.rc:5205
 #, c-format
 msgid ""
 "Different codepages: left (cp%d), right (cp%d).\n"
@@ -7363,51 +7358,51 @@ msgstr ""
 "¿Mostrar en su codificación (mejor visualización) o en la codificación predeterminada de Windows (combinación más segura)?\n"
 "(Recomendado: codificación predeterminada de Windows)"
 
-#: Merge.rc:5208
+#: Merge.rc:5207
 msgid "Information lost due to encoding errors: both files"
 msgstr "Información perdida debido a errores de codificación: ambos ficheros"
 
-#: Merge.rc:5210
+#: Merge.rc:5209
 msgid "Information lost due to encoding errors: first file"
 msgstr "Información perdida debido a errores de codificación: primer fichero"
 
-#: Merge.rc:5212
+#: Merge.rc:5211
 msgid "Information lost due to encoding errors: second file"
 msgstr "Información perdida debido a errores de codificación: segundo fichero"
 
-#: Merge.rc:5214
+#: Merge.rc:5213
 msgid "Information lost due to encoding errors: third file"
 msgstr "Información perdida debido a errores de codificación: tercer fichero"
 
 #. IDS_LINEDIFF_NODIFF
-#: Merge.rc:5220
+#: Merge.rc:5219
 msgid "No difference"
 msgstr "No hay diferencia"
 
 #. IDS_LINEDIFF_NODIFF_CAPTION
-#: Merge.rc:5221
+#: Merge.rc:5220
 msgid "Line difference"
 msgstr "Diferencia de línea"
 
 #. IDS_NUM_REPLACED
-#: Merge.rc:5227
+#: Merge.rc:5226
 #, c-format
 msgid "Replaced %1 string(s)."
 msgstr "Sustituida(s) %1 cadena(s)."
 
 #. IDS_EDIT_TEXT_NOT_FOUND
-#: Merge.rc:5228
+#: Merge.rc:5227
 #, c-format
 msgid "Cannot find string \"%s\"."
 msgstr "Imposible encontrar la cadena \"%s\"."
 
 #. IDS_MERGE_MODE
-#: Merge.rc:5234
+#: Merge.rc:5233
 msgid "Entering Merge Mode. Press F9 to turn off."
 msgstr "Va a activar el modo de combinación. Si desea desactivarlo presione la tecla F9."
 
 #. IDS_AUTO_MERGE
-#: Merge.rc:5240
+#: Merge.rc:5239
 #, c-format
 msgid ""
 "Automatic merges: %1\n"
@@ -7417,89 +7412,89 @@ msgstr ""
 "Número de conflictos sin resolver: %2"
 
 #. IDS_CODEPAGE_MERGED
-#: Merge.rc:5241
+#: Merge.rc:5240
 msgid "Codepage change merged."
 msgstr "Se ha combinado el cambio de codificación."
 
 #. IDS_CODEPAGE_CONFLICT
-#: Merge.rc:5242
+#: Merge.rc:5241
 msgid "Codepage changes are conflicting."
 msgstr "Los cambios en la codificación son conflictivos."
 
 #. IDS_EOL_MERGED
-#: Merge.rc:5243
+#: Merge.rc:5242
 msgid "EOL change merged."
 msgstr "El cambio de fin de línea se ha combinado."
 
 #. IDS_EOL_CONFLICT
-#: Merge.rc:5244
+#: Merge.rc:5243
 msgid "EOL changes are conflicting."
 msgstr "Los cambios de fin de línea son conflictivos."
 
 #. IDS_LOCBAR_CAPTION
-#: Merge.rc:5250
+#: Merge.rc:5249
 msgid "Location Pane"
 msgstr "Panel de localización"
 
 #. IDS_DIFFBAR_CAPTION
-#: Merge.rc:5251
+#: Merge.rc:5250
 msgid "Diff Pane"
 msgstr "Panel de diferencias"
 
 #. IDS_DIFF_SUCCEEDED
-#: Merge.rc:5258
+#: Merge.rc:5257
 msgid "Patch file written."
 msgstr "Archivo de corrección escrito correctamente."
 
 #. IDS_DIFF_FILEOVERWRITE
-#: Merge.rc:5259
+#: Merge.rc:5258
 msgid "Patch file already exists. Overwrite?"
 msgstr "El archivo de corrección ya existe. ¿Desea sobrescribirlo?"
 
 #. IDS_DIFF_SELECTEDFILES
-#: Merge.rc:5260
+#: Merge.rc:5259
 #, c-format
 msgid "[%1 files selected]"
 msgstr "[%1 archivos seleccionados]"
 
 #. IDS_DIFF_NORMAL
-#: Merge.rc:5261
+#: Merge.rc:5260
 msgid "Normal"
 msgstr "Normal"
 
 #. IDS_DIFF_CONTEXT
-#: Merge.rc:5262
+#: Merge.rc:5261
 msgid "Context"
 msgstr "Contexto"
 
 #. IDS_DIFF_UNIFIED
-#: Merge.rc:5263
+#: Merge.rc:5262
 msgid "Unified"
 msgstr "Unificado"
 
 #. IDS_FILEWRITE_ERROR
-#: Merge.rc:5265
+#: Merge.rc:5264
 #, c-format
 msgid "Could not write to file %1."
 msgstr "No se puede escribir en el archivo %1."
 
 #. IDS_PATH_NOT_ABSOLUTE
-#: Merge.rc:5266
+#: Merge.rc:5265
 #, c-format
 msgid "Output path is not absolute: %1"
 msgstr "La ruta de salida especificada no es absoluta: %1"
 
 #. IDS_MUST_SPECIFY_OUTPUT
-#: Merge.rc:5267
+#: Merge.rc:5266
 msgid "Specify an output file."
 msgstr "Especifique un archivo de salida."
 
-#: Merge.rc:5269
+#: Merge.rc:5268
 msgid "Cannot create patch from binary files."
 msgstr "No se puede crear un archivo de corrección a partir de archivos binarios."
 
 #. IDS_SAVEFILES_FORPATCH
-#: Merge.rc:5270
+#: Merge.rc:5269
 msgid ""
 "Save all files first.\n"
 "\n"
@@ -7510,22 +7505,22 @@ msgstr ""
 "Para crear una corrección es necesario que no haya cambios sin guardar."
 
 #. IDS_FOLDER_NOTEXIST
-#: Merge.rc:5271
+#: Merge.rc:5270
 msgid "Folder does not exist."
 msgstr "La carpeta no existe."
 
 #. IDS_ARCHIVE_SUCCEEDED
-#: Merge.rc:5277
+#: Merge.rc:5276
 msgid "Archive file written."
 msgstr ""
 
 #. IDS_ARCHIVE_SAVEFILES
-#: Merge.rc:5278
+#: Merge.rc:5277
 msgid "Save all files first.\n\nCreating an archive requires no unsaved changes."
 msgstr ""
 
 #. IDS_NO_ZIP_SUPPORT
-#: Merge.rc:5283
+#: Merge.rc:5282
 msgid ""
 "Archive support not enabled.\n"
 "7-Zip and/or Merge7z*.dll not found.\n"
@@ -7536,37 +7531,37 @@ msgstr ""
 "Consulte el manual para más información acerca del soporte de archivos y cómo habilitarlo."
 
 #. IDS_OPT_EXPORT_CAPTION
-#: Merge.rc:5284
+#: Merge.rc:5283
 msgid "Select file for export"
 msgstr "Seleccione archivo a exportar"
 
 #. IDS_OPT_IMPORT_CAPTION
-#: Merge.rc:5285
+#: Merge.rc:5284
 msgid "Select file for import"
 msgstr "Seleccione archivo a importar"
 
 #. IDS_OPT_IMPORT_DONE
-#: Merge.rc:5286
+#: Merge.rc:5285
 msgid "Options imported from file."
 msgstr "Opciones importadas desde el archivo."
 
 #. IDS_OPT_EXPORT_DONE
-#: Merge.rc:5287
+#: Merge.rc:5286
 msgid "Options exported to file."
 msgstr "Opciones exportadas al archivo."
 
 #. IDS_OPT_IMPORT_ERR
-#: Merge.rc:5288
+#: Merge.rc:5287
 msgid "Failed to import options from file."
 msgstr "Error al importar opciones del archivo."
 
 #. IDS_OPT_EXPORT_ERR
-#: Merge.rc:5289
+#: Merge.rc:5288
 msgid "Failed to write options to file."
 msgstr "Error al escribir las opciones en el archivo."
 
 #. IDS_CLOSEALL_WINDOWS
-#: Merge.rc:5290
+#: Merge.rc:5289
 msgid ""
 "Close multiple compare windows?\n"
 "\n"
@@ -7577,34 +7572,34 @@ msgstr ""
 "¿Desea continuar?"
 
 #. IDS_EOL_BIN
-#: Merge.rc:5300
+#: Merge.rc:5299
 msgctxt "EOL Type"
 msgid "Binary"
 msgstr "Binario"
 
 #. IDS_MARKER_COLOR_FMT
-#: Merge.rc:5305
+#: Merge.rc:5304
 #, c-format
 msgid "Marker Color %d"
 msgstr "Color del marcador %d"
 
 #. IDS_MARKER_NEW_PATTERN
-#: Merge.rc:5306
+#: Merge.rc:5305
 msgid "New Pattern"
 msgstr "Nuevo patrón"
 
 #. IDS_PLUGINSLIST_TYPE
-#: Merge.rc:5312
+#: Merge.rc:5311
 msgid "Type"
 msgstr "Tipo"
 
 #. IDS_PLUGINS_TYPE_EDITSCRIPT
-#: Merge.rc:5316
+#: Merge.rc:5315
 msgid "Editor script"
 msgstr "Editor de secuencia de comandos"
 
 #. ID_SELECTLINEDIFF
-#: Merge.rc:5322
+#: Merge.rc:5321
 msgid ""
 "\n"
 "Difference in Current Line (F4)"
@@ -7613,7 +7608,7 @@ msgstr ""
 "Diferencia en la línea actual (F4)"
 
 #. ID_OPTIONS
-#: Merge.rc:5323
+#: Merge.rc:5322
 msgid ""
 "\n"
 "Options"
@@ -7622,7 +7617,7 @@ msgstr ""
 "Opciones"
 
 #. ID_REFRESH
-#: Merge.rc:5324
+#: Merge.rc:5323
 msgid ""
 "\n"
 "Refresh (F5)"
@@ -7631,7 +7626,7 @@ msgstr ""
 "Actualizar (F5)"
 
 #. ID_PREVDIFF
-#: Merge.rc:5330
+#: Merge.rc:5329
 msgid ""
 "\n"
 "Previous Difference (Alt+Up)"
@@ -7640,7 +7635,7 @@ msgstr ""
 "Diferencia anterior (Alt+Arriba)"
 
 #. ID_NEXTDIFF
-#: Merge.rc:5331
+#: Merge.rc:5330
 msgid ""
 "\n"
 "Next Difference (Alt+Down)"
@@ -7649,7 +7644,7 @@ msgstr ""
 "Diferencia siguiente (Alt+Abajo)"
 
 #. ID_PREVCONFLICT
-#: Merge.rc:5332
+#: Merge.rc:5331
 msgid ""
 "\n"
 "Previous Conflict (Alt+Shift+Up)"
@@ -7658,7 +7653,7 @@ msgstr ""
 "Conflicto anterior (Alt+Mayús+Arriba)"
 
 #. ID_NEXTCONFLICT
-#: Merge.rc:5333
+#: Merge.rc:5332
 msgid ""
 "\n"
 "Next Conflict (Alt+Shift+Down)"
@@ -7667,7 +7662,7 @@ msgstr ""
 "Conflicto siguiente (Alt+Mayús+Abajo)"
 
 #. ID_FIRSTDIFF
-#: Merge.rc:5338
+#: Merge.rc:5337
 msgid ""
 "\n"
 "First Difference (Alt+Home)"
@@ -7676,7 +7671,7 @@ msgstr ""
 "Primera diferencia (Alt+Inicio)"
 
 #. ID_CURDIFF
-#: Merge.rc:5339
+#: Merge.rc:5338
 msgid ""
 "\n"
 "Current Difference (Alt+Enter)"
@@ -7685,7 +7680,7 @@ msgstr ""
 "Diferencia actual (Alt+Enter)"
 
 #. ID_LASTDIFF
-#: Merge.rc:5340
+#: Merge.rc:5339
 msgid ""
 "\n"
 "Last Difference (Alt+End)"
@@ -7694,7 +7689,7 @@ msgstr ""
 "Última diferencia (Alt+Fin)"
 
 #. ID_L2R
-#: Merge.rc:5341
+#: Merge.rc:5340
 msgid ""
 "\n"
 "Copy to Right (Alt+Right)"
@@ -7703,7 +7698,7 @@ msgstr ""
 "Copiar al derecho (Alt+Derecha)"
 
 #. ID_R2L
-#: Merge.rc:5342
+#: Merge.rc:5341
 msgid ""
 "\n"
 "Copy to Left (Alt+Left)"
@@ -7712,7 +7707,7 @@ msgstr ""
 "Copiar al izquierdo (Alt+Izquierda)"
 
 #. ID_L2RNEXT
-#: Merge.rc:5343
+#: Merge.rc:5342
 msgid ""
 "\n"
 "Copy to Right and Advance (Ctrl+Alt+Right)"
@@ -7721,7 +7716,7 @@ msgstr ""
 "Copiar al derecho y avanzar (Ctrl+Alt+Derecha)"
 
 #. ID_R2LNEXT
-#: Merge.rc:5344
+#: Merge.rc:5343
 msgid ""
 "\n"
 "Copy to Left and Advance (Ctrl+Alt+Left)"
@@ -7730,7 +7725,7 @@ msgstr ""
 "Copiar al izquierdo y avanzar (Ctrl+Alt+Izquierda)"
 
 #. ID_ALL_RIGHT
-#: Merge.rc:5345
+#: Merge.rc:5344
 msgid ""
 "\n"
 "Copy All to Right"
@@ -7739,7 +7734,7 @@ msgstr ""
 "Copiar todo al derecho"
 
 #. ID_ALL_LEFT
-#: Merge.rc:5346
+#: Merge.rc:5345
 msgid ""
 "\n"
 "Copy All to Left"
@@ -7748,7 +7743,7 @@ msgstr ""
 "Copiar todo al izquierdo"
 
 #. ID_AUTO_MERGE
-#: Merge.rc:5347
+#: Merge.rc:5346
 msgid ""
 "\n"
 "Auto Merge (Ctrl+Alt+M)"
@@ -7757,7 +7752,7 @@ msgstr ""
 "Autocombinar (Ctrl+Alt+M)"
 
 #. ID_FIRSTFILE
-#: Merge.rc:5348
+#: Merge.rc:5347
 msgid ""
 "\n"
 "First File"
@@ -7766,7 +7761,7 @@ msgstr ""
 "Primer archivo"
 
 #. ID_NEXTFILE
-#: Merge.rc:5349
+#: Merge.rc:5348
 msgid ""
 "\n"
 "Next File (Ctrl+F8)"
@@ -7775,7 +7770,7 @@ msgstr ""
 "Siguiente archivo (Ctrl+F8)"
 
 #. ID_LASTFILE
-#: Merge.rc:5350
+#: Merge.rc:5349
 msgid ""
 "\n"
 "Last File"
@@ -7784,7 +7779,7 @@ msgstr ""
 "Último archivo"
 
 #. ID_PREVFILE
-#: Merge.rc:5351
+#: Merge.rc:5350
 msgid ""
 "\n"
 "Previous File (Ctrl+F7)"
@@ -7793,142 +7788,142 @@ msgstr ""
 "Fichero anterior (Ctrl+F7)"
 
 #. IDS_UNPACK_AUTO
-#: Merge.rc:5358
+#: Merge.rc:5357
 msgid "Adapted unpacker applied to both files (one needs extension)."
 msgstr "El descompresor elegido se aplica a ambos archivos (solo un archivo necesita tener la extensión)."
 
 #. IDS_NO_PREDIFFER
-#: Merge.rc:5359
+#: Merge.rc:5358
 msgid "No Prediffer (Normal)"
 msgstr "Sin prediferenciación (normal)"
 
 #. IDS_SUGGESTED_PLUGINS
-#: Merge.rc:5360
+#: Merge.rc:5359
 msgid "Suggested Plugins"
 msgstr "Complementos sugeridos"
 
 #. IDS_NOT_SUGGESTED_PLUGINS
-#: Merge.rc:5361
+#: Merge.rc:5360
 msgid "All Plugins"
 msgstr "Todos los complementos"
 
 #. IDS_PRIVATEBUILD_FMT
-#: Merge.rc:5367
+#: Merge.rc:5366
 #, c-format
 msgid "Private Build: %1"
 msgstr "Compilación privada: %1"
 
 #. IDS_ALLRIGHTS_RESERVED
-#: Merge.rc:5368
+#: Merge.rc:5367
 msgid " - All rights reserved."
 msgstr " - Todos los derechos reservados."
 
 #. IDS_TITLE_PLUGINS_SETTINGS
-#: Merge.rc:5374
+#: Merge.rc:5373
 msgid "Plugin Settings"
 msgstr "Configuración de complementos"
 
 #. IDS_NO_SCT_SCRIPTS
-#: Merge.rc:5376
+#: Merge.rc:5375
 msgid "WSH not found - .sct scripts disabled"
 msgstr "WSH no encontrado - Scripts .sct deshabilitados"
 
 #. IDS_LOCBAR_GOTOLINE_FMT
-#: Merge.rc:5384
+#: Merge.rc:5383
 #, c-format
 msgid "G&o to Line %1"
 msgstr "Ir a &línea %1"
 
 #. IDS_GOTO_MOVED_LINE
-#: Merge.rc:5390
+#: Merge.rc:5389
 msgid "Go to Moved Line\tCtrl+Shift+G"
 msgstr "Ir a la línea desplazada\tCtrl+Mayús+G"
 
 #. IDS_AUTOCOMPLETE_DISABLED
-#: Merge.rc:5396
+#: Merge.rc:5395
 msgctxt "Options dialog|General|Open dialog Auto completion"
 msgid "Disabled"
 msgstr "Deshabilitado"
 
 #. IDS_AUTOCOMPLETE_FILE_SYS
-#: Merge.rc:5397
+#: Merge.rc:5396
 msgid "From file system"
 msgstr "Del sistema de archivos"
 
 #. IDS_AUTOCOMPLETE_MRU
-#: Merge.rc:5398
+#: Merge.rc:5397
 msgid "From Most Recently Used list"
 msgstr "De la lista de los más usados"
 
 #. IDS_COLORSCHEME_PLAIN
-#: Merge.rc:5404
+#: Merge.rc:5403
 msgid "No Highlighting"
 msgstr "Sin resaltar"
 
 #. IDS_COLORSCHEME_PO
-#: Merge.rc:5439
+#: Merge.rc:5438
 msgid "Portable Object"
 msgstr "Objeto portable"
 
 #. IDS_COLORSCHEME_RSRC
-#: Merge.rc:5444
+#: Merge.rc:5443
 msgid "Resources"
 msgstr "Recursos"
 
 #. IDS_COLORSCHEME_SH
-#: Merge.rc:5448
+#: Merge.rc:5447
 msgid "Shell"
 msgstr "Intérprete de comandos"
 
 #. IDS_CLOSE_LEFT_TABS
-#: Merge.rc:5469
+#: Merge.rc:5468
 msgid "Close &Left Tabs"
 msgstr "Cerrar pestañas a &la izquierda"
 
 #. IDS_CLOSE_RIGHT_TABS
-#: Merge.rc:5470
+#: Merge.rc:5469
 msgid "Close R&ight Tabs"
 msgstr "Cerrar pe&stañas a la derecha"
 
 #. IDS_CLOSE_OTHER_TABS
-#: Merge.rc:5471
+#: Merge.rc:5470
 msgid "Close &Other Tabs"
 msgstr "Cerrar &otras pestañas"
 
 #. IDS_TABBAR_AUTO_MAXWIDTH
-#: Merge.rc:5472
+#: Merge.rc:5471
 msgid "Enable &Auto Max Width"
 msgstr "Habilitar ancho máximo &automático"
 
 #. IDS_WEBPAGE_MENU
-#: Merge.rc:5482
+#: Merge.rc:5481
 msgid "We&bpage"
 msgstr "Página we&b"
 
 #. IDS_VIEW_WRAP_TEXT
-#: Merge.rc:5487
+#: Merge.rc:5486
 msgid "W&rap Text"
 msgstr "Ajusta&r texto"
 
 #. IDS_NOTINSTALLED
-#: Merge.rc:5492
+#: Merge.rc:5491
 #, c-format
 msgid "%1 is not installed."
 msgstr "No está instalado %1."
 
 #. IDS_CREATE_FOLDER
-#: Merge.rc:5497
+#: Merge.rc:5496
 #, c-format
 msgid "%1 does not exist. Create it?"
 msgstr "%1 no existe. ¿Desea crearlo?"
 
 #. IDS_CREATE_FOLDER_ERROR
-#: Merge.rc:5498
+#: Merge.rc:5497
 msgid "Failed to create folder."
 msgstr "Error al crear la carpeta."
 
 #. IDC_EXT_EDITOR_PATH
-#: Merge.rc:5503
+#: Merge.rc:5502
 msgid ""
 "Parameters:\n"
 "$file: Current file path\n"
@@ -7939,491 +7934,491 @@ msgstr ""
 "$linenum: número de línea de la posición actual del cursor"
 
 #. IDS_DIFF_ALGORITHM_DEFAULT
-#: Merge.rc:5508
+#: Merge.rc:5507
 msgid "default"
 msgstr "predeterminado"
 
 #. IDS_DIFF_ALGORITHM_MINIMAL
-#: Merge.rc:5509
+#: Merge.rc:5508
 msgid "minimal"
 msgstr "mínimo"
 
 #. IDS_DIFF_ALGORITHM_PATIENCE
-#: Merge.rc:5510
+#: Merge.rc:5509
 msgid "patience"
 msgstr "solitario"
 
 #. IDS_DIFF_ALGORITHM_HISTOGRAM
-#: Merge.rc:5511
+#: Merge.rc:5510
 msgid "histogram"
 msgstr "histograma"
 
 #. IDS_DIFF_ALGORITHM_NONE
-#: Merge.rc:5512
+#: Merge.rc:5511
 msgid "none"
 msgstr "ninguno/a"
 
 #. IDS_RENDERING_MODE_GDI
-#: Merge.rc:5517
+#: Merge.rc:5516
 msgid "GDI"
 msgstr "GDI"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_DEFAULT
-#: Merge.rc:5518
+#: Merge.rc:5517
 msgid "DirectWrite Default"
 msgstr "DirectWrite predeterminado"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_ALIASED
-#: Merge.rc:5519
+#: Merge.rc:5518
 msgid "DirectWrite Aliased"
 msgstr "Alias de DirectWrite"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_GDI_CLASSIC
-#: Merge.rc:5520
+#: Merge.rc:5519
 msgid "DirectWrite GDI Classic"
 msgstr "DirectWrite GDI clásico"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_GDI_NATURAL
-#: Merge.rc:5521
+#: Merge.rc:5520
 msgid "DirectWrite GDI Natural"
 msgstr "DirectWrite GDI natural"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_NATURAL
-#: Merge.rc:5522
+#: Merge.rc:5521
 msgid "DirectWrite Natural"
 msgstr "DirectWrite natural"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_NATURAL_SYMMETRIC
-#: Merge.rc:5523
+#: Merge.rc:5522
 msgid "DirectWrite Natural Symmetric"
 msgstr "DirectWrite natural simétrico"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_DISABLED
-#: Merge.rc:5528
+#: Merge.rc:5527
 msgctxt "Options dialog|General|Close windows with Esc"
 msgid "Disabled"
 msgstr "Deshabilitado"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_1
-#: Merge.rc:5529
+#: Merge.rc:5528
 msgid "MDI child window or main window"
 msgstr "Ventana secundaria MDI o ventana principal"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_2
-#: Merge.rc:5530
+#: Merge.rc:5529
 msgid "MDI child window only"
 msgstr "Solo ventana secundaria MDI"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_3
-#: Merge.rc:5531
+#: Merge.rc:5530
 msgid "Close main window if only one MDI child window"
 msgstr "Cerrar ventana principal solo si hay una ventana MDI secundaria"
 
 #. IDS_DIFF_GROUP
-#: Merge.rc:5536
+#: Merge.rc:5535
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Diff"
 msgstr "Diferencias"
 
 #. IDS_DIFF_HIGHLIGHT
-#: Merge.rc:5537
+#: Merge.rc:5536
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Highlight"
 msgstr "Resaltado"
 
 #. IDS_DIFF_BLINK
-#: Merge.rc:5538
+#: Merge.rc:5537
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Blink"
 msgstr "Parpadeo"
 
 #. IDS_DIFF_BLOCKSIZE
-#: Merge.rc:5539
+#: Merge.rc:5538
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Block Size"
 msgstr "Tamaño del bloque"
 
 #. IDS_DIFF_BLOCKALPHA
-#: Merge.rc:5540
+#: Merge.rc:5539
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Block Alpha"
 msgstr "Bloque Alpha"
 
 #. IDS_DIFF_CDTHRESHOLD
-#: Merge.rc:5541
+#: Merge.rc:5540
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "CD Threshold"
 msgstr "Límite CD"
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION
-#: Merge.rc:5542
+#: Merge.rc:5541
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Ins/Del Detection"
 msgstr "Detectar Ins/Borrar"
 
 #. IDS_OVERLAY_MODE_NONE
-#: Merge.rc:5543 Merge.rc:5548
+#: Merge.rc:5542 Merge.rc:5547
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "None"
 msgstr "Ninguno"
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION_VERTICAL
-#: Merge.rc:5544
+#: Merge.rc:5543
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Vertical"
 msgstr "Vertical"
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION_HORIZONTAL
-#: Merge.rc:5545
+#: Merge.rc:5544
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Horizontal"
 msgstr "Horizontal"
 
 #. IDS_OVERLAY_GROUP
-#: Merge.rc:5546
+#: Merge.rc:5545
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Overlay"
 msgstr "Superponer"
 
 #. IDS_OVERLAY_ALPHA
-#: Merge.rc:5547
+#: Merge.rc:5546
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha"
 msgstr "Alpha"
 
 #. IDS_OVERLAY_MODE_XOR
-#: Merge.rc:5549
+#: Merge.rc:5548
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "XOR"
 msgstr "XOR"
 
 #. IDS_OVERLAY_MODE_ALPHA
-#: Merge.rc:5550
+#: Merge.rc:5549
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha Blend"
 msgstr "Mezcla Alpha"
 
 #. IDS_OVERLAY_MODE_ALPHA_ANIMATION
-#: Merge.rc:5551
+#: Merge.rc:5550
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha Animation"
 msgstr "Animación Alpha"
 
 #. IDS_ZOOM
-#: Merge.rc:5552
+#: Merge.rc:5551
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Zoom"
 msgstr "Zoom"
 
 #. IDS_PAGE
-#: Merge.rc:5553
+#: Merge.rc:5552
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Page:"
 msgstr "Página:"
 
 #. IDS_IMGCMP_STATUS_PT_RGBA_FMT
-#: Merge.rc:5554
+#: Merge.rc:5553
 #, c-format
 msgid "Pt: (%d, %d)  RGBA: (%d, %d, %d, %d)  "
 msgstr "Pto: (%d, %d)  RGBA: (%d, %d, %d, %d)  "
 
 #. IDS_IMGCMP_STATUS_DIST1_FMT
-#: Merge.rc:5555
+#: Merge.rc:5554
 #, c-format
 msgid "Dist: %g  "
 msgstr "Dist: %g  "
 
 #. IDS_IMGCMP_STATUS_DIST2_FMT
-#: Merge.rc:5556
+#: Merge.rc:5555
 #, c-format
 msgid "Dist: %g, %g  "
 msgstr "Dist: %g, %g  "
 
 #. IDS_IMGCMP_STATUS_PAGE_ZOOM_SIZE_BPP_FMT
-#: Merge.rc:5557
+#: Merge.rc:5556
 #, c-format
 msgid "Page: %d/%d  Zoom: %d%%  %dx%dpx  %dbpp  "
 msgstr "Página: %d/%d  Zoom: %d%%  %dx%dpx  %dbpp  "
 
 #. IDS_IMGCMP_STATUS_RC_FMT
-#: Merge.rc:5558
+#: Merge.rc:5557
 #, c-format
 msgid "Rc: (%d, %d)  "
 msgstr "Rc: (%d, %d)  "
 
 #. IDS_IMGCMP_STATUS_FLIPPED_FMT
-#: Merge.rc:5559
+#: Merge.rc:5558
 #, c-format
 msgid "Flipped: %s  "
 msgstr "Invertida: %s "
 
 #. IDS_IMGCMP_STATUS_ROTATED_FMT
-#: Merge.rc:5560
+#: Merge.rc:5559
 #, c-format
 msgid "Rotated: %d  "
 msgstr "Rotada: %d "
 
 #. IDS_IMGCMP_REPORT_ALLPAGES
-#: Merge.rc:5561
+#: Merge.rc:5560
 msgid "All pages"
 msgstr "Todas las páginas"
 
 #. IDS_IGNSUB_STR1
-#: Merge.rc:5566
+#: Merge.rc:5565
 msgid "<Edit here>"
 msgstr "<Editar aquí>"
 
 #. IDS_IGNSUB_STR2
-#: Merge.rc:5567
+#: Merge.rc:5566
 msgid "No differences found to select"
 msgstr "No se han encontrado diferencias para seleccionar"
 
 #. IDS_IGNSUB_STR3
-#: Merge.rc:5568
+#: Merge.rc:5567
 msgid "No differences found to add as substitution filter"
 msgstr "No se encontraron diferencias para añadirlas como filtro de sustitución"
 
 #. IDS_IGNSUB_STR4
-#: Merge.rc:5569
+#: Merge.rc:5568
 msgid "The pair is already in the Substitution Filters list"
 msgstr "La pareja ya está presente en la lista de Filtros de sustitución"
 
 #. IDS_IGNSUB_STR5
-#: Merge.rc:5570
+#: Merge.rc:5569
 msgid "Add this change to Substitution Filters?"
 msgstr "¿Añadir este cambio a los Filtros de sustitución?"
 
 #. IDS_OCRRESULT_TEXTONLY
-#: Merge.rc:5575
+#: Merge.rc:5574
 msgid "Text only"
 msgstr "Solo texto"
 
 #. IDS_OCRRESULT_POS_LINE
-#: Merge.rc:5576
+#: Merge.rc:5575
 msgid "Line-by-line position and text"
 msgstr "Posición y texto línea por línea"
 
 #. IDS_OCRRESULT_POS_WORD
-#: Merge.rc:5577
+#: Merge.rc:5576
 msgid "Word-by-word position and text"
 msgstr "Posición y texto palabra por palabra"
 
 #. IDS_USERDATAFOLDER_APPDATA
-#: Merge.rc:5582
+#: Merge.rc:5581
 msgid "AppData (Roaming) folder"
 msgstr "Carpeta AppData (Roaming)"
 
 #. IDS_USERDATAFOLDER_INSTALL
-#: Merge.rc:5583
+#: Merge.rc:5582
 msgid "Install folder"
 msgstr "Carpeta de instalación"
 
 #. IDS_USERDATAFOLDER_DOCUMENTS
-#: Merge.rc:5584
+#: Merge.rc:5583
 msgid "Documents folder"
 msgstr "Carpeta Documentos"
 
 #. IDS_SINGLEINSTANCE_DISABLED
-#: Merge.rc:5589
+#: Merge.rc:5588
 msgctxt "Options dialog|General|Single instance mode"
 msgid "Disabled"
 msgstr "Deshabilitado"
 
 #. IDS_SINGLEINSTANCE_STR1
-#: Merge.rc:5590
+#: Merge.rc:5589
 msgid "Allow only one instance to run"
 msgstr "Permitir solo una instancia en ejecución"
 
 #. IDS_CLIPBOARD_HISTORY
-#: Merge.rc:5591
+#: Merge.rc:5590
 msgid "Clipboard &History"
 msgstr "&Historial del Portapapeles"
 
 #. IDS_SINGLEINSTANCE_STR2
-#: Merge.rc:5592
+#: Merge.rc:5591
 msgid "Allow only one instance; wait for termination"
 msgstr "Permitir únicamente una instancia en ejecución y esperar hasta que termine"
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_DISABLED
-#: Merge.rc:5597
+#: Merge.rc:5596
 msgctxt "Options dialog|General|Auto-reload modified files"
 msgid "Disabled"
 msgstr "Deshabilitado"
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_STR1
-#: Merge.rc:5598
+#: Merge.rc:5597
 msgid "Only on window activated"
 msgstr "Solo con la ventana activada"
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_STR2
-#: Merge.rc:5599
+#: Merge.rc:5598
 msgid "Immediately"
 msgstr "Inmediatamente"
 
 #. IDS_PLUGIN_ALL
-#: Merge.rc:5604
+#: Merge.rc:5603
 msgid "Al&l"
 msgstr "&Todo"
 
 #. IDS_PLUGIN_OTHERS
-#: Merge.rc:5605
+#: Merge.rc:5604
 msgid "&Others"
 msgstr "&Otros"
 
-#: Merge.rc:5607
+#: Merge.rc:5606
 #, c-format
 msgid "Missing plugin name in pipeline: %1"
 msgstr "Falta el nombre del complemento en el conjunto de procesos: %1"
 
-#: Merge.rc:5609
+#: Merge.rc:5608
 #, c-format
 msgid "Missing quote in plugin pipeline: %1"
 msgstr "Faltan comillas en el conjunto de procesos: %1"
 
 #. IDS_PLUGIN_NAME_ALREADY_EXISTS
-#: Merge.rc:5610
+#: Merge.rc:5609
 #, c-format
 msgid "Plugin name '%1' already exists."
 msgstr "El nombre del complemento '%1' ya existe."
 
 #. IDS_PLUGIN_TITLE1
-#: Merge.rc:5611
+#: Merge.rc:5610
 msgid "Specify plugin arguments"
 msgstr "Especifique argumentos del complemento"
 
-#: Merge.rc:5613
+#: Merge.rc:5612
 #, c-format
 msgid "Plugin not found or invalid: %1"
 msgstr "Complemento no encontrado o no válido: %1"
 
 #. IDS_PLUGIN_NOT_UNPACK
-#: Merge.rc:5614
+#: Merge.rc:5613
 #, c-format
 msgid "'%1' is not an unpacker plugin"
 msgstr "'%1' no es un complemento descompresor"
 
 #. IDS_PLUGIN_NOT_PREDIFF
-#: Merge.rc:5615
+#: Merge.rc:5614
 #, c-format
 msgid "'%1' is not a prediffer plugin"
 msgstr "'%1' no es un complemento prediferenciador"
 
-#: Merge.rc:5617
+#: Merge.rc:5616
 #, c-format
 msgid "Error prediffing '%1' with '%2'. Prediffing disabled."
 msgstr "Hubo un error al prediferenciar el fichero '%1' con el complemento '%2'. Prediferenciación desactivada."
 
 #. IDS_PLUGIN_CIRCULAR_REFERENCE
-#: Merge.rc:5618
+#: Merge.rc:5617
 #, c-format
 msgid "Circular reference in plugin pipeline: %1"
 msgstr "Referencia circular en el conjunto de procesos: %1"
 
 #. IDS_PLUGIN_TYPE1
-#: Merge.rc:5619
+#: Merge.rc:5618
 msgid "URL Handler"
 msgstr "Gestor de URL"
 
 #. IDS_PLUGIN_TYPE2
-#: Merge.rc:5620
+#: Merge.rc:5619
 msgid "File Unpacker"
 msgstr "Descompresor de archivos"
 
 #. IDS_PLUGIN_TYPE3
-#: Merge.rc:5621
+#: Merge.rc:5620
 msgid "File or Folder Unpacker"
 msgstr "Descompresor de archivos o carpetas"
 
 #. IDS_PLUGIN_TYPE5
-#: Merge.rc:5623
+#: Merge.rc:5622
 msgid "Alias for Unpacker"
 msgstr "Alias para el descompresor"
 
 #. IDS_PLUGIN_TYPE6
-#: Merge.rc:5624
+#: Merge.rc:5623
 msgid "Alias for Prediffer"
 msgstr "Alias para el prediferenciador"
 
 #. IDS_PLUGIN_TYPE7
-#: Merge.rc:5625
+#: Merge.rc:5624
 msgid "Alias for Editor script"
 msgstr "Alias para el editor de secuencia de comandos"
 
 #. IDS_PLUGIN_ALIAS_DESC
-#: Merge.rc:5626
+#: Merge.rc:5625
 #, c-format
 msgid "Alias for plugin pipeline '%1'"
 msgstr "Alias para el conjunto de procesos. '%1'"
 
 #. IDS_PLUGIN_NEW_DESC
-#: Merge.rc:5627
+#: Merge.rc:5626
 msgid "New plugin description"
 msgstr "Nueva descripción de complemento"
 
 #. IDS_PLUGIN_TARGETS_ALL
-#: Merge.rc:5628
+#: Merge.rc:5627
 msgid "All"
 msgstr "Todo"
 
 #. IDS_PLUGIN_TARGETS_1ST
-#: Merge.rc:5629
+#: Merge.rc:5628
 msgid "1st"
 msgstr "1.º"
 
 #. IDS_PLUGIN_TARGETS_2ND
-#: Merge.rc:5630
+#: Merge.rc:5629
 msgid "2nd"
 msgstr "2.º"
 
 #. IDS_PLUGIN_TARGETS_3RD
-#: Merge.rc:5631
+#: Merge.rc:5630
 msgid "3rd"
 msgstr "3.º"
 
 #. IDS_PLUGIN_TARGETS_1ST_2ND
-#: Merge.rc:5632
+#: Merge.rc:5631
 msgid "1st and 2nd"
 msgstr "1.º y 2.º"
 
 #. IDS_PLUGIN_TARGETS_1ST_3RD
-#: Merge.rc:5633
+#: Merge.rc:5632
 msgid "1st and 3rd"
 msgstr "1.º y 3.º"
 
 #. IDS_PLUGIN_TARGETS_2ND_3RD
-#: Merge.rc:5634
+#: Merge.rc:5633
 msgid "2nd and 3rd"
 msgstr "2.º y 3.º"
 
 #. IDS_PLUGIN_CTRL_CLICK
-#: Merge.rc:5635
+#: Merge.rc:5634
 msgid "(Ctrl+Click to add to pipeline)"
 msgstr ""
 
 #. IDS_FILTER_APPLIED
-#: Merge.rc:5640
+#: Merge.rc:5639
 msgid "Filter applied"
 msgstr "Filtro aplicado"
 
 #. IDS_FILTERMENU_COMPARE
-#: Merge.rc:5645
+#: Merge.rc:5644
 #, c-format
 msgid "Compare %1"
 msgstr "Comparar %1"
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN2
-#: Merge.rc:5647
+#: Merge.rc:5646
 msgid "&Filter by This Column..."
 msgstr "&Filtrar por esta columna..."
 
 #. IDS_CLIPBOARDHISTORY_TIME
-#: Merge.rc:5652
+#: Merge.rc:5651
 #, c-format
 msgid "Clipboard at %s"
 msgstr "Portapapeles en %s"
 
 #. IDS_CLIPBOARDHISTORY_DISABLED
-#: Merge.rc:5653
+#: Merge.rc:5652
 msgid ""
 "Clipboard history disabled.\r\n"
 "Enable: Windows logo key + V, then Turn on."
@@ -8431,115 +8426,115 @@ msgstr ""
 "El historial del Portapapeles está deshabilitado.\r\n"
 "Para habilitarlo, presione la tecla Windows + V y luego presione el botón Activar."
 
-#: Merge.rc:5655
+#: Merge.rc:5654
 msgid "This system does not support clipboard history."
 msgstr "Este sistema no soporta historial del Portapapeles."
 
-#: Merge.rc:5657
+#: Merge.rc:5656
 msgid "32-bit WinMerge does not support Clipboard Compare"
 msgstr "La versión de 32 bits de WinMerge no soporta comparación de Portapapeles"
 
 #. IDS_WEBVIEW2_RUNTIME_NOT_INSTALLED
-#: Merge.rc:5662
+#: Merge.rc:5661
 msgid "WebView2 runtime not installed. Download it?"
 msgstr "WebView2 Runtime no está instalado. ¿Desea descargarlo?"
 
 #. IDS_JUMPLIST_NEW_TEXT_COMPARE
-#: Merge.rc:5667
+#: Merge.rc:5666
 msgid "New Text Compare"
 msgstr "Nueva comparación de texto"
 
 #. IDS_JUMPLIST_NEW_TABLE_COMPARE
-#: Merge.rc:5668
+#: Merge.rc:5667
 msgid "New Table Compare"
 msgstr "Nueva comparación de tabla"
 
 #. IDS_JUMPLIST_NEW_BINARY_COMPARE
-#: Merge.rc:5669
+#: Merge.rc:5668
 msgid "New Binary Compare"
 msgstr "Nueva comparación binaria"
 
 #. IDS_JUMPLIST_NEW_IMAGE_COMPARE
-#: Merge.rc:5670
+#: Merge.rc:5669
 msgid "New Image Compare"
 msgstr "Nueva comparación de imágen"
 
 #. IDS_JUMPLIST_NEW_WEBPAGE_COMPARE
-#: Merge.rc:5671
+#: Merge.rc:5670
 msgid "New Webpage Compare"
 msgstr "Nueva comparación de página web"
 
 #. IDS_JUMPLIST_NEW_FOLDER_COMPARE
-#: Merge.rc:5672
+#: Merge.rc:5671
 msgid "New Folder Compare"
 msgstr "Nueva comparación de carpetas"
 
 #. IDS_JUMPLIST_CLIPBOARD_COMPARE
-#: Merge.rc:5673
+#: Merge.rc:5672
 msgid "Clipboard Compare"
 msgstr "Nueva comparación de Portapapeles"
 
 #. IDS_PREVIEWBAR_PRINT
-#: Merge.rc:5678
+#: Merge.rc:5677
 msgid "&Print..."
 msgstr "Im&primir..."
 
 #. IDS_PREVIEWBAR_PREVPAGE
-#: Merge.rc:5680
+#: Merge.rc:5679
 msgid "Pre&v Page"
 msgstr "Página an&terior"
 
 #. IDS_PREVIEWBAR_TWOPAGE
-#: Merge.rc:5681
+#: Merge.rc:5680
 msgid "&Two Page"
 msgstr "&Dos páginas"
 
 #. IDS_PREVIEWBAR_ONEPAGE
-#: Merge.rc:5682
+#: Merge.rc:5681
 msgid "&One Page"
 msgstr "Un&a página"
 
 #. IDS_PREVIEWBAR_ZOOMIN
-#: Merge.rc:5683
+#: Merge.rc:5682
 msgid "Zoom &In"
 msgstr "Aumentar &zoom"
 
 #. IDS_PREVIEWBAR_ZOOMOUT
-#: Merge.rc:5684
+#: Merge.rc:5683
 msgid "Zoom &Out"
 msgstr "Reducir z&oom"
 
 #. IDS_WEBPAGE_COMPARING
-#: Merge.rc:5690
+#: Merge.rc:5689
 msgid "Comparing..."
 msgstr "Comparando..."
 
 #. IDS_WEBPAGE_ZOOM
-#: Merge.rc:5691
+#: Merge.rc:5690
 msgid "Zoom:"
 msgstr "Ampliar:"
 
 #. IDS_COPY_GRANULARITY_DIFFHUNK
-#: Merge.rc:5696
+#: Merge.rc:5695
 msgid "Diff hunk"
 msgstr "Fragmentos de diferencias"
 
 #. IDS_COPY_GRANULARITY_INLINE
-#: Merge.rc:5697
+#: Merge.rc:5696
 msgid "Inline diff"
 msgstr "Diferencia en línea"
 
 #. IDS_COPY_GRANULARITY_LINE
-#: Merge.rc:5698
+#: Merge.rc:5697
 msgid "Line"
 msgstr "Línea"
 
-#: Merge.rc:5699
+#: Merge.rc:5698
 msgid "Character"
 msgstr "Carácter"
 
 #. ID_MICE_PREVDIFF
-#: Merge.rc:5704
+#: Merge.rc:5703
 msgid ""
 "\n"
 "Previous Difference (Alt+Up)\n"
@@ -8552,7 +8547,7 @@ msgstr ""
 "(Alt+Rueda adelante)"
 
 #. ID_MICE_NEXTDIFF
-#: Merge.rc:5705
+#: Merge.rc:5704
 msgid ""
 "\n"
 "Next Difference (Alt+Down)\n"
@@ -8565,7 +8560,7 @@ msgstr ""
 "(Alt+Rueda atrás)"
 
 #. ID_MICE_L2R
-#: Merge.rc:5706
+#: Merge.rc:5705
 msgid ""
 "\n"
 "Copy to Right (Alt+Right)\n"
@@ -8580,7 +8575,7 @@ msgstr ""
 "(Alt+Mayús+Rueda atrás)"
 
 #. ID_MICE_R2L
-#: Merge.rc:5707
+#: Merge.rc:5706
 msgid ""
 "\n"
 "Copy to Left (Alt+Left)\n"
@@ -8595,7 +8590,7 @@ msgstr ""
 "(Alt+Mayús+Rueda adelante)"
 
 #. ID_MICE_L2RNEXT
-#: Merge.rc:5708
+#: Merge.rc:5707
 msgid ""
 "\n"
 "Copy to Right and Advance (Ctrl+Alt+Right)\n"
@@ -8608,7 +8603,7 @@ msgstr ""
 "(Ctrl+Alt+Mayús+Rueda atrás)"
 
 #. ID_MICE_R2LNEXT
-#: Merge.rc:5709
+#: Merge.rc:5708
 msgid ""
 "\n"
 "Copy to Left and Advance (Ctrl+Alt+Left)\n"
@@ -8621,257 +8616,257 @@ msgstr ""
 "(Ctrl+Alt+Mayús+Rueda adelante)"
 
 #. IDS_LOG_COMPARING_2
-#: Merge.rc:5719
+#: Merge.rc:5718
 #, c-format
 msgid "Comparing %1 with %2"
 msgstr "Comparando %1 con %2"
 
 #. IDS_LOG_COMPARING_3
-#: Merge.rc:5720
+#: Merge.rc:5719
 #, c-format
 msgid "Comparing %1 with %2 and %3"
 msgstr "Comparando %1 con %2 y %3"
 
 #. IDS_LOG_COMPARE_COMPLETED
-#: Merge.rc:5721
+#: Merge.rc:5720
 msgid "Comparison completed"
 msgstr "Comparación completada"
 
 #. IDS_LOG_COMPARE_ERROR_2
-#: Merge.rc:5722
+#: Merge.rc:5721
 #, c-format
 msgid "Failed to compare %1 with %2: "
 msgstr "No se ha podido comparar %1 con %2: "
 
 #. IDS_LOG_COMPARE_ERROR_3
-#: Merge.rc:5723
+#: Merge.rc:5722
 #, c-format
 msgid "Failed to compare %1 with %2 and %3: "
 msgstr "No se ha podido comparar %1 con %2 y %3: "
 
 #. IDS_LOG_FILE_SAVED
-#: Merge.rc:5724
+#: Merge.rc:5723
 msgid "File saved"
 msgstr "Archivo guardado"
 
 #. IDS_LOG_COPYING_FILES
-#: Merge.rc:5725
+#: Merge.rc:5724
 msgid "Copying files..."
 msgstr "Copiando archivos..."
 
 #. IDS_LOG_MOVING_FILES
-#: Merge.rc:5726
+#: Merge.rc:5725
 msgid "Moving files..."
 msgstr "Moviendo archivos..."
 
 #. IDS_LOG_DELETING_FILES
-#: Merge.rc:5727
+#: Merge.rc:5726
 msgid "Deleting files..."
 msgstr "Eliminando archivos..."
 
 #. IDS_LOG_RECYCLEBIN
-#: Merge.rc:5728
+#: Merge.rc:5727
 msgid "Recycle Bin"
 msgstr "Papelera de reciclaje"
 
 #. IDS_LOG_PERMANENTLY_DELETED
-#: Merge.rc:5729
+#: Merge.rc:5728
 msgid "Permanently deleted"
 msgstr "Eliminado permanentemente"
 
 #. IDS_LOG_FILEOPERATION_COMPLETED
-#: Merge.rc:5730
+#: Merge.rc:5729
 msgid "File operation completed successfully"
 msgstr "Operación de archivo completada correctamente"
 
 #. IDS_LOG_FILEOPERATION_CANCELED
-#: Merge.rc:5731
+#: Merge.rc:5730
 msgid "File operation canceled"
 msgstr "Operación de archivo cancelada"
 
 #. IDS_FILTER_ERROR_NO_ERROR
-#: Merge.rc:5736
+#: Merge.rc:5735
 msgid "No error"
 msgstr "Sin errores"
 
 #. IDS_FILTER_ERROR_EMPTY_EXPRESSION
-#: Merge.rc:5737
+#: Merge.rc:5736
 msgid "Filter expression is empty"
 msgstr "La expresión del filtro está vacía"
 
 #. IDS_FILTER_ERROR_UNKNOWN_CHAR
-#: Merge.rc:5738
+#: Merge.rc:5737
 msgid "Unknown character in filter expression"
 msgstr "Carácter desconocido en la expresión del filtro"
 
 #. IDS_FILTER_ERROR_UNTERMINATED_STRING
-#: Merge.rc:5739
+#: Merge.rc:5738
 msgid "Unterminated string literal"
 msgstr "Literal de cadena sin terminar"
 
 #. IDS_FILTER_ERROR_SYNTAX_ERROR
-#: Merge.rc:5740
+#: Merge.rc:5739
 msgid "Syntax error in filter expression"
 msgstr "Error de sintaxis en la expresión del filtro"
 
 #. IDS_FILTER_ERROR_PARSE_FAILURE
-#: Merge.rc:5741
+#: Merge.rc:5740
 msgid "Failed to parse filter expression"
 msgstr "No se pudo analizar la expresión del filtro"
 
 #. IDS_FILTER_ERROR_INVALID_LITERAL
-#: Merge.rc:5742
+#: Merge.rc:5741
 msgid "Invalid literal value"
 msgstr "Valor literal no válido"
 
 #. IDS_FILTER_ERROR_INVALID_REGULAR_EXPRESSION
-#: Merge.rc:5743
+#: Merge.rc:5742
 msgid "Invalid regular expression"
 msgstr "Expresión regular no válida"
 
 #. IDS_FILTER_ERROR_UNDEFINED_IDENTIFIER
-#: Merge.rc:5744
+#: Merge.rc:5743
 msgid "Undefined identifier"
 msgstr "Identificador no definido"
 
 #. IDS_FILTER_ERROR_INVALID_ARGUMENT_COUNT
-#: Merge.rc:5745
+#: Merge.rc:5744
 msgid "Invalid number of arguments"
 msgstr "Número de argumentos no válido"
 
 #. IDS_FILTER_ERROR_FILTER_NAME_NOT_FOUND
-#: Merge.rc:5746
+#: Merge.rc:5745
 msgid "Filter name not found"
 msgstr "Nombre de filtro no encontrado"
 
 #. IDS_FILTER_ERROR_DIVIDE_BY_ZERO
-#: Merge.rc:5747
+#: Merge.rc:5746
 msgid "Division by zero in filter expression"
 msgstr "División por cero en la expresión del filtro"
 
 #. IDS_FILTER_ERROR_UNKNOWN_ERROR
-#: Merge.rc:5748
+#: Merge.rc:5747
 msgid "Unknown error"
 msgstr "Error desconocido"
 
 #. IDS_FILTER_ERROR_INVALID_PROPERTY_NAME
-#: Merge.rc:5749
+#: Merge.rc:5748
 msgid "Invalid property name"
 msgstr "Nombre de propiedad no válido"
 
 #. IDS_FILTER_ERROR_INVALID_DIRECTIVE
-#: Merge.rc:5750
+#: Merge.rc:5749
 msgid "Invalid directive"
 msgstr "Directiva no válida"
 
 #. IDS_FILTER_OP_EQUALS
-#: Merge.rc:5755
+#: Merge.rc:5754
 msgid "Equals"
 msgstr "Iguales"
 
 #. IDS_FILTER_OP_NOT_EQUALS
-#: Merge.rc:5756
+#: Merge.rc:5755
 msgid "Does not equal"
 msgstr "No es igual"
 
 #. IDS_FILTER_OP_LESS_THAN
-#: Merge.rc:5757
+#: Merge.rc:5756
 msgid "Less than"
 msgstr "Menor que"
 
 #. IDS_FILTER_OP_LESS_EQUAL
-#: Merge.rc:5758
+#: Merge.rc:5757
 msgid "Less than or equal to"
 msgstr "Menor o igual que"
 
 #. IDS_FILTER_OP_GREATER_EQUAL
-#: Merge.rc:5759
+#: Merge.rc:5758
 msgid "Greater than or equal to"
 msgstr "Mayor o igual que"
 
 #. IDS_FILTER_OP_GREATER_THAN
-#: Merge.rc:5760
+#: Merge.rc:5759
 msgid "Greater than"
 msgstr "Mayor que"
 
 #. IDS_FILTER_OP_BETWEEN
-#: Merge.rc:5761
+#: Merge.rc:5760
 msgid "Between"
 msgstr "Entre"
 
 #. IDS_FILTER_OP_NOT_BETWEEN
-#: Merge.rc:5762
+#: Merge.rc:5761
 msgid "Not Between"
 msgstr "No entre"
 
 #. IDS_FILTER_OP_CONTAINS
-#: Merge.rc:5763
+#: Merge.rc:5762
 msgid "Contains"
 msgstr "Contiene"
 
 #. IDS_FILTER_OP_NOT_CONTAINS
-#: Merge.rc:5764
+#: Merge.rc:5763
 msgid "Not Contains"
 msgstr "No contiene"
 
 #. IDS_FILTER_OP_RECONTAINS
-#: Merge.rc:5765
+#: Merge.rc:5764
 msgid "Contains (regex)"
 msgstr "Contiene (regex)"
 
 #. IDS_FILTER_OP_NOT_RECONTAINS
-#: Merge.rc:5766
+#: Merge.rc:5765
 msgid "Not Contains (regex)"
 msgstr "No contiene (regex)"
 
 #. IDS_FILTER_OP_LIKE
-#: Merge.rc:5767
+#: Merge.rc:5766
 msgid "Match (wildcard)"
 msgstr "Coincide (comodín)"
 
 #. IDS_FILTER_OP_NOT_LIKE
-#: Merge.rc:5768
+#: Merge.rc:5767
 msgid "Not match (wildcard)"
 msgstr "No coincide (comodín)"
 
 #. IDS_FILTER_OP_MATCHES
-#: Merge.rc:5769
+#: Merge.rc:5768
 msgid "Match (regex)"
 msgstr "Coincide (expresión regular)"
 
 #. IDS_FILTER_OP_NOT_MATCHES
-#: Merge.rc:5770
+#: Merge.rc:5769
 msgid "Not match (regex)"
 msgstr "No coincide (expresión regular)"
 
 #. IDS_COLORMODE_LIGHT
-#: Merge.rc:5775
+#: Merge.rc:5774
 msgid "Light"
 msgstr "Claro"
 
 #. IDS_COLORMODE_DARK
-#: Merge.rc:5776
+#: Merge.rc:5775
 msgid "Dark"
 msgstr "Oscuro"
 
 #. IDS_COLORMODE_FOLLOWSYSTEM
-#: Merge.rc:5777
+#: Merge.rc:5776
 msgid "Follow system"
 msgstr "Según el sistema"
 
 #. IDS_EXAMPLE
-#: Merge.rc:5782
+#: Merge.rc:5781
 #, c-format
 msgid "e.g. %1"
 msgstr "ejemplo %1"
 
 #. IDS_DETECTED_PREVIOUS_CRASH
-#: Merge.rc:5787
+#: Merge.rc:5786
 msgid "WinMerge detected a previous crash. Please report this if possible."
 msgstr "WinMerge ha detectado un fallo anterior. Si es posible, por favor, infórmenos de ello."
 
 #. IDS_REGEX_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5792
+#: Merge.rc:5791
 msgid ""
 "# Regex replacement list\r\n"
 "# Format: regex<TAB>replacement\r\n"
@@ -8886,7 +8881,7 @@ msgstr ""
 "(\\d{4})-(\\d{2})-(\\d{2})\t$1_$2_$3\r\n"
 
 #. IDS_STRING_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5793
+#: Merge.rc:5792
 msgid ""
 "# Replacement list\r\n"
 "# Format: search<TAB>replacement\r\n"
@@ -8903,22 +8898,22 @@ msgstr ""
 "desde2\thasta2\r\n"
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_ONLY
-#: Merge.rc:5798
+#: Merge.rc:5797
 msgid "Built-in only"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_FIRST
-#: Merge.rc:5799
+#: Merge.rc:5798
 msgid "Built-in first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_FIRST
-#: Merge.rc:5800
+#: Merge.rc:5799
 msgid "Tree-sitter first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_ONLY
-#: Merge.rc:5801
+#: Merge.rc:5800
 msgid "Tree-sitter only"
 msgstr ""
 

--- a/Translations/WinMerge/Swedish.po
+++ b/Translations/WinMerge/Swedish.po
@@ -26,7 +26,7 @@ msgstr ""
 "X-Generator: Poedit 3.7\n"
 
 #. LANGUAGE, SUBLANGUAGE
-#: Merge.rc:26 Merge.rc:59 Merge.rc:5818
+#: Merge.rc:26 Merge.rc:59 Merge.rc:5817
 msgid "LANG_ENGLISH, SUBLANG_ENGLISH_US"
 msgstr "LANG_SWEDISH, SUBLANG_DEFAULT"
 
@@ -168,7 +168,7 @@ msgstr "Skript"
 #. IDS_NO_EDIT_SCRIPTS
 #: Merge.rc:127 Merge.rc:352 Merge.rc:463 Merge.rc:673 Merge.rc:678
 #: Merge.rc:887 Merge.rc:899 Merge.rc:906 Merge.rc:963 Merge.rc:1210
-#: Merge.rc:5375
+#: Merge.rc:5374
 msgid "< Empty >"
 msgstr "< Tom >"
 
@@ -233,7 +233,7 @@ msgid "Auto-Fit All Columns"
 msgstr "Automatisk passning för alla kolumner"
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN
-#: Merge.rc:153 Merge.rc:5646
+#: Merge.rc:153 Merge.rc:5645
 msgid "&Filter by This Column"
 msgstr ""
 
@@ -294,7 +294,7 @@ msgid "&Previous Page"
 msgstr "Föregående sida"
 
 #. IDS_PREVIEWBAR_NEXTPAGE
-#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5679
+#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5678
 msgid "&Next Page"
 msgstr "Nästa sida"
 
@@ -545,7 +545,7 @@ msgstr "Binär"
 #. IDS_IMAGE_MENU
 #: Merge.rc:329 Merge.rc:338 Merge.rc:432 Merge.rc:441 Merge.rc:609
 #: Merge.rc:618 Merge.rc:670 Merge.rc:960 Merge.rc:1187 Merge.rc:1200
-#: Merge.rc:5477
+#: Merge.rc:5476
 msgid "&Image"
 msgstr "Bild"
 
@@ -667,7 +667,7 @@ msgid "&Huge"
 msgstr "Enorm"
 
 #. IDS_VIEW_MENU_BAR
-#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5714
+#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5713
 msgid "Men&u Bar"
 msgstr "Menyrad"
 
@@ -1322,7 +1322,7 @@ msgid "Lo&cation Pane"
 msgstr "Positionsruta"
 
 #. IDS_OUTPUTBAR_CAPTION
-#: Merge.rc:782 Merge.rc:5252
+#: Merge.rc:782 Merge.rc:5251
 msgid "Output Pane"
 msgstr "Utmatningsruta"
 
@@ -1585,55 +1585,55 @@ msgid "Co&mpare As"
 msgstr "Jämför som"
 
 #. IDS_COPY_LEFT_TO_MIDDLE2
-#: Merge.rc:968 Merge.rc:980 Merge.rc:4852
+#: Merge.rc:968 Merge.rc:980 Merge.rc:4851
 #, c-format
 msgid "Left to Middle (%1 of %2)"
 msgstr "Vänster till mitten (%1 av %2)"
 
 #. IDS_COPY_LEFT_TO_RIGHT2
-#: Merge.rc:969 Merge.rc:981 Merge.rc:4851
+#: Merge.rc:969 Merge.rc:981 Merge.rc:4850
 #, c-format
 msgid "Left to Right (%1 of %2)"
 msgstr "Vänster till höger (%1 av %2)"
 
 #. IDS_MOVE_LEFT_TO2
-#: Merge.rc:970 Merge.rc:982 Merge.rc:1045 Merge.rc:4863 Merge.rc:4892
+#: Merge.rc:970 Merge.rc:982 Merge.rc:1045 Merge.rc:4862 Merge.rc:4891
 #, c-format
 msgid "Left to... (%1 of %2)"
 msgstr "Vänster till... (%1 av %2)"
 
 #. IDS_COPY_MIDDLE_TO_LEFT2
-#: Merge.rc:971 Merge.rc:983 Merge.rc:4849
+#: Merge.rc:971 Merge.rc:983 Merge.rc:4848
 #, c-format
 msgid "Middle to Left (%1 of %2)"
 msgstr "Mitten till vänster (%1 av %2)"
 
 #. IDS_COPY_MIDDLE_TO_RIGHT2
-#: Merge.rc:972 Merge.rc:984 Merge.rc:4850
+#: Merge.rc:972 Merge.rc:984 Merge.rc:4849
 #, c-format
 msgid "Middle to Right (%1 of %2)"
 msgstr "Mitten till höger (%1 av %2)"
 
 #. IDS_MOVE_MIDDLE_TO2
-#: Merge.rc:973 Merge.rc:985 Merge.rc:1046 Merge.rc:4864 Merge.rc:4893
+#: Merge.rc:973 Merge.rc:985 Merge.rc:1046 Merge.rc:4863 Merge.rc:4892
 #, c-format
 msgid "Middle to... (%1 of %2)"
 msgstr "Mitten till... (%1 av %2)"
 
 #. IDS_COPY_RIGHT_TO_MIDDLE2
-#: Merge.rc:974 Merge.rc:986 Merge.rc:4848
+#: Merge.rc:974 Merge.rc:986 Merge.rc:4847
 #, c-format
 msgid "Right to Middle (%1 of %2)"
 msgstr "Höger till mitten (%1 av %2)"
 
 #. IDS_COPY_RIGHT_TO_LEFT2
-#: Merge.rc:975 Merge.rc:987 Merge.rc:4847
+#: Merge.rc:975 Merge.rc:987 Merge.rc:4846
 #, c-format
 msgid "Right to Left (%1 of %2)"
 msgstr "Höger till vänster (%1 av %2)"
 
 #. IDS_MOVE_RIGHT_TO2
-#: Merge.rc:976 Merge.rc:988 Merge.rc:1047 Merge.rc:4865 Merge.rc:4894
+#: Merge.rc:976 Merge.rc:988 Merge.rc:1047 Merge.rc:4864 Merge.rc:4893
 #, c-format
 msgid "Right to... (%1 of %2)"
 msgstr "Höger till... (%1 av %2)"
@@ -1689,31 +1689,31 @@ msgid "Cop&y Paths"
 msgstr "Kopiera sökvägar"
 
 #. IDS_DEL_LEFT_FMT2
-#: Merge.rc:1026 Merge.rc:1035 Merge.rc:4880
+#: Merge.rc:1026 Merge.rc:1035 Merge.rc:4879
 #, c-format
 msgid "Left (%1 of %2)"
 msgstr "Vänster (%1 av %2)"
 
 #. IDS_DEL_MIDDLE_FMT2
-#: Merge.rc:1027 Merge.rc:1036 Merge.rc:4881
+#: Merge.rc:1027 Merge.rc:1036 Merge.rc:4880
 #, c-format
 msgid "Middle (%1 of %2)"
 msgstr "Mitten (%1 av %2)"
 
 #. IDS_DEL_RIGHT_FMT2
-#: Merge.rc:1028 Merge.rc:1037 Merge.rc:4882
+#: Merge.rc:1028 Merge.rc:1037 Merge.rc:4881
 #, c-format
 msgid "Right (%1 of %2)"
 msgstr "Höger (%1 av %2)"
 
 #. IDS_DEL_BOTH_FMT2
-#: Merge.rc:1029 Merge.rc:1038 Merge.rc:4883
+#: Merge.rc:1029 Merge.rc:1038 Merge.rc:4882
 #, c-format
 msgid "Both (%1 of %2)"
 msgstr "Båda (%1 av %2)"
 
 #. IDS_DEL_ALL_FMT2
-#: Merge.rc:1030 Merge.rc:1039 Merge.rc:4888
+#: Merge.rc:1030 Merge.rc:1039 Merge.rc:4887
 #, c-format
 msgid "All (%1 of %2)"
 msgstr "Samtliga (%1 av %2)"
@@ -1739,19 +1739,19 @@ msgid "&Zip"
 msgstr "Zip"
 
 #. IDS_COPY_BOTH_TO2
-#: Merge.rc:1048 Merge.rc:4866
+#: Merge.rc:1048 Merge.rc:4865
 #, c-format
 msgid "Both to... (%1 of %2)"
 msgstr "Båda till... (%1 av %2)"
 
 #. IDS_COPY_ALL_TO2
-#: Merge.rc:1049 Merge.rc:4867
+#: Merge.rc:1049 Merge.rc:4866
 #, c-format
 msgid "All to... (%1 of %2)"
 msgstr "Samtliga till... (%1 av %2)"
 
 #. IDS_COPY_DIFFERENCES_TO2
-#: Merge.rc:1050 Merge.rc:4868
+#: Merge.rc:1050 Merge.rc:4867
 #, c-format
 msgid "Differences to... (%1 of %2)"
 msgstr "Skillnader till... (%1 av %2)"
@@ -1818,12 +1818,12 @@ msgstr "Inställningar för uppackare"
 
 #. IDS_USERCHOICE_NONE
 #: Merge.rc:1088 Merge.rc:1094 Merge.rc:1836 Merge.rc:1840 Merge.rc:2031
-#: Merge.rc:2035 Merge.rc:5377
+#: Merge.rc:2035 Merge.rc:5376
 msgid "<None>"
 msgstr "<Ingen>"
 
 #. IDS_USERCHOICE_AUTOMATIC
-#: Merge.rc:1089 Merge.rc:1095 Merge.rc:5378
+#: Merge.rc:1089 Merge.rc:1095 Merge.rc:5377
 msgid "<Automatic>"
 msgstr "<Automatisk>"
 
@@ -2753,12 +2753,12 @@ msgid "Text files only"
 msgstr ""
 
 #. IDS_EOL_NONE
-#: Merge.rc:1667 Merge.rc:1918 Merge.rc:5304
+#: Merge.rc:1667 Merge.rc:1918 Merge.rc:5303
 msgid "None"
 msgstr "Ingen"
 
 #. IDS_EOL_MIXED
-#: Merge.rc:1668 Merge.rc:5299
+#: Merge.rc:1668 Merge.rc:5298
 msgid "Mixed"
 msgstr "Blandat"
 
@@ -3030,13 +3030,13 @@ msgstr ""
 
 #. IDS_DIFFERENT
 #: Merge.rc:1904 Merge.rc:1988 Merge.rc:2866 Merge.rc:3036 Merge.rc:3077
-#: Merge.rc:5058
+#: Merge.rc:5057
 msgid "Different"
 msgstr "Olika"
 
 #. IDS_IDENTICAL
 #: Merge.rc:1905 Merge.rc:1989 Merge.rc:2865 Merge.rc:3055 Merge.rc:3116
-#: Merge.rc:5048
+#: Merge.rc:5047
 msgid "Identical"
 msgstr "Identiska"
 
@@ -3056,7 +3056,7 @@ msgid "Missing"
 msgstr ""
 
 #. IDS_MOVED
-#: Merge.rc:1910 Merge.rc:5076
+#: Merge.rc:1910 Merge.rc:5075
 msgid "Moved"
 msgstr ""
 
@@ -3792,7 +3792,7 @@ msgid "&Use custom system colors"
 msgstr "Använd anpassade systemfärger"
 
 #. IDS_PRPCAT_SYSTEM
-#: Merge.rc:2565 Merge.rc:4559 Merge.rc:4560 Merge.rc:5007
+#: Merge.rc:2565 Merge.rc:4559 Merge.rc:4560 Merge.rc:5006
 msgid "System"
 msgstr "System"
 
@@ -4192,7 +4192,7 @@ msgid "Items compared:"
 msgstr "Jämförda objekt:"
 
 #. IDS_PREVIEWBAR_CLOSE
-#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5685
+#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5684
 msgid "&Close"
 msgstr "Stäng"
 
@@ -4815,7 +4815,7 @@ msgid "A&ppend timestamp"
 msgstr "Lägg till tidstämpel"
 
 #. IDS_CONFIRM_COPY_CAPTION
-#: Merge.rc:3214 Merge.rc:4915
+#: Merge.rc:3214 Merge.rc:4914
 msgid "Confirm Copy"
 msgstr "Bekräfta kopiera"
 
@@ -5052,7 +5052,7 @@ msgid "&Character Set..."
 msgstr "Teckenuppsättning..."
 
 #. IDS_PRPCAT_IMAGE
-#: Merge.rc:3351 Merge.rc:4574 Merge.rc:5015
+#: Merge.rc:3351 Merge.rc:4574 Merge.rc:5014
 msgid "Image"
 msgstr "Bild"
 
@@ -5445,7 +5445,7 @@ msgid "Project"
 msgstr "Projekt"
 
 #. IDS_COLHDR_NSDIFFS
-#: Merge.rc:4566 Merge.rc:4990
+#: Merge.rc:4566 Merge.rc:4989
 msgid "Differences"
 msgstr "Skillnader"
 
@@ -5587,12 +5587,12 @@ msgid "File Type"
 msgstr "Filtyp"
 
 #. IDS_COLHDR_EXTENSION
-#: Merge.rc:4653 Merge.rc:4947
+#: Merge.rc:4653 Merge.rc:4946
 msgid "Extension"
 msgstr "Filändelse"
 
 #. IDS_PRPCAT_MESSAGE
-#: Merge.rc:4659 Merge.rc:5019
+#: Merge.rc:4659 Merge.rc:5018
 msgid "Message"
 msgstr "Meddelande"
 
@@ -5632,7 +5632,7 @@ msgid "Hidden Items"
 msgstr "Dolda objekt"
 
 #. IDS_PLUGINSLIST_NAME
-#: Merge.rc:4680 Merge.rc:5311
+#: Merge.rc:4680 Merge.rc:5310
 msgid "Name"
 msgstr "Namn"
 
@@ -5652,7 +5652,7 @@ msgid "[F] "
 msgstr "[F] "
 
 #. IDS_PLUGINSLIST_DESC
-#: Merge.rc:4684 Merge.rc:5313
+#: Merge.rc:4684 Merge.rc:5312
 msgid "Description"
 msgstr "Beskrivning"
 
@@ -5820,155 +5820,150 @@ msgstr "Rad: %s  Kolumn: %d/%d  Tecken: %d/%d"
 msgid "  Sel: %d | %d"
 msgstr "  Markerat: %d | %d"
 
-#. IDS_MERGEMODE_MERGING
-#: Merge.rc:4734
-msgid "Merge"
-msgstr "Sammanfoga"
-
 #. IDS_DIFF_NUMBER_STATUS_FMT
-#: Merge.rc:4735
+#: Merge.rc:4734
 #, c-format
 msgid "Difference %1 of %2"
 msgstr "Skillnad %1 av %2"
 
 #. IDS_NO_DIFF_SEL_FMT
-#: Merge.rc:4736
+#: Merge.rc:4735
 #, c-format
 msgid "%1 Differences Found"
 msgstr "%1 skillnader funna"
 
 #. IDS_1_DIFF_FOUND
-#: Merge.rc:4737
+#: Merge.rc:4736
 msgid "1 Difference Found"
 msgstr "1 skillnad funnen"
 
 #. IDS_NO_ERR_SEL_FMT
-#: Merge.rc:4738
+#: Merge.rc:4737
 #, c-format
 msgid "%1 Errors Found"
 msgstr "&1 fel funna"
 
 #. IDS_1_ERR_FOUND
-#: Merge.rc:4739
+#: Merge.rc:4738
 msgid "1 Error Found"
 msgstr "1 fel funnet"
 
 #. IDS_STATUSBAR_READONLY, Abbreviation from "Read Only"
-#: Merge.rc:4740
+#: Merge.rc:4739
 msgid "RO"
 msgstr "RO"
 
 #. IDS_DIRVIEW_STATUS_FMT_FOCUS
-#: Merge.rc:4746
+#: Merge.rc:4745
 #, c-format
 msgid "Item %1 of %2"
 msgstr "Förekomst %1 av %2"
 
 #. IDS_DIRVIEW_STATUS_FMT_NOFOCUS
-#: Merge.rc:4747
+#: Merge.rc:4746
 #, c-format
 msgid "Items: %1"
 msgstr "Förekomster: %1"
 
 #. IDS_DIRVIEW_STATUS_COMPARING
-#: Merge.rc:4748
+#: Merge.rc:4747
 msgid "Comparing items..."
 msgstr "Jämför objekt..."
 
 #. IDS_ITEMS_PER_SEC
-#: Merge.rc:4749
+#: Merge.rc:4748
 #, c-format
 msgid "%.1f[items/sec]"
 msgstr "%.1f[objekt/s]"
 
 #. IDS_ERROR_INCOMPARABLE
-#: Merge.rc:4755
+#: Merge.rc:4754
 msgid "Select two existing folders/files to compare."
 msgstr "Välj två befintliga kataloger eller filer att jämföra."
 
 #. IDS_DIRSEL_TAG
-#: Merge.rc:4756
+#: Merge.rc:4755
 msgid "Folder Selection"
 msgstr "Val av katalog"
 
 #. IDS_OPEN_FILESDIRS
-#: Merge.rc:4757
+#: Merge.rc:4756
 msgid "Select two (or three) folders/files to compare."
 msgstr "Välj två (eller tre) filer eller kataloger att jämföra."
 
 #. IDS_OPEN_LEFTINVALID
-#: Merge.rc:4758
+#: Merge.rc:4757
 msgid "Left (1st) path is invalid!"
 msgstr "Vänster (1:a) sökväg är ogiltlig!"
 
 #. IDS_OPEN_MIDDLEINVALID
-#: Merge.rc:4759
+#: Merge.rc:4758
 msgid "Middle (2nd) path is invalid!"
 msgstr "Mittens (2:a) sökväg är ogiltlig!"
 
 #. IDS_OPEN_RIGHTINVALID2
-#: Merge.rc:4760
+#: Merge.rc:4759
 msgid "Right (2nd) path is invalid!"
 msgstr "Höger (2:a) sökväg är ogiltlig!"
 
 #. IDS_OPEN_RIGHTINVALID3
-#: Merge.rc:4761
+#: Merge.rc:4760
 msgid "Right (3rd) path is invalid!"
 msgstr "Höger (3:e) sökväg är ogiltlig!"
 
 #. IDS_OPEN_BOTHINVALID
-#: Merge.rc:4762
+#: Merge.rc:4761
 msgid "Both paths are invalid!"
 msgstr "Båda sökvägarna är ogiltliga!"
 
-#: Merge.rc:4764
+#: Merge.rc:4763
 msgid "Left (1st) and Middle (2nd) paths are invalid!"
 msgstr "Vänster (1:a) och mittens (2:a) sökvägar är ogiltliga!"
 
 #. IDS_OPEN_LEFTRIGHTINVALID
-#: Merge.rc:4765
+#: Merge.rc:4764
 msgid "Left (1st) and Right (3rd) paths are invalid!"
 msgstr "Vänster (1:a) och höger (3:e) sökväg är ogiltliga!"
 
-#: Merge.rc:4767
+#: Merge.rc:4766
 msgid "Middle (2nd) and Right (3rd) paths are invalid!"
 msgstr "Mitten (2:a) och höger (3:e) sökvägar är ogiltliga!"
 
 #. IDS_OPEN_ALLINVALID
-#: Merge.rc:4768
+#: Merge.rc:4767
 msgid "All paths are invalid!"
 msgstr "Samtliga sökvägar är ogiltliga!"
 
 #. IDS_OPEN_UNPACKERDISABLED
-#: Merge.rc:4769
+#: Merge.rc:4768
 msgid "Only enabled for file comparisons"
 msgstr "Endast möjligt vid filjämförelse"
 
 #. IDS_OPEN_MISMATCH
-#: Merge.rc:4770
+#: Merge.rc:4769
 msgid "Cannot compare file and folder!"
 msgstr "Kan inte jämföra fil med en katalog!"
 
 #. IDS_ERROR_FILE_NOT_FOUND
-#: Merge.rc:4776
+#: Merge.rc:4775
 #, c-format
 msgid "File not found: %1"
 msgstr "Kan inte hitta: %1"
 
 #. IDS_ERROR_FOLDER_NOT_FOUND
-#: Merge.rc:4777
+#: Merge.rc:4776
 #, c-format
 msgid "Folder not found: %1"
 msgstr ""
 
 #. IDS_ERROR_FILE_NOT_UNPACKED
-#: Merge.rc:4778
+#: Merge.rc:4777
 #, c-format
 msgid "File not unpacked: %1"
 msgstr "Filen är inte uppackad: %1"
 
 #. IDS_ERROR_FILEOPEN
-#: Merge.rc:4779
+#: Merge.rc:4778
 #, c-format
 msgid ""
 "Cannot open file\n"
@@ -5982,12 +5977,12 @@ msgstr ""
 "%2"
 
 #. IDS_ERROR_CONF_RESOLVE
-#: Merge.rc:4780
+#: Merge.rc:4779
 msgid "Failed to parse conflict file."
 msgstr "Kunde inte tolka konfliktfilen."
 
 #. IDS_NOT_CONFLICT_FILE
-#: Merge.rc:4781
+#: Merge.rc:4780
 #, c-format
 msgid ""
 "The file\n"
@@ -5999,7 +5994,7 @@ msgstr ""
 "är inte en konfliktfil."
 
 #. IDS_COMPARE_LARGE_FILES
-#: Merge.rc:4782
+#: Merge.rc:4781
 msgid ""
 "Comparing large files requires significant memory.\n"
 "Show only comparison results (not file contents)?"
@@ -6008,28 +6003,28 @@ msgstr ""
 "Visa bara jämförresultat (inte filinnehåll)?"
 
 #. IDS_SAVE_AS_TITLE
-#: Merge.rc:4788
+#: Merge.rc:4787
 msgid "Save As"
 msgstr "Spara som"
 
 #. IDS_SAVE_FMT
-#: Merge.rc:4789
+#: Merge.rc:4788
 #, c-format
 msgid "Save changes to %1?"
 msgstr "Spara ändringar i %1?"
 
 #. IDS_SAVEREADONLY_FMT
-#: Merge.rc:4790
+#: Merge.rc:4789
 #, c-format
 msgid "%1 is read-only. Override? Or 'No' to save as new filename?"
 msgstr "%1 är skrivskyddad. Vill du skriva över filen (välj Nej för att spara filen under annat namn)?"
 
 #. IDS_ERROR_BACKUP
-#: Merge.rc:4791
+#: Merge.rc:4790
 msgid "Error backing up file"
 msgstr "Fel vid säkerhetskopiering av filen"
 
-#: Merge.rc:4793
+#: Merge.rc:4792
 #, c-format
 msgid ""
 "Unable to backup original file:\n"
@@ -6043,7 +6038,7 @@ msgstr ""
 "Vill du fortsätta ändå?"
 
 #. IDS_FILESAVE_FAILED
-#: Merge.rc:4794
+#: Merge.rc:4793
 #, c-format
 msgid ""
 "Saving file failed.\n"
@@ -6059,7 +6054,7 @@ msgstr ""
 "\t- använda ett annat filnamn (Tryck OK)\n"
 "\t- avbryta sparande av fil (Tryck Avbryt)?"
 
-#: Merge.rc:4796
+#: Merge.rc:4795
 #, c-format
 msgid ""
 "Plugin '%2' cannot pack changes to left file into '%1'.\n"
@@ -6072,7 +6067,7 @@ msgstr ""
 "\n"
 "Vill du spara den uppackade versionen till en annan fil?"
 
-#: Merge.rc:4798
+#: Merge.rc:4797
 #, c-format
 msgid ""
 "Plugin '%2' cannot pack changes to middle file into '%1'.\n"
@@ -6085,7 +6080,7 @@ msgstr ""
 "\n"
 "Vill du spara den uppackade versionen till en annan fil?"
 
-#: Merge.rc:4800
+#: Merge.rc:4799
 #, c-format
 msgid ""
 "Plugin '%2' cannot pack changes to right file into '%1'.\n"
@@ -6099,7 +6094,7 @@ msgstr ""
 "Vill du spara den uppackade versionen till en annan fil?"
 
 #. IDS_FILECHANGED_ONDISK
-#: Merge.rc:4801
+#: Merge.rc:4800
 #, c-format
 msgid ""
 "Another application updated\n"
@@ -6115,7 +6110,7 @@ msgstr ""
 "Vill du skriva över den ändrade filen ändå?"
 
 #. IDS_SAVEREADONLY_MULTI
-#: Merge.rc:4802
+#: Merge.rc:4801
 #, c-format
 msgid ""
 "%1\n"
@@ -6125,7 +6120,7 @@ msgstr ""
 "är markerad som skrivskyddad. Vill du överskrida detta?"
 
 #. IDS_FILECHANGED_RESCAN
-#: Merge.rc:4803
+#: Merge.rc:4802
 #, c-format
 msgid ""
 "Another application updated\n"
@@ -6141,22 +6136,22 @@ msgstr ""
 "Vill du läsa in den på nytt?"
 
 #. IDS_SAVE_LEFT_AS
-#: Merge.rc:4804
+#: Merge.rc:4803
 msgid "Save Left File As"
 msgstr "Spara vänster fil som"
 
 #. IDS_SAVE_MIDDLE_AS
-#: Merge.rc:4805
+#: Merge.rc:4804
 msgid "Save Middle File As"
 msgstr "Spara fil i mitten som"
 
 #. IDS_SAVE_RIGHT_AS
-#: Merge.rc:4806
+#: Merge.rc:4805
 msgid "Save Right File As"
 msgstr "Spara höger fil som"
 
 #. IDS_FILE_DISAPPEARED
-#: Merge.rc:4811
+#: Merge.rc:4810
 #, c-format
 msgid ""
 "File\n"
@@ -6168,7 +6163,7 @@ msgstr ""
 "har försvunnit. Vänligen spara en kopia av filen för att fortsätta."
 
 #. IDS_VIEWS_OUTOFSYNC
-#: Merge.rc:4817
+#: Merge.rc:4816
 msgid ""
 "Cannot merge unsynched documents.\n"
 "\n"
@@ -6179,186 +6174,186 @@ msgstr ""
 "Läs in filerna på nytt innan du fortsätter."
 
 #. IDS_BREAK_ON_WHITESPACE
-#: Merge.rc:4822
+#: Merge.rc:4821
 msgid "Break at whitespace"
 msgstr "Bryt vid mellanslag"
 
 #. IDS_BREAK_ON_PUNCTUATION
-#: Merge.rc:4823
+#: Merge.rc:4822
 msgid "Break at whitespace or punctuation"
 msgstr "Bryt vid mellanslag eller punkt"
 
 #. IDS_L2M
-#: Merge.rc:4829
+#: Merge.rc:4828
 msgid "Copy to &Middle\tAlt+Right"
 msgstr "Kopiera till &mitten\tAlt+Höger"
 
 #. IDS_R2M
-#: Merge.rc:4830
+#: Merge.rc:4829
 msgid "Copy to &Middle\tAlt+Left"
 msgstr "Kopiera till &mitten\tAlt+Vänster"
 
 #. IDS_COPY_FROM_MIDDLE_R
-#: Merge.rc:4831
+#: Merge.rc:4830
 msgid "Copy from Middle\tAlt+Shift+Right"
 msgstr "Kopiera från mitten\tAlt+Shift+Right"
 
 #. IDS_COPY_FROM_MIDDLE_L
-#: Merge.rc:4832
+#: Merge.rc:4831
 msgid "Copy from Middle\tAlt+Shift+Left"
 msgstr "Kopiera från mitten\tAlt+Shift+Left"
 
 #. IDS_L2MNEXT
-#: Merge.rc:4833
+#: Merge.rc:4832
 msgid "Copy to Middle and Advance\tCtrl+Alt+Right"
 msgstr "Kopiera till mitten och gå till nästa\tCtrl+Alt+Höger"
 
 #. IDS_R2MNEXT
-#: Merge.rc:4834
+#: Merge.rc:4833
 msgid "Copy to Middle and Advance\tCtrl+Alt+Left"
 msgstr "Kopiera till mitten och gå till nästa\tCtrl+Alt+Vänster"
 
 #. IDS_ALL_MIDDLE
-#: Merge.rc:4835
+#: Merge.rc:4834
 msgid "Copy All to Middle"
 msgstr "Kopiera allt till mitten"
 
 #. IDS_COPY_RIGHT_TO_LEFT
-#: Merge.rc:4841
+#: Merge.rc:4840
 #, c-format
 msgid "Right to Left (%1)"
 msgstr "Höger till vänster (%1)"
 
 #. IDS_COPY_RIGHT_TO_MIDDLE
-#: Merge.rc:4842
+#: Merge.rc:4841
 #, c-format
 msgid "Right to Middle (%1)"
 msgstr "Höger till mitten (%1)"
 
 #. IDS_COPY_MIDDLE_TO_LEFT
-#: Merge.rc:4843
+#: Merge.rc:4842
 #, c-format
 msgid "Middle to Left (%1)"
 msgstr "Mitten till vänster (%1)"
 
 #. IDS_COPY_MIDDLE_TO_RIGHT
-#: Merge.rc:4844
+#: Merge.rc:4843
 #, c-format
 msgid "Middle to Right (%1)"
 msgstr "Mitten till höger (%1)"
 
 #. IDS_COPY_LEFT_TO_RIGHT
-#: Merge.rc:4845
+#: Merge.rc:4844
 #, c-format
 msgid "Left to Right (%1)"
 msgstr "Vänster till höger (%1)"
 
 #. IDS_COPY_LEFT_TO_MIDDLE
-#: Merge.rc:4846
+#: Merge.rc:4845
 #, c-format
 msgid "Left to Middle (%1)"
 msgstr "Vänster till mitten (%1)"
 
 #. IDS_MOVE_LEFT_TO
-#: Merge.rc:4857 Merge.rc:4889
+#: Merge.rc:4856 Merge.rc:4888
 #, c-format
 msgid "Left to... (%1)"
 msgstr "Vänster till... (%1)"
 
 #. IDS_MOVE_MIDDLE_TO
-#: Merge.rc:4858 Merge.rc:4890
+#: Merge.rc:4857 Merge.rc:4889
 #, c-format
 msgid "Middle to... (%1)"
 msgstr "Mitten till... (%1)"
 
 #. IDS_MOVE_RIGHT_TO
-#: Merge.rc:4859 Merge.rc:4891
+#: Merge.rc:4858 Merge.rc:4890
 #, c-format
 msgid "Right to... (%1)"
 msgstr "Höger till... (%1)"
 
 #. IDS_COPY_BOTH_TO
-#: Merge.rc:4860
+#: Merge.rc:4859
 #, c-format
 msgid "Both to... (%1)"
 msgstr "Båda till... (%1)"
 
 #. IDS_COPY_ALL_TO
-#: Merge.rc:4861
+#: Merge.rc:4860
 #, c-format
 msgid "All to... (%1)"
 msgstr "Samtliga till... (%1)"
 
 #. IDS_COPY_DIFFERENCES_TO
-#: Merge.rc:4862
+#: Merge.rc:4861
 #, c-format
 msgid "Differences to... (%1)"
 msgstr "Skillnader till... (%1)"
 
 #. IDS_ONLYDIFFITEMS_CONFIRM
-#: Merge.rc:4869
+#: Merge.rc:4868
 msgid "Some selected items are identical or skipped.\nProcess only items with differences?"
 msgstr ""
 
 #. IDS_DEL_LEFT_FMT
-#: Merge.rc:4875
+#: Merge.rc:4874
 #, c-format
 msgid "Left (%1)"
 msgstr "Vänster (%1)"
 
 #. IDS_DEL_MIDDLE_FMT
-#: Merge.rc:4876
+#: Merge.rc:4875
 #, c-format
 msgid "Middle (%1)"
 msgstr "Mitten (%1)"
 
 #. IDS_DEL_RIGHT_FMT
-#: Merge.rc:4877
+#: Merge.rc:4876
 #, c-format
 msgid "Right (%1)"
 msgstr "Höger (%1)"
 
 #. IDS_DEL_BOTH_FMT
-#: Merge.rc:4878
+#: Merge.rc:4877
 #, c-format
 msgid "Both (%1)"
 msgstr "Båda (%1)"
 
 #. IDS_DEL_ALL_FMT
-#: Merge.rc:4879
+#: Merge.rc:4878
 #, c-format
 msgid "All (%1)"
 msgstr "Samtliga (%1)"
 
 #. IDS_SELECT_DEST_LEFT
-#: Merge.rc:4895
+#: Merge.rc:4894
 msgid "Left Side - Select Destination Folder:"
 msgstr "Vänster sida - välj målkatalog:"
 
 #. IDS_SELECT_DEST_MIDDLE
-#: Merge.rc:4896
+#: Merge.rc:4895
 msgid "Middle Side - Select Destination Folder:"
 msgstr "Mitten - välj målkatalog:"
 
 #. IDS_SELECT_DEST_RIGHT
-#: Merge.rc:4897
+#: Merge.rc:4896
 msgid "Right Side - Select Destination Folder:"
 msgstr "Höger sida - välj målkatalog:"
 
 #. IDS_FILES_AFFECTED_FMT
-#: Merge.rc:4898
+#: Merge.rc:4897
 #, c-format
 msgid "(%1 Files Affected)"
 msgstr "(%1 filer påverkade)"
 
 #. IDS_FILES_AFFECTED_FMT2
-#: Merge.rc:4899
+#: Merge.rc:4898
 #, c-format
 msgid "(%1 of %2 Files Affected)"
 msgstr "(%1 av %2 filer påverkade)"
 
 #. IDS_CONFIRM_DELETE_SINGLE
-#: Merge.rc:4905
+#: Merge.rc:4904
 #, c-format
 msgid ""
 "Are you sure you want to delete\n"
@@ -6370,18 +6365,18 @@ msgstr ""
 "%1 ?"
 
 #. IDS_CONFIRM_SINGLE_COPY
-#: Merge.rc:4906
+#: Merge.rc:4905
 msgid "Are you sure you want to copy?"
 msgstr "Är du säker på att du vill kopiera?"
 
 #. IDS_CONFIRM_MULTIPLE_COPY
-#: Merge.rc:4907
+#: Merge.rc:4906
 #, c-format
 msgid "Are you sure you want to copy %d items?"
 msgstr "Är du säker på att du vill kopiera %d objekt?"
 
 #. IDS_DIRCMP_NOTSYNC
-#: Merge.rc:4908
+#: Merge.rc:4907
 #, c-format
 msgid ""
 "Operation aborted!\n"
@@ -6401,46 +6396,46 @@ msgstr ""
 "Vänligen läs in jämförelsen på nytt."
 
 #. IDS_CONFIRM_SINGLE_MOVE
-#: Merge.rc:4913
+#: Merge.rc:4912
 msgid "Are you sure you want to move?"
 msgstr "Är du säker på att du vill flytta?"
 
 #. IDS_CONFIRM_MULTIPLE_MOVE
-#: Merge.rc:4914
+#: Merge.rc:4913
 #, c-format
 msgid "Are you sure you want to move %d items?"
 msgstr "Är du säker på att du vill flytta %d objekt?"
 
 #. IDS_CONFIRM_MOVE_CAPTION
-#: Merge.rc:4916
+#: Merge.rc:4915
 msgid "Confirm Move"
 msgstr "Bekräfta flytt"
 
-#: Merge.rc:4918
+#: Merge.rc:4917
 msgid "Close the folder comparison window?"
 msgstr "Du är på väg att stänga fönstret som jämför kataloger. Är du säker på att du vill stänga fönstret?"
 
-#: Merge.rc:4920
+#: Merge.rc:4919
 msgid "Close the folder comparison window, which took a long time?"
 msgstr "Du är på väg att stänga katalogjämförelsefönstret som tog mycket tid. Är du säker på att du vill stänga fönstret?"
 
 #. IDS_ERROR_INVALID_DIR_FILE_NAME
-#: Merge.rc:4921
+#: Merge.rc:4920
 msgid "The file or folder name is invalid."
 msgstr "Den angivna filen eller katalogen är ogiltig."
 
 #. IDS_ERROR_EXECUTE_FILE
-#: Merge.rc:4927
+#: Merge.rc:4926
 #, c-format
 msgid "Failed to execute external editor: %1"
 msgstr "Kunde inte starta den externa redigeraren: %1"
 
 #. IDS_UNKNOWN_ARCHIVE_FORMAT
-#: Merge.rc:4933
+#: Merge.rc:4932
 msgid "Unknown archive format"
 msgstr "Okänt format för komprimerade mappar"
 
-#: Merge.rc:4935
+#: Merge.rc:4934
 msgid ""
 "Failed to extract archive.\n"
 "Compare as text file?"
@@ -6449,746 +6444,746 @@ msgstr ""
 "Vill du jämföra de komprimerade mapparna som textfiler?"
 
 #. IDS_COLHDR_FILENAME
-#: Merge.rc:4941
+#: Merge.rc:4940
 msgid "Filename"
 msgstr "Filnamn"
 
 #. IDS_COLHDR_DIR
-#: Merge.rc:4942
+#: Merge.rc:4941
 msgctxt "DirView|ColumnHeader"
 msgid "Folder"
 msgstr "Katalog"
 
 #. IDS_COLHDR_RESULT
-#: Merge.rc:4943
+#: Merge.rc:4942
 msgid "Comparison Result"
 msgstr "Jämförelseresultat"
 
 #. IDS_COLHDR_LTIMEM
-#: Merge.rc:4944
+#: Merge.rc:4943
 msgid "Left Date"
 msgstr "Datum vänster"
 
 #. IDS_COLHDR_RTIMEM
-#: Merge.rc:4945
+#: Merge.rc:4944
 msgid "Right Date"
 msgstr "Datum höger"
 
 #. IDS_COLHDR_MTIMEM
-#: Merge.rc:4946
+#: Merge.rc:4945
 msgid "Middle Date"
 msgstr "Datum mitten"
 
 #. IDS_COLHDR_LSIZE
-#: Merge.rc:4948
+#: Merge.rc:4947
 msgid "Left Size"
 msgstr "Storlek vänster"
 
 #. IDS_COLHDR_RSIZE
-#: Merge.rc:4949
+#: Merge.rc:4948
 msgid "Right Size"
 msgstr "Storlek höger"
 
 #. IDS_COLHDR_MSIZE
-#: Merge.rc:4954
+#: Merge.rc:4953
 msgid "Middle Size"
 msgstr "Storlek mitten"
 
 #. IDS_COLHDR_RSIZE_SHORT
-#: Merge.rc:4955
+#: Merge.rc:4954
 msgid "Right Size (Short)"
 msgstr "Storlek höger (kort)"
 
 #. IDS_COLHDR_LSIZE_SHORT
-#: Merge.rc:4956
+#: Merge.rc:4955
 msgid "Left Size (Short)"
 msgstr "Vänster storlek (kort)"
 
 #. IDS_COLHDR_MSIZE_SHORT
-#: Merge.rc:4957
+#: Merge.rc:4956
 msgid "Middle Size (Short)"
 msgstr "Storlek mitten (kort)"
 
 #. IDS_COLHDR_LTIMEC
-#: Merge.rc:4963
+#: Merge.rc:4962
 msgid "Left Creation Time"
 msgstr "Tid skapad vänster"
 
 #. IDS_COLHDR_RTIMEC
-#: Merge.rc:4964
+#: Merge.rc:4963
 msgid "Right Creation Time"
 msgstr "Tid skapad höger"
 
 #. IDS_COLHDR_MTIMEC
-#: Merge.rc:4965
+#: Merge.rc:4964
 msgid "Middle Creation Time"
 msgstr "Skapelsedatum mitten"
 
 #. IDS_COLHDR_NEWER
-#: Merge.rc:4966
+#: Merge.rc:4965
 msgid "Newer File"
 msgstr "Nyare fil"
 
 #. IDS_COLHDR_LVERSION
-#: Merge.rc:4967
+#: Merge.rc:4966
 msgid "Left File Version"
 msgstr "Vänster filversion"
 
 #. IDS_COLHDR_RVERSION
-#: Merge.rc:4968
+#: Merge.rc:4967
 msgid "Right File Version"
 msgstr "Höger filversion"
 
 #. IDS_COLHDR_MVERSION
-#: Merge.rc:4969
+#: Merge.rc:4968
 msgid "Middle File Version"
 msgstr "Filversion i mitten"
 
 #. IDS_COLHDR_RESULT_ABBR
-#: Merge.rc:4970
+#: Merge.rc:4969
 msgid "Short Result"
 msgstr "Kort resultat"
 
 #. IDS_COLHDR_LATTRIBUTES
-#: Merge.rc:4971
+#: Merge.rc:4970
 msgid "Left Attributes"
 msgstr "Attribut vänster"
 
 #. IDS_COLHDR_RATTRIBUTES
-#: Merge.rc:4972
+#: Merge.rc:4971
 msgid "Right Attributes"
 msgstr "Attribut höger"
 
 #. IDS_COLHDR_MATTRIBUTES
-#: Merge.rc:4973
+#: Merge.rc:4972
 msgid "Middle Attributes"
 msgstr "Attribut mitten"
 
 #. IDS_COLHDR_LEOL_TYPE
-#: Merge.rc:4978
+#: Merge.rc:4977
 msgid "Left EOL"
 msgstr "Radslutsformat vänster"
 
 #. IDS_COLHDR_MEOL_TYPE
-#: Merge.rc:4979
+#: Merge.rc:4978
 msgid "Middle EOL"
 msgstr "Radslutsformat mitten"
 
 #. IDS_COLHDR_REOL_TYPE
-#: Merge.rc:4980
+#: Merge.rc:4979
 msgid "Right EOL"
 msgstr "Radslutsformat höger"
 
 #. IDS_COLHDR_LENCODING
-#: Merge.rc:4986
+#: Merge.rc:4985
 msgid "Left Encoding"
 msgstr "Teckenukodning vänster"
 
 #. IDS_COLHDR_RENCODING
-#: Merge.rc:4987
+#: Merge.rc:4986
 msgid "Right Encoding"
 msgstr "Teckenkodning höger"
 
 #. IDS_COLHDR_MENCODING
-#: Merge.rc:4988
+#: Merge.rc:4987
 msgid "Middle Encoding"
 msgstr "Teckenkodning mitten"
 
 #. IDS_COLHDR_NIDIFFS
-#: Merge.rc:4989
+#: Merge.rc:4988
 msgid "Ignored Diff"
 msgstr "Ignorerade skillnader"
 
 #. IDS_COLHDR_BINARY
-#: Merge.rc:4991
+#: Merge.rc:4990
 msgctxt "DirView|ColumnHeader"
 msgid "Binary"
 msgstr "Binär"
 
 #. IDS_PLUGINS_TYPE_UNPACKER
-#: Merge.rc:4992 Merge.rc:5314
+#: Merge.rc:4991 Merge.rc:5313
 msgid "Unpacker"
 msgstr "Uppackare"
 
 #. IDS_PLUGIN_TYPE4
-#: Merge.rc:4993 Merge.rc:5315 Merge.rc:5622
+#: Merge.rc:4992 Merge.rc:5314 Merge.rc:5621
 msgid "Prediffer"
 msgstr "Förjämförelse/Prediffer"
 
 #. IDS_COLHDR_LEFT
-#: Merge.rc:4994
+#: Merge.rc:4993
 msgid "Left"
 msgstr "Vänster"
 
 #. IDS_COLHDR_MIDDLE
-#: Merge.rc:4995
+#: Merge.rc:4994
 msgid "Middle"
 msgstr "Mitten"
 
 #. IDS_COLHDR_RIGHT
-#: Merge.rc:4996
+#: Merge.rc:4995
 msgid "Right"
 msgstr "Höger"
 
 #. IDS_COLHDR_DIFF
-#: Merge.rc:4997
+#: Merge.rc:4996
 msgid "Diff"
 msgstr "Skillnad"
 
 #. IDS_COLHDR_LEFT_DUPLICATE
-#: Merge.rc:4998
+#: Merge.rc:4997
 msgid "Left Duplicate Count"
 msgstr "Dubblettantal vänster"
 
 #. IDS_COLHDR_RIGHT_DUPLICATE
-#: Merge.rc:4999
+#: Merge.rc:4998
 msgid "Right Duplicate Count"
 msgstr "Dubblettantal höger"
 
 #. IDS_COLHDR_MIDDLE_DUPLICATE
-#: Merge.rc:5000
+#: Merge.rc:4999
 msgid "Middle Duplicate Count"
 msgstr "Dubblettantal i mitten"
 
 #. IDS_COLHDR_MOVE
-#: Merge.rc:5001
+#: Merge.rc:5000
 msgid "Move"
 msgstr "Flytta"
 
 #. IDS_PRPCAT_AUDIO
-#: Merge.rc:5008
+#: Merge.rc:5007
 msgid "Audio"
 msgstr "Ljud"
 
 #. IDS_PRPCAT_CALENDAR
-#: Merge.rc:5009
+#: Merge.rc:5008
 msgid "Calendar"
 msgstr "Kalender"
 
 #. IDS_PRPCAT_COMMUNICATION
-#: Merge.rc:5010
+#: Merge.rc:5009
 msgid "Communication"
 msgstr "Kommunikation"
 
 #. IDS_PRPCAT_CONTACT
-#: Merge.rc:5011
+#: Merge.rc:5010
 msgid "Contact"
 msgstr "Kontakt"
 
 #. IDS_PRPCAT_DEVICES
-#: Merge.rc:5012
+#: Merge.rc:5011
 msgid "Devices"
 msgstr "Enheter"
 
 #. IDS_PRPCAT_DOCUMENT
-#: Merge.rc:5013
+#: Merge.rc:5012
 msgid "Document"
 msgstr "Dokument"
 
 #. IDS_PRPCAT_HOME
-#: Merge.rc:5014
+#: Merge.rc:5013
 msgid "Home"
 msgstr "Hem"
 
 #. IDS_PRPCAT_JOURNAL
-#: Merge.rc:5016
+#: Merge.rc:5015
 msgid "Journal"
 msgstr "Journal"
 
 #. IDS_PRPCAT_LINK
-#: Merge.rc:5017
+#: Merge.rc:5016
 msgid "Link"
 msgstr "Länk"
 
 #. IDS_PRPCAT_MEDIA
-#: Merge.rc:5018
+#: Merge.rc:5017
 msgid "Media"
 msgstr "Media"
 
 #. IDS_PRPCAT_MUSIC
-#: Merge.rc:5020
+#: Merge.rc:5019
 msgid "Music"
 msgstr "Musik"
 
 #. IDS_PRPCAT_NOTE
-#: Merge.rc:5021
+#: Merge.rc:5020
 msgid "Note"
 msgstr "Anteckning"
 
 #. IDS_PRPCAT_PHOTO
-#: Merge.rc:5022
+#: Merge.rc:5021
 msgid "Photo"
 msgstr "Foto"
 
 #. IDS_PRPCAT_RECORDEDTV
-#: Merge.rc:5023
+#: Merge.rc:5022
 msgid "RecordedTV"
 msgstr "Inspelad TV"
 
 #. IDS_PRPCAT_SEARCH
-#: Merge.rc:5024
+#: Merge.rc:5023
 msgid "Search"
 msgstr "Sök"
 
 #. IDS_PRPCAT_SECURITY
-#: Merge.rc:5025
+#: Merge.rc:5024
 msgid "Security"
 msgstr "Säkerhet"
 
 #. IDS_PRPCAT_SOFTWARE
-#: Merge.rc:5026
+#: Merge.rc:5025
 msgid "Software"
 msgstr "Mjukvara"
 
 #. IDS_PRPCAT_TASK
-#: Merge.rc:5027
+#: Merge.rc:5026
 msgid "Task"
 msgstr "Uppgift"
 
 #. IDS_PRPCAT_VIDEO
-#: Merge.rc:5028
+#: Merge.rc:5027
 msgid "Video"
 msgstr "Video"
 
 #. IDS_PRPCAT_HASH
-#: Merge.rc:5029
+#: Merge.rc:5028
 msgid "Hash"
 msgstr "Kontrollsumma"
 
 #. IDS_CANT_COMPARE_FILES
-#: Merge.rc:5035
+#: Merge.rc:5034
 msgid "Unable to compare files"
 msgstr "Kan inte jämföra filerna"
 
 #. IDS_ABORTED_ITEM
-#: Merge.rc:5036
+#: Merge.rc:5035
 msgid "Item aborted"
 msgstr "Objekt avbrutet"
 
 #. IDS_FILE_SKIPPED
-#: Merge.rc:5037
+#: Merge.rc:5036
 msgid "File skipped"
 msgstr "Hoppade över filen"
 
 #. IDS_DIR_SKIPPED
-#: Merge.rc:5038
+#: Merge.rc:5037
 msgid "Folder skipped"
 msgstr "Hoppade över katalogen"
 
 #. IDS_LEFT_ONLY_IN_FMT
-#: Merge.rc:5039
+#: Merge.rc:5038
 #, c-format
 msgid "Left only: %1"
 msgstr "Bara vänster: %1"
 
 #. IDS_MIDDLE_ONLY_IN_FMT
-#: Merge.rc:5040
+#: Merge.rc:5039
 #, c-format
 msgid "Middle only: %1"
 msgstr "Bara mitten: %1"
 
 #. IDS_RIGHT_ONLY_IN_FMT
-#: Merge.rc:5041
+#: Merge.rc:5040
 #, c-format
 msgid "Right only: %1"
 msgstr "Bara höger: %1"
 
 #. IDS_DOES_NOT_EXIST_IN_FMT
-#: Merge.rc:5042
+#: Merge.rc:5041
 #, c-format
 msgid "Does not exist in %1"
 msgstr "Finns ej i %1"
 
 #. IDS_BIN_FILES_SAME
-#: Merge.rc:5043
+#: Merge.rc:5042
 msgid "Binary files are identical"
 msgstr "De binära filerna är identiska"
 
 #. IDS_BIN_FILES_DIFF
-#: Merge.rc:5049
+#: Merge.rc:5048
 msgid "Binary files are different"
 msgstr "De binära filerna är olika"
 
 #. IDS_FILES_ARE_DIFFERENT
-#: Merge.rc:5050
+#: Merge.rc:5049
 msgid "Files are different"
 msgstr "Filerna är olika"
 
 #. IDS_FOLDERS_ARE_DIFFERENT
-#: Merge.rc:5051
+#: Merge.rc:5050
 msgid "Folders are different"
 msgstr "Katalogerna är olika"
 
 #. IDS_LEFTONLY
-#: Merge.rc:5052
+#: Merge.rc:5051
 msgid "Left Only"
 msgstr "Endast vänster"
 
 #. IDS_RIGHTONLY
-#: Merge.rc:5053
+#: Merge.rc:5052
 msgid "Right Only"
 msgstr "Endast höger"
 
 #. IDS_MIDDLEONLY
-#: Merge.rc:5054
+#: Merge.rc:5053
 msgid "Middle Only"
 msgstr "Endast i mitten"
 
 #. IDS_NOITEMLEFT
-#: Merge.rc:5055
+#: Merge.rc:5054
 msgid "No item in left"
 msgstr "Inga objekt i vänster"
 
 #. IDS_NOITEMRIGHT
-#: Merge.rc:5056
+#: Merge.rc:5055
 msgid "No item in right"
 msgstr "Inga objekt i höger"
 
 #. IDS_NOITEMMIDDLE
-#: Merge.rc:5057
+#: Merge.rc:5056
 msgid "No item in middle"
 msgstr "Inga objekt i mitten"
 
 #. IDS_CMPRES_ERROR
-#: Merge.rc:5059
+#: Merge.rc:5058
 msgid "Error"
 msgstr "Fel"
 
 #. IDS_TEXT_FILES_SAME
-#: Merge.rc:5060
+#: Merge.rc:5059
 msgid "Text files are identical"
 msgstr "Textfilerna är identiska"
 
 #. IDS_LEFTONLY_DIFF
-#: Merge.rc:5061
+#: Merge.rc:5060
 msgid " (Middle and right are identical)"
 msgstr " (Mitten och höger är identiska)"
 
 #. IDS_MIDDLEONLY_DIFF
-#: Merge.rc:5062
+#: Merge.rc:5061
 msgid " (Left and right are identical)"
 msgstr " (Vänster och höger är identiska)"
 
 #. IDS_RIGHTONLY_DIFF
-#: Merge.rc:5063
+#: Merge.rc:5062
 msgid " (Left and middle are identical)"
 msgstr " (Vänster och mitten är identiska)"
 
 #. IDS_PATH_MISMATCH
-#: Merge.rc:5064
+#: Merge.rc:5063
 msgid " (paths differ)"
 msgstr ""
 
 #. IDS_TEXT_FILES_DIFF
-#: Merge.rc:5065
+#: Merge.rc:5064
 msgid "Text files are different"
 msgstr "Textfilerna är olika"
 
 #. IDS_IMAGE_FILES_SAME
-#: Merge.rc:5066
+#: Merge.rc:5065
 msgid "Image files are identical"
 msgstr "Bilderna är identiska"
 
 #. IDS_IMAGE_FILES_DIFF
-#: Merge.rc:5067
+#: Merge.rc:5066
 msgid "Image files are different"
 msgstr "Bilderna är olika"
 
 #. IDS_EXPR_DIFF
-#: Merge.rc:5068
+#: Merge.rc:5067
 #, c-format
 msgid "Files are different (expr: %1)"
 msgstr ""
 
 #. IDS_HASH_GROUP
-#: Merge.rc:5069
+#: Merge.rc:5068
 #, c-format
 msgid "Group%d"
 msgstr "Grupp%d"
 
 #. IDS_RENAME_MOVE_DETECTION_DISALBED
-#: Merge.rc:5070
+#: Merge.rc:5069
 msgctxt "Options dialog|Compare|Folder|Detect renames and moves"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_RENAME_MOVE_DETECTION_RENAME
-#: Merge.rc:5071
+#: Merge.rc:5070
 msgid "Detect renames"
 msgstr ""
 
 #. IDS_RENAME_MOVE_DETECTION_RENAME_MOVE
-#: Merge.rc:5072
+#: Merge.rc:5071
 msgid "Detect renames and moves"
 msgstr ""
 
 #. IDS_RENAME_MOVE_MERGE_MODE_RENAME
-#: Merge.rc:5073
+#: Merge.rc:5072
 msgid "Merge renames"
 msgstr ""
 
 #. IDS_RENAME_MOVE_MERGE_MODE_RENAME_MOVE
-#: Merge.rc:5074
+#: Merge.rc:5073
 msgid "Merge renames and moves"
 msgstr ""
 
 #. IDS_RENAMED
-#: Merge.rc:5075
+#: Merge.rc:5074
 msgid "Renamed"
 msgstr ""
 
 #. IDS_RENAMED_MOVED
-#: Merge.rc:5077
+#: Merge.rc:5076
 msgid "Renamed/Moved"
 msgstr ""
 
 #. IDS_RENAMED_MOVED_ITEMS
-#: Merge.rc:5078
+#: Merge.rc:5077
 #, c-format
 msgid "(%1 items)"
 msgstr ""
 
 #. IDS_RENAMED_MOVED_RESULT
-#: Merge.rc:5079
+#: Merge.rc:5078
 #, c-format
 msgid "%1 (set %2): "
 msgstr ""
 
 #. IDS_SWITCH_FLAT_MODE
-#: Merge.rc:5080
+#: Merge.rc:5079
 msgid "Some moved items have been merged.\nIn Tree Mode, these items may appear in positions that do not reflect the actual folder structure, which can be confusing.\nSwitch to Flat Mode?"
 msgstr ""
 
 #. IDS_ELAPSED_TIME
-#: Merge.rc:5086
+#: Merge.rc:5085
 #, c-format
 msgid "Elapsed time: %ld ms"
 msgstr "Tidsförlopp: %ld ms"
 
 #. IDS_STATUS_SELITEM1
-#: Merge.rc:5087
+#: Merge.rc:5086
 msgid "1 item selected"
 msgstr "1 objekt valt"
 
 #. IDS_STATUS_SELITEMS
-#: Merge.rc:5088
+#: Merge.rc:5087
 #, c-format
 msgid "%1 items selected"
 msgstr "%1 objekt valda"
 
 #. IDS_COLDESC_FILENAME
-#: Merge.rc:5094
+#: Merge.rc:5093
 msgid "Filename or folder name."
 msgstr "Fil- eller katalognamn."
 
 #. IDS_COLDESC_DIR
-#: Merge.rc:5095
+#: Merge.rc:5094
 msgid "Subfolder name when subfolders are included."
 msgstr "Namn på underkatalog när underkataloger omfattas."
 
 #. IDS_COLDESC_RESULT
-#: Merge.rc:5096
+#: Merge.rc:5095
 msgid "Comparison result, long form."
 msgstr "Jämförelseresultat, lång version."
 
 #. IDS_COLDESC_LTIMEM
-#: Merge.rc:5101
+#: Merge.rc:5100
 msgid "Left side modification date."
 msgstr "Ändringsdatum för vänster sida."
 
 #. IDS_COLDESC_RTIMEM
-#: Merge.rc:5102
+#: Merge.rc:5101
 msgid "Right side modification date."
 msgstr "Ändringsdatum för höger sida."
 
 #. IDS_COLDESC_MTIMEM
-#: Merge.rc:5103
+#: Merge.rc:5102
 msgid "Middle side modification date."
 msgstr "Ändringsdatum för mitten."
 
 #. IDS_COLDESC_EXTENSION
-#: Merge.rc:5104
+#: Merge.rc:5103
 msgid "File's extension."
 msgstr "Filtillägg."
 
 #. IDS_COLDESC_LSIZE
-#: Merge.rc:5105
+#: Merge.rc:5104
 msgid "Left file size in bytes."
 msgstr "Vänster fils storlek i bytes."
 
 #. IDS_COLDESC_RSIZE
-#: Merge.rc:5106
+#: Merge.rc:5105
 msgid "Right file size in bytes."
 msgstr "Höger fils storlek i bytes."
 
 #. IDS_COLDESC_MSIZE
-#: Merge.rc:5107
+#: Merge.rc:5106
 msgid "Middle file size in bytes."
 msgstr "Filstorlek för mitten."
 
 #. IDS_COLDESC_LSIZE_SHORT
-#: Merge.rc:5108
+#: Merge.rc:5107
 msgid "Left file size abbreviated."
 msgstr "Vänster filstorlek är förkortad."
 
 #. IDS_COLDESC_RSIZE_SHORT
-#: Merge.rc:5109
+#: Merge.rc:5108
 msgid "Right file size abbreviated."
 msgstr "Höger filstorlek är förkortad."
 
 #. IDS_COLDESC_MSIZE_SHORT
-#: Merge.rc:5110
+#: Merge.rc:5109
 msgid "Middle file size abbreviated."
 msgstr "Filstorlek för mitten är förkortad."
 
 #. IDS_COLDESC_LTIMEC
-#: Merge.rc:5116
+#: Merge.rc:5115
 msgid "Left side creation time."
 msgstr "Tid för skapelse av vänster sida."
 
 #. IDS_COLDESC_RTIMEC
-#: Merge.rc:5117
+#: Merge.rc:5116
 msgid "Right side creation time."
 msgstr "Tid för skapelse av höger sida."
 
 #. IDS_COLDESC_MTIMEC
-#: Merge.rc:5118
+#: Merge.rc:5117
 msgid "Middle side creation time."
 msgstr "Tid för skapelse av mitten."
 
 #. IDS_COLDESC_NEWER
-#: Merge.rc:5119
+#: Merge.rc:5118
 msgid "Tells which side has newer modification date."
 msgstr "Visar vilken sida som har en senare tidpunkt för ändringar."
 
 #. IDS_COLDESC_LVERSION
-#: Merge.rc:5120
+#: Merge.rc:5119
 msgid "Left side file version, only for some file types."
 msgstr "Filversion vänster sida, bara för några filtyper."
 
 #. IDS_COLDESC_RVERSION
-#: Merge.rc:5121
+#: Merge.rc:5120
 msgid "Right side file version, only for some file types."
 msgstr "Filversion höger sida, bara för några filtyper."
 
 #. IDS_COLDESC_MVERSION
-#: Merge.rc:5126
+#: Merge.rc:5125
 msgid "Middle side file version, only for some file types."
 msgstr "Filversion mitten, bara för några filtyper."
 
 #. IDS_COLDESC_RESULT_ABBR
-#: Merge.rc:5127
+#: Merge.rc:5126
 msgid "Short comparison result."
 msgstr "Kort jämförelseresultat."
 
 #. IDS_COLDESC_LATTRIBUTES
-#: Merge.rc:5128
+#: Merge.rc:5127
 msgid "Left side attributes."
 msgstr "Filattribut för vänster sida."
 
 #. IDS_COLDESC_RATTRIBUTES
-#: Merge.rc:5129
+#: Merge.rc:5128
 msgid "Right side attributes."
 msgstr "Filattribut för höger sida."
 
 #. IDS_COLDESC_MATTRIBUTES
-#: Merge.rc:5130
+#: Merge.rc:5129
 msgid "Middle side attributes."
 msgstr "Filattribut för mitten."
 
 #. IDS_COLDESC_LEOL_TYPE
-#: Merge.rc:5131
+#: Merge.rc:5130
 msgid "Left side file EOL type."
 msgstr "Radslutsformat för vänster sida."
 
 #. IDS_COLDESC_REOL_TYPE
-#: Merge.rc:5132
+#: Merge.rc:5131
 msgid "Right side file EOL type."
 msgstr "Radslutsformat för höger sida."
 
 #. IDS_COLDESC_MEOL_TYPE
-#: Merge.rc:5133
+#: Merge.rc:5132
 msgid "Middle side file EOL type."
 msgstr "Radslutsformat för mitten."
 
 #. IDS_COLDESC_LENCODING
-#: Merge.rc:5139
+#: Merge.rc:5138
 msgid "Left side encoding."
 msgstr "Filkodning/teckenuppsättning för vänster sida."
 
 #. IDS_COLDESC_RENCODING
-#: Merge.rc:5140
+#: Merge.rc:5139
 msgid "Right side encoding."
 msgstr "Filkodning/teckenuppsättning för höger sida."
 
 #. IDS_COLDESC_MENCODING
-#: Merge.rc:5141
+#: Merge.rc:5140
 msgid "Middle side encoding."
 msgstr "Filkodning/teckenuppsättning för mitten."
 
 #. IDS_COLDESC_NIDIFFS
-#: Merge.rc:5142
+#: Merge.rc:5141
 msgid "Number of ignored differences in file. Ignored and cannot be merged."
 msgstr "Antalet ignorerade skillnader i filen. Dessa skillnader ignorerades av WinMerge och kan inte sammanfogas."
 
 #. IDS_COLDESC_NSDIFFS
-#: Merge.rc:5143
+#: Merge.rc:5142
 msgid "Number of differences in file (excluding ignored)."
 msgstr "Antalet skillnader i filen. Detta antal omfattar inte ignorerade skillnader."
 
 #. IDS_COLDESC_BINARY
-#: Merge.rc:5144
+#: Merge.rc:5143
 msgid "Shows an asterisk (*) if the file is binary."
 msgstr "Visar en asterisk (*) om filen är binär."
 
 #. IDS_COLDESC_UNPACKER
-#: Merge.rc:5145
+#: Merge.rc:5144
 msgid "Unpacker plugin name or pipeline."
 msgstr "Namn på uppackare eller kommandoslinga."
 
 #. IDS_COLDESC_PREDIFFER
-#: Merge.rc:5146
+#: Merge.rc:5145
 msgid "Prediffer plugin name or pipeline."
 msgstr "Prediffer pluginnamn eller process."
 
 #. IDS_DIRECTORY_REPORT_TITLE
-#: Merge.rc:5152
+#: Merge.rc:5151
 #, c-format
 msgid "Compare %1 with %2"
 msgstr "Jämför %1 med %2"
 
 #. IDS_DIRECTORY_REPORT_TITLE3
-#: Merge.rc:5153
+#: Merge.rc:5152
 #, c-format
 msgid "Compare %1 with %2 and %3"
 msgstr "Jämför %1 med %2 och %3"
 
 #. IDS_REPORT_COMMALIST
-#: Merge.rc:5154
+#: Merge.rc:5153
 msgid "Comma-separated list"
 msgstr "Kommaseparerad lista"
 
 #. IDS_REPORT_TABLIST
-#: Merge.rc:5155
+#: Merge.rc:5154
 msgid "Tab-separated list"
 msgstr "Tabbavgränsad lista"
 
 #. IDS_REPORT_SIMPLEHTML
-#: Merge.rc:5156
+#: Merge.rc:5155
 msgid "Simple HTML"
 msgstr "Enkel HTML"
 
 #. IDS_REPORT_SIMPLEXML
-#: Merge.rc:5157
+#: Merge.rc:5156
 msgid "Simple XML"
 msgstr "Enkel XML"
 
-#: Merge.rc:5159
+#: Merge.rc:5158
 msgid "Report file already exists. Overwrite?"
 msgstr "Rapportfilen finns redan. Vill du skriva över befintlig fil?"
 
 #. IDS_REPORT_ERROR
-#: Merge.rc:5164
+#: Merge.rc:5163
 #, c-format
 msgid ""
 "Error creating the report:\n"
@@ -7198,57 +7193,57 @@ msgstr ""
 "%1"
 
 #. IDS_REPORT_SUCCESS
-#: Merge.rc:5165
+#: Merge.rc:5164
 msgid "Report created successfully."
 msgstr "Rapporten har skapats."
 
 #. IDS_SYNCPOINT_LASTBLOCK
-#: Merge.rc:5171
+#: Merge.rc:5170
 msgid "Cannot add a synchronization point at this line."
 msgstr "Kan ej lägga till synkroniseringspunkt på denna rad."
 
 #. IDS_FILE_TO_ITSELF
-#: Merge.rc:5177
+#: Merge.rc:5176
 msgid "Same file is opened in both panes."
 msgstr "Samma fil är öppnad i båda rutorna."
 
 #. IDS_FILESSAME
-#: Merge.rc:5178
+#: Merge.rc:5177
 msgid "Selected files are identical."
 msgstr "De valda filerna är identiska."
 
 #. IDS_FILESSAME_CURCFG
-#: Merge.rc:5179
+#: Merge.rc:5178
 msgid "Selected files are identical (with current settings).\r\nChecking binary identity..."
 msgstr ""
 
 #. IDS_FILESSAME_BINERROR
-#: Merge.rc:5180
+#: Merge.rc:5179
 msgid "Selected files are identical (with current settings).\r\nBut binary comparison failed."
 msgstr ""
 
 #. IDS_FILESSAME_BINSAME
-#: Merge.rc:5181
+#: Merge.rc:5180
 msgid "Selected files are identical (binary match)."
 msgstr ""
 
 #. IDS_FILESSAME_BINDIFF
-#: Merge.rc:5182
+#: Merge.rc:5181
 msgid "Selected files are identical (with current settings).\r\nBut differ at the binary level."
 msgstr ""
 
 #. IDS_FILEERROR
-#: Merge.rc:5183
+#: Merge.rc:5182
 msgid "An error occurred while comparing files."
 msgstr "Ett fel inträffade under jämförelsen av filerna."
 
 #. IDS_TEMP_FILEERROR
-#: Merge.rc:5184
+#: Merge.rc:5183
 msgid "Could not create temporary files. Check your temporary path settings."
 msgstr "Temporära filer kunde inte skapas. Kontrollera sökvägar för temporära filer under inställningar."
 
 #. IDS_SUGGEST_IGNOREEOL
-#: Merge.rc:5185
+#: Merge.rc:5184
 msgid ""
 "Files use different EOL.\n"
 "\n"
@@ -7263,17 +7258,17 @@ msgstr ""
 "Notera: Om du alltid vill behandla alla tecken för radslut som likvärdiga, markera alternativet 'Ignorera skillnader i radslut (Windows/Unix/Mac)' i Jämför-fliken i Inställningarna (finns under Redigera/Inställningar)."
 
 #. IDS_INVALID_DIRECTORY
-#: Merge.rc:5186
+#: Merge.rc:5185
 msgid "Selected folder is invalid."
 msgstr "Den angivna katalogen är ogiltig."
 
 #. IDS_CANNOT_OPEN_BINARYFILE
-#: Merge.rc:5187
+#: Merge.rc:5186
 msgid "Cannot open a binary file in Editor."
 msgstr "Kan inte öppna en binär fil för redigering."
 
 #. IDS_CREATE_PAIR_FOLDER
-#: Merge.rc:5188
+#: Merge.rc:5187
 #, c-format
 msgid ""
 "Create matching folder:\n"
@@ -7287,41 +7282,41 @@ msgstr ""
 "på andra sidan och öppna dessa kataloger?"
 
 #. IDS_CONFIRM_COPY_ALL_DIFFS
-#: Merge.rc:5189
+#: Merge.rc:5188
 msgid "Copy all differences to other file?"
 msgstr "Är du säker att du vill kopiera alla skillnader till den andra filen?"
 
 #. IDS_MOVE_TO_NEXTFILE
-#: Merge.rc:5194
+#: Merge.rc:5193
 msgid "Move to next file?"
 msgstr "Vill du gå till nästa fil?"
 
 #. IDS_MOVE_TO_PREVFILE
-#: Merge.rc:5195
+#: Merge.rc:5194
 msgid "Move to previous file?"
 msgstr "Vill du gå till föregående fil?"
 
 #. IDS_MOVE_TO_NEXTPAGE
-#: Merge.rc:5196
+#: Merge.rc:5195
 msgid "Move to next page?"
 msgstr "Vill du gå till nästa sida?"
 
 #. IDS_MOVE_TO_PREVPAGE
-#: Merge.rc:5197
+#: Merge.rc:5196
 msgid "Move to previous page?"
 msgstr "Vill du gå till föregående sida?"
 
 #. IDS_MOVE_TO_FIRSTFILE
-#: Merge.rc:5198
+#: Merge.rc:5197
 msgid "Move to first file?"
 msgstr "Vill du gå till den första filen?"
 
 #. IDS_MOVE_TO_LASTFILE
-#: Merge.rc:5199
+#: Merge.rc:5198
 msgid "Move to last file?"
 msgstr "Vill du gå till den sista filen?"
 
-#: Merge.rc:5206
+#: Merge.rc:5205
 #, c-format
 msgid ""
 "Different codepages: left (cp%d), right (cp%d).\n"
@@ -7332,51 +7327,51 @@ msgstr ""
 "Att visa  filerna i deras egna kodning ger en bättre visning men sammanfogning/kopiering blir farligt.\n"
 "Vill du att båda filer betraktas som att de är i Windows förvalda kodning (rekommenderat)?"
 
-#: Merge.rc:5208
+#: Merge.rc:5207
 msgid "Information lost due to encoding errors: both files"
 msgstr "Information förlorades på grund av teckenkodningsfel i: båda filerna"
 
-#: Merge.rc:5210
+#: Merge.rc:5209
 msgid "Information lost due to encoding errors: first file"
 msgstr "Information förlorades på grund av teckenkodningsfel i: första filen"
 
-#: Merge.rc:5212
+#: Merge.rc:5211
 msgid "Information lost due to encoding errors: second file"
 msgstr "Information förlorades på grund av teckenkodningsfel i: andra filen"
 
-#: Merge.rc:5214
+#: Merge.rc:5213
 msgid "Information lost due to encoding errors: third file"
 msgstr "Information förlorades på grund av teckenkodningsfel i: tredje filen"
 
 #. IDS_LINEDIFF_NODIFF
-#: Merge.rc:5220
+#: Merge.rc:5219
 msgid "No difference"
 msgstr "Ingen skillnad"
 
 #. IDS_LINEDIFF_NODIFF_CAPTION
-#: Merge.rc:5221
+#: Merge.rc:5220
 msgid "Line difference"
 msgstr "Radskillnad"
 
 #. IDS_NUM_REPLACED
-#: Merge.rc:5227
+#: Merge.rc:5226
 #, c-format
 msgid "Replaced %1 string(s)."
 msgstr "Ersatt %1 sträng(ar)."
 
 #. IDS_EDIT_TEXT_NOT_FOUND
-#: Merge.rc:5228
+#: Merge.rc:5227
 #, c-format
 msgid "Cannot find string \"%s\"."
 msgstr "Kan inte hitta strängen \"%s\"."
 
 #. IDS_MERGE_MODE
-#: Merge.rc:5234
+#: Merge.rc:5233
 msgid "Entering Merge Mode. Press F9 to turn off."
 msgstr "Du går nu in i sammanfogningsläge. Om du vill avbryta detta läge, tryck på 'F9'."
 
 #. IDS_AUTO_MERGE
-#: Merge.rc:5240
+#: Merge.rc:5239
 #, c-format
 msgid ""
 "Automatic merges: %1\n"
@@ -7386,89 +7381,89 @@ msgstr ""
 "Antalet ouppklarade konflikter: %2"
 
 #. IDS_CODEPAGE_MERGED
-#: Merge.rc:5241
+#: Merge.rc:5240
 msgid "Codepage change merged."
 msgstr "Ändringen av teckenkodning har gjorts."
 
 #. IDS_CODEPAGE_CONFLICT
-#: Merge.rc:5242
+#: Merge.rc:5241
 msgid "Codepage changes are conflicting."
 msgstr "Ändringar i teckenuppsättning är under konflikt."
 
 #. IDS_EOL_MERGED
-#: Merge.rc:5243
+#: Merge.rc:5242
 msgid "EOL change merged."
 msgstr "Ändringar av tecken för radslut har gjorts."
 
 #. IDS_EOL_CONFLICT
-#: Merge.rc:5244
+#: Merge.rc:5243
 msgid "EOL changes are conflicting."
 msgstr "Ändringar av tecken för radslut är under konflikt."
 
 #. IDS_LOCBAR_CAPTION
-#: Merge.rc:5250
+#: Merge.rc:5249
 msgid "Location Pane"
 msgstr "Översiktsruta"
 
 #. IDS_DIFFBAR_CAPTION
-#: Merge.rc:5251
+#: Merge.rc:5250
 msgid "Diff Pane"
 msgstr "Ruta för differensöverssikt"
 
 #. IDS_DIFF_SUCCEEDED
-#: Merge.rc:5258
+#: Merge.rc:5257
 msgid "Patch file written."
 msgstr "Patchfilen sparades."
 
 #. IDS_DIFF_FILEOVERWRITE
-#: Merge.rc:5259
+#: Merge.rc:5258
 msgid "Patch file already exists. Overwrite?"
 msgstr "Patchfilen finns redan. Vill du skriva över den?"
 
 #. IDS_DIFF_SELECTEDFILES
-#: Merge.rc:5260
+#: Merge.rc:5259
 #, c-format
 msgid "[%1 files selected]"
 msgstr "[%1 filer valda]"
 
 #. IDS_DIFF_NORMAL
-#: Merge.rc:5261
+#: Merge.rc:5260
 msgid "Normal"
 msgstr "Normal"
 
 #. IDS_DIFF_CONTEXT
-#: Merge.rc:5262
+#: Merge.rc:5261
 msgid "Context"
 msgstr "Innehåll"
 
 #. IDS_DIFF_UNIFIED
-#: Merge.rc:5263
+#: Merge.rc:5262
 msgid "Unified"
 msgstr "Förenad"
 
 #. IDS_FILEWRITE_ERROR
-#: Merge.rc:5265
+#: Merge.rc:5264
 #, c-format
 msgid "Could not write to file %1."
 msgstr "Kunde inte skriva till filen %1."
 
 #. IDS_PATH_NOT_ABSOLUTE
-#: Merge.rc:5266
+#: Merge.rc:5265
 #, c-format
 msgid "Output path is not absolute: %1"
 msgstr "Den specificerade resultatsökvägen är inte en absolut sökväg: %1"
 
 #. IDS_MUST_SPECIFY_OUTPUT
-#: Merge.rc:5267
+#: Merge.rc:5266
 msgid "Specify an output file."
 msgstr "Ange ett filnamn för resultatet."
 
-#: Merge.rc:5269
+#: Merge.rc:5268
 msgid "Cannot create patch from binary files."
 msgstr "Kan inte skapa en patchfil från binära filer."
 
 #. IDS_SAVEFILES_FORPATCH
-#: Merge.rc:5270
+#: Merge.rc:5269
 msgid ""
 "Save all files first.\n"
 "\n"
@@ -7479,22 +7474,22 @@ msgstr ""
 "Att skapa en patch kräver att det inte finns några icke sparade ändringar i filerna."
 
 #. IDS_FOLDER_NOTEXIST
-#: Merge.rc:5271
+#: Merge.rc:5270
 msgid "Folder does not exist."
 msgstr "Katalogen finns inte."
 
 #. IDS_ARCHIVE_SUCCEEDED
-#: Merge.rc:5277
+#: Merge.rc:5276
 msgid "Archive file written."
 msgstr ""
 
 #. IDS_ARCHIVE_SAVEFILES
-#: Merge.rc:5278
+#: Merge.rc:5277
 msgid "Save all files first.\n\nCreating an archive requires no unsaved changes."
 msgstr ""
 
 #. IDS_NO_ZIP_SUPPORT
-#: Merge.rc:5283
+#: Merge.rc:5282
 msgid ""
 "Archive support not enabled.\n"
 "7-Zip and/or Merge7z*.dll not found.\n"
@@ -7505,37 +7500,37 @@ msgstr ""
 "Se manualen för mer information om hur man konfigurerar stöd för komprimerade kataloger."
 
 #. IDS_OPT_EXPORT_CAPTION
-#: Merge.rc:5284
+#: Merge.rc:5283
 msgid "Select file for export"
 msgstr "Ange fil att exportera"
 
 #. IDS_OPT_IMPORT_CAPTION
-#: Merge.rc:5285
+#: Merge.rc:5284
 msgid "Select file for import"
 msgstr "Ange fil att importera"
 
 #. IDS_OPT_IMPORT_DONE
-#: Merge.rc:5286
+#: Merge.rc:5285
 msgid "Options imported from file."
 msgstr "Inställningar importerades från filen."
 
 #. IDS_OPT_EXPORT_DONE
-#: Merge.rc:5287
+#: Merge.rc:5286
 msgid "Options exported to file."
 msgstr "Inställningar exporterades till filen."
 
 #. IDS_OPT_IMPORT_ERR
-#: Merge.rc:5288
+#: Merge.rc:5287
 msgid "Failed to import options from file."
 msgstr "Det gick inte att importera inställningar från filen."
 
 #. IDS_OPT_EXPORT_ERR
-#: Merge.rc:5289
+#: Merge.rc:5288
 msgid "Failed to write options to file."
 msgstr "Det gick inte att spara inställningar till filen."
 
 #. IDS_CLOSEALL_WINDOWS
-#: Merge.rc:5290
+#: Merge.rc:5289
 msgid ""
 "Close multiple compare windows?\n"
 "\n"
@@ -7546,34 +7541,34 @@ msgstr ""
 "Vill du fortsätta?"
 
 #. IDS_EOL_BIN
-#: Merge.rc:5300
+#: Merge.rc:5299
 msgctxt "EOL Type"
 msgid "Binary"
 msgstr "Binär"
 
 #. IDS_MARKER_COLOR_FMT
-#: Merge.rc:5305
+#: Merge.rc:5304
 #, c-format
 msgid "Marker Color %d"
 msgstr "Markeringsfärg %d"
 
 #. IDS_MARKER_NEW_PATTERN
-#: Merge.rc:5306
+#: Merge.rc:5305
 msgid "New Pattern"
 msgstr "Nytt mönster"
 
 #. IDS_PLUGINSLIST_TYPE
-#: Merge.rc:5312
+#: Merge.rc:5311
 msgid "Type"
 msgstr "Typ"
 
 #. IDS_PLUGINS_TYPE_EDITSCRIPT
-#: Merge.rc:5316
+#: Merge.rc:5315
 msgid "Editor script"
 msgstr "Editoirskript"
 
 #. ID_SELECTLINEDIFF
-#: Merge.rc:5322
+#: Merge.rc:5321
 msgid ""
 "\n"
 "Difference in Current Line (F4)"
@@ -7582,7 +7577,7 @@ msgstr ""
 "Skillnad på nuvarande rad (F4)"
 
 #. ID_OPTIONS
-#: Merge.rc:5323
+#: Merge.rc:5322
 msgid ""
 "\n"
 "Options"
@@ -7591,7 +7586,7 @@ msgstr ""
 "Inställningar"
 
 #. ID_REFRESH
-#: Merge.rc:5324
+#: Merge.rc:5323
 msgid ""
 "\n"
 "Refresh (F5)"
@@ -7600,7 +7595,7 @@ msgstr ""
 "Uppdatera (F5)"
 
 #. ID_PREVDIFF
-#: Merge.rc:5330
+#: Merge.rc:5329
 msgid ""
 "\n"
 "Previous Difference (Alt+Up)"
@@ -7609,7 +7604,7 @@ msgstr ""
 "Föregående skillnad (Alt+Upp)"
 
 #. ID_NEXTDIFF
-#: Merge.rc:5331
+#: Merge.rc:5330
 msgid ""
 "\n"
 "Next Difference (Alt+Down)"
@@ -7618,7 +7613,7 @@ msgstr ""
 "Nästa skillnad (Alt+Ned)"
 
 #. ID_PREVCONFLICT
-#: Merge.rc:5332
+#: Merge.rc:5331
 msgid ""
 "\n"
 "Previous Conflict (Alt+Shift+Up)"
@@ -7627,7 +7622,7 @@ msgstr ""
 "Föregående konflikt (Alt+Shift+Upp)"
 
 #. ID_NEXTCONFLICT
-#: Merge.rc:5333
+#: Merge.rc:5332
 msgid ""
 "\n"
 "Next Conflict (Alt+Shift+Down)"
@@ -7636,7 +7631,7 @@ msgstr ""
 "Nästa konflikt (Alt+Shift+Ned)"
 
 #. ID_FIRSTDIFF
-#: Merge.rc:5338
+#: Merge.rc:5337
 msgid ""
 "\n"
 "First Difference (Alt+Home)"
@@ -7645,7 +7640,7 @@ msgstr ""
 "Första skillnad (Alt+Home)"
 
 #. ID_CURDIFF
-#: Merge.rc:5339
+#: Merge.rc:5338
 msgid ""
 "\n"
 "Current Difference (Alt+Enter)"
@@ -7654,7 +7649,7 @@ msgstr ""
 "Nuvarande skillnad (Alt+Enter)"
 
 #. ID_LASTDIFF
-#: Merge.rc:5340
+#: Merge.rc:5339
 msgid ""
 "\n"
 "Last Difference (Alt+End)"
@@ -7663,7 +7658,7 @@ msgstr ""
 "Sista skillnad (Alt+End)"
 
 #. ID_L2R
-#: Merge.rc:5341
+#: Merge.rc:5340
 msgid ""
 "\n"
 "Copy to Right (Alt+Right)"
@@ -7672,7 +7667,7 @@ msgstr ""
 "Kopiera till höger (Alt+Höger)"
 
 #. ID_R2L
-#: Merge.rc:5342
+#: Merge.rc:5341
 msgid ""
 "\n"
 "Copy to Left (Alt+Left)"
@@ -7681,7 +7676,7 @@ msgstr ""
 "Kopiera till vänster (Alt+Vänster)"
 
 #. ID_L2RNEXT
-#: Merge.rc:5343
+#: Merge.rc:5342
 msgid ""
 "\n"
 "Copy to Right and Advance (Ctrl+Alt+Right)"
@@ -7690,7 +7685,7 @@ msgstr ""
 "Kopiera till höger och gå till nästa (Ctrl+Alt+Höger)"
 
 #. ID_R2LNEXT
-#: Merge.rc:5344
+#: Merge.rc:5343
 msgid ""
 "\n"
 "Copy to Left and Advance (Ctrl+Alt+Left)"
@@ -7699,7 +7694,7 @@ msgstr ""
 "Kopiera till vänster och gå till nästa (Ctrl+Alt+Vänster)"
 
 #. ID_ALL_RIGHT
-#: Merge.rc:5345
+#: Merge.rc:5344
 msgid ""
 "\n"
 "Copy All to Right"
@@ -7708,7 +7703,7 @@ msgstr ""
 "Kopiera allt till höger"
 
 #. ID_ALL_LEFT
-#: Merge.rc:5346
+#: Merge.rc:5345
 msgid ""
 "\n"
 "Copy All to Left"
@@ -7717,7 +7712,7 @@ msgstr ""
 "Kopiera allt till vänster"
 
 #. ID_AUTO_MERGE
-#: Merge.rc:5347
+#: Merge.rc:5346
 msgid ""
 "\n"
 "Auto Merge (Ctrl+Alt+M)"
@@ -7726,7 +7721,7 @@ msgstr ""
 "Automatisk sammanfogning (Ctrl+Alt+M)"
 
 #. ID_FIRSTFILE
-#: Merge.rc:5348
+#: Merge.rc:5347
 msgid ""
 "\n"
 "First File"
@@ -7735,7 +7730,7 @@ msgstr ""
 "Första filen"
 
 #. ID_NEXTFILE
-#: Merge.rc:5349
+#: Merge.rc:5348
 msgid ""
 "\n"
 "Next File (Ctrl+F8)"
@@ -7744,7 +7739,7 @@ msgstr ""
 "Nästa fil (Ctrl+F8)"
 
 #. ID_LASTFILE
-#: Merge.rc:5350
+#: Merge.rc:5349
 msgid ""
 "\n"
 "Last File"
@@ -7753,7 +7748,7 @@ msgstr ""
 "Sista filen"
 
 #. ID_PREVFILE
-#: Merge.rc:5351
+#: Merge.rc:5350
 msgid ""
 "\n"
 "Previous File (Ctrl+F7)"
@@ -7762,142 +7757,142 @@ msgstr ""
 "Föregående fil (Ctrl+F7)"
 
 #. IDS_UNPACK_AUTO
-#: Merge.rc:5358
+#: Merge.rc:5357
 msgid "Adapted unpacker applied to both files (one needs extension)."
 msgstr "Den valda uppackaren används för båda filerna (bara en fil behöver ha filändelse)."
 
 #. IDS_NO_PREDIFFER
-#: Merge.rc:5359
+#: Merge.rc:5358
 msgid "No Prediffer (Normal)"
 msgstr "Ingen förjämförelse (standard)"
 
 #. IDS_SUGGESTED_PLUGINS
-#: Merge.rc:5360
+#: Merge.rc:5359
 msgid "Suggested Plugins"
 msgstr "Föreslagna programtillägg"
 
 #. IDS_NOT_SUGGESTED_PLUGINS
-#: Merge.rc:5361
+#: Merge.rc:5360
 msgid "All Plugins"
 msgstr "Alla programtillägg"
 
 #. IDS_PRIVATEBUILD_FMT
-#: Merge.rc:5367
+#: Merge.rc:5366
 #, c-format
 msgid "Private Build: %1"
 msgstr "Privat kompilering: %1"
 
 #. IDS_ALLRIGHTS_RESERVED
-#: Merge.rc:5368
+#: Merge.rc:5367
 msgid " - All rights reserved."
 msgstr " - Alla rättigheter reserverade."
 
 #. IDS_TITLE_PLUGINS_SETTINGS
-#: Merge.rc:5374
+#: Merge.rc:5373
 msgid "Plugin Settings"
 msgstr "Inställningar för programtillägg"
 
 #. IDS_NO_SCT_SCRIPTS
-#: Merge.rc:5376
+#: Merge.rc:5375
 msgid "WSH not found - .sct scripts disabled"
 msgstr "Windows Script Host ('wscript.exe') hittades inte - .sct skript inaktiverade"
 
 #. IDS_LOCBAR_GOTOLINE_FMT
-#: Merge.rc:5384
+#: Merge.rc:5383
 #, c-format
 msgid "G&o to Line %1"
 msgstr "Gå till rad %1"
 
 #. IDS_GOTO_MOVED_LINE
-#: Merge.rc:5390
+#: Merge.rc:5389
 msgid "Go to Moved Line\tCtrl+Shift+G"
 msgstr "Gå till flyttad rad\tCtrl+Shift+G"
 
 #. IDS_AUTOCOMPLETE_DISABLED
-#: Merge.rc:5396
+#: Merge.rc:5395
 msgctxt "Options dialog|General|Open dialog Auto completion"
 msgid "Disabled"
 msgstr "Avstängd"
 
 #. IDS_AUTOCOMPLETE_FILE_SYS
-#: Merge.rc:5397
+#: Merge.rc:5396
 msgid "From file system"
 msgstr "Från filsystem"
 
 #. IDS_AUTOCOMPLETE_MRU
-#: Merge.rc:5398
+#: Merge.rc:5397
 msgid "From Most Recently Used list"
 msgstr "Från listan Senast använda filer"
 
 #. IDS_COLORSCHEME_PLAIN
-#: Merge.rc:5404
+#: Merge.rc:5403
 msgid "No Highlighting"
 msgstr "Ingen framhävning"
 
 #. IDS_COLORSCHEME_PO
-#: Merge.rc:5439
+#: Merge.rc:5438
 msgid "Portable Object"
 msgstr "Flyttbart objekt"
 
 #. IDS_COLORSCHEME_RSRC
-#: Merge.rc:5444
+#: Merge.rc:5443
 msgid "Resources"
 msgstr "Resurser"
 
 #. IDS_COLORSCHEME_SH
-#: Merge.rc:5448
+#: Merge.rc:5447
 msgid "Shell"
 msgstr "Shell"
 
 #. IDS_CLOSE_LEFT_TABS
-#: Merge.rc:5469
+#: Merge.rc:5468
 msgid "Close &Left Tabs"
 msgstr "Stäng vänster flik"
 
 #. IDS_CLOSE_RIGHT_TABS
-#: Merge.rc:5470
+#: Merge.rc:5469
 msgid "Close R&ight Tabs"
 msgstr "Stäng höger flik"
 
 #. IDS_CLOSE_OTHER_TABS
-#: Merge.rc:5471
+#: Merge.rc:5470
 msgid "Close &Other Tabs"
 msgstr "Stäng andra flikar"
 
 #. IDS_TABBAR_AUTO_MAXWIDTH
-#: Merge.rc:5472
+#: Merge.rc:5471
 msgid "Enable &Auto Max Width"
 msgstr "Aktivera automatisk högsta bredd"
 
 #. IDS_WEBPAGE_MENU
-#: Merge.rc:5482
+#: Merge.rc:5481
 msgid "We&bpage"
 msgstr "Websida"
 
 #. IDS_VIEW_WRAP_TEXT
-#: Merge.rc:5487
+#: Merge.rc:5486
 msgid "W&rap Text"
 msgstr "Vänd på text"
 
 #. IDS_NOTINSTALLED
-#: Merge.rc:5492
+#: Merge.rc:5491
 #, c-format
 msgid "%1 is not installed."
 msgstr "%1 är inte installerad."
 
 #. IDS_CREATE_FOLDER
-#: Merge.rc:5497
+#: Merge.rc:5496
 #, c-format
 msgid "%1 does not exist. Create it?"
 msgstr "%1 finns inte. Vill du skapa den?"
 
 #. IDS_CREATE_FOLDER_ERROR
-#: Merge.rc:5498
+#: Merge.rc:5497
 msgid "Failed to create folder."
 msgstr "Misslyckades att skapa katalog."
 
 #. IDC_EXT_EDITOR_PATH
-#: Merge.rc:5503
+#: Merge.rc:5502
 msgid ""
 "Parameters:\n"
 "$file: Current file path\n"
@@ -7908,491 +7903,491 @@ msgstr ""
 "$linenum: Radnumret för markörens nuvarande position"
 
 #. IDS_DIFF_ALGORITHM_DEFAULT
-#: Merge.rc:5508
+#: Merge.rc:5507
 msgid "default"
 msgstr "standard"
 
 #. IDS_DIFF_ALGORITHM_MINIMAL
-#: Merge.rc:5509
+#: Merge.rc:5508
 msgid "minimal"
 msgstr "minimal"
 
 #. IDS_DIFF_ALGORITHM_PATIENCE
-#: Merge.rc:5510
+#: Merge.rc:5509
 msgid "patience"
 msgstr "långvarig"
 
 #. IDS_DIFF_ALGORITHM_HISTOGRAM
-#: Merge.rc:5511
+#: Merge.rc:5510
 msgid "histogram"
 msgstr "histogram"
 
 #. IDS_DIFF_ALGORITHM_NONE
-#: Merge.rc:5512
+#: Merge.rc:5511
 msgid "none"
 msgstr "inga"
 
 #. IDS_RENDERING_MODE_GDI
-#: Merge.rc:5517
+#: Merge.rc:5516
 msgid "GDI"
 msgstr "GDI"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_DEFAULT
-#: Merge.rc:5518
+#: Merge.rc:5517
 msgid "DirectWrite Default"
 msgstr "DirectWrite förval"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_ALIASED
-#: Merge.rc:5519
+#: Merge.rc:5518
 msgid "DirectWrite Aliased"
 msgstr "DirectWrite aliaserat"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_GDI_CLASSIC
-#: Merge.rc:5520
+#: Merge.rc:5519
 msgid "DirectWrite GDI Classic"
 msgstr "DirectWrite GDI klassisk"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_GDI_NATURAL
-#: Merge.rc:5521
+#: Merge.rc:5520
 msgid "DirectWrite GDI Natural"
 msgstr "DirectWrite GDI naturlig"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_NATURAL
-#: Merge.rc:5522
+#: Merge.rc:5521
 msgid "DirectWrite Natural"
 msgstr "DirectWrite naturlig"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_NATURAL_SYMMETRIC
-#: Merge.rc:5523
+#: Merge.rc:5522
 msgid "DirectWrite Natural Symmetric"
 msgstr "DirectWrite naturlig symmetrisk"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_DISABLED
-#: Merge.rc:5528
+#: Merge.rc:5527
 msgctxt "Options dialog|General|Close windows with Esc"
 msgid "Disabled"
 msgstr "Avstängd"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_1
-#: Merge.rc:5529
+#: Merge.rc:5528
 msgid "MDI child window or main window"
 msgstr "MDI nedärvda fönster eller huvudfönster"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_2
-#: Merge.rc:5530
+#: Merge.rc:5529
 msgid "MDI child window only"
 msgstr "Bara nedärvda MDI-fönster"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_3
-#: Merge.rc:5531
+#: Merge.rc:5530
 msgid "Close main window if only one MDI child window"
 msgstr "Stäng huvudfönstret om det bara finns ett nedärvt MDI-fönster"
 
 #. IDS_DIFF_GROUP
-#: Merge.rc:5536
+#: Merge.rc:5535
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Diff"
 msgstr "Skillnad"
 
 #. IDS_DIFF_HIGHLIGHT
-#: Merge.rc:5537
+#: Merge.rc:5536
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Highlight"
 msgstr "Framhäv"
 
 #. IDS_DIFF_BLINK
-#: Merge.rc:5538
+#: Merge.rc:5537
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Blink"
 msgstr "Blinka"
 
 #. IDS_DIFF_BLOCKSIZE
-#: Merge.rc:5539
+#: Merge.rc:5538
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Block Size"
 msgstr "Blockstorlek"
 
 #. IDS_DIFF_BLOCKALPHA
-#: Merge.rc:5540
+#: Merge.rc:5539
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Block Alpha"
 msgstr "Block Alpha"
 
 #. IDS_DIFF_CDTHRESHOLD
-#: Merge.rc:5541
+#: Merge.rc:5540
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "CD Threshold"
 msgstr "CD tröskel"
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION
-#: Merge.rc:5542
+#: Merge.rc:5541
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Ins/Del Detection"
 msgstr "Infoga/radera upptäckning"
 
 #. IDS_OVERLAY_MODE_NONE
-#: Merge.rc:5543 Merge.rc:5548
+#: Merge.rc:5542 Merge.rc:5547
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "None"
 msgstr "Ingen"
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION_VERTICAL
-#: Merge.rc:5544
+#: Merge.rc:5543
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Vertical"
 msgstr "Vertikalt"
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION_HORIZONTAL
-#: Merge.rc:5545
+#: Merge.rc:5544
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Horizontal"
 msgstr "Horisontellt"
 
 #. IDS_OVERLAY_GROUP
-#: Merge.rc:5546
+#: Merge.rc:5545
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Overlay"
 msgstr "Övertäckning"
 
 #. IDS_OVERLAY_ALPHA
-#: Merge.rc:5547
+#: Merge.rc:5546
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha"
 msgstr "Alpha"
 
 #. IDS_OVERLAY_MODE_XOR
-#: Merge.rc:5549
+#: Merge.rc:5548
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "XOR"
 msgstr "XOR"
 
 #. IDS_OVERLAY_MODE_ALPHA
-#: Merge.rc:5550
+#: Merge.rc:5549
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha Blend"
 msgstr "Alpha transparens"
 
 #. IDS_OVERLAY_MODE_ALPHA_ANIMATION
-#: Merge.rc:5551
+#: Merge.rc:5550
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha Animation"
 msgstr "Alpha-animering"
 
 #. IDS_ZOOM
-#: Merge.rc:5552
+#: Merge.rc:5551
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Zoom"
 msgstr "Zoom"
 
 #. IDS_PAGE
-#: Merge.rc:5553
+#: Merge.rc:5552
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Page:"
 msgstr "Sida:"
 
 #. IDS_IMGCMP_STATUS_PT_RGBA_FMT
-#: Merge.rc:5554
+#: Merge.rc:5553
 #, c-format
 msgid "Pt: (%d, %d)  RGBA: (%d, %d, %d, %d)  "
 msgstr "Pt: (%d, %d)  RGBA: (%d, %d, %d, %d)  "
 
 #. IDS_IMGCMP_STATUS_DIST1_FMT
-#: Merge.rc:5555
+#: Merge.rc:5554
 #, c-format
 msgid "Dist: %g  "
 msgstr "Dist: %g  "
 
 #. IDS_IMGCMP_STATUS_DIST2_FMT
-#: Merge.rc:5556
+#: Merge.rc:5555
 #, c-format
 msgid "Dist: %g, %g  "
 msgstr "Dist: %g, %g  "
 
 #. IDS_IMGCMP_STATUS_PAGE_ZOOM_SIZE_BPP_FMT
-#: Merge.rc:5557
+#: Merge.rc:5556
 #, c-format
 msgid "Page: %d/%d  Zoom: %d%%  %dx%dpx  %dbpp  "
 msgstr "Sida: %d/%d  Zoom: %d%%  %dx%dpx  %dbpp  "
 
 #. IDS_IMGCMP_STATUS_RC_FMT
-#: Merge.rc:5558
+#: Merge.rc:5557
 #, c-format
 msgid "Rc: (%d, %d)  "
 msgstr "Rc: (%d, %d)  "
 
 #. IDS_IMGCMP_STATUS_FLIPPED_FMT
-#: Merge.rc:5559
+#: Merge.rc:5558
 #, c-format
 msgid "Flipped: %s  "
 msgstr "Vriden: %s  "
 
 #. IDS_IMGCMP_STATUS_ROTATED_FMT
-#: Merge.rc:5560
+#: Merge.rc:5559
 #, c-format
 msgid "Rotated: %d  "
 msgstr "Roterad: %d  "
 
 #. IDS_IMGCMP_REPORT_ALLPAGES
-#: Merge.rc:5561
+#: Merge.rc:5560
 msgid "All pages"
 msgstr "Alla sidor"
 
 #. IDS_IGNSUB_STR1
-#: Merge.rc:5566
+#: Merge.rc:5565
 msgid "<Edit here>"
 msgstr "<Redigera här>"
 
 #. IDS_IGNSUB_STR2
-#: Merge.rc:5567
+#: Merge.rc:5566
 msgid "No differences found to select"
 msgstr "Inga skillnader för val funna"
 
 #. IDS_IGNSUB_STR3
-#: Merge.rc:5568
+#: Merge.rc:5567
 msgid "No differences found to add as substitution filter"
 msgstr "Inga skillnader funna att lägga till ersättningsfilter"
 
 #. IDS_IGNSUB_STR4
-#: Merge.rc:5569
+#: Merge.rc:5568
 msgid "The pair is already in the Substitution Filters list"
 msgstr "Paret är redan i listan av ersättningsfilter"
 
 #. IDS_IGNSUB_STR5
-#: Merge.rc:5570
+#: Merge.rc:5569
 msgid "Add this change to Substitution Filters?"
 msgstr "Lägg till denna skillnad till ersättningsfilter?"
 
 #. IDS_OCRRESULT_TEXTONLY
-#: Merge.rc:5575
+#: Merge.rc:5574
 msgid "Text only"
 msgstr "Endast text"
 
 #. IDS_OCRRESULT_POS_LINE
-#: Merge.rc:5576
+#: Merge.rc:5575
 msgid "Line-by-line position and text"
 msgstr "Rad-för-rad position och text"
 
 #. IDS_OCRRESULT_POS_WORD
-#: Merge.rc:5577
+#: Merge.rc:5576
 msgid "Word-by-word position and text"
 msgstr "Ord-för-ord position och text"
 
 #. IDS_USERDATAFOLDER_APPDATA
-#: Merge.rc:5582
+#: Merge.rc:5581
 msgid "AppData (Roaming) folder"
 msgstr ""
 
 #. IDS_USERDATAFOLDER_INSTALL
-#: Merge.rc:5583
+#: Merge.rc:5582
 msgid "Install folder"
 msgstr "Installationskatalog"
 
 #. IDS_USERDATAFOLDER_DOCUMENTS
-#: Merge.rc:5584
+#: Merge.rc:5583
 msgid "Documents folder"
 msgstr ""
 
 #. IDS_SINGLEINSTANCE_DISABLED
-#: Merge.rc:5589
+#: Merge.rc:5588
 msgctxt "Options dialog|General|Single instance mode"
 msgid "Disabled"
 msgstr "Avstängd"
 
 #. IDS_SINGLEINSTANCE_STR1
-#: Merge.rc:5590
+#: Merge.rc:5589
 msgid "Allow only one instance to run"
 msgstr "Tillåt endast att en instans körs"
 
 #. IDS_CLIPBOARD_HISTORY
-#: Merge.rc:5591
+#: Merge.rc:5590
 msgid "Clipboard &History"
 msgstr ""
 
 #. IDS_SINGLEINSTANCE_STR2
-#: Merge.rc:5592
+#: Merge.rc:5591
 msgid "Allow only one instance; wait for termination"
 msgstr "Tillåt bara att en instans körs; vänta på avslutning"
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_DISABLED
-#: Merge.rc:5597
+#: Merge.rc:5596
 msgctxt "Options dialog|General|Auto-reload modified files"
 msgid "Disabled"
 msgstr "Avstängd"
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_STR1
-#: Merge.rc:5598
+#: Merge.rc:5597
 msgid "Only on window activated"
 msgstr "Endast vid fönster aktvierat"
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_STR2
-#: Merge.rc:5599
+#: Merge.rc:5598
 msgid "Immediately"
 msgstr "Omgående"
 
 #. IDS_PLUGIN_ALL
-#: Merge.rc:5604
+#: Merge.rc:5603
 msgid "Al&l"
 msgstr "AI&I"
 
 #. IDS_PLUGIN_OTHERS
-#: Merge.rc:5605
+#: Merge.rc:5604
 msgid "&Others"
 msgstr "Övriga"
 
-#: Merge.rc:5607
+#: Merge.rc:5606
 #, c-format
 msgid "Missing plugin name in pipeline: %1"
 msgstr "Saknar programtilläggets namn i kommandoslinga: %1"
 
-#: Merge.rc:5609
+#: Merge.rc:5608
 #, c-format
 msgid "Missing quote in plugin pipeline: %1"
 msgstr "Saknar citationstecken i programtilläggets kommandoslinga: %1"
 
 #. IDS_PLUGIN_NAME_ALREADY_EXISTS
-#: Merge.rc:5610
+#: Merge.rc:5609
 #, c-format
 msgid "Plugin name '%1' already exists."
 msgstr "Pluginnamnet '%1' finns redan."
 
 #. IDS_PLUGIN_TITLE1
-#: Merge.rc:5611
+#: Merge.rc:5610
 msgid "Specify plugin arguments"
 msgstr "Ange programtilläggets kommandoalternativ"
 
-#: Merge.rc:5613
+#: Merge.rc:5612
 #, c-format
 msgid "Plugin not found or invalid: %1"
 msgstr "Plugin hittades inte eller ogiltigt: %1"
 
 #. IDS_PLUGIN_NOT_UNPACK
-#: Merge.rc:5614
+#: Merge.rc:5613
 #, c-format
 msgid "'%1' is not an unpacker plugin"
 msgstr "'%1' är inte något uppackningsplugin'"
 
 #. IDS_PLUGIN_NOT_PREDIFF
-#: Merge.rc:5615
+#: Merge.rc:5614
 #, c-format
 msgid "'%1' is not a prediffer plugin"
 msgstr "'%1' är inte någon predifferplugin"
 
-#: Merge.rc:5617
+#: Merge.rc:5616
 #, c-format
 msgid "Error prediffing '%1' with '%2'. Prediffing disabled."
 msgstr "Ett fel hände vid prediffing av filen '%1' med plugin '%2'. Prediffing används inte mer."
 
 #. IDS_PLUGIN_CIRCULAR_REFERENCE
-#: Merge.rc:5618
+#: Merge.rc:5617
 #, c-format
 msgid "Circular reference in plugin pipeline: %1"
 msgstr "Cirkulärreferens i pluginpipeline: %1"
 
 #. IDS_PLUGIN_TYPE1
-#: Merge.rc:5619
+#: Merge.rc:5618
 msgid "URL Handler"
 msgstr "URLhanterare"
 
 #. IDS_PLUGIN_TYPE2
-#: Merge.rc:5620
+#: Merge.rc:5619
 msgid "File Unpacker"
 msgstr "Filuppackare"
 
 #. IDS_PLUGIN_TYPE3
-#: Merge.rc:5621
+#: Merge.rc:5620
 msgid "File or Folder Unpacker"
 msgstr "Fil- eller kataloguppackare"
 
 #. IDS_PLUGIN_TYPE5
-#: Merge.rc:5623
+#: Merge.rc:5622
 msgid "Alias for Unpacker"
 msgstr "Alias för uppackare"
 
 #. IDS_PLUGIN_TYPE6
-#: Merge.rc:5624
+#: Merge.rc:5623
 msgid "Alias for Prediffer"
 msgstr "A lias för Prediffer"
 
 #. IDS_PLUGIN_TYPE7
-#: Merge.rc:5625
+#: Merge.rc:5624
 msgid "Alias for Editor script"
 msgstr "Alias för Editorskript"
 
 #. IDS_PLUGIN_ALIAS_DESC
-#: Merge.rc:5626
+#: Merge.rc:5625
 #, c-format
 msgid "Alias for plugin pipeline '%1'"
 msgstr "Alias för pluginpipeline '%1'"
 
 #. IDS_PLUGIN_NEW_DESC
-#: Merge.rc:5627
+#: Merge.rc:5626
 msgid "New plugin description"
 msgstr "Ny pluginbeskrivning"
 
 #. IDS_PLUGIN_TARGETS_ALL
-#: Merge.rc:5628
+#: Merge.rc:5627
 msgid "All"
 msgstr "Allt"
 
 #. IDS_PLUGIN_TARGETS_1ST
-#: Merge.rc:5629
+#: Merge.rc:5628
 msgid "1st"
 msgstr "Första"
 
 #. IDS_PLUGIN_TARGETS_2ND
-#: Merge.rc:5630
+#: Merge.rc:5629
 msgid "2nd"
 msgstr "Andra"
 
 #. IDS_PLUGIN_TARGETS_3RD
-#: Merge.rc:5631
+#: Merge.rc:5630
 msgid "3rd"
 msgstr "Tredje"
 
 #. IDS_PLUGIN_TARGETS_1ST_2ND
-#: Merge.rc:5632
+#: Merge.rc:5631
 msgid "1st and 2nd"
 msgstr "Första och Andra"
 
 #. IDS_PLUGIN_TARGETS_1ST_3RD
-#: Merge.rc:5633
+#: Merge.rc:5632
 msgid "1st and 3rd"
 msgstr "Första och Tredje"
 
 #. IDS_PLUGIN_TARGETS_2ND_3RD
-#: Merge.rc:5634
+#: Merge.rc:5633
 msgid "2nd and 3rd"
 msgstr "Andra och Tredje"
 
 #. IDS_PLUGIN_CTRL_CLICK
-#: Merge.rc:5635
+#: Merge.rc:5634
 msgid "(Ctrl+Click to add to pipeline)"
 msgstr ""
 
 #. IDS_FILTER_APPLIED
-#: Merge.rc:5640
+#: Merge.rc:5639
 msgid "Filter applied"
 msgstr "Filter verkställt"
 
 #. IDS_FILTERMENU_COMPARE
-#: Merge.rc:5645
+#: Merge.rc:5644
 #, c-format
 msgid "Compare %1"
 msgstr ""
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN2
-#: Merge.rc:5647
+#: Merge.rc:5646
 msgid "&Filter by This Column..."
 msgstr ""
 
 #. IDS_CLIPBOARDHISTORY_TIME
-#: Merge.rc:5652
+#: Merge.rc:5651
 #, c-format
 msgid "Clipboard at %s"
 msgstr "Klippbordet vid %s"
 
 #. IDS_CLIPBOARDHISTORY_DISABLED
-#: Merge.rc:5653
+#: Merge.rc:5652
 msgid ""
 "Clipboard history disabled.\r\n"
 "Enable: Windows logo key + V, then Turn on."
@@ -8400,115 +8395,115 @@ msgstr ""
 "Klippbordshistorik är inaktiverat.\r\n"
 "\" För att aktivera Klippbordshistorik, tryck på Windows-tangenten + V och klicka på Aktivera.."
 
-#: Merge.rc:5655
+#: Merge.rc:5654
 msgid "This system does not support clipboard history."
 msgstr "Det här systemet stöder inte Klippbordshistorik."
 
-#: Merge.rc:5657
+#: Merge.rc:5656
 msgid "32-bit WinMerge does not support Clipboard Compare"
 msgstr "32-bitarsversionen av WinMerge stöder inte jämförelse med Klippbordet"
 
 #. IDS_WEBVIEW2_RUNTIME_NOT_INSTALLED
-#: Merge.rc:5662
+#: Merge.rc:5661
 msgid "WebView2 runtime not installed. Download it?"
 msgstr "Körbara filer för WebView2 är inte installerade. Vill du ladda ned det?"
 
 #. IDS_JUMPLIST_NEW_TEXT_COMPARE
-#: Merge.rc:5667
+#: Merge.rc:5666
 msgid "New Text Compare"
 msgstr "Ny Textjämförelse"
 
 #. IDS_JUMPLIST_NEW_TABLE_COMPARE
-#: Merge.rc:5668
+#: Merge.rc:5667
 msgid "New Table Compare"
 msgstr "Ny tabelljämförelse"
 
 #. IDS_JUMPLIST_NEW_BINARY_COMPARE
-#: Merge.rc:5669
+#: Merge.rc:5668
 msgid "New Binary Compare"
 msgstr "Ny binär jämförelse"
 
 #. IDS_JUMPLIST_NEW_IMAGE_COMPARE
-#: Merge.rc:5670
+#: Merge.rc:5669
 msgid "New Image Compare"
 msgstr "Ny bildjämförelse"
 
 #. IDS_JUMPLIST_NEW_WEBPAGE_COMPARE
-#: Merge.rc:5671
+#: Merge.rc:5670
 msgid "New Webpage Compare"
 msgstr "Ny Webbsidojämförelse"
 
 #. IDS_JUMPLIST_NEW_FOLDER_COMPARE
-#: Merge.rc:5672
+#: Merge.rc:5671
 msgid "New Folder Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_CLIPBOARD_COMPARE
-#: Merge.rc:5673
+#: Merge.rc:5672
 msgid "Clipboard Compare"
 msgstr "Klippbordsjämförelse"
 
 #. IDS_PREVIEWBAR_PRINT
-#: Merge.rc:5678
+#: Merge.rc:5677
 msgid "&Print..."
 msgstr "Skriv ut..."
 
 #. IDS_PREVIEWBAR_PREVPAGE
-#: Merge.rc:5680
+#: Merge.rc:5679
 msgid "Pre&v Page"
 msgstr "Förra sidan"
 
 #. IDS_PREVIEWBAR_TWOPAGE
-#: Merge.rc:5681
+#: Merge.rc:5680
 msgid "&Two Page"
 msgstr "Två sidor"
 
 #. IDS_PREVIEWBAR_ONEPAGE
-#: Merge.rc:5682
+#: Merge.rc:5681
 msgid "&One Page"
 msgstr "En sida"
 
 #. IDS_PREVIEWBAR_ZOOMIN
-#: Merge.rc:5683
+#: Merge.rc:5682
 msgid "Zoom &In"
 msgstr "Zooma in"
 
 #. IDS_PREVIEWBAR_ZOOMOUT
-#: Merge.rc:5684
+#: Merge.rc:5683
 msgid "Zoom &Out"
 msgstr "Zooma ut"
 
 #. IDS_WEBPAGE_COMPARING
-#: Merge.rc:5690
+#: Merge.rc:5689
 msgid "Comparing..."
 msgstr "Jämför..."
 
 #. IDS_WEBPAGE_ZOOM
-#: Merge.rc:5691
+#: Merge.rc:5690
 msgid "Zoom:"
 msgstr "Zooma:"
 
 #. IDS_COPY_GRANULARITY_DIFFHUNK
-#: Merge.rc:5696
+#: Merge.rc:5695
 msgid "Diff hunk"
 msgstr "Skillnadsmassa"
 
 #. IDS_COPY_GRANULARITY_INLINE
-#: Merge.rc:5697
+#: Merge.rc:5696
 msgid "Inline diff"
 msgstr "Inlineskillnad"
 
 #. IDS_COPY_GRANULARITY_LINE
-#: Merge.rc:5698
+#: Merge.rc:5697
 msgid "Line"
 msgstr "Rad"
 
-#: Merge.rc:5699
+#: Merge.rc:5698
 msgid "Character"
 msgstr "Tecken"
 
 #. ID_MICE_PREVDIFF
-#: Merge.rc:5704
+#: Merge.rc:5703
 msgid ""
 "\n"
 "Previous Difference (Alt+Up)\n"
@@ -8521,7 +8516,7 @@ msgstr ""
 "(Alt+Hjul Upp)"
 
 #. ID_MICE_NEXTDIFF
-#: Merge.rc:5705
+#: Merge.rc:5704
 msgid ""
 "\n"
 "Next Difference (Alt+Down)\n"
@@ -8534,7 +8529,7 @@ msgstr ""
 "(Alt+Hjul Ner)"
 
 #. ID_MICE_L2R
-#: Merge.rc:5706
+#: Merge.rc:5705
 msgid ""
 "\n"
 "Copy to Right (Alt+Right)\n"
@@ -8549,7 +8544,7 @@ msgstr ""
 "(Alt+Shift+Hjul Ner)"
 
 #. ID_MICE_R2L
-#: Merge.rc:5707
+#: Merge.rc:5706
 msgid ""
 "\n"
 "Copy to Left (Alt+Left)\n"
@@ -8564,7 +8559,7 @@ msgstr ""
 "(Alt+Shift+Hjul Upp)"
 
 #. ID_MICE_L2RNEXT
-#: Merge.rc:5708
+#: Merge.rc:5707
 msgid ""
 "\n"
 "Copy to Right and Advance (Ctrl+Alt+Right)\n"
@@ -8577,7 +8572,7 @@ msgstr ""
 "(Ctrl+Alt+Shift+Hjul Ner)"
 
 #. ID_MICE_R2LNEXT
-#: Merge.rc:5709
+#: Merge.rc:5708
 msgid ""
 "\n"
 "Copy to Left and Advance (Ctrl+Alt+Left)\n"
@@ -8590,282 +8585,282 @@ msgstr ""
 "(Ctrl+Alt+Shift+Hjul Upp)"
 
 #. IDS_LOG_COMPARING_2
-#: Merge.rc:5719
+#: Merge.rc:5718
 #, c-format
 msgid "Comparing %1 with %2"
 msgstr "Jämför %1 med %2"
 
 #. IDS_LOG_COMPARING_3
-#: Merge.rc:5720
+#: Merge.rc:5719
 #, c-format
 msgid "Comparing %1 with %2 and %3"
 msgstr "Jämför %1 med %2 och %3"
 
 #. IDS_LOG_COMPARE_COMPLETED
-#: Merge.rc:5721
+#: Merge.rc:5720
 msgid "Comparison completed"
 msgstr "Jämförelse färdig"
 
 #. IDS_LOG_COMPARE_ERROR_2
-#: Merge.rc:5722
+#: Merge.rc:5721
 #, c-format
 msgid "Failed to compare %1 with %2: "
 msgstr "Kunde inte jämföra %1 med %2: "
 
 #. IDS_LOG_COMPARE_ERROR_3
-#: Merge.rc:5723
+#: Merge.rc:5722
 #, c-format
 msgid "Failed to compare %1 with %2 and %3: "
 msgstr "Kunde inte jämföra %1 med %2 och %3: "
 
 #. IDS_LOG_FILE_SAVED
-#: Merge.rc:5724
+#: Merge.rc:5723
 msgid "File saved"
 msgstr "Fil sparad"
 
 #. IDS_LOG_COPYING_FILES
-#: Merge.rc:5725
+#: Merge.rc:5724
 msgid "Copying files..."
 msgstr "Kopierar filer..."
 
 #. IDS_LOG_MOVING_FILES
-#: Merge.rc:5726
+#: Merge.rc:5725
 msgid "Moving files..."
 msgstr "Flyttar filer..."
 
 #. IDS_LOG_DELETING_FILES
-#: Merge.rc:5727
+#: Merge.rc:5726
 msgid "Deleting files..."
 msgstr "Tar bort filer..."
 
 #. IDS_LOG_RECYCLEBIN
-#: Merge.rc:5728
+#: Merge.rc:5727
 msgid "Recycle Bin"
 msgstr "Papperskorg"
 
 #. IDS_LOG_PERMANENTLY_DELETED
-#: Merge.rc:5729
+#: Merge.rc:5728
 msgid "Permanently deleted"
 msgstr "Permanent borttagen"
 
 #. IDS_LOG_FILEOPERATION_COMPLETED
-#: Merge.rc:5730
+#: Merge.rc:5729
 msgid "File operation completed successfully"
 msgstr "Filoperation framgångsrikt gjord"
 
 #. IDS_LOG_FILEOPERATION_CANCELED
-#: Merge.rc:5731
+#: Merge.rc:5730
 msgid "File operation canceled"
 msgstr "Filoperation avbruten"
 
 #. IDS_FILTER_ERROR_NO_ERROR
-#: Merge.rc:5736
+#: Merge.rc:5735
 msgid "No error"
 msgstr "Inget fel"
 
 #. IDS_FILTER_ERROR_EMPTY_EXPRESSION
-#: Merge.rc:5737
+#: Merge.rc:5736
 msgid "Filter expression is empty"
 msgstr "Filteruttrycket är tomt"
 
 #. IDS_FILTER_ERROR_UNKNOWN_CHAR
-#: Merge.rc:5738
+#: Merge.rc:5737
 msgid "Unknown character in filter expression"
 msgstr "Okänt tecken i filteruttryck"
 
 #. IDS_FILTER_ERROR_UNTERMINATED_STRING
-#: Merge.rc:5739
+#: Merge.rc:5738
 msgid "Unterminated string literal"
 msgstr "Oavslutad litterär text"
 
 #. IDS_FILTER_ERROR_SYNTAX_ERROR
-#: Merge.rc:5740
+#: Merge.rc:5739
 msgid "Syntax error in filter expression"
 msgstr "Syntaxfel i filteruttryck"
 
 #. IDS_FILTER_ERROR_PARSE_FAILURE
-#: Merge.rc:5741
+#: Merge.rc:5740
 msgid "Failed to parse filter expression"
 msgstr "Kunde inte tolka filteruttryck"
 
 #. IDS_FILTER_ERROR_INVALID_LITERAL
-#: Merge.rc:5742
+#: Merge.rc:5741
 msgid "Invalid literal value"
 msgstr "Ogiltigt litterärt värde"
 
 #. IDS_FILTER_ERROR_INVALID_REGULAR_EXPRESSION
-#: Merge.rc:5743
+#: Merge.rc:5742
 msgid "Invalid regular expression"
 msgstr "Ogiltigt reguljärt uttryck"
 
 #. IDS_FILTER_ERROR_UNDEFINED_IDENTIFIER
-#: Merge.rc:5744
+#: Merge.rc:5743
 msgid "Undefined identifier"
 msgstr "Odefinierad identifierare"
 
 #. IDS_FILTER_ERROR_INVALID_ARGUMENT_COUNT
-#: Merge.rc:5745
+#: Merge.rc:5744
 msgid "Invalid number of arguments"
 msgstr ""
 
 #. IDS_FILTER_ERROR_FILTER_NAME_NOT_FOUND
-#: Merge.rc:5746
+#: Merge.rc:5745
 msgid "Filter name not found"
 msgstr "Filternamn hittades inte"
 
 #. IDS_FILTER_ERROR_DIVIDE_BY_ZERO
-#: Merge.rc:5747
+#: Merge.rc:5746
 msgid "Division by zero in filter expression"
 msgstr "Division med noll i filteruttryck"
 
 #. IDS_FILTER_ERROR_UNKNOWN_ERROR
-#: Merge.rc:5748
+#: Merge.rc:5747
 msgid "Unknown error"
 msgstr "Okänt fel"
 
 #. IDS_FILTER_ERROR_INVALID_PROPERTY_NAME
-#: Merge.rc:5749
+#: Merge.rc:5748
 msgid "Invalid property name"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_DIRECTIVE
-#: Merge.rc:5750
+#: Merge.rc:5749
 msgid "Invalid directive"
 msgstr ""
 
 #. IDS_FILTER_OP_EQUALS
-#: Merge.rc:5755
+#: Merge.rc:5754
 msgid "Equals"
 msgstr "Lika med"
 
 #. IDS_FILTER_OP_NOT_EQUALS
-#: Merge.rc:5756
+#: Merge.rc:5755
 msgid "Does not equal"
 msgstr "Inte lika med"
 
 #. IDS_FILTER_OP_LESS_THAN
-#: Merge.rc:5757
+#: Merge.rc:5756
 msgid "Less than"
 msgstr "Mindre än"
 
 #. IDS_FILTER_OP_LESS_EQUAL
-#: Merge.rc:5758
+#: Merge.rc:5757
 msgid "Less than or equal to"
 msgstr "Mindre än eller lika med"
 
 #. IDS_FILTER_OP_GREATER_EQUAL
-#: Merge.rc:5759
+#: Merge.rc:5758
 msgid "Greater than or equal to"
 msgstr "Större än eller lika med"
 
 #. IDS_FILTER_OP_GREATER_THAN
-#: Merge.rc:5760
+#: Merge.rc:5759
 msgid "Greater than"
 msgstr "Större än"
 
 #. IDS_FILTER_OP_BETWEEN
-#: Merge.rc:5761
+#: Merge.rc:5760
 msgid "Between"
 msgstr "Mellan"
 
 #. IDS_FILTER_OP_NOT_BETWEEN
-#: Merge.rc:5762
+#: Merge.rc:5761
 msgid "Not Between"
 msgstr "Inte mellan"
 
 #. IDS_FILTER_OP_CONTAINS
-#: Merge.rc:5763
+#: Merge.rc:5762
 msgid "Contains"
 msgstr "Innehåller"
 
 #. IDS_FILTER_OP_NOT_CONTAINS
-#: Merge.rc:5764
+#: Merge.rc:5763
 msgid "Not Contains"
 msgstr "Innehåller inte"
 
 #. IDS_FILTER_OP_RECONTAINS
-#: Merge.rc:5765
+#: Merge.rc:5764
 msgid "Contains (regex)"
 msgstr "Innehåller (RegExp)"
 
 #. IDS_FILTER_OP_NOT_RECONTAINS
-#: Merge.rc:5766
+#: Merge.rc:5765
 msgid "Not Contains (regex)"
 msgstr "Innehåller inte (RegExp)"
 
 #. IDS_FILTER_OP_LIKE
-#: Merge.rc:5767
+#: Merge.rc:5766
 msgid "Match (wildcard)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_LIKE
-#: Merge.rc:5768
+#: Merge.rc:5767
 msgid "Not match (wildcard)"
 msgstr ""
 
 #. IDS_FILTER_OP_MATCHES
-#: Merge.rc:5769
+#: Merge.rc:5768
 msgid "Match (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_MATCHES
-#: Merge.rc:5770
+#: Merge.rc:5769
 msgid "Not match (regex)"
 msgstr ""
 
 #. IDS_COLORMODE_LIGHT
-#: Merge.rc:5775
+#: Merge.rc:5774
 msgid "Light"
 msgstr "Ljus"
 
 #. IDS_COLORMODE_DARK
-#: Merge.rc:5776
+#: Merge.rc:5775
 msgid "Dark"
 msgstr "Mörk"
 
 #. IDS_COLORMODE_FOLLOWSYSTEM
-#: Merge.rc:5777
+#: Merge.rc:5776
 msgid "Follow system"
 msgstr "Följ system"
 
 #. IDS_EXAMPLE
-#: Merge.rc:5782
+#: Merge.rc:5781
 #, c-format
 msgid "e.g. %1"
 msgstr ""
 
 #. IDS_DETECTED_PREVIOUS_CRASH
-#: Merge.rc:5787
+#: Merge.rc:5786
 msgid "WinMerge detected a previous crash. Please report this if possible."
 msgstr ""
 
 #. IDS_REGEX_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5792
+#: Merge.rc:5791
 msgid "# Regex replacement list\r\n# Format: regex<TAB>replacement\r\n# Backreferences like $1, $2 are supported\r\n\r\n(\\d{4})-(\\d{2})-(\\d{2})\t$1_$2_$3\r\n"
 msgstr ""
 
 #. IDS_STRING_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5793
+#: Merge.rc:5792
 msgid "# Replacement list\r\n# Format: search<TAB>replacement\r\n# Lines starting with # are ignored\r\n\r\nfrom1\tto1\r\nfrom2\tto2\r\n"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_ONLY
-#: Merge.rc:5798
+#: Merge.rc:5797
 msgid "Built-in only"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_FIRST
-#: Merge.rc:5799
+#: Merge.rc:5798
 msgid "Built-in first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_FIRST
-#: Merge.rc:5800
+#: Merge.rc:5799
 msgid "Tree-sitter first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_ONLY
-#: Merge.rc:5801
+#: Merge.rc:5800
 msgid "Tree-sitter only"
 msgstr ""
 

--- a/Translations/WinMerge/Tamil.po
+++ b/Translations/WinMerge/Tamil.po
@@ -21,7 +21,7 @@ msgstr ""
 "X-Poedit-SourceCharset: UTF-8\n"
 
 #. LANGUAGE, SUBLANGUAGE
-#: Merge.rc:26 Merge.rc:59 Merge.rc:5818
+#: Merge.rc:26 Merge.rc:59 Merge.rc:5817
 msgid "LANG_ENGLISH, SUBLANG_ENGLISH_US"
 msgstr "LANG_TAMIL, SUBLANG_TAMIL_INDIA"
 
@@ -171,7 +171,7 @@ msgstr "கைஉரைகள்"
 #. IDS_NO_EDIT_SCRIPTS
 #: Merge.rc:127 Merge.rc:352 Merge.rc:463 Merge.rc:673 Merge.rc:678
 #: Merge.rc:887 Merge.rc:899 Merge.rc:906 Merge.rc:963 Merge.rc:1210
-#: Merge.rc:5375
+#: Merge.rc:5374
 msgid "< Empty >"
 msgstr "< காலி >"
 
@@ -237,7 +237,7 @@ msgid "Auto-Fit All Columns"
 msgstr "அனைத்து நெடுவரிசைகளையும் தானாக பொருத்து"
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN
-#: Merge.rc:153 Merge.rc:5646
+#: Merge.rc:153 Merge.rc:5645
 msgid "&Filter by This Column"
 msgstr ""
 
@@ -298,7 +298,7 @@ msgid "&Previous Page"
 msgstr "முந்தைய பக்கம்"
 
 #. IDS_PREVIEWBAR_NEXTPAGE
-#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5679
+#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5678
 msgid "&Next Page"
 msgstr "அடுத்த பக்கம்"
 
@@ -549,7 +549,7 @@ msgstr "இருமம்"
 #. IDS_IMAGE_MENU
 #: Merge.rc:329 Merge.rc:338 Merge.rc:432 Merge.rc:441 Merge.rc:609
 #: Merge.rc:618 Merge.rc:670 Merge.rc:960 Merge.rc:1187 Merge.rc:1200
-#: Merge.rc:5477
+#: Merge.rc:5476
 msgid "&Image"
 msgstr "படம்"
 
@@ -671,7 +671,7 @@ msgid "&Huge"
 msgstr "பெரிய"
 
 #. IDS_VIEW_MENU_BAR
-#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5714
+#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5713
 msgid "Men&u Bar"
 msgstr "பட்டியல் பட்டி"
 
@@ -1326,7 +1326,7 @@ msgid "Lo&cation Pane"
 msgstr "இருப்பிட பலகம்"
 
 #. IDS_OUTPUTBAR_CAPTION
-#: Merge.rc:782 Merge.rc:5252
+#: Merge.rc:782 Merge.rc:5251
 msgid "Output Pane"
 msgstr "வெளியீட்டு பலகம்"
 
@@ -1589,55 +1589,55 @@ msgid "Co&mpare As"
 msgstr "இவ்வாறு ஒப்பிடு"
 
 #. IDS_COPY_LEFT_TO_MIDDLE2
-#: Merge.rc:968 Merge.rc:980 Merge.rc:4852
+#: Merge.rc:968 Merge.rc:980 Merge.rc:4851
 #, c-format
 msgid "Left to Middle (%1 of %2)"
 msgstr "இடமிருந்து நடுப்பகுதிக்கு (%2 இல் %1)"
 
 #. IDS_COPY_LEFT_TO_RIGHT2
-#: Merge.rc:969 Merge.rc:981 Merge.rc:4851
+#: Merge.rc:969 Merge.rc:981 Merge.rc:4850
 #, c-format
 msgid "Left to Right (%1 of %2)"
 msgstr "இடமிருந்து வலமாக (%2 இல் %1)"
 
 #. IDS_MOVE_LEFT_TO2
-#: Merge.rc:970 Merge.rc:982 Merge.rc:1045 Merge.rc:4863 Merge.rc:4892
+#: Merge.rc:970 Merge.rc:982 Merge.rc:1045 Merge.rc:4862 Merge.rc:4891
 #, c-format
 msgid "Left to... (%1 of %2)"
 msgstr "இடது... (%2 இல் %1)"
 
 #. IDS_COPY_MIDDLE_TO_LEFT2
-#: Merge.rc:971 Merge.rc:983 Merge.rc:4849
+#: Merge.rc:971 Merge.rc:983 Merge.rc:4848
 #, c-format
 msgid "Middle to Left (%1 of %2)"
 msgstr "நடுவிலிருந்து இடது (%2 இல் %1)"
 
 #. IDS_COPY_MIDDLE_TO_RIGHT2
-#: Merge.rc:972 Merge.rc:984 Merge.rc:4850
+#: Merge.rc:972 Merge.rc:984 Merge.rc:4849
 #, c-format
 msgid "Middle to Right (%1 of %2)"
 msgstr "நடுவிலிருந்து வலமாக (%2 இல் %1)"
 
 #. IDS_MOVE_MIDDLE_TO2
-#: Merge.rc:973 Merge.rc:985 Merge.rc:1046 Merge.rc:4864 Merge.rc:4893
+#: Merge.rc:973 Merge.rc:985 Merge.rc:1046 Merge.rc:4863 Merge.rc:4892
 #, c-format
 msgid "Middle to... (%1 of %2)"
 msgstr "மத்தியில் இருந்து... (%2 இல் %1)"
 
 #. IDS_COPY_RIGHT_TO_MIDDLE2
-#: Merge.rc:974 Merge.rc:986 Merge.rc:4848
+#: Merge.rc:974 Merge.rc:986 Merge.rc:4847
 #, c-format
 msgid "Right to Middle (%1 of %2)"
 msgstr "வலமிருந்து நடுவிற்கு (%2 இல் %1)"
 
 #. IDS_COPY_RIGHT_TO_LEFT2
-#: Merge.rc:975 Merge.rc:987 Merge.rc:4847
+#: Merge.rc:975 Merge.rc:987 Merge.rc:4846
 #, c-format
 msgid "Right to Left (%1 of %2)"
 msgstr "வலமிருந்து இடமாக (%2 இல் %1)"
 
 #. IDS_MOVE_RIGHT_TO2
-#: Merge.rc:976 Merge.rc:988 Merge.rc:1047 Merge.rc:4865 Merge.rc:4894
+#: Merge.rc:976 Merge.rc:988 Merge.rc:1047 Merge.rc:4864 Merge.rc:4893
 #, c-format
 msgid "Right to... (%1 of %2)"
 msgstr "வலமிருந்து... (%2 இல் %1)"
@@ -1693,31 +1693,31 @@ msgid "Cop&y Paths"
 msgstr "பாதை பெயர்களை நகலெடு"
 
 #. IDS_DEL_LEFT_FMT2
-#: Merge.rc:1026 Merge.rc:1035 Merge.rc:4880
+#: Merge.rc:1026 Merge.rc:1035 Merge.rc:4879
 #, c-format
 msgid "Left (%1 of %2)"
 msgstr "இடது (%1 இல் %2)"
 
 #. IDS_DEL_MIDDLE_FMT2
-#: Merge.rc:1027 Merge.rc:1036 Merge.rc:4881
+#: Merge.rc:1027 Merge.rc:1036 Merge.rc:4880
 #, c-format
 msgid "Middle (%1 of %2)"
 msgstr "நடுநிலை (%2 இல் %1)"
 
 #. IDS_DEL_RIGHT_FMT2
-#: Merge.rc:1028 Merge.rc:1037 Merge.rc:4882
+#: Merge.rc:1028 Merge.rc:1037 Merge.rc:4881
 #, c-format
 msgid "Right (%1 of %2)"
 msgstr "வலது (%2 இல் %1)"
 
 #. IDS_DEL_BOTH_FMT2
-#: Merge.rc:1029 Merge.rc:1038 Merge.rc:4883
+#: Merge.rc:1029 Merge.rc:1038 Merge.rc:4882
 #, c-format
 msgid "Both (%1 of %2)"
 msgstr "இரண்டும் (%2 இல் %1)"
 
 #. IDS_DEL_ALL_FMT2
-#: Merge.rc:1030 Merge.rc:1039 Merge.rc:4888
+#: Merge.rc:1030 Merge.rc:1039 Merge.rc:4887
 #, c-format
 msgid "All (%1 of %2)"
 msgstr "அனைத்தும் (%2 இல் %1)"
@@ -1743,19 +1743,19 @@ msgid "&Zip"
 msgstr "சுருக்கு"
 
 #. IDS_COPY_BOTH_TO2
-#: Merge.rc:1048 Merge.rc:4866
+#: Merge.rc:1048 Merge.rc:4865
 #, c-format
 msgid "Both to... (%1 of %2)"
 msgstr "இரண்டுக்கும்... (%2 இல் %1)"
 
 #. IDS_COPY_ALL_TO2
-#: Merge.rc:1049 Merge.rc:4867
+#: Merge.rc:1049 Merge.rc:4866
 #, c-format
 msgid "All to... (%1 of %2)"
 msgstr "அனைவருக்கும்... (%2 இல் %1)"
 
 #. IDS_COPY_DIFFERENCES_TO2
-#: Merge.rc:1050 Merge.rc:4868
+#: Merge.rc:1050 Merge.rc:4867
 #, c-format
 msgid "Differences to... (%1 of %2)"
 msgstr "இதற்கான வேறுபாடுகள்... (%2 இல் %1)"
@@ -1822,12 +1822,12 @@ msgstr "பிரிப்பான் அமைப்புகள்"
 
 #. IDS_USERCHOICE_NONE
 #: Merge.rc:1088 Merge.rc:1094 Merge.rc:1836 Merge.rc:1840 Merge.rc:2031
-#: Merge.rc:2035 Merge.rc:5377
+#: Merge.rc:2035 Merge.rc:5376
 msgid "<None>"
 msgstr "<இல்லை>"
 
 #. IDS_USERCHOICE_AUTOMATIC
-#: Merge.rc:1089 Merge.rc:1095 Merge.rc:5378
+#: Merge.rc:1089 Merge.rc:1095 Merge.rc:5377
 msgid "<Automatic>"
 msgstr "<தானியங்கி>"
 
@@ -2758,12 +2758,12 @@ msgid "Text files only"
 msgstr ""
 
 #. IDS_EOL_NONE
-#: Merge.rc:1667 Merge.rc:1918 Merge.rc:5304
+#: Merge.rc:1667 Merge.rc:1918 Merge.rc:5303
 msgid "None"
 msgstr "இல்லை"
 
 #. IDS_EOL_MIXED
-#: Merge.rc:1668 Merge.rc:5299
+#: Merge.rc:1668 Merge.rc:5298
 msgid "Mixed"
 msgstr "கலவை"
 
@@ -3035,13 +3035,13 @@ msgstr ""
 
 #. IDS_DIFFERENT
 #: Merge.rc:1904 Merge.rc:1988 Merge.rc:2866 Merge.rc:3036 Merge.rc:3077
-#: Merge.rc:5058
+#: Merge.rc:5057
 msgid "Different"
 msgstr "வேறு"
 
 #. IDS_IDENTICAL
 #: Merge.rc:1905 Merge.rc:1989 Merge.rc:2865 Merge.rc:3055 Merge.rc:3116
-#: Merge.rc:5048
+#: Merge.rc:5047
 msgid "Identical"
 msgstr "ஒத்த"
 
@@ -3061,7 +3061,7 @@ msgid "Missing"
 msgstr ""
 
 #. IDS_MOVED
-#: Merge.rc:1910 Merge.rc:5076
+#: Merge.rc:1910 Merge.rc:5075
 msgid "Moved"
 msgstr ""
 
@@ -3805,7 +3805,7 @@ msgid "&Use custom system colors"
 msgstr "தனிப்பயன் கணினி வண்ணங்களைப் பயன்படுத்துங்கள்"
 
 #. IDS_PRPCAT_SYSTEM
-#: Merge.rc:2565 Merge.rc:4559 Merge.rc:4560 Merge.rc:5007
+#: Merge.rc:2565 Merge.rc:4559 Merge.rc:4560 Merge.rc:5006
 msgid "System"
 msgstr "அமைப்பு"
 
@@ -4209,7 +4209,7 @@ msgid "Items compared:"
 msgstr "ஒப்பிடப்பட்ட உருப்படிகள்:"
 
 #. IDS_PREVIEWBAR_CLOSE
-#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5685
+#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5684
 msgid "&Close"
 msgstr "மூடு"
 
@@ -4834,7 +4834,7 @@ msgid "A&ppend timestamp"
 msgstr "நேர முத்திரையை ஒரு&சேர்க்கவும்"
 
 #. IDS_CONFIRM_COPY_CAPTION
-#: Merge.rc:3214 Merge.rc:4915
+#: Merge.rc:3214 Merge.rc:4914
 msgid "Confirm Copy"
 msgstr "நகலை உறுதிப்படுத்து"
 
@@ -5073,7 +5073,7 @@ msgid "&Character Set..."
 msgstr "&எழுத்து தொகுப்பு..."
 
 #. IDS_PRPCAT_IMAGE
-#: Merge.rc:3351 Merge.rc:4574 Merge.rc:5015
+#: Merge.rc:3351 Merge.rc:4574 Merge.rc:5014
 msgid "Image"
 msgstr "படம்"
 
@@ -5476,7 +5476,7 @@ msgid "Project"
 msgstr "திட்டம்"
 
 #. IDS_COLHDR_NSDIFFS
-#: Merge.rc:4566 Merge.rc:4990
+#: Merge.rc:4566 Merge.rc:4989
 msgid "Differences"
 msgstr "வேறுபாடுகள்"
 
@@ -5625,12 +5625,12 @@ msgid "File Type"
 msgstr "கோப்பு வகை"
 
 #. IDS_COLHDR_EXTENSION
-#: Merge.rc:4653 Merge.rc:4947
+#: Merge.rc:4653 Merge.rc:4946
 msgid "Extension"
 msgstr "நீட்டிப்பு"
 
 #. IDS_PRPCAT_MESSAGE
-#: Merge.rc:4659 Merge.rc:5019
+#: Merge.rc:4659 Merge.rc:5018
 msgid "Message"
 msgstr "செய்தி"
 
@@ -5670,7 +5670,7 @@ msgid "Hidden Items"
 msgstr "மறைக்கப்பட்ட பொருட்கள்"
 
 #. IDS_PLUGINSLIST_NAME
-#: Merge.rc:4680 Merge.rc:5311
+#: Merge.rc:4680 Merge.rc:5310
 msgid "Name"
 msgstr "பெயர்"
 
@@ -5690,7 +5690,7 @@ msgid "[F] "
 msgstr "[F] "
 
 #. IDS_PLUGINSLIST_DESC
-#: Merge.rc:4684 Merge.rc:5313
+#: Merge.rc:4684 Merge.rc:5312
 msgid "Description"
 msgstr "விளக்கம்"
 
@@ -5858,159 +5858,154 @@ msgstr "வரி: %s நெடு: %d/%d எழுத்து: %d/%d"
 msgid "  Sel: %d | %d"
 msgstr "  தேர்வு: %d | %d"
 
-#. IDS_MERGEMODE_MERGING
-#: Merge.rc:4734
-msgid "Merge"
-msgstr "ஒன்றிணைத்தல்"
-
 #. IDS_DIFF_NUMBER_STATUS_FMT
-#: Merge.rc:4735
+#: Merge.rc:4734
 #, c-format
 msgid "Difference %1 of %2"
 msgstr "வேறுபாடு %2 இல் %1"
 
 #. IDS_NO_DIFF_SEL_FMT
-#: Merge.rc:4736
+#: Merge.rc:4735
 #, c-format
 msgid "%1 Differences Found"
 msgstr "%1 வேறுபாடுகள் காணப்பட்டன"
 
 #. IDS_1_DIFF_FOUND
-#: Merge.rc:4737
+#: Merge.rc:4736
 msgid "1 Difference Found"
 msgstr "1 வேறுபாடு காணப்பட்டது"
 
 #. IDS_NO_ERR_SEL_FMT
-#: Merge.rc:4738
+#: Merge.rc:4737
 #, c-format
 msgid "%1 Errors Found"
 msgstr "%1 பிழைகள் காணப்பட்டன"
 
 #. IDS_1_ERR_FOUND
-#: Merge.rc:4739
+#: Merge.rc:4738
 msgid "1 Error Found"
 msgstr "1 பிழை காணப்பட்டது"
 
 #. IDS_STATUSBAR_READONLY, Abbreviation from "Read Only"
-#: Merge.rc:4740
+#: Merge.rc:4739
 msgid "RO"
 msgstr "பம"
 
 #. IDS_DIRVIEW_STATUS_FMT_FOCUS
-#: Merge.rc:4746
+#: Merge.rc:4745
 #, c-format
 msgid "Item %1 of %2"
 msgstr "உருப்படி %2 இல் %1"
 
 #. IDS_DIRVIEW_STATUS_FMT_NOFOCUS
-#: Merge.rc:4747
+#: Merge.rc:4746
 #, c-format
 msgid "Items: %1"
 msgstr "உருப்படிகள்: %1"
 
 #. IDS_DIRVIEW_STATUS_COMPARING
-#: Merge.rc:4748
+#: Merge.rc:4747
 msgid "Comparing items..."
 msgstr "உருப்படிகளை ஒப்பிடுகிறது..."
 
 #. IDS_ITEMS_PER_SEC
-#: Merge.rc:4749
+#: Merge.rc:4748
 #, c-format
 msgid "%.1f[items/sec]"
 msgstr "%.1f[உருப்படிகள்/நொடி]"
 
 #. IDS_ERROR_INCOMPARABLE
-#: Merge.rc:4755
+#: Merge.rc:4754
 msgid "Select two existing folders/files to compare."
 msgstr ""
 "ஒப்பிடுவதற்கு ஏற்கனவே உள்ள இரண்டு கோப்புறைகள் அல்லது கோப்புகளைத் "
 "தேர்ந்தெடு."
 
 #. IDS_DIRSEL_TAG
-#: Merge.rc:4756
+#: Merge.rc:4755
 msgid "Folder Selection"
 msgstr "கோப்புறை தேர்வு"
 
 #. IDS_OPEN_FILESDIRS
-#: Merge.rc:4757
+#: Merge.rc:4756
 msgid "Select two (or three) folders/files to compare."
 msgstr ""
 "ஒப்பிட இரண்டு (அல்லது மூன்று) கோப்புறைகள் அல்லது இரண்டு (அல்லது மூன்று) "
 "கோப்புகளைத் தேர்ந்தெடு."
 
 #. IDS_OPEN_LEFTINVALID
-#: Merge.rc:4758
+#: Merge.rc:4757
 msgid "Left (1st) path is invalid!"
 msgstr "இடது (1வது) பாதை தவறானது!"
 
 #. IDS_OPEN_MIDDLEINVALID
-#: Merge.rc:4759
+#: Merge.rc:4758
 msgid "Middle (2nd) path is invalid!"
 msgstr "நடு (2வது) பாதை தவறானது!"
 
 #. IDS_OPEN_RIGHTINVALID2
-#: Merge.rc:4760
+#: Merge.rc:4759
 msgid "Right (2nd) path is invalid!"
 msgstr "வலது (2வது) பாதை தவறானது!"
 
 #. IDS_OPEN_RIGHTINVALID3
-#: Merge.rc:4761
+#: Merge.rc:4760
 msgid "Right (3rd) path is invalid!"
 msgstr "வலது (3வது) பாதை தவறானது!"
 
 #. IDS_OPEN_BOTHINVALID
-#: Merge.rc:4762
+#: Merge.rc:4761
 msgid "Both paths are invalid!"
 msgstr "இரண்டு பாதைகளும் தவறானவை!"
 
-#: Merge.rc:4764
+#: Merge.rc:4763
 msgid "Left (1st) and Middle (2nd) paths are invalid!"
 msgstr "இடது (1வது) மற்றும் நடு (2வது) பாதைகள் தவறானவை!"
 
 #. IDS_OPEN_LEFTRIGHTINVALID
-#: Merge.rc:4765
+#: Merge.rc:4764
 msgid "Left (1st) and Right (3rd) paths are invalid!"
 msgstr "இடது (1வது) மற்றும் வலது (3வது) பாதைகள் தவறானவை!"
 
-#: Merge.rc:4767
+#: Merge.rc:4766
 msgid "Middle (2nd) and Right (3rd) paths are invalid!"
 msgstr "நடு (2வது) மற்றும் வலது (3வது) பாதைகள் தவறானவை!"
 
 #. IDS_OPEN_ALLINVALID
-#: Merge.rc:4768
+#: Merge.rc:4767
 msgid "All paths are invalid!"
 msgstr "அனைத்து பாதைகளும் தவறானவை!"
 
 #. IDS_OPEN_UNPACKERDISABLED
-#: Merge.rc:4769
+#: Merge.rc:4768
 msgid "Only enabled for file comparisons"
 msgstr "கோப்பு ஒப்பீடுகளுக்கு மட்டும் இயக்கப்பட்டது"
 
 #. IDS_OPEN_MISMATCH
-#: Merge.rc:4770
+#: Merge.rc:4769
 msgid "Cannot compare file and folder!"
 msgstr "கோப்பு மற்றும் கோப்புறையை ஒப்பிட முடியாது!"
 
 #. IDS_ERROR_FILE_NOT_FOUND
-#: Merge.rc:4776
+#: Merge.rc:4775
 #, c-format
 msgid "File not found: %1"
 msgstr "கோப்பு கிடைக்கவில்லை: %1"
 
 #. IDS_ERROR_FOLDER_NOT_FOUND
-#: Merge.rc:4777
+#: Merge.rc:4776
 #, c-format
 msgid "Folder not found: %1"
 msgstr ""
 
 #. IDS_ERROR_FILE_NOT_UNPACKED
-#: Merge.rc:4778
+#: Merge.rc:4777
 #, c-format
 msgid "File not unpacked: %1"
 msgstr "கோப்பு திறக்கப்படவில்லை: %1"
 
 #. IDS_ERROR_FILEOPEN
-#: Merge.rc:4779
+#: Merge.rc:4778
 #, c-format
 msgid ""
 "Cannot open file\n"
@@ -6024,12 +6019,12 @@ msgstr ""
 "%2"
 
 #. IDS_ERROR_CONF_RESOLVE
-#: Merge.rc:4780
+#: Merge.rc:4779
 msgid "Failed to parse conflict file."
 msgstr "மோதல் கோப்பை அலசுவதில் தோல்வி."
 
 #. IDS_NOT_CONFLICT_FILE
-#: Merge.rc:4781
+#: Merge.rc:4780
 #, c-format
 msgid ""
 "The file\n"
@@ -6041,7 +6036,7 @@ msgstr ""
 "ஒரு மோதல் கோப்பு அல்ல."
 
 #. IDS_COMPARE_LARGE_FILES
-#: Merge.rc:4782
+#: Merge.rc:4781
 msgid ""
 "Comparing large files requires significant memory.\n"
 "Show only comparison results (not file contents)?"
@@ -6052,18 +6047,18 @@ msgstr ""
 "\n"
 
 #. IDS_SAVE_AS_TITLE
-#: Merge.rc:4788
+#: Merge.rc:4787
 msgid "Save As"
 msgstr "இவ்வாறு சேமி"
 
 #. IDS_SAVE_FMT
-#: Merge.rc:4789
+#: Merge.rc:4788
 #, c-format
 msgid "Save changes to %1?"
 msgstr "மாற்றங்களை %1 இல் சேமிக்கவா?"
 
 #. IDS_SAVEREADONLY_FMT
-#: Merge.rc:4790
+#: Merge.rc:4789
 #, c-format
 msgid "%1 is read-only. Override? Or 'No' to save as new filename?"
 msgstr ""
@@ -6071,11 +6066,11 @@ msgstr ""
 " விரும்புகிறீர்களா? (புதிய கோப்புப் பெயராகச் சேமிக்க வேண்டாம்.)"
 
 #. IDS_ERROR_BACKUP
-#: Merge.rc:4791
+#: Merge.rc:4790
 msgid "Error backing up file"
 msgstr "கோப்பை காப்புப் பிரதி எடுப்பதில் பிழை"
 
-#: Merge.rc:4793
+#: Merge.rc:4792
 #, c-format
 msgid ""
 "Unable to backup original file:\n"
@@ -6089,7 +6084,7 @@ msgstr ""
 "எப்படியும் தொடரலாமா?"
 
 #. IDS_FILESAVE_FAILED
-#: Merge.rc:4794
+#: Merge.rc:4793
 #, c-format
 msgid ""
 "Saving file failed.\n"
@@ -6105,7 +6100,7 @@ msgstr ""
 "\t- வேறு கோப்புப் பெயரைப் பயன்படுத்து (சரி)\n"
 "\t- நிறுத்து (நீக்கறல்)?"
 
-#: Merge.rc:4796
+#: Merge.rc:4795
 #, c-format
 msgid ""
 "Plugin '%2' cannot pack changes to left file into '%1'.\n"
@@ -6118,7 +6113,7 @@ msgstr ""
 "\n"
 "தொகுக்கப்படாத பதிப்பை வேறொரு கோப்பில் சேமிக்க விரும்புகிறீர்களா?"
 
-#: Merge.rc:4798
+#: Merge.rc:4797
 #, c-format
 msgid ""
 "Plugin '%2' cannot pack changes to middle file into '%1'.\n"
@@ -6131,7 +6126,7 @@ msgstr ""
 "\n"
 "தொகுக்கப்படாத பதிப்பை வேறொரு கோப்பில் சேமிக்க விரும்புகிறீர்களா?"
 
-#: Merge.rc:4800
+#: Merge.rc:4799
 #, c-format
 msgid ""
 "Plugin '%2' cannot pack changes to right file into '%1'.\n"
@@ -6145,7 +6140,7 @@ msgstr ""
 "தொகுக்கப்படாத பதிப்பை வேறொரு கோப்பில் சேமிக்க விரும்புகிறீர்களா?"
 
 #. IDS_FILECHANGED_ONDISK
-#: Merge.rc:4801
+#: Merge.rc:4800
 #, c-format
 msgid ""
 "Another application updated\n"
@@ -6161,7 +6156,7 @@ msgstr ""
 "மாற்றப்பட்ட கோப்பை மேலெழுதவா?"
 
 #. IDS_SAVEREADONLY_MULTI
-#: Merge.rc:4802
+#: Merge.rc:4801
 #, c-format
 msgid ""
 "%1\n"
@@ -6171,7 +6166,7 @@ msgstr ""
 "படிக்க மட்டுமே என்று குறிக்கப்பட்டுள்ளது. படிக்க மட்டுமேயான உருப்படியை மேலெழுத விரும்புகிறீர்களா?"
 
 #. IDS_FILECHANGED_RESCAN
-#: Merge.rc:4803
+#: Merge.rc:4802
 #, c-format
 msgid ""
 "Another application updated\n"
@@ -6187,22 +6182,22 @@ msgstr ""
 "மீண்டும் ஏற்றவா?"
 
 #. IDS_SAVE_LEFT_AS
-#: Merge.rc:4804
+#: Merge.rc:4803
 msgid "Save Left File As"
 msgstr "இடது கோப்பை இவ்வாறு சேமி"
 
 #. IDS_SAVE_MIDDLE_AS
-#: Merge.rc:4805
+#: Merge.rc:4804
 msgid "Save Middle File As"
 msgstr "நடு கோப்பை இவ்வாறு சேமி"
 
 #. IDS_SAVE_RIGHT_AS
-#: Merge.rc:4806
+#: Merge.rc:4805
 msgid "Save Right File As"
 msgstr "வலது கோப்பை இவ்வாறு சேமி"
 
 #. IDS_FILE_DISAPPEARED
-#: Merge.rc:4811
+#: Merge.rc:4810
 #, c-format
 msgid ""
 "File\n"
@@ -6214,7 +6209,7 @@ msgstr ""
 "மறைந்துவிட்டது. தொடர கோப்பின் நகலை சேமி."
 
 #. IDS_VIEWS_OUTOFSYNC
-#: Merge.rc:4817
+#: Merge.rc:4816
 msgid ""
 "Cannot merge unsynched documents.\n"
 "\n"
@@ -6225,186 +6220,186 @@ msgstr ""
 "தொடர்வதற்கு முன் ஆவணங்களைப் புதுப்பி."
 
 #. IDS_BREAK_ON_WHITESPACE
-#: Merge.rc:4822
+#: Merge.rc:4821
 msgid "Break at whitespace"
 msgstr "வெள்ளைவெளியில் உடைக்கவும்"
 
 #. IDS_BREAK_ON_PUNCTUATION
-#: Merge.rc:4823
+#: Merge.rc:4822
 msgid "Break at whitespace or punctuation"
 msgstr "வெள்ளை இடத்தில் அல்லது நிறுத்தற்குறியில் உடைக்கவும்"
 
 #. IDS_L2M
-#: Merge.rc:4829
+#: Merge.rc:4828
 msgid "Copy to &Middle\tAlt+Right"
 msgstr "நடுவிற்கு நகலெடு\tமாற்று+வலது"
 
 #. IDS_R2M
-#: Merge.rc:4830
+#: Merge.rc:4829
 msgid "Copy to &Middle\tAlt+Left"
 msgstr "நடுவிற்கு நகலெடு\tமாற்று+இடது"
 
 #. IDS_COPY_FROM_MIDDLE_R
-#: Merge.rc:4831
+#: Merge.rc:4830
 msgid "Copy from Middle\tAlt+Shift+Right"
 msgstr "நடுவில் இருந்து நகலெடு\tமாற்று+தூக்கு+வலது"
 
 #. IDS_COPY_FROM_MIDDLE_L
-#: Merge.rc:4832
+#: Merge.rc:4831
 msgid "Copy from Middle\tAlt+Shift+Left"
 msgstr "நடுஇலிருந்து நகலெடு\tமாற்று+தூக்கு+இடது "
 
 #. IDS_L2MNEXT
-#: Merge.rc:4833
+#: Merge.rc:4832
 msgid "Copy to Middle and Advance\tCtrl+Alt+Right"
 msgstr "நடுவிற்கு நகலெடு மேலும்\tகட்டு+மாற்று+வலது"
 
 #. IDS_R2MNEXT
-#: Merge.rc:4834
+#: Merge.rc:4833
 msgid "Copy to Middle and Advance\tCtrl+Alt+Left"
 msgstr "நடுவிற்கு நகலெடு மேலும்\tகட்டு+மாற்று+இடது"
 
 #. IDS_ALL_MIDDLE
-#: Merge.rc:4835
+#: Merge.rc:4834
 msgid "Copy All to Middle"
 msgstr "அனைத்தையும் நடுவில் நகலெடு"
 
 #. IDS_COPY_RIGHT_TO_LEFT
-#: Merge.rc:4841
+#: Merge.rc:4840
 #, c-format
 msgid "Right to Left (%1)"
 msgstr "வலமிருந்து இடமாக (%1)"
 
 #. IDS_COPY_RIGHT_TO_MIDDLE
-#: Merge.rc:4842
+#: Merge.rc:4841
 #, c-format
 msgid "Right to Middle (%1)"
 msgstr "வலமிருந்து நடுவிற்கு (%1)"
 
 #. IDS_COPY_MIDDLE_TO_LEFT
-#: Merge.rc:4843
+#: Merge.rc:4842
 #, c-format
 msgid "Middle to Left (%1)"
 msgstr "நடுவிலிருந்து இடது (%1)"
 
 #. IDS_COPY_MIDDLE_TO_RIGHT
-#: Merge.rc:4844
+#: Merge.rc:4843
 #, c-format
 msgid "Middle to Right (%1)"
 msgstr "நடுவில் இருந்து வலது (%1)"
 
 #. IDS_COPY_LEFT_TO_RIGHT
-#: Merge.rc:4845
+#: Merge.rc:4844
 #, c-format
 msgid "Left to Right (%1)"
 msgstr "இடமிருந்து வலமாக (%1)"
 
 #. IDS_COPY_LEFT_TO_MIDDLE
-#: Merge.rc:4846
+#: Merge.rc:4845
 #, c-format
 msgid "Left to Middle (%1)"
 msgstr "இடமிருந்து நடு (%1)"
 
 #. IDS_MOVE_LEFT_TO
-#: Merge.rc:4857 Merge.rc:4889
+#: Merge.rc:4856 Merge.rc:4888
 #, c-format
 msgid "Left to... (%1)"
 msgstr "இடமிருந்து... (%1)"
 
 #. IDS_MOVE_MIDDLE_TO
-#: Merge.rc:4858 Merge.rc:4890
+#: Merge.rc:4857 Merge.rc:4889
 #, c-format
 msgid "Middle to... (%1)"
 msgstr "நடுவில் இருந்து... (%1)"
 
 #. IDS_MOVE_RIGHT_TO
-#: Merge.rc:4859 Merge.rc:4891
+#: Merge.rc:4858 Merge.rc:4890
 #, c-format
 msgid "Right to... (%1)"
 msgstr "வலமிருந்து... (%1)"
 
 #. IDS_COPY_BOTH_TO
-#: Merge.rc:4860
+#: Merge.rc:4859
 #, c-format
 msgid "Both to... (%1)"
 msgstr "இரண்டுக்கும்... (%1)"
 
 #. IDS_COPY_ALL_TO
-#: Merge.rc:4861
+#: Merge.rc:4860
 #, c-format
 msgid "All to... (%1)"
 msgstr "அனைத்திற்கும்... (%1)"
 
 #. IDS_COPY_DIFFERENCES_TO
-#: Merge.rc:4862
+#: Merge.rc:4861
 #, c-format
 msgid "Differences to... (%1)"
 msgstr "வேறுபாடுகள்... (%1)"
 
 #. IDS_ONLYDIFFITEMS_CONFIRM
-#: Merge.rc:4869
+#: Merge.rc:4868
 msgid "Some selected items are identical or skipped.\nProcess only items with differences?"
 msgstr ""
 
 #. IDS_DEL_LEFT_FMT
-#: Merge.rc:4875
+#: Merge.rc:4874
 #, c-format
 msgid "Left (%1)"
 msgstr "இடது (%1)"
 
 #. IDS_DEL_MIDDLE_FMT
-#: Merge.rc:4876
+#: Merge.rc:4875
 #, c-format
 msgid "Middle (%1)"
 msgstr "நடுநிலை (%1)"
 
 #. IDS_DEL_RIGHT_FMT
-#: Merge.rc:4877
+#: Merge.rc:4876
 #, c-format
 msgid "Right (%1)"
 msgstr "வலது (%1)"
 
 #. IDS_DEL_BOTH_FMT
-#: Merge.rc:4878
+#: Merge.rc:4877
 #, c-format
 msgid "Both (%1)"
 msgstr "இரண்டும் (%1)"
 
 #. IDS_DEL_ALL_FMT
-#: Merge.rc:4879
+#: Merge.rc:4878
 #, c-format
 msgid "All (%1)"
 msgstr "அனைத்தும் (%1)"
 
 #. IDS_SELECT_DEST_LEFT
-#: Merge.rc:4895
+#: Merge.rc:4894
 msgid "Left Side - Select Destination Folder:"
 msgstr "இடது பக்கம் - இலக்கு கோப்புறையைத் தேர்ந்தெடு:"
 
 #. IDS_SELECT_DEST_MIDDLE
-#: Merge.rc:4896
+#: Merge.rc:4895
 msgid "Middle Side - Select Destination Folder:"
 msgstr "நடுபக்கம் - இலக்கு கோப்புறையை தேர்ந்தெடு:"
 
 #. IDS_SELECT_DEST_RIGHT
-#: Merge.rc:4897
+#: Merge.rc:4896
 msgid "Right Side - Select Destination Folder:"
 msgstr "வலது பக்கம் - இலக்கு கோப்புறையைத் தேர்ந்தெடு:"
 
 #. IDS_FILES_AFFECTED_FMT
-#: Merge.rc:4898
+#: Merge.rc:4897
 #, c-format
 msgid "(%1 Files Affected)"
 msgstr "(%1 கோப்புகள் பாதிக்கப்பட்டுள்ளன)"
 
 #. IDS_FILES_AFFECTED_FMT2
-#: Merge.rc:4899
+#: Merge.rc:4898
 #, c-format
 msgid "(%1 of %2 Files Affected)"
 msgstr "(%2 கோப்புகளில் %1 பாதிக்கப்பட்டது)"
 
 #. IDS_CONFIRM_DELETE_SINGLE
-#: Merge.rc:4905
+#: Merge.rc:4904
 #, c-format
 msgid ""
 "Are you sure you want to delete\n"
@@ -6416,18 +6411,18 @@ msgstr ""
 "% 1 ?"
 
 #. IDS_CONFIRM_SINGLE_COPY
-#: Merge.rc:4906
+#: Merge.rc:4905
 msgid "Are you sure you want to copy?"
 msgstr "நீங்கள் நிச்சயமாக நகலெடுக்க விரும்புகிறீர்களா?"
 
 #. IDS_CONFIRM_MULTIPLE_COPY
-#: Merge.rc:4907
+#: Merge.rc:4906
 #, c-format
 msgid "Are you sure you want to copy %d items?"
 msgstr "%d உருப்படிகளை நிச்சயமாக நகலெடுக்க விரும்புகிறீர்களா?"
 
 #. IDS_DIRCMP_NOTSYNC
-#: Merge.rc:4908
+#: Merge.rc:4907
 #, c-format
 msgid ""
 "Operation aborted!\n"
@@ -6447,48 +6442,48 @@ msgstr ""
 "தயவுசெய்து ஒப்பீட்டைப் புதுப்பி."
 
 #. IDS_CONFIRM_SINGLE_MOVE
-#: Merge.rc:4913
+#: Merge.rc:4912
 msgid "Are you sure you want to move?"
 msgstr "நீங்கள் நிச்சயமாக நகர்த்த விரும்புகிறீர்களா?"
 
 #. IDS_CONFIRM_MULTIPLE_MOVE
-#: Merge.rc:4914
+#: Merge.rc:4913
 #, c-format
 msgid "Are you sure you want to move %d items?"
 msgstr "%d உருப்படிகளை நிச்சயமாக நகர்த்த விரும்புகிறீர்களா?"
 
 #. IDS_CONFIRM_MOVE_CAPTION
-#: Merge.rc:4916
+#: Merge.rc:4915
 msgid "Confirm Move"
 msgstr "நகர்த்தலை உறுதிப்படுத்து"
 
-#: Merge.rc:4918
+#: Merge.rc:4917
 msgid "Close the folder comparison window?"
 msgstr ""
 "கோப்புறைகளை ஒப்பிடும் சாளரத்தை மூட உள்ளீர்கள். நிச்சயமாக நீங்கள் சாளரத்தை "
 "மூட விரும்புகிறீர்களா?"
 
-#: Merge.rc:4920
+#: Merge.rc:4919
 msgid "Close the folder comparison window, which took a long time?"
 msgstr "கோப்புறை ஒப்பீட்டு சாளரத்தை மூடு, இது நீண்ட நேரம் எடுத்தது?"
 
 #. IDS_ERROR_INVALID_DIR_FILE_NAME
-#: Merge.rc:4921
+#: Merge.rc:4920
 msgid "The file or folder name is invalid."
 msgstr "கோப்பு அல்லது கோப்புறையின் பெயர் தவறானது."
 
 #. IDS_ERROR_EXECUTE_FILE
-#: Merge.rc:4927
+#: Merge.rc:4926
 #, c-format
 msgid "Failed to execute external editor: %1"
 msgstr "வெளிப்புற எடிட்டரை இயக்குவதில் தோல்வி: %1"
 
 #. IDS_UNKNOWN_ARCHIVE_FORMAT
-#: Merge.rc:4933
+#: Merge.rc:4932
 msgid "Unknown archive format"
 msgstr "தெரியாத காப்பக வடிவம்"
 
-#: Merge.rc:4935
+#: Merge.rc:4934
 msgid ""
 "Failed to extract archive.\n"
 "Compare as text file?"
@@ -6497,752 +6492,752 @@ msgstr ""
 "காப்பகக் கோப்புகளை உரைக் கோப்புகளாக ஒப்பிட விரும்புகிறீர்களா?"
 
 #. IDS_COLHDR_FILENAME
-#: Merge.rc:4941
+#: Merge.rc:4940
 msgid "Filename"
 msgstr "கோப்புபெயர்"
 
 #. IDS_COLHDR_DIR
-#: Merge.rc:4942
+#: Merge.rc:4941
 msgctxt "DirView|ColumnHeader"
 msgid "Folder"
 msgstr "கோப்புறை"
 
 #. IDS_COLHDR_RESULT
-#: Merge.rc:4943
+#: Merge.rc:4942
 msgid "Comparison Result"
 msgstr "ஒப்பீடு முடிவு"
 
 #. IDS_COLHDR_LTIMEM
-#: Merge.rc:4944
+#: Merge.rc:4943
 msgid "Left Date"
 msgstr "இடது தேதி"
 
 #. IDS_COLHDR_RTIMEM
-#: Merge.rc:4945
+#: Merge.rc:4944
 msgid "Right Date"
 msgstr "வலது தேதி"
 
 #. IDS_COLHDR_MTIMEM
-#: Merge.rc:4946
+#: Merge.rc:4945
 msgid "Middle Date"
 msgstr "நடு தேதி"
 
 #. IDS_COLHDR_LSIZE
-#: Merge.rc:4948
+#: Merge.rc:4947
 msgid "Left Size"
 msgstr "இடது அளவு"
 
 #. IDS_COLHDR_RSIZE
-#: Merge.rc:4949
+#: Merge.rc:4948
 msgid "Right Size"
 msgstr "வலது அளவு"
 
 #. IDS_COLHDR_MSIZE
-#: Merge.rc:4954
+#: Merge.rc:4953
 msgid "Middle Size"
 msgstr "நடு அளவு"
 
 #. IDS_COLHDR_RSIZE_SHORT
-#: Merge.rc:4955
+#: Merge.rc:4954
 msgid "Right Size (Short)"
 msgstr "வலது அளவு (குறுகிய)"
 
 #. IDS_COLHDR_LSIZE_SHORT
-#: Merge.rc:4956
+#: Merge.rc:4955
 msgid "Left Size (Short)"
 msgstr "இடது அளவு (குறுகிய)"
 
 #. IDS_COLHDR_MSIZE_SHORT
-#: Merge.rc:4957
+#: Merge.rc:4956
 msgid "Middle Size (Short)"
 msgstr "நடு அளவு (குறுகிய)"
 
 #. IDS_COLHDR_LTIMEC
-#: Merge.rc:4963
+#: Merge.rc:4962
 msgid "Left Creation Time"
 msgstr "இடது உருவாக்க நேரம்"
 
 #. IDS_COLHDR_RTIMEC
-#: Merge.rc:4964
+#: Merge.rc:4963
 msgid "Right Creation Time"
 msgstr "வலது உருவாக்க நேரம்"
 
 #. IDS_COLHDR_MTIMEC
-#: Merge.rc:4965
+#: Merge.rc:4964
 msgid "Middle Creation Time"
 msgstr "நடு உருவாக்க நேரம்"
 
 #. IDS_COLHDR_NEWER
-#: Merge.rc:4966
+#: Merge.rc:4965
 msgid "Newer File"
 msgstr "புதிய கோப்பு"
 
 #. IDS_COLHDR_LVERSION
-#: Merge.rc:4967
+#: Merge.rc:4966
 msgid "Left File Version"
 msgstr "இடது கோப்பு பதிப்பு"
 
 #. IDS_COLHDR_RVERSION
-#: Merge.rc:4968
+#: Merge.rc:4967
 msgid "Right File Version"
 msgstr "வலது கோப்பு பதிப்பு"
 
 #. IDS_COLHDR_MVERSION
-#: Merge.rc:4969
+#: Merge.rc:4968
 msgid "Middle File Version"
 msgstr "நடு கோப்பு பதிப்பு"
 
 #. IDS_COLHDR_RESULT_ABBR
-#: Merge.rc:4970
+#: Merge.rc:4969
 msgid "Short Result"
 msgstr "குறுகிய முடிவு"
 
 #. IDS_COLHDR_LATTRIBUTES
-#: Merge.rc:4971
+#: Merge.rc:4970
 msgid "Left Attributes"
 msgstr "இடது பண்புக்கூறுகள்"
 
 #. IDS_COLHDR_RATTRIBUTES
-#: Merge.rc:4972
+#: Merge.rc:4971
 msgid "Right Attributes"
 msgstr "வலது பண்புக்கூறுகள்"
 
 #. IDS_COLHDR_MATTRIBUTES
-#: Merge.rc:4973
+#: Merge.rc:4972
 msgid "Middle Attributes"
 msgstr "நடு பண்புக்கூறுகள்"
 
 #. IDS_COLHDR_LEOL_TYPE
-#: Merge.rc:4978
+#: Merge.rc:4977
 msgid "Left EOL"
 msgstr "இடது வரிமுடிவு"
 
 #. IDS_COLHDR_MEOL_TYPE
-#: Merge.rc:4979
+#: Merge.rc:4978
 msgid "Middle EOL"
 msgstr "நடு வரிமுடிவு"
 
 #. IDS_COLHDR_REOL_TYPE
-#: Merge.rc:4980
+#: Merge.rc:4979
 msgid "Right EOL"
 msgstr "வலது வரிமுடிவு"
 
 #. IDS_COLHDR_LENCODING
-#: Merge.rc:4986
+#: Merge.rc:4985
 msgid "Left Encoding"
 msgstr "இடது குறியாக்கம்"
 
 #. IDS_COLHDR_RENCODING
-#: Merge.rc:4987
+#: Merge.rc:4986
 msgid "Right Encoding"
 msgstr "வலது குறியாக்கம்"
 
 #. IDS_COLHDR_MENCODING
-#: Merge.rc:4988
+#: Merge.rc:4987
 msgid "Middle Encoding"
 msgstr "நடு குறியாக்கம்"
 
 #. IDS_COLHDR_NIDIFFS
-#: Merge.rc:4989
+#: Merge.rc:4988
 msgid "Ignored Diff"
 msgstr "புறக்கணிக்கப்பட்ட வேறுபாடு"
 
 #. IDS_COLHDR_BINARY
-#: Merge.rc:4991
+#: Merge.rc:4990
 msgctxt "DirView|ColumnHeader"
 msgid "Binary"
 msgstr "இருமம்"
 
 #. IDS_PLUGINS_TYPE_UNPACKER
-#: Merge.rc:4992 Merge.rc:5314
+#: Merge.rc:4991 Merge.rc:5313
 msgid "Unpacker"
 msgstr "பிரிப்பான்"
 
 #. IDS_PLUGIN_TYPE4
-#: Merge.rc:4993 Merge.rc:5315 Merge.rc:5622
+#: Merge.rc:4992 Merge.rc:5314 Merge.rc:5621
 msgid "Prediffer"
 msgstr "முன்வேறுபாடு"
 
 #. IDS_COLHDR_LEFT
-#: Merge.rc:4994
+#: Merge.rc:4993
 msgid "Left"
 msgstr "இடது"
 
 #. IDS_COLHDR_MIDDLE
-#: Merge.rc:4995
+#: Merge.rc:4994
 msgid "Middle"
 msgstr "நடு"
 
 #. IDS_COLHDR_RIGHT
-#: Merge.rc:4996
+#: Merge.rc:4995
 msgid "Right"
 msgstr "வலது"
 
 #. IDS_COLHDR_DIFF
-#: Merge.rc:4997
+#: Merge.rc:4996
 msgid "Diff"
 msgstr "வேறுபாடு"
 
 #. IDS_COLHDR_LEFT_DUPLICATE
-#: Merge.rc:4998
+#: Merge.rc:4997
 msgid "Left Duplicate Count"
 msgstr "இடது நகல் எண்ணிக்கை"
 
 #. IDS_COLHDR_RIGHT_DUPLICATE
-#: Merge.rc:4999
+#: Merge.rc:4998
 msgid "Right Duplicate Count"
 msgstr "வலது நகல் எண்ணிக்கை"
 
 #. IDS_COLHDR_MIDDLE_DUPLICATE
-#: Merge.rc:5000
+#: Merge.rc:4999
 msgid "Middle Duplicate Count"
 msgstr "நடு நகல் எண்ணிக்கை"
 
 #. IDS_COLHDR_MOVE
-#: Merge.rc:5001
+#: Merge.rc:5000
 msgid "Move"
 msgstr "நகர்த்து"
 
 #. IDS_PRPCAT_AUDIO
-#: Merge.rc:5008
+#: Merge.rc:5007
 msgid "Audio"
 msgstr "ஆடியோ"
 
 #. IDS_PRPCAT_CALENDAR
-#: Merge.rc:5009
+#: Merge.rc:5008
 msgid "Calendar"
 msgstr "நாட்காட்டி"
 
 #. IDS_PRPCAT_COMMUNICATION
-#: Merge.rc:5010
+#: Merge.rc:5009
 msgid "Communication"
 msgstr "தொடர்பு"
 
 #. IDS_PRPCAT_CONTACT
-#: Merge.rc:5011
+#: Merge.rc:5010
 msgid "Contact"
 msgstr "தொடர்பு"
 
 #. IDS_PRPCAT_DEVICES
-#: Merge.rc:5012
+#: Merge.rc:5011
 msgid "Devices"
 msgstr "சாதனங்கள்"
 
 #. IDS_PRPCAT_DOCUMENT
-#: Merge.rc:5013
+#: Merge.rc:5012
 msgid "Document"
 msgstr "ஆவணம்"
 
 #. IDS_PRPCAT_HOME
-#: Merge.rc:5014
+#: Merge.rc:5013
 msgid "Home"
 msgstr "முகப்பு"
 
 #. IDS_PRPCAT_JOURNAL
-#: Merge.rc:5016
+#: Merge.rc:5015
 msgid "Journal"
 msgstr "பத்திரிகை"
 
 #. IDS_PRPCAT_LINK
-#: Merge.rc:5017
+#: Merge.rc:5016
 msgid "Link"
 msgstr "இணைப்பு"
 
 #. IDS_PRPCAT_MEDIA
-#: Merge.rc:5018
+#: Merge.rc:5017
 msgid "Media"
 msgstr "ஊடகம்"
 
 #. IDS_PRPCAT_MUSIC
-#: Merge.rc:5020
+#: Merge.rc:5019
 msgid "Music"
 msgstr "இசை"
 
 #. IDS_PRPCAT_NOTE
-#: Merge.rc:5021
+#: Merge.rc:5020
 msgid "Note"
 msgstr "குறிப்பு"
 
 #. IDS_PRPCAT_PHOTO
-#: Merge.rc:5022
+#: Merge.rc:5021
 msgid "Photo"
 msgstr "புகைப்படம்"
 
 #. IDS_PRPCAT_RECORDEDTV
-#: Merge.rc:5023
+#: Merge.rc:5022
 msgid "RecordedTV"
 msgstr "பதிவுசெய்யப்பட்ட டிவி"
 
 #. IDS_PRPCAT_SEARCH
-#: Merge.rc:5024
+#: Merge.rc:5023
 msgid "Search"
 msgstr "தேடல்"
 
 #. IDS_PRPCAT_SECURITY
-#: Merge.rc:5025
+#: Merge.rc:5024
 msgid "Security"
 msgstr "பாதுகாப்பு"
 
 #. IDS_PRPCAT_SOFTWARE
-#: Merge.rc:5026
+#: Merge.rc:5025
 msgid "Software"
 msgstr "மென்பொருள்"
 
 #. IDS_PRPCAT_TASK
-#: Merge.rc:5027
+#: Merge.rc:5026
 msgid "Task"
 msgstr "பணி"
 
 #. IDS_PRPCAT_VIDEO
-#: Merge.rc:5028
+#: Merge.rc:5027
 msgid "Video"
 msgstr "காணொளி"
 
 #. IDS_PRPCAT_HASH
-#: Merge.rc:5029
+#: Merge.rc:5028
 msgid "Hash"
 msgstr "கொத்து"
 
 #. IDS_CANT_COMPARE_FILES
-#: Merge.rc:5035
+#: Merge.rc:5034
 msgid "Unable to compare files"
 msgstr "கோப்புகளை ஒப்பிட முடியவில்லை"
 
 #. IDS_ABORTED_ITEM
-#: Merge.rc:5036
+#: Merge.rc:5035
 msgid "Item aborted"
 msgstr "உருப்படி நிறுத்தப்பட்டது"
 
 #. IDS_FILE_SKIPPED
-#: Merge.rc:5037
+#: Merge.rc:5036
 msgid "File skipped"
 msgstr "கோப்பு தவிர்க்கப்பட்டது"
 
 #. IDS_DIR_SKIPPED
-#: Merge.rc:5038
+#: Merge.rc:5037
 msgid "Folder skipped"
 msgstr "கோப்புறை தவிர்க்கப்பட்டது"
 
 #. IDS_LEFT_ONLY_IN_FMT
-#: Merge.rc:5039
+#: Merge.rc:5038
 #, c-format
 msgid "Left only: %1"
 msgstr "இடது மட்டும்: %1"
 
 #. IDS_MIDDLE_ONLY_IN_FMT
-#: Merge.rc:5040
+#: Merge.rc:5039
 #, c-format
 msgid "Middle only: %1"
 msgstr "நடுவில் மட்டும்: %1"
 
 #. IDS_RIGHT_ONLY_IN_FMT
-#: Merge.rc:5041
+#: Merge.rc:5040
 #, c-format
 msgid "Right only: %1"
 msgstr "வலது மட்டும்: %1"
 
 #. IDS_DOES_NOT_EXIST_IN_FMT
-#: Merge.rc:5042
+#: Merge.rc:5041
 #, c-format
 msgid "Does not exist in %1"
 msgstr "%1 இல் இல்லை"
 
 #. IDS_BIN_FILES_SAME
-#: Merge.rc:5043
+#: Merge.rc:5042
 msgid "Binary files are identical"
 msgstr "இருமம் கோப்புகள் ஒரே மாதிரியானவை"
 
 #. IDS_BIN_FILES_DIFF
-#: Merge.rc:5049
+#: Merge.rc:5048
 msgid "Binary files are different"
 msgstr "இருமம் கோப்புகள் வேறுபட்டவை"
 
 #. IDS_FILES_ARE_DIFFERENT
-#: Merge.rc:5050
+#: Merge.rc:5049
 msgid "Files are different"
 msgstr "கோப்புகள் வேறுபட்டவை"
 
 #. IDS_FOLDERS_ARE_DIFFERENT
-#: Merge.rc:5051
+#: Merge.rc:5050
 msgid "Folders are different"
 msgstr "கோப்புறைகள் வேறுபட்டவை"
 
 #. IDS_LEFTONLY
-#: Merge.rc:5052
+#: Merge.rc:5051
 msgid "Left Only"
 msgstr "இடது மட்டும்"
 
 #. IDS_RIGHTONLY
-#: Merge.rc:5053
+#: Merge.rc:5052
 msgid "Right Only"
 msgstr "வலது மட்டும்"
 
 #. IDS_MIDDLEONLY
-#: Merge.rc:5054
+#: Merge.rc:5053
 msgid "Middle Only"
 msgstr "நடு மட்டும்"
 
 #. IDS_NOITEMLEFT
-#: Merge.rc:5055
+#: Merge.rc:5054
 msgid "No item in left"
 msgstr "இடதுபுறத்தில் உருப்படி இல்லை"
 
 #. IDS_NOITEMRIGHT
-#: Merge.rc:5056
+#: Merge.rc:5055
 msgid "No item in right"
 msgstr "வலதுபுறத்தில் உருப்படி இல்லை"
 
 #. IDS_NOITEMMIDDLE
-#: Merge.rc:5057
+#: Merge.rc:5056
 msgid "No item in middle"
 msgstr "நடுவில் உருப்படி இல்லை"
 
 #. IDS_CMPRES_ERROR
-#: Merge.rc:5059
+#: Merge.rc:5058
 msgid "Error"
 msgstr "பிழை"
 
 #. IDS_TEXT_FILES_SAME
-#: Merge.rc:5060
+#: Merge.rc:5059
 msgid "Text files are identical"
 msgstr "உரை கோப்புகள் ஒரே மாதிரியானவை"
 
 #. IDS_LEFTONLY_DIFF
-#: Merge.rc:5061
+#: Merge.rc:5060
 msgid " (Middle and right are identical)"
 msgstr " (நடு மற்றும் வலது ஒரே மாதிரியானவை)"
 
 #. IDS_MIDDLEONLY_DIFF
-#: Merge.rc:5062
+#: Merge.rc:5061
 msgid " (Left and right are identical)"
 msgstr " (இடது மற்றும் வலது ஒரே மாதிரியானவை)"
 
 #. IDS_RIGHTONLY_DIFF
-#: Merge.rc:5063
+#: Merge.rc:5062
 msgid " (Left and middle are identical)"
 msgstr " (இடது மற்றும் நடு ஒரே மாதிரியானவை)"
 
 #. IDS_PATH_MISMATCH
-#: Merge.rc:5064
+#: Merge.rc:5063
 msgid " (paths differ)"
 msgstr ""
 
 #. IDS_TEXT_FILES_DIFF
-#: Merge.rc:5065
+#: Merge.rc:5064
 msgid "Text files are different"
 msgstr "உரை கோப்புகள் வேறுபட்டவை"
 
 #. IDS_IMAGE_FILES_SAME
-#: Merge.rc:5066
+#: Merge.rc:5065
 msgid "Image files are identical"
 msgstr "பட கோப்புகள் ஒரே மாதிரியானவை"
 
 #. IDS_IMAGE_FILES_DIFF
-#: Merge.rc:5067
+#: Merge.rc:5066
 msgid "Image files are different"
 msgstr "பட கோப்புகள் வேறுபட்டவை"
 
 #. IDS_EXPR_DIFF
-#: Merge.rc:5068
+#: Merge.rc:5067
 #, c-format
 msgid "Files are different (expr: %1)"
 msgstr ""
 
 #. IDS_HASH_GROUP
-#: Merge.rc:5069
+#: Merge.rc:5068
 #, c-format
 msgid "Group%d"
 msgstr "குழு%d"
 
 #. IDS_RENAME_MOVE_DETECTION_DISALBED
-#: Merge.rc:5070
+#: Merge.rc:5069
 msgctxt "Options dialog|Compare|Folder|Detect renames and moves"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_RENAME_MOVE_DETECTION_RENAME
-#: Merge.rc:5071
+#: Merge.rc:5070
 msgid "Detect renames"
 msgstr ""
 
 #. IDS_RENAME_MOVE_DETECTION_RENAME_MOVE
-#: Merge.rc:5072
+#: Merge.rc:5071
 msgid "Detect renames and moves"
 msgstr ""
 
 #. IDS_RENAME_MOVE_MERGE_MODE_RENAME
-#: Merge.rc:5073
+#: Merge.rc:5072
 msgid "Merge renames"
 msgstr ""
 
 #. IDS_RENAME_MOVE_MERGE_MODE_RENAME_MOVE
-#: Merge.rc:5074
+#: Merge.rc:5073
 msgid "Merge renames and moves"
 msgstr ""
 
 #. IDS_RENAMED
-#: Merge.rc:5075
+#: Merge.rc:5074
 msgid "Renamed"
 msgstr ""
 
 #. IDS_RENAMED_MOVED
-#: Merge.rc:5077
+#: Merge.rc:5076
 msgid "Renamed/Moved"
 msgstr ""
 
 #. IDS_RENAMED_MOVED_ITEMS
-#: Merge.rc:5078
+#: Merge.rc:5077
 #, c-format
 msgid "(%1 items)"
 msgstr ""
 
 #. IDS_RENAMED_MOVED_RESULT
-#: Merge.rc:5079
+#: Merge.rc:5078
 #, c-format
 msgid "%1 (set %2): "
 msgstr ""
 
 #. IDS_SWITCH_FLAT_MODE
-#: Merge.rc:5080
+#: Merge.rc:5079
 msgid "Some moved items have been merged.\nIn Tree Mode, these items may appear in positions that do not reflect the actual folder structure, which can be confusing.\nSwitch to Flat Mode?"
 msgstr ""
 
 #. IDS_ELAPSED_TIME
-#: Merge.rc:5086
+#: Merge.rc:5085
 #, c-format
 msgid "Elapsed time: %ld ms"
 msgstr "கடந்த நேரம்: %ld ms"
 
 #. IDS_STATUS_SELITEM1
-#: Merge.rc:5087
+#: Merge.rc:5086
 msgid "1 item selected"
 msgstr "1 உருப்படி தேர்ந்தெடுக்கப்பட்டது"
 
 #. IDS_STATUS_SELITEMS
-#: Merge.rc:5088
+#: Merge.rc:5087
 #, c-format
 msgid "%1 items selected"
 msgstr "%1 உருப்படிகள் தேர்ந்தெடுக்கப்பட்டன"
 
 #. IDS_COLDESC_FILENAME
-#: Merge.rc:5094
+#: Merge.rc:5093
 msgid "Filename or folder name."
 msgstr "கோப்பு பெயர் அல்லது கோப்புறை பெயர்."
 
 #. IDS_COLDESC_DIR
-#: Merge.rc:5095
+#: Merge.rc:5094
 msgid "Subfolder name when subfolders are included."
 msgstr "துணை கோப்புறைகள் சேர்க்கப்படும் போது துணை கோப்புறையின் பெயர்."
 
 #. IDS_COLDESC_RESULT
-#: Merge.rc:5096
+#: Merge.rc:5095
 msgid "Comparison result, long form."
 msgstr "ஒப்பீடு முடிவு, நீண்ட வடிவம்."
 
 #. IDS_COLDESC_LTIMEM
-#: Merge.rc:5101
+#: Merge.rc:5100
 msgid "Left side modification date."
 msgstr "இடது பக்க மாற்றம் தேதி."
 
 #. IDS_COLDESC_RTIMEM
-#: Merge.rc:5102
+#: Merge.rc:5101
 msgid "Right side modification date."
 msgstr "வலது பக்க மாற்றம் தேதி."
 
 #. IDS_COLDESC_MTIMEM
-#: Merge.rc:5103
+#: Merge.rc:5102
 msgid "Middle side modification date."
 msgstr "நடு பக்க மாற்றம் தேதி."
 
 #. IDS_COLDESC_EXTENSION
-#: Merge.rc:5104
+#: Merge.rc:5103
 msgid "File's extension."
 msgstr "கோப்பின் நீட்டிப்பு."
 
 #. IDS_COLDESC_LSIZE
-#: Merge.rc:5105
+#: Merge.rc:5104
 msgid "Left file size in bytes."
 msgstr "இடது கோப்பு அளவு பைட்டுகளில்."
 
 #. IDS_COLDESC_RSIZE
-#: Merge.rc:5106
+#: Merge.rc:5105
 msgid "Right file size in bytes."
 msgstr "பைட்டுகளில் வலது கோப்பு அளவு."
 
 #. IDS_COLDESC_MSIZE
-#: Merge.rc:5107
+#: Merge.rc:5106
 msgid "Middle file size in bytes."
 msgstr "பைட்டுகளில் நடு கோப்பு அளவு."
 
 #. IDS_COLDESC_LSIZE_SHORT
-#: Merge.rc:5108
+#: Merge.rc:5107
 msgid "Left file size abbreviated."
 msgstr "இடது கோப்பு அளவு சுருக்கப்பட்டது."
 
 #. IDS_COLDESC_RSIZE_SHORT
-#: Merge.rc:5109
+#: Merge.rc:5108
 msgid "Right file size abbreviated."
 msgstr "வலது கோப்பு அளவு சுருக்கப்பட்டது."
 
 #. IDS_COLDESC_MSIZE_SHORT
-#: Merge.rc:5110
+#: Merge.rc:5109
 msgid "Middle file size abbreviated."
 msgstr "நடு கோப்பு அளவு சுருக்கப்பட்டது."
 
 #. IDS_COLDESC_LTIMEC
-#: Merge.rc:5116
+#: Merge.rc:5115
 msgid "Left side creation time."
 msgstr "இடது பக்கம் உருவாக்கும் நேரம்."
 
 #. IDS_COLDESC_RTIMEC
-#: Merge.rc:5117
+#: Merge.rc:5116
 msgid "Right side creation time."
 msgstr "வலது பக்க உருவாக்கும் நேரம்."
 
 #. IDS_COLDESC_MTIMEC
-#: Merge.rc:5118
+#: Merge.rc:5117
 msgid "Middle side creation time."
 msgstr "நடு பக்க உருவாக்கும் நேரம்."
 
 #. IDS_COLDESC_NEWER
-#: Merge.rc:5119
+#: Merge.rc:5118
 msgid "Tells which side has newer modification date."
 msgstr "எந்தப் பக்கம் புதிய மாற்றியமைக்கும் தேதியைக் கூறுகிறது."
 
 #. IDS_COLDESC_LVERSION
-#: Merge.rc:5120
+#: Merge.rc:5119
 msgid "Left side file version, only for some file types."
 msgstr "இடது பக்க கோப்பு பதிப்பு, சில கோப்பு வகைகளுக்கு மட்டும்."
 
 #. IDS_COLDESC_RVERSION
-#: Merge.rc:5121
+#: Merge.rc:5120
 msgid "Right side file version, only for some file types."
 msgstr "வலது பக்க கோப்பு பதிப்பு, சில கோப்பு வகைகளுக்கு மட்டும்."
 
 #. IDS_COLDESC_MVERSION
-#: Merge.rc:5126
+#: Merge.rc:5125
 msgid "Middle side file version, only for some file types."
 msgstr "நடு பக்க கோப்பு பதிப்பு, சில கோப்பு வகைகளுக்கு மட்டும்."
 
 #. IDS_COLDESC_RESULT_ABBR
-#: Merge.rc:5127
+#: Merge.rc:5126
 msgid "Short comparison result."
 msgstr "குறுகிய ஒப்பீட்டு முடிவு."
 
 #. IDS_COLDESC_LATTRIBUTES
-#: Merge.rc:5128
+#: Merge.rc:5127
 msgid "Left side attributes."
 msgstr "இடது பக்க பண்புக்கூறுகள்."
 
 #. IDS_COLDESC_RATTRIBUTES
-#: Merge.rc:5129
+#: Merge.rc:5128
 msgid "Right side attributes."
 msgstr "வலது பக்க பண்புக்கூறுகள்."
 
 #. IDS_COLDESC_MATTRIBUTES
-#: Merge.rc:5130
+#: Merge.rc:5129
 msgid "Middle side attributes."
 msgstr "நடு பக்க பண்புக்கூறுகள்."
 
 #. IDS_COLDESC_LEOL_TYPE
-#: Merge.rc:5131
+#: Merge.rc:5130
 msgid "Left side file EOL type."
 msgstr "இடது பக்க கோப்பு வரிமுடிவு வகை."
 
 #. IDS_COLDESC_REOL_TYPE
-#: Merge.rc:5132
+#: Merge.rc:5131
 msgid "Right side file EOL type."
 msgstr "வலது பக்க கோப்பு வரிமுடிவு வகை."
 
 #. IDS_COLDESC_MEOL_TYPE
-#: Merge.rc:5133
+#: Merge.rc:5132
 msgid "Middle side file EOL type."
 msgstr "நடு பக்க கோப்பு வரிமுடிவு வகை."
 
 #. IDS_COLDESC_LENCODING
-#: Merge.rc:5139
+#: Merge.rc:5138
 msgid "Left side encoding."
 msgstr "இடது பக்க குறியாக்கம்."
 
 #. IDS_COLDESC_RENCODING
-#: Merge.rc:5140
+#: Merge.rc:5139
 msgid "Right side encoding."
 msgstr "வலது பக்க குறியாக்கம்."
 
 #. IDS_COLDESC_MENCODING
-#: Merge.rc:5141
+#: Merge.rc:5140
 msgid "Middle side encoding."
 msgstr "நடு பக்க குறியாக்கம்."
 
 #. IDS_COLDESC_NIDIFFS
-#: Merge.rc:5142
+#: Merge.rc:5141
 msgid "Number of ignored differences in file. Ignored and cannot be merged."
 msgstr ""
 "கோப்பில் புறக்கணிக்கப்பட்ட வேறுபாடுகளின் எண்ணிக்கை."
 "புறக்கணிக்கப்படுகின்றன மற்றும் இணைக்க முடியாது."
 
 #. IDS_COLDESC_NSDIFFS
-#: Merge.rc:5143
+#: Merge.rc:5142
 msgid "Number of differences in file (excluding ignored)."
 msgstr ""
 "கோப்பில் உள்ள வேறுபாடுகளின் எண்ணிக்கை. இந்த எண்ணில் புறக்கணிக்கப்பட்ட "
 "வேறுபாடுகள் இல்லை."
 
 #. IDS_COLDESC_BINARY
-#: Merge.rc:5144
+#: Merge.rc:5143
 msgid "Shows an asterisk (*) if the file is binary."
 msgstr "கோப்பு இருமம்யாக இருந்தால் ஒரு நட்சத்திரத்தை (*) காட்டுகிறது."
 
 #. IDS_COLDESC_UNPACKER
-#: Merge.rc:5145
+#: Merge.rc:5144
 msgid "Unpacker plugin name or pipeline."
 msgstr "பிரிப்பான் சொருகி பெயர் அல்லது குழாய்வழி."
 
 #. IDS_COLDESC_PREDIFFER
-#: Merge.rc:5146
+#: Merge.rc:5145
 msgid "Prediffer plugin name or pipeline."
 msgstr "முன்வேறுபாடு சொருகி பெயர் அல்லது குழாய்வழி."
 
 #. IDS_DIRECTORY_REPORT_TITLE
-#: Merge.rc:5152
+#: Merge.rc:5151
 #, c-format
 msgid "Compare %1 with %2"
 msgstr "%1 ஐ %2 உடன் ஒப்பிடு"
 
 #. IDS_DIRECTORY_REPORT_TITLE3
-#: Merge.rc:5153
+#: Merge.rc:5152
 #, c-format
 msgid "Compare %1 with %2 and %3"
 msgstr "%1 ஐ %2 மற்றும் %3 உடன் ஒப்பிடு"
 
 #. IDS_REPORT_COMMALIST
-#: Merge.rc:5154
+#: Merge.rc:5153
 msgid "Comma-separated list"
 msgstr "காற்புள்ளியால் பிரிக்கப்பட்ட பட்டியல்"
 
 #. IDS_REPORT_TABLIST
-#: Merge.rc:5155
+#: Merge.rc:5154
 msgid "Tab-separated list"
 msgstr "தாவல் பிரிக்கப்பட்ட பட்டியல்"
 
 #. IDS_REPORT_SIMPLEHTML
-#: Merge.rc:5156
+#: Merge.rc:5155
 msgid "Simple HTML"
 msgstr "எளிய உஉகுமொ"
 
 #. IDS_REPORT_SIMPLEXML
-#: Merge.rc:5157
+#: Merge.rc:5156
 msgid "Simple XML"
 msgstr "எளிய எக்ச்எம்எல்"
 
-#: Merge.rc:5159
+#: Merge.rc:5158
 msgid "Report file already exists. Overwrite?"
 msgstr ""
 "அறிக்கை கோப்பு ஏற்கனவே உள்ளது. ஏற்கனவே உள்ள கோப்பை மேலெழுத "
 "விரும்புகிறீர்களா?"
 
 #. IDS_REPORT_ERROR
-#: Merge.rc:5164
+#: Merge.rc:5163
 #, c-format
 msgid ""
 "Error creating the report:\n"
@@ -7252,59 +7247,59 @@ msgstr ""
 "%1"
 
 #. IDS_REPORT_SUCCESS
-#: Merge.rc:5165
+#: Merge.rc:5164
 msgid "Report created successfully."
 msgstr "அறிக்கை வெற்றிகரமாக உருவாக்கப்பட்டது."
 
 #. IDS_SYNCPOINT_LASTBLOCK
-#: Merge.rc:5171
+#: Merge.rc:5170
 msgid "Cannot add a synchronization point at this line."
 msgstr "இந்த வரியில் ஒரு ஒத்திசைவு புள்ளியை சேர்க்க முடியாது."
 
 #. IDS_FILE_TO_ITSELF
-#: Merge.rc:5177
+#: Merge.rc:5176
 msgid "Same file is opened in both panes."
 msgstr "இரண்டு பேனல்களிலும் ஒரே கோப்பு திறக்கப்பட்டுள்ளது."
 
 #. IDS_FILESSAME
-#: Merge.rc:5178
+#: Merge.rc:5177
 msgid "Selected files are identical."
 msgstr "தேர்ந்தெடுக்கப்பட்ட கோப்புகள் ஒரே மாதிரியானவை."
 
 #. IDS_FILESSAME_CURCFG
-#: Merge.rc:5179
+#: Merge.rc:5178
 msgid "Selected files are identical (with current settings).\r\nChecking binary identity..."
 msgstr ""
 
 #. IDS_FILESSAME_BINERROR
-#: Merge.rc:5180
+#: Merge.rc:5179
 msgid "Selected files are identical (with current settings).\r\nBut binary comparison failed."
 msgstr ""
 
 #. IDS_FILESSAME_BINSAME
-#: Merge.rc:5181
+#: Merge.rc:5180
 msgid "Selected files are identical (binary match)."
 msgstr ""
 
 #. IDS_FILESSAME_BINDIFF
-#: Merge.rc:5182
+#: Merge.rc:5181
 msgid "Selected files are identical (with current settings).\r\nBut differ at the binary level."
 msgstr ""
 
 #. IDS_FILEERROR
-#: Merge.rc:5183
+#: Merge.rc:5182
 msgid "An error occurred while comparing files."
 msgstr "கோப்புகளை ஒப்பிடும் போது பிழை ஏற்பட்டது."
 
 #. IDS_TEMP_FILEERROR
-#: Merge.rc:5184
+#: Merge.rc:5183
 msgid "Could not create temporary files. Check your temporary path settings."
 msgstr ""
 "தற்காலிக கோப்புகளை உருவாக்க முடியவில்லை. உங்கள் தற்காலிக பாதை அமைப்புகளை "
 "சரிபார்க்கவும்."
 
 #. IDS_SUGGEST_IGNOREEOL
-#: Merge.rc:5185
+#: Merge.rc:5184
 msgid ""
 "Files use different EOL.\n"
 "\n"
@@ -7319,17 +7314,17 @@ msgstr ""
 "குறிப்பு: நீங்கள் எப்பொழுதும் அனைத்து கேரேச் ரிட்டர்ன் வகைகளையும் சமமானதாகக் கருத விரும்பினால், விருப்பத்தேர்வுகளின் ஒப்பீட்டு உரையாடலின் தாவலில் (திருத்து/விருப்பங்களின் கீழ் கிடைக்கும்) 'கேரேச் ரிட்டர்ன் வேறுபாடுகளை புறக்கணி (சாளரங்கள்/யூனிக்ச்/மேக்)' விருப்பத்தை அமை."
 
 #. IDS_INVALID_DIRECTORY
-#: Merge.rc:5186
+#: Merge.rc:5185
 msgid "Selected folder is invalid."
 msgstr "தேர்ந்தெடுக்கப்பட்ட கோப்புறை தவறானது."
 
 #. IDS_CANNOT_OPEN_BINARYFILE
-#: Merge.rc:5187
+#: Merge.rc:5186
 msgid "Cannot open a binary file in Editor."
 msgstr "திருத்திக்கு இருமம் கோப்பை திறக்க முடியாது."
 
 #. IDS_CREATE_PAIR_FOLDER
-#: Merge.rc:5188
+#: Merge.rc:5187
 #, c-format
 msgid ""
 "Create matching folder:\n"
@@ -7343,41 +7338,41 @@ msgstr ""
 "மறுபுறம் சென்று இந்தக் கோப்புறைகளைத் திறக்கவா?"
 
 #. IDS_CONFIRM_COPY_ALL_DIFFS
-#: Merge.rc:5189
+#: Merge.rc:5188
 msgid "Copy all differences to other file?"
 msgstr "அனைத்து வேறுபாடுகளையும் மற்ற கோப்பில் நகலெடுக்கவா?"
 
 #. IDS_MOVE_TO_NEXTFILE
-#: Merge.rc:5194
+#: Merge.rc:5193
 msgid "Move to next file?"
 msgstr "அடுத்த கோப்புக்கு செல்ல வேண்டுமா?"
 
 #. IDS_MOVE_TO_PREVFILE
-#: Merge.rc:5195
+#: Merge.rc:5194
 msgid "Move to previous file?"
 msgstr "முந்தைய கோப்பிற்கு செல்ல விரும்புகிறீர்களா?"
 
 #. IDS_MOVE_TO_NEXTPAGE
-#: Merge.rc:5196
+#: Merge.rc:5195
 msgid "Move to next page?"
 msgstr "அடுத்த பக்கத்திற்கு செல்ல விரும்புகிறீர்களா?"
 
 #. IDS_MOVE_TO_PREVPAGE
-#: Merge.rc:5197
+#: Merge.rc:5196
 msgid "Move to previous page?"
 msgstr "முந்தைய பக்கத்திற்கு செல்ல விரும்புகிறீர்களா?"
 
 #. IDS_MOVE_TO_FIRSTFILE
-#: Merge.rc:5198
+#: Merge.rc:5197
 msgid "Move to first file?"
 msgstr "முதல் கோப்பிற்கு செல்ல விரும்புகிறீர்களா?"
 
 #. IDS_MOVE_TO_LASTFILE
-#: Merge.rc:5199
+#: Merge.rc:5198
 msgid "Move to last file?"
 msgstr "கடைசி கோப்பிற்கு செல்ல விரும்புகிறீர்களா?"
 
-#: Merge.rc:5206
+#: Merge.rc:5205
 #, c-format
 msgid ""
 "Different codepages: left (cp%d), right (cp%d).\n"
@@ -7388,53 +7383,53 @@ msgstr ""
 "ஒவ்வொரு கோப்பையும் அதன் குறியீட்டுப் பக்கத்தில் காண்பிப்பது சிறந்த காட்சியைக் கொடுக்கும், ஆனால் ஒன்றிணைப்பது/நகல் செய்வது ஆபத்தானது.\n"
 "இரண்டு கோப்புகளையும் இயல்புநிலை சாளரங்கள் குறியீட்டுப் பக்கத்தில் (பரிந்துரைக்கப்பட்டது) உள்ளதாகக் கருத விரும்புகிறீர்களா?"
 
-#: Merge.rc:5208
+#: Merge.rc:5207
 msgid "Information lost due to encoding errors: both files"
 msgstr "குறியீட்டு பிழைகள் காரணமாக தகவல் இழந்தது: இரண்டு கோப்புகளும்"
 
-#: Merge.rc:5210
+#: Merge.rc:5209
 msgid "Information lost due to encoding errors: first file"
 msgstr "குறியீட்டு பிழைகள் காரணமாக தகவல் இழந்தது: முதல் கோப்பு"
 
-#: Merge.rc:5212
+#: Merge.rc:5211
 msgid "Information lost due to encoding errors: second file"
 msgstr "குறியீட்டு பிழைகள் காரணமாக தகவல் இழந்தது: இரண்டாவது கோப்பு"
 
-#: Merge.rc:5214
+#: Merge.rc:5213
 msgid "Information lost due to encoding errors: third file"
 msgstr "குறியீட்டு பிழைகள் காரணமாக தகவல் இழந்தது: மூன்றாவது கோப்பு"
 
 #. IDS_LINEDIFF_NODIFF
-#: Merge.rc:5220
+#: Merge.rc:5219
 msgid "No difference"
 msgstr "வேறுபாடு இல்லை"
 
 #. IDS_LINEDIFF_NODIFF_CAPTION
-#: Merge.rc:5221
+#: Merge.rc:5220
 msgid "Line difference"
 msgstr "வரி வேறுபாடு"
 
 #. IDS_NUM_REPLACED
-#: Merge.rc:5227
+#: Merge.rc:5226
 #, c-format
 msgid "Replaced %1 string(s)."
 msgstr "%1 சரம்(கள்) மாற்றப்பட்டது."
 
 #. IDS_EDIT_TEXT_NOT_FOUND
-#: Merge.rc:5228
+#: Merge.rc:5227
 #, c-format
 msgid "Cannot find string \"%s\"."
 msgstr "\"%s\" சரத்தை கண்டுபிடிக்க முடியவில்லை."
 
 #. IDS_MERGE_MODE
-#: Merge.rc:5234
+#: Merge.rc:5233
 msgid "Entering Merge Mode. Press F9 to turn off."
 msgstr ""
 "நீங்கள் இப்போது ஒன்றிணைக்கும் பயன்முறையில் நுழைகிறீர்கள். நீங்கள் "
 "ஒன்றிணைக்கும் பயன்முறையை முடக்க விரும்பினால், F9 விசையை அழுத்தவும்."
 
 #. IDS_AUTO_MERGE
-#: Merge.rc:5240
+#: Merge.rc:5239
 #, c-format
 msgid ""
 "Automatic merges: %1\n"
@@ -7444,89 +7439,89 @@ msgstr ""
 "தீர்க்கப்படாத முரண்பாடுகளின் எண்ணிக்கை:% 2"
 
 #. IDS_CODEPAGE_MERGED
-#: Merge.rc:5241
+#: Merge.rc:5240
 msgid "Codepage change merged."
 msgstr "குறியீட்டுப் பக்கத்தின் மாற்றம் ஒன்றிணைக்கப்பட்டுள்ளது."
 
 #. IDS_CODEPAGE_CONFLICT
-#: Merge.rc:5242
+#: Merge.rc:5241
 msgid "Codepage changes are conflicting."
 msgstr "குறியீட்டுப் பக்கத்தின் மாற்றங்கள் முரண்படுகின்றன."
 
 #. IDS_EOL_MERGED
-#: Merge.rc:5243
+#: Merge.rc:5242
 msgid "EOL change merged."
 msgstr "வரிமுடிவின் மாற்றம் இணைக்கப்பட்டுள்ளது."
 
 #. IDS_EOL_CONFLICT
-#: Merge.rc:5244
+#: Merge.rc:5243
 msgid "EOL changes are conflicting."
 msgstr "வரிமுடிவின் மாற்றங்கள் முரண்படுகின்றன."
 
 #. IDS_LOCBAR_CAPTION
-#: Merge.rc:5250
+#: Merge.rc:5249
 msgid "Location Pane"
 msgstr "இருப்பிடம் பலகம்"
 
 #. IDS_DIFFBAR_CAPTION
-#: Merge.rc:5251
+#: Merge.rc:5250
 msgid "Diff Pane"
 msgstr "டிஃப் பேன்"
 
 #. IDS_DIFF_SUCCEEDED
-#: Merge.rc:5258
+#: Merge.rc:5257
 msgid "Patch file written."
 msgstr "ஒட்டு கோப்பு வெற்றிகரமாக எழுதப்பட்டது."
 
 #. IDS_DIFF_FILEOVERWRITE
-#: Merge.rc:5259
+#: Merge.rc:5258
 msgid "Patch file already exists. Overwrite?"
 msgstr "ஒட்டு கோப்பு ஏற்கனவே உள்ளது. நீங்கள் அதை மேலெழுத விரும்புகிறீர்களா?"
 
 #. IDS_DIFF_SELECTEDFILES
-#: Merge.rc:5260
+#: Merge.rc:5259
 #, c-format
 msgid "[%1 files selected]"
 msgstr "[%1 கோப்புகள் தேர்ந்தெடுக்கப்பட்டன]"
 
 #. IDS_DIFF_NORMAL
-#: Merge.rc:5261
+#: Merge.rc:5260
 msgid "Normal"
 msgstr "இயல்பு"
 
 #. IDS_DIFF_CONTEXT
-#: Merge.rc:5262
+#: Merge.rc:5261
 msgid "Context"
 msgstr "சூழல்"
 
 #. IDS_DIFF_UNIFIED
-#: Merge.rc:5263
+#: Merge.rc:5262
 msgid "Unified"
 msgstr "ஒருங்கிணைக்கப்பட்ட"
 
 #. IDS_FILEWRITE_ERROR
-#: Merge.rc:5265
+#: Merge.rc:5264
 #, c-format
 msgid "Could not write to file %1."
 msgstr "%1 கோப்பில் எழுத முடியவில்லை."
 
 #. IDS_PATH_NOT_ABSOLUTE
-#: Merge.rc:5266
+#: Merge.rc:5265
 #, c-format
 msgid "Output path is not absolute: %1"
 msgstr "குறிப்பிடப்பட்ட வெளியீட்டு பாதை ஒரு முழுமையான பாதை அல்ல: %1"
 
 #. IDS_MUST_SPECIFY_OUTPUT
-#: Merge.rc:5267
+#: Merge.rc:5266
 msgid "Specify an output file."
 msgstr "ஒரு வெளியீட்டு கோப்பை குறிப்பிடவும்."
 
-#: Merge.rc:5269
+#: Merge.rc:5268
 msgid "Cannot create patch from binary files."
 msgstr "இருமம் கோப்புகளிலிருந்து ஒட்டு கோப்பை உருவாக்க முடியாது."
 
 #. IDS_SAVEFILES_FORPATCH
-#: Merge.rc:5270
+#: Merge.rc:5269
 msgid ""
 "Save all files first.\n"
 "\n"
@@ -7537,22 +7532,22 @@ msgstr ""
 "ஒரு ஒட்டைப் உருவாக்க, கோப்புகளில் சேமிக்கப்படாத மாற்றங்கள் எதுவும் இல்லை."
 
 #. IDS_FOLDER_NOTEXIST
-#: Merge.rc:5271
+#: Merge.rc:5270
 msgid "Folder does not exist."
 msgstr "கோப்புறை இல்லை."
 
 #. IDS_ARCHIVE_SUCCEEDED
-#: Merge.rc:5277
+#: Merge.rc:5276
 msgid "Archive file written."
 msgstr ""
 
 #. IDS_ARCHIVE_SAVEFILES
-#: Merge.rc:5278
+#: Merge.rc:5277
 msgid "Save all files first.\n\nCreating an archive requires no unsaved changes."
 msgstr ""
 
 #. IDS_NO_ZIP_SUPPORT
-#: Merge.rc:5283
+#: Merge.rc:5282
 msgid ""
 "Archive support not enabled.\n"
 "7-Zip and/or Merge7z*.dll not found.\n"
@@ -7563,37 +7558,37 @@ msgstr ""
 "கோப்பு ஆதரவு மற்றும் அதை எவ்வாறு இயக்குவது என்பது பற்றிய கூடுதல் தகவலுக்கு கையேட்டைப் பார்க்கவும்."
 
 #. IDS_OPT_EXPORT_CAPTION
-#: Merge.rc:5284
+#: Merge.rc:5283
 msgid "Select file for export"
 msgstr "ஏற்றுமதிக்கான கோப்பை தேர்ந்தெடு"
 
 #. IDS_OPT_IMPORT_CAPTION
-#: Merge.rc:5285
+#: Merge.rc:5284
 msgid "Select file for import"
 msgstr "இறக்குமதிக்கான கோப்பை தேர்ந்தெடு"
 
 #. IDS_OPT_IMPORT_DONE
-#: Merge.rc:5286
+#: Merge.rc:5285
 msgid "Options imported from file."
 msgstr "கோப்பில் இருந்து இறக்குமதி செய்யப்பட்ட விருப்பங்கள்."
 
 #. IDS_OPT_EXPORT_DONE
-#: Merge.rc:5287
+#: Merge.rc:5286
 msgid "Options exported to file."
 msgstr "கோப்புக்கு ஏற்றுமதி செய்யப்பட்ட விருப்பங்கள்."
 
 #. IDS_OPT_IMPORT_ERR
-#: Merge.rc:5288
+#: Merge.rc:5287
 msgid "Failed to import options from file."
 msgstr "கோப்பில் இருந்து விருப்பங்களை இறக்குமதி செய்வதில் தோல்வி."
 
 #. IDS_OPT_EXPORT_ERR
-#: Merge.rc:5289
+#: Merge.rc:5288
 msgid "Failed to write options to file."
 msgstr "கோப்பில் விருப்பங்களை எழுதுவதில் தோல்வி."
 
 #. IDS_CLOSEALL_WINDOWS
-#: Merge.rc:5290
+#: Merge.rc:5289
 msgid ""
 "Close multiple compare windows?\n"
 "\n"
@@ -7604,34 +7599,34 @@ msgstr ""
 "நீங்கள் தொடர விரும்புகிறீர்களா?"
 
 #. IDS_EOL_BIN
-#: Merge.rc:5300
+#: Merge.rc:5299
 msgctxt "EOL Type"
 msgid "Binary"
 msgstr "இருமம்"
 
 #. IDS_MARKER_COLOR_FMT
-#: Merge.rc:5305
+#: Merge.rc:5304
 #, c-format
 msgid "Marker Color %d"
 msgstr "குறிப்பான் நிறம் %d"
 
 #. IDS_MARKER_NEW_PATTERN
-#: Merge.rc:5306
+#: Merge.rc:5305
 msgid "New Pattern"
 msgstr "புதிய முறை"
 
 #. IDS_PLUGINSLIST_TYPE
-#: Merge.rc:5312
+#: Merge.rc:5311
 msgid "Type"
 msgstr "வகை"
 
 #. IDS_PLUGINS_TYPE_EDITSCRIPT
-#: Merge.rc:5316
+#: Merge.rc:5315
 msgid "Editor script"
 msgstr "கைஉரை திருத்தி"
 
 #. ID_SELECTLINEDIFF
-#: Merge.rc:5322
+#: Merge.rc:5321
 msgid ""
 "\n"
 "Difference in Current Line (F4)"
@@ -7640,7 +7635,7 @@ msgstr ""
 "தற்போதைய வரியில் உள்ள வேறுபாடு (F4)"
 
 #. ID_OPTIONS
-#: Merge.rc:5323
+#: Merge.rc:5322
 msgid ""
 "\n"
 "Options"
@@ -7649,7 +7644,7 @@ msgstr ""
 "விருப்பங்கள்"
 
 #. ID_REFRESH
-#: Merge.rc:5324
+#: Merge.rc:5323
 msgid ""
 "\n"
 "Refresh (F5)"
@@ -7658,7 +7653,7 @@ msgstr ""
 "புதுப்பித்தல் (F5)"
 
 #. ID_PREVDIFF
-#: Merge.rc:5330
+#: Merge.rc:5329
 msgid ""
 "\n"
 "Previous Difference (Alt+Up)"
@@ -7667,7 +7662,7 @@ msgstr ""
 "முந்தைய வேறுபாடு (Alt+Up)"
 
 #. ID_NEXTDIFF
-#: Merge.rc:5331
+#: Merge.rc:5330
 msgid ""
 "\n"
 "Next Difference (Alt+Down)"
@@ -7676,7 +7671,7 @@ msgstr ""
 "அடுத்த வேறுபாடு (Alt+Down)"
 
 #. ID_PREVCONFLICT
-#: Merge.rc:5332
+#: Merge.rc:5331
 msgid ""
 "\n"
 "Previous Conflict (Alt+Shift+Up)"
@@ -7685,7 +7680,7 @@ msgstr ""
 "முந்தைய மோதல் (Alt+Shift+Up)"
 
 #. ID_NEXTCONFLICT
-#: Merge.rc:5333
+#: Merge.rc:5332
 msgid ""
 "\n"
 "Next Conflict (Alt+Shift+Down)"
@@ -7694,7 +7689,7 @@ msgstr ""
 "அடுத்த மோதல் (Alt+Shift+Down)"
 
 #. ID_FIRSTDIFF
-#: Merge.rc:5338
+#: Merge.rc:5337
 msgid ""
 "\n"
 "First Difference (Alt+Home)"
@@ -7703,7 +7698,7 @@ msgstr ""
 "முதல் வேறுபாடு (Alt+Home)"
 
 #. ID_CURDIFF
-#: Merge.rc:5339
+#: Merge.rc:5338
 msgid ""
 "\n"
 "Current Difference (Alt+Enter)"
@@ -7712,7 +7707,7 @@ msgstr ""
 "தற்போதைய வேறுபாடு (Alt+Enter)"
 
 #. ID_LASTDIFF
-#: Merge.rc:5340
+#: Merge.rc:5339
 msgid ""
 "\n"
 "Last Difference (Alt+End)"
@@ -7721,7 +7716,7 @@ msgstr ""
 "கடைசி வேறுபாடு (Alt+End)"
 
 #. ID_L2R
-#: Merge.rc:5341
+#: Merge.rc:5340
 msgid ""
 "\n"
 "Copy to Right (Alt+Right)"
@@ -7730,7 +7725,7 @@ msgstr ""
 "வலமிருந்து நகலெடு (Alt+வலது)"
 
 #. ID_R2L
-#: Merge.rc:5342
+#: Merge.rc:5341
 msgid ""
 "\n"
 "Copy to Left (Alt+Left)"
@@ -7739,7 +7734,7 @@ msgstr ""
 "இடதுக்கு நகலெடு (Alt+Left)"
 
 #. ID_L2RNEXT
-#: Merge.rc:5343
+#: Merge.rc:5342
 msgid ""
 "\n"
 "Copy to Right and Advance (Ctrl+Alt+Right)"
@@ -7748,7 +7743,7 @@ msgstr ""
 "வலது மற்றும் முன்னேற்றத்திற்கு நகலெடு (Ctrl+Alt+Right)"
 
 #. ID_R2LNEXT
-#: Merge.rc:5344
+#: Merge.rc:5343
 msgid ""
 "\n"
 "Copy to Left and Advance (Ctrl+Alt+Left)"
@@ -7757,7 +7752,7 @@ msgstr ""
 "இடது மற்றும் முன்னேற்றத்திற்கு நகலெடு (Ctrl+Alt+Left)"
 
 #. ID_ALL_RIGHT
-#: Merge.rc:5345
+#: Merge.rc:5344
 msgid ""
 "\n"
 "Copy All to Right"
@@ -7766,7 +7761,7 @@ msgstr ""
 "அனைத்தையும் வலமாக நகலெடு"
 
 #. ID_ALL_LEFT
-#: Merge.rc:5346
+#: Merge.rc:5345
 msgid ""
 "\n"
 "Copy All to Left"
@@ -7775,7 +7770,7 @@ msgstr ""
 "அனைத்தையும் இடதுபுறமாக நகலெடு"
 
 #. ID_AUTO_MERGE
-#: Merge.rc:5347
+#: Merge.rc:5346
 msgid ""
 "\n"
 "Auto Merge (Ctrl+Alt+M)"
@@ -7784,7 +7779,7 @@ msgstr ""
 "ஆட்டோ மெர்ச் (Ctrl+Alt+M)"
 
 #. ID_FIRSTFILE
-#: Merge.rc:5348
+#: Merge.rc:5347
 msgid ""
 "\n"
 "First File"
@@ -7793,7 +7788,7 @@ msgstr ""
 "முதல் கோப்பு"
 
 #. ID_NEXTFILE
-#: Merge.rc:5349
+#: Merge.rc:5348
 msgid ""
 "\n"
 "Next File (Ctrl+F8)"
@@ -7802,7 +7797,7 @@ msgstr ""
 "அடுத்த கோப்பு (Ctrl+F8)"
 
 #. ID_LASTFILE
-#: Merge.rc:5350
+#: Merge.rc:5349
 msgid ""
 "\n"
 "Last File"
@@ -7811,7 +7806,7 @@ msgstr ""
 "கடைசி கோப்பு"
 
 #. ID_PREVFILE
-#: Merge.rc:5351
+#: Merge.rc:5350
 msgid ""
 "\n"
 "Previous File (Ctrl+F7)"
@@ -7820,143 +7815,143 @@ msgstr ""
 "முந்தைய கோப்பு (Ctrl+F7)"
 
 #. IDS_UNPACK_AUTO
-#: Merge.rc:5358
+#: Merge.rc:5357
 msgid "Adapted unpacker applied to both files (one needs extension)."
 msgstr ""
 "அடடாப் செய்யப்பட்ட பிரிப்பான் இரண்டு கோப்புகளுக்கும் பயன்படுத்தப்படுகிறது "
 "(ஒரு கோப்பிற்கு மட்டும் நீட்டிப்பு தேவை)."
 
 #. IDS_NO_PREDIFFER
-#: Merge.rc:5359
+#: Merge.rc:5358
 msgid "No Prediffer (Normal)"
 msgstr "முன்வேறுபாடு இல்லை (இயல்பான)"
 
 #. IDS_SUGGESTED_PLUGINS
-#: Merge.rc:5360
+#: Merge.rc:5359
 msgid "Suggested Plugins"
 msgstr "பரிந்துரைக்கப்பட்ட செருகுநிரல்கள்"
 
 #. IDS_NOT_SUGGESTED_PLUGINS
-#: Merge.rc:5361
+#: Merge.rc:5360
 msgid "All Plugins"
 msgstr "அனைத்து செருகுநிரல்களும்"
 
 #. IDS_PRIVATEBUILD_FMT
-#: Merge.rc:5367
+#: Merge.rc:5366
 #, c-format
 msgid "Private Build: %1"
 msgstr "தனியார் உருவாக்கம்: %1"
 
 #. IDS_ALLRIGHTS_RESERVED
-#: Merge.rc:5368
+#: Merge.rc:5367
 msgid " - All rights reserved."
 msgstr ""
 
 #. IDS_TITLE_PLUGINS_SETTINGS
-#: Merge.rc:5374
+#: Merge.rc:5373
 msgid "Plugin Settings"
 msgstr "சொருகி அமைப்புகள்"
 
 #. IDS_NO_SCT_SCRIPTS
-#: Merge.rc:5376
+#: Merge.rc:5375
 msgid "WSH not found - .sct scripts disabled"
 msgstr "WSH காணப்படவில்லை - .sct கைஉரைகள் முடக்கப்பட்டுள்ளன"
 
 #. IDS_LOCBAR_GOTOLINE_FMT
-#: Merge.rc:5384
+#: Merge.rc:5383
 #, c-format
 msgid "G&o to Line %1"
 msgstr "வரி %1க்குச் செல்"
 
 #. IDS_GOTO_MOVED_LINE
-#: Merge.rc:5390
+#: Merge.rc:5389
 msgid "Go to Moved Line\tCtrl+Shift+G"
 msgstr "நகர்த்தப்பட்ட வரிக்கு செல்க\tகட்டு+தூக்கு+G"
 
 #. IDS_AUTOCOMPLETE_DISABLED
-#: Merge.rc:5396
+#: Merge.rc:5395
 msgctxt "Options dialog|General|Open dialog Auto completion"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_AUTOCOMPLETE_FILE_SYS
-#: Merge.rc:5397
+#: Merge.rc:5396
 msgid "From file system"
 msgstr "கோப்பு அமைப்பிலிருந்து"
 
 #. IDS_AUTOCOMPLETE_MRU
-#: Merge.rc:5398
+#: Merge.rc:5397
 msgid "From Most Recently Used list"
 msgstr "மிக அண்மைக் காலத்தில் பயன்படுத்தப்பட்ட பட்டியலில் இருந்து"
 
 #. IDS_COLORSCHEME_PLAIN
-#: Merge.rc:5404
+#: Merge.rc:5403
 msgid "No Highlighting"
 msgstr "சிறப்பு செய்யவில்லை"
 
 #. IDS_COLORSCHEME_PO
-#: Merge.rc:5439
+#: Merge.rc:5438
 msgid "Portable Object"
 msgstr "கையடக்க பொருள்"
 
 #. IDS_COLORSCHEME_RSRC
-#: Merge.rc:5444
+#: Merge.rc:5443
 msgid "Resources"
 msgstr "வளங்கள்"
 
 #. IDS_COLORSCHEME_SH
-#: Merge.rc:5448
+#: Merge.rc:5447
 msgid "Shell"
 msgstr "ஓடு"
 
 #. IDS_CLOSE_LEFT_TABS
-#: Merge.rc:5469
+#: Merge.rc:5468
 msgid "Close &Left Tabs"
 msgstr "இடது தாவல்களை மூடு"
 
 #. IDS_CLOSE_RIGHT_TABS
-#: Merge.rc:5470
+#: Merge.rc:5469
 msgid "Close R&ight Tabs"
 msgstr "வலது தாவல்களை மூடு"
 
 #. IDS_CLOSE_OTHER_TABS
-#: Merge.rc:5471
+#: Merge.rc:5470
 msgid "Close &Other Tabs"
 msgstr "மற்ற தாவல்களை மூடு"
 
 #. IDS_TABBAR_AUTO_MAXWIDTH
-#: Merge.rc:5472
+#: Merge.rc:5471
 msgid "Enable &Auto Max Width"
 msgstr "தானியங்கு அதிகஅளவு அகலத்தை இயக்கு"
 
 #. IDS_WEBPAGE_MENU
-#: Merge.rc:5482
+#: Merge.rc:5481
 msgid "We&bpage"
 msgstr "வலைப்பக்கம்"
 
 #. IDS_VIEW_WRAP_TEXT
-#: Merge.rc:5487
+#: Merge.rc:5486
 msgid "W&rap Text"
 msgstr "உரை மடக்கு"
 
 #. IDS_NOTINSTALLED
-#: Merge.rc:5492
+#: Merge.rc:5491
 msgid "%1 is not installed."
 msgstr "%1 நிறுவப்படவில்லை."
 
 #. IDS_CREATE_FOLDER
-#: Merge.rc:5497
+#: Merge.rc:5496
 #, c-format
 msgid "%1 does not exist. Create it?"
 msgstr "%1 இல்லை. அதை உருவாக்க விரும்புகிறீர்களா?"
 
 #. IDS_CREATE_FOLDER_ERROR
-#: Merge.rc:5498
+#: Merge.rc:5497
 msgid "Failed to create folder."
 msgstr "கோப்புறையை உருவாக்குவதில் தோல்வி."
 
 #. IDC_EXT_EDITOR_PATH
-#: Merge.rc:5503
+#: Merge.rc:5502
 msgid ""
 "Parameters:\n"
 "$file: Current file path\n"
@@ -7967,493 +7962,493 @@ msgstr ""
 "$linenum: தற்போதைய சுட்டி நிலையின் வரி எண்"
 
 #. IDS_DIFF_ALGORITHM_DEFAULT
-#: Merge.rc:5508
+#: Merge.rc:5507
 msgid "default"
 msgstr "இயல்புநிலை"
 
 #. IDS_DIFF_ALGORITHM_MINIMAL
-#: Merge.rc:5509
+#: Merge.rc:5508
 msgid "minimal"
 msgstr "குறைந்தபட்சம்"
 
 #. IDS_DIFF_ALGORITHM_PATIENCE
-#: Merge.rc:5510
+#: Merge.rc:5509
 msgid "patience"
 msgstr "பொறுமை"
 
 #. IDS_DIFF_ALGORITHM_HISTOGRAM
-#: Merge.rc:5511
+#: Merge.rc:5510
 msgid "histogram"
 msgstr "பட்டை வரைபடம்"
 
 #. IDS_DIFF_ALGORITHM_NONE
-#: Merge.rc:5512
+#: Merge.rc:5511
 msgid "none"
 msgstr "இல்லை"
 
 #. IDS_RENDERING_MODE_GDI
-#: Merge.rc:5517
+#: Merge.rc:5516
 msgid "GDI"
 msgstr "சிடிஐ"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_DEFAULT
-#: Merge.rc:5518
+#: Merge.rc:5517
 msgid "DirectWrite Default"
 msgstr "நேரடிஎழுத்து இயல்புநிலை"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_ALIASED
-#: Merge.rc:5519
+#: Merge.rc:5518
 msgid "DirectWrite Aliased"
 msgstr "நேரடிஎழுத்து அலியாச்டு"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_GDI_CLASSIC
-#: Merge.rc:5520
+#: Merge.rc:5519
 msgid "DirectWrite GDI Classic"
 msgstr "நேரடிஎழுத்து சிடிஐ கிளாசிக்"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_GDI_NATURAL
-#: Merge.rc:5521
+#: Merge.rc:5520
 msgid "DirectWrite GDI Natural"
 msgstr "நேரடிஎழுத்து சிடிஐ இயற்கை"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_NATURAL
-#: Merge.rc:5522
+#: Merge.rc:5521
 msgid "DirectWrite Natural"
 msgstr "நேரடிஎழுத்து இயற்கை"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_NATURAL_SYMMETRIC
-#: Merge.rc:5523
+#: Merge.rc:5522
 msgid "DirectWrite Natural Symmetric"
 msgstr "நேரடிஎழுத்து இயற்கை சமச்சீர்"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_DISABLED
-#: Merge.rc:5528
+#: Merge.rc:5527
 msgctxt "Options dialog|General|Close windows with Esc"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_1
-#: Merge.rc:5529
+#: Merge.rc:5528
 msgid "MDI child window or main window"
 msgstr "எம்டிஐ குழந்தை சாளரம் அல்லது முக்கிய சாளரம்"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_2
-#: Merge.rc:5530
+#: Merge.rc:5529
 msgid "MDI child window only"
 msgstr "எம்டிஐ குழந்தை சாளரம் மட்டும்"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_3
-#: Merge.rc:5531
+#: Merge.rc:5530
 msgid "Close main window if only one MDI child window"
 msgstr "ஒரே ஒரு எம்டிஐ குழந்தை சாளரம் இருந்தால் பிரதான சாளரத்தை மூடு"
 
 #. IDS_DIFF_GROUP
-#: Merge.rc:5536
+#: Merge.rc:5535
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Diff"
 msgstr "வேறுபாடு"
 
 #. IDS_DIFF_HIGHLIGHT
-#: Merge.rc:5537
+#: Merge.rc:5536
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Highlight"
 msgstr "உயர்படுத்தப்பட்டது"
 
 #. IDS_DIFF_BLINK
-#: Merge.rc:5538
+#: Merge.rc:5537
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Blink"
 msgstr "சிமிட்டல்"
 
 #. IDS_DIFF_BLOCKSIZE
-#: Merge.rc:5539
+#: Merge.rc:5538
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Block Size"
 msgstr "தடு அளவு"
 
 #. IDS_DIFF_BLOCKALPHA
-#: Merge.rc:5540
+#: Merge.rc:5539
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Block Alpha"
 msgstr "அன்னா தடு"
 
 #. IDS_DIFF_CDTHRESHOLD
-#: Merge.rc:5541
+#: Merge.rc:5540
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "CD Threshold"
 msgstr "சிடி வரம்பு"
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION
-#: Merge.rc:5542
+#: Merge.rc:5541
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Ins/Del Detection"
 msgstr "சொருகு/நீக்கு கண்டறிதல்"
 
 #. IDS_OVERLAY_MODE_NONE
-#: Merge.rc:5543 Merge.rc:5548
+#: Merge.rc:5542 Merge.rc:5547
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "None"
 msgstr "இல்லை"
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION_VERTICAL
-#: Merge.rc:5544
+#: Merge.rc:5543
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Vertical"
 msgstr "செங்குத்து"
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION_HORIZONTAL
-#: Merge.rc:5545
+#: Merge.rc:5544
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Horizontal"
 msgstr "கிடைமட்டமாக"
 
 #. IDS_OVERLAY_GROUP
-#: Merge.rc:5546
+#: Merge.rc:5545
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Overlay"
 msgstr "மேற்பரப்பு"
 
 #. IDS_OVERLAY_ALPHA
-#: Merge.rc:5547
+#: Merge.rc:5546
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha"
 msgstr "அன்னா"
 
 #. IDS_OVERLAY_MODE_XOR
-#: Merge.rc:5549
+#: Merge.rc:5548
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "XOR"
 msgstr "அல்லதில்"
 
 #. IDS_OVERLAY_MODE_ALPHA
-#: Merge.rc:5550
+#: Merge.rc:5549
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha Blend"
 msgstr "அன்னா கலவை"
 
 #. IDS_OVERLAY_MODE_ALPHA_ANIMATION
-#: Merge.rc:5551
+#: Merge.rc:5550
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha Animation"
 msgstr "அன்னா அசைவுட்டம்"
 
 #. IDS_ZOOM
-#: Merge.rc:5552
+#: Merge.rc:5551
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Zoom"
 msgstr "பெரிதாக்கு"
 
 #. IDS_PAGE
-#: Merge.rc:5553
+#: Merge.rc:5552
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Page:"
 msgstr "பக்கம்:"
 
 #. IDS_IMGCMP_STATUS_PT_RGBA_FMT
-#: Merge.rc:5554
+#: Merge.rc:5553
 #, c-format
 msgid "Pt: (%d, %d)  RGBA: (%d, %d, %d, %d)  "
 msgstr "புள்: (%d, %d) சிபநீஅ: (%d, %d, %d, %d) "
 
 #. IDS_IMGCMP_STATUS_DIST1_FMT
-#: Merge.rc:5555
+#: Merge.rc:5554
 #, c-format
 msgid "Dist: %g  "
 msgstr "தொ: %g "
 
 #. IDS_IMGCMP_STATUS_DIST2_FMT
-#: Merge.rc:5556
+#: Merge.rc:5555
 #, c-format
 msgid "Dist: %g, %g  "
 msgstr "தொ: %g, %g  "
 
 #. IDS_IMGCMP_STATUS_PAGE_ZOOM_SIZE_BPP_FMT
-#: Merge.rc:5557
+#: Merge.rc:5556
 #, c-format
 msgid "Page: %d/%d  Zoom: %d%%  %dx%dpx  %dbpp  "
 msgstr "பக்கம்: %d/%d பெரிதாக்கு: %d%% %dx%dpx %dbpp  "
 
 #. IDS_IMGCMP_STATUS_RC_FMT
-#: Merge.rc:5558
+#: Merge.rc:5557
 #, c-format
 msgid "Rc: (%d, %d)  "
 msgstr "ஆர்சி: (%d, %d) "
 
 #. IDS_IMGCMP_STATUS_FLIPPED_FMT
-#: Merge.rc:5559
+#: Merge.rc:5558
 #, c-format
 msgid "Flipped: %s  "
 msgstr "புரட்டப்பட்டது: %s  "
 
 #. IDS_IMGCMP_STATUS_ROTATED_FMT
-#: Merge.rc:5560
+#: Merge.rc:5559
 #, c-format
 msgid "Rotated: %d  "
 msgstr "சுழற்றப்பட்டது: %d  "
 
 #. IDS_IMGCMP_REPORT_ALLPAGES
-#: Merge.rc:5561
+#: Merge.rc:5560
 msgid "All pages"
 msgstr "அனைத்து பக்கங்களும்"
 
 #. IDS_IGNSUB_STR1
-#: Merge.rc:5566
+#: Merge.rc:5565
 msgid "<Edit here>"
 msgstr "<இங்கே திருத்து>"
 
 #. IDS_IGNSUB_STR2
-#: Merge.rc:5567
+#: Merge.rc:5566
 msgid "No differences found to select"
 msgstr "தேர்ந்தெடுக்க வேறுபாடுகள் இல்லை"
 
 #. IDS_IGNSUB_STR3
-#: Merge.rc:5568
+#: Merge.rc:5567
 msgid "No differences found to add as substitution filter"
 msgstr "மாற்று வடிப்பானாக சேர்க்க வேறுபாடுகள் எதுவும் இல்லை"
 
 #. IDS_IGNSUB_STR4
-#: Merge.rc:5569
+#: Merge.rc:5568
 msgid "The pair is already in the Substitution Filters list"
 msgstr "இந்த இணை ஏற்கனவே மாற்று வடிப்பான்களின் பட்டியலில் உள்ளது"
 
 #. IDS_IGNSUB_STR5
-#: Merge.rc:5570
+#: Merge.rc:5569
 msgid "Add this change to Substitution Filters?"
 msgstr "இந்த மாற்றத்தை மாற்று வடிப்பான்களில் சேர்க்கவா?"
 
 #. IDS_OCRRESULT_TEXTONLY
-#: Merge.rc:5575
+#: Merge.rc:5574
 msgid "Text only"
 msgstr "உரை மட்டும்"
 
 #. IDS_OCRRESULT_POS_LINE
-#: Merge.rc:5576
+#: Merge.rc:5575
 msgid "Line-by-line position and text"
 msgstr "வரிக்கு-வரி நிலை மற்றும் உரை"
 
 #. IDS_OCRRESULT_POS_WORD
-#: Merge.rc:5577
+#: Merge.rc:5576
 msgid "Word-by-word position and text"
 msgstr "சொல்லுக்கு சொல் நிலை மற்றும் உரை"
 
 #. IDS_USERDATAFOLDER_APPDATA
-#: Merge.rc:5582
+#: Merge.rc:5581
 msgid "AppData (Roaming) folder"
 msgstr ""
 
 #. IDS_USERDATAFOLDER_INSTALL
-#: Merge.rc:5583
+#: Merge.rc:5582
 msgid "Install folder"
 msgstr "நிறுவல் கோப்புறை"
 
 #. IDS_USERDATAFOLDER_DOCUMENTS
-#: Merge.rc:5584
+#: Merge.rc:5583
 msgid "Documents folder"
 msgstr ""
 
 #. IDS_SINGLEINSTANCE_DISABLED
-#: Merge.rc:5589
+#: Merge.rc:5588
 msgctxt "Options dialog|General|Single instance mode"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_SINGLEINSTANCE_STR1
-#: Merge.rc:5590
+#: Merge.rc:5589
 msgid "Allow only one instance to run"
 msgstr "ஒரே ஒரு நிகழ்வை இயக்க அனுமதி"
 
 #. IDS_CLIPBOARD_HISTORY
-#: Merge.rc:5591
+#: Merge.rc:5590
 msgid "Clipboard &History"
 msgstr ""
 
 #. IDS_SINGLEINSTANCE_STR2
-#: Merge.rc:5592
+#: Merge.rc:5591
 msgid "Allow only one instance; wait for termination"
 msgstr ""
 "ஒரே ஒரு நிகழ்வை இயக்க அனுமதிக்கவும் மற்றும் நிகழ்வு முடிவடையும் வரை "
 "காத்திருக்கவும்"
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_DISABLED
-#: Merge.rc:5597
+#: Merge.rc:5596
 msgctxt "Options dialog|General|Auto-reload modified files"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_STR1
-#: Merge.rc:5598
+#: Merge.rc:5597
 msgid "Only on window activated"
 msgstr "சாளரத்தில் மட்டுமே செயல்படுத்தப்பட்டது"
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_STR2
-#: Merge.rc:5599
+#: Merge.rc:5598
 msgid "Immediately"
 msgstr "உடனடியாக"
 
 #. IDS_PLUGIN_ALL
-#: Merge.rc:5604
+#: Merge.rc:5603
 msgid "Al&l"
 msgstr "அனைத்தும்"
 
 #. IDS_PLUGIN_OTHERS
-#: Merge.rc:5605
+#: Merge.rc:5604
 msgid "&Others"
 msgstr "மற்றவை"
 
-#: Merge.rc:5607
+#: Merge.rc:5606
 #, c-format
 msgid "Missing plugin name in pipeline: %1"
 msgstr "சொருகி குழாய்வழியில் சொருகி பெயர் காணவில்லை: %1"
 
-#: Merge.rc:5609
+#: Merge.rc:5608
 #, c-format
 msgid "Missing quote in plugin pipeline: %1"
 msgstr "சொருகி குழாய்வழியில் மேற்கோள் குறி காணவில்லை: %1"
 
 #. IDS_PLUGIN_NAME_ALREADY_EXISTS
-#: Merge.rc:5610
+#: Merge.rc:5609
 #, c-format
 msgid "Plugin name '%1' already exists."
 msgstr "சொருகி பெயர் '%1' ஏற்கனவே உள்ளது."
 
 #. IDS_PLUGIN_TITLE1
-#: Merge.rc:5611
+#: Merge.rc:5610
 msgid "Specify plugin arguments"
 msgstr "சொருகி வாதங்களைக் குறிப்பிடவும்"
 
-#: Merge.rc:5613
+#: Merge.rc:5612
 #, c-format
 msgid "Plugin not found or invalid: %1"
 msgstr "சொருகி காணப்படவில்லை அல்லது தவறானது: %1"
 
 #. IDS_PLUGIN_NOT_UNPACK
-#: Merge.rc:5614
+#: Merge.rc:5613
 #, c-format
 msgid "'%1' is not an unpacker plugin"
 msgstr "'%1' என்பது ஒரு பயனற்ற சொருகி அல்ல"
 
 #. IDS_PLUGIN_NOT_PREDIFF
-#: Merge.rc:5615
+#: Merge.rc:5614
 #, c-format
 msgid "'%1' is not a prediffer plugin"
 msgstr "'%1' ஒரு முன்வேறுபாடு சொருகி அல்ல"
 
-#: Merge.rc:5617
+#: Merge.rc:5616
 #, c-format
 msgid "Error prediffing '%1' with '%2'. Prediffing disabled."
 msgstr "'%2' உடன் '%1' ஐ முன்வேறுபாடுத்தும் பிழை. முன்வேறுபாடுத்துதல் முடக்கப்பட்டது."
 
 #. IDS_PLUGIN_CIRCULAR_REFERENCE
-#: Merge.rc:5618
+#: Merge.rc:5617
 #, c-format
 msgid "Circular reference in plugin pipeline: %1"
 msgstr "சொருகி குழாய்வழியில் வட்ட குறிப்பு: %1"
 
 #. IDS_PLUGIN_TYPE1
-#: Merge.rc:5619
+#: Merge.rc:5618
 msgid "URL Handler"
 msgstr "முகவரி வர்த்தகங்கள்"
 
 #. IDS_PLUGIN_TYPE2
-#: Merge.rc:5620
+#: Merge.rc:5619
 msgid "File Unpacker"
 msgstr "கோப்பு பிரிப்பான்"
 
 #. IDS_PLUGIN_TYPE3
-#: Merge.rc:5621
+#: Merge.rc:5620
 msgid "File or Folder Unpacker"
 msgstr "கோப்பு அல்லது கோப்புறை பிரிப்பான்"
 
 #. IDS_PLUGIN_TYPE5
-#: Merge.rc:5623
+#: Merge.rc:5622
 msgid "Alias for Unpacker"
 msgstr "பிரிப்பானுக்கு மாற்றுப்பெயர்"
 
 #. IDS_PLUGIN_TYPE6
-#: Merge.rc:5624
+#: Merge.rc:5623
 msgid "Alias for Prediffer"
 msgstr "முன்வேறுபாடு மாற்றுப்பெயர்"
 
 #. IDS_PLUGIN_TYPE7
-#: Merge.rc:5625
+#: Merge.rc:5624
 msgid "Alias for Editor script"
 msgstr "திருத்தி கைஉரைக்கான மாற்றுப்பெயர்"
 
 #. IDS_PLUGIN_ALIAS_DESC
-#: Merge.rc:5626
+#: Merge.rc:5625
 #, c-format
 msgid "Alias for plugin pipeline '%1'"
 msgstr "சொருகி குழாய்வழி '%1' க்கான மாற்றுப்பெயர்"
 
 #. IDS_PLUGIN_NEW_DESC
-#: Merge.rc:5627
+#: Merge.rc:5626
 msgid "New plugin description"
 msgstr "புதிய சொருகி விளக்கம்"
 
 #. IDS_PLUGIN_TARGETS_ALL
-#: Merge.rc:5628
+#: Merge.rc:5627
 msgid "All"
 msgstr "அனைத்தும்"
 
 #. IDS_PLUGIN_TARGETS_1ST
-#: Merge.rc:5629
+#: Merge.rc:5628
 msgid "1st"
 msgstr "1 தண்டு"
 
 #. IDS_PLUGIN_TARGETS_2ND
-#: Merge.rc:5630
+#: Merge.rc:5629
 msgid "2nd"
 msgstr "பேரிக்காய்"
 
 #. IDS_PLUGIN_TARGETS_3RD
-#: Merge.rc:5631
+#: Merge.rc:5630
 msgid "3rd"
 msgstr "ஒரு சலுகை"
 
 #. IDS_PLUGIN_TARGETS_1ST_2ND
-#: Merge.rc:5632
+#: Merge.rc:5631
 msgid "1st and 2nd"
 msgstr "1 மற்றும் 2 வது"
 
 #. IDS_PLUGIN_TARGETS_1ST_3RD
-#: Merge.rc:5633
+#: Merge.rc:5632
 msgid "1st and 3rd"
 msgstr "1 மற்றும் 3 வது"
 
 #. IDS_PLUGIN_TARGETS_2ND_3RD
-#: Merge.rc:5634
+#: Merge.rc:5633
 msgid "2nd and 3rd"
 msgstr "2 மற்றும் 3 வது"
 
 #. IDS_PLUGIN_CTRL_CLICK
-#: Merge.rc:5635
+#: Merge.rc:5634
 msgid "(Ctrl+Click to add to pipeline)"
 msgstr ""
 
 #. IDS_FILTER_APPLIED
-#: Merge.rc:5640
+#: Merge.rc:5639
 msgid "Filter applied"
 msgstr "வடிகட்டி பயன்படுத்தப்பட்டது"
 
 #. IDS_FILTERMENU_COMPARE
-#: Merge.rc:5645
+#: Merge.rc:5644
 #, c-format
 msgid "Compare %1"
 msgstr ""
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN2
-#: Merge.rc:5647
+#: Merge.rc:5646
 msgid "&Filter by This Column..."
 msgstr ""
 
 #. IDS_CLIPBOARDHISTORY_TIME
-#: Merge.rc:5652
+#: Merge.rc:5651
 #, c-format
 msgid "Clipboard at %s"
 msgstr "%s இல் இடைநிலைப்பலகை"
 
 #. IDS_CLIPBOARDHISTORY_DISABLED
-#: Merge.rc:5653
+#: Merge.rc:5652
 msgid ""
 "Clipboard history disabled.\r\n"
 "Enable: Windows logo key + V, then Turn on."
@@ -8461,117 +8456,117 @@ msgstr ""
 "இடைநிலைப்பலகை வரலாறு முடக்கப்பட்டுள்ளது.\r\n"
 "இடைநிலைப்பலகை வரலாற்றை இயக்க, சாளரங்கள் சின்னம் + V ஐ அழுத்தி, பின்னர் இயக்கு பொத்தானைக் சொடுக்கவும்."
 
-#: Merge.rc:5655
+#: Merge.rc:5654
 msgid "This system does not support clipboard history."
 msgstr "இந்த அமைப்பு இடைநிலைப்பலகை வரலாற்றை ஆதரிக்காது."
 
-#: Merge.rc:5657
+#: Merge.rc:5656
 msgid "32-bit WinMerge does not support Clipboard Compare"
 msgstr "சாளரொன்றிணையின் 32-இரும பதிப்பு இடைநிலைப்பலகை ஒப்பீட்டை ஆதரிக்கவில்லை"
 
 #. IDS_WEBVIEW2_RUNTIME_NOT_INSTALLED
-#: Merge.rc:5662
+#: Merge.rc:5661
 msgid "WebView2 runtime not installed. Download it?"
 msgstr ""
 "வலைக்காட்சி2 இயக்கநேரம் நிறுவப்படவில்லை. நீங்கள் அதைப் பதிவிறக்க "
 "விரும்புகிறீர்களா?"
 
 #. IDS_JUMPLIST_NEW_TEXT_COMPARE
-#: Merge.rc:5667
+#: Merge.rc:5666
 msgid "New Text Compare"
 msgstr "புதிய உரை ஒப்பிடுக"
 
 #. IDS_JUMPLIST_NEW_TABLE_COMPARE
-#: Merge.rc:5668
+#: Merge.rc:5667
 msgid "New Table Compare"
 msgstr "புதிய அட்டவணை ஒப்பிடுக"
 
 #. IDS_JUMPLIST_NEW_BINARY_COMPARE
-#: Merge.rc:5669
+#: Merge.rc:5668
 msgid "New Binary Compare"
 msgstr "புதிய இருமம் ஒப்பீடு"
 
 #. IDS_JUMPLIST_NEW_IMAGE_COMPARE
-#: Merge.rc:5670
+#: Merge.rc:5669
 msgid "New Image Compare"
 msgstr "புதிய படம் ஒப்பிடுக"
 
 #. IDS_JUMPLIST_NEW_WEBPAGE_COMPARE
-#: Merge.rc:5671
+#: Merge.rc:5670
 msgid "New Webpage Compare"
 msgstr "புதிய வலைப்பக்கம் ஒப்பிடுக"
 
 #. IDS_JUMPLIST_NEW_FOLDER_COMPARE
-#: Merge.rc:5672
+#: Merge.rc:5671
 msgid "New Folder Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_CLIPBOARD_COMPARE
-#: Merge.rc:5673
+#: Merge.rc:5672
 msgid "Clipboard Compare"
 msgstr "இடைநிலைப்பலகை ஒப்பிடுக"
 
 #. IDS_PREVIEWBAR_PRINT
-#: Merge.rc:5678
+#: Merge.rc:5677
 msgid "&Print..."
 msgstr "அச்சிடு... (&p)"
 
 #. IDS_PREVIEWBAR_PREVPAGE
-#: Merge.rc:5680
+#: Merge.rc:5679
 msgid "Pre&v Page"
 msgstr "முன் & வி பக்கம்"
 
 #. IDS_PREVIEWBAR_TWOPAGE
-#: Merge.rc:5681
+#: Merge.rc:5680
 msgid "&Two Page"
 msgstr "& இரண்டு பக்கம்"
 
 #. IDS_PREVIEWBAR_ONEPAGE
-#: Merge.rc:5682
+#: Merge.rc:5681
 msgid "&One Page"
 msgstr "ஒரு பக்கம்"
 
 #. IDS_PREVIEWBAR_ZOOMIN
-#: Merge.rc:5683
+#: Merge.rc:5682
 msgid "Zoom &In"
 msgstr "சூம் & இன்"
 
 #. IDS_PREVIEWBAR_ZOOMOUT
-#: Merge.rc:5684
+#: Merge.rc:5683
 msgid "Zoom &Out"
 msgstr "பெரிதாக்கவும்"
 
 #. IDS_WEBPAGE_COMPARING
-#: Merge.rc:5690
+#: Merge.rc:5689
 msgid "Comparing..."
 msgstr "ஒப்பிடுவது ..."
 
 #. IDS_WEBPAGE_ZOOM
-#: Merge.rc:5691
+#: Merge.rc:5690
 msgid "Zoom:"
 msgstr "சூம்:"
 
 #. IDS_COPY_GRANULARITY_DIFFHUNK
-#: Merge.rc:5696
+#: Merge.rc:5695
 msgid "Diff hunk"
 msgstr "வேறு கொத்து"
 
 #. IDS_COPY_GRANULARITY_INLINE
-#: Merge.rc:5697
+#: Merge.rc:5696
 msgid "Inline diff"
 msgstr "உள்வரி வேறுபாடு"
 
 #. IDS_COPY_GRANULARITY_LINE
-#: Merge.rc:5698
+#: Merge.rc:5697
 msgid "Line"
 msgstr "வரி"
 
-#: Merge.rc:5699
+#: Merge.rc:5698
 msgid "Character"
 msgstr "எழுத்து"
 
 #. ID_MICE_PREVDIFF
-#: Merge.rc:5704
+#: Merge.rc:5703
 msgid ""
 "\n"
 "Previous Difference (Alt+Up)\n"
@@ -8584,7 +8579,7 @@ msgstr ""
 "(Alt+வீல் அப்)"
 
 #. ID_MICE_NEXTDIFF
-#: Merge.rc:5705
+#: Merge.rc:5704
 msgid ""
 "\n"
 "Next Difference (Alt+Down)\n"
@@ -8597,7 +8592,7 @@ msgstr ""
 "(Alt+வீல் டவுன்)"
 
 #. ID_MICE_L2R
-#: Merge.rc:5706
+#: Merge.rc:5705
 msgid ""
 "\n"
 "Copy to Right (Alt+Right)\n"
@@ -8612,7 +8607,7 @@ msgstr ""
 "(Alt+Shift+Wheel Down)"
 
 #. ID_MICE_R2L
-#: Merge.rc:5707
+#: Merge.rc:5706
 msgid ""
 "\n"
 "Copy to Left (Alt+Left)\n"
@@ -8627,7 +8622,7 @@ msgstr ""
 "(Alt+Shift+Wheel UP)"
 
 #. ID_MICE_L2RNEXT
-#: Merge.rc:5708
+#: Merge.rc:5707
 msgid ""
 "\n"
 "Copy to Right and Advance (Ctrl+Alt+Right)\n"
@@ -8640,7 +8635,7 @@ msgstr ""
 "(Ctrl+Alt+Shift+Wheel Town)"
 
 #. ID_MICE_R2LNEXT
-#: Merge.rc:5709
+#: Merge.rc:5708
 msgid ""
 "\n"
 "Copy to Left and Advance (Ctrl+Alt+Left)\n"
@@ -8653,282 +8648,282 @@ msgstr ""
 "(Ctrl+alt+shift+wheel Up)"
 
 #. IDS_LOG_COMPARING_2
-#: Merge.rc:5719
+#: Merge.rc:5718
 #, c-format
 msgid "Comparing %1 with %2"
 msgstr "%1 ஐ %2 உடன் ஒப்பிடுகிறது"
 
 #. IDS_LOG_COMPARING_3
-#: Merge.rc:5720
+#: Merge.rc:5719
 #, c-format
 msgid "Comparing %1 with %2 and %3"
 msgstr "%1 ஐ %2 மற்றும் %3 உடன் ஒப்பிடுகிறது"
 
 #. IDS_LOG_COMPARE_COMPLETED
-#: Merge.rc:5721
+#: Merge.rc:5720
 msgid "Comparison completed"
 msgstr "ஒப்பீடு முடிந்தது"
 
 #. IDS_LOG_COMPARE_ERROR_2
-#: Merge.rc:5722
+#: Merge.rc:5721
 #, c-format
 msgid "Failed to compare %1 with %2: "
 msgstr "%1 ஐ %2 உடன் ஒப்பிடுவதில் தோல்வி:"
 
 #. IDS_LOG_COMPARE_ERROR_3
-#: Merge.rc:5723
+#: Merge.rc:5722
 #, c-format
 msgid "Failed to compare %1 with %2 and %3: "
 msgstr "%1 ஐ %2 மற்றும் %3 உடன் ஒப்பிடுவதில் தோல்வி:"
 
 #. IDS_LOG_FILE_SAVED
-#: Merge.rc:5724
+#: Merge.rc:5723
 msgid "File saved"
 msgstr "கோப்பு சேமிக்கப்பட்டது"
 
 #. IDS_LOG_COPYING_FILES
-#: Merge.rc:5725
+#: Merge.rc:5724
 msgid "Copying files..."
 msgstr "கோப்புகளை நகலெடுக்கிறது..."
 
 #. IDS_LOG_MOVING_FILES
-#: Merge.rc:5726
+#: Merge.rc:5725
 msgid "Moving files..."
 msgstr "நகரும் கோப்புகள் ..."
 
 #. IDS_LOG_DELETING_FILES
-#: Merge.rc:5727
+#: Merge.rc:5726
 msgid "Deleting files..."
 msgstr "கோப்புகளை நீக்குதல் ..."
 
 #. IDS_LOG_RECYCLEBIN
-#: Merge.rc:5728
+#: Merge.rc:5727
 msgid "Recycle Bin"
 msgstr "மறுசுழற்சி தொட்டி"
 
 #. IDS_LOG_PERMANENTLY_DELETED
-#: Merge.rc:5729
+#: Merge.rc:5728
 msgid "Permanently deleted"
 msgstr "நிரந்தரமாக நீக்கப்பட்டது"
 
 #. IDS_LOG_FILEOPERATION_COMPLETED
-#: Merge.rc:5730
+#: Merge.rc:5729
 msgid "File operation completed successfully"
 msgstr "கோப்பு செயல்பாடு வெற்றிகரமாக முடிந்தது"
 
 #. IDS_LOG_FILEOPERATION_CANCELED
-#: Merge.rc:5731
+#: Merge.rc:5730
 msgid "File operation canceled"
 msgstr "கோப்பு செயல்பாடு கைவிடப்பட்டது"
 
 #. IDS_FILTER_ERROR_NO_ERROR
-#: Merge.rc:5736
+#: Merge.rc:5735
 msgid "No error"
 msgstr ""
 
 #. IDS_FILTER_ERROR_EMPTY_EXPRESSION
-#: Merge.rc:5737
+#: Merge.rc:5736
 msgid "Filter expression is empty"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNKNOWN_CHAR
-#: Merge.rc:5738
+#: Merge.rc:5737
 msgid "Unknown character in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNTERMINATED_STRING
-#: Merge.rc:5739
+#: Merge.rc:5738
 msgid "Unterminated string literal"
 msgstr ""
 
 #. IDS_FILTER_ERROR_SYNTAX_ERROR
-#: Merge.rc:5740
+#: Merge.rc:5739
 msgid "Syntax error in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_PARSE_FAILURE
-#: Merge.rc:5741
+#: Merge.rc:5740
 msgid "Failed to parse filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_LITERAL
-#: Merge.rc:5742
+#: Merge.rc:5741
 msgid "Invalid literal value"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_REGULAR_EXPRESSION
-#: Merge.rc:5743
+#: Merge.rc:5742
 msgid "Invalid regular expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNDEFINED_IDENTIFIER
-#: Merge.rc:5744
+#: Merge.rc:5743
 msgid "Undefined identifier"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_ARGUMENT_COUNT
-#: Merge.rc:5745
+#: Merge.rc:5744
 msgid "Invalid number of arguments"
 msgstr ""
 
 #. IDS_FILTER_ERROR_FILTER_NAME_NOT_FOUND
-#: Merge.rc:5746
+#: Merge.rc:5745
 msgid "Filter name not found"
 msgstr ""
 
 #. IDS_FILTER_ERROR_DIVIDE_BY_ZERO
-#: Merge.rc:5747
+#: Merge.rc:5746
 msgid "Division by zero in filter expression"
 msgstr ""
 
 #. IDS_FILTER_ERROR_UNKNOWN_ERROR
-#: Merge.rc:5748
+#: Merge.rc:5747
 msgid "Unknown error"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_PROPERTY_NAME
-#: Merge.rc:5749
+#: Merge.rc:5748
 msgid "Invalid property name"
 msgstr ""
 
 #. IDS_FILTER_ERROR_INVALID_DIRECTIVE
-#: Merge.rc:5750
+#: Merge.rc:5749
 msgid "Invalid directive"
 msgstr ""
 
 #. IDS_FILTER_OP_EQUALS
-#: Merge.rc:5755
+#: Merge.rc:5754
 msgid "Equals"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_EQUALS
-#: Merge.rc:5756
+#: Merge.rc:5755
 msgid "Does not equal"
 msgstr ""
 
 #. IDS_FILTER_OP_LESS_THAN
-#: Merge.rc:5757
+#: Merge.rc:5756
 msgid "Less than"
 msgstr ""
 
 #. IDS_FILTER_OP_LESS_EQUAL
-#: Merge.rc:5758
+#: Merge.rc:5757
 msgid "Less than or equal to"
 msgstr ""
 
 #. IDS_FILTER_OP_GREATER_EQUAL
-#: Merge.rc:5759
+#: Merge.rc:5758
 msgid "Greater than or equal to"
 msgstr ""
 
 #. IDS_FILTER_OP_GREATER_THAN
-#: Merge.rc:5760
+#: Merge.rc:5759
 msgid "Greater than"
 msgstr ""
 
 #. IDS_FILTER_OP_BETWEEN
-#: Merge.rc:5761
+#: Merge.rc:5760
 msgid "Between"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_BETWEEN
-#: Merge.rc:5762
+#: Merge.rc:5761
 msgid "Not Between"
 msgstr ""
 
 #. IDS_FILTER_OP_CONTAINS
-#: Merge.rc:5763
+#: Merge.rc:5762
 msgid "Contains"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_CONTAINS
-#: Merge.rc:5764
+#: Merge.rc:5763
 msgid "Not Contains"
 msgstr ""
 
 #. IDS_FILTER_OP_RECONTAINS
-#: Merge.rc:5765
+#: Merge.rc:5764
 msgid "Contains (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_RECONTAINS
-#: Merge.rc:5766
+#: Merge.rc:5765
 msgid "Not Contains (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_LIKE
-#: Merge.rc:5767
+#: Merge.rc:5766
 msgid "Match (wildcard)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_LIKE
-#: Merge.rc:5768
+#: Merge.rc:5767
 msgid "Not match (wildcard)"
 msgstr ""
 
 #. IDS_FILTER_OP_MATCHES
-#: Merge.rc:5769
+#: Merge.rc:5768
 msgid "Match (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_MATCHES
-#: Merge.rc:5770
+#: Merge.rc:5769
 msgid "Not match (regex)"
 msgstr ""
 
 #. IDS_COLORMODE_LIGHT
-#: Merge.rc:5775
+#: Merge.rc:5774
 msgid "Light"
 msgstr ""
 
 #. IDS_COLORMODE_DARK
-#: Merge.rc:5776
+#: Merge.rc:5775
 msgid "Dark"
 msgstr ""
 
 #. IDS_COLORMODE_FOLLOWSYSTEM
-#: Merge.rc:5777
+#: Merge.rc:5776
 msgid "Follow system"
 msgstr ""
 
 #. IDS_EXAMPLE
-#: Merge.rc:5782
+#: Merge.rc:5781
 #, c-format
 msgid "e.g. %1"
 msgstr ""
 
 #. IDS_DETECTED_PREVIOUS_CRASH
-#: Merge.rc:5787
+#: Merge.rc:5786
 msgid "WinMerge detected a previous crash. Please report this if possible."
 msgstr ""
 
 #. IDS_REGEX_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5792
+#: Merge.rc:5791
 msgid "# Regex replacement list\r\n# Format: regex<TAB>replacement\r\n# Backreferences like $1, $2 are supported\r\n\r\n(\\d{4})-(\\d{2})-(\\d{2})\t$1_$2_$3\r\n"
 msgstr ""
 
 #. IDS_STRING_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5793
+#: Merge.rc:5792
 msgid "# Replacement list\r\n# Format: search<TAB>replacement\r\n# Lines starting with # are ignored\r\n\r\nfrom1\tto1\r\nfrom2\tto2\r\n"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_ONLY
-#: Merge.rc:5798
+#: Merge.rc:5797
 msgid "Built-in only"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_FIRST
-#: Merge.rc:5799
+#: Merge.rc:5798
 msgid "Built-in first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_FIRST
-#: Merge.rc:5800
+#: Merge.rc:5799
 msgid "Tree-sitter first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_ONLY
-#: Merge.rc:5801
+#: Merge.rc:5800
 msgid "Tree-sitter only"
 msgstr ""
 

--- a/Translations/WinMerge/Turkish.po
+++ b/Translations/WinMerge/Turkish.po
@@ -24,7 +24,7 @@ msgstr ""
 "X-Generator: Poedit 3.9\n"
 
 #. LANGUAGE, SUBLANGUAGE
-#: Merge.rc:26 Merge.rc:59 Merge.rc:5818
+#: Merge.rc:26 Merge.rc:59 Merge.rc:5817
 msgid "LANG_ENGLISH, SUBLANG_ENGLISH_US"
 msgstr "LANG_TURKISH, SUBLANG_DEFAULT"
 
@@ -166,7 +166,7 @@ msgstr "&Betikler"
 #. IDS_NO_EDIT_SCRIPTS
 #: Merge.rc:127 Merge.rc:352 Merge.rc:463 Merge.rc:673 Merge.rc:678
 #: Merge.rc:887 Merge.rc:899 Merge.rc:906 Merge.rc:963 Merge.rc:1210
-#: Merge.rc:5375
+#: Merge.rc:5374
 msgid "< Empty >"
 msgstr "< Boş >"
 
@@ -231,7 +231,7 @@ msgid "Auto-Fit All Columns"
 msgstr "Tüm sütunlar otomatik sığdırılsın"
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN
-#: Merge.rc:153 Merge.rc:5646
+#: Merge.rc:153 Merge.rc:5645
 msgid "&Filter by This Column"
 msgstr "Bu sütuna göre &filtrele"
 
@@ -292,7 +292,7 @@ msgid "&Previous Page"
 msgstr "Ö&nceki sayfa"
 
 #. IDS_PREVIEWBAR_NEXTPAGE
-#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5679
+#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5678
 msgid "&Next Page"
 msgstr "So&nraki sayfa"
 
@@ -543,7 +543,7 @@ msgstr "&Binary"
 #. IDS_IMAGE_MENU
 #: Merge.rc:329 Merge.rc:338 Merge.rc:432 Merge.rc:441 Merge.rc:609
 #: Merge.rc:618 Merge.rc:670 Merge.rc:960 Merge.rc:1187 Merge.rc:1200
-#: Merge.rc:5477
+#: Merge.rc:5476
 msgid "&Image"
 msgstr "&Görsel"
 
@@ -665,7 +665,7 @@ msgid "&Huge"
 msgstr "Çok &büyük"
 
 #. IDS_VIEW_MENU_BAR
-#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5714
+#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5713
 msgid "Men&u Bar"
 msgstr "Me&nü çubuğu"
 
@@ -1320,7 +1320,7 @@ msgid "Lo&cation Pane"
 msgstr "&Konum panosu"
 
 #. IDS_OUTPUTBAR_CAPTION
-#: Merge.rc:782 Merge.rc:5252
+#: Merge.rc:782 Merge.rc:5251
 msgid "Output Pane"
 msgstr "Çıktı panosu"
 
@@ -1583,55 +1583,55 @@ msgid "Co&mpare As"
 msgstr "&Farklı karşılaştır"
 
 #. IDS_COPY_LEFT_TO_MIDDLE2
-#: Merge.rc:968 Merge.rc:980 Merge.rc:4852
+#: Merge.rc:968 Merge.rc:980 Merge.rc:4851
 #, c-format
 msgid "Left to Middle (%1 of %2)"
 msgstr "Soldakini ortaya (%1 / %2)"
 
 #. IDS_COPY_LEFT_TO_RIGHT2
-#: Merge.rc:969 Merge.rc:981 Merge.rc:4851
+#: Merge.rc:969 Merge.rc:981 Merge.rc:4850
 #, c-format
 msgid "Left to Right (%1 of %2)"
 msgstr "Soldakini sağa (%1 / %2)"
 
 #. IDS_MOVE_LEFT_TO2
-#: Merge.rc:970 Merge.rc:982 Merge.rc:1045 Merge.rc:4863 Merge.rc:4892
+#: Merge.rc:970 Merge.rc:982 Merge.rc:1045 Merge.rc:4862 Merge.rc:4891
 #, c-format
 msgid "Left to... (%1 of %2)"
 msgstr "Soldakini şuraya... (%1 / %2)"
 
 #. IDS_COPY_MIDDLE_TO_LEFT2
-#: Merge.rc:971 Merge.rc:983 Merge.rc:4849
+#: Merge.rc:971 Merge.rc:983 Merge.rc:4848
 #, c-format
 msgid "Middle to Left (%1 of %2)"
 msgstr "Ortadakini sola (%1 / %2)"
 
 #. IDS_COPY_MIDDLE_TO_RIGHT2
-#: Merge.rc:972 Merge.rc:984 Merge.rc:4850
+#: Merge.rc:972 Merge.rc:984 Merge.rc:4849
 #, c-format
 msgid "Middle to Right (%1 of %2)"
 msgstr "Ortadakini sağa (%1 / %2)"
 
 #. IDS_MOVE_MIDDLE_TO2
-#: Merge.rc:973 Merge.rc:985 Merge.rc:1046 Merge.rc:4864 Merge.rc:4893
+#: Merge.rc:973 Merge.rc:985 Merge.rc:1046 Merge.rc:4863 Merge.rc:4892
 #, c-format
 msgid "Middle to... (%1 of %2)"
 msgstr "Ortadakini şuraya... (%1 / %2)"
 
 #. IDS_COPY_RIGHT_TO_MIDDLE2
-#: Merge.rc:974 Merge.rc:986 Merge.rc:4848
+#: Merge.rc:974 Merge.rc:986 Merge.rc:4847
 #, c-format
 msgid "Right to Middle (%1 of %2)"
 msgstr "Sağdakini ortaya (%1 / %2)"
 
 #. IDS_COPY_RIGHT_TO_LEFT2
-#: Merge.rc:975 Merge.rc:987 Merge.rc:4847
+#: Merge.rc:975 Merge.rc:987 Merge.rc:4846
 #, c-format
 msgid "Right to Left (%1 of %2)"
 msgstr "Sağdakini sola (%1 / %2)"
 
 #. IDS_MOVE_RIGHT_TO2
-#: Merge.rc:976 Merge.rc:988 Merge.rc:1047 Merge.rc:4865 Merge.rc:4894
+#: Merge.rc:976 Merge.rc:988 Merge.rc:1047 Merge.rc:4864 Merge.rc:4893
 #, c-format
 msgid "Right to... (%1 of %2)"
 msgstr "Sağdakini şuraya... (%1 / %2)"
@@ -1687,31 +1687,31 @@ msgid "Cop&y Paths"
 msgstr "&Yol adlarını kopyala"
 
 #. IDS_DEL_LEFT_FMT2
-#: Merge.rc:1026 Merge.rc:1035 Merge.rc:4880
+#: Merge.rc:1026 Merge.rc:1035 Merge.rc:4879
 #, c-format
 msgid "Left (%1 of %2)"
 msgstr "Soldakini (%1 / %2)"
 
 #. IDS_DEL_MIDDLE_FMT2
-#: Merge.rc:1027 Merge.rc:1036 Merge.rc:4881
+#: Merge.rc:1027 Merge.rc:1036 Merge.rc:4880
 #, c-format
 msgid "Middle (%1 of %2)"
 msgstr "Ortadakini (%1 / %2)"
 
 #. IDS_DEL_RIGHT_FMT2
-#: Merge.rc:1028 Merge.rc:1037 Merge.rc:4882
+#: Merge.rc:1028 Merge.rc:1037 Merge.rc:4881
 #, c-format
 msgid "Right (%1 of %2)"
 msgstr "Sağdakini (%1 / %2)"
 
 #. IDS_DEL_BOTH_FMT2
-#: Merge.rc:1029 Merge.rc:1038 Merge.rc:4883
+#: Merge.rc:1029 Merge.rc:1038 Merge.rc:4882
 #, c-format
 msgid "Both (%1 of %2)"
 msgstr "İkisini de (%1 / %2)"
 
 #. IDS_DEL_ALL_FMT2
-#: Merge.rc:1030 Merge.rc:1039 Merge.rc:4888
+#: Merge.rc:1030 Merge.rc:1039 Merge.rc:4887
 #, c-format
 msgid "All (%1 of %2)"
 msgstr "Tümü (%1 / %2)"
@@ -1737,19 +1737,19 @@ msgid "&Zip"
 msgstr "&Sıkıştır"
 
 #. IDS_COPY_BOTH_TO2
-#: Merge.rc:1048 Merge.rc:4866
+#: Merge.rc:1048 Merge.rc:4865
 #, c-format
 msgid "Both to... (%1 of %2)"
 msgstr "İkisini de... (%1 / %2)"
 
 #. IDS_COPY_ALL_TO2
-#: Merge.rc:1049 Merge.rc:4867
+#: Merge.rc:1049 Merge.rc:4866
 #, c-format
 msgid "All to... (%1 of %2)"
 msgstr "Tümünü... (%1 / %2)"
 
 #. IDS_COPY_DIFFERENCES_TO2
-#: Merge.rc:1050 Merge.rc:4868
+#: Merge.rc:1050 Merge.rc:4867
 #, c-format
 msgid "Differences to... (%1 of %2)"
 msgstr "&Farklı olanları... (%1 / %2)"
@@ -1816,12 +1816,12 @@ msgstr "Çıkarıcı ayarları"
 
 #. IDS_USERCHOICE_NONE
 #: Merge.rc:1088 Merge.rc:1094 Merge.rc:1836 Merge.rc:1840 Merge.rc:2031
-#: Merge.rc:2035 Merge.rc:5377
+#: Merge.rc:2035 Merge.rc:5376
 msgid "<None>"
 msgstr "<Yok>"
 
 #. IDS_USERCHOICE_AUTOMATIC
-#: Merge.rc:1089 Merge.rc:1095 Merge.rc:5378
+#: Merge.rc:1089 Merge.rc:1095 Merge.rc:5377
 msgid "<Automatic>"
 msgstr "<Otomatik>"
 
@@ -2751,12 +2751,12 @@ msgid "Text files only"
 msgstr "Yalnızca metin dosyaları"
 
 #. IDS_EOL_NONE
-#: Merge.rc:1667 Merge.rc:1918 Merge.rc:5304
+#: Merge.rc:1667 Merge.rc:1918 Merge.rc:5303
 msgid "None"
 msgstr "Yok"
 
 #. IDS_EOL_MIXED
-#: Merge.rc:1668 Merge.rc:5299
+#: Merge.rc:1668 Merge.rc:5298
 msgid "Mixed"
 msgstr "Karma"
 
@@ -3028,13 +3028,13 @@ msgstr "&Satır durumu"
 
 #. IDS_DIFFERENT
 #: Merge.rc:1904 Merge.rc:1988 Merge.rc:2866 Merge.rc:3036 Merge.rc:3077
-#: Merge.rc:5058
+#: Merge.rc:5057
 msgid "Different"
 msgstr "Farklılık"
 
 #. IDS_IDENTICAL
 #: Merge.rc:1905 Merge.rc:1989 Merge.rc:2865 Merge.rc:3055 Merge.rc:3116
-#: Merge.rc:5048
+#: Merge.rc:5047
 msgid "Identical"
 msgstr "Aynı"
 
@@ -3054,7 +3054,7 @@ msgid "Missing"
 msgstr "Yok"
 
 #. IDS_MOVED
-#: Merge.rc:1910 Merge.rc:5076
+#: Merge.rc:1910 Merge.rc:5075
 msgid "Moved"
 msgstr "Taşındı"
 
@@ -3790,7 +3790,7 @@ msgid "&Use custom system colors"
 msgstr "Özel &sistem renkleri kullanılsın"
 
 #. IDS_PRPCAT_SYSTEM
-#: Merge.rc:2565 Merge.rc:4559 Merge.rc:4560 Merge.rc:5007
+#: Merge.rc:2565 Merge.rc:4559 Merge.rc:4560 Merge.rc:5006
 msgid "System"
 msgstr "Sistem"
 
@@ -4190,7 +4190,7 @@ msgid "Items compared:"
 msgstr "Karşılaştırılan öge:"
 
 #. IDS_PREVIEWBAR_CLOSE
-#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5685
+#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5684
 msgid "&Close"
 msgstr "&Kapat"
 
@@ -4813,7 +4813,7 @@ msgid "A&ppend timestamp"
 msgstr "Sonuna tarih da&mgası eklensin"
 
 #. IDS_CONFIRM_COPY_CAPTION
-#: Merge.rc:3214 Merge.rc:4915
+#: Merge.rc:3214 Merge.rc:4914
 msgid "Confirm Copy"
 msgstr "Kopya doğrulansın"
 
@@ -5050,7 +5050,7 @@ msgid "&Character Set..."
 msgstr "&Karakter kümesi..."
 
 #. IDS_PRPCAT_IMAGE
-#: Merge.rc:3351 Merge.rc:4574 Merge.rc:5015
+#: Merge.rc:3351 Merge.rc:4574 Merge.rc:5014
 msgid "Image"
 msgstr "Görsel"
 
@@ -5457,7 +5457,7 @@ msgid "Project"
 msgstr "Proje"
 
 #. IDS_COLHDR_NSDIFFS
-#: Merge.rc:4566 Merge.rc:4990
+#: Merge.rc:4566 Merge.rc:4989
 msgid "Differences"
 msgstr "Farklar"
 
@@ -5602,12 +5602,12 @@ msgid "File Type"
 msgstr "Dosya türü"
 
 #. IDS_COLHDR_EXTENSION
-#: Merge.rc:4653 Merge.rc:4947
+#: Merge.rc:4653 Merge.rc:4946
 msgid "Extension"
 msgstr "Uzantı"
 
 #. IDS_PRPCAT_MESSAGE
-#: Merge.rc:4659 Merge.rc:5019
+#: Merge.rc:4659 Merge.rc:5018
 msgid "Message"
 msgstr "İleti"
 
@@ -5647,7 +5647,7 @@ msgid "Hidden Items"
 msgstr "Gizli ögeler"
 
 #. IDS_PLUGINSLIST_NAME
-#: Merge.rc:4680 Merge.rc:5311
+#: Merge.rc:4680 Merge.rc:5310
 msgid "Name"
 msgstr "Ad"
 
@@ -5667,7 +5667,7 @@ msgid "[F] "
 msgstr "[F] "
 
 #. IDS_PLUGINSLIST_DESC
-#: Merge.rc:4684 Merge.rc:5313
+#: Merge.rc:4684 Merge.rc:5312
 msgid "Description"
 msgstr "Açıklama"
 
@@ -5835,155 +5835,150 @@ msgstr "Satır: %s  Sütun: %d/%d  Karakter: %d/%d"
 msgid "  Sel: %d | %d"
 msgstr "  Seç: %d | %d"
 
-#. IDS_MERGEMODE_MERGING
-#: Merge.rc:4734
-msgid "Merge"
-msgstr "Birleştir"
-
 #. IDS_DIFF_NUMBER_STATUS_FMT
-#: Merge.rc:4735
+#: Merge.rc:4734
 #, c-format
 msgid "Difference %1 of %2"
 msgstr "Fark %1 / %2"
 
 #. IDS_NO_DIFF_SEL_FMT
-#: Merge.rc:4736
+#: Merge.rc:4735
 #, c-format
 msgid "%1 Differences Found"
 msgstr "%1 fark bulundu"
 
 #. IDS_1_DIFF_FOUND
-#: Merge.rc:4737
+#: Merge.rc:4736
 msgid "1 Difference Found"
 msgstr "1 fark bulundu"
 
 #. IDS_NO_ERR_SEL_FMT
-#: Merge.rc:4738
+#: Merge.rc:4737
 #, c-format
 msgid "%1 Errors Found"
 msgstr "%1 Hata Bulundu"
 
 #. IDS_1_ERR_FOUND
-#: Merge.rc:4739
+#: Merge.rc:4738
 msgid "1 Error Found"
 msgstr "1 Hata Bulundu"
 
 #. IDS_STATUSBAR_READONLY, Abbreviation from "Read Only"
-#: Merge.rc:4740
+#: Merge.rc:4739
 msgid "RO"
 msgstr "SO"
 
 #. IDS_DIRVIEW_STATUS_FMT_FOCUS
-#: Merge.rc:4746
+#: Merge.rc:4745
 #, c-format
 msgid "Item %1 of %2"
 msgstr "Öge %1 / %2"
 
 #. IDS_DIRVIEW_STATUS_FMT_NOFOCUS
-#: Merge.rc:4747
+#: Merge.rc:4746
 #, c-format
 msgid "Items: %1"
 msgstr "Ögeler: %1"
 
 #. IDS_DIRVIEW_STATUS_COMPARING
-#: Merge.rc:4748
+#: Merge.rc:4747
 msgid "Comparing items..."
 msgstr "Ögeler karşılaştırılıyor..."
 
 #. IDS_ITEMS_PER_SEC
-#: Merge.rc:4749
+#: Merge.rc:4748
 #, c-format
 msgid "%.1f[items/sec]"
 msgstr "%.1f[öge/sn]"
 
 #. IDS_ERROR_INCOMPARABLE
-#: Merge.rc:4755
+#: Merge.rc:4754
 msgid "Select two existing folders/files to compare."
 msgstr "Karşılaştırmak için var olan iki klasör ya da dosya seçin."
 
 #. IDS_DIRSEL_TAG
-#: Merge.rc:4756
+#: Merge.rc:4755
 msgid "Folder Selection"
 msgstr "Klasör seçimi"
 
 #. IDS_OPEN_FILESDIRS
-#: Merge.rc:4757
+#: Merge.rc:4756
 msgid "Select two (or three) folders/files to compare."
 msgstr "Karşılaştırılacak iki (ya da üç) klasör ya da iki (ya da üç) dosya seçin."
 
 #. IDS_OPEN_LEFTINVALID
-#: Merge.rc:4758
+#: Merge.rc:4757
 msgid "Left (1st) path is invalid!"
 msgstr "Sol (1.) yol geçersiz!"
 
 #. IDS_OPEN_MIDDLEINVALID
-#: Merge.rc:4759
+#: Merge.rc:4758
 msgid "Middle (2nd) path is invalid!"
 msgstr "Orta (2.) yol geçersiz!"
 
 #. IDS_OPEN_RIGHTINVALID2
-#: Merge.rc:4760
+#: Merge.rc:4759
 msgid "Right (2nd) path is invalid!"
 msgstr "Sağ (2.) yol geçersiz!"
 
 #. IDS_OPEN_RIGHTINVALID3
-#: Merge.rc:4761
+#: Merge.rc:4760
 msgid "Right (3rd) path is invalid!"
 msgstr "Sağ (3.) yol geçersiz!"
 
 #. IDS_OPEN_BOTHINVALID
-#: Merge.rc:4762
+#: Merge.rc:4761
 msgid "Both paths are invalid!"
 msgstr "Yolların ikisi de geçersiz!"
 
-#: Merge.rc:4764
+#: Merge.rc:4763
 msgid "Left (1st) and Middle (2nd) paths are invalid!"
 msgstr "Sol (1.) ve Orta (2.) yollar geçersiz!"
 
 #. IDS_OPEN_LEFTRIGHTINVALID
-#: Merge.rc:4765
+#: Merge.rc:4764
 msgid "Left (1st) and Right (3rd) paths are invalid!"
 msgstr "Sol (1.) ve Sağ (3.) yollar geçersiz!"
 
-#: Merge.rc:4767
+#: Merge.rc:4766
 msgid "Middle (2nd) and Right (3rd) paths are invalid!"
 msgstr "Orta (2.) ve Sağ (3.) yollar geçersiz!"
 
 #. IDS_OPEN_ALLINVALID
-#: Merge.rc:4768
+#: Merge.rc:4767
 msgid "All paths are invalid!"
 msgstr "Yolların tümü geçersiz!"
 
 #. IDS_OPEN_UNPACKERDISABLED
-#: Merge.rc:4769
+#: Merge.rc:4768
 msgid "Only enabled for file comparisons"
 msgstr "Yalnızca dosya karşılaştırması için kullanılabilir"
 
 #. IDS_OPEN_MISMATCH
-#: Merge.rc:4770
+#: Merge.rc:4769
 msgid "Cannot compare file and folder!"
 msgstr "Dosya ile klasör karşılaştırılamaz!"
 
 #. IDS_ERROR_FILE_NOT_FOUND
-#: Merge.rc:4776
+#: Merge.rc:4775
 #, c-format
 msgid "File not found: %1"
 msgstr "%1 dosyası bulunamadı"
 
 #. IDS_ERROR_FOLDER_NOT_FOUND
-#: Merge.rc:4777
+#: Merge.rc:4776
 #, c-format
 msgid "Folder not found: %1"
 msgstr "Klasör bulunamadı: %1"
 
 #. IDS_ERROR_FILE_NOT_UNPACKED
-#: Merge.rc:4778
+#: Merge.rc:4777
 #, c-format
 msgid "File not unpacked: %1"
 msgstr "%1 dosyası ayıklanamadı"
 
 #. IDS_ERROR_FILEOPEN
-#: Merge.rc:4779
+#: Merge.rc:4778
 #, c-format
 msgid ""
 "Cannot open file\n"
@@ -5997,12 +5992,12 @@ msgstr ""
 "%2"
 
 #. IDS_ERROR_CONF_RESOLVE
-#: Merge.rc:4780
+#: Merge.rc:4779
 msgid "Failed to parse conflict file."
 msgstr "Çelişki dosyası işlenemedi."
 
 #. IDS_NOT_CONFLICT_FILE
-#: Merge.rc:4781
+#: Merge.rc:4780
 #, c-format
 msgid ""
 "The file\n"
@@ -6014,7 +6009,7 @@ msgstr ""
 "bir çelişki dosyası değil."
 
 #. IDS_COMPARE_LARGE_FILES
-#: Merge.rc:4782
+#: Merge.rc:4781
 msgid ""
 "Comparing large files requires significant memory.\n"
 "Show only comparison results (not file contents)?"
@@ -6023,28 +6018,28 @@ msgstr ""
 "Yalnızca karşılaştırma sonuçlarını göster (dosya içeriklerini değil)?"
 
 #. IDS_SAVE_AS_TITLE
-#: Merge.rc:4788
+#: Merge.rc:4787
 msgid "Save As"
 msgstr "Farklı kaydet"
 
 #. IDS_SAVE_FMT
-#: Merge.rc:4789
+#: Merge.rc:4788
 #, c-format
 msgid "Save changes to %1?"
 msgstr "%1 içindeki değişiklikler kaydedilsin mi?"
 
 #. IDS_SAVEREADONLY_FMT
-#: Merge.rc:4790
+#: Merge.rc:4789
 #, c-format
 msgid "%1 is read-only. Override? Or 'No' to save as new filename?"
 msgstr "%1 salt okunur. Üzerine yazılsın mı? Veya yeni adla kaydetmek için “Hayır” mı seçilsin?"
 
 #. IDS_ERROR_BACKUP
-#: Merge.rc:4791
+#: Merge.rc:4790
 msgid "Error backing up file"
 msgstr "Dosya yedekleme sorunu"
 
-#: Merge.rc:4793
+#: Merge.rc:4792
 #, c-format
 msgid ""
 "Unable to backup original file:\n"
@@ -6058,7 +6053,7 @@ msgstr ""
 "Gene de devam edilsin mi?"
 
 #. IDS_FILESAVE_FAILED
-#: Merge.rc:4794
+#: Merge.rc:4793
 #, c-format
 msgid ""
 "Saving file failed.\n"
@@ -6074,7 +6069,7 @@ msgstr ""
 "\t- Farklı bir ad kullanılsın (Tamam üzerine tıklayın)\n"
 "\t- Bu işlem iptal edilsin (İptal üzerine tıklayın)"
 
-#: Merge.rc:4796
+#: Merge.rc:4795
 #, c-format
 msgid ""
 "Plugin '%2' cannot pack changes to left file into '%1'.\n"
@@ -6087,7 +6082,7 @@ msgstr ""
 "\n"
 "Ayıklanmış sürümü başka bir dosyaya kaydetmek ister misiniz?"
 
-#: Merge.rc:4798
+#: Merge.rc:4797
 #, c-format
 msgid ""
 "Plugin '%2' cannot pack changes to middle file into '%1'.\n"
@@ -6100,7 +6095,7 @@ msgstr ""
 "\n"
 "Ayıklanmış sürümü başka bir dosyaya kaydetmek ister misiniz?"
 
-#: Merge.rc:4800
+#: Merge.rc:4799
 #, c-format
 msgid ""
 "Plugin '%2' cannot pack changes to right file into '%1'.\n"
@@ -6114,7 +6109,7 @@ msgstr ""
 "Ayıklanmış sürümü başka bir dosyaya kaydetmek ister misiniz?"
 
 #. IDS_FILECHANGED_ONDISK
-#: Merge.rc:4801
+#: Merge.rc:4800
 #, c-format
 msgid ""
 "Another application updated\n"
@@ -6130,7 +6125,7 @@ msgstr ""
 "Değiştirilmiş dosyanın üzerine yazılsın mı?"
 
 #. IDS_SAVEREADONLY_MULTI
-#: Merge.rc:4802
+#: Merge.rc:4801
 #, c-format
 msgid ""
 "%1\n"
@@ -6140,7 +6135,7 @@ msgstr ""
 "salt okunur. Üzerine yazılsın mı?"
 
 #. IDS_FILECHANGED_RESCAN
-#: Merge.rc:4803
+#: Merge.rc:4802
 #, c-format
 msgid ""
 "Another application updated\n"
@@ -6156,22 +6151,22 @@ msgstr ""
 "Dosyanın yeniden yüklenmesini ister misiniz?"
 
 #. IDS_SAVE_LEFT_AS
-#: Merge.rc:4804
+#: Merge.rc:4803
 msgid "Save Left File As"
 msgstr "Sol dosyayı farklı kaydet"
 
 #. IDS_SAVE_MIDDLE_AS
-#: Merge.rc:4805
+#: Merge.rc:4804
 msgid "Save Middle File As"
 msgstr "Orta dosyayı farklı kaydet"
 
 #. IDS_SAVE_RIGHT_AS
-#: Merge.rc:4806
+#: Merge.rc:4805
 msgid "Save Right File As"
 msgstr "Sağ dosyayı farklı kaydet"
 
 #. IDS_FILE_DISAPPEARED
-#: Merge.rc:4811
+#: Merge.rc:4810
 #, c-format
 msgid ""
 "File\n"
@@ -6183,7 +6178,7 @@ msgstr ""
 "yok oldu. Devam etmek için dosyanın bir kopyasını kaydedin."
 
 #. IDS_VIEWS_OUTOFSYNC
-#: Merge.rc:4817
+#: Merge.rc:4816
 msgid ""
 "Cannot merge unsynched documents.\n"
 "\n"
@@ -6194,124 +6189,124 @@ msgstr ""
 "Devam etmeden önce belgeleri yenileyin."
 
 #. IDS_BREAK_ON_WHITESPACE
-#: Merge.rc:4822
+#: Merge.rc:4821
 msgid "Break at whitespace"
 msgstr "Beyaz boşlukta kesilsin"
 
 #. IDS_BREAK_ON_PUNCTUATION
-#: Merge.rc:4823
+#: Merge.rc:4822
 msgid "Break at whitespace or punctuation"
 msgstr "Beyaz boşlukta ya da noktalamada kesilsin"
 
 #. IDS_L2M
-#: Merge.rc:4829
+#: Merge.rc:4828
 msgid "Copy to &Middle\tAlt+Right"
 msgstr "Or&taya kopyala\tAlt+Sağa"
 
 #. IDS_R2M
-#: Merge.rc:4830
+#: Merge.rc:4829
 msgid "Copy to &Middle\tAlt+Left"
 msgstr "Or&taya kopyala\tAlt+Sola"
 
 #. IDS_COPY_FROM_MIDDLE_R
-#: Merge.rc:4831
+#: Merge.rc:4830
 msgid "Copy from Middle\tAlt+Shift+Right"
 msgstr "Ortadan kopyala\tAlt+Shift+Sağa"
 
 #. IDS_COPY_FROM_MIDDLE_L
-#: Merge.rc:4832
+#: Merge.rc:4831
 msgid "Copy from Middle\tAlt+Shift+Left"
 msgstr "Ortadan kopyala\tAlt+Shift+Sola"
 
 #. IDS_L2MNEXT
-#: Merge.rc:4833
+#: Merge.rc:4832
 msgid "Copy to Middle and Advance\tCtrl+Alt+Right"
 msgstr "Ortaya kopyala ve ilerle\tCtrl+Alt+Sağa"
 
 #. IDS_R2MNEXT
-#: Merge.rc:4834
+#: Merge.rc:4833
 msgid "Copy to Middle and Advance\tCtrl+Alt+Left"
 msgstr "Ortaya kopyala ve ilerle\tCtrl+Alt+Sola"
 
 #. IDS_ALL_MIDDLE
-#: Merge.rc:4835
+#: Merge.rc:4834
 msgid "Copy All to Middle"
 msgstr "Tümünü ortaya kopyala"
 
 #. IDS_COPY_RIGHT_TO_LEFT
-#: Merge.rc:4841
+#: Merge.rc:4840
 #, c-format
 msgid "Right to Left (%1)"
 msgstr "Sağdakini sola (%1)"
 
 #. IDS_COPY_RIGHT_TO_MIDDLE
-#: Merge.rc:4842
+#: Merge.rc:4841
 #, c-format
 msgid "Right to Middle (%1)"
 msgstr "Sağdakini ortaya (%1)"
 
 #. IDS_COPY_MIDDLE_TO_LEFT
-#: Merge.rc:4843
+#: Merge.rc:4842
 #, c-format
 msgid "Middle to Left (%1)"
 msgstr "Ortadakini sola (%1)"
 
 #. IDS_COPY_MIDDLE_TO_RIGHT
-#: Merge.rc:4844
+#: Merge.rc:4843
 #, c-format
 msgid "Middle to Right (%1)"
 msgstr "Ortadakini sağa (%1)"
 
 #. IDS_COPY_LEFT_TO_RIGHT
-#: Merge.rc:4845
+#: Merge.rc:4844
 #, c-format
 msgid "Left to Right (%1)"
 msgstr "Soldakini sağa (%1)"
 
 #. IDS_COPY_LEFT_TO_MIDDLE
-#: Merge.rc:4846
+#: Merge.rc:4845
 #, c-format
 msgid "Left to Middle (%1)"
 msgstr "Soldakini ortaya (%1)"
 
 #. IDS_MOVE_LEFT_TO
-#: Merge.rc:4857 Merge.rc:4889
+#: Merge.rc:4856 Merge.rc:4888
 #, c-format
 msgid "Left to... (%1)"
 msgstr "Soldakini... (%1)"
 
 #. IDS_MOVE_MIDDLE_TO
-#: Merge.rc:4858 Merge.rc:4890
+#: Merge.rc:4857 Merge.rc:4889
 #, c-format
 msgid "Middle to... (%1)"
 msgstr "Ortadakini... (%1)"
 
 #. IDS_MOVE_RIGHT_TO
-#: Merge.rc:4859 Merge.rc:4891
+#: Merge.rc:4858 Merge.rc:4890
 #, c-format
 msgid "Right to... (%1)"
 msgstr "Sağdakini... (%1)"
 
 #. IDS_COPY_BOTH_TO
-#: Merge.rc:4860
+#: Merge.rc:4859
 #, c-format
 msgid "Both to... (%1)"
 msgstr "İkisini de... (%1)"
 
 #. IDS_COPY_ALL_TO
-#: Merge.rc:4861
+#: Merge.rc:4860
 #, c-format
 msgid "All to... (%1)"
 msgstr "Tümünü... (%1)"
 
 #. IDS_COPY_DIFFERENCES_TO
-#: Merge.rc:4862
+#: Merge.rc:4861
 #, c-format
 msgid "Differences to... (%1)"
 msgstr "Farklı olanları... (%1)"
 
 #. IDS_ONLYDIFFITEMS_CONFIRM
-#: Merge.rc:4869
+#: Merge.rc:4868
 msgid ""
 "Some selected items are identical or skipped.\n"
 "Process only items with differences?"
@@ -6320,64 +6315,64 @@ msgstr ""
 "Yalnızca farklı olan ögeler işlensin mi?"
 
 #. IDS_DEL_LEFT_FMT
-#: Merge.rc:4875
+#: Merge.rc:4874
 #, c-format
 msgid "Left (%1)"
 msgstr "Soldakini (%1)"
 
 #. IDS_DEL_MIDDLE_FMT
-#: Merge.rc:4876
+#: Merge.rc:4875
 #, c-format
 msgid "Middle (%1)"
 msgstr "Ortadakini (%1)"
 
 #. IDS_DEL_RIGHT_FMT
-#: Merge.rc:4877
+#: Merge.rc:4876
 #, c-format
 msgid "Right (%1)"
 msgstr "Sağdakini (%1)"
 
 #. IDS_DEL_BOTH_FMT
-#: Merge.rc:4878
+#: Merge.rc:4877
 #, c-format
 msgid "Both (%1)"
 msgstr "İkisini de (%1)"
 
 #. IDS_DEL_ALL_FMT
-#: Merge.rc:4879
+#: Merge.rc:4878
 #, c-format
 msgid "All (%1)"
 msgstr "Tümünü (%1)"
 
 #. IDS_SELECT_DEST_LEFT
-#: Merge.rc:4895
+#: Merge.rc:4894
 msgid "Left Side - Select Destination Folder:"
 msgstr "Sol panonun hedef klasörünü seçin:"
 
 #. IDS_SELECT_DEST_MIDDLE
-#: Merge.rc:4896
+#: Merge.rc:4895
 msgid "Middle Side - Select Destination Folder:"
 msgstr "Orta panonun hedef klasörünü seçin:"
 
 #. IDS_SELECT_DEST_RIGHT
-#: Merge.rc:4897
+#: Merge.rc:4896
 msgid "Right Side - Select Destination Folder:"
 msgstr "Sağ panonun hedef klasörünü seçin:"
 
 #. IDS_FILES_AFFECTED_FMT
-#: Merge.rc:4898
+#: Merge.rc:4897
 #, c-format
 msgid "(%1 Files Affected)"
 msgstr "(%1 dosya etkilendi)"
 
 #. IDS_FILES_AFFECTED_FMT2
-#: Merge.rc:4899
+#: Merge.rc:4898
 #, c-format
 msgid "(%1 of %2 Files Affected)"
 msgstr "(%1 / %2 dosya etkilendi)"
 
 #. IDS_CONFIRM_DELETE_SINGLE
-#: Merge.rc:4905
+#: Merge.rc:4904
 #, c-format
 msgid ""
 "Are you sure you want to delete\n"
@@ -6389,18 +6384,18 @@ msgstr ""
 "%1 ?"
 
 #. IDS_CONFIRM_SINGLE_COPY
-#: Merge.rc:4906
+#: Merge.rc:4905
 msgid "Are you sure you want to copy?"
 msgstr "Kopyalamak istediğinize emin misiniz?"
 
 #. IDS_CONFIRM_MULTIPLE_COPY
-#: Merge.rc:4907
+#: Merge.rc:4906
 #, c-format
 msgid "Are you sure you want to copy %d items?"
 msgstr "%d ögeyi kopyalamak istediğinize emin misiniz?"
 
 #. IDS_DIRCMP_NOTSYNC
-#: Merge.rc:4908
+#: Merge.rc:4907
 #, c-format
 msgid ""
 "Operation aborted!\n"
@@ -6420,46 +6415,46 @@ msgstr ""
 "Lütfen karşılaştırmayı yenileyin."
 
 #. IDS_CONFIRM_SINGLE_MOVE
-#: Merge.rc:4913
+#: Merge.rc:4912
 msgid "Are you sure you want to move?"
 msgstr "Taşımak istediğinize emin misiniz?"
 
 #. IDS_CONFIRM_MULTIPLE_MOVE
-#: Merge.rc:4914
+#: Merge.rc:4913
 #, c-format
 msgid "Are you sure you want to move %d items?"
 msgstr "%d ögeyi taşımak istediğinize emin misiniz?"
 
 #. IDS_CONFIRM_MOVE_CAPTION
-#: Merge.rc:4916
+#: Merge.rc:4915
 msgid "Confirm Move"
 msgstr "Taşımayı onayla"
 
-#: Merge.rc:4918
+#: Merge.rc:4917
 msgid "Close the folder comparison window?"
 msgstr "Klasör karşılaştırma penceresini kapatmak üzeresiniz. Bunu yapmak istediğinize emin misiniz?"
 
-#: Merge.rc:4920
+#: Merge.rc:4919
 msgid "Close the folder comparison window, which took a long time?"
 msgstr "Önemli bir zaman harcanan klasör karşılaştırma penceresini kapatmak üzeresiniz. Bunu yapmak istediğinize emin misiniz?"
 
 #. IDS_ERROR_INVALID_DIR_FILE_NAME
-#: Merge.rc:4921
+#: Merge.rc:4920
 msgid "The file or folder name is invalid."
 msgstr "Dosya ya da klasör adı geçersiz."
 
 #. IDS_ERROR_EXECUTE_FILE
-#: Merge.rc:4927
+#: Merge.rc:4926
 #, c-format
 msgid "Failed to execute external editor: %1"
 msgstr "%1 dış düzenleyicisi çalıştırılamadı"
 
 #. IDS_UNKNOWN_ARCHIVE_FORMAT
-#: Merge.rc:4933
+#: Merge.rc:4932
 msgid "Unknown archive format"
 msgstr "Sıkıştırma biçimi bilinmiyor"
 
-#: Merge.rc:4935
+#: Merge.rc:4934
 msgid ""
 "Failed to extract archive.\n"
 "Compare as text file?"
@@ -6468,513 +6463,513 @@ msgstr ""
 "Arşiv dosyalarını metin dosyaları olarak karşılaştırmak ister misiniz?"
 
 #. IDS_COLHDR_FILENAME
-#: Merge.rc:4941
+#: Merge.rc:4940
 msgid "Filename"
 msgstr "Dosya adı"
 
 #. IDS_COLHDR_DIR
-#: Merge.rc:4942
+#: Merge.rc:4941
 msgctxt "DirView|ColumnHeader"
 msgid "Folder"
 msgstr "Klasör"
 
 #. IDS_COLHDR_RESULT
-#: Merge.rc:4943
+#: Merge.rc:4942
 msgid "Comparison Result"
 msgstr "Karşılaştırma sonucu"
 
 #. IDS_COLHDR_LTIMEM
-#: Merge.rc:4944
+#: Merge.rc:4943
 msgid "Left Date"
 msgstr "Sol dosya tarihi"
 
 #. IDS_COLHDR_RTIMEM
-#: Merge.rc:4945
+#: Merge.rc:4944
 msgid "Right Date"
 msgstr "Sağ dosya tarihi"
 
 #. IDS_COLHDR_MTIMEM
-#: Merge.rc:4946
+#: Merge.rc:4945
 msgid "Middle Date"
 msgstr "Orta dosya tarihi"
 
 #. IDS_COLHDR_LSIZE
-#: Merge.rc:4948
+#: Merge.rc:4947
 msgid "Left Size"
 msgstr "Sol dosya boyutu"
 
 #. IDS_COLHDR_RSIZE
-#: Merge.rc:4949
+#: Merge.rc:4948
 msgid "Right Size"
 msgstr "Sağ dosya boyutu"
 
 #. IDS_COLHDR_MSIZE
-#: Merge.rc:4954
+#: Merge.rc:4953
 msgid "Middle Size"
 msgstr "Orta dosya boyutu"
 
 #. IDS_COLHDR_RSIZE_SHORT
-#: Merge.rc:4955
+#: Merge.rc:4954
 msgid "Right Size (Short)"
 msgstr "Sağ dosya boyutu (kısa)"
 
 #. IDS_COLHDR_LSIZE_SHORT
-#: Merge.rc:4956
+#: Merge.rc:4955
 msgid "Left Size (Short)"
 msgstr "Sol dosya boyutu (kısa)"
 
 #. IDS_COLHDR_MSIZE_SHORT
-#: Merge.rc:4957
+#: Merge.rc:4956
 msgid "Middle Size (Short)"
 msgstr "Orta dosya boyutu (kısa)"
 
 #. IDS_COLHDR_LTIMEC
-#: Merge.rc:4963
+#: Merge.rc:4962
 msgid "Left Creation Time"
 msgstr "Sol dosya oluşturulma zamanı"
 
 #. IDS_COLHDR_RTIMEC
-#: Merge.rc:4964
+#: Merge.rc:4963
 msgid "Right Creation Time"
 msgstr "Sağ dosya oluşturulma zamanı"
 
 #. IDS_COLHDR_MTIMEC
-#: Merge.rc:4965
+#: Merge.rc:4964
 msgid "Middle Creation Time"
 msgstr "Orta dosya oluşturulma zamanı"
 
 #. IDS_COLHDR_NEWER
-#: Merge.rc:4966
+#: Merge.rc:4965
 msgid "Newer File"
 msgstr "Daha yeni dosya"
 
 #. IDS_COLHDR_LVERSION
-#: Merge.rc:4967
+#: Merge.rc:4966
 msgid "Left File Version"
 msgstr "Sol dosya sürümü"
 
 #. IDS_COLHDR_RVERSION
-#: Merge.rc:4968
+#: Merge.rc:4967
 msgid "Right File Version"
 msgstr "Sağ dosya sürümü"
 
 #. IDS_COLHDR_MVERSION
-#: Merge.rc:4969
+#: Merge.rc:4968
 msgid "Middle File Version"
 msgstr "Orta dosya sürümü"
 
 #. IDS_COLHDR_RESULT_ABBR
-#: Merge.rc:4970
+#: Merge.rc:4969
 msgid "Short Result"
 msgstr "Sonuç özeti"
 
 #. IDS_COLHDR_LATTRIBUTES
-#: Merge.rc:4971
+#: Merge.rc:4970
 msgid "Left Attributes"
 msgstr "Sol dosya öznitelikleri"
 
 #. IDS_COLHDR_RATTRIBUTES
-#: Merge.rc:4972
+#: Merge.rc:4971
 msgid "Right Attributes"
 msgstr "Sağ dosya önitelikleri"
 
 #. IDS_COLHDR_MATTRIBUTES
-#: Merge.rc:4973
+#: Merge.rc:4972
 msgid "Middle Attributes"
 msgstr "Orta dosya önitelikleri"
 
 #. IDS_COLHDR_LEOL_TYPE
-#: Merge.rc:4978
+#: Merge.rc:4977
 msgid "Left EOL"
 msgstr "Sol dosya satır sonu"
 
 #. IDS_COLHDR_MEOL_TYPE
-#: Merge.rc:4979
+#: Merge.rc:4978
 msgid "Middle EOL"
 msgstr "Orta dosya satır sonu"
 
 #. IDS_COLHDR_REOL_TYPE
-#: Merge.rc:4980
+#: Merge.rc:4979
 msgid "Right EOL"
 msgstr "Sağ dosya satır sonu"
 
 #. IDS_COLHDR_LENCODING
-#: Merge.rc:4986
+#: Merge.rc:4985
 msgid "Left Encoding"
 msgstr "Sol dosya kodlaması"
 
 #. IDS_COLHDR_RENCODING
-#: Merge.rc:4987
+#: Merge.rc:4986
 msgid "Right Encoding"
 msgstr "Sağ dosya kodlaması"
 
 #. IDS_COLHDR_MENCODING
-#: Merge.rc:4988
+#: Merge.rc:4987
 msgid "Middle Encoding"
 msgstr "Orta dosya kodlaması"
 
 #. IDS_COLHDR_NIDIFFS
-#: Merge.rc:4989
+#: Merge.rc:4988
 msgid "Ignored Diff"
 msgstr "Yok sayılan farklılıklar"
 
 #. IDS_COLHDR_BINARY
-#: Merge.rc:4991
+#: Merge.rc:4990
 msgctxt "DirView|ColumnHeader"
 msgid "Binary"
 msgstr "Binary"
 
 #. IDS_PLUGINS_TYPE_UNPACKER
-#: Merge.rc:4992 Merge.rc:5314
+#: Merge.rc:4991 Merge.rc:5313
 msgid "Unpacker"
 msgstr "Çıkarıcı"
 
 #. IDS_PLUGIN_TYPE4
-#: Merge.rc:4993 Merge.rc:5315 Merge.rc:5622
+#: Merge.rc:4992 Merge.rc:5314 Merge.rc:5621
 msgid "Prediffer"
 msgstr "Ön farklılaştırıcı"
 
 #. IDS_COLHDR_LEFT
-#: Merge.rc:4994
+#: Merge.rc:4993
 msgid "Left"
 msgstr "Sol"
 
 #. IDS_COLHDR_MIDDLE
-#: Merge.rc:4995
+#: Merge.rc:4994
 msgid "Middle"
 msgstr "Orta"
 
 #. IDS_COLHDR_RIGHT
-#: Merge.rc:4996
+#: Merge.rc:4995
 msgid "Right"
 msgstr "Sağ"
 
 #. IDS_COLHDR_DIFF
-#: Merge.rc:4997
+#: Merge.rc:4996
 msgid "Diff"
 msgstr "Fark"
 
 #. IDS_COLHDR_LEFT_DUPLICATE
-#: Merge.rc:4998
+#: Merge.rc:4997
 msgid "Left Duplicate Count"
 msgstr "Soldaki çift satır sayısı"
 
 #. IDS_COLHDR_RIGHT_DUPLICATE
-#: Merge.rc:4999
+#: Merge.rc:4998
 msgid "Right Duplicate Count"
 msgstr "Sağdaki çift satır sayısı"
 
 #. IDS_COLHDR_MIDDLE_DUPLICATE
-#: Merge.rc:5000
+#: Merge.rc:4999
 msgid "Middle Duplicate Count"
 msgstr "Ortadaki çift satır sayısı"
 
 #. IDS_COLHDR_MOVE
-#: Merge.rc:5001
+#: Merge.rc:5000
 msgid "Move"
 msgstr "Taşı"
 
 #. IDS_PRPCAT_AUDIO
-#: Merge.rc:5008
+#: Merge.rc:5007
 msgid "Audio"
 msgstr "Ses"
 
 #. IDS_PRPCAT_CALENDAR
-#: Merge.rc:5009
+#: Merge.rc:5008
 msgid "Calendar"
 msgstr "Takvim"
 
 #. IDS_PRPCAT_COMMUNICATION
-#: Merge.rc:5010
+#: Merge.rc:5009
 msgid "Communication"
 msgstr "İletişim"
 
 #. IDS_PRPCAT_CONTACT
-#: Merge.rc:5011
+#: Merge.rc:5010
 msgid "Contact"
 msgstr "İlgili"
 
 #. IDS_PRPCAT_DEVICES
-#: Merge.rc:5012
+#: Merge.rc:5011
 msgid "Devices"
 msgstr "Aygıtlar"
 
 #. IDS_PRPCAT_DOCUMENT
-#: Merge.rc:5013
+#: Merge.rc:5012
 msgid "Document"
 msgstr "Belge"
 
 #. IDS_PRPCAT_HOME
-#: Merge.rc:5014
+#: Merge.rc:5013
 msgid "Home"
 msgstr "Giriş"
 
 #. IDS_PRPCAT_JOURNAL
-#: Merge.rc:5016
+#: Merge.rc:5015
 msgid "Journal"
 msgstr "Günlük"
 
 #. IDS_PRPCAT_LINK
-#: Merge.rc:5017
+#: Merge.rc:5016
 msgid "Link"
 msgstr "Bağlantı"
 
 #. IDS_PRPCAT_MEDIA
-#: Merge.rc:5018
+#: Merge.rc:5017
 msgid "Media"
 msgstr "Ortam"
 
 #. IDS_PRPCAT_MUSIC
-#: Merge.rc:5020
+#: Merge.rc:5019
 msgid "Music"
 msgstr "Müzik"
 
 #. IDS_PRPCAT_NOTE
-#: Merge.rc:5021
+#: Merge.rc:5020
 msgid "Note"
 msgstr "Not"
 
 #. IDS_PRPCAT_PHOTO
-#: Merge.rc:5022
+#: Merge.rc:5021
 msgid "Photo"
 msgstr "Fotoğraf"
 
 #. IDS_PRPCAT_RECORDEDTV
-#: Merge.rc:5023
+#: Merge.rc:5022
 msgid "RecordedTV"
 msgstr "TV kaydı"
 
 #. IDS_PRPCAT_SEARCH
-#: Merge.rc:5024
+#: Merge.rc:5023
 msgid "Search"
 msgstr "Arama"
 
 #. IDS_PRPCAT_SECURITY
-#: Merge.rc:5025
+#: Merge.rc:5024
 msgid "Security"
 msgstr "Güvenlik"
 
 #. IDS_PRPCAT_SOFTWARE
-#: Merge.rc:5026
+#: Merge.rc:5025
 msgid "Software"
 msgstr "Yazılım"
 
 #. IDS_PRPCAT_TASK
-#: Merge.rc:5027
+#: Merge.rc:5026
 msgid "Task"
 msgstr "Görev"
 
 #. IDS_PRPCAT_VIDEO
-#: Merge.rc:5028
+#: Merge.rc:5027
 msgid "Video"
 msgstr "Görüntü"
 
 #. IDS_PRPCAT_HASH
-#: Merge.rc:5029
+#: Merge.rc:5028
 msgid "Hash"
 msgstr "Karma"
 
 #. IDS_CANT_COMPARE_FILES
-#: Merge.rc:5035
+#: Merge.rc:5034
 msgid "Unable to compare files"
 msgstr "Dosyalar karşılaştırılamıyor"
 
 #. IDS_ABORTED_ITEM
-#: Merge.rc:5036
+#: Merge.rc:5035
 msgid "Item aborted"
 msgstr "Ögeden vazgeçildi"
 
 #. IDS_FILE_SKIPPED
-#: Merge.rc:5037
+#: Merge.rc:5036
 msgid "File skipped"
 msgstr "Dosya atlandı"
 
 #. IDS_DIR_SKIPPED
-#: Merge.rc:5038
+#: Merge.rc:5037
 msgid "Folder skipped"
 msgstr "Klasör atlandı"
 
 #. IDS_LEFT_ONLY_IN_FMT
-#: Merge.rc:5039
+#: Merge.rc:5038
 #, c-format
 msgid "Left only: %1"
 msgstr "Yalnızca solda: %1"
 
 #. IDS_MIDDLE_ONLY_IN_FMT
-#: Merge.rc:5040
+#: Merge.rc:5039
 #, c-format
 msgid "Middle only: %1"
 msgstr "Yalnızca ortada: %1"
 
 #. IDS_RIGHT_ONLY_IN_FMT
-#: Merge.rc:5041
+#: Merge.rc:5040
 #, c-format
 msgid "Right only: %1"
 msgstr "Yalnızca sağda: %1"
 
 #. IDS_DOES_NOT_EXIST_IN_FMT
-#: Merge.rc:5042
+#: Merge.rc:5041
 #, c-format
 msgid "Does not exist in %1"
 msgstr "%1 içinde bulunamadı"
 
 #. IDS_BIN_FILES_SAME
-#: Merge.rc:5043
+#: Merge.rc:5042
 msgid "Binary files are identical"
 msgstr "Binary dosyaları aynı"
 
 #. IDS_BIN_FILES_DIFF
-#: Merge.rc:5049
+#: Merge.rc:5048
 msgid "Binary files are different"
 msgstr "Binary dosyaları farklı"
 
 #. IDS_FILES_ARE_DIFFERENT
-#: Merge.rc:5050
+#: Merge.rc:5049
 msgid "Files are different"
 msgstr "Dosyalar farklı"
 
 #. IDS_FOLDERS_ARE_DIFFERENT
-#: Merge.rc:5051
+#: Merge.rc:5050
 msgid "Folders are different"
 msgstr "Klasörler farklı"
 
 #. IDS_LEFTONLY
-#: Merge.rc:5052
+#: Merge.rc:5051
 msgid "Left Only"
 msgstr "Yalnızca soldaki"
 
 #. IDS_RIGHTONLY
-#: Merge.rc:5053
+#: Merge.rc:5052
 msgid "Right Only"
 msgstr "Yalnızca sağdaki"
 
 #. IDS_MIDDLEONLY
-#: Merge.rc:5054
+#: Merge.rc:5053
 msgid "Middle Only"
 msgstr "Yalnızca ortadaki"
 
 #. IDS_NOITEMLEFT
-#: Merge.rc:5055
+#: Merge.rc:5054
 msgid "No item in left"
 msgstr "Solda herhangi bir öge yok"
 
 #. IDS_NOITEMRIGHT
-#: Merge.rc:5056
+#: Merge.rc:5055
 msgid "No item in right"
 msgstr "Sağda herhangi bir öge yok"
 
 #. IDS_NOITEMMIDDLE
-#: Merge.rc:5057
+#: Merge.rc:5056
 msgid "No item in middle"
 msgstr "Ortada herhangi bir öge yok"
 
 #. IDS_CMPRES_ERROR
-#: Merge.rc:5059
+#: Merge.rc:5058
 msgid "Error"
 msgstr "Sorun"
 
 #. IDS_TEXT_FILES_SAME
-#: Merge.rc:5060
+#: Merge.rc:5059
 msgid "Text files are identical"
 msgstr "Metin dosyaları aynı"
 
 #. IDS_LEFTONLY_DIFF
-#: Merge.rc:5061
+#: Merge.rc:5060
 msgid " (Middle and right are identical)"
 msgstr " (Orta ve sağ dosya aynı)"
 
 #. IDS_MIDDLEONLY_DIFF
-#: Merge.rc:5062
+#: Merge.rc:5061
 msgid " (Left and right are identical)"
 msgstr " (Sol ve sağ dosya aynı)"
 
 #. IDS_RIGHTONLY_DIFF
-#: Merge.rc:5063
+#: Merge.rc:5062
 msgid " (Left and middle are identical)"
 msgstr " (Sol ve orta dosya aynı)"
 
 #. IDS_PATH_MISMATCH
-#: Merge.rc:5064
+#: Merge.rc:5063
 msgid " (paths differ)"
 msgstr " (yollar farklı)"
 
 #. IDS_TEXT_FILES_DIFF
-#: Merge.rc:5065
+#: Merge.rc:5064
 msgid "Text files are different"
 msgstr "Metin dosyaları farklı"
 
 #. IDS_IMAGE_FILES_SAME
-#: Merge.rc:5066
+#: Merge.rc:5065
 msgid "Image files are identical"
 msgstr "Görsel dosyaları aynı"
 
 #. IDS_IMAGE_FILES_DIFF
-#: Merge.rc:5067
+#: Merge.rc:5066
 msgid "Image files are different"
 msgstr "Görsel dosyaları farklı"
 
 #. IDS_EXPR_DIFF
-#: Merge.rc:5068
+#: Merge.rc:5067
 #, c-format
 msgid "Files are different (expr: %1)"
 msgstr "Dosyalar farklı (ifade: %1)"
 
 #. IDS_HASH_GROUP
-#: Merge.rc:5069
+#: Merge.rc:5068
 #, c-format
 msgid "Group%d"
 msgstr "Grup%d"
 
 #. IDS_RENAME_MOVE_DETECTION_DISALBED
-#: Merge.rc:5070
+#: Merge.rc:5069
 msgctxt "Options dialog|Compare|Folder|Detect renames and moves"
 msgid "Disabled"
 msgstr "Devre dışı"
 
 #. IDS_RENAME_MOVE_DETECTION_RENAME
-#: Merge.rc:5071
+#: Merge.rc:5070
 msgid "Detect renames"
 msgstr "Yeniden adlandırmaları algıla"
 
 #. IDS_RENAME_MOVE_DETECTION_RENAME_MOVE
-#: Merge.rc:5072
+#: Merge.rc:5071
 msgid "Detect renames and moves"
 msgstr "Yeniden adlandırmaları ve taşımaları algıla"
 
 #. IDS_RENAME_MOVE_MERGE_MODE_RENAME
-#: Merge.rc:5073
+#: Merge.rc:5072
 msgid "Merge renames"
 msgstr "Yeniden adlandırmaları birleştir"
 
 #. IDS_RENAME_MOVE_MERGE_MODE_RENAME_MOVE
-#: Merge.rc:5074
+#: Merge.rc:5073
 msgid "Merge renames and moves"
 msgstr "Yeniden adlandırma ve taşıma işlemlerini birleştir"
 
 #. IDS_RENAMED
-#: Merge.rc:5075
+#: Merge.rc:5074
 msgid "Renamed"
 msgstr "Yeniden adlandırıldı"
 
 #. IDS_RENAMED_MOVED
-#: Merge.rc:5077
+#: Merge.rc:5076
 msgid "Renamed/Moved"
 msgstr "Yeniden adlandırıldı/Taşındı"
 
 #. IDS_RENAMED_MOVED_ITEMS
-#: Merge.rc:5078
+#: Merge.rc:5077
 #, c-format
 msgid "(%1 items)"
 msgstr "(%1 öge)"
 
 #. IDS_RENAMED_MOVED_RESULT
-#: Merge.rc:5079
+#: Merge.rc:5078
 #, c-format
 msgid "%1 (set %2): "
 msgstr "%1 (%2 kümesi): "
 
 #. IDS_SWITCH_FLAT_MODE
-#: Merge.rc:5080
+#: Merge.rc:5079
 msgid ""
 "Some moved items have been merged.\n"
 "In Tree Mode, these items may appear in positions that do not reflect the actual folder structure, which can be confusing.\n"
@@ -6985,235 +6980,235 @@ msgstr ""
 "Düz Mod’a geçmek ister misiniz?"
 
 #. IDS_ELAPSED_TIME
-#: Merge.rc:5086
+#: Merge.rc:5085
 #, c-format
 msgid "Elapsed time: %ld ms"
 msgstr "Geçen süre: %ld ms"
 
 #. IDS_STATUS_SELITEM1
-#: Merge.rc:5087
+#: Merge.rc:5086
 msgid "1 item selected"
 msgstr "1 öge seçilmiş"
 
 #. IDS_STATUS_SELITEMS
-#: Merge.rc:5088
+#: Merge.rc:5087
 #, c-format
 msgid "%1 items selected"
 msgstr "%1 öge seçilmiş"
 
 #. IDS_COLDESC_FILENAME
-#: Merge.rc:5094
+#: Merge.rc:5093
 msgid "Filename or folder name."
 msgstr "Dosya ya da klasör adı."
 
 #. IDS_COLDESC_DIR
-#: Merge.rc:5095
+#: Merge.rc:5094
 msgid "Subfolder name when subfolders are included."
 msgstr "Alt klasörler katıldığında alt klasör adı."
 
 #. IDS_COLDESC_RESULT
-#: Merge.rc:5096
+#: Merge.rc:5095
 msgid "Comparison result, long form."
 msgstr "Karşılaştırma sonucu, uzun biçim."
 
 #. IDS_COLDESC_LTIMEM
-#: Merge.rc:5101
+#: Merge.rc:5100
 msgid "Left side modification date."
 msgstr "Soldaki dosyanın değiştirilme tarihi."
 
 #. IDS_COLDESC_RTIMEM
-#: Merge.rc:5102
+#: Merge.rc:5101
 msgid "Right side modification date."
 msgstr "Sağdaki dosyanın değiştirilme tarihi."
 
 #. IDS_COLDESC_MTIMEM
-#: Merge.rc:5103
+#: Merge.rc:5102
 msgid "Middle side modification date."
 msgstr "Ortadaki dosyanın değiştirilme tarihi."
 
 #. IDS_COLDESC_EXTENSION
-#: Merge.rc:5104
+#: Merge.rc:5103
 msgid "File's extension."
 msgstr "Dosya uzantısı."
 
 #. IDS_COLDESC_LSIZE
-#: Merge.rc:5105
+#: Merge.rc:5104
 msgid "Left file size in bytes."
 msgstr "Soldaki dosyanın bayt olarak boyutu."
 
 #. IDS_COLDESC_RSIZE
-#: Merge.rc:5106
+#: Merge.rc:5105
 msgid "Right file size in bytes."
 msgstr "Sağdaki dosyanın bayt olarak boyutu."
 
 #. IDS_COLDESC_MSIZE
-#: Merge.rc:5107
+#: Merge.rc:5106
 msgid "Middle file size in bytes."
 msgstr "Ortadaki dosyanın bayt olarak boyutu."
 
 #. IDS_COLDESC_LSIZE_SHORT
-#: Merge.rc:5108
+#: Merge.rc:5107
 msgid "Left file size abbreviated."
 msgstr "Soldaki dosyanın kısaltılmış boyutu."
 
 #. IDS_COLDESC_RSIZE_SHORT
-#: Merge.rc:5109
+#: Merge.rc:5108
 msgid "Right file size abbreviated."
 msgstr "Sağdaki dosyanın kısaltılmış boyutu."
 
 #. IDS_COLDESC_MSIZE_SHORT
-#: Merge.rc:5110
+#: Merge.rc:5109
 msgid "Middle file size abbreviated."
 msgstr "Ortadaki dosyanın kısaltılmış boyutu."
 
 #. IDS_COLDESC_LTIMEC
-#: Merge.rc:5116
+#: Merge.rc:5115
 msgid "Left side creation time."
 msgstr "Soldaki dosyanın oluşturulma zamanı."
 
 #. IDS_COLDESC_RTIMEC
-#: Merge.rc:5117
+#: Merge.rc:5116
 msgid "Right side creation time."
 msgstr "Sağdaki dosyanın oluşturulma zamanı."
 
 #. IDS_COLDESC_MTIMEC
-#: Merge.rc:5118
+#: Merge.rc:5117
 msgid "Middle side creation time."
 msgstr "Ortadaki dosyanın oluşturulma zamanı."
 
 #. IDS_COLDESC_NEWER
-#: Merge.rc:5119
+#: Merge.rc:5118
 msgid "Tells which side has newer modification date."
 msgstr "Hangi panonun en son değişiklik tarihine sahip olduğunu söyler."
 
 #. IDS_COLDESC_LVERSION
-#: Merge.rc:5120
+#: Merge.rc:5119
 msgid "Left side file version, only for some file types."
 msgstr "Soldaki dosyanın sürümü, yalnızca bazı dosya türleri için."
 
 #. IDS_COLDESC_RVERSION
-#: Merge.rc:5121
+#: Merge.rc:5120
 msgid "Right side file version, only for some file types."
 msgstr "Sağdaki dosyanın sürümü, yalnızca bazı dosya türleri için."
 
 #. IDS_COLDESC_MVERSION
-#: Merge.rc:5126
+#: Merge.rc:5125
 msgid "Middle side file version, only for some file types."
 msgstr "Ortadaki dosyanın sürümü, yalnızca bazı dosya türleri için."
 
 #. IDS_COLDESC_RESULT_ABBR
-#: Merge.rc:5127
+#: Merge.rc:5126
 msgid "Short comparison result."
 msgstr "Kısa karşılaştırma sonucu."
 
 #. IDS_COLDESC_LATTRIBUTES
-#: Merge.rc:5128
+#: Merge.rc:5127
 msgid "Left side attributes."
 msgstr "Soldaki dosyanın öznitelikleri."
 
 #. IDS_COLDESC_RATTRIBUTES
-#: Merge.rc:5129
+#: Merge.rc:5128
 msgid "Right side attributes."
 msgstr "Sağdaki dosyanın öznitelikleri."
 
 #. IDS_COLDESC_MATTRIBUTES
-#: Merge.rc:5130
+#: Merge.rc:5129
 msgid "Middle side attributes."
 msgstr "Ortadaki dosyanın öznitelikleri."
 
 #. IDS_COLDESC_LEOL_TYPE
-#: Merge.rc:5131
+#: Merge.rc:5130
 msgid "Left side file EOL type."
 msgstr "Soldaki dosyanın satır sonu türü."
 
 #. IDS_COLDESC_REOL_TYPE
-#: Merge.rc:5132
+#: Merge.rc:5131
 msgid "Right side file EOL type."
 msgstr "Sağdaki dosyanın satır sonu türü."
 
 #. IDS_COLDESC_MEOL_TYPE
-#: Merge.rc:5133
+#: Merge.rc:5132
 msgid "Middle side file EOL type."
 msgstr "Ortadaki dosyanın satır sonu türü."
 
 #. IDS_COLDESC_LENCODING
-#: Merge.rc:5139
+#: Merge.rc:5138
 msgid "Left side encoding."
 msgstr "Soldaki dosyanın kodlaması."
 
 #. IDS_COLDESC_RENCODING
-#: Merge.rc:5140
+#: Merge.rc:5139
 msgid "Right side encoding."
 msgstr "Sağdaki dosyanın kodlaması."
 
 #. IDS_COLDESC_MENCODING
-#: Merge.rc:5141
+#: Merge.rc:5140
 msgid "Middle side encoding."
 msgstr "Ortadaki dosyanın kodlaması."
 
 #. IDS_COLDESC_NIDIFFS
-#: Merge.rc:5142
+#: Merge.rc:5141
 msgid "Number of ignored differences in file. Ignored and cannot be merged."
 msgstr "Dosyada yok sayılan farkların sayısı. Bu farklar WinMerge tarafından yok sayılır ve birleştirilemez."
 
 #. IDS_COLDESC_NSDIFFS
-#: Merge.rc:5143
+#: Merge.rc:5142
 msgid "Number of differences in file (excluding ignored)."
 msgstr "Dosyadaki fark sayısı. Bu sayıya yok sayılan farklar katılmamıştır."
 
 #. IDS_COLDESC_BINARY
-#: Merge.rc:5144
+#: Merge.rc:5143
 msgid "Shows an asterisk (*) if the file is binary."
 msgstr "Dosya binary ise yıldız (*) ile görüntülensin."
 
 #. IDS_COLDESC_UNPACKER
-#: Merge.rc:5145
+#: Merge.rc:5144
 msgid "Unpacker plugin name or pipeline."
 msgstr "Çıkarıcı eklentisi adı ya da bağlantı yolu."
 
 #. IDS_COLDESC_PREDIFFER
-#: Merge.rc:5146
+#: Merge.rc:5145
 msgid "Prediffer plugin name or pipeline."
 msgstr "Ön farklılaştırıcı eklentisi adı ya da bağlantı yolu."
 
 #. IDS_DIRECTORY_REPORT_TITLE
-#: Merge.rc:5152
+#: Merge.rc:5151
 #, c-format
 msgid "Compare %1 with %2"
 msgstr "%1 ile %2 ögesini karşılaştır"
 
 #. IDS_DIRECTORY_REPORT_TITLE3
-#: Merge.rc:5153
+#: Merge.rc:5152
 #, c-format
 msgid "Compare %1 with %2 and %3"
 msgstr "%1 ile %2 ve %3 ögelerini karşılaştır"
 
 #. IDS_REPORT_COMMALIST
-#: Merge.rc:5154
+#: Merge.rc:5153
 msgid "Comma-separated list"
 msgstr "Virgül ile ayrılmış liste"
 
 #. IDS_REPORT_TABLIST
-#: Merge.rc:5155
+#: Merge.rc:5154
 msgid "Tab-separated list"
 msgstr "Sekme ile ayrılmış liste"
 
 #. IDS_REPORT_SIMPLEHTML
-#: Merge.rc:5156
+#: Merge.rc:5155
 msgid "Simple HTML"
 msgstr "Basit HTML"
 
 #. IDS_REPORT_SIMPLEXML
-#: Merge.rc:5157
+#: Merge.rc:5156
 msgid "Simple XML"
 msgstr "Basit XML"
 
-#: Merge.rc:5159
+#: Merge.rc:5158
 msgid "Report file already exists. Overwrite?"
 msgstr "Rapor dosyası zaten var. Üzerine yazılmasını ister misiniz?"
 
 #. IDS_REPORT_ERROR
-#: Merge.rc:5164
+#: Merge.rc:5163
 #, c-format
 msgid ""
 "Error creating the report:\n"
@@ -7223,27 +7218,27 @@ msgstr ""
 "%1"
 
 #. IDS_REPORT_SUCCESS
-#: Merge.rc:5165
+#: Merge.rc:5164
 msgid "Report created successfully."
 msgstr "Rapor hazırlandı."
 
 #. IDS_SYNCPOINT_LASTBLOCK
-#: Merge.rc:5171
+#: Merge.rc:5170
 msgid "Cannot add a synchronization point at this line."
 msgstr "Bu satıra bir eşitleme noktası eklenemedi."
 
 #. IDS_FILE_TO_ITSELF
-#: Merge.rc:5177
+#: Merge.rc:5176
 msgid "Same file is opened in both panes."
 msgstr "İki panoda da de aynı dosya açıldı."
 
 #. IDS_FILESSAME
-#: Merge.rc:5178
+#: Merge.rc:5177
 msgid "Selected files are identical."
 msgstr "Seçilmiş dosyalar aynı."
 
 #. IDS_FILESSAME_CURCFG
-#: Merge.rc:5179
+#: Merge.rc:5178
 msgid ""
 "Selected files are identical (with current settings).\r\n"
 "Checking binary identity..."
@@ -7252,7 +7247,7 @@ msgstr ""
 "İkili (binary) özdeşlik kontrol ediliyor…"
 
 #. IDS_FILESSAME_BINERROR
-#: Merge.rc:5180
+#: Merge.rc:5179
 msgid ""
 "Selected files are identical (with current settings).\r\n"
 "But binary comparison failed."
@@ -7261,12 +7256,12 @@ msgstr ""
 "Ancak ikili (binary) karşılaştırma başarısız oldu."
 
 #. IDS_FILESSAME_BINSAME
-#: Merge.rc:5181
+#: Merge.rc:5180
 msgid "Selected files are identical (binary match)."
 msgstr "Seçilen dosyalar özdeş (binary eşleşme)."
 
 #. IDS_FILESSAME_BINDIFF
-#: Merge.rc:5182
+#: Merge.rc:5181
 msgid ""
 "Selected files are identical (with current settings).\r\n"
 "But differ at the binary level."
@@ -7275,17 +7270,17 @@ msgstr ""
 "Ancak ikili (binary) düzeyde farklılar."
 
 #. IDS_FILEERROR
-#: Merge.rc:5183
+#: Merge.rc:5182
 msgid "An error occurred while comparing files."
 msgstr "Dosyalar karşılaştırılırken bir sorun çıktı."
 
 #. IDS_TEMP_FILEERROR
-#: Merge.rc:5184
+#: Merge.rc:5183
 msgid "Could not create temporary files. Check your temporary path settings."
 msgstr "Geçici klasör oluşturulamadı. Geçici klasör yolu ayarlarınızı denetleyin."
 
 #. IDS_SUGGEST_IGNOREEOL
-#: Merge.rc:5185
+#: Merge.rc:5184
 msgid ""
 "Files use different EOL.\n"
 "\n"
@@ -7301,17 +7296,17 @@ msgstr ""
 "Unix/Mac)' seçeneğini işaretleyin."
 
 #. IDS_INVALID_DIRECTORY
-#: Merge.rc:5186
+#: Merge.rc:5185
 msgid "Selected folder is invalid."
 msgstr "Seçilmiş klasör geçersiz."
 
 #. IDS_CANNOT_OPEN_BINARYFILE
-#: Merge.rc:5187
+#: Merge.rc:5186
 msgid "Cannot open a binary file in Editor."
 msgstr "Bir binary dosyası düzenleyicide açılamaz."
 
 #. IDS_CREATE_PAIR_FOLDER
-#: Merge.rc:5188
+#: Merge.rc:5187
 #, c-format
 msgid ""
 "Create matching folder:\n"
@@ -7325,41 +7320,41 @@ msgstr ""
 "ve bu klasörleri açmak istiyor musunuz?"
 
 #. IDS_CONFIRM_COPY_ALL_DIFFS
-#: Merge.rc:5189
+#: Merge.rc:5188
 msgid "Copy all differences to other file?"
 msgstr "Tüm farkları diğer dosyaya kopyalamak istediğinize emin misiniz?"
 
 #. IDS_MOVE_TO_NEXTFILE
-#: Merge.rc:5194
+#: Merge.rc:5193
 msgid "Move to next file?"
 msgstr "Sonraki dosyaya geçmek ister misiniz?"
 
 #. IDS_MOVE_TO_PREVFILE
-#: Merge.rc:5195
+#: Merge.rc:5194
 msgid "Move to previous file?"
 msgstr "Önceki dosyaya geçmek ister misiniz?"
 
 #. IDS_MOVE_TO_NEXTPAGE
-#: Merge.rc:5196
+#: Merge.rc:5195
 msgid "Move to next page?"
 msgstr "Sonraki sayfaya geçmek ister misiniz?"
 
 #. IDS_MOVE_TO_PREVPAGE
-#: Merge.rc:5197
+#: Merge.rc:5196
 msgid "Move to previous page?"
 msgstr "Önceki sayfaya geçmek ister misiniz?"
 
 #. IDS_MOVE_TO_FIRSTFILE
-#: Merge.rc:5198
+#: Merge.rc:5197
 msgid "Move to first file?"
 msgstr "İlk dosyaya geçmek ister misiniz?"
 
 #. IDS_MOVE_TO_LASTFILE
-#: Merge.rc:5199
+#: Merge.rc:5198
 msgid "Move to last file?"
 msgstr "Son dosyaya geçmek ister misiniz?"
 
-#: Merge.rc:5206
+#: Merge.rc:5205
 #, c-format
 msgid ""
 "Different codepages: left (cp%d), right (cp%d).\n"
@@ -7370,51 +7365,51 @@ msgstr ""
 "Dosyalar kendi kod sayfalarında daha iyi bir görüntülenir ancak birleştirme/kopyalama işlemleri tehlikeli olur.\n"
 "Dosyaların varsayılan Windows kod sayfasını kullanıyormuş gibi işlenmesini ister misiniz (önerilir)?"
 
-#: Merge.rc:5208
+#: Merge.rc:5207
 msgid "Information lost due to encoding errors: both files"
 msgstr "Kodlama sorunları yüzünden iki dosyada da bilgi kaybı oldu"
 
-#: Merge.rc:5210
+#: Merge.rc:5209
 msgid "Information lost due to encoding errors: first file"
 msgstr "Kodlama sorunları yüzünden ilk dosyada bilgi kaybı oldu"
 
-#: Merge.rc:5212
+#: Merge.rc:5211
 msgid "Information lost due to encoding errors: second file"
 msgstr "Kodlama sorunları yüzünden ikinci dosyada bilgi kaybı oldu"
 
-#: Merge.rc:5214
+#: Merge.rc:5213
 msgid "Information lost due to encoding errors: third file"
 msgstr "Kodlama sorunları yüzünden üçüncü dosyada bilgi kaybı oldu"
 
 #. IDS_LINEDIFF_NODIFF
-#: Merge.rc:5220
+#: Merge.rc:5219
 msgid "No difference"
 msgstr "Fark yok"
 
 #. IDS_LINEDIFF_NODIFF_CAPTION
-#: Merge.rc:5221
+#: Merge.rc:5220
 msgid "Line difference"
 msgstr "Satır farkı"
 
 #. IDS_NUM_REPLACED
-#: Merge.rc:5227
+#: Merge.rc:5226
 #, c-format
 msgid "Replaced %1 string(s)."
 msgstr "%1 dizge değiştirildi."
 
 #. IDS_EDIT_TEXT_NOT_FOUND
-#: Merge.rc:5228
+#: Merge.rc:5227
 #, c-format
 msgid "Cannot find string \"%s\"."
 msgstr "Aranan \"%s\" ifadesi bulunamadı."
 
 #. IDS_MERGE_MODE
-#: Merge.rc:5234
+#: Merge.rc:5233
 msgid "Entering Merge Mode. Press F9 to turn off."
 msgstr "Birleştirme kipine geçiyorsunuz. Birleştirme kipinden çıkmak için F9 tuşuna basın."
 
 #. IDS_AUTO_MERGE
-#: Merge.rc:5240
+#: Merge.rc:5239
 #, c-format
 msgid ""
 "Automatic merges: %1\n"
@@ -7424,89 +7419,89 @@ msgstr ""
 "Çözümlenmemiş çelişki sayısı: %2"
 
 #. IDS_CODEPAGE_MERGED
-#: Merge.rc:5241
+#: Merge.rc:5240
 msgid "Codepage change merged."
 msgstr "Kod sayfası değişikliği birleştirildi."
 
 #. IDS_CODEPAGE_CONFLICT
-#: Merge.rc:5242
+#: Merge.rc:5241
 msgid "Codepage changes are conflicting."
 msgstr "Kod sayfası değişiklikleri çelişiyor."
 
 #. IDS_EOL_MERGED
-#: Merge.rc:5243
+#: Merge.rc:5242
 msgid "EOL change merged."
 msgstr "Satır sonu değişikliği birleştirildi."
 
 #. IDS_EOL_CONFLICT
-#: Merge.rc:5244
+#: Merge.rc:5243
 msgid "EOL changes are conflicting."
 msgstr "Satır sonu değişiklikleri çelişiyor."
 
 #. IDS_LOCBAR_CAPTION
-#: Merge.rc:5250
+#: Merge.rc:5249
 msgid "Location Pane"
 msgstr "Konum panosu"
 
 #. IDS_DIFFBAR_CAPTION
-#: Merge.rc:5251
+#: Merge.rc:5250
 msgid "Diff Pane"
 msgstr "Fark panosu"
 
 #. IDS_DIFF_SUCCEEDED
-#: Merge.rc:5258
+#: Merge.rc:5257
 msgid "Patch file written."
 msgstr "Yama dosyası kaydedildi."
 
 #. IDS_DIFF_FILEOVERWRITE
-#: Merge.rc:5259
+#: Merge.rc:5258
 msgid "Patch file already exists. Overwrite?"
 msgstr "Yama dosyası zaten var. Üzerine yazılmasını ister misiniz?"
 
 #. IDS_DIFF_SELECTEDFILES
-#: Merge.rc:5260
+#: Merge.rc:5259
 #, c-format
 msgid "[%1 files selected]"
 msgstr "[%1 dosya seçildi]"
 
 #. IDS_DIFF_NORMAL
-#: Merge.rc:5261
+#: Merge.rc:5260
 msgid "Normal"
 msgstr "Normal"
 
 #. IDS_DIFF_CONTEXT
-#: Merge.rc:5262
+#: Merge.rc:5261
 msgid "Context"
 msgstr "Bağlam"
 
 #. IDS_DIFF_UNIFIED
-#: Merge.rc:5263
+#: Merge.rc:5262
 msgid "Unified"
 msgstr "Birleşik"
 
 #. IDS_FILEWRITE_ERROR
-#: Merge.rc:5265
+#: Merge.rc:5264
 #, c-format
 msgid "Could not write to file %1."
 msgstr "%1 dosyasına yazılamadı."
 
 #. IDS_PATH_NOT_ABSOLUTE
-#: Merge.rc:5266
+#: Merge.rc:5265
 #, c-format
 msgid "Output path is not absolute: %1"
 msgstr "Belirtilen çıktı klasörü mutlak bir yol değil: %1"
 
 #. IDS_MUST_SPECIFY_OUTPUT
-#: Merge.rc:5267
+#: Merge.rc:5266
 msgid "Specify an output file."
 msgstr "Bir çıktı dosyası belirtin."
 
-#: Merge.rc:5269
+#: Merge.rc:5268
 msgid "Cannot create patch from binary files."
 msgstr "Binary dosyalarından, yama dosyası hazırlanamaz."
 
 #. IDS_SAVEFILES_FORPATCH
-#: Merge.rc:5270
+#: Merge.rc:5269
 msgid ""
 "Save all files first.\n"
 "\n"
@@ -7517,17 +7512,17 @@ msgstr ""
 "Bir yama hazırlamak için dosyalardaki değişikliklerin kaydedilmiş olması gerekir."
 
 #. IDS_FOLDER_NOTEXIST
-#: Merge.rc:5271
+#: Merge.rc:5270
 msgid "Folder does not exist."
 msgstr "Klasör bulunamadı."
 
 #. IDS_ARCHIVE_SUCCEEDED
-#: Merge.rc:5277
+#: Merge.rc:5276
 msgid "Archive file written."
 msgstr "Arşiv dosyası yazıldı."
 
 #. IDS_ARCHIVE_SAVEFILES
-#: Merge.rc:5278
+#: Merge.rc:5277
 msgid ""
 "Save all files first.\n"
 "\n"
@@ -7538,7 +7533,7 @@ msgstr ""
 "Arşiv oluşturmak için kaydedilmemiş değişiklik bulunmamalıdır."
 
 #. IDS_NO_ZIP_SUPPORT
-#: Merge.rc:5283
+#: Merge.rc:5282
 msgid ""
 "Archive support not enabled.\n"
 "7-Zip and/or Merge7z*.dll not found.\n"
@@ -7549,37 +7544,37 @@ msgstr ""
 "Sıkıştırılmış dosya desteği ve nasıl etkinleştirileceği ile ilgili ayrıntılı bilgi almak için kullanım kitabına bakabilirsiniz."
 
 #. IDS_OPT_EXPORT_CAPTION
-#: Merge.rc:5284
+#: Merge.rc:5283
 msgid "Select file for export"
 msgstr "Dışa aktarılacak dosyayı seçin"
 
 #. IDS_OPT_IMPORT_CAPTION
-#: Merge.rc:5285
+#: Merge.rc:5284
 msgid "Select file for import"
 msgstr "İçe aktarılacak dosyayı seçin"
 
 #. IDS_OPT_IMPORT_DONE
-#: Merge.rc:5286
+#: Merge.rc:5285
 msgid "Options imported from file."
 msgstr "Ayarlar dosyadan içe aktarıldı."
 
 #. IDS_OPT_EXPORT_DONE
-#: Merge.rc:5287
+#: Merge.rc:5286
 msgid "Options exported to file."
 msgstr "Ayarlar dosyaya dışa aktarıldı."
 
 #. IDS_OPT_IMPORT_ERR
-#: Merge.rc:5288
+#: Merge.rc:5287
 msgid "Failed to import options from file."
 msgstr "Ayarlar dosyadan içe aktarılamadı."
 
 #. IDS_OPT_EXPORT_ERR
-#: Merge.rc:5289
+#: Merge.rc:5288
 msgid "Failed to write options to file."
 msgstr "Ayarlar dosyaya dışa aktarılamadı."
 
 #. IDS_CLOSEALL_WINDOWS
-#: Merge.rc:5290
+#: Merge.rc:5289
 msgid ""
 "Close multiple compare windows?\n"
 "\n"
@@ -7590,34 +7585,34 @@ msgstr ""
 "Devam etmek istiyor musunuz?"
 
 #. IDS_EOL_BIN
-#: Merge.rc:5300
+#: Merge.rc:5299
 msgctxt "EOL Type"
 msgid "Binary"
 msgstr "Binary"
 
 #. IDS_MARKER_COLOR_FMT
-#: Merge.rc:5305
+#: Merge.rc:5304
 #, c-format
 msgid "Marker Color %d"
 msgstr "İşaretleyici rengi %d"
 
 #. IDS_MARKER_NEW_PATTERN
-#: Merge.rc:5306
+#: Merge.rc:5305
 msgid "New Pattern"
 msgstr "Yeni model"
 
 #. IDS_PLUGINSLIST_TYPE
-#: Merge.rc:5312
+#: Merge.rc:5311
 msgid "Type"
 msgstr "Tür"
 
 #. IDS_PLUGINS_TYPE_EDITSCRIPT
-#: Merge.rc:5316
+#: Merge.rc:5315
 msgid "Editor script"
 msgstr "Düzenleyici betiği"
 
 #. ID_SELECTLINEDIFF
-#: Merge.rc:5322
+#: Merge.rc:5321
 msgid ""
 "\n"
 "Difference in Current Line (F4)"
@@ -7626,7 +7621,7 @@ msgstr ""
 "Geçerli satırdaki fark (F4)"
 
 #. ID_OPTIONS
-#: Merge.rc:5323
+#: Merge.rc:5322
 msgid ""
 "\n"
 "Options"
@@ -7635,7 +7630,7 @@ msgstr ""
 "Ayarlar"
 
 #. ID_REFRESH
-#: Merge.rc:5324
+#: Merge.rc:5323
 msgid ""
 "\n"
 "Refresh (F5)"
@@ -7644,7 +7639,7 @@ msgstr ""
 "Yenile (F5)"
 
 #. ID_PREVDIFF
-#: Merge.rc:5330
+#: Merge.rc:5329
 msgid ""
 "\n"
 "Previous Difference (Alt+Up)"
@@ -7653,7 +7648,7 @@ msgstr ""
 "Önceki fark (Alt+Yukarı)"
 
 #. ID_NEXTDIFF
-#: Merge.rc:5331
+#: Merge.rc:5330
 msgid ""
 "\n"
 "Next Difference (Alt+Down)"
@@ -7662,7 +7657,7 @@ msgstr ""
 "Sonraki fark (Alt+Aşağı)"
 
 #. ID_PREVCONFLICT
-#: Merge.rc:5332
+#: Merge.rc:5331
 msgid ""
 "\n"
 "Previous Conflict (Alt+Shift+Up)"
@@ -7671,7 +7666,7 @@ msgstr ""
 "Önceki çelişki (Alt+Shift+Yukarı)"
 
 #. ID_NEXTCONFLICT
-#: Merge.rc:5333
+#: Merge.rc:5332
 msgid ""
 "\n"
 "Next Conflict (Alt+Shift+Down)"
@@ -7680,7 +7675,7 @@ msgstr ""
 "Sonraki çelişki (Alt+Shift+Aşağı)"
 
 #. ID_FIRSTDIFF
-#: Merge.rc:5338
+#: Merge.rc:5337
 msgid ""
 "\n"
 "First Difference (Alt+Home)"
@@ -7689,7 +7684,7 @@ msgstr ""
 "İlk fark (Alt+Home)"
 
 #. ID_CURDIFF
-#: Merge.rc:5339
+#: Merge.rc:5338
 msgid ""
 "\n"
 "Current Difference (Alt+Enter)"
@@ -7698,7 +7693,7 @@ msgstr ""
 "İmleçteki fark (Alt+Enter)"
 
 #. ID_LASTDIFF
-#: Merge.rc:5340
+#: Merge.rc:5339
 msgid ""
 "\n"
 "Last Difference (Alt+End)"
@@ -7707,7 +7702,7 @@ msgstr ""
 "Son fark (Alt+End)"
 
 #. ID_L2R
-#: Merge.rc:5341
+#: Merge.rc:5340
 msgid ""
 "\n"
 "Copy to Right (Alt+Right)"
@@ -7716,7 +7711,7 @@ msgstr ""
 "Sağa kopyala (Alt+Sağa)"
 
 #. ID_R2L
-#: Merge.rc:5342
+#: Merge.rc:5341
 msgid ""
 "\n"
 "Copy to Left (Alt+Left)"
@@ -7725,7 +7720,7 @@ msgstr ""
 "Sola kopyala (Alt+Sola)"
 
 #. ID_L2RNEXT
-#: Merge.rc:5343
+#: Merge.rc:5342
 msgid ""
 "\n"
 "Copy to Right and Advance (Ctrl+Alt+Right)"
@@ -7734,7 +7729,7 @@ msgstr ""
 "Sağa kopyala ve ilerle (Ctrl+Alt+Sağa)"
 
 #. ID_R2LNEXT
-#: Merge.rc:5344
+#: Merge.rc:5343
 msgid ""
 "\n"
 "Copy to Left and Advance (Ctrl+Alt+Left)"
@@ -7743,7 +7738,7 @@ msgstr ""
 "Sola kopyala ve ilerle (Ctrl+Alt+Sola)"
 
 #. ID_ALL_RIGHT
-#: Merge.rc:5345
+#: Merge.rc:5344
 msgid ""
 "\n"
 "Copy All to Right"
@@ -7752,7 +7747,7 @@ msgstr ""
 "Tü&münü sağa kopyala"
 
 #. ID_ALL_LEFT
-#: Merge.rc:5346
+#: Merge.rc:5345
 msgid ""
 "\n"
 "Copy All to Left"
@@ -7761,7 +7756,7 @@ msgstr ""
 "&Tümünü sola kopyala"
 
 #. ID_AUTO_MERGE
-#: Merge.rc:5347
+#: Merge.rc:5346
 msgid ""
 "\n"
 "Auto Merge (Ctrl+Alt+M)"
@@ -7770,7 +7765,7 @@ msgstr ""
 "Otomatik karşılaştır (Ctrl+Alt+M)"
 
 #. ID_FIRSTFILE
-#: Merge.rc:5348
+#: Merge.rc:5347
 msgid ""
 "\n"
 "First File"
@@ -7779,7 +7774,7 @@ msgstr ""
 "İlk dosya"
 
 #. ID_NEXTFILE
-#: Merge.rc:5349
+#: Merge.rc:5348
 msgid ""
 "\n"
 "Next File (Ctrl+F8)"
@@ -7788,7 +7783,7 @@ msgstr ""
 "Sonraki dosya (Ctrl+F8)"
 
 #. ID_LASTFILE
-#: Merge.rc:5350
+#: Merge.rc:5349
 msgid ""
 "\n"
 "Last File"
@@ -7797,7 +7792,7 @@ msgstr ""
 "Son dosya"
 
 #. ID_PREVFILE
-#: Merge.rc:5351
+#: Merge.rc:5350
 msgid ""
 "\n"
 "Previous File (Ctrl+F7)"
@@ -7806,142 +7801,142 @@ msgstr ""
 "Önceki dosya (Ctrl+F7)"
 
 #. IDS_UNPACK_AUTO
-#: Merge.rc:5358
+#: Merge.rc:5357
 msgid "Adapted unpacker applied to both files (one needs extension)."
 msgstr "Uyarlanan çıkarıcı iki dosyaya da uygulandı (yalnızca bir dosya bu eklentiye gerek duyuyor)."
 
 #. IDS_NO_PREDIFFER
-#: Merge.rc:5359
+#: Merge.rc:5358
 msgid "No Prediffer (Normal)"
 msgstr "Ön farklılaştırıcı yok (normal)"
 
 #. IDS_SUGGESTED_PLUGINS
-#: Merge.rc:5360
+#: Merge.rc:5359
 msgid "Suggested Plugins"
 msgstr "Önerilen eklentiler"
 
 #. IDS_NOT_SUGGESTED_PLUGINS
-#: Merge.rc:5361
+#: Merge.rc:5360
 msgid "All Plugins"
 msgstr "Tüm eklentiler"
 
 #. IDS_PRIVATEBUILD_FMT
-#: Merge.rc:5367
+#: Merge.rc:5366
 #, c-format
 msgid "Private Build: %1"
 msgstr "Özel yapım: %1"
 
 #. IDS_ALLRIGHTS_RESERVED
-#: Merge.rc:5368
+#: Merge.rc:5367
 msgid " - All rights reserved."
 msgstr " - Her hakkı saklıdır."
 
 #. IDS_TITLE_PLUGINS_SETTINGS
-#: Merge.rc:5374
+#: Merge.rc:5373
 msgid "Plugin Settings"
 msgstr "Eklenti ayarları"
 
 #. IDS_NO_SCT_SCRIPTS
-#: Merge.rc:5376
+#: Merge.rc:5375
 msgid "WSH not found - .sct scripts disabled"
 msgstr "Windows Script Host bulunamadı - .sct betikleri etkisizleştirildi"
 
 #. IDS_LOCBAR_GOTOLINE_FMT
-#: Merge.rc:5384
+#: Merge.rc:5383
 #, c-format
 msgid "G&o to Line %1"
 msgstr "%1. &satıra git"
 
 #. IDS_GOTO_MOVED_LINE
-#: Merge.rc:5390
+#: Merge.rc:5389
 msgid "Go to Moved Line\tCtrl+Shift+G"
 msgstr "Taşınmış satıra git\tCtrl+Shift+G"
 
 #. IDS_AUTOCOMPLETE_DISABLED
-#: Merge.rc:5396
+#: Merge.rc:5395
 msgctxt "Options dialog|General|Open dialog Auto completion"
 msgid "Disabled"
 msgstr "Engelli"
 
 #. IDS_AUTOCOMPLETE_FILE_SYS
-#: Merge.rc:5397
+#: Merge.rc:5396
 msgid "From file system"
 msgstr "Dosya sisteminden"
 
 #. IDS_AUTOCOMPLETE_MRU
-#: Merge.rc:5398
+#: Merge.rc:5397
 msgid "From Most Recently Used list"
 msgstr "Sık kullanılanlar listesinden"
 
 #. IDS_COLORSCHEME_PLAIN
-#: Merge.rc:5404
+#: Merge.rc:5403
 msgid "No Highlighting"
 msgstr "Vurgulama yok"
 
 #. IDS_COLORSCHEME_PO
-#: Merge.rc:5439
+#: Merge.rc:5438
 msgid "Portable Object"
 msgstr "Taşınabilir nesne"
 
 #. IDS_COLORSCHEME_RSRC
-#: Merge.rc:5444
+#: Merge.rc:5443
 msgid "Resources"
 msgstr "Kaynaklar"
 
 #. IDS_COLORSCHEME_SH
-#: Merge.rc:5448
+#: Merge.rc:5447
 msgid "Shell"
 msgstr "Kabuk"
 
 #. IDS_CLOSE_LEFT_TABS
-#: Merge.rc:5469
+#: Merge.rc:5468
 msgid "Close &Left Tabs"
 msgstr "So&ldaki sekmeleri kapat"
 
 #. IDS_CLOSE_RIGHT_TABS
-#: Merge.rc:5470
+#: Merge.rc:5469
 msgid "Close R&ight Tabs"
 msgstr "&Sağdaki sekmeleri kapat"
 
 #. IDS_CLOSE_OTHER_TABS
-#: Merge.rc:5471
+#: Merge.rc:5470
 msgid "Close &Other Tabs"
 msgstr "&Diğer sekmeleri kapat"
 
 #. IDS_TABBAR_AUTO_MAXWIDTH
-#: Merge.rc:5472
+#: Merge.rc:5471
 msgid "Enable &Auto Max Width"
 msgstr "Otom&atik en fazla genişlik"
 
 #. IDS_WEBPAGE_MENU
-#: Merge.rc:5482
+#: Merge.rc:5481
 msgid "We&bpage"
 msgstr "İnternet &sayfası"
 
 #. IDS_VIEW_WRAP_TEXT
-#: Merge.rc:5487
+#: Merge.rc:5486
 msgid "W&rap Text"
 msgstr "&Metin kaydırılsın"
 
 #. IDS_NOTINSTALLED
-#: Merge.rc:5492
+#: Merge.rc:5491
 #, c-format
 msgid "%1 is not installed."
 msgstr "%1 kurulmamış."
 
 #. IDS_CREATE_FOLDER
-#: Merge.rc:5497
+#: Merge.rc:5496
 #, c-format
 msgid "%1 does not exist. Create it?"
 msgstr "%1 bulunamadı. Oluşturmak ister misiniz?"
 
 #. IDS_CREATE_FOLDER_ERROR
-#: Merge.rc:5498
+#: Merge.rc:5497
 msgid "Failed to create folder."
 msgstr "Klasör oluşturulamadı."
 
 #. IDC_EXT_EDITOR_PATH
-#: Merge.rc:5503
+#: Merge.rc:5502
 msgid ""
 "Parameters:\n"
 "$file: Current file path\n"
@@ -7952,491 +7947,491 @@ msgstr ""
 "$linenum: Geçerli imleç konumunun satır numarası"
 
 #. IDS_DIFF_ALGORITHM_DEFAULT
-#: Merge.rc:5508
+#: Merge.rc:5507
 msgid "default"
 msgstr "varsayılan"
 
 #. IDS_DIFF_ALGORITHM_MINIMAL
-#: Merge.rc:5509
+#: Merge.rc:5508
 msgid "minimal"
 msgstr "en az"
 
 #. IDS_DIFF_ALGORITHM_PATIENCE
-#: Merge.rc:5510
+#: Merge.rc:5509
 msgid "patience"
 msgstr "tahammül"
 
 #. IDS_DIFF_ALGORITHM_HISTOGRAM
-#: Merge.rc:5511
+#: Merge.rc:5510
 msgid "histogram"
 msgstr "çubuk grafik"
 
 #. IDS_DIFF_ALGORITHM_NONE
-#: Merge.rc:5512
+#: Merge.rc:5511
 msgid "none"
 msgstr "yok"
 
 #. IDS_RENDERING_MODE_GDI
-#: Merge.rc:5517
+#: Merge.rc:5516
 msgid "GDI"
 msgstr "GDI"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_DEFAULT
-#: Merge.rc:5518
+#: Merge.rc:5517
 msgid "DirectWrite Default"
 msgstr "DirectWrite varsayılan"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_ALIASED
-#: Merge.rc:5519
+#: Merge.rc:5518
 msgid "DirectWrite Aliased"
 msgstr "DirectWrite kısaltılmış"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_GDI_CLASSIC
-#: Merge.rc:5520
+#: Merge.rc:5519
 msgid "DirectWrite GDI Classic"
 msgstr "DirectWrite GFI klasik"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_GDI_NATURAL
-#: Merge.rc:5521
+#: Merge.rc:5520
 msgid "DirectWrite GDI Natural"
 msgstr "DirectWrite GDI doğal"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_NATURAL
-#: Merge.rc:5522
+#: Merge.rc:5521
 msgid "DirectWrite Natural"
 msgstr "DirectWrite doğal"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_NATURAL_SYMMETRIC
-#: Merge.rc:5523
+#: Merge.rc:5522
 msgid "DirectWrite Natural Symmetric"
 msgstr "DirectWrite doğal simetrik"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_DISABLED
-#: Merge.rc:5528
+#: Merge.rc:5527
 msgctxt "Options dialog|General|Close windows with Esc"
 msgid "Disabled"
 msgstr "Engelli"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_1
-#: Merge.rc:5529
+#: Merge.rc:5528
 msgid "MDI child window or main window"
 msgstr "MDI alt penceresini ya da ana pencereyi"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_2
-#: Merge.rc:5530
+#: Merge.rc:5529
 msgid "MDI child window only"
 msgstr "Yalnızca MDI alt penceresini"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_3
-#: Merge.rc:5531
+#: Merge.rc:5530
 msgid "Close main window if only one MDI child window"
 msgstr "Yalnızca bir MDI alt penceresi varsa ana pencere kapatılsın"
 
 #. IDS_DIFF_GROUP
-#: Merge.rc:5536
+#: Merge.rc:5535
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Diff"
 msgstr "Fark"
 
 #. IDS_DIFF_HIGHLIGHT
-#: Merge.rc:5537
+#: Merge.rc:5536
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Highlight"
 msgstr "Vurgula"
 
 #. IDS_DIFF_BLINK
-#: Merge.rc:5538
+#: Merge.rc:5537
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Blink"
 msgstr "Işıltı"
 
 #. IDS_DIFF_BLOCKSIZE
-#: Merge.rc:5539
+#: Merge.rc:5538
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Block Size"
 msgstr "Blok boyutu"
 
 #. IDS_DIFF_BLOCKALPHA
-#: Merge.rc:5540
+#: Merge.rc:5539
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Block Alpha"
 msgstr "Blok alfa"
 
 #. IDS_DIFF_CDTHRESHOLD
-#: Merge.rc:5541
+#: Merge.rc:5540
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "CD Threshold"
 msgstr "CD eşiği"
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION
-#: Merge.rc:5542
+#: Merge.rc:5541
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Ins/Del Detection"
 msgstr "Ekleme/silme algılaması"
 
 #. IDS_OVERLAY_MODE_NONE
-#: Merge.rc:5543 Merge.rc:5548
+#: Merge.rc:5542 Merge.rc:5547
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "None"
 msgstr "Yok"
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION_VERTICAL
-#: Merge.rc:5544
+#: Merge.rc:5543
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Vertical"
 msgstr "Dikey"
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION_HORIZONTAL
-#: Merge.rc:5545
+#: Merge.rc:5544
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Horizontal"
 msgstr "Yatay"
 
 #. IDS_OVERLAY_GROUP
-#: Merge.rc:5546
+#: Merge.rc:5545
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Overlay"
 msgstr "Kaplama"
 
 #. IDS_OVERLAY_ALPHA
-#: Merge.rc:5547
+#: Merge.rc:5546
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha"
 msgstr "Alfa"
 
 #. IDS_OVERLAY_MODE_XOR
-#: Merge.rc:5549
+#: Merge.rc:5548
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "XOR"
 msgstr "XOR"
 
 #. IDS_OVERLAY_MODE_ALPHA
-#: Merge.rc:5550
+#: Merge.rc:5549
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha Blend"
 msgstr "Alfa karıştırma"
 
 #. IDS_OVERLAY_MODE_ALPHA_ANIMATION
-#: Merge.rc:5551
+#: Merge.rc:5550
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha Animation"
 msgstr "Alfa canlandırma"
 
 #. IDS_ZOOM
-#: Merge.rc:5552
+#: Merge.rc:5551
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Zoom"
 msgstr "Yakınlaştırma"
 
 #. IDS_PAGE
-#: Merge.rc:5553
+#: Merge.rc:5552
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Page:"
 msgstr "Sayfa:"
 
 #. IDS_IMGCMP_STATUS_PT_RGBA_FMT
-#: Merge.rc:5554
+#: Merge.rc:5553
 #, c-format
 msgid "Pt: (%d, %d)  RGBA: (%d, %d, %d, %d)  "
 msgstr "Nokta:(%d, %d)  RGBA : (%d, %d, %d, %d)  "
 
 #. IDS_IMGCMP_STATUS_DIST1_FMT
-#: Merge.rc:5555
+#: Merge.rc:5554
 #, c-format
 msgid "Dist: %g  "
 msgstr "Uzaklık:%g  "
 
 #. IDS_IMGCMP_STATUS_DIST2_FMT
-#: Merge.rc:5556
+#: Merge.rc:5555
 #, c-format
 msgid "Dist: %g, %g  "
 msgstr "Uzaklık:%g,%g  "
 
 #. IDS_IMGCMP_STATUS_PAGE_ZOOM_SIZE_BPP_FMT
-#: Merge.rc:5557
+#: Merge.rc:5556
 #, c-format
 msgid "Page: %d/%d  Zoom: %d%%  %dx%dpx  %dbpp  "
 msgstr "Sayfa:%d/%d  Yakınlaştırma:%d%%  %dx%dpiksel  %dbpp "
 
 #. IDS_IMGCMP_STATUS_RC_FMT
-#: Merge.rc:5558
+#: Merge.rc:5557
 #, c-format
 msgid "Rc: (%d, %d)  "
 msgstr "Al: (%d, %d)  "
 
 #. IDS_IMGCMP_STATUS_FLIPPED_FMT
-#: Merge.rc:5559
+#: Merge.rc:5558
 #, c-format
 msgid "Flipped: %s  "
 msgstr "Çevrildi: %s  "
 
 #. IDS_IMGCMP_STATUS_ROTATED_FMT
-#: Merge.rc:5560
+#: Merge.rc:5559
 #, c-format
 msgid "Rotated: %d  "
 msgstr "Döndürüldü: %d  "
 
 #. IDS_IMGCMP_REPORT_ALLPAGES
-#: Merge.rc:5561
+#: Merge.rc:5560
 msgid "All pages"
 msgstr "Tüm sayfalar"
 
 #. IDS_IGNSUB_STR1
-#: Merge.rc:5566
+#: Merge.rc:5565
 msgid "<Edit here>"
 msgstr "<Burayı düzenleyin>"
 
 #. IDS_IGNSUB_STR2
-#: Merge.rc:5567
+#: Merge.rc:5566
 msgid "No differences found to select"
 msgstr "Seçilebilecek bir fark bulunamadı"
 
 #. IDS_IGNSUB_STR3
-#: Merge.rc:5568
+#: Merge.rc:5567
 msgid "No differences found to add as substitution filter"
 msgstr "Değişiklik filtresi ekleyecek bir fark bulunamadı"
 
 #. IDS_IGNSUB_STR4
-#: Merge.rc:5569
+#: Merge.rc:5568
 msgid "The pair is already in the Substitution Filters list"
 msgstr "Bu çift zaten Değişiklik Filtreleri listesinde var"
 
 #. IDS_IGNSUB_STR5
-#: Merge.rc:5570
+#: Merge.rc:5569
 msgid "Add this change to Substitution Filters?"
 msgstr "Bu değişiklik Değişiklik Filtrelerine eklensin mi?"
 
 #. IDS_OCRRESULT_TEXTONLY
-#: Merge.rc:5575
+#: Merge.rc:5574
 msgid "Text only"
 msgstr "Yalnızca metin"
 
 #. IDS_OCRRESULT_POS_LINE
-#: Merge.rc:5576
+#: Merge.rc:5575
 msgid "Line-by-line position and text"
 msgstr "Satır satır konum ve metin"
 
 #. IDS_OCRRESULT_POS_WORD
-#: Merge.rc:5577
+#: Merge.rc:5576
 msgid "Word-by-word position and text"
 msgstr "Sözcük sözcük konum ve metin"
 
 #. IDS_USERDATAFOLDER_APPDATA
-#: Merge.rc:5582
+#: Merge.rc:5581
 msgid "AppData (Roaming) folder"
 msgstr "AppData (Roaming) klasörü"
 
 #. IDS_USERDATAFOLDER_INSTALL
-#: Merge.rc:5583
+#: Merge.rc:5582
 msgid "Install folder"
 msgstr "Kurulum klasörü"
 
 #. IDS_USERDATAFOLDER_DOCUMENTS
-#: Merge.rc:5584
+#: Merge.rc:5583
 msgid "Documents folder"
 msgstr "Belgeler klasörü"
 
 #. IDS_SINGLEINSTANCE_DISABLED
-#: Merge.rc:5589
+#: Merge.rc:5588
 msgctxt "Options dialog|General|Single instance mode"
 msgid "Disabled"
 msgstr "Engelli"
 
 #. IDS_SINGLEINSTANCE_STR1
-#: Merge.rc:5590
+#: Merge.rc:5589
 msgid "Allow only one instance to run"
 msgstr "Yalnızca bir kopya çalışsın"
 
 #. IDS_CLIPBOARD_HISTORY
-#: Merge.rc:5591
+#: Merge.rc:5590
 msgid "Clipboard &History"
 msgstr "Pano &geçmişi"
 
 #. IDS_SINGLEINSTANCE_STR2
-#: Merge.rc:5592
+#: Merge.rc:5591
 msgid "Allow only one instance; wait for termination"
 msgstr "Yalnızca bir kopyanın çalışsın ve kopyanın sonlandırılması beklensin"
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_DISABLED
-#: Merge.rc:5597
+#: Merge.rc:5596
 msgctxt "Options dialog|General|Auto-reload modified files"
 msgid "Disabled"
 msgstr "Engelli"
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_STR1
-#: Merge.rc:5598
+#: Merge.rc:5597
 msgid "Only on window activated"
 msgstr "Yalnızca pencere etkinleştirildiğinde"
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_STR2
-#: Merge.rc:5599
+#: Merge.rc:5598
 msgid "Immediately"
 msgstr "Anında"
 
 #. IDS_PLUGIN_ALL
-#: Merge.rc:5604
+#: Merge.rc:5603
 msgid "Al&l"
 msgstr "&Tümü"
 
 #. IDS_PLUGIN_OTHERS
-#: Merge.rc:5605
+#: Merge.rc:5604
 msgid "&Others"
 msgstr "&Diğerleri"
 
-#: Merge.rc:5607
+#: Merge.rc:5606
 #, c-format
 msgid "Missing plugin name in pipeline: %1"
 msgstr "Eklenti bağlantı yolunda eklenti adı eksik: %1"
 
-#: Merge.rc:5609
+#: Merge.rc:5608
 #, c-format
 msgid "Missing quote in plugin pipeline: %1"
 msgstr "Eklenti bağlantı yolunda tırnak karakteri eksik: %1"
 
 #. IDS_PLUGIN_NAME_ALREADY_EXISTS
-#: Merge.rc:5610
+#: Merge.rc:5609
 #, c-format
 msgid "Plugin name '%1' already exists."
 msgstr "'%1' adlı bir eklenti zaten var."
 
 #. IDS_PLUGIN_TITLE1
-#: Merge.rc:5611
+#: Merge.rc:5610
 msgid "Specify plugin arguments"
 msgstr "Eklenti değişkenlerini belirtin"
 
-#: Merge.rc:5613
+#: Merge.rc:5612
 #, c-format
 msgid "Plugin not found or invalid: %1"
 msgstr "%1 eklentisi bulunamadı ya da geçersiz"
 
 #. IDS_PLUGIN_NOT_UNPACK
-#: Merge.rc:5614
+#: Merge.rc:5613
 #, c-format
 msgid "'%1' is not an unpacker plugin"
 msgstr "'%1' bir çıkarıcı eklentisi değil"
 
 #. IDS_PLUGIN_NOT_PREDIFF
-#: Merge.rc:5615
+#: Merge.rc:5614
 #, c-format
 msgid "'%1' is not a prediffer plugin"
 msgstr "'%1' bir ön farklılaştırıcı eklentisi değil"
 
-#: Merge.rc:5617
+#: Merge.rc:5616
 #, c-format
 msgid "Error prediffing '%1' with '%2'. Prediffing disabled."
 msgstr "'%1' dosyasında '%2' eklentisi ile ön farklılaştırma yapılırken bir sorun çıktı. Artık ön farklılaştırma uygulanamıyor."
 
 #. IDS_PLUGIN_CIRCULAR_REFERENCE
-#: Merge.rc:5618
+#: Merge.rc:5617
 #, c-format
 msgid "Circular reference in plugin pipeline: %1"
 msgstr "Eklenti hattında çevrim başvurusu: %1"
 
 #. IDS_PLUGIN_TYPE1
-#: Merge.rc:5619
+#: Merge.rc:5618
 msgid "URL Handler"
 msgstr "Adres işleyici"
 
 #. IDS_PLUGIN_TYPE2
-#: Merge.rc:5620
+#: Merge.rc:5619
 msgid "File Unpacker"
 msgstr "Dosya çıkarıcı"
 
 #. IDS_PLUGIN_TYPE3
-#: Merge.rc:5621
+#: Merge.rc:5620
 msgid "File or Folder Unpacker"
 msgstr "Dosya ya da klasör çıkarıcı"
 
 #. IDS_PLUGIN_TYPE5
-#: Merge.rc:5623
+#: Merge.rc:5622
 msgid "Alias for Unpacker"
 msgstr "Çıkarıcı kısaltması"
 
 #. IDS_PLUGIN_TYPE6
-#: Merge.rc:5624
+#: Merge.rc:5623
 msgid "Alias for Prediffer"
 msgstr "Ön farklılaştırıcı kısaltması"
 
 #. IDS_PLUGIN_TYPE7
-#: Merge.rc:5625
+#: Merge.rc:5624
 msgid "Alias for Editor script"
 msgstr "Düzenleyici betiği kısaltması"
 
 #. IDS_PLUGIN_ALIAS_DESC
-#: Merge.rc:5626
+#: Merge.rc:5625
 #, c-format
 msgid "Alias for plugin pipeline '%1'"
 msgstr "'%1' eklenti hattı kısaltması"
 
 #. IDS_PLUGIN_NEW_DESC
-#: Merge.rc:5627
+#: Merge.rc:5626
 msgid "New plugin description"
 msgstr "Yeni eklenti açıklaması"
 
 #. IDS_PLUGIN_TARGETS_ALL
-#: Merge.rc:5628
+#: Merge.rc:5627
 msgid "All"
 msgstr "Tümü"
 
 #. IDS_PLUGIN_TARGETS_1ST
-#: Merge.rc:5629
+#: Merge.rc:5628
 msgid "1st"
 msgstr "Birinci"
 
 #. IDS_PLUGIN_TARGETS_2ND
-#: Merge.rc:5630
+#: Merge.rc:5629
 msgid "2nd"
 msgstr "İkinci"
 
 #. IDS_PLUGIN_TARGETS_3RD
-#: Merge.rc:5631
+#: Merge.rc:5630
 msgid "3rd"
 msgstr "Üçüncü"
 
 #. IDS_PLUGIN_TARGETS_1ST_2ND
-#: Merge.rc:5632
+#: Merge.rc:5631
 msgid "1st and 2nd"
 msgstr "Birinci ve ikinci"
 
 #. IDS_PLUGIN_TARGETS_1ST_3RD
-#: Merge.rc:5633
+#: Merge.rc:5632
 msgid "1st and 3rd"
 msgstr "Birinci ve üçüncü"
 
 #. IDS_PLUGIN_TARGETS_2ND_3RD
-#: Merge.rc:5634
+#: Merge.rc:5633
 msgid "2nd and 3rd"
 msgstr "İkinci ve üçüncü"
 
 #. IDS_PLUGIN_CTRL_CLICK
-#: Merge.rc:5635
+#: Merge.rc:5634
 msgid "(Ctrl+Click to add to pipeline)"
 msgstr ""
 
 #. IDS_FILTER_APPLIED
-#: Merge.rc:5640
+#: Merge.rc:5639
 msgid "Filter applied"
 msgstr "Filtre uygulandı"
 
 #. IDS_FILTERMENU_COMPARE
-#: Merge.rc:5645
+#: Merge.rc:5644
 #, c-format
 msgid "Compare %1"
 msgstr "%1’i karşılaştır"
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN2
-#: Merge.rc:5647
+#: Merge.rc:5646
 msgid "&Filter by This Column..."
 msgstr "Bu sütuna göre &filtrele..."
 
 #. IDS_CLIPBOARDHISTORY_TIME
-#: Merge.rc:5652
+#: Merge.rc:5651
 #, c-format
 msgid "Clipboard at %s"
 msgstr "%s zamanındaki pano"
 
 #. IDS_CLIPBOARDHISTORY_DISABLED
-#: Merge.rc:5653
+#: Merge.rc:5652
 msgid ""
 "Clipboard history disabled.\r\n"
 "Enable: Windows logo key + V, then Turn on."
@@ -8444,115 +8439,115 @@ msgstr ""
 "Pano geçmişi devre dışı bırakılmış.\r\n"
 "Pano geçmişini etkinleştirmek için, Windows + V tuşlarına basıp açılan pencerede Aç üzerine tıklayın."
 
-#: Merge.rc:5655
+#: Merge.rc:5654
 msgid "This system does not support clipboard history."
 msgstr "Bu sistemde pano geçmişi özelliği yok."
 
-#: Merge.rc:5657
+#: Merge.rc:5656
 msgid "32-bit WinMerge does not support Clipboard Compare"
 msgstr "32-bit WinMerge sürümünde pano karşılaştırma özelliği yok"
 
 #. IDS_WEBVIEW2_RUNTIME_NOT_INSTALLED
-#: Merge.rc:5662
+#: Merge.rc:5661
 msgid "WebView2 runtime not installed. Download it?"
 msgstr "WebView2 çalıştırıcı bulunamadı. İndirmek ister misiniz?"
 
 #. IDS_JUMPLIST_NEW_TEXT_COMPARE
-#: Merge.rc:5667
+#: Merge.rc:5666
 msgid "New Text Compare"
 msgstr "Yeni metin karşılaştırması"
 
 #. IDS_JUMPLIST_NEW_TABLE_COMPARE
-#: Merge.rc:5668
+#: Merge.rc:5667
 msgid "New Table Compare"
 msgstr "Yeni tablo karşılaştırması"
 
 #. IDS_JUMPLIST_NEW_BINARY_COMPARE
-#: Merge.rc:5669
+#: Merge.rc:5668
 msgid "New Binary Compare"
 msgstr "Yeni binary karşılaştırması"
 
 #. IDS_JUMPLIST_NEW_IMAGE_COMPARE
-#: Merge.rc:5670
+#: Merge.rc:5669
 msgid "New Image Compare"
 msgstr "Yeni görsel karşılaştırması"
 
 #. IDS_JUMPLIST_NEW_WEBPAGE_COMPARE
-#: Merge.rc:5671
+#: Merge.rc:5670
 msgid "New Webpage Compare"
 msgstr "Yeni site sayfası karşılaştırması"
 
 #. IDS_JUMPLIST_NEW_FOLDER_COMPARE
-#: Merge.rc:5672
+#: Merge.rc:5671
 msgid "New Folder Compare"
 msgstr "Yeni klasör karşılaştırması"
 
 #. IDS_JUMPLIST_CLIPBOARD_COMPARE
-#: Merge.rc:5673
+#: Merge.rc:5672
 msgid "Clipboard Compare"
 msgstr "Pano karşılaştırması"
 
 #. IDS_PREVIEWBAR_PRINT
-#: Merge.rc:5678
+#: Merge.rc:5677
 msgid "&Print..."
 msgstr "&Yazdır..."
 
 #. IDS_PREVIEWBAR_PREVPAGE
-#: Merge.rc:5680
+#: Merge.rc:5679
 msgid "Pre&v Page"
 msgstr "Ö&nceki sayfa"
 
 #. IDS_PREVIEWBAR_TWOPAGE
-#: Merge.rc:5681
+#: Merge.rc:5680
 msgid "&Two Page"
 msgstr "İ&ki sayfa"
 
 #. IDS_PREVIEWBAR_ONEPAGE
-#: Merge.rc:5682
+#: Merge.rc:5681
 msgid "&One Page"
 msgstr "&Bir sayfa"
 
 #. IDS_PREVIEWBAR_ZOOMIN
-#: Merge.rc:5683
+#: Merge.rc:5682
 msgid "Zoom &In"
 msgstr "Y&akınlaştır"
 
 #. IDS_PREVIEWBAR_ZOOMOUT
-#: Merge.rc:5684
+#: Merge.rc:5683
 msgid "Zoom &Out"
 msgstr "&Uzaklaştır"
 
 #. IDS_WEBPAGE_COMPARING
-#: Merge.rc:5690
+#: Merge.rc:5689
 msgid "Comparing..."
 msgstr "Karşılaştırılıyor..."
 
 #. IDS_WEBPAGE_ZOOM
-#: Merge.rc:5691
+#: Merge.rc:5690
 msgid "Zoom:"
 msgstr "Yakınlaştıma:"
 
 #. IDS_COPY_GRANULARITY_DIFFHUNK
-#: Merge.rc:5696
+#: Merge.rc:5695
 msgid "Diff hunk"
 msgstr "Fark parçası"
 
 #. IDS_COPY_GRANULARITY_INLINE
-#: Merge.rc:5697
+#: Merge.rc:5696
 msgid "Inline diff"
 msgstr "Satır arası fark"
 
 #. IDS_COPY_GRANULARITY_LINE
-#: Merge.rc:5698
+#: Merge.rc:5697
 msgid "Line"
 msgstr "Satır"
 
-#: Merge.rc:5699
+#: Merge.rc:5698
 msgid "Character"
 msgstr "Karakter"
 
 #. ID_MICE_PREVDIFF
-#: Merge.rc:5704
+#: Merge.rc:5703
 msgid ""
 "\n"
 "Previous Difference (Alt+Up)\n"
@@ -8565,7 +8560,7 @@ msgstr ""
 "(Alt+Tekerlek Yukarı)"
 
 #. ID_MICE_NEXTDIFF
-#: Merge.rc:5705
+#: Merge.rc:5704
 msgid ""
 "\n"
 "Next Difference (Alt+Down)\n"
@@ -8578,7 +8573,7 @@ msgstr ""
 "(Alt+Tekerlek Aşağı)"
 
 #. ID_MICE_L2R
-#: Merge.rc:5706
+#: Merge.rc:5705
 msgid ""
 "\n"
 "Copy to Right (Alt+Right)\n"
@@ -8593,7 +8588,7 @@ msgstr ""
 "(Alt+Shift+Tekerlek Aşağı)"
 
 #. ID_MICE_R2L
-#: Merge.rc:5707
+#: Merge.rc:5706
 msgid ""
 "\n"
 "Copy to Left (Alt+Left)\n"
@@ -8608,7 +8603,7 @@ msgstr ""
 "(Alt+Shift+Tekerlek Yukarı)"
 
 #. ID_MICE_L2RNEXT
-#: Merge.rc:5708
+#: Merge.rc:5707
 msgid ""
 "\n"
 "Copy to Right and Advance (Ctrl+Alt+Right)\n"
@@ -8621,7 +8616,7 @@ msgstr ""
 "(Ctrl+Alt+Shift+Tekerlek Aşağı)"
 
 #. ID_MICE_R2LNEXT
-#: Merge.rc:5709
+#: Merge.rc:5708
 msgid ""
 "\n"
 "Copy to Left and Advance (Ctrl+Alt+Left)\n"
@@ -8634,257 +8629,257 @@ msgstr ""
 "(Ctrl+Alt+Shift+Tekerlek Yukarı)"
 
 #. IDS_LOG_COMPARING_2
-#: Merge.rc:5719
+#: Merge.rc:5718
 #, c-format
 msgid "Comparing %1 with %2"
 msgstr "%1 ile %2 karşılaştırılıyor"
 
 #. IDS_LOG_COMPARING_3
-#: Merge.rc:5720
+#: Merge.rc:5719
 #, c-format
 msgid "Comparing %1 with %2 and %3"
 msgstr "%1 ile %2 ve %3 ile karşılaştırılıyor"
 
 #. IDS_LOG_COMPARE_COMPLETED
-#: Merge.rc:5721
+#: Merge.rc:5720
 msgid "Comparison completed"
 msgstr "Karşılaştırma tamamlandı"
 
 #. IDS_LOG_COMPARE_ERROR_2
-#: Merge.rc:5722
+#: Merge.rc:5721
 #, c-format
 msgid "Failed to compare %1 with %2: "
 msgstr "%1 ile %2 karşılaştırılamadı: "
 
 #. IDS_LOG_COMPARE_ERROR_3
-#: Merge.rc:5723
+#: Merge.rc:5722
 #, c-format
 msgid "Failed to compare %1 with %2 and %3: "
 msgstr "%1 ile %2 ve %3 karşılaştırılamadı: "
 
 #. IDS_LOG_FILE_SAVED
-#: Merge.rc:5724
+#: Merge.rc:5723
 msgid "File saved"
 msgstr "Dosya kaydedildi"
 
 #. IDS_LOG_COPYING_FILES
-#: Merge.rc:5725
+#: Merge.rc:5724
 msgid "Copying files..."
 msgstr "Dosyalar kopyalanıyor..."
 
 #. IDS_LOG_MOVING_FILES
-#: Merge.rc:5726
+#: Merge.rc:5725
 msgid "Moving files..."
 msgstr "Dosyalar taşınıyor..."
 
 #. IDS_LOG_DELETING_FILES
-#: Merge.rc:5727
+#: Merge.rc:5726
 msgid "Deleting files..."
 msgstr "Dosyalar siliniyor..."
 
 #. IDS_LOG_RECYCLEBIN
-#: Merge.rc:5728
+#: Merge.rc:5727
 msgid "Recycle Bin"
 msgstr "Geri Dönüşüm Kutusu"
 
 #. IDS_LOG_PERMANENTLY_DELETED
-#: Merge.rc:5729
+#: Merge.rc:5728
 msgid "Permanently deleted"
 msgstr "Kalıcı olarak silindi"
 
 #. IDS_LOG_FILEOPERATION_COMPLETED
-#: Merge.rc:5730
+#: Merge.rc:5729
 msgid "File operation completed successfully"
 msgstr "Dosya işlemi başarıyla tamamlandı"
 
 #. IDS_LOG_FILEOPERATION_CANCELED
-#: Merge.rc:5731
+#: Merge.rc:5730
 msgid "File operation canceled"
 msgstr "Dosya işlemi iptal edildi"
 
 #. IDS_FILTER_ERROR_NO_ERROR
-#: Merge.rc:5736
+#: Merge.rc:5735
 msgid "No error"
 msgstr "Hata yok"
 
 #. IDS_FILTER_ERROR_EMPTY_EXPRESSION
-#: Merge.rc:5737
+#: Merge.rc:5736
 msgid "Filter expression is empty"
 msgstr "Filtre ifadesi boş"
 
 #. IDS_FILTER_ERROR_UNKNOWN_CHAR
-#: Merge.rc:5738
+#: Merge.rc:5737
 msgid "Unknown character in filter expression"
 msgstr "Filtre ifadesinde bilinmeyen karakter"
 
 #. IDS_FILTER_ERROR_UNTERMINATED_STRING
-#: Merge.rc:5739
+#: Merge.rc:5738
 msgid "Unterminated string literal"
 msgstr "Sonlandırılmamış dize sabiti"
 
 #. IDS_FILTER_ERROR_SYNTAX_ERROR
-#: Merge.rc:5740
+#: Merge.rc:5739
 msgid "Syntax error in filter expression"
 msgstr "Filtre ifadesinde söz dizimi hatası"
 
 #. IDS_FILTER_ERROR_PARSE_FAILURE
-#: Merge.rc:5741
+#: Merge.rc:5740
 msgid "Failed to parse filter expression"
 msgstr "Filtre ifadesi ayrıştırılamadı"
 
 #. IDS_FILTER_ERROR_INVALID_LITERAL
-#: Merge.rc:5742
+#: Merge.rc:5741
 msgid "Invalid literal value"
 msgstr "Geçersiz sabit değer"
 
 #. IDS_FILTER_ERROR_INVALID_REGULAR_EXPRESSION
-#: Merge.rc:5743
+#: Merge.rc:5742
 msgid "Invalid regular expression"
 msgstr "Geçersiz düzenli ifade"
 
 #. IDS_FILTER_ERROR_UNDEFINED_IDENTIFIER
-#: Merge.rc:5744
+#: Merge.rc:5743
 msgid "Undefined identifier"
 msgstr "Tanımsız tanımlayıcı"
 
 #. IDS_FILTER_ERROR_INVALID_ARGUMENT_COUNT
-#: Merge.rc:5745
+#: Merge.rc:5744
 msgid "Invalid number of arguments"
 msgstr "Geçersiz değişken sayısı"
 
 #. IDS_FILTER_ERROR_FILTER_NAME_NOT_FOUND
-#: Merge.rc:5746
+#: Merge.rc:5745
 msgid "Filter name not found"
 msgstr "Filtre adı bulunamadı"
 
 #. IDS_FILTER_ERROR_DIVIDE_BY_ZERO
-#: Merge.rc:5747
+#: Merge.rc:5746
 msgid "Division by zero in filter expression"
 msgstr "Filtre ifadesinde sıfıra bölme işlemi"
 
 #. IDS_FILTER_ERROR_UNKNOWN_ERROR
-#: Merge.rc:5748
+#: Merge.rc:5747
 msgid "Unknown error"
 msgstr "Bilinmeyen hata"
 
 #. IDS_FILTER_ERROR_INVALID_PROPERTY_NAME
-#: Merge.rc:5749
+#: Merge.rc:5748
 msgid "Invalid property name"
 msgstr "Geçersiz özellik adı"
 
 #. IDS_FILTER_ERROR_INVALID_DIRECTIVE
-#: Merge.rc:5750
+#: Merge.rc:5749
 msgid "Invalid directive"
 msgstr "Geçersiz yönerge"
 
 #. IDS_FILTER_OP_EQUALS
-#: Merge.rc:5755
+#: Merge.rc:5754
 msgid "Equals"
 msgstr "Eşittir"
 
 #. IDS_FILTER_OP_NOT_EQUALS
-#: Merge.rc:5756
+#: Merge.rc:5755
 msgid "Does not equal"
 msgstr "Eşit değil"
 
 #. IDS_FILTER_OP_LESS_THAN
-#: Merge.rc:5757
+#: Merge.rc:5756
 msgid "Less than"
 msgstr "Daha az"
 
 #. IDS_FILTER_OP_LESS_EQUAL
-#: Merge.rc:5758
+#: Merge.rc:5757
 msgid "Less than or equal to"
 msgstr "Küçük veya eşit"
 
 #. IDS_FILTER_OP_GREATER_EQUAL
-#: Merge.rc:5759
+#: Merge.rc:5758
 msgid "Greater than or equal to"
 msgstr "Büyük veya eşit"
 
 #. IDS_FILTER_OP_GREATER_THAN
-#: Merge.rc:5760
+#: Merge.rc:5759
 msgid "Greater than"
 msgstr "Daha büyük"
 
 #. IDS_FILTER_OP_BETWEEN
-#: Merge.rc:5761
+#: Merge.rc:5760
 msgid "Between"
 msgstr "Arasında"
 
 #. IDS_FILTER_OP_NOT_BETWEEN
-#: Merge.rc:5762
+#: Merge.rc:5761
 msgid "Not Between"
 msgstr "Arasında değil"
 
 #. IDS_FILTER_OP_CONTAINS
-#: Merge.rc:5763
+#: Merge.rc:5762
 msgid "Contains"
 msgstr "İçerir"
 
 #. IDS_FILTER_OP_NOT_CONTAINS
-#: Merge.rc:5764
+#: Merge.rc:5763
 msgid "Not Contains"
 msgstr "İçermez"
 
 #. IDS_FILTER_OP_RECONTAINS
-#: Merge.rc:5765
+#: Merge.rc:5764
 msgid "Contains (regex)"
 msgstr "İçerir (regex)"
 
 #. IDS_FILTER_OP_NOT_RECONTAINS
-#: Merge.rc:5766
+#: Merge.rc:5765
 msgid "Not Contains (regex)"
 msgstr "İçermez (regex)"
 
 #. IDS_FILTER_OP_LIKE
-#: Merge.rc:5767
+#: Merge.rc:5766
 msgid "Match (wildcard)"
 msgstr "Eşleştir (joker karakter)"
 
 #. IDS_FILTER_OP_NOT_LIKE
-#: Merge.rc:5768
+#: Merge.rc:5767
 msgid "Not match (wildcard)"
 msgstr "Eşleşmez (joker karakter)"
 
 #. IDS_FILTER_OP_MATCHES
-#: Merge.rc:5769
+#: Merge.rc:5768
 msgid "Match (regex)"
 msgstr "Eşleştir (regex)"
 
 #. IDS_FILTER_OP_NOT_MATCHES
-#: Merge.rc:5770
+#: Merge.rc:5769
 msgid "Not match (regex)"
 msgstr "Eşleşmez (regex)"
 
 #. IDS_COLORMODE_LIGHT
-#: Merge.rc:5775
+#: Merge.rc:5774
 msgid "Light"
 msgstr "Aydınlık"
 
 #. IDS_COLORMODE_DARK
-#: Merge.rc:5776
+#: Merge.rc:5775
 msgid "Dark"
 msgstr "Karanlık"
 
 #. IDS_COLORMODE_FOLLOWSYSTEM
-#: Merge.rc:5777
+#: Merge.rc:5776
 msgid "Follow system"
 msgstr "Sistem ayarını seç"
 
 #. IDS_EXAMPLE
-#: Merge.rc:5782
+#: Merge.rc:5781
 #, c-format
 msgid "e.g. %1"
 msgstr "örn. %1"
 
 #. IDS_DETECTED_PREVIOUS_CRASH
-#: Merge.rc:5787
+#: Merge.rc:5786
 msgid "WinMerge detected a previous crash. Please report this if possible."
 msgstr "WinMerge, önceki bir çökme tespit etti. Mümkünse lütfen bunu bildirin."
 
 #. IDS_REGEX_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5792
+#: Merge.rc:5791
 msgid ""
 "# Regex replacement list\r\n"
 "# Format: regex<TAB>replacement\r\n"
@@ -8899,7 +8894,7 @@ msgstr ""
 "(\\d{4})-(\\d{2})-(\\d{2})\t$1_$2_$3\r\n"
 
 #. IDS_STRING_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5793
+#: Merge.rc:5792
 msgid ""
 "# Replacement list\r\n"
 "# Format: search<TAB>replacement\r\n"
@@ -8916,22 +8911,22 @@ msgstr ""
 "from2\tto2\r\n"
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_ONLY
-#: Merge.rc:5798
+#: Merge.rc:5797
 msgid "Built-in only"
 msgstr "Yalnızca yerleşik"
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_FIRST
-#: Merge.rc:5799
+#: Merge.rc:5798
 msgid "Built-in first"
 msgstr "Önce yerleşik olanlar"
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_FIRST
-#: Merge.rc:5800
+#: Merge.rc:5799
 msgid "Tree-sitter first"
 msgstr "Önce Tree-sitter"
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_ONLY
-#: Merge.rc:5801
+#: Merge.rc:5800
 msgid "Tree-sitter only"
 msgstr "Yalnızca Tree-sitter"
 

--- a/Translations/WinMerge/Ukrainian.po
+++ b/Translations/WinMerge/Ukrainian.po
@@ -23,7 +23,7 @@ msgstr ""
 "X-Generator: Poedit 3.8\n"
 
 #. LANGUAGE, SUBLANGUAGE
-#: Merge.rc:26 Merge.rc:59 Merge.rc:5818
+#: Merge.rc:26 Merge.rc:59 Merge.rc:5817
 msgid "LANG_ENGLISH, SUBLANG_ENGLISH_US"
 msgstr "LANG_UKRAINIAN, SUBLANG_DEFAULT"
 
@@ -165,7 +165,7 @@ msgstr "&Сценарії"
 #. IDS_NO_EDIT_SCRIPTS
 #: Merge.rc:127 Merge.rc:352 Merge.rc:463 Merge.rc:673 Merge.rc:678
 #: Merge.rc:887 Merge.rc:899 Merge.rc:906 Merge.rc:963 Merge.rc:1210
-#: Merge.rc:5375
+#: Merge.rc:5374
 msgid "< Empty >"
 msgstr "< Порожньо >"
 
@@ -230,7 +230,7 @@ msgid "Auto-Fit All Columns"
 msgstr "Автоширина стовпців"
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN
-#: Merge.rc:153 Merge.rc:5646
+#: Merge.rc:153 Merge.rc:5645
 msgid "&Filter by This Column"
 msgstr ""
 
@@ -291,7 +291,7 @@ msgid "&Previous Page"
 msgstr "&Попередня сторінка"
 
 #. IDS_PREVIEWBAR_NEXTPAGE
-#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5679
+#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5678
 msgid "&Next Page"
 msgstr "&Наступна сторінка"
 
@@ -542,7 +542,7 @@ msgstr "&Двійковий"
 #. IDS_IMAGE_MENU
 #: Merge.rc:329 Merge.rc:338 Merge.rc:432 Merge.rc:441 Merge.rc:609
 #: Merge.rc:618 Merge.rc:670 Merge.rc:960 Merge.rc:1187 Merge.rc:1200
-#: Merge.rc:5477
+#: Merge.rc:5476
 msgid "&Image"
 msgstr "&Зображення"
 
@@ -664,7 +664,7 @@ msgid "&Huge"
 msgstr "&Величезні"
 
 #. IDS_VIEW_MENU_BAR
-#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5714
+#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5713
 msgid "Men&u Bar"
 msgstr "Рядок м&еню"
 
@@ -1319,7 +1319,7 @@ msgid "Lo&cation Pane"
 msgstr "Панель пози&цій"
 
 #. IDS_OUTPUTBAR_CAPTION
-#: Merge.rc:782 Merge.rc:5252
+#: Merge.rc:782 Merge.rc:5251
 msgid "Output Pane"
 msgstr "Панель виводу"
 
@@ -1582,55 +1582,55 @@ msgid "Co&mpare As"
 msgstr "Порівняти як"
 
 #. IDS_COPY_LEFT_TO_MIDDLE2
-#: Merge.rc:968 Merge.rc:980 Merge.rc:4852
+#: Merge.rc:968 Merge.rc:980 Merge.rc:4851
 #, c-format
 msgid "Left to Middle (%1 of %2)"
 msgstr "Зліва в центр  (%1 of %2)"
 
 #. IDS_COPY_LEFT_TO_RIGHT2
-#: Merge.rc:969 Merge.rc:981 Merge.rc:4851
+#: Merge.rc:969 Merge.rc:981 Merge.rc:4850
 #, c-format
 msgid "Left to Right (%1 of %2)"
 msgstr "Зліва праворуч (%1 з %2)"
 
 #. IDS_MOVE_LEFT_TO2
-#: Merge.rc:970 Merge.rc:982 Merge.rc:1045 Merge.rc:4863 Merge.rc:4892
+#: Merge.rc:970 Merge.rc:982 Merge.rc:1045 Merge.rc:4862 Merge.rc:4891
 #, c-format
 msgid "Left to... (%1 of %2)"
 msgstr "Зліва в... (%1 з %2)"
 
 #. IDS_COPY_MIDDLE_TO_LEFT2
-#: Merge.rc:971 Merge.rc:983 Merge.rc:4849
+#: Merge.rc:971 Merge.rc:983 Merge.rc:4848
 #, c-format
 msgid "Middle to Left (%1 of %2)"
 msgstr "Центральний ліворуч (%1 of %2)"
 
 #. IDS_COPY_MIDDLE_TO_RIGHT2
-#: Merge.rc:972 Merge.rc:984 Merge.rc:4850
+#: Merge.rc:972 Merge.rc:984 Merge.rc:4849
 #, c-format
 msgid "Middle to Right (%1 of %2)"
 msgstr "Центральний праворуч (%1 of %2)"
 
 #. IDS_MOVE_MIDDLE_TO2
-#: Merge.rc:973 Merge.rc:985 Merge.rc:1046 Merge.rc:4864 Merge.rc:4893
+#: Merge.rc:973 Merge.rc:985 Merge.rc:1046 Merge.rc:4863 Merge.rc:4892
 #, c-format
 msgid "Middle to... (%1 of %2)"
 msgstr "Центральний в... (%1 of %2)"
 
 #. IDS_COPY_RIGHT_TO_MIDDLE2
-#: Merge.rc:974 Merge.rc:986 Merge.rc:4848
+#: Merge.rc:974 Merge.rc:986 Merge.rc:4847
 #, c-format
 msgid "Right to Middle (%1 of %2)"
 msgstr "Правий в центр (%1 of %2)"
 
 #. IDS_COPY_RIGHT_TO_LEFT2
-#: Merge.rc:975 Merge.rc:987 Merge.rc:4847
+#: Merge.rc:975 Merge.rc:987 Merge.rc:4846
 #, c-format
 msgid "Right to Left (%1 of %2)"
 msgstr "Справа ліворуч (%1 з %2)"
 
 #. IDS_MOVE_RIGHT_TO2
-#: Merge.rc:976 Merge.rc:988 Merge.rc:1047 Merge.rc:4865 Merge.rc:4894
+#: Merge.rc:976 Merge.rc:988 Merge.rc:1047 Merge.rc:4864 Merge.rc:4893
 #, c-format
 msgid "Right to... (%1 of %2)"
 msgstr "Справа... (%1 з %2)"
@@ -1686,31 +1686,31 @@ msgid "Cop&y Paths"
 msgstr "Скопіювати &шляхи"
 
 #. IDS_DEL_LEFT_FMT2
-#: Merge.rc:1026 Merge.rc:1035 Merge.rc:4880
+#: Merge.rc:1026 Merge.rc:1035 Merge.rc:4879
 #, c-format
 msgid "Left (%1 of %2)"
 msgstr "Зліва (%1 з %2)"
 
 #. IDS_DEL_MIDDLE_FMT2
-#: Merge.rc:1027 Merge.rc:1036 Merge.rc:4881
+#: Merge.rc:1027 Merge.rc:1036 Merge.rc:4880
 #, c-format
 msgid "Middle (%1 of %2)"
 msgstr "З центру (%1 of %2)"
 
 #. IDS_DEL_RIGHT_FMT2
-#: Merge.rc:1028 Merge.rc:1037 Merge.rc:4882
+#: Merge.rc:1028 Merge.rc:1037 Merge.rc:4881
 #, c-format
 msgid "Right (%1 of %2)"
 msgstr "Справа (%1 з %2)"
 
 #. IDS_DEL_BOTH_FMT2
-#: Merge.rc:1029 Merge.rc:1038 Merge.rc:4883
+#: Merge.rc:1029 Merge.rc:1038 Merge.rc:4882
 #, c-format
 msgid "Both (%1 of %2)"
 msgstr "Обидва (%1 з %2)"
 
 #. IDS_DEL_ALL_FMT2
-#: Merge.rc:1030 Merge.rc:1039 Merge.rc:4888
+#: Merge.rc:1030 Merge.rc:1039 Merge.rc:4887
 #, c-format
 msgid "All (%1 of %2)"
 msgstr "Усе (%1 of %2)"
@@ -1736,19 +1736,19 @@ msgid "&Zip"
 msgstr "&Заархівувати"
 
 #. IDS_COPY_BOTH_TO2
-#: Merge.rc:1048 Merge.rc:4866
+#: Merge.rc:1048 Merge.rc:4865
 #, c-format
 msgid "Both to... (%1 of %2)"
 msgstr "Обидва в... (%1 of %2)"
 
 #. IDS_COPY_ALL_TO2
-#: Merge.rc:1049 Merge.rc:4867
+#: Merge.rc:1049 Merge.rc:4866
 #, c-format
 msgid "All to... (%1 of %2)"
 msgstr "Усі в... (%1 of %2)"
 
 #. IDS_COPY_DIFFERENCES_TO2
-#: Merge.rc:1050 Merge.rc:4868
+#: Merge.rc:1050 Merge.rc:4867
 #, c-format
 msgid "Differences to... (%1 of %2)"
 msgstr "Відмінності в... (%1 of %2)"
@@ -1815,12 +1815,12 @@ msgstr "Налаштування розпакувальника"
 
 #. IDS_USERCHOICE_NONE
 #: Merge.rc:1088 Merge.rc:1094 Merge.rc:1836 Merge.rc:1840 Merge.rc:2031
-#: Merge.rc:2035 Merge.rc:5377
+#: Merge.rc:2035 Merge.rc:5376
 msgid "<None>"
 msgstr "<Немає>"
 
 #. IDS_USERCHOICE_AUTOMATIC
-#: Merge.rc:1089 Merge.rc:1095 Merge.rc:5378
+#: Merge.rc:1089 Merge.rc:1095 Merge.rc:5377
 msgid "<Automatic>"
 msgstr "<Автоматично>"
 
@@ -2750,12 +2750,12 @@ msgid "Text files only"
 msgstr ""
 
 #. IDS_EOL_NONE
-#: Merge.rc:1667 Merge.rc:1918 Merge.rc:5304
+#: Merge.rc:1667 Merge.rc:1918 Merge.rc:5303
 msgid "None"
 msgstr "Немає"
 
 #. IDS_EOL_MIXED
-#: Merge.rc:1668 Merge.rc:5299
+#: Merge.rc:1668 Merge.rc:5298
 msgid "Mixed"
 msgstr "Мішаний"
 
@@ -3027,13 +3027,13 @@ msgstr ""
 
 #. IDS_DIFFERENT
 #: Merge.rc:1904 Merge.rc:1988 Merge.rc:2866 Merge.rc:3036 Merge.rc:3077
-#: Merge.rc:5058
+#: Merge.rc:5057
 msgid "Different"
 msgstr "Відрізняються"
 
 #. IDS_IDENTICAL
 #: Merge.rc:1905 Merge.rc:1989 Merge.rc:2865 Merge.rc:3055 Merge.rc:3116
-#: Merge.rc:5048
+#: Merge.rc:5047
 msgid "Identical"
 msgstr "Однакові"
 
@@ -3053,7 +3053,7 @@ msgid "Missing"
 msgstr ""
 
 #. IDS_MOVED
-#: Merge.rc:1910 Merge.rc:5076
+#: Merge.rc:1910 Merge.rc:5075
 msgid "Moved"
 msgstr ""
 
@@ -3789,7 +3789,7 @@ msgid "&Use custom system colors"
 msgstr "&Використовувати власні системні кольори"
 
 #. IDS_PRPCAT_SYSTEM
-#: Merge.rc:2565 Merge.rc:4559 Merge.rc:4560 Merge.rc:5007
+#: Merge.rc:2565 Merge.rc:4559 Merge.rc:4560 Merge.rc:5006
 msgid "System"
 msgstr "Система"
 
@@ -4189,7 +4189,7 @@ msgid "Items compared:"
 msgstr "Порівняно елементів:"
 
 #. IDS_PREVIEWBAR_CLOSE
-#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5685
+#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5684
 msgid "&Close"
 msgstr "&Закрити"
 
@@ -4812,7 +4812,7 @@ msgid "A&ppend timestamp"
 msgstr "Д&одати дату"
 
 #. IDS_CONFIRM_COPY_CAPTION
-#: Merge.rc:3214 Merge.rc:4915
+#: Merge.rc:3214 Merge.rc:4914
 msgid "Confirm Copy"
 msgstr "Підтвердження"
 
@@ -5049,7 +5049,7 @@ msgid "&Character Set..."
 msgstr "&Набір символів..."
 
 #. IDS_PRPCAT_IMAGE
-#: Merge.rc:3351 Merge.rc:4574 Merge.rc:5015
+#: Merge.rc:3351 Merge.rc:4574 Merge.rc:5014
 msgid "Image"
 msgstr "Зображення"
 
@@ -5446,7 +5446,7 @@ msgid "Project"
 msgstr "Проєкт"
 
 #. IDS_COLHDR_NSDIFFS
-#: Merge.rc:4566 Merge.rc:4990
+#: Merge.rc:4566 Merge.rc:4989
 msgid "Differences"
 msgstr "Відмінності"
 
@@ -5591,12 +5591,12 @@ msgid "File Type"
 msgstr "Тип файлу"
 
 #. IDS_COLHDR_EXTENSION
-#: Merge.rc:4653 Merge.rc:4947
+#: Merge.rc:4653 Merge.rc:4946
 msgid "Extension"
 msgstr "Розширення"
 
 #. IDS_PRPCAT_MESSAGE
-#: Merge.rc:4659 Merge.rc:5019
+#: Merge.rc:4659 Merge.rc:5018
 msgid "Message"
 msgstr "Повідомлення"
 
@@ -5636,7 +5636,7 @@ msgid "Hidden Items"
 msgstr "Приховані елементи"
 
 #. IDS_PLUGINSLIST_NAME
-#: Merge.rc:4680 Merge.rc:5311
+#: Merge.rc:4680 Merge.rc:5310
 msgid "Name"
 msgstr "Ім'я"
 
@@ -5656,7 +5656,7 @@ msgid "[F] "
 msgstr "[F] "
 
 #. IDS_PLUGINSLIST_DESC
-#: Merge.rc:4684 Merge.rc:5313
+#: Merge.rc:4684 Merge.rc:5312
 msgid "Description"
 msgstr "Опис"
 
@@ -5824,155 +5824,150 @@ msgstr "Рд: %s  Ст: %d/%d  Симв: %d/%d"
 msgid "  Sel: %d | %d"
 msgstr "  Вибр: %d | %d"
 
-#. IDS_MERGEMODE_MERGING
-#: Merge.rc:4734
-msgid "Merge"
-msgstr "Об'єднання"
-
 #. IDS_DIFF_NUMBER_STATUS_FMT
-#: Merge.rc:4735
+#: Merge.rc:4734
 #, c-format
 msgid "Difference %1 of %2"
 msgstr "Відмінність %1 з %2"
 
 #. IDS_NO_DIFF_SEL_FMT
-#: Merge.rc:4736
+#: Merge.rc:4735
 #, c-format
 msgid "%1 Differences Found"
 msgstr "Знайдено відмінностей: %1"
 
 #. IDS_1_DIFF_FOUND
-#: Merge.rc:4737
+#: Merge.rc:4736
 msgid "1 Difference Found"
 msgstr "Знайдено відмінностей: 1"
 
 #. IDS_NO_ERR_SEL_FMT
-#: Merge.rc:4738
+#: Merge.rc:4737
 #, c-format
 msgid "%1 Errors Found"
 msgstr "Знайдено помилок: %1"
 
 #. IDS_1_ERR_FOUND
-#: Merge.rc:4739
+#: Merge.rc:4738
 msgid "1 Error Found"
 msgstr "Знайдено помилок: 1"
 
 #. IDS_STATUSBAR_READONLY, Abbreviation from "Read Only"
-#: Merge.rc:4740
+#: Merge.rc:4739
 msgid "RO"
 msgstr "RO"
 
 #. IDS_DIRVIEW_STATUS_FMT_FOCUS
-#: Merge.rc:4746
+#: Merge.rc:4745
 #, c-format
 msgid "Item %1 of %2"
 msgstr "Елемент %1 з %2"
 
 #. IDS_DIRVIEW_STATUS_FMT_NOFOCUS
-#: Merge.rc:4747
+#: Merge.rc:4746
 #, c-format
 msgid "Items: %1"
 msgstr "Елементів: %1"
 
 #. IDS_DIRVIEW_STATUS_COMPARING
-#: Merge.rc:4748
+#: Merge.rc:4747
 msgid "Comparing items..."
 msgstr "Триває порівняння..."
 
 #. IDS_ITEMS_PER_SEC
-#: Merge.rc:4749
+#: Merge.rc:4748
 #, c-format
 msgid "%.1f[items/sec]"
 msgstr "%.1f[шт/сек]"
 
 #. IDS_ERROR_INCOMPARABLE
-#: Merge.rc:4755
+#: Merge.rc:4754
 msgid "Select two existing folders/files to compare."
 msgstr "Виберіть дві існуючі папки або файли для порівняння."
 
 #. IDS_DIRSEL_TAG
-#: Merge.rc:4756
+#: Merge.rc:4755
 msgid "Folder Selection"
 msgstr "Вибір папки"
 
 #. IDS_OPEN_FILESDIRS
-#: Merge.rc:4757
+#: Merge.rc:4756
 msgid "Select two (or three) folders/files to compare."
 msgstr "Виберіть дві (або три) папки/файли для порівняння."
 
 #. IDS_OPEN_LEFTINVALID
-#: Merge.rc:4758
+#: Merge.rc:4757
 msgid "Left (1st) path is invalid!"
 msgstr "Шлях лівого (1-го) елемента недійсний!"
 
 #. IDS_OPEN_MIDDLEINVALID
-#: Merge.rc:4759
+#: Merge.rc:4758
 msgid "Middle (2nd) path is invalid!"
 msgstr "Шлях середнього (2-го) елемента недійсний!"
 
 #. IDS_OPEN_RIGHTINVALID2
-#: Merge.rc:4760
+#: Merge.rc:4759
 msgid "Right (2nd) path is invalid!"
 msgstr "Шлях правого (2-го) елемента недійсний!"
 
 #. IDS_OPEN_RIGHTINVALID3
-#: Merge.rc:4761
+#: Merge.rc:4760
 msgid "Right (3rd) path is invalid!"
 msgstr "Шлях правого (3-го) елемента недійсний!"
 
 #. IDS_OPEN_BOTHINVALID
-#: Merge.rc:4762
+#: Merge.rc:4761
 msgid "Both paths are invalid!"
 msgstr "Обидва шляхи недійсні!"
 
-#: Merge.rc:4764
+#: Merge.rc:4763
 msgid "Left (1st) and Middle (2nd) paths are invalid!"
 msgstr "Шляхи лівого (1-го) та середнього (2-го) елементів недійсні!"
 
 #. IDS_OPEN_LEFTRIGHTINVALID
-#: Merge.rc:4765
+#: Merge.rc:4764
 msgid "Left (1st) and Right (3rd) paths are invalid!"
 msgstr "Шляхи лівого (1-го) та правого (3-го) елементів недійсні!"
 
-#: Merge.rc:4767
+#: Merge.rc:4766
 msgid "Middle (2nd) and Right (3rd) paths are invalid!"
 msgstr "Шляхи середнього (2-го) та правого (3-го) елементів недійсні!"
 
 #. IDS_OPEN_ALLINVALID
-#: Merge.rc:4768
+#: Merge.rc:4767
 msgid "All paths are invalid!"
 msgstr "Всі шляхи недійсні!"
 
 #. IDS_OPEN_UNPACKERDISABLED
-#: Merge.rc:4769
+#: Merge.rc:4768
 msgid "Only enabled for file comparisons"
 msgstr "Доступно лише для порівняння файлів"
 
 #. IDS_OPEN_MISMATCH
-#: Merge.rc:4770
+#: Merge.rc:4769
 msgid "Cannot compare file and folder!"
 msgstr "Неможливе порівняння файлу і папки!"
 
 #. IDS_ERROR_FILE_NOT_FOUND
-#: Merge.rc:4776
+#: Merge.rc:4775
 #, c-format
 msgid "File not found: %1"
 msgstr "Файл не знайдений: %1"
 
 #. IDS_ERROR_FOLDER_NOT_FOUND
-#: Merge.rc:4777
+#: Merge.rc:4776
 #, c-format
 msgid "Folder not found: %1"
 msgstr ""
 
 #. IDS_ERROR_FILE_NOT_UNPACKED
-#: Merge.rc:4778
+#: Merge.rc:4777
 #, c-format
 msgid "File not unpacked: %1"
 msgstr "Файл не розпакований: %1"
 
 #. IDS_ERROR_FILEOPEN
-#: Merge.rc:4779
+#: Merge.rc:4778
 #, c-format
 msgid ""
 "Cannot open file\n"
@@ -5986,12 +5981,12 @@ msgstr ""
 "%2"
 
 #. IDS_ERROR_CONF_RESOLVE
-#: Merge.rc:4780
+#: Merge.rc:4779
 msgid "Failed to parse conflict file."
 msgstr "Не вдалося розібрати файл конфліктів."
 
 #. IDS_NOT_CONFLICT_FILE
-#: Merge.rc:4781
+#: Merge.rc:4780
 #, c-format
 msgid ""
 "The file\n"
@@ -6003,7 +5998,7 @@ msgstr ""
 "не є файлом конфліктів."
 
 #. IDS_COMPARE_LARGE_FILES
-#: Merge.rc:4782
+#: Merge.rc:4781
 msgid ""
 "Comparing large files requires significant memory.\n"
 "Show only comparison results (not file contents)?"
@@ -6012,28 +6007,28 @@ msgstr ""
 "Показати лише результати порівняння (без вмісту файлів)?"
 
 #. IDS_SAVE_AS_TITLE
-#: Merge.rc:4788
+#: Merge.rc:4787
 msgid "Save As"
 msgstr "Зберегти як"
 
 #. IDS_SAVE_FMT
-#: Merge.rc:4789
+#: Merge.rc:4788
 #, c-format
 msgid "Save changes to %1?"
 msgstr "Зберегти зміни в %1?"
 
 #. IDS_SAVEREADONLY_FMT
-#: Merge.rc:4790
+#: Merge.rc:4789
 #, c-format
 msgid "%1 is read-only. Override? Or 'No' to save as new filename?"
 msgstr "%1 позначений як лише для читання. Чи згодні ви замінити цей файл? (Не дозволяє вказати нове ім'я файлу)"
 
 #. IDS_ERROR_BACKUP
-#: Merge.rc:4791
+#: Merge.rc:4790
 msgid "Error backing up file"
 msgstr "Помилка створення резервної копії"
 
-#: Merge.rc:4793
+#: Merge.rc:4792
 #, c-format
 msgid ""
 "Unable to backup original file:\n"
@@ -6047,7 +6042,7 @@ msgstr ""
 "Продовжити в будь-якому випадку?"
 
 #. IDS_FILESAVE_FAILED
-#: Merge.rc:4794
+#: Merge.rc:4793
 #, c-format
 msgid ""
 "Saving file failed.\n"
@@ -6063,7 +6058,7 @@ msgstr ""
 "\t- використати інше ім'я файлу (Натисніть OК)\n"
 "\t- скасувати поточну операцію (Натисніть Скасувати)?"
 
-#: Merge.rc:4796
+#: Merge.rc:4795
 #, c-format
 msgid ""
 "Plugin '%2' cannot pack changes to left file into '%1'.\n"
@@ -6074,7 +6069,7 @@ msgstr ""
 "\n"
 "Оригінал не змінено. Зберегти розпаковану версію?"
 
-#: Merge.rc:4798
+#: Merge.rc:4797
 #, c-format
 msgid ""
 "Plugin '%2' cannot pack changes to middle file into '%1'.\n"
@@ -6085,7 +6080,7 @@ msgstr ""
 "\n"
 "Оригінал не змінено. Зберегти розпаковану версію?"
 
-#: Merge.rc:4800
+#: Merge.rc:4799
 #, c-format
 msgid ""
 "Plugin '%2' cannot pack changes to right file into '%1'.\n"
@@ -6097,7 +6092,7 @@ msgstr ""
 "Оригінал не змінено. Зберегти розпаковану версію?"
 
 #. IDS_FILECHANGED_ONDISK
-#: Merge.rc:4801
+#: Merge.rc:4800
 #, c-format
 msgid ""
 "Another application updated\n"
@@ -6113,7 +6108,7 @@ msgstr ""
 "Перезаписати змінений файл?"
 
 #. IDS_SAVEREADONLY_MULTI
-#: Merge.rc:4802
+#: Merge.rc:4801
 #, c-format
 msgid ""
 "%1\n"
@@ -6121,7 +6116,7 @@ msgid ""
 msgstr "%1 позначений як лише для читання. Чи згодні ви замінити цей файл?"
 
 #. IDS_FILECHANGED_RESCAN
-#: Merge.rc:4803
+#: Merge.rc:4802
 #, c-format
 msgid ""
 "Another application updated\n"
@@ -6137,22 +6132,22 @@ msgstr ""
 "Ви хочете перезавантажити файл?"
 
 #. IDS_SAVE_LEFT_AS
-#: Merge.rc:4804
+#: Merge.rc:4803
 msgid "Save Left File As"
 msgstr "Зберегти лівий файл як"
 
 #. IDS_SAVE_MIDDLE_AS
-#: Merge.rc:4805
+#: Merge.rc:4804
 msgid "Save Middle File As"
 msgstr "Зберегти файл в центрі як"
 
 #. IDS_SAVE_RIGHT_AS
-#: Merge.rc:4806
+#: Merge.rc:4805
 msgid "Save Right File As"
 msgstr "Зберегти правий файл як"
 
 #. IDS_FILE_DISAPPEARED
-#: Merge.rc:4811
+#: Merge.rc:4810
 #, c-format
 msgid ""
 "File\n"
@@ -6164,7 +6159,7 @@ msgstr ""
 "вилучається. Збережіть копію файлу для продовження."
 
 #. IDS_VIEWS_OUTOFSYNC
-#: Merge.rc:4817
+#: Merge.rc:4816
 msgid ""
 "Cannot merge unsynched documents.\n"
 "\n"
@@ -6175,186 +6170,186 @@ msgstr ""
 "Оновіть документи перед продовженням."
 
 #. IDS_BREAK_ON_WHITESPACE
-#: Merge.rc:4822
+#: Merge.rc:4821
 msgid "Break at whitespace"
 msgstr "Розбивати за пропусками"
 
 #. IDS_BREAK_ON_PUNCTUATION
-#: Merge.rc:4823
+#: Merge.rc:4822
 msgid "Break at whitespace or punctuation"
 msgstr "Розбивати за пропусками і символами пунктуації"
 
 #. IDS_L2M
-#: Merge.rc:4829
+#: Merge.rc:4828
 msgid "Copy to &Middle\tAlt+Right"
 msgstr "Копіювати в &центр\tAlt+Right"
 
 #. IDS_R2M
-#: Merge.rc:4830
+#: Merge.rc:4829
 msgid "Copy to &Middle\tAlt+Left"
 msgstr "Копіювати в &центр\tAlt+Left"
 
 #. IDS_COPY_FROM_MIDDLE_R
-#: Merge.rc:4831
+#: Merge.rc:4830
 msgid "Copy from Middle\tAlt+Shift+Right"
 msgstr "Копіювати з центру\tAlt+Shift+Right"
 
 #. IDS_COPY_FROM_MIDDLE_L
-#: Merge.rc:4832
+#: Merge.rc:4831
 msgid "Copy from Middle\tAlt+Shift+Left"
 msgstr "Копіювати з центру\tAlt+Shift+Left"
 
 #. IDS_L2MNEXT
-#: Merge.rc:4833
+#: Merge.rc:4832
 msgid "Copy to Middle and Advance\tCtrl+Alt+Right"
 msgstr "Копіювати в центр і перейти далі\tCtrl+Alt+Right"
 
 #. IDS_R2MNEXT
-#: Merge.rc:4834
+#: Merge.rc:4833
 msgid "Copy to Middle and Advance\tCtrl+Alt+Left"
 msgstr "Копіювати в центр і перейти далі\tCtrl+Alt+Left"
 
 #. IDS_ALL_MIDDLE
-#: Merge.rc:4835
+#: Merge.rc:4834
 msgid "Copy All to Middle"
 msgstr "Копіювати все в центр"
 
 #. IDS_COPY_RIGHT_TO_LEFT
-#: Merge.rc:4841
+#: Merge.rc:4840
 #, c-format
 msgid "Right to Left (%1)"
 msgstr "Скопіювати на ліву сторону %1 з %2 вибраних елементів"
 
 #. IDS_COPY_RIGHT_TO_MIDDLE
-#: Merge.rc:4842
+#: Merge.rc:4841
 #, c-format
 msgid "Right to Middle (%1)"
 msgstr "Справа в центр (%1)"
 
 #. IDS_COPY_MIDDLE_TO_LEFT
-#: Merge.rc:4843
+#: Merge.rc:4842
 #, c-format
 msgid "Middle to Left (%1)"
 msgstr "З центру в ліво (%1)"
 
 #. IDS_COPY_MIDDLE_TO_RIGHT
-#: Merge.rc:4844
+#: Merge.rc:4843
 #, c-format
 msgid "Middle to Right (%1)"
 msgstr "З центру вправо (%1)"
 
 #. IDS_COPY_LEFT_TO_RIGHT
-#: Merge.rc:4845
+#: Merge.rc:4844
 #, c-format
 msgid "Left to Right (%1)"
 msgstr "Скопіювати на праву сторону %1 з %2 вибраних елементів"
 
 #. IDS_COPY_LEFT_TO_MIDDLE
-#: Merge.rc:4846
+#: Merge.rc:4845
 #, c-format
 msgid "Left to Middle (%1)"
 msgstr "Зліва в центр (%1)"
 
 #. IDS_MOVE_LEFT_TO
-#: Merge.rc:4857 Merge.rc:4889
+#: Merge.rc:4856 Merge.rc:4888
 #, c-format
 msgid "Left to... (%1)"
 msgstr "Зліва в... (%1)"
 
 #. IDS_MOVE_MIDDLE_TO
-#: Merge.rc:4858 Merge.rc:4890
+#: Merge.rc:4857 Merge.rc:4889
 #, c-format
 msgid "Middle to... (%1)"
 msgstr "З центру в... (%1)"
 
 #. IDS_MOVE_RIGHT_TO
-#: Merge.rc:4859 Merge.rc:4891
+#: Merge.rc:4858 Merge.rc:4890
 #, c-format
 msgid "Right to... (%1)"
 msgstr "Справа в... (%1)"
 
 #. IDS_COPY_BOTH_TO
-#: Merge.rc:4860
+#: Merge.rc:4859
 #, c-format
 msgid "Both to... (%1)"
 msgstr "Обидва в... (%1)"
 
 #. IDS_COPY_ALL_TO
-#: Merge.rc:4861
+#: Merge.rc:4860
 #, c-format
 msgid "All to... (%1)"
 msgstr "Усі в... (%1)"
 
 #. IDS_COPY_DIFFERENCES_TO
-#: Merge.rc:4862
+#: Merge.rc:4861
 #, c-format
 msgid "Differences to... (%1)"
 msgstr "Відмінності в... (%1)"
 
 #. IDS_ONLYDIFFITEMS_CONFIRM
-#: Merge.rc:4869
+#: Merge.rc:4868
 msgid "Some selected items are identical or skipped.\nProcess only items with differences?"
 msgstr ""
 
 #. IDS_DEL_LEFT_FMT
-#: Merge.rc:4875
+#: Merge.rc:4874
 #, c-format
 msgid "Left (%1)"
 msgstr "Ліворуч (%1)"
 
 #. IDS_DEL_MIDDLE_FMT
-#: Merge.rc:4876
+#: Merge.rc:4875
 #, c-format
 msgid "Middle (%1)"
 msgstr "В центр (%1)"
 
 #. IDS_DEL_RIGHT_FMT
-#: Merge.rc:4877
+#: Merge.rc:4876
 #, c-format
 msgid "Right (%1)"
 msgstr "Праворуч (%1)"
 
 #. IDS_DEL_BOTH_FMT
-#: Merge.rc:4878
+#: Merge.rc:4877
 #, c-format
 msgid "Both (%1)"
 msgstr "Обидва (%1)"
 
 #. IDS_DEL_ALL_FMT
-#: Merge.rc:4879
+#: Merge.rc:4878
 #, c-format
 msgid "All (%1)"
 msgstr "Усе (%1)"
 
 #. IDS_SELECT_DEST_LEFT
-#: Merge.rc:4895
+#: Merge.rc:4894
 msgid "Left Side - Select Destination Folder:"
 msgstr "Ліва сторона - вибір теки призначення:"
 
 #. IDS_SELECT_DEST_MIDDLE
-#: Merge.rc:4896
+#: Merge.rc:4895
 msgid "Middle Side - Select Destination Folder:"
 msgstr "Центральна сторона - вибір папки призначення:"
 
 #. IDS_SELECT_DEST_RIGHT
-#: Merge.rc:4897
+#: Merge.rc:4896
 msgid "Right Side - Select Destination Folder:"
 msgstr "Права сторона - вибір теки призначення:"
 
 #. IDS_FILES_AFFECTED_FMT
-#: Merge.rc:4898
+#: Merge.rc:4897
 #, c-format
 msgid "(%1 Files Affected)"
 msgstr "(%1 файлів опрацьовані)"
 
 #. IDS_FILES_AFFECTED_FMT2
-#: Merge.rc:4899
+#: Merge.rc:4898
 #, c-format
 msgid "(%1 of %2 Files Affected)"
 msgstr "(%1 з %2 файлів опрацьовані)"
 
 #. IDS_CONFIRM_DELETE_SINGLE
-#: Merge.rc:4905
+#: Merge.rc:4904
 #, c-format
 msgid ""
 "Are you sure you want to delete\n"
@@ -6366,18 +6361,18 @@ msgstr ""
 "%1 ?"
 
 #. IDS_CONFIRM_SINGLE_COPY
-#: Merge.rc:4906
+#: Merge.rc:4905
 msgid "Are you sure you want to copy?"
 msgstr "Ви впевнені, що хочете скопіювати?"
 
 #. IDS_CONFIRM_MULTIPLE_COPY
-#: Merge.rc:4907
+#: Merge.rc:4906
 #, c-format
 msgid "Are you sure you want to copy %d items?"
 msgstr "Ви впевнені, що хочете скопіювати %d елементів?"
 
 #. IDS_DIRCMP_NOTSYNC
-#: Merge.rc:4908
+#: Merge.rc:4907
 #, c-format
 msgid ""
 "Operation aborted!\n"
@@ -6397,46 +6392,46 @@ msgstr ""
 "Оновіть порівняння."
 
 #. IDS_CONFIRM_SINGLE_MOVE
-#: Merge.rc:4913
+#: Merge.rc:4912
 msgid "Are you sure you want to move?"
 msgstr "Ви дійсно хочете перемістити?"
 
 #. IDS_CONFIRM_MULTIPLE_MOVE
-#: Merge.rc:4914
+#: Merge.rc:4913
 #, c-format
 msgid "Are you sure you want to move %d items?"
 msgstr "Ви дійсно хочете перемістити %d елементів?"
 
 #. IDS_CONFIRM_MOVE_CAPTION
-#: Merge.rc:4916
+#: Merge.rc:4915
 msgid "Confirm Move"
 msgstr "Підтвердження переміщення"
 
-#: Merge.rc:4918
+#: Merge.rc:4917
 msgid "Close the folder comparison window?"
 msgstr "Закрити вікно порівняння папок?"
 
-#: Merge.rc:4920
+#: Merge.rc:4919
 msgid "Close the folder comparison window, which took a long time?"
 msgstr "Закрити вікно порівняння папок, яке зайняло багато часу?"
 
 #. IDS_ERROR_INVALID_DIR_FILE_NAME
-#: Merge.rc:4921
+#: Merge.rc:4920
 msgid "The file or folder name is invalid."
 msgstr "Ім'я файлу або папки неприпустиме."
 
 #. IDS_ERROR_EXECUTE_FILE
-#: Merge.rc:4927
+#: Merge.rc:4926
 #, c-format
 msgid "Failed to execute external editor: %1"
 msgstr "Неможливо виконати %1"
 
 #. IDS_UNKNOWN_ARCHIVE_FORMAT
-#: Merge.rc:4933
+#: Merge.rc:4932
 msgid "Unknown archive format"
 msgstr "Невідомий формат архіву"
 
-#: Merge.rc:4935
+#: Merge.rc:4934
 msgid ""
 "Failed to extract archive.\n"
 "Compare as text file?"
@@ -6445,747 +6440,747 @@ msgstr ""
 "Порівняти як текстовий файл?"
 
 #. IDS_COLHDR_FILENAME
-#: Merge.rc:4941
+#: Merge.rc:4940
 msgid "Filename"
 msgstr "Ім'я файлу"
 
 #. IDS_COLHDR_DIR
-#: Merge.rc:4942
+#: Merge.rc:4941
 msgctxt "DirView|ColumnHeader"
 msgid "Folder"
 msgstr "Папка"
 
 #. IDS_COLHDR_RESULT
-#: Merge.rc:4943
+#: Merge.rc:4942
 msgid "Comparison Result"
 msgstr "Результат порівняння"
 
 #. IDS_COLHDR_LTIMEM
-#: Merge.rc:4944
+#: Merge.rc:4943
 msgid "Left Date"
 msgstr "Дата ліворуч"
 
 #. IDS_COLHDR_RTIMEM
-#: Merge.rc:4945
+#: Merge.rc:4944
 msgid "Right Date"
 msgstr "Дата праворуч"
 
 #. IDS_COLHDR_MTIMEM
-#: Merge.rc:4946
+#: Merge.rc:4945
 msgid "Middle Date"
 msgstr "Дата в центрі"
 
 #. IDS_COLHDR_LSIZE
-#: Merge.rc:4948
+#: Merge.rc:4947
 msgid "Left Size"
 msgstr "Розмір ліворуч"
 
 #. IDS_COLHDR_RSIZE
-#: Merge.rc:4949
+#: Merge.rc:4948
 msgid "Right Size"
 msgstr "Розмір праворуч"
 
 #. IDS_COLHDR_MSIZE
-#: Merge.rc:4954
+#: Merge.rc:4953
 msgid "Middle Size"
 msgstr "Розмір в центрі"
 
 #. IDS_COLHDR_RSIZE_SHORT
-#: Merge.rc:4955
+#: Merge.rc:4954
 msgid "Right Size (Short)"
 msgstr "Розмір праворуч (скор.)"
 
 #. IDS_COLHDR_LSIZE_SHORT
-#: Merge.rc:4956
+#: Merge.rc:4955
 msgid "Left Size (Short)"
 msgstr "Розмір ліворуч (скор.)"
 
 #. IDS_COLHDR_MSIZE_SHORT
-#: Merge.rc:4957
+#: Merge.rc:4956
 msgid "Middle Size (Short)"
 msgstr "Розмір в центрі (скор.)"
 
 #. IDS_COLHDR_LTIMEC
-#: Merge.rc:4963
+#: Merge.rc:4962
 msgid "Left Creation Time"
 msgstr "Час створення файлу ліворуч"
 
 #. IDS_COLHDR_RTIMEC
-#: Merge.rc:4964
+#: Merge.rc:4963
 msgid "Right Creation Time"
 msgstr "Час створення файлу праворуч"
 
 #. IDS_COLHDR_MTIMEC
-#: Merge.rc:4965
+#: Merge.rc:4964
 msgid "Middle Creation Time"
 msgstr "Час створення в центрі"
 
 #. IDS_COLHDR_NEWER
-#: Merge.rc:4966
+#: Merge.rc:4965
 msgid "Newer File"
 msgstr "Новіший файл"
 
 #. IDS_COLHDR_LVERSION
-#: Merge.rc:4967
+#: Merge.rc:4966
 msgid "Left File Version"
 msgstr "Версія файлу ліворуч"
 
 #. IDS_COLHDR_RVERSION
-#: Merge.rc:4968
+#: Merge.rc:4967
 msgid "Right File Version"
 msgstr "Версія файлу праворуч"
 
 #. IDS_COLHDR_MVERSION
-#: Merge.rc:4969
+#: Merge.rc:4968
 msgid "Middle File Version"
 msgstr "Версія файлу в центрі"
 
 #. IDS_COLHDR_RESULT_ABBR
-#: Merge.rc:4970
+#: Merge.rc:4969
 msgid "Short Result"
 msgstr "Спрощений результат"
 
 #. IDS_COLHDR_LATTRIBUTES
-#: Merge.rc:4971
+#: Merge.rc:4970
 msgid "Left Attributes"
 msgstr "Атрибути файлу ліворуч"
 
 #. IDS_COLHDR_RATTRIBUTES
-#: Merge.rc:4972
+#: Merge.rc:4971
 msgid "Right Attributes"
 msgstr "Атрибути файлу праворуч"
 
 #. IDS_COLHDR_MATTRIBUTES
-#: Merge.rc:4973
+#: Merge.rc:4972
 msgid "Middle Attributes"
 msgstr "Атрибути в центрі"
 
 #. IDS_COLHDR_LEOL_TYPE
-#: Merge.rc:4978
+#: Merge.rc:4977
 msgid "Left EOL"
 msgstr "Символ завершення рядка зліва"
 
 #. IDS_COLHDR_MEOL_TYPE
-#: Merge.rc:4979
+#: Merge.rc:4978
 msgid "Middle EOL"
 msgstr "Символ завершення рядка в центрі"
 
 #. IDS_COLHDR_REOL_TYPE
-#: Merge.rc:4980
+#: Merge.rc:4979
 msgid "Right EOL"
 msgstr "Символ завершення рядка справа"
 
 #. IDS_COLHDR_LENCODING
-#: Merge.rc:4986
+#: Merge.rc:4985
 msgid "Left Encoding"
 msgstr "Кодування файлу зліва"
 
 #. IDS_COLHDR_RENCODING
-#: Merge.rc:4987
+#: Merge.rc:4986
 msgid "Right Encoding"
 msgstr "Кодування файлу справа"
 
 #. IDS_COLHDR_MENCODING
-#: Merge.rc:4988
+#: Merge.rc:4987
 msgid "Middle Encoding"
 msgstr "Кодування файлу в центрі"
 
 #. IDS_COLHDR_NIDIFFS
-#: Merge.rc:4989
+#: Merge.rc:4988
 msgid "Ignored Diff"
 msgstr "Знех. відмінності"
 
 #. IDS_COLHDR_BINARY
-#: Merge.rc:4991
+#: Merge.rc:4990
 msgctxt "DirView|ColumnHeader"
 msgid "Binary"
 msgstr "Двійковий"
 
 #. IDS_PLUGINS_TYPE_UNPACKER
-#: Merge.rc:4992 Merge.rc:5314
+#: Merge.rc:4991 Merge.rc:5313
 msgid "Unpacker"
 msgstr "Розпакувальник"
 
 #. IDS_PLUGIN_TYPE4
-#: Merge.rc:4993 Merge.rc:5315 Merge.rc:5622
+#: Merge.rc:4992 Merge.rc:5314 Merge.rc:5621
 msgid "Prediffer"
 msgstr "Попередній порівнювач"
 
 #. IDS_COLHDR_LEFT
-#: Merge.rc:4994
+#: Merge.rc:4993
 msgid "Left"
 msgstr "Зліва"
 
 #. IDS_COLHDR_MIDDLE
-#: Merge.rc:4995
+#: Merge.rc:4994
 msgid "Middle"
 msgstr "В центрі"
 
 #. IDS_COLHDR_RIGHT
-#: Merge.rc:4996
+#: Merge.rc:4995
 msgid "Right"
 msgstr "Справа"
 
 #. IDS_COLHDR_DIFF
-#: Merge.rc:4997
+#: Merge.rc:4996
 msgid "Diff"
 msgstr "Відмінність"
 
 #. IDS_COLHDR_LEFT_DUPLICATE
-#: Merge.rc:4998
+#: Merge.rc:4997
 msgid "Left Duplicate Count"
 msgstr "Кількість дублікатів зліва"
 
 #. IDS_COLHDR_RIGHT_DUPLICATE
-#: Merge.rc:4999
+#: Merge.rc:4998
 msgid "Right Duplicate Count"
 msgstr "Кількість дублікатів справа"
 
 #. IDS_COLHDR_MIDDLE_DUPLICATE
-#: Merge.rc:5000
+#: Merge.rc:4999
 msgid "Middle Duplicate Count"
 msgstr "Кількість дублікатів в центрі"
 
 #. IDS_COLHDR_MOVE
-#: Merge.rc:5001
+#: Merge.rc:5000
 msgid "Move"
 msgstr "Перемістити"
 
 #. IDS_PRPCAT_AUDIO
-#: Merge.rc:5008
+#: Merge.rc:5007
 msgid "Audio"
 msgstr "Аудіо"
 
 #. IDS_PRPCAT_CALENDAR
-#: Merge.rc:5009
+#: Merge.rc:5008
 msgid "Calendar"
 msgstr "Календар"
 
 #. IDS_PRPCAT_COMMUNICATION
-#: Merge.rc:5010
+#: Merge.rc:5009
 msgid "Communication"
 msgstr "Комунікація"
 
 #. IDS_PRPCAT_CONTACT
-#: Merge.rc:5011
+#: Merge.rc:5010
 msgid "Contact"
 msgstr "Контакт"
 
 #. IDS_PRPCAT_DEVICES
-#: Merge.rc:5012
+#: Merge.rc:5011
 msgid "Devices"
 msgstr "Пристрої"
 
 #. IDS_PRPCAT_DOCUMENT
-#: Merge.rc:5013
+#: Merge.rc:5012
 msgid "Document"
 msgstr "Документ"
 
 #. IDS_PRPCAT_HOME
-#: Merge.rc:5014
+#: Merge.rc:5013
 msgid "Home"
 msgstr "Домівка"
 
 #. IDS_PRPCAT_JOURNAL
-#: Merge.rc:5016
+#: Merge.rc:5015
 msgid "Journal"
 msgstr "Журнал"
 
 #. IDS_PRPCAT_LINK
-#: Merge.rc:5017
+#: Merge.rc:5016
 msgid "Link"
 msgstr "Посилання"
 
 #. IDS_PRPCAT_MEDIA
-#: Merge.rc:5018
+#: Merge.rc:5017
 msgid "Media"
 msgstr "Медіа"
 
 #. IDS_PRPCAT_MUSIC
-#: Merge.rc:5020
+#: Merge.rc:5019
 msgid "Music"
 msgstr "Музика"
 
 #. IDS_PRPCAT_NOTE
-#: Merge.rc:5021
+#: Merge.rc:5020
 msgid "Note"
 msgstr "Нотатка"
 
 #. IDS_PRPCAT_PHOTO
-#: Merge.rc:5022
+#: Merge.rc:5021
 msgid "Photo"
 msgstr "Фото"
 
 #. IDS_PRPCAT_RECORDEDTV
-#: Merge.rc:5023
+#: Merge.rc:5022
 msgid "RecordedTV"
 msgstr "Записане ТВ"
 
 #. IDS_PRPCAT_SEARCH
-#: Merge.rc:5024
+#: Merge.rc:5023
 msgid "Search"
 msgstr "Пошук"
 
 #. IDS_PRPCAT_SECURITY
-#: Merge.rc:5025
+#: Merge.rc:5024
 msgid "Security"
 msgstr "Безпека"
 
 #. IDS_PRPCAT_SOFTWARE
-#: Merge.rc:5026
+#: Merge.rc:5025
 msgid "Software"
 msgstr "Програмне забезпечення"
 
 #. IDS_PRPCAT_TASK
-#: Merge.rc:5027
+#: Merge.rc:5026
 msgid "Task"
 msgstr "Завдання"
 
 #. IDS_PRPCAT_VIDEO
-#: Merge.rc:5028
+#: Merge.rc:5027
 msgid "Video"
 msgstr "Відео"
 
 #. IDS_PRPCAT_HASH
-#: Merge.rc:5029
+#: Merge.rc:5028
 msgid "Hash"
 msgstr "Хеш"
 
 #. IDS_CANT_COMPARE_FILES
-#: Merge.rc:5035
+#: Merge.rc:5034
 msgid "Unable to compare files"
 msgstr "Неможливо порівняти файли"
 
 #. IDS_ABORTED_ITEM
-#: Merge.rc:5036
+#: Merge.rc:5035
 msgid "Item aborted"
 msgstr "Порівняння перерване"
 
 #. IDS_FILE_SKIPPED
-#: Merge.rc:5037
+#: Merge.rc:5036
 msgid "File skipped"
 msgstr "Файл пропущений"
 
 #. IDS_DIR_SKIPPED
-#: Merge.rc:5038
+#: Merge.rc:5037
 msgid "Folder skipped"
 msgstr "Папка пропущена"
 
 #. IDS_LEFT_ONLY_IN_FMT
-#: Merge.rc:5039
+#: Merge.rc:5038
 #, c-format
 msgid "Left only: %1"
 msgstr "Лише ліворуч: %1"
 
 #. IDS_MIDDLE_ONLY_IN_FMT
-#: Merge.rc:5040
+#: Merge.rc:5039
 #, c-format
 msgid "Middle only: %1"
 msgstr "Лише в центрі: %1"
 
 #. IDS_RIGHT_ONLY_IN_FMT
-#: Merge.rc:5041
+#: Merge.rc:5040
 #, c-format
 msgid "Right only: %1"
 msgstr "Лише праворуч: %1"
 
 #. IDS_DOES_NOT_EXIST_IN_FMT
-#: Merge.rc:5042
+#: Merge.rc:5041
 #, c-format
 msgid "Does not exist in %1"
 msgstr "Не існує в %1"
 
 #. IDS_BIN_FILES_SAME
-#: Merge.rc:5043
+#: Merge.rc:5042
 msgid "Binary files are identical"
 msgstr "Двійкові файли ідентичні"
 
 #. IDS_BIN_FILES_DIFF
-#: Merge.rc:5049
+#: Merge.rc:5048
 msgid "Binary files are different"
 msgstr "Двійкові файли відрізняються"
 
 #. IDS_FILES_ARE_DIFFERENT
-#: Merge.rc:5050
+#: Merge.rc:5049
 msgid "Files are different"
 msgstr "Файли відрізняються"
 
 #. IDS_FOLDERS_ARE_DIFFERENT
-#: Merge.rc:5051
+#: Merge.rc:5050
 msgid "Folders are different"
 msgstr "Теки різні"
 
 #. IDS_LEFTONLY
-#: Merge.rc:5052
+#: Merge.rc:5051
 msgid "Left Only"
 msgstr "Лише ліворуч"
 
 #. IDS_RIGHTONLY
-#: Merge.rc:5053
+#: Merge.rc:5052
 msgid "Right Only"
 msgstr "Лише праворуч"
 
 #. IDS_MIDDLEONLY
-#: Merge.rc:5054
+#: Merge.rc:5053
 msgid "Middle Only"
 msgstr "Лише в центрі"
 
 #. IDS_NOITEMLEFT
-#: Merge.rc:5055
+#: Merge.rc:5054
 msgid "No item in left"
 msgstr "Немає елемента ліворуч"
 
 #. IDS_NOITEMRIGHT
-#: Merge.rc:5056
+#: Merge.rc:5055
 msgid "No item in right"
 msgstr "Немає елемента праворуч"
 
 #. IDS_NOITEMMIDDLE
-#: Merge.rc:5057
+#: Merge.rc:5056
 msgid "No item in middle"
 msgstr "Немає елемента в центрі"
 
 #. IDS_CMPRES_ERROR
-#: Merge.rc:5059
+#: Merge.rc:5058
 msgid "Error"
 msgstr "Помилка"
 
 #. IDS_TEXT_FILES_SAME
-#: Merge.rc:5060
+#: Merge.rc:5059
 msgid "Text files are identical"
 msgstr "Текстові файли однакові"
 
 #. IDS_LEFTONLY_DIFF
-#: Merge.rc:5061
+#: Merge.rc:5060
 msgid " (Middle and right are identical)"
 msgstr " (У центрі та справа однакові)"
 
 #. IDS_MIDDLEONLY_DIFF
-#: Merge.rc:5062
+#: Merge.rc:5061
 msgid " (Left and right are identical)"
 msgstr " (Зліва та справа однакові)"
 
 #. IDS_RIGHTONLY_DIFF
-#: Merge.rc:5063
+#: Merge.rc:5062
 msgid " (Left and middle are identical)"
 msgstr " (Зліва та У центрі однакові)"
 
 #. IDS_PATH_MISMATCH
-#: Merge.rc:5064
+#: Merge.rc:5063
 msgid " (paths differ)"
 msgstr ""
 
 #. IDS_TEXT_FILES_DIFF
-#: Merge.rc:5065
+#: Merge.rc:5064
 msgid "Text files are different"
 msgstr "Текстові файли різні"
 
 #. IDS_IMAGE_FILES_SAME
-#: Merge.rc:5066
+#: Merge.rc:5065
 msgid "Image files are identical"
 msgstr "Файли зображень однакові"
 
 #. IDS_IMAGE_FILES_DIFF
-#: Merge.rc:5067
+#: Merge.rc:5066
 msgid "Image files are different"
 msgstr "Файли зображень відрузняються"
 
 #. IDS_EXPR_DIFF
-#: Merge.rc:5068
+#: Merge.rc:5067
 #, c-format
 msgid "Files are different (expr: %1)"
 msgstr "Файли відрузняються (вираз: %1)"
 
 #. IDS_HASH_GROUP
-#: Merge.rc:5069
+#: Merge.rc:5068
 #, c-format
 msgid "Group%d"
 msgstr "Група%d"
 
 #. IDS_RENAME_MOVE_DETECTION_DISALBED
-#: Merge.rc:5070
+#: Merge.rc:5069
 msgctxt "Options dialog|Compare|Folder|Detect renames and moves"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_RENAME_MOVE_DETECTION_RENAME
-#: Merge.rc:5071
+#: Merge.rc:5070
 msgid "Detect renames"
 msgstr ""
 
 #. IDS_RENAME_MOVE_DETECTION_RENAME_MOVE
-#: Merge.rc:5072
+#: Merge.rc:5071
 msgid "Detect renames and moves"
 msgstr ""
 
 #. IDS_RENAME_MOVE_MERGE_MODE_RENAME
-#: Merge.rc:5073
+#: Merge.rc:5072
 msgid "Merge renames"
 msgstr ""
 
 #. IDS_RENAME_MOVE_MERGE_MODE_RENAME_MOVE
-#: Merge.rc:5074
+#: Merge.rc:5073
 msgid "Merge renames and moves"
 msgstr ""
 
 #. IDS_RENAMED
-#: Merge.rc:5075
+#: Merge.rc:5074
 msgid "Renamed"
 msgstr ""
 
 #. IDS_RENAMED_MOVED
-#: Merge.rc:5077
+#: Merge.rc:5076
 msgid "Renamed/Moved"
 msgstr ""
 
 #. IDS_RENAMED_MOVED_ITEMS
-#: Merge.rc:5078
+#: Merge.rc:5077
 #, c-format
 msgid "(%1 items)"
 msgstr ""
 
 #. IDS_RENAMED_MOVED_RESULT
-#: Merge.rc:5079
+#: Merge.rc:5078
 #, c-format
 msgid "%1 (set %2): "
 msgstr ""
 
 #. IDS_SWITCH_FLAT_MODE
-#: Merge.rc:5080
+#: Merge.rc:5079
 msgid "Some moved items have been merged.\nIn Tree Mode, these items may appear in positions that do not reflect the actual folder structure, which can be confusing.\nSwitch to Flat Mode?"
 msgstr ""
 
 #. IDS_ELAPSED_TIME
-#: Merge.rc:5086
+#: Merge.rc:5085
 #, c-format
 msgid "Elapsed time: %ld ms"
 msgstr "Витрачений час: %ld мс"
 
 #. IDS_STATUS_SELITEM1
-#: Merge.rc:5087
+#: Merge.rc:5086
 msgid "1 item selected"
 msgstr "Вибраний 1 елемент"
 
 #. IDS_STATUS_SELITEMS
-#: Merge.rc:5088
+#: Merge.rc:5087
 #, c-format
 msgid "%1 items selected"
 msgstr "Вибрані елементи: %1"
 
 #. IDS_COLDESC_FILENAME
-#: Merge.rc:5094
+#: Merge.rc:5093
 msgid "Filename or folder name."
 msgstr "Ім'я файлу або папки."
 
 #. IDS_COLDESC_DIR
-#: Merge.rc:5095
+#: Merge.rc:5094
 msgid "Subfolder name when subfolders are included."
 msgstr "Імена вкладених папок, якщо вкладені папки включені."
 
 #. IDS_COLDESC_RESULT
-#: Merge.rc:5096
+#: Merge.rc:5095
 msgid "Comparison result, long form."
 msgstr "Результат порівняння, довга форма."
 
 #. IDS_COLDESC_LTIMEM
-#: Merge.rc:5101
+#: Merge.rc:5100
 msgid "Left side modification date."
 msgstr "Дата змін з лівої сторони."
 
 #. IDS_COLDESC_RTIMEM
-#: Merge.rc:5102
+#: Merge.rc:5101
 msgid "Right side modification date."
 msgstr "Дата змін з правої сторони."
 
 #. IDS_COLDESC_MTIMEM
-#: Merge.rc:5103
+#: Merge.rc:5102
 msgid "Middle side modification date."
 msgstr "Дата змін у центрі."
 
 #. IDS_COLDESC_EXTENSION
-#: Merge.rc:5104
+#: Merge.rc:5103
 msgid "File's extension."
 msgstr "Розширення файлу."
 
 #. IDS_COLDESC_LSIZE
-#: Merge.rc:5105
+#: Merge.rc:5104
 msgid "Left file size in bytes."
 msgstr "Розмір лівого файлу у байтах."
 
 #. IDS_COLDESC_RSIZE
-#: Merge.rc:5106
+#: Merge.rc:5105
 msgid "Right file size in bytes."
 msgstr "Розмір правого файлу у байтах."
 
 #. IDS_COLDESC_MSIZE
-#: Merge.rc:5107
+#: Merge.rc:5106
 msgid "Middle file size in bytes."
 msgstr "Розмір файлу в центрі у байтах."
 
 #. IDS_COLDESC_LSIZE_SHORT
-#: Merge.rc:5108
+#: Merge.rc:5107
 msgid "Left file size abbreviated."
 msgstr "Розмір лівого файлу (скор.)"
 
 #. IDS_COLDESC_RSIZE_SHORT
-#: Merge.rc:5109
+#: Merge.rc:5108
 msgid "Right file size abbreviated."
 msgstr "Розмір правого файлу (скор.)"
 
 #. IDS_COLDESC_MSIZE_SHORT
-#: Merge.rc:5110
+#: Merge.rc:5109
 msgid "Middle file size abbreviated."
 msgstr "Скорочений розмір файлу в центрі."
 
 #. IDS_COLDESC_LTIMEC
-#: Merge.rc:5116
+#: Merge.rc:5115
 msgid "Left side creation time."
 msgstr "Час створення лівої сторони."
 
 #. IDS_COLDESC_RTIMEC
-#: Merge.rc:5117
+#: Merge.rc:5116
 msgid "Right side creation time."
 msgstr "Час створення правої сторони."
 
 #. IDS_COLDESC_MTIMEC
-#: Merge.rc:5118
+#: Merge.rc:5117
 msgid "Middle side creation time."
 msgstr "Час створення центаральної сторони."
 
 #. IDS_COLDESC_NEWER
-#: Merge.rc:5119
+#: Merge.rc:5118
 msgid "Tells which side has newer modification date."
 msgstr "Повідомляє, з якого боку зміни новіші."
 
 #. IDS_COLDESC_LVERSION
-#: Merge.rc:5120
+#: Merge.rc:5119
 msgid "Left side file version, only for some file types."
 msgstr "Версія файлу ліворуч, лише для деяких типів файлів."
 
 #. IDS_COLDESC_RVERSION
-#: Merge.rc:5121
+#: Merge.rc:5120
 msgid "Right side file version, only for some file types."
 msgstr "Версія файлу праворуч, лише для деяких типів файлів."
 
 #. IDS_COLDESC_MVERSION
-#: Merge.rc:5126
+#: Merge.rc:5125
 msgid "Middle side file version, only for some file types."
 msgstr "Версія файлу в центрі, лише для деяких типів файлів."
 
 #. IDS_COLDESC_RESULT_ABBR
-#: Merge.rc:5127
+#: Merge.rc:5126
 msgid "Short comparison result."
 msgstr "Результат швидкого порівняння."
 
 #. IDS_COLDESC_LATTRIBUTES
-#: Merge.rc:5128
+#: Merge.rc:5127
 msgid "Left side attributes."
 msgstr "Атрибути лівої сторони."
 
 #. IDS_COLDESC_RATTRIBUTES
-#: Merge.rc:5129
+#: Merge.rc:5128
 msgid "Right side attributes."
 msgstr "Атрибути правої сторони."
 
 #. IDS_COLDESC_MATTRIBUTES
-#: Merge.rc:5130
+#: Merge.rc:5129
 msgid "Middle side attributes."
 msgstr "Атрибути центру."
 
 #. IDS_COLDESC_LEOL_TYPE
-#: Merge.rc:5131
+#: Merge.rc:5130
 msgid "Left side file EOL type."
 msgstr "Позначка закінчення рядка для лівого файлу."
 
 #. IDS_COLDESC_REOL_TYPE
-#: Merge.rc:5132
+#: Merge.rc:5131
 msgid "Right side file EOL type."
 msgstr "Позначка закінчення рядка для правого файлу."
 
 #. IDS_COLDESC_MEOL_TYPE
-#: Merge.rc:5133
+#: Merge.rc:5132
 msgid "Middle side file EOL type."
 msgstr "Позначка закінчення рядка для файлу в центрі."
 
 #. IDS_COLDESC_LENCODING
-#: Merge.rc:5139
+#: Merge.rc:5138
 msgid "Left side encoding."
 msgstr "Кодування лівої сторони."
 
 #. IDS_COLDESC_RENCODING
-#: Merge.rc:5140
+#: Merge.rc:5139
 msgid "Right side encoding."
 msgstr "Кодування правої сторони."
 
 #. IDS_COLDESC_MENCODING
-#: Merge.rc:5141
+#: Merge.rc:5140
 msgid "Middle side encoding."
 msgstr "Кодування центру."
 
 #. IDS_COLDESC_NIDIFFS
-#: Merge.rc:5142
+#: Merge.rc:5141
 msgid "Number of ignored differences in file. Ignored and cannot be merged."
 msgstr ""
 "Кількість ігнорованих відмінностей у файлі. Ці відмінності були ігноровані WinMerge і не можуть бути опрацьовані."
 
 #. IDS_COLDESC_NSDIFFS
-#: Merge.rc:5143
+#: Merge.rc:5142
 msgid "Number of differences in file (excluding ignored)."
 msgstr "Кількість відмінностей у файлі. Ігноровані відмінності не враховані."
 
 #. IDS_COLDESC_BINARY
-#: Merge.rc:5144
+#: Merge.rc:5143
 msgid "Shows an asterisk (*) if the file is binary."
 msgstr "Показати зірочку (*) якщо файл двійковий."
 
 #. IDS_COLDESC_UNPACKER
-#: Merge.rc:5145
+#: Merge.rc:5144
 msgid "Unpacker plugin name or pipeline."
 msgstr "Ім'я плагіна розпакувальника або конвеєра."
 
 #. IDS_COLDESC_PREDIFFER
-#: Merge.rc:5146
+#: Merge.rc:5145
 msgid "Prediffer plugin name or pipeline."
 msgstr "Ім'я плагіна попереднього порівняння або конвеєра."
 
 #. IDS_DIRECTORY_REPORT_TITLE
-#: Merge.rc:5152
+#: Merge.rc:5151
 #, c-format
 msgid "Compare %1 with %2"
 msgstr "Порівняння %1 з %2"
 
 #. IDS_DIRECTORY_REPORT_TITLE3
-#: Merge.rc:5153
+#: Merge.rc:5152
 #, c-format
 msgid "Compare %1 with %2 and %3"
 msgstr "Порівняння %1 з %2 та %3"
 
 #. IDS_REPORT_COMMALIST
-#: Merge.rc:5154
+#: Merge.rc:5153
 msgid "Comma-separated list"
 msgstr "Список, розділений комами"
 
 #. IDS_REPORT_TABLIST
-#: Merge.rc:5155
+#: Merge.rc:5154
 msgid "Tab-separated list"
 msgstr "Список, розділений табуляторами"
 
 #. IDS_REPORT_SIMPLEHTML
-#: Merge.rc:5156
+#: Merge.rc:5155
 msgid "Simple HTML"
 msgstr "Простий HTML"
 
 #. IDS_REPORT_SIMPLEXML
-#: Merge.rc:5157
+#: Merge.rc:5156
 msgid "Simple XML"
 msgstr "Простий XML"
 
-#: Merge.rc:5159
+#: Merge.rc:5158
 msgid "Report file already exists. Overwrite?"
 msgstr "Файл звіту вже існує. Перезаписати??"
 
 #. IDS_REPORT_ERROR
-#: Merge.rc:5164
+#: Merge.rc:5163
 #, c-format
 msgid ""
 "Error creating the report:\n"
@@ -7195,27 +7190,27 @@ msgstr ""
 "%1"
 
 #. IDS_REPORT_SUCCESS
-#: Merge.rc:5165
+#: Merge.rc:5164
 msgid "Report created successfully."
 msgstr "Звіт успішно створено."
 
 #. IDS_SYNCPOINT_LASTBLOCK
-#: Merge.rc:5171
+#: Merge.rc:5170
 msgid "Cannot add a synchronization point at this line."
 msgstr "Неможливо додати точку синхронізації в цьому рядку."
 
 #. IDS_FILE_TO_ITSELF
-#: Merge.rc:5177
+#: Merge.rc:5176
 msgid "Same file is opened in both panes."
 msgstr "На обох панелях відкритий той самий файл."
 
 #. IDS_FILESSAME
-#: Merge.rc:5178
+#: Merge.rc:5177
 msgid "Selected files are identical."
 msgstr "Вибрані файли ідентичні."
 
 #. IDS_FILESSAME_CURCFG
-#: Merge.rc:5179
+#: Merge.rc:5178
 msgid ""
 "Selected files are identical (with current settings).\r\n"
 "Checking binary identity..."
@@ -7224,7 +7219,7 @@ msgstr ""
 "Перевірка двійкової ідентичності..."
 
 #. IDS_FILESSAME_BINERROR
-#: Merge.rc:5180
+#: Merge.rc:5179
 msgid ""
 "Selected files are identical (with current settings).\r\n"
 "But binary comparison failed."
@@ -7233,12 +7228,12 @@ msgstr ""
 "Але двійкове порівняння не вдалося."
 
 #. IDS_FILESSAME_BINSAME
-#: Merge.rc:5181
+#: Merge.rc:5180
 msgid "Selected files are identical (binary match)."
 msgstr "Вибрані файли однакові (двійкове співпадіння)."
 
 #. IDS_FILESSAME_BINDIFF
-#: Merge.rc:5182
+#: Merge.rc:5181
 msgid ""
 "Selected files are identical (with current settings).\r\n"
 "But differ at the binary level."
@@ -7247,17 +7242,17 @@ msgstr ""
 "Але відрізняються на двійковому рівні."
 
 #. IDS_FILEERROR
-#: Merge.rc:5183
+#: Merge.rc:5182
 msgid "An error occurred while comparing files."
 msgstr "При порівнянні файлів виникла помилка."
 
 #. IDS_TEMP_FILEERROR
-#: Merge.rc:5184
+#: Merge.rc:5183
 msgid "Could not create temporary files. Check your temporary path settings."
 msgstr "Не вдалося створити тимчасові файли. Перевірте налаштування шляхів для тимчасових файлів."
 
 #. IDS_SUGGEST_IGNOREEOL
-#: Merge.rc:5185
+#: Merge.rc:5184
 msgid ""
 "Files use different EOL.\n"
 "\n"
@@ -7273,17 +7268,17 @@ msgstr ""
 "рядків' на вкладці Порівняння в Налаштуваннях."
 
 #. IDS_INVALID_DIRECTORY
-#: Merge.rc:5186
+#: Merge.rc:5185
 msgid "Selected folder is invalid."
 msgstr "Вибрана папка є недійсною."
 
 #. IDS_CANNOT_OPEN_BINARYFILE
-#: Merge.rc:5187
+#: Merge.rc:5186
 msgid "Cannot open a binary file in Editor."
 msgstr "Неможливо відкрити двійковий файл у редакторі."
 
 #. IDS_CREATE_PAIR_FOLDER
-#: Merge.rc:5188
+#: Merge.rc:5187
 #, c-format
 msgid ""
 "Create matching folder:\n"
@@ -7297,41 +7292,41 @@ msgstr ""
 "з іншої сторони і відкрити обидві?"
 
 #. IDS_CONFIRM_COPY_ALL_DIFFS
-#: Merge.rc:5189
+#: Merge.rc:5188
 msgid "Copy all differences to other file?"
 msgstr "Скопіювати всі відмінності в інший файл?"
 
 #. IDS_MOVE_TO_NEXTFILE
-#: Merge.rc:5194
+#: Merge.rc:5193
 msgid "Move to next file?"
 msgstr "Перейти до наступного файлу?"
 
 #. IDS_MOVE_TO_PREVFILE
-#: Merge.rc:5195
+#: Merge.rc:5194
 msgid "Move to previous file?"
 msgstr "Перейти до попереднього файлу?"
 
 #. IDS_MOVE_TO_NEXTPAGE
-#: Merge.rc:5196
+#: Merge.rc:5195
 msgid "Move to next page?"
 msgstr "Перейти до наступної сторінки?"
 
 #. IDS_MOVE_TO_PREVPAGE
-#: Merge.rc:5197
+#: Merge.rc:5196
 msgid "Move to previous page?"
 msgstr "Перейти до попередньої сторінки?"
 
 #. IDS_MOVE_TO_FIRSTFILE
-#: Merge.rc:5198
+#: Merge.rc:5197
 msgid "Move to first file?"
 msgstr "Перейти до першого файлу?"
 
 #. IDS_MOVE_TO_LASTFILE
-#: Merge.rc:5199
+#: Merge.rc:5198
 msgid "Move to last file?"
 msgstr "Перейти до останнього файлу?"
 
-#: Merge.rc:5206
+#: Merge.rc:5205
 #, c-format
 msgid ""
 "Different codepages: left (cp%d), right (cp%d).\n"
@@ -7342,51 +7337,51 @@ msgstr ""
 "Кожний з файлів може бути показаний в своєму кодуванні, але їхнє злиття або копіювання може пошкодити інформацію.\n"
 "Показати обидва файли в системному кодуванні (рекомендується)?"
 
-#: Merge.rc:5208
+#: Merge.rc:5207
 msgid "Information lost due to encoding errors: both files"
 msgstr "Інформація втрачена через помилкове кодування: обидва файли"
 
-#: Merge.rc:5210
+#: Merge.rc:5209
 msgid "Information lost due to encoding errors: first file"
 msgstr "Інформація втрачена через помилкове кодування: перший файл"
 
-#: Merge.rc:5212
+#: Merge.rc:5211
 msgid "Information lost due to encoding errors: second file"
 msgstr "Інформація втрачена через помилкове кодування: другий файл"
 
-#: Merge.rc:5214
+#: Merge.rc:5213
 msgid "Information lost due to encoding errors: third file"
 msgstr "Інформація втрачена через помилкове кодування: третій файл"
 
 #. IDS_LINEDIFF_NODIFF
-#: Merge.rc:5220
+#: Merge.rc:5219
 msgid "No difference"
 msgstr "Нема відмінностей"
 
 #. IDS_LINEDIFF_NODIFF_CAPTION
-#: Merge.rc:5221
+#: Merge.rc:5220
 msgid "Line difference"
 msgstr "Рядок відмінностей"
 
 #. IDS_NUM_REPLACED
-#: Merge.rc:5227
+#: Merge.rc:5226
 #, c-format
 msgid "Replaced %1 string(s)."
 msgstr "Замінено %1 рядків."
 
 #. IDS_EDIT_TEXT_NOT_FOUND
-#: Merge.rc:5228
+#: Merge.rc:5227
 #, c-format
 msgid "Cannot find string \"%s\"."
 msgstr "Не вдалося знайти рядок \"%s\"."
 
 #. IDS_MERGE_MODE
-#: Merge.rc:5234
+#: Merge.rc:5233
 msgid "Entering Merge Mode. Press F9 to turn off."
 msgstr "Переход у режим злиття. Натисніть F9, щоб вимкнути."
 
 #. IDS_AUTO_MERGE
-#: Merge.rc:5240
+#: Merge.rc:5239
 #, c-format
 msgid ""
 "Automatic merges: %1\n"
@@ -7396,89 +7391,89 @@ msgstr ""
 "Нерозв'язаних конфліктів: %2"
 
 #. IDS_CODEPAGE_MERGED
-#: Merge.rc:5241
+#: Merge.rc:5240
 msgid "Codepage change merged."
 msgstr "Зміни в кодуванні були об'єднані."
 
 #. IDS_CODEPAGE_CONFLICT
-#: Merge.rc:5242
+#: Merge.rc:5241
 msgid "Codepage changes are conflicting."
 msgstr "Конфліктують зміни в кодуванні."
 
 #. IDS_EOL_MERGED
-#: Merge.rc:5243
+#: Merge.rc:5242
 msgid "EOL change merged."
 msgstr "Зміни в EOL були об'єднані."
 
 #. IDS_EOL_CONFLICT
-#: Merge.rc:5244
+#: Merge.rc:5243
 msgid "EOL changes are conflicting."
 msgstr "Конфліктують зміни в EOL."
 
 #. IDS_LOCBAR_CAPTION
-#: Merge.rc:5250
+#: Merge.rc:5249
 msgid "Location Pane"
 msgstr "Панель позицій"
 
 #. IDS_DIFFBAR_CAPTION
-#: Merge.rc:5251
+#: Merge.rc:5250
 msgid "Diff Pane"
 msgstr "Пане&ль відмінностей"
 
 #. IDS_DIFF_SUCCEEDED
-#: Merge.rc:5258
+#: Merge.rc:5257
 msgid "Patch file written."
 msgstr "Файл патча записано."
 
 #. IDS_DIFF_FILEOVERWRITE
-#: Merge.rc:5259
+#: Merge.rc:5258
 msgid "Patch file already exists. Overwrite?"
 msgstr "Файл патча вже існує. Перезаписати?"
 
 #. IDS_DIFF_SELECTEDFILES
-#: Merge.rc:5260
+#: Merge.rc:5259
 #, c-format
 msgid "[%1 files selected]"
 msgstr "[%1 файлів вибрані]"
 
 #. IDS_DIFF_NORMAL
-#: Merge.rc:5261
+#: Merge.rc:5260
 msgid "Normal"
 msgstr "Нормальний"
 
 #. IDS_DIFF_CONTEXT
-#: Merge.rc:5262
+#: Merge.rc:5261
 msgid "Context"
 msgstr "Контекст"
 
 #. IDS_DIFF_UNIFIED
-#: Merge.rc:5263
+#: Merge.rc:5262
 msgid "Unified"
 msgstr "Уніфікований"
 
 #. IDS_FILEWRITE_ERROR
-#: Merge.rc:5265
+#: Merge.rc:5264
 #, c-format
 msgid "Could not write to file %1."
 msgstr "Нема можливості записати у файл %1."
 
 #. IDS_PATH_NOT_ABSOLUTE
-#: Merge.rc:5266
+#: Merge.rc:5265
 #, c-format
 msgid "Output path is not absolute: %1"
 msgstr "Зазначений шлях для кінцевого файлу не є абсолютним: %1"
 
 #. IDS_MUST_SPECIFY_OUTPUT
-#: Merge.rc:5267
+#: Merge.rc:5266
 msgid "Specify an output file."
 msgstr "Вказати кінцевий файл."
 
-#: Merge.rc:5269
+#: Merge.rc:5268
 msgid "Cannot create patch from binary files."
 msgstr "Неможливо створити патч з двійкових файлів."
 
 #. IDS_SAVEFILES_FORPATCH
-#: Merge.rc:5270
+#: Merge.rc:5269
 msgid ""
 "Save all files first.\n"
 "\n"
@@ -7489,22 +7484,22 @@ msgstr ""
 "Створення патча вимагає збереження усіх змін."
 
 #. IDS_FOLDER_NOTEXIST
-#: Merge.rc:5271
+#: Merge.rc:5270
 msgid "Folder does not exist."
 msgstr "Папка не існує."
 
 #. IDS_ARCHIVE_SUCCEEDED
-#: Merge.rc:5277
+#: Merge.rc:5276
 msgid "Archive file written."
 msgstr ""
 
 #. IDS_ARCHIVE_SAVEFILES
-#: Merge.rc:5278
+#: Merge.rc:5277
 msgid "Save all files first.\n\nCreating an archive requires no unsaved changes."
 msgstr ""
 
 #. IDS_NO_ZIP_SUPPORT
-#: Merge.rc:5283
+#: Merge.rc:5282
 msgid ""
 "Archive support not enabled.\n"
 "7-Zip and/or Merge7z*.dll not found.\n"
@@ -7516,37 +7511,37 @@ msgstr ""
 "Подивіться інструкцію, щоб довідатися більше про підтримку архівів і як її ввімкнути."
 
 #. IDS_OPT_EXPORT_CAPTION
-#: Merge.rc:5284
+#: Merge.rc:5283
 msgid "Select file for export"
 msgstr "Вибрати файл для експорту"
 
 #. IDS_OPT_IMPORT_CAPTION
-#: Merge.rc:5285
+#: Merge.rc:5284
 msgid "Select file for import"
 msgstr "Вибрати файл для імпорту"
 
 #. IDS_OPT_IMPORT_DONE
-#: Merge.rc:5286
+#: Merge.rc:5285
 msgid "Options imported from file."
 msgstr "Налаштування, імпортовані з файлу."
 
 #. IDS_OPT_EXPORT_DONE
-#: Merge.rc:5287
+#: Merge.rc:5286
 msgid "Options exported to file."
 msgstr "Налаштування, експортовані в файл."
 
 #. IDS_OPT_IMPORT_ERR
-#: Merge.rc:5288
+#: Merge.rc:5287
 msgid "Failed to import options from file."
 msgstr "Помилка імпорту налаштувань з файлу."
 
 #. IDS_OPT_EXPORT_ERR
-#: Merge.rc:5289
+#: Merge.rc:5288
 msgid "Failed to write options to file."
 msgstr "Помилка експорту налаштувань в файл."
 
 #. IDS_CLOSEALL_WINDOWS
-#: Merge.rc:5290
+#: Merge.rc:5289
 msgid ""
 "Close multiple compare windows?\n"
 "\n"
@@ -7557,34 +7552,34 @@ msgstr ""
 "Продовжити?"
 
 #. IDS_EOL_BIN
-#: Merge.rc:5300
+#: Merge.rc:5299
 msgctxt "EOL Type"
 msgid "Binary"
 msgstr "Двійковий"
 
 #. IDS_MARKER_COLOR_FMT
-#: Merge.rc:5305
+#: Merge.rc:5304
 #, c-format
 msgid "Marker Color %d"
 msgstr "Колір маркера %d"
 
 #. IDS_MARKER_NEW_PATTERN
-#: Merge.rc:5306
+#: Merge.rc:5305
 msgid "New Pattern"
 msgstr "Новий шаблон"
 
 #. IDS_PLUGINSLIST_TYPE
-#: Merge.rc:5312
+#: Merge.rc:5311
 msgid "Type"
 msgstr "Тип"
 
 #. IDS_PLUGINS_TYPE_EDITSCRIPT
-#: Merge.rc:5316
+#: Merge.rc:5315
 msgid "Editor script"
 msgstr "Сценарій редактора"
 
 #. ID_SELECTLINEDIFF
-#: Merge.rc:5322
+#: Merge.rc:5321
 msgid ""
 "\n"
 "Difference in Current Line (F4)"
@@ -7593,7 +7588,7 @@ msgstr ""
 "Відмінність у поточному рядку (F4)"
 
 #. ID_OPTIONS
-#: Merge.rc:5323
+#: Merge.rc:5322
 msgid ""
 "\n"
 "Options"
@@ -7602,7 +7597,7 @@ msgstr ""
 "Налаштування"
 
 #. ID_REFRESH
-#: Merge.rc:5324
+#: Merge.rc:5323
 msgid ""
 "\n"
 "Refresh (F5)"
@@ -7611,7 +7606,7 @@ msgstr ""
 "Оновити (F5)"
 
 #. ID_PREVDIFF
-#: Merge.rc:5330
+#: Merge.rc:5329
 msgid ""
 "\n"
 "Previous Difference (Alt+Up)"
@@ -7620,7 +7615,7 @@ msgstr ""
 "Попередня відмінність (Alt+Up)"
 
 #. ID_NEXTDIFF
-#: Merge.rc:5331
+#: Merge.rc:5330
 msgid ""
 "\n"
 "Next Difference (Alt+Down)"
@@ -7629,7 +7624,7 @@ msgstr ""
 "Наступна відмінність (Alt+Down)"
 
 #. ID_PREVCONFLICT
-#: Merge.rc:5332
+#: Merge.rc:5331
 msgid ""
 "\n"
 "Previous Conflict (Alt+Shift+Up)"
@@ -7638,7 +7633,7 @@ msgstr ""
 "Попередній конфлікт (Alt+Shift+Up)"
 
 #. ID_NEXTCONFLICT
-#: Merge.rc:5333
+#: Merge.rc:5332
 msgid ""
 "\n"
 "Next Conflict (Alt+Shift+Down)"
@@ -7647,7 +7642,7 @@ msgstr ""
 "Наступний конфлікт (Alt+Shift+Down)"
 
 #. ID_FIRSTDIFF
-#: Merge.rc:5338
+#: Merge.rc:5337
 msgid ""
 "\n"
 "First Difference (Alt+Home)"
@@ -7656,7 +7651,7 @@ msgstr ""
 "Перша відмінність (Alt+Home)"
 
 #. ID_CURDIFF
-#: Merge.rc:5339
+#: Merge.rc:5338
 msgid ""
 "\n"
 "Current Difference (Alt+Enter)"
@@ -7665,7 +7660,7 @@ msgstr ""
 "Поточна відмінність (Alt+Enter)"
 
 #. ID_LASTDIFF
-#: Merge.rc:5340
+#: Merge.rc:5339
 msgid ""
 "\n"
 "Last Difference (Alt+End)"
@@ -7674,7 +7669,7 @@ msgstr ""
 "Остання відмінність (Alt+End)"
 
 #. ID_L2R
-#: Merge.rc:5341
+#: Merge.rc:5340
 msgid ""
 "\n"
 "Copy to Right (Alt+Right)"
@@ -7683,7 +7678,7 @@ msgstr ""
 "Копіювати праворуч (Alt+Right)"
 
 #. ID_R2L
-#: Merge.rc:5342
+#: Merge.rc:5341
 msgid ""
 "\n"
 "Copy to Left (Alt+Left)"
@@ -7692,7 +7687,7 @@ msgstr ""
 "Копіювати ліворуч (Alt+Left)"
 
 #. ID_L2RNEXT
-#: Merge.rc:5343
+#: Merge.rc:5342
 msgid ""
 "\n"
 "Copy to Right and Advance (Ctrl+Alt+Right)"
@@ -7701,7 +7696,7 @@ msgstr ""
 "Копіювати праворуч і перейти далі (Ctrl+Alt+Right)"
 
 #. ID_R2LNEXT
-#: Merge.rc:5344
+#: Merge.rc:5343
 msgid ""
 "\n"
 "Copy to Left and Advance (Ctrl+Alt+Left)"
@@ -7710,7 +7705,7 @@ msgstr ""
 "Копіювати ліворуч і перейти далі (Ctrl+Alt+Left)"
 
 #. ID_ALL_RIGHT
-#: Merge.rc:5345
+#: Merge.rc:5344
 msgid ""
 "\n"
 "Copy All to Right"
@@ -7719,7 +7714,7 @@ msgstr ""
 "Копіювати все праворуч"
 
 #. ID_ALL_LEFT
-#: Merge.rc:5346
+#: Merge.rc:5345
 msgid ""
 "\n"
 "Copy All to Left"
@@ -7728,7 +7723,7 @@ msgstr ""
 "Копіювати все ліворуч"
 
 #. ID_AUTO_MERGE
-#: Merge.rc:5347
+#: Merge.rc:5346
 msgid ""
 "\n"
 "Auto Merge (Ctrl+Alt+M)"
@@ -7737,7 +7732,7 @@ msgstr ""
 "Автоматичне злиття (Ctrl+Alt+M)"
 
 #. ID_FIRSTFILE
-#: Merge.rc:5348
+#: Merge.rc:5347
 msgid ""
 "\n"
 "First File"
@@ -7746,7 +7741,7 @@ msgstr ""
 "Перший файл"
 
 #. ID_NEXTFILE
-#: Merge.rc:5349
+#: Merge.rc:5348
 msgid ""
 "\n"
 "Next File (Ctrl+F8)"
@@ -7755,7 +7750,7 @@ msgstr ""
 "Наступний файл (Ctrl+F8)"
 
 #. ID_LASTFILE
-#: Merge.rc:5350
+#: Merge.rc:5349
 msgid ""
 "\n"
 "Last File"
@@ -7764,7 +7759,7 @@ msgstr ""
 "Останній файл"
 
 #. ID_PREVFILE
-#: Merge.rc:5351
+#: Merge.rc:5350
 msgid ""
 "\n"
 "Previous File (Ctrl+F7)"
@@ -7773,142 +7768,142 @@ msgstr ""
 "Попередній файл (Ctrl+F7)"
 
 #. IDS_UNPACK_AUTO
-#: Merge.rc:5358
+#: Merge.rc:5357
 msgid "Adapted unpacker applied to both files (one needs extension)."
 msgstr "Автоматичний підбір розпакувальника (вкажіть розширення хоча б одного з файлів)."
 
 #. IDS_NO_PREDIFFER
-#: Merge.rc:5359
+#: Merge.rc:5358
 msgid "No Prediffer (Normal)"
 msgstr "Без попереднього порівняння (звичайне)"
 
 #. IDS_SUGGESTED_PLUGINS
-#: Merge.rc:5360
+#: Merge.rc:5359
 msgid "Suggested Plugins"
 msgstr "Рекомендовані плагіни"
 
 #. IDS_NOT_SUGGESTED_PLUGINS
-#: Merge.rc:5361
+#: Merge.rc:5360
 msgid "All Plugins"
 msgstr "Усі плагіни"
 
 #. IDS_PRIVATEBUILD_FMT
-#: Merge.rc:5367
+#: Merge.rc:5366
 #, c-format
 msgid "Private Build: %1"
 msgstr "Приватний білд: %1"
 
 #. IDS_ALLRIGHTS_RESERVED
-#: Merge.rc:5368
+#: Merge.rc:5367
 msgid " - All rights reserved."
 msgstr " - Усі права захищені."
 
 #. IDS_TITLE_PLUGINS_SETTINGS
-#: Merge.rc:5374
+#: Merge.rc:5373
 msgid "Plugin Settings"
 msgstr "Налаштування плагіну"
 
 #. IDS_NO_SCT_SCRIPTS
-#: Merge.rc:5376
+#: Merge.rc:5375
 msgid "WSH not found - .sct scripts disabled"
 msgstr "WSH не знайдений - .sct сценарії вимкнуті"
 
 #. IDS_LOCBAR_GOTOLINE_FMT
-#: Merge.rc:5384
+#: Merge.rc:5383
 #, c-format
 msgid "G&o to Line %1"
 msgstr "Перейти до &рядка %1"
 
 #. IDS_GOTO_MOVED_LINE
-#: Merge.rc:5390
+#: Merge.rc:5389
 msgid "Go to Moved Line\tCtrl+Shift+G"
 msgstr "Перейти до переміщеного рядка\tCtrl+Shift+G"
 
 #. IDS_AUTOCOMPLETE_DISABLED
-#: Merge.rc:5396
+#: Merge.rc:5395
 msgctxt "Options dialog|General|Open dialog Auto completion"
 msgid "Disabled"
 msgstr "Вимкнено"
 
 #. IDS_AUTOCOMPLETE_FILE_SYS
-#: Merge.rc:5397
+#: Merge.rc:5396
 msgid "From file system"
 msgstr "Як на диску"
 
 #. IDS_AUTOCOMPLETE_MRU
-#: Merge.rc:5398
+#: Merge.rc:5397
 msgid "From Most Recently Used list"
 msgstr "Як в списку нещодавніх документів"
 
 #. IDS_COLORSCHEME_PLAIN
-#: Merge.rc:5404
+#: Merge.rc:5403
 msgid "No Highlighting"
 msgstr "Не підсвічувати"
 
 #. IDS_COLORSCHEME_PO
-#: Merge.rc:5439
+#: Merge.rc:5438
 msgid "Portable Object"
 msgstr "Portable Object"
 
 #. IDS_COLORSCHEME_RSRC
-#: Merge.rc:5444
+#: Merge.rc:5443
 msgid "Resources"
 msgstr "Ресурси"
 
 #. IDS_COLORSCHEME_SH
-#: Merge.rc:5448
+#: Merge.rc:5447
 msgid "Shell"
 msgstr "Shell"
 
 #. IDS_CLOSE_LEFT_TABS
-#: Merge.rc:5469
+#: Merge.rc:5468
 msgid "Close &Left Tabs"
 msgstr "Закрити вкладки зліва"
 
 #. IDS_CLOSE_RIGHT_TABS
-#: Merge.rc:5470
+#: Merge.rc:5469
 msgid "Close R&ight Tabs"
 msgstr "Закрити вкладки справа"
 
 #. IDS_CLOSE_OTHER_TABS
-#: Merge.rc:5471
+#: Merge.rc:5470
 msgid "Close &Other Tabs"
 msgstr "Закрити інші вкладки"
 
 #. IDS_TABBAR_AUTO_MAXWIDTH
-#: Merge.rc:5472
+#: Merge.rc:5471
 msgid "Enable &Auto Max Width"
 msgstr "Увімкнути автоматичну максимальну ширину"
 
 #. IDS_WEBPAGE_MENU
-#: Merge.rc:5482
+#: Merge.rc:5481
 msgid "We&bpage"
 msgstr "Ве&бсторінка"
 
 #. IDS_VIEW_WRAP_TEXT
-#: Merge.rc:5487
+#: Merge.rc:5486
 msgid "W&rap Text"
 msgstr "П&ереносити текст"
 
 #. IDS_NOTINSTALLED
-#: Merge.rc:5492
+#: Merge.rc:5491
 #, c-format
 msgid "%1 is not installed."
 msgstr "%1 не встановлено."
 
 #. IDS_CREATE_FOLDER
-#: Merge.rc:5497
+#: Merge.rc:5496
 #, c-format
 msgid "%1 does not exist. Create it?"
 msgstr "%1 не існує. Створити?"
 
 #. IDS_CREATE_FOLDER_ERROR
-#: Merge.rc:5498
+#: Merge.rc:5497
 msgid "Failed to create folder."
 msgstr "Не вдалося створити папку."
 
 #. IDC_EXT_EDITOR_PATH
-#: Merge.rc:5503
+#: Merge.rc:5502
 msgid ""
 "Parameters:\n"
 "$file: Current file path\n"
@@ -7919,492 +7914,492 @@ msgstr ""
 "$linenum: Поточний номер рядка курсора"
 
 #. IDS_DIFF_ALGORITHM_DEFAULT
-#: Merge.rc:5508
+#: Merge.rc:5507
 msgid "default"
 msgstr "за замовчуванням"
 
 #. IDS_DIFF_ALGORITHM_MINIMAL
-#: Merge.rc:5509
+#: Merge.rc:5508
 msgid "minimal"
 msgstr "мінімально"
 
 #. IDS_DIFF_ALGORITHM_PATIENCE
-#: Merge.rc:5510
+#: Merge.rc:5509
 msgid "patience"
 msgstr "терплячо"
 
 #. IDS_DIFF_ALGORITHM_HISTOGRAM
-#: Merge.rc:5511
+#: Merge.rc:5510
 msgid "histogram"
 msgstr "гістограма"
 
 #. IDS_DIFF_ALGORITHM_NONE
-#: Merge.rc:5512
+#: Merge.rc:5511
 msgid "none"
 msgstr "немає"
 
 #. IDS_RENDERING_MODE_GDI
-#: Merge.rc:5517
+#: Merge.rc:5516
 msgid "GDI"
 msgstr "GDI"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_DEFAULT
-#: Merge.rc:5518
+#: Merge.rc:5517
 msgid "DirectWrite Default"
 msgstr "DirectWrite за замовчуванням"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_ALIASED
-#: Merge.rc:5519
+#: Merge.rc:5518
 msgid "DirectWrite Aliased"
 msgstr "DirectWrite Aliased"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_GDI_CLASSIC
-#: Merge.rc:5520
+#: Merge.rc:5519
 msgid "DirectWrite GDI Classic"
 msgstr "DirectWrite GDI Classic"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_GDI_NATURAL
-#: Merge.rc:5521
+#: Merge.rc:5520
 msgid "DirectWrite GDI Natural"
 msgstr "DirectWrite GDI Natural"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_NATURAL
-#: Merge.rc:5522
+#: Merge.rc:5521
 msgid "DirectWrite Natural"
 msgstr "DirectWrite Natural"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_NATURAL_SYMMETRIC
-#: Merge.rc:5523
+#: Merge.rc:5522
 msgid "DirectWrite Natural Symmetric"
 msgstr "DirectWrite Natural Symmetric"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_DISABLED
-#: Merge.rc:5528
+#: Merge.rc:5527
 msgctxt "Options dialog|General|Close windows with Esc"
 msgid "Disabled"
 msgstr "Вимкнено"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_1
-#: Merge.rc:5529
+#: Merge.rc:5528
 msgid "MDI child window or main window"
 msgstr "Дочірнє вікно MDI або головне вікно"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_2
-#: Merge.rc:5530
+#: Merge.rc:5529
 msgid "MDI child window only"
 msgstr "Лише дочірнє вікно MDI"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_3
-#: Merge.rc:5531
+#: Merge.rc:5530
 msgid "Close main window if only one MDI child window"
 msgstr "Закривати головне вікно, якщо є лише одне дочірнє вікно MDI"
 
 #. IDS_DIFF_GROUP
-#: Merge.rc:5536
+#: Merge.rc:5535
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Diff"
 msgstr "Відмінність"
 
 #. IDS_DIFF_HIGHLIGHT
-#: Merge.rc:5537
+#: Merge.rc:5536
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Highlight"
 msgstr "Підсвітити"
 
 #. IDS_DIFF_BLINK
-#: Merge.rc:5538
+#: Merge.rc:5537
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Blink"
 msgstr "Блимати"
 
 #. IDS_DIFF_BLOCKSIZE
-#: Merge.rc:5539
+#: Merge.rc:5538
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Block Size"
 msgstr "Розмір блоку"
 
 #. IDS_DIFF_BLOCKALPHA
-#: Merge.rc:5540
+#: Merge.rc:5539
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Block Alpha"
 msgstr "Прозорість блоку"
 
 #. IDS_DIFF_CDTHRESHOLD
-#: Merge.rc:5541
+#: Merge.rc:5540
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "CD Threshold"
 msgstr "Поріг розрізнення кольорів"
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION
-#: Merge.rc:5542
+#: Merge.rc:5541
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Ins/Del Detection"
 msgstr "Виявлення вставок/видалень"
 
 #. IDS_OVERLAY_MODE_NONE
-#: Merge.rc:5543 Merge.rc:5548
+#: Merge.rc:5542 Merge.rc:5547
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "None"
 msgstr "Немає"
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION_VERTICAL
-#: Merge.rc:5544
+#: Merge.rc:5543
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Vertical"
 msgstr "Вертикальних"
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION_HORIZONTAL
-#: Merge.rc:5545
+#: Merge.rc:5544
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Horizontal"
 msgstr "Горизонтальних"
 
 #. IDS_OVERLAY_GROUP
-#: Merge.rc:5546
+#: Merge.rc:5545
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Overlay"
 msgstr "Накладання"
 
 #. IDS_OVERLAY_ALPHA
-#: Merge.rc:5547
+#: Merge.rc:5546
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha"
 msgstr "Альфа"
 
 #. IDS_OVERLAY_MODE_XOR
-#: Merge.rc:5549
+#: Merge.rc:5548
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "XOR"
 msgstr "XOR"
 
 #. IDS_OVERLAY_MODE_ALPHA
-#: Merge.rc:5550
+#: Merge.rc:5549
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha Blend"
 msgstr "Змішування прозорості"
 
 #. IDS_OVERLAY_MODE_ALPHA_ANIMATION
-#: Merge.rc:5551
+#: Merge.rc:5550
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha Animation"
 msgstr "Анімація прозорості"
 
 #. IDS_ZOOM
-#: Merge.rc:5552
+#: Merge.rc:5551
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Zoom"
 msgstr "Масштаб"
 
 #. IDS_PAGE
-#: Merge.rc:5553
+#: Merge.rc:5552
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Page:"
 msgstr "Сторінка:"
 
 #. IDS_IMGCMP_STATUS_PT_RGBA_FMT
-#: Merge.rc:5554
+#: Merge.rc:5553
 #, c-format
 msgid "Pt: (%d, %d)  RGBA: (%d, %d, %d, %d)  "
 msgstr "Точка: (%d, %d)  RGBA: (%d, %d, %d, %d)  "
 
 #. IDS_IMGCMP_STATUS_DIST1_FMT
-#: Merge.rc:5555
+#: Merge.rc:5554
 #, c-format
 msgid "Dist: %g  "
 msgstr "Відстань: %g  "
 
 #. IDS_IMGCMP_STATUS_DIST2_FMT
-#: Merge.rc:5556
+#: Merge.rc:5555
 #, c-format
 msgid "Dist: %g, %g  "
 msgstr "Відстань: %g, %g  "
 
 #. IDS_IMGCMP_STATUS_PAGE_ZOOM_SIZE_BPP_FMT
-#: Merge.rc:5557
+#: Merge.rc:5556
 #, c-format
 msgid "Page: %d/%d  Zoom: %d%%  %dx%dpx  %dbpp  "
 msgstr "Сторінка: %d/%d  Масштаб: %d%%  %dx%dпікс  %dbpp  "
 
 #. IDS_IMGCMP_STATUS_RC_FMT
-#: Merge.rc:5558
+#: Merge.rc:5557
 #, c-format
 msgid "Rc: (%d, %d)  "
 msgstr "Rc: (%d, %d)  "
 
 #. IDS_IMGCMP_STATUS_FLIPPED_FMT
-#: Merge.rc:5559
+#: Merge.rc:5558
 #, c-format
 msgid "Flipped: %s  "
 msgstr "Перевернуто: %s  "
 
 #. IDS_IMGCMP_STATUS_ROTATED_FMT
-#: Merge.rc:5560
+#: Merge.rc:5559
 #, c-format
 msgid "Rotated: %d  "
 msgstr "Повернуто: %d  "
 
 #. IDS_IMGCMP_REPORT_ALLPAGES
-#: Merge.rc:5561
+#: Merge.rc:5560
 msgid "All pages"
 msgstr "Всі сторінки"
 
 #. IDS_IGNSUB_STR1
-#: Merge.rc:5566
+#: Merge.rc:5565
 msgid "<Edit here>"
 msgstr "<Редагувати тут>"
 
 #. IDS_IGNSUB_STR2
-#: Merge.rc:5567
+#: Merge.rc:5566
 msgid "No differences found to select"
 msgstr "Не знайдено відмінностей для вибору"
 
 #. IDS_IGNSUB_STR3
-#: Merge.rc:5568
+#: Merge.rc:5567
 msgid "No differences found to add as substitution filter"
 msgstr "Не знайдено відмінностей для додавання як фільтр підміни"
 
 #. IDS_IGNSUB_STR4
-#: Merge.rc:5569
+#: Merge.rc:5568
 msgid "The pair is already in the Substitution Filters list"
 msgstr "Пара вже є в списку фільтрів підміни"
 
 #. IDS_IGNSUB_STR5
-#: Merge.rc:5570
+#: Merge.rc:5569
 msgid "Add this change to Substitution Filters?"
 msgstr "Додати цю зміну до фільтрів підміни?"
 
 #. IDS_OCRRESULT_TEXTONLY
-#: Merge.rc:5575
+#: Merge.rc:5574
 msgid "Text only"
 msgstr "Тільки текст"
 
 #. IDS_OCRRESULT_POS_LINE
-#: Merge.rc:5576
+#: Merge.rc:5575
 msgid "Line-by-line position and text"
 msgstr "Порядкова позиція та текст"
 
 #. IDS_OCRRESULT_POS_WORD
-#: Merge.rc:5577
+#: Merge.rc:5576
 msgid "Word-by-word position and text"
 msgstr "Послівна позиція та текст"
 
 #. IDS_USERDATAFOLDER_APPDATA
-#: Merge.rc:5582
+#: Merge.rc:5581
 msgid "AppData (Roaming) folder"
 msgstr "Папка AppData (Roaming)"
 
 #. IDS_USERDATAFOLDER_INSTALL
-#: Merge.rc:5583
+#: Merge.rc:5582
 msgid "Install folder"
 msgstr "Папка встановлення"
 
 #. IDS_USERDATAFOLDER_DOCUMENTS
-#: Merge.rc:5584
+#: Merge.rc:5583
 msgid "Documents folder"
 msgstr "Папка Документів"
 
 #. IDS_SINGLEINSTANCE_DISABLED
-#: Merge.rc:5589
+#: Merge.rc:5588
 msgctxt "Options dialog|General|Single instance mode"
 msgid "Disabled"
 msgstr "Вимкнено"
 
 #. IDS_SINGLEINSTANCE_STR1
-#: Merge.rc:5590
+#: Merge.rc:5589
 msgid "Allow only one instance to run"
 msgstr "Дозволити запуск лише однієї копії"
 
 #. IDS_CLIPBOARD_HISTORY
-#: Merge.rc:5591
+#: Merge.rc:5590
 msgid "Clipboard &History"
 msgstr ""
 
 #. IDS_SINGLEINSTANCE_STR2
-#: Merge.rc:5592
+#: Merge.rc:5591
 msgid "Allow only one instance; wait for termination"
 msgstr "Дозволити лише одну копію; чекати завершення"
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_DISABLED
-#: Merge.rc:5597
+#: Merge.rc:5596
 msgctxt "Options dialog|General|Auto-reload modified files"
 msgid "Disabled"
 msgstr "Вимкнено"
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_STR1
-#: Merge.rc:5598
+#: Merge.rc:5597
 msgid "Only on window activated"
 msgstr "Тільки при активному вікні"
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_STR2
-#: Merge.rc:5599
+#: Merge.rc:5598
 msgid "Immediately"
 msgstr "Негайно"
 
 #. IDS_PLUGIN_ALL
-#: Merge.rc:5604
+#: Merge.rc:5603
 msgid "Al&l"
 msgstr "Ус&і"
 
 #  Context of the string - "Plugin type: Others". "Інший" is singular and it feets better.
 #. IDS_PLUGIN_OTHERS
-#: Merge.rc:5605
+#: Merge.rc:5604
 msgid "&Others"
 msgstr "&Інший"
 
-#: Merge.rc:5607
+#: Merge.rc:5606
 #, c-format
 msgid "Missing plugin name in pipeline: %1"
 msgstr "Відсутня назва плагіна в конвеєрі: %1"
 
-#: Merge.rc:5609
+#: Merge.rc:5608
 #, c-format
 msgid "Missing quote in plugin pipeline: %1"
 msgstr "Відсутня лапка в конвеєрі плагіна: %1"
 
 #. IDS_PLUGIN_NAME_ALREADY_EXISTS
-#: Merge.rc:5610
+#: Merge.rc:5609
 #, c-format
 msgid "Plugin name '%1' already exists."
 msgstr "Плагін з назвою '%1' вже існує."
 
 #. IDS_PLUGIN_TITLE1
-#: Merge.rc:5611
+#: Merge.rc:5610
 msgid "Specify plugin arguments"
 msgstr "Вкажіть аргументи плагіна"
 
-#: Merge.rc:5613
+#: Merge.rc:5612
 #, c-format
 msgid "Plugin not found or invalid: %1"
 msgstr "Плагін не знайден або є недійсним: %1"
 
 #. IDS_PLUGIN_NOT_UNPACK
-#: Merge.rc:5614
+#: Merge.rc:5613
 #, c-format
 msgid "'%1' is not an unpacker plugin"
 msgstr "'%1' не є плагіном розпакувальника"
 
 #. IDS_PLUGIN_NOT_PREDIFF
-#: Merge.rc:5615
+#: Merge.rc:5614
 #, c-format
 msgid "'%1' is not a prediffer plugin"
 msgstr "'%1' не є плагіном попереднього порівняння"
 
-#: Merge.rc:5617
+#: Merge.rc:5616
 #, c-format
 msgid "Error prediffing '%1' with '%2'. Prediffing disabled."
 msgstr "Помилка при попередньому порівнянні '%1' з '%2'. Попереднє порівняння вимкнено."
 
 #. IDS_PLUGIN_CIRCULAR_REFERENCE
-#: Merge.rc:5618
+#: Merge.rc:5617
 #, c-format
 msgid "Circular reference in plugin pipeline: %1"
 msgstr "Кільцева залежність у конвеєрі плагінів: %1"
 
 #. IDS_PLUGIN_TYPE1
-#: Merge.rc:5619
+#: Merge.rc:5618
 msgid "URL Handler"
 msgstr "Обробник URL"
 
 #. IDS_PLUGIN_TYPE2
-#: Merge.rc:5620
+#: Merge.rc:5619
 msgid "File Unpacker"
 msgstr "Розпакувальник файла"
 
 #. IDS_PLUGIN_TYPE3
-#: Merge.rc:5621
+#: Merge.rc:5620
 msgid "File or Folder Unpacker"
 msgstr "Розпакувальник файли або папки"
 
 #. IDS_PLUGIN_TYPE5
-#: Merge.rc:5623
+#: Merge.rc:5622
 msgid "Alias for Unpacker"
 msgstr "Псевдонім для розпакувальника"
 
 #. IDS_PLUGIN_TYPE6
-#: Merge.rc:5624
+#: Merge.rc:5623
 msgid "Alias for Prediffer"
 msgstr "Псевдонім для попередньогр порівнювача"
 
 #. IDS_PLUGIN_TYPE7
-#: Merge.rc:5625
+#: Merge.rc:5624
 msgid "Alias for Editor script"
 msgstr "Псевдонім для редактора сценаріїв"
 
 #. IDS_PLUGIN_ALIAS_DESC
-#: Merge.rc:5626
+#: Merge.rc:5625
 #, c-format
 msgid "Alias for plugin pipeline '%1'"
 msgstr "Псевдонім для конвеєра плагінів '%1'"
 
 #. IDS_PLUGIN_NEW_DESC
-#: Merge.rc:5627
+#: Merge.rc:5626
 msgid "New plugin description"
 msgstr "Опис нового плагіна"
 
 #. IDS_PLUGIN_TARGETS_ALL
-#: Merge.rc:5628
+#: Merge.rc:5627
 msgid "All"
 msgstr "Все"
 
 #. IDS_PLUGIN_TARGETS_1ST
-#: Merge.rc:5629
+#: Merge.rc:5628
 msgid "1st"
 msgstr "1-й"
 
 #. IDS_PLUGIN_TARGETS_2ND
-#: Merge.rc:5630
+#: Merge.rc:5629
 msgid "2nd"
 msgstr "2-й"
 
 #. IDS_PLUGIN_TARGETS_3RD
-#: Merge.rc:5631
+#: Merge.rc:5630
 msgid "3rd"
 msgstr "3-й"
 
 #. IDS_PLUGIN_TARGETS_1ST_2ND
-#: Merge.rc:5632
+#: Merge.rc:5631
 msgid "1st and 2nd"
 msgstr "1-й та 2-й"
 
 #. IDS_PLUGIN_TARGETS_1ST_3RD
-#: Merge.rc:5633
+#: Merge.rc:5632
 msgid "1st and 3rd"
 msgstr "1-й та 3-й"
 
 #. IDS_PLUGIN_TARGETS_2ND_3RD
-#: Merge.rc:5634
+#: Merge.rc:5633
 msgid "2nd and 3rd"
 msgstr "2-й та 3-й"
 
 #. IDS_PLUGIN_CTRL_CLICK
-#: Merge.rc:5635
+#: Merge.rc:5634
 msgid "(Ctrl+Click to add to pipeline)"
 msgstr ""
 
 #. IDS_FILTER_APPLIED
-#: Merge.rc:5640
+#: Merge.rc:5639
 msgid "Filter applied"
 msgstr "Застосован Фільтр"
 
 #. IDS_FILTERMENU_COMPARE
-#: Merge.rc:5645
+#: Merge.rc:5644
 #, c-format
 msgid "Compare %1"
 msgstr "Порівняти %1"
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN2
-#: Merge.rc:5647
+#: Merge.rc:5646
 msgid "&Filter by This Column..."
 msgstr ""
 
 #. IDS_CLIPBOARDHISTORY_TIME
-#: Merge.rc:5652
+#: Merge.rc:5651
 #, c-format
 msgid "Clipboard at %s"
 msgstr "Буфера обміну в %s"
 
 #. IDS_CLIPBOARDHISTORY_DISABLED
-#: Merge.rc:5653
+#: Merge.rc:5652
 msgid ""
 "Clipboard history disabled.\r\n"
 "Enable: Windows logo key + V, then Turn on."
@@ -8412,115 +8407,115 @@ msgstr ""
 "Історію буфера обміну вимкнено.\r\n"
 "Увімкнути: Win + V, потім увімкнути."
 
-#: Merge.rc:5655
+#: Merge.rc:5654
 msgid "This system does not support clipboard history."
 msgstr "Ця сисмтема не підтримує історію буфера обміну."
 
-#: Merge.rc:5657
+#: Merge.rc:5656
 msgid "32-bit WinMerge does not support Clipboard Compare"
 msgstr "32-бітна версія WinMerge не підтримує порівняння з буфера обміну"
 
 #. IDS_WEBVIEW2_RUNTIME_NOT_INSTALLED
-#: Merge.rc:5662
+#: Merge.rc:5661
 msgid "WebView2 runtime not installed. Download it?"
 msgstr "Середовище виконання WebView2 не встановлено. Завантажити?"
 
 #. IDS_JUMPLIST_NEW_TEXT_COMPARE
-#: Merge.rc:5667
+#: Merge.rc:5666
 msgid "New Text Compare"
 msgstr "Нове порівняння тексту"
 
 #. IDS_JUMPLIST_NEW_TABLE_COMPARE
-#: Merge.rc:5668
+#: Merge.rc:5667
 msgid "New Table Compare"
 msgstr "Нове порівняння таблиць"
 
 #. IDS_JUMPLIST_NEW_BINARY_COMPARE
-#: Merge.rc:5669
+#: Merge.rc:5668
 msgid "New Binary Compare"
 msgstr "Нове двійкове порівняння"
 
 #. IDS_JUMPLIST_NEW_IMAGE_COMPARE
-#: Merge.rc:5670
+#: Merge.rc:5669
 msgid "New Image Compare"
 msgstr "Нове порівняння зображень"
 
 #. IDS_JUMPLIST_NEW_WEBPAGE_COMPARE
-#: Merge.rc:5671
+#: Merge.rc:5670
 msgid "New Webpage Compare"
 msgstr "Нове порівняння вебсторінки"
 
 #. IDS_JUMPLIST_NEW_FOLDER_COMPARE
-#: Merge.rc:5672
+#: Merge.rc:5671
 msgid "New Folder Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_CLIPBOARD_COMPARE
-#: Merge.rc:5673
+#: Merge.rc:5672
 msgid "Clipboard Compare"
 msgstr "Порівняння буфера обміну"
 
 #. IDS_PREVIEWBAR_PRINT
-#: Merge.rc:5678
+#: Merge.rc:5677
 msgid "&Print..."
 msgstr "&Друк..."
 
 #. IDS_PREVIEWBAR_PREVPAGE
-#: Merge.rc:5680
+#: Merge.rc:5679
 msgid "Pre&v Page"
 msgstr "Поп&ередня сторінка"
 
 #. IDS_PREVIEWBAR_TWOPAGE
-#: Merge.rc:5681
+#: Merge.rc:5680
 msgid "&Two Page"
 msgstr "&Дві сторінки"
 
 #. IDS_PREVIEWBAR_ONEPAGE
-#: Merge.rc:5682
+#: Merge.rc:5681
 msgid "&One Page"
 msgstr "&Одна сторінка"
 
 #. IDS_PREVIEWBAR_ZOOMIN
-#: Merge.rc:5683
+#: Merge.rc:5682
 msgid "Zoom &In"
 msgstr "Збільши&ти"
 
 #. IDS_PREVIEWBAR_ZOOMOUT
-#: Merge.rc:5684
+#: Merge.rc:5683
 msgid "Zoom &Out"
 msgstr "З&меншити масштаб"
 
 #. IDS_WEBPAGE_COMPARING
-#: Merge.rc:5690
+#: Merge.rc:5689
 msgid "Comparing..."
 msgstr "Порівняння..."
 
 #. IDS_WEBPAGE_ZOOM
-#: Merge.rc:5691
+#: Merge.rc:5690
 msgid "Zoom:"
 msgstr "Масштаб:"
 
 #. IDS_COPY_GRANULARITY_DIFFHUNK
-#: Merge.rc:5696
+#: Merge.rc:5695
 msgid "Diff hunk"
 msgstr "Блок відмінностей"
 
 #. IDS_COPY_GRANULARITY_INLINE
-#: Merge.rc:5697
+#: Merge.rc:5696
 msgid "Inline diff"
 msgstr "Відмінності у рядку"
 
 #. IDS_COPY_GRANULARITY_LINE
-#: Merge.rc:5698
+#: Merge.rc:5697
 msgid "Line"
 msgstr "Рядок"
 
-#: Merge.rc:5699
+#: Merge.rc:5698
 msgid "Character"
 msgstr "Символ"
 
 #. ID_MICE_PREVDIFF
-#: Merge.rc:5704
+#: Merge.rc:5703
 msgid ""
 "\n"
 "Previous Difference (Alt+Up)\n"
@@ -8533,7 +8528,7 @@ msgstr ""
 "(Alt+Wheel Up)"
 
 #. ID_MICE_NEXTDIFF
-#: Merge.rc:5705
+#: Merge.rc:5704
 msgid ""
 "\n"
 "Next Difference (Alt+Down)\n"
@@ -8545,7 +8540,7 @@ msgstr ""
 "(Alt+Wheel Down)"
 
 #. ID_MICE_L2R
-#: Merge.rc:5706
+#: Merge.rc:5705
 msgid ""
 "\n"
 "Copy to Right (Alt+Right)\n"
@@ -8560,7 +8555,7 @@ msgstr ""
 "(Alt+Shift+Wheel Down)"
 
 #. ID_MICE_R2L
-#: Merge.rc:5707
+#: Merge.rc:5706
 msgid ""
 "\n"
 "Copy to Left (Alt+Left)\n"
@@ -8575,7 +8570,7 @@ msgstr ""
 "(Alt+Shift+Wheel Up)"
 
 #. ID_MICE_L2RNEXT
-#: Merge.rc:5708
+#: Merge.rc:5707
 msgid ""
 "\n"
 "Copy to Right and Advance (Ctrl+Alt+Right)\n"
@@ -8588,7 +8583,7 @@ msgstr ""
 "(Ctrl+Alt+Shift+Wheel Down)"
 
 #. ID_MICE_R2LNEXT
-#: Merge.rc:5709
+#: Merge.rc:5708
 msgid ""
 "\n"
 "Copy to Left and Advance (Ctrl+Alt+Left)\n"
@@ -8601,282 +8596,282 @@ msgstr ""
 "(Ctrl+Alt+Shift+Wheel Up)"
 
 #. IDS_LOG_COMPARING_2
-#: Merge.rc:5719
+#: Merge.rc:5718
 #, c-format
 msgid "Comparing %1 with %2"
 msgstr "Порівняння  %1 з %2"
 
 #. IDS_LOG_COMPARING_3
-#: Merge.rc:5720
+#: Merge.rc:5719
 #, c-format
 msgid "Comparing %1 with %2 and %3"
 msgstr "Порівняння  %1 з %2 та %3"
 
 #. IDS_LOG_COMPARE_COMPLETED
-#: Merge.rc:5721
+#: Merge.rc:5720
 msgid "Comparison completed"
 msgstr "Порівняння завершено"
 
 #. IDS_LOG_COMPARE_ERROR_2
-#: Merge.rc:5722
+#: Merge.rc:5721
 #, c-format
 msgid "Failed to compare %1 with %2: "
 msgstr "Не вдалося порівняти %1 із %2: "
 
 #. IDS_LOG_COMPARE_ERROR_3
-#: Merge.rc:5723
+#: Merge.rc:5722
 #, c-format
 msgid "Failed to compare %1 with %2 and %3: "
 msgstr "Не вдалося порівняти %1 із %2 та %3: "
 
 #. IDS_LOG_FILE_SAVED
-#: Merge.rc:5724
+#: Merge.rc:5723
 msgid "File saved"
 msgstr "Файл збережено"
 
 #. IDS_LOG_COPYING_FILES
-#: Merge.rc:5725
+#: Merge.rc:5724
 msgid "Copying files..."
 msgstr "Копіювання файлів..."
 
 #. IDS_LOG_MOVING_FILES
-#: Merge.rc:5726
+#: Merge.rc:5725
 msgid "Moving files..."
 msgstr "Переміщення файлів..."
 
 #. IDS_LOG_DELETING_FILES
-#: Merge.rc:5727
+#: Merge.rc:5726
 msgid "Deleting files..."
 msgstr "Видалення файлів..."
 
 #. IDS_LOG_RECYCLEBIN
-#: Merge.rc:5728
+#: Merge.rc:5727
 msgid "Recycle Bin"
 msgstr "Кошик"
 
 #. IDS_LOG_PERMANENTLY_DELETED
-#: Merge.rc:5729
+#: Merge.rc:5728
 msgid "Permanently deleted"
 msgstr "Видалено остаточно"
 
 #. IDS_LOG_FILEOPERATION_COMPLETED
-#: Merge.rc:5730
+#: Merge.rc:5729
 msgid "File operation completed successfully"
 msgstr "Операція над файлами виконана успішно"
 
 #. IDS_LOG_FILEOPERATION_CANCELED
-#: Merge.rc:5731
+#: Merge.rc:5730
 msgid "File operation canceled"
 msgstr "Операція над файлами скасована"
 
 #. IDS_FILTER_ERROR_NO_ERROR
-#: Merge.rc:5736
+#: Merge.rc:5735
 msgid "No error"
 msgstr "Без помилок"
 
 #. IDS_FILTER_ERROR_EMPTY_EXPRESSION
-#: Merge.rc:5737
+#: Merge.rc:5736
 msgid "Filter expression is empty"
 msgstr "Вираз фільтра порожній"
 
 #. IDS_FILTER_ERROR_UNKNOWN_CHAR
-#: Merge.rc:5738
+#: Merge.rc:5737
 msgid "Unknown character in filter expression"
 msgstr "Невідомий символ у виразі фільтра"
 
 #. IDS_FILTER_ERROR_UNTERMINATED_STRING
-#: Merge.rc:5739
+#: Merge.rc:5738
 msgid "Unterminated string literal"
 msgstr "Незавершений рядковий літерал"
 
 #. IDS_FILTER_ERROR_SYNTAX_ERROR
-#: Merge.rc:5740
+#: Merge.rc:5739
 msgid "Syntax error in filter expression"
 msgstr "Синтаксична помилка у виразі фільтра"
 
 #. IDS_FILTER_ERROR_PARSE_FAILURE
-#: Merge.rc:5741
+#: Merge.rc:5740
 msgid "Failed to parse filter expression"
 msgstr "Не вдалося розібрати вираз фільтра"
 
 #. IDS_FILTER_ERROR_INVALID_LITERAL
-#: Merge.rc:5742
+#: Merge.rc:5741
 msgid "Invalid literal value"
 msgstr "Неприпустиме значення літерала"
 
 #. IDS_FILTER_ERROR_INVALID_REGULAR_EXPRESSION
-#: Merge.rc:5743
+#: Merge.rc:5742
 msgid "Invalid regular expression"
 msgstr "Неприпустимий регулярний вираз"
 
 #. IDS_FILTER_ERROR_UNDEFINED_IDENTIFIER
-#: Merge.rc:5744
+#: Merge.rc:5743
 msgid "Undefined identifier"
 msgstr "Невизначений ідентифікатор"
 
 #. IDS_FILTER_ERROR_INVALID_ARGUMENT_COUNT
-#: Merge.rc:5745
+#: Merge.rc:5744
 msgid "Invalid number of arguments"
 msgstr "Невірна кількість аргументів"
 
 #. IDS_FILTER_ERROR_FILTER_NAME_NOT_FOUND
-#: Merge.rc:5746
+#: Merge.rc:5745
 msgid "Filter name not found"
 msgstr "Ім'я фільтра не знайдено"
 
 #. IDS_FILTER_ERROR_DIVIDE_BY_ZERO
-#: Merge.rc:5747
+#: Merge.rc:5746
 msgid "Division by zero in filter expression"
 msgstr "Ділення на нуль у виразі фільтра"
 
 #. IDS_FILTER_ERROR_UNKNOWN_ERROR
-#: Merge.rc:5748
+#: Merge.rc:5747
 msgid "Unknown error"
 msgstr "Невідома помилка"
 
 #. IDS_FILTER_ERROR_INVALID_PROPERTY_NAME
-#: Merge.rc:5749
+#: Merge.rc:5748
 msgid "Invalid property name"
 msgstr "Неприпустимиа назва властивості"
 
 #. IDS_FILTER_ERROR_INVALID_DIRECTIVE
-#: Merge.rc:5750
+#: Merge.rc:5749
 msgid "Invalid directive"
 msgstr ""
 
 #. IDS_FILTER_OP_EQUALS
-#: Merge.rc:5755
+#: Merge.rc:5754
 msgid "Equals"
 msgstr "Дорівнює"
 
 #. IDS_FILTER_OP_NOT_EQUALS
-#: Merge.rc:5756
+#: Merge.rc:5755
 msgid "Does not equal"
 msgstr "Не дорівнює"
 
 #. IDS_FILTER_OP_LESS_THAN
-#: Merge.rc:5757
+#: Merge.rc:5756
 msgid "Less than"
 msgstr "Менше ніж"
 
 #. IDS_FILTER_OP_LESS_EQUAL
-#: Merge.rc:5758
+#: Merge.rc:5757
 msgid "Less than or equal to"
 msgstr "Менше або дорівнює"
 
 #. IDS_FILTER_OP_GREATER_EQUAL
-#: Merge.rc:5759
+#: Merge.rc:5758
 msgid "Greater than or equal to"
 msgstr "Більше або дорівнює"
 
 #. IDS_FILTER_OP_GREATER_THAN
-#: Merge.rc:5760
+#: Merge.rc:5759
 msgid "Greater than"
 msgstr "Більше ніж"
 
 #. IDS_FILTER_OP_BETWEEN
-#: Merge.rc:5761
+#: Merge.rc:5760
 msgid "Between"
 msgstr "В межах"
 
 #. IDS_FILTER_OP_NOT_BETWEEN
-#: Merge.rc:5762
+#: Merge.rc:5761
 msgid "Not Between"
 msgstr "Не в межах"
 
 #. IDS_FILTER_OP_CONTAINS
-#: Merge.rc:5763
+#: Merge.rc:5762
 msgid "Contains"
 msgstr "Містить"
 
 #. IDS_FILTER_OP_NOT_CONTAINS
-#: Merge.rc:5764
+#: Merge.rc:5763
 msgid "Not Contains"
 msgstr "Не містить"
 
 #. IDS_FILTER_OP_RECONTAINS
-#: Merge.rc:5765
+#: Merge.rc:5764
 msgid "Contains (regex)"
 msgstr "Містить (регулярний вираз)"
 
 #. IDS_FILTER_OP_NOT_RECONTAINS
-#: Merge.rc:5766
+#: Merge.rc:5765
 msgid "Not Contains (regex)"
 msgstr "Не містить (регулярний вираз)"
 
 #. IDS_FILTER_OP_LIKE
-#: Merge.rc:5767
+#: Merge.rc:5766
 msgid "Match (wildcard)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_LIKE
-#: Merge.rc:5768
+#: Merge.rc:5767
 msgid "Not match (wildcard)"
 msgstr ""
 
 #. IDS_FILTER_OP_MATCHES
-#: Merge.rc:5769
+#: Merge.rc:5768
 msgid "Match (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_MATCHES
-#: Merge.rc:5770
+#: Merge.rc:5769
 msgid "Not match (regex)"
 msgstr ""
 
 #. IDS_COLORMODE_LIGHT
-#: Merge.rc:5775
+#: Merge.rc:5774
 msgid "Light"
 msgstr "Світла"
 
 #. IDS_COLORMODE_DARK
-#: Merge.rc:5776
+#: Merge.rc:5775
 msgid "Dark"
 msgstr "Темна"
 
 #. IDS_COLORMODE_FOLLOWSYSTEM
-#: Merge.rc:5777
+#: Merge.rc:5776
 msgid "Follow system"
 msgstr "Як в системі"
 
 #. IDS_EXAMPLE
-#: Merge.rc:5782
+#: Merge.rc:5781
 #, c-format
 msgid "e.g. %1"
 msgstr ""
 
 #. IDS_DETECTED_PREVIOUS_CRASH
-#: Merge.rc:5787
+#: Merge.rc:5786
 msgid "WinMerge detected a previous crash. Please report this if possible."
 msgstr ""
 
 #. IDS_REGEX_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5792
+#: Merge.rc:5791
 msgid "# Regex replacement list\r\n# Format: regex<TAB>replacement\r\n# Backreferences like $1, $2 are supported\r\n\r\n(\\d{4})-(\\d{2})-(\\d{2})\t$1_$2_$3\r\n"
 msgstr ""
 
 #. IDS_STRING_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5793
+#: Merge.rc:5792
 msgid "# Replacement list\r\n# Format: search<TAB>replacement\r\n# Lines starting with # are ignored\r\n\r\nfrom1\tto1\r\nfrom2\tto2\r\n"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_ONLY
-#: Merge.rc:5798
+#: Merge.rc:5797
 msgid "Built-in only"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_FIRST
-#: Merge.rc:5799
+#: Merge.rc:5798
 msgid "Built-in first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_FIRST
-#: Merge.rc:5800
+#: Merge.rc:5799
 msgid "Tree-sitter first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_ONLY
-#: Merge.rc:5801
+#: Merge.rc:5800
 msgid "Tree-sitter only"
 msgstr ""
 

--- a/Translations/WinMerge/Vietnamese.po
+++ b/Translations/WinMerge/Vietnamese.po
@@ -23,7 +23,7 @@ msgstr ""
 "X-Source-Language: en\n"
 
 #. LANGUAGE, SUBLANGUAGE
-#: Merge.rc:26 Merge.rc:59 Merge.rc:5818
+#: Merge.rc:26 Merge.rc:59 Merge.rc:5817
 msgid "LANG_ENGLISH, SUBLANG_ENGLISH_US"
 msgstr "LANG_VIETNAMESE, SUBLANG_DEFAULT"
 
@@ -165,7 +165,7 @@ msgstr "&Kịch bản"
 #. IDS_NO_EDIT_SCRIPTS
 #: Merge.rc:127 Merge.rc:352 Merge.rc:463 Merge.rc:673 Merge.rc:678
 #: Merge.rc:887 Merge.rc:899 Merge.rc:906 Merge.rc:963 Merge.rc:1210
-#: Merge.rc:5375
+#: Merge.rc:5374
 msgid "< Empty >"
 msgstr "< Trống >"
 
@@ -230,7 +230,7 @@ msgid "Auto-Fit All Columns"
 msgstr "Tự động khớp tất cả các cột"
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN
-#: Merge.rc:153 Merge.rc:5646
+#: Merge.rc:153 Merge.rc:5645
 msgid "&Filter by This Column"
 msgstr ""
 
@@ -291,7 +291,7 @@ msgid "&Previous Page"
 msgstr "Trang &trước"
 
 #. IDS_PREVIEWBAR_NEXTPAGE
-#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5679
+#: Merge.rc:194 Merge.rc:202 Merge.rc:1266 Merge.rc:5678
 msgid "&Next Page"
 msgstr "Trang &sau"
 
@@ -542,7 +542,7 @@ msgstr "&Nhị phân"
 #. IDS_IMAGE_MENU
 #: Merge.rc:329 Merge.rc:338 Merge.rc:432 Merge.rc:441 Merge.rc:609
 #: Merge.rc:618 Merge.rc:670 Merge.rc:960 Merge.rc:1187 Merge.rc:1200
-#: Merge.rc:5477
+#: Merge.rc:5476
 msgid "&Image"
 msgstr "&Hình ảnh"
 
@@ -664,7 +664,7 @@ msgid "&Huge"
 msgstr "&Khổng lồ"
 
 #. IDS_VIEW_MENU_BAR
-#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5714
+#: Merge.rc:378 Merge.rc:529 Merge.rc:777 Merge.rc:5713
 msgid "Men&u Bar"
 msgstr "Thanh &bảng chọn"
 
@@ -1319,7 +1319,7 @@ msgid "Lo&cation Pane"
 msgstr "Khung &vị trí"
 
 #. IDS_OUTPUTBAR_CAPTION
-#: Merge.rc:782 Merge.rc:5252
+#: Merge.rc:782 Merge.rc:5251
 msgid "Output Pane"
 msgstr "Khung kết quả"
 
@@ -1582,55 +1582,55 @@ msgid "Co&mpare As"
 msgstr "So &sánh dưới dạng"
 
 #. IDS_COPY_LEFT_TO_MIDDLE2
-#: Merge.rc:968 Merge.rc:980 Merge.rc:4852
+#: Merge.rc:968 Merge.rc:980 Merge.rc:4851
 #, c-format
 msgid "Left to Middle (%1 of %2)"
 msgstr "Trái sang giữa (%1 trên %2)"
 
 #. IDS_COPY_LEFT_TO_RIGHT2
-#: Merge.rc:969 Merge.rc:981 Merge.rc:4851
+#: Merge.rc:969 Merge.rc:981 Merge.rc:4850
 #, c-format
 msgid "Left to Right (%1 of %2)"
 msgstr "Trái sang phải (%1 trên %2)"
 
 #. IDS_MOVE_LEFT_TO2
-#: Merge.rc:970 Merge.rc:982 Merge.rc:1045 Merge.rc:4863 Merge.rc:4892
+#: Merge.rc:970 Merge.rc:982 Merge.rc:1045 Merge.rc:4862 Merge.rc:4891
 #, c-format
 msgid "Left to... (%1 of %2)"
 msgstr "Trái sang... (%1 trên %2)"
 
 #. IDS_COPY_MIDDLE_TO_LEFT2
-#: Merge.rc:971 Merge.rc:983 Merge.rc:4849
+#: Merge.rc:971 Merge.rc:983 Merge.rc:4848
 #, c-format
 msgid "Middle to Left (%1 of %2)"
 msgstr "Giữa sang trái (%1 trên %2)"
 
 #. IDS_COPY_MIDDLE_TO_RIGHT2
-#: Merge.rc:972 Merge.rc:984 Merge.rc:4850
+#: Merge.rc:972 Merge.rc:984 Merge.rc:4849
 #, c-format
 msgid "Middle to Right (%1 of %2)"
 msgstr "Giữa sang phải (%1 trên %2)"
 
 #. IDS_MOVE_MIDDLE_TO2
-#: Merge.rc:973 Merge.rc:985 Merge.rc:1046 Merge.rc:4864 Merge.rc:4893
+#: Merge.rc:973 Merge.rc:985 Merge.rc:1046 Merge.rc:4863 Merge.rc:4892
 #, c-format
 msgid "Middle to... (%1 of %2)"
 msgstr "Giữa sang... (%1 trên %2)"
 
 #. IDS_COPY_RIGHT_TO_MIDDLE2
-#: Merge.rc:974 Merge.rc:986 Merge.rc:4848
+#: Merge.rc:974 Merge.rc:986 Merge.rc:4847
 #, c-format
 msgid "Right to Middle (%1 of %2)"
 msgstr "Phải sang giữa (%1 trên %2)"
 
 #. IDS_COPY_RIGHT_TO_LEFT2
-#: Merge.rc:975 Merge.rc:987 Merge.rc:4847
+#: Merge.rc:975 Merge.rc:987 Merge.rc:4846
 #, c-format
 msgid "Right to Left (%1 of %2)"
 msgstr "Phải sang trái (%1 trên %2)"
 
 #. IDS_MOVE_RIGHT_TO2
-#: Merge.rc:976 Merge.rc:988 Merge.rc:1047 Merge.rc:4865 Merge.rc:4894
+#: Merge.rc:976 Merge.rc:988 Merge.rc:1047 Merge.rc:4864 Merge.rc:4893
 #, c-format
 msgid "Right to... (%1 of %2)"
 msgstr "Phải sang... (%1 trên %2)"
@@ -1686,31 +1686,31 @@ msgid "Cop&y Paths"
 msgstr "Sao &chép các đường dẫn"
 
 #. IDS_DEL_LEFT_FMT2
-#: Merge.rc:1026 Merge.rc:1035 Merge.rc:4880
+#: Merge.rc:1026 Merge.rc:1035 Merge.rc:4879
 #, c-format
 msgid "Left (%1 of %2)"
 msgstr "Bên trái (%1 trên %2)"
 
 #. IDS_DEL_MIDDLE_FMT2
-#: Merge.rc:1027 Merge.rc:1036 Merge.rc:4881
+#: Merge.rc:1027 Merge.rc:1036 Merge.rc:4880
 #, c-format
 msgid "Middle (%1 of %2)"
 msgstr "Ở giữa (%1 trên %2)"
 
 #. IDS_DEL_RIGHT_FMT2
-#: Merge.rc:1028 Merge.rc:1037 Merge.rc:4882
+#: Merge.rc:1028 Merge.rc:1037 Merge.rc:4881
 #, c-format
 msgid "Right (%1 of %2)"
 msgstr "Bên phải (%1 trên %2)"
 
 #. IDS_DEL_BOTH_FMT2
-#: Merge.rc:1029 Merge.rc:1038 Merge.rc:4883
+#: Merge.rc:1029 Merge.rc:1038 Merge.rc:4882
 #, c-format
 msgid "Both (%1 of %2)"
 msgstr "Cả hai (%1 trên %2)"
 
 #. IDS_DEL_ALL_FMT2
-#: Merge.rc:1030 Merge.rc:1039 Merge.rc:4888
+#: Merge.rc:1030 Merge.rc:1039 Merge.rc:4887
 #, c-format
 msgid "All (%1 of %2)"
 msgstr "Tất cả (%1 trên %2)"
@@ -1736,19 +1736,19 @@ msgid "&Zip"
 msgstr "&Nén"
 
 #. IDS_COPY_BOTH_TO2
-#: Merge.rc:1048 Merge.rc:4866
+#: Merge.rc:1048 Merge.rc:4865
 #, c-format
 msgid "Both to... (%1 of %2)"
 msgstr "Cả hai sang... (%1 trên %2)"
 
 #. IDS_COPY_ALL_TO2
-#: Merge.rc:1049 Merge.rc:4867
+#: Merge.rc:1049 Merge.rc:4866
 #, c-format
 msgid "All to... (%1 of %2)"
 msgstr "Tất cả sang... (%1 trên %2)"
 
 #. IDS_COPY_DIFFERENCES_TO2
-#: Merge.rc:1050 Merge.rc:4868
+#: Merge.rc:1050 Merge.rc:4867
 #, c-format
 msgid "Differences to... (%1 of %2)"
 msgstr "Các khác biệt sang... (%1 trên %2)"
@@ -1815,12 +1815,12 @@ msgstr "Thiết đặt trình bung gói"
 
 #. IDS_USERCHOICE_NONE
 #: Merge.rc:1088 Merge.rc:1094 Merge.rc:1836 Merge.rc:1840 Merge.rc:2031
-#: Merge.rc:2035 Merge.rc:5377
+#: Merge.rc:2035 Merge.rc:5376
 msgid "<None>"
 msgstr "<Không có>"
 
 #. IDS_USERCHOICE_AUTOMATIC
-#: Merge.rc:1089 Merge.rc:1095 Merge.rc:5378
+#: Merge.rc:1089 Merge.rc:1095 Merge.rc:5377
 msgid "<Automatic>"
 msgstr "<Tự động>"
 
@@ -2750,12 +2750,12 @@ msgid "Text files only"
 msgstr ""
 
 #. IDS_EOL_NONE
-#: Merge.rc:1667 Merge.rc:1918 Merge.rc:5304
+#: Merge.rc:1667 Merge.rc:1918 Merge.rc:5303
 msgid "None"
 msgstr "Không có"
 
 #. IDS_EOL_MIXED
-#: Merge.rc:1668 Merge.rc:5299
+#: Merge.rc:1668 Merge.rc:5298
 msgid "Mixed"
 msgstr "Hỗn hợp"
 
@@ -3027,13 +3027,13 @@ msgstr ""
 
 #. IDS_DIFFERENT
 #: Merge.rc:1904 Merge.rc:1988 Merge.rc:2866 Merge.rc:3036 Merge.rc:3077
-#: Merge.rc:5058
+#: Merge.rc:5057
 msgid "Different"
 msgstr "Khác biệt"
 
 #. IDS_IDENTICAL
 #: Merge.rc:1905 Merge.rc:1989 Merge.rc:2865 Merge.rc:3055 Merge.rc:3116
-#: Merge.rc:5048
+#: Merge.rc:5047
 msgid "Identical"
 msgstr "Giống hệt"
 
@@ -3053,7 +3053,7 @@ msgid "Missing"
 msgstr ""
 
 #. IDS_MOVED
-#: Merge.rc:1910 Merge.rc:5076
+#: Merge.rc:1910 Merge.rc:5075
 msgid "Moved"
 msgstr ""
 
@@ -3793,7 +3793,7 @@ msgid "&Use custom system colors"
 msgstr "Sử dụng màu hệ thống tuỳ chỉnh"
 
 #. IDS_PRPCAT_SYSTEM
-#: Merge.rc:2565 Merge.rc:4559 Merge.rc:4560 Merge.rc:5007
+#: Merge.rc:2565 Merge.rc:4559 Merge.rc:4560 Merge.rc:5006
 msgid "System"
 msgstr "Hệ thống"
 
@@ -4197,7 +4197,7 @@ msgid "Items compared:"
 msgstr "Mục đã so sánh:"
 
 #. IDS_PREVIEWBAR_CLOSE
-#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5685
+#: Merge.rc:2791 Merge.rc:3168 Merge.rc:5684
 msgid "&Close"
 msgstr "&Đóng"
 
@@ -4820,7 +4820,7 @@ msgid "A&ppend timestamp"
 msgstr "Thêm tem &thời gian"
 
 #. IDS_CONFIRM_COPY_CAPTION
-#: Merge.rc:3214 Merge.rc:4915
+#: Merge.rc:3214 Merge.rc:4914
 msgid "Confirm Copy"
 msgstr "Xác nhận sao chép"
 
@@ -5057,7 +5057,7 @@ msgid "&Character Set..."
 msgstr "Tập &ký tự..."
 
 #. IDS_PRPCAT_IMAGE
-#: Merge.rc:3351 Merge.rc:4574 Merge.rc:5015
+#: Merge.rc:3351 Merge.rc:4574 Merge.rc:5014
 msgid "Image"
 msgstr "Hình ảnh"
 
@@ -5460,7 +5460,7 @@ msgid "Project"
 msgstr "Dự án"
 
 #. IDS_COLHDR_NSDIFFS
-#: Merge.rc:4566 Merge.rc:4990
+#: Merge.rc:4566 Merge.rc:4989
 msgid "Differences"
 msgstr "Khác biệt"
 
@@ -5606,12 +5606,12 @@ msgid "File Type"
 msgstr "Loại tệp"
 
 #. IDS_COLHDR_EXTENSION
-#: Merge.rc:4653 Merge.rc:4947
+#: Merge.rc:4653 Merge.rc:4946
 msgid "Extension"
 msgstr "Phần mở rộng"
 
 #. IDS_PRPCAT_MESSAGE
-#: Merge.rc:4659 Merge.rc:5019
+#: Merge.rc:4659 Merge.rc:5018
 msgid "Message"
 msgstr "Thông điệp"
 
@@ -5651,7 +5651,7 @@ msgid "Hidden Items"
 msgstr "Các mục ẩn"
 
 #. IDS_PLUGINSLIST_NAME
-#: Merge.rc:4680 Merge.rc:5311
+#: Merge.rc:4680 Merge.rc:5310
 msgid "Name"
 msgstr "Tên"
 
@@ -5671,7 +5671,7 @@ msgid "[F] "
 msgstr "[F] "
 
 #. IDS_PLUGINSLIST_DESC
-#: Merge.rc:4684 Merge.rc:5313
+#: Merge.rc:4684 Merge.rc:5312
 msgid "Description"
 msgstr "Mô tả"
 
@@ -5840,155 +5840,150 @@ msgstr "Dòng: %s  Cột: %d/%d  Kí tự: %d/%d"
 msgid "  Sel: %d | %d"
 msgstr "  Phần chọn: %d | %d"
 
-#. IDS_MERGEMODE_MERGING
-#: Merge.rc:4734
-msgid "Merge"
-msgstr "Trộn"
-
 #. IDS_DIFF_NUMBER_STATUS_FMT
-#: Merge.rc:4735
+#: Merge.rc:4734
 #, c-format
 msgid "Difference %1 of %2"
 msgstr "Khác biệt %1 trên %2"
 
 #. IDS_NO_DIFF_SEL_FMT
-#: Merge.rc:4736
+#: Merge.rc:4735
 #, c-format
 msgid "%1 Differences Found"
 msgstr "Tìm thấy %1 khác biệt"
 
 #. IDS_1_DIFF_FOUND
-#: Merge.rc:4737
+#: Merge.rc:4736
 msgid "1 Difference Found"
 msgstr "Tìm thấy 1 khác biệt"
 
 #. IDS_NO_ERR_SEL_FMT
-#: Merge.rc:4738
+#: Merge.rc:4737
 #, c-format
 msgid "%1 Errors Found"
 msgstr "Tìm thấy %1 lỗi"
 
 #. IDS_1_ERR_FOUND
-#: Merge.rc:4739
+#: Merge.rc:4738
 msgid "1 Error Found"
 msgstr "Tìm thấy 1 lỗi"
 
 #. IDS_STATUSBAR_READONLY, Abbreviation from "Read Only"
-#: Merge.rc:4740
+#: Merge.rc:4739
 msgid "RO"
 msgstr "CĐ"
 
 #. IDS_DIRVIEW_STATUS_FMT_FOCUS
-#: Merge.rc:4746
+#: Merge.rc:4745
 #, c-format
 msgid "Item %1 of %2"
 msgstr "Mục %1 trên %2"
 
 #. IDS_DIRVIEW_STATUS_FMT_NOFOCUS
-#: Merge.rc:4747
+#: Merge.rc:4746
 #, c-format
 msgid "Items: %1"
 msgstr "Số mục: %1"
 
 #. IDS_DIRVIEW_STATUS_COMPARING
-#: Merge.rc:4748
+#: Merge.rc:4747
 msgid "Comparing items..."
 msgstr "Đang so sánh các mục..."
 
 #. IDS_ITEMS_PER_SEC
-#: Merge.rc:4749
+#: Merge.rc:4748
 #, c-format
 msgid "%.1f[items/sec]"
 msgstr "%.1f[mục/giây]"
 
 #. IDS_ERROR_INCOMPARABLE
-#: Merge.rc:4755
+#: Merge.rc:4754
 msgid "Select two existing folders/files to compare."
 msgstr "Chọn hai thư mục/tệp hiện có để so sánh."
 
 #. IDS_DIRSEL_TAG
-#: Merge.rc:4756
+#: Merge.rc:4755
 msgid "Folder Selection"
 msgstr "Chọn thư mục"
 
 #. IDS_OPEN_FILESDIRS
-#: Merge.rc:4757
+#: Merge.rc:4756
 msgid "Select two (or three) folders/files to compare."
 msgstr "Chọn hai (hoặc ba) thư mục / tệp để so sánh."
 
 #. IDS_OPEN_LEFTINVALID
-#: Merge.rc:4758
+#: Merge.rc:4757
 msgid "Left (1st) path is invalid!"
 msgstr "Đường dẫn bên trái (thứ nhất) không hợp lệ!"
 
 #. IDS_OPEN_MIDDLEINVALID
-#: Merge.rc:4759
+#: Merge.rc:4758
 msgid "Middle (2nd) path is invalid!"
 msgstr "Đường dẫn ở giữa (thứ 2) không hợp lệ!"
 
 #. IDS_OPEN_RIGHTINVALID2
-#: Merge.rc:4760
+#: Merge.rc:4759
 msgid "Right (2nd) path is invalid!"
 msgstr "Đường dẫn bên phải (thứ 2) không hợp lệ!"
 
 #. IDS_OPEN_RIGHTINVALID3
-#: Merge.rc:4761
+#: Merge.rc:4760
 msgid "Right (3rd) path is invalid!"
 msgstr "Đường dẫn bên phải (thứ 3) không hợp lệ!"
 
 #. IDS_OPEN_BOTHINVALID
-#: Merge.rc:4762
+#: Merge.rc:4761
 msgid "Both paths are invalid!"
 msgstr "Cả hai đường dẫn đều không hợp lệ!"
 
-#: Merge.rc:4764
+#: Merge.rc:4763
 msgid "Left (1st) and Middle (2nd) paths are invalid!"
 msgstr "Đường dẫn bên trái (1) và ở giữa (2) không hợp lệ!"
 
 #. IDS_OPEN_LEFTRIGHTINVALID
-#: Merge.rc:4765
+#: Merge.rc:4764
 msgid "Left (1st) and Right (3rd) paths are invalid!"
 msgstr "Đường dẫn bên trái (1) và bên phải (3) không hợp lệ!"
 
-#: Merge.rc:4767
+#: Merge.rc:4766
 msgid "Middle (2nd) and Right (3rd) paths are invalid!"
 msgstr "Đường dẫn ở giữa (2) và bên phải (3) không hợp lệ!"
 
 #. IDS_OPEN_ALLINVALID
-#: Merge.rc:4768
+#: Merge.rc:4767
 msgid "All paths are invalid!"
 msgstr "Tất cả đường dẫn đều không hợp lệ!"
 
 #. IDS_OPEN_UNPACKERDISABLED
-#: Merge.rc:4769
+#: Merge.rc:4768
 msgid "Only enabled for file comparisons"
 msgstr "Chỉ bật cho so sánh tệp"
 
 #. IDS_OPEN_MISMATCH
-#: Merge.rc:4770
+#: Merge.rc:4769
 msgid "Cannot compare file and folder!"
 msgstr "Không thể so sánh tệp và thư mục!"
 
 #. IDS_ERROR_FILE_NOT_FOUND
-#: Merge.rc:4776
+#: Merge.rc:4775
 #, c-format
 msgid "File not found: %1"
 msgstr "Không tìm thấy tệp: %1"
 
 #. IDS_ERROR_FOLDER_NOT_FOUND
-#: Merge.rc:4777
+#: Merge.rc:4776
 #, c-format
 msgid "Folder not found: %1"
 msgstr ""
 
 #. IDS_ERROR_FILE_NOT_UNPACKED
-#: Merge.rc:4778
+#: Merge.rc:4777
 #, c-format
 msgid "File not unpacked: %1"
 msgstr "Tệp chưa được bung gói: %1"
 
 #. IDS_ERROR_FILEOPEN
-#: Merge.rc:4779
+#: Merge.rc:4778
 #, c-format
 msgid ""
 "Cannot open file\n"
@@ -6002,12 +5997,12 @@ msgstr ""
 "%2"
 
 #. IDS_ERROR_CONF_RESOLVE
-#: Merge.rc:4780
+#: Merge.rc:4779
 msgid "Failed to parse conflict file."
 msgstr "Không thể phân tích cú pháp tệp xung đột."
 
 #. IDS_NOT_CONFLICT_FILE
-#: Merge.rc:4781
+#: Merge.rc:4780
 #, c-format
 msgid ""
 "The file\n"
@@ -6019,7 +6014,7 @@ msgstr ""
 "không phải là một tệp xung đột."
 
 #. IDS_COMPARE_LARGE_FILES
-#: Merge.rc:4782
+#: Merge.rc:4781
 msgid ""
 "Comparing large files requires significant memory.\n"
 "Show only comparison results (not file contents)?"
@@ -6028,18 +6023,18 @@ msgstr ""
 "Chỉ hiển thị kết quả so sánh (không hiện nội dung tệp) nhé?"
 
 #. IDS_SAVE_AS_TITLE
-#: Merge.rc:4788
+#: Merge.rc:4787
 msgid "Save As"
 msgstr "Lưu thành"
 
 #. IDS_SAVE_FMT
-#: Merge.rc:4789
+#: Merge.rc:4788
 #, c-format
 msgid "Save changes to %1?"
 msgstr "Có lưu các thay đổi vào %1 nhé?"
 
 #. IDS_SAVEREADONLY_FMT
-#: Merge.rc:4790
+#: Merge.rc:4789
 #, c-format
 msgid "%1 is read-only. Override? Or 'No' to save as new filename?"
 msgstr ""
@@ -6047,11 +6042,11 @@ msgstr ""
 "mới?"
 
 #. IDS_ERROR_BACKUP
-#: Merge.rc:4791
+#: Merge.rc:4790
 msgid "Error backing up file"
 msgstr "Lỗi khi sao lưu tệp"
 
-#: Merge.rc:4793
+#: Merge.rc:4792
 #, c-format
 msgid ""
 "Unable to backup original file:\n"
@@ -6065,7 +6060,7 @@ msgstr ""
 "Vẫn tiếp tục nhé?"
 
 #. IDS_FILESAVE_FAILED
-#: Merge.rc:4794
+#: Merge.rc:4793
 #, c-format
 msgid ""
 "Saving file failed.\n"
@@ -6080,7 +6075,7 @@ msgstr ""
 "\t- Sử dụng tên tệp khác (OK)\n"
 "\t- Huỷ bỏ (Huỷ)?"
 
-#: Merge.rc:4796
+#: Merge.rc:4795
 #, c-format
 msgid ""
 "Plugin '%2' cannot pack changes to left file into '%1'.\n"
@@ -6091,7 +6086,7 @@ msgstr ""
 "\n"
 "Tệp gốc chưa thay đổi. Có lưu phiên bản đã bung gói không?"
 
-#: Merge.rc:4798
+#: Merge.rc:4797
 #, c-format
 msgid ""
 "Plugin '%2' cannot pack changes to middle file into '%1'.\n"
@@ -6102,7 +6097,7 @@ msgstr ""
 "\n"
 "Tệp gốc chưa thay đổi. Có lưu phiên bản đã bung gói không?"
 
-#: Merge.rc:4800
+#: Merge.rc:4799
 #, c-format
 msgid ""
 "Plugin '%2' cannot pack changes to right file into '%1'.\n"
@@ -6114,7 +6109,7 @@ msgstr ""
 "Tệp gốc chưa thay đổi. Có lưu phiên bản đã bung gói không?"
 
 #. IDS_FILECHANGED_ONDISK
-#: Merge.rc:4801
+#: Merge.rc:4800
 #, c-format
 msgid ""
 "Another application updated\n"
@@ -6130,7 +6125,7 @@ msgstr ""
 "Có ghi đè không?"
 
 #. IDS_SAVEREADONLY_MULTI
-#: Merge.rc:4802
+#: Merge.rc:4801
 #, c-format
 msgid ""
 "%1\n"
@@ -6140,7 +6135,7 @@ msgstr ""
 "là tệp chỉ-đọc. Có ghi đè không?"
 
 #. IDS_FILECHANGED_RESCAN
-#: Merge.rc:4803
+#: Merge.rc:4802
 #, c-format
 msgid ""
 "Another application updated\n"
@@ -6156,22 +6151,22 @@ msgstr ""
 "Có tải lại không?"
 
 #. IDS_SAVE_LEFT_AS
-#: Merge.rc:4804
+#: Merge.rc:4803
 msgid "Save Left File As"
 msgstr "Lưu tệp bên trái thành"
 
 #. IDS_SAVE_MIDDLE_AS
-#: Merge.rc:4805
+#: Merge.rc:4804
 msgid "Save Middle File As"
 msgstr "Lưu tệp ở giữa thành"
 
 #. IDS_SAVE_RIGHT_AS
-#: Merge.rc:4806
+#: Merge.rc:4805
 msgid "Save Right File As"
 msgstr "Lưu tệp bên phải thành"
 
 #. IDS_FILE_DISAPPEARED
-#: Merge.rc:4811
+#: Merge.rc:4810
 #, c-format
 msgid ""
 "File\n"
@@ -6183,7 +6178,7 @@ msgstr ""
 "không tìm thấy. Lưu một bản sao để tiếp tục."
 
 #. IDS_VIEWS_OUTOFSYNC
-#: Merge.rc:4817
+#: Merge.rc:4816
 msgid ""
 "Cannot merge unsynched documents.\n"
 "\n"
@@ -6194,186 +6189,186 @@ msgstr ""
 "Hãy làm mới trước khi tiếp tục."
 
 #. IDS_BREAK_ON_WHITESPACE
-#: Merge.rc:4822
+#: Merge.rc:4821
 msgid "Break at whitespace"
 msgstr "Ngắt tại khoảng trắng"
 
 #. IDS_BREAK_ON_PUNCTUATION
-#: Merge.rc:4823
+#: Merge.rc:4822
 msgid "Break at whitespace or punctuation"
 msgstr "Ngắt tại khoảng trắng hoặc dấu câu"
 
 #. IDS_L2M
-#: Merge.rc:4829
+#: Merge.rc:4828
 msgid "Copy to &Middle\tAlt+Right"
 msgstr "Chép sang &giữa\tAlt+Right"
 
 #. IDS_R2M
-#: Merge.rc:4830
+#: Merge.rc:4829
 msgid "Copy to &Middle\tAlt+Left"
 msgstr "Chép sang &giữa\tAlt+Left"
 
 #. IDS_COPY_FROM_MIDDLE_R
-#: Merge.rc:4831
+#: Merge.rc:4830
 msgid "Copy from Middle\tAlt+Shift+Right"
 msgstr "Chép từ giữa\tAlt+Shift+Right"
 
 #. IDS_COPY_FROM_MIDDLE_L
-#: Merge.rc:4832
+#: Merge.rc:4831
 msgid "Copy from Middle\tAlt+Shift+Left"
 msgstr "Chép từ giữa\tAlt+Shift+Left"
 
 #. IDS_L2MNEXT
-#: Merge.rc:4833
+#: Merge.rc:4832
 msgid "Copy to Middle and Advance\tCtrl+Alt+Right"
 msgstr "Chép sang giữa và tiến tiếp\tCtrl+Alt+Right"
 
 #. IDS_R2MNEXT
-#: Merge.rc:4834
+#: Merge.rc:4833
 msgid "Copy to Middle and Advance\tCtrl+Alt+Left"
 msgstr "Chép sang giữa và tiến tiếp\tCtrl+Alt+Left"
 
 #. IDS_ALL_MIDDLE
-#: Merge.rc:4835
+#: Merge.rc:4834
 msgid "Copy All to Middle"
 msgstr "Chép tất cả sang giữa"
 
 #. IDS_COPY_RIGHT_TO_LEFT
-#: Merge.rc:4841
+#: Merge.rc:4840
 #, c-format
 msgid "Right to Left (%1)"
 msgstr "Phải sang trái (%1)"
 
 #. IDS_COPY_RIGHT_TO_MIDDLE
-#: Merge.rc:4842
+#: Merge.rc:4841
 #, c-format
 msgid "Right to Middle (%1)"
 msgstr "Phải sang giữa (%1)"
 
 #. IDS_COPY_MIDDLE_TO_LEFT
-#: Merge.rc:4843
+#: Merge.rc:4842
 #, c-format
 msgid "Middle to Left (%1)"
 msgstr "Giữa sang trái (%1)"
 
 #. IDS_COPY_MIDDLE_TO_RIGHT
-#: Merge.rc:4844
+#: Merge.rc:4843
 #, c-format
 msgid "Middle to Right (%1)"
 msgstr "Giữa sang phải (%1)"
 
 #. IDS_COPY_LEFT_TO_RIGHT
-#: Merge.rc:4845
+#: Merge.rc:4844
 #, c-format
 msgid "Left to Right (%1)"
 msgstr "Trái sang phải (%1)"
 
 #. IDS_COPY_LEFT_TO_MIDDLE
-#: Merge.rc:4846
+#: Merge.rc:4845
 #, c-format
 msgid "Left to Middle (%1)"
 msgstr "Trái sang giữa (%1)"
 
 #. IDS_MOVE_LEFT_TO
-#: Merge.rc:4857 Merge.rc:4889
+#: Merge.rc:4856 Merge.rc:4888
 #, c-format
 msgid "Left to... (%1)"
 msgstr "Trái sang... (%1)"
 
 #. IDS_MOVE_MIDDLE_TO
-#: Merge.rc:4858 Merge.rc:4890
+#: Merge.rc:4857 Merge.rc:4889
 #, c-format
 msgid "Middle to... (%1)"
 msgstr "Giữa sang... (%1)"
 
 #. IDS_MOVE_RIGHT_TO
-#: Merge.rc:4859 Merge.rc:4891
+#: Merge.rc:4858 Merge.rc:4890
 #, c-format
 msgid "Right to... (%1)"
 msgstr "Phải sang... (%1)"
 
 #. IDS_COPY_BOTH_TO
-#: Merge.rc:4860
+#: Merge.rc:4859
 #, c-format
 msgid "Both to... (%1)"
 msgstr "Cả hai sang... (%1)"
 
 #. IDS_COPY_ALL_TO
-#: Merge.rc:4861
+#: Merge.rc:4860
 #, c-format
 msgid "All to... (%1)"
 msgstr "Tất cả sang... (%1)"
 
 #. IDS_COPY_DIFFERENCES_TO
-#: Merge.rc:4862
+#: Merge.rc:4861
 #, c-format
 msgid "Differences to... (%1)"
 msgstr "Khác biệt sang... (%1)"
 
 #. IDS_ONLYDIFFITEMS_CONFIRM
-#: Merge.rc:4869
+#: Merge.rc:4868
 msgid "Some selected items are identical or skipped.\nProcess only items with differences?"
 msgstr ""
 
 #. IDS_DEL_LEFT_FMT
-#: Merge.rc:4875
+#: Merge.rc:4874
 #, c-format
 msgid "Left (%1)"
 msgstr "Bên trái (%1)"
 
 #. IDS_DEL_MIDDLE_FMT
-#: Merge.rc:4876
+#: Merge.rc:4875
 #, c-format
 msgid "Middle (%1)"
 msgstr "Giữa (%1)"
 
 #. IDS_DEL_RIGHT_FMT
-#: Merge.rc:4877
+#: Merge.rc:4876
 #, c-format
 msgid "Right (%1)"
 msgstr "Phải (%1)"
 
 #. IDS_DEL_BOTH_FMT
-#: Merge.rc:4878
+#: Merge.rc:4877
 #, c-format
 msgid "Both (%1)"
 msgstr "Cả hai (%1)"
 
 #. IDS_DEL_ALL_FMT
-#: Merge.rc:4879
+#: Merge.rc:4878
 #, c-format
 msgid "All (%1)"
 msgstr "Tất cả (%1)"
 
 #. IDS_SELECT_DEST_LEFT
-#: Merge.rc:4895
+#: Merge.rc:4894
 msgid "Left Side - Select Destination Folder:"
 msgstr "Bên trái - chọn thư mục đích:"
 
 #. IDS_SELECT_DEST_MIDDLE
-#: Merge.rc:4896
+#: Merge.rc:4895
 msgid "Middle Side - Select Destination Folder:"
 msgstr "Ở giữa - chọn thư mục đích:"
 
 #. IDS_SELECT_DEST_RIGHT
-#: Merge.rc:4897
+#: Merge.rc:4896
 msgid "Right Side - Select Destination Folder:"
 msgstr "Bên phải - chọn thư mục đích:"
 
 #. IDS_FILES_AFFECTED_FMT
-#: Merge.rc:4898
+#: Merge.rc:4897
 #, c-format
 msgid "(%1 Files Affected)"
 msgstr "(%1 tệp bị ảnh hưởng)"
 
 #. IDS_FILES_AFFECTED_FMT2
-#: Merge.rc:4899
+#: Merge.rc:4898
 #, c-format
 msgid "(%1 of %2 Files Affected)"
 msgstr "(%1 trên %2 tệp bị ảnh hưởng)"
 
 #. IDS_CONFIRM_DELETE_SINGLE
-#: Merge.rc:4905
+#: Merge.rc:4904
 #, c-format
 msgid ""
 "Are you sure you want to delete\n"
@@ -6385,18 +6380,18 @@ msgstr ""
 "%1 không?"
 
 #. IDS_CONFIRM_SINGLE_COPY
-#: Merge.rc:4906
+#: Merge.rc:4905
 msgid "Are you sure you want to copy?"
 msgstr "Bạn có chắc chắn muốn sao chép không?"
 
 #. IDS_CONFIRM_MULTIPLE_COPY
-#: Merge.rc:4907
+#: Merge.rc:4906
 #, c-format
 msgid "Are you sure you want to copy %d items?"
 msgstr "Bạn có chắc chắn muốn sao chép %d mục không?"
 
 #. IDS_DIRCMP_NOTSYNC
-#: Merge.rc:4908
+#: Merge.rc:4907
 #, c-format
 msgid ""
 "Operation aborted!\n"
@@ -6416,47 +6411,47 @@ msgstr ""
 "Hãy làm mới lại việc so sánh."
 
 #. IDS_CONFIRM_SINGLE_MOVE
-#: Merge.rc:4913
+#: Merge.rc:4912
 msgid "Are you sure you want to move?"
 msgstr "Bạn có chắc chắn muốn di chuyển không?"
 
 #. IDS_CONFIRM_MULTIPLE_MOVE
-#: Merge.rc:4914
+#: Merge.rc:4913
 #, c-format
 msgid "Are you sure you want to move %d items?"
 msgstr "Bạn có chắc chắn muốn di chuyển %d mục không?"
 
 #. IDS_CONFIRM_MOVE_CAPTION
-#: Merge.rc:4916
+#: Merge.rc:4915
 msgid "Confirm Move"
 msgstr "Xác nhận di chuyển"
 
-#: Merge.rc:4918
+#: Merge.rc:4917
 msgid "Close the folder comparison window?"
 msgstr "Có đóng cửa sổ so sánh thư mục không?"
 
-#: Merge.rc:4920
+#: Merge.rc:4919
 msgid "Close the folder comparison window, which took a long time?"
 msgstr ""
 "Có đóng cửa sổ so sánh thư mục không (việc này tốn khá nhiều thời gian)?"
 
 #. IDS_ERROR_INVALID_DIR_FILE_NAME
-#: Merge.rc:4921
+#: Merge.rc:4920
 msgid "The file or folder name is invalid."
 msgstr "Tên tệp hoặc tên thư mục không hợp lệ."
 
 #. IDS_ERROR_EXECUTE_FILE
-#: Merge.rc:4927
+#: Merge.rc:4926
 #, c-format
 msgid "Failed to execute external editor: %1"
 msgstr "Không thể thực thi trình chỉnh sửa bên ngoài: %1"
 
 #. IDS_UNKNOWN_ARCHIVE_FORMAT
-#: Merge.rc:4933
+#: Merge.rc:4932
 msgid "Unknown archive format"
 msgstr "Định dạng tệp nén không xác định"
 
-#: Merge.rc:4935
+#: Merge.rc:4934
 msgid ""
 "Failed to extract archive.\n"
 "Compare as text file?"
@@ -6465,747 +6460,747 @@ msgstr ""
 "Có so sánh dưới dạng tệp văn bản không?"
 
 #. IDS_COLHDR_FILENAME
-#: Merge.rc:4941
+#: Merge.rc:4940
 msgid "Filename"
 msgstr "Tên tệp"
 
 #. IDS_COLHDR_DIR
-#: Merge.rc:4942
+#: Merge.rc:4941
 msgctxt "DirView|ColumnHeader"
 msgid "Folder"
 msgstr "Thư mục"
 
 #. IDS_COLHDR_RESULT
-#: Merge.rc:4943
+#: Merge.rc:4942
 msgid "Comparison Result"
 msgstr "Kết quả so sánh"
 
 #. IDS_COLHDR_LTIMEM
-#: Merge.rc:4944
+#: Merge.rc:4943
 msgid "Left Date"
 msgstr "Ngày (trái)"
 
 #. IDS_COLHDR_RTIMEM
-#: Merge.rc:4945
+#: Merge.rc:4944
 msgid "Right Date"
 msgstr "Ngày (phải)"
 
 #. IDS_COLHDR_MTIMEM
-#: Merge.rc:4946
+#: Merge.rc:4945
 msgid "Middle Date"
 msgstr "Ngày (giữa)"
 
 #. IDS_COLHDR_LSIZE
-#: Merge.rc:4948
+#: Merge.rc:4947
 msgid "Left Size"
 msgstr "Kích cỡ (trái)"
 
 #. IDS_COLHDR_RSIZE
-#: Merge.rc:4949
+#: Merge.rc:4948
 msgid "Right Size"
 msgstr "Kích cỡ (phải)"
 
 #. IDS_COLHDR_MSIZE
-#: Merge.rc:4954
+#: Merge.rc:4953
 msgid "Middle Size"
 msgstr "Kích cỡ (giữa)"
 
 #. IDS_COLHDR_RSIZE_SHORT
-#: Merge.rc:4955
+#: Merge.rc:4954
 msgid "Right Size (Short)"
 msgstr "Kích cỡ (phải, ngắn)"
 
 #. IDS_COLHDR_LSIZE_SHORT
-#: Merge.rc:4956
+#: Merge.rc:4955
 msgid "Left Size (Short)"
 msgstr "Kích cỡ (trái, ngắn)"
 
 #. IDS_COLHDR_MSIZE_SHORT
-#: Merge.rc:4957
+#: Merge.rc:4956
 msgid "Middle Size (Short)"
 msgstr "Kích cỡ (giữa, ngắn)"
 
 #. IDS_COLHDR_LTIMEC
-#: Merge.rc:4963
+#: Merge.rc:4962
 msgid "Left Creation Time"
 msgstr "Thời gian tạo (trái)"
 
 #. IDS_COLHDR_RTIMEC
-#: Merge.rc:4964
+#: Merge.rc:4963
 msgid "Right Creation Time"
 msgstr "Thời gian tạo (phải)"
 
 #. IDS_COLHDR_MTIMEC
-#: Merge.rc:4965
+#: Merge.rc:4964
 msgid "Middle Creation Time"
 msgstr "Thời gian tạo (giữa)"
 
 #. IDS_COLHDR_NEWER
-#: Merge.rc:4966
+#: Merge.rc:4965
 msgid "Newer File"
 msgstr "Tệp mới hơn"
 
 #. IDS_COLHDR_LVERSION
-#: Merge.rc:4967
+#: Merge.rc:4966
 msgid "Left File Version"
 msgstr "Phiên bản tệp (trái)"
 
 #. IDS_COLHDR_RVERSION
-#: Merge.rc:4968
+#: Merge.rc:4967
 msgid "Right File Version"
 msgstr "Phiên bản tệp (phải)"
 
 #. IDS_COLHDR_MVERSION
-#: Merge.rc:4969
+#: Merge.rc:4968
 msgid "Middle File Version"
 msgstr "Phiên bản tệp (giữa)"
 
 #. IDS_COLHDR_RESULT_ABBR
-#: Merge.rc:4970
+#: Merge.rc:4969
 msgid "Short Result"
 msgstr "Kết quả ngắn"
 
 #. IDS_COLHDR_LATTRIBUTES
-#: Merge.rc:4971
+#: Merge.rc:4970
 msgid "Left Attributes"
 msgstr "Thuộc tính (trái)"
 
 #. IDS_COLHDR_RATTRIBUTES
-#: Merge.rc:4972
+#: Merge.rc:4971
 msgid "Right Attributes"
 msgstr "Thuộc tính (phải)"
 
 #. IDS_COLHDR_MATTRIBUTES
-#: Merge.rc:4973
+#: Merge.rc:4972
 msgid "Middle Attributes"
 msgstr "Thuộc tính (giữa)"
 
 #. IDS_COLHDR_LEOL_TYPE
-#: Merge.rc:4978
+#: Merge.rc:4977
 msgid "Left EOL"
 msgstr "EOL (trái)"
 
 #. IDS_COLHDR_MEOL_TYPE
-#: Merge.rc:4979
+#: Merge.rc:4978
 msgid "Middle EOL"
 msgstr "EOL (giữa)"
 
 #. IDS_COLHDR_REOL_TYPE
-#: Merge.rc:4980
+#: Merge.rc:4979
 msgid "Right EOL"
 msgstr "EOL (phải)"
 
 #. IDS_COLHDR_LENCODING
-#: Merge.rc:4986
+#: Merge.rc:4985
 msgid "Left Encoding"
 msgstr "Biên mã (trái)"
 
 #. IDS_COLHDR_RENCODING
-#: Merge.rc:4987
+#: Merge.rc:4986
 msgid "Right Encoding"
 msgstr "Biên mã (phải)"
 
 #. IDS_COLHDR_MENCODING
-#: Merge.rc:4988
+#: Merge.rc:4987
 msgid "Middle Encoding"
 msgstr "Biên mã (giữa)"
 
 #. IDS_COLHDR_NIDIFFS
-#: Merge.rc:4989
+#: Merge.rc:4988
 msgid "Ignored Diff"
 msgstr "Khác biệt đã bỏ qua"
 
 #. IDS_COLHDR_BINARY
-#: Merge.rc:4991
+#: Merge.rc:4990
 msgctxt "DirView|ColumnHeader"
 msgid "Binary"
 msgstr "Nhị phân"
 
 #. IDS_PLUGINS_TYPE_UNPACKER
-#: Merge.rc:4992 Merge.rc:5314
+#: Merge.rc:4991 Merge.rc:5313
 msgid "Unpacker"
 msgstr "Trình bung gói"
 
 #. IDS_PLUGIN_TYPE4
-#: Merge.rc:4993 Merge.rc:5315 Merge.rc:5622
+#: Merge.rc:4992 Merge.rc:5314 Merge.rc:5621
 msgid "Prediffer"
 msgstr "Trình tiền so sánh"
 
 #. IDS_COLHDR_LEFT
-#: Merge.rc:4994
+#: Merge.rc:4993
 msgid "Left"
 msgstr "Trái"
 
 #. IDS_COLHDR_MIDDLE
-#: Merge.rc:4995
+#: Merge.rc:4994
 msgid "Middle"
 msgstr "Giữa"
 
 #. IDS_COLHDR_RIGHT
-#: Merge.rc:4996
+#: Merge.rc:4995
 msgid "Right"
 msgstr "Phải"
 
 #. IDS_COLHDR_DIFF
-#: Merge.rc:4997
+#: Merge.rc:4996
 msgid "Diff"
 msgstr "Khác biệt"
 
 #. IDS_COLHDR_LEFT_DUPLICATE
-#: Merge.rc:4998
+#: Merge.rc:4997
 msgid "Left Duplicate Count"
 msgstr "Số lượng trùng lặp (trái)"
 
 #. IDS_COLHDR_RIGHT_DUPLICATE
-#: Merge.rc:4999
+#: Merge.rc:4998
 msgid "Right Duplicate Count"
 msgstr "Số lượng trùng lặp (phải)"
 
 #. IDS_COLHDR_MIDDLE_DUPLICATE
-#: Merge.rc:5000
+#: Merge.rc:4999
 msgid "Middle Duplicate Count"
 msgstr "Số lượng trùng lặp (giữa)"
 
 #. IDS_COLHDR_MOVE
-#: Merge.rc:5001
+#: Merge.rc:5000
 msgid "Move"
 msgstr "Di chuyển"
 
 #. IDS_PRPCAT_AUDIO
-#: Merge.rc:5008
+#: Merge.rc:5007
 msgid "Audio"
 msgstr "Âm thanh"
 
 #. IDS_PRPCAT_CALENDAR
-#: Merge.rc:5009
+#: Merge.rc:5008
 msgid "Calendar"
 msgstr "Lịch"
 
 #. IDS_PRPCAT_COMMUNICATION
-#: Merge.rc:5010
+#: Merge.rc:5009
 msgid "Communication"
 msgstr "Truyền thông"
 
 #. IDS_PRPCAT_CONTACT
-#: Merge.rc:5011
+#: Merge.rc:5010
 msgid "Contact"
 msgstr "Liên hệ"
 
 #. IDS_PRPCAT_DEVICES
-#: Merge.rc:5012
+#: Merge.rc:5011
 msgid "Devices"
 msgstr "Thiết bị"
 
 #. IDS_PRPCAT_DOCUMENT
-#: Merge.rc:5013
+#: Merge.rc:5012
 msgid "Document"
 msgstr "Tài liệu"
 
 #. IDS_PRPCAT_HOME
-#: Merge.rc:5014
+#: Merge.rc:5013
 msgid "Home"
 msgstr "Trang chủ"
 
 #. IDS_PRPCAT_JOURNAL
-#: Merge.rc:5016
+#: Merge.rc:5015
 msgid "Journal"
 msgstr "Nhật ký"
 
 #. IDS_PRPCAT_LINK
-#: Merge.rc:5017
+#: Merge.rc:5016
 msgid "Link"
 msgstr "Liên kết"
 
 #. IDS_PRPCAT_MEDIA
-#: Merge.rc:5018
+#: Merge.rc:5017
 msgid "Media"
 msgstr "Phương tiện"
 
 #. IDS_PRPCAT_MUSIC
-#: Merge.rc:5020
+#: Merge.rc:5019
 msgid "Music"
 msgstr "Nhạc"
 
 #. IDS_PRPCAT_NOTE
-#: Merge.rc:5021
+#: Merge.rc:5020
 msgid "Note"
 msgstr "Ghi chú"
 
 #. IDS_PRPCAT_PHOTO
-#: Merge.rc:5022
+#: Merge.rc:5021
 msgid "Photo"
 msgstr "Ảnh"
 
 #. IDS_PRPCAT_RECORDEDTV
-#: Merge.rc:5023
+#: Merge.rc:5022
 msgid "RecordedTV"
 msgstr "TV đã ghi"
 
 #. IDS_PRPCAT_SEARCH
-#: Merge.rc:5024
+#: Merge.rc:5023
 msgid "Search"
 msgstr "Tìm kiếm"
 
 #. IDS_PRPCAT_SECURITY
-#: Merge.rc:5025
+#: Merge.rc:5024
 msgid "Security"
 msgstr "Bảo mật"
 
 #. IDS_PRPCAT_SOFTWARE
-#: Merge.rc:5026
+#: Merge.rc:5025
 msgid "Software"
 msgstr "Phần mềm"
 
 #. IDS_PRPCAT_TASK
-#: Merge.rc:5027
+#: Merge.rc:5026
 msgid "Task"
 msgstr "Công việc"
 
 #. IDS_PRPCAT_VIDEO
-#: Merge.rc:5028
+#: Merge.rc:5027
 msgid "Video"
 msgstr "Video"
 
 #. IDS_PRPCAT_HASH
-#: Merge.rc:5029
+#: Merge.rc:5028
 msgid "Hash"
 msgstr "Mã băm"
 
 #. IDS_CANT_COMPARE_FILES
-#: Merge.rc:5035
+#: Merge.rc:5034
 msgid "Unable to compare files"
 msgstr "Không thể so sánh các tệp"
 
 #. IDS_ABORTED_ITEM
-#: Merge.rc:5036
+#: Merge.rc:5035
 msgid "Item aborted"
 msgstr "Mục bị huỷ bỏ"
 
 #. IDS_FILE_SKIPPED
-#: Merge.rc:5037
+#: Merge.rc:5036
 msgid "File skipped"
 msgstr "Tệp bị bỏ qua"
 
 #. IDS_DIR_SKIPPED
-#: Merge.rc:5038
+#: Merge.rc:5037
 msgid "Folder skipped"
 msgstr "Thư mục bị bỏ qua"
 
 #. IDS_LEFT_ONLY_IN_FMT
-#: Merge.rc:5039
+#: Merge.rc:5038
 #, c-format
 msgid "Left only: %1"
 msgstr "Chỉ bên trái: %1"
 
 #. IDS_MIDDLE_ONLY_IN_FMT
-#: Merge.rc:5040
+#: Merge.rc:5039
 #, c-format
 msgid "Middle only: %1"
 msgstr "Chỉ ở giữa: %1"
 
 #. IDS_RIGHT_ONLY_IN_FMT
-#: Merge.rc:5041
+#: Merge.rc:5040
 #, c-format
 msgid "Right only: %1"
 msgstr "Chỉ bên phải: %1"
 
 #. IDS_DOES_NOT_EXIST_IN_FMT
-#: Merge.rc:5042
+#: Merge.rc:5041
 #, c-format
 msgid "Does not exist in %1"
 msgstr "Không tồn tại trong %1"
 
 #. IDS_BIN_FILES_SAME
-#: Merge.rc:5043
+#: Merge.rc:5042
 msgid "Binary files are identical"
 msgstr "Các tệp nhị phân giống hệt nhau"
 
 #. IDS_BIN_FILES_DIFF
-#: Merge.rc:5049
+#: Merge.rc:5048
 msgid "Binary files are different"
 msgstr "Các tệp nhị phân này khác nhau"
 
 #. IDS_FILES_ARE_DIFFERENT
-#: Merge.rc:5050
+#: Merge.rc:5049
 msgid "Files are different"
 msgstr "Các tệp này khác nhau"
 
 #. IDS_FOLDERS_ARE_DIFFERENT
-#: Merge.rc:5051
+#: Merge.rc:5050
 msgid "Folders are different"
 msgstr "Các thư mục này khác nhau"
 
 #. IDS_LEFTONLY
-#: Merge.rc:5052
+#: Merge.rc:5051
 msgid "Left Only"
 msgstr "Chỉ bên trái"
 
 #. IDS_RIGHTONLY
-#: Merge.rc:5053
+#: Merge.rc:5052
 msgid "Right Only"
 msgstr "Chỉ bên phải"
 
 #. IDS_MIDDLEONLY
-#: Merge.rc:5054
+#: Merge.rc:5053
 msgid "Middle Only"
 msgstr "Chỉ ở giữa"
 
 #. IDS_NOITEMLEFT
-#: Merge.rc:5055
+#: Merge.rc:5054
 msgid "No item in left"
 msgstr "Không có mục nào ở bên trái"
 
 #. IDS_NOITEMRIGHT
-#: Merge.rc:5056
+#: Merge.rc:5055
 msgid "No item in right"
 msgstr "Không có mục nào ở bên phải"
 
 #. IDS_NOITEMMIDDLE
-#: Merge.rc:5057
+#: Merge.rc:5056
 msgid "No item in middle"
 msgstr "Không có mục nào ở giữa"
 
 #. IDS_CMPRES_ERROR
-#: Merge.rc:5059
+#: Merge.rc:5058
 msgid "Error"
 msgstr "Lỗi"
 
 #. IDS_TEXT_FILES_SAME
-#: Merge.rc:5060
+#: Merge.rc:5059
 msgid "Text files are identical"
 msgstr "Các tệp văn bản giống hệt nhau"
 
 #. IDS_LEFTONLY_DIFF
-#: Merge.rc:5061
+#: Merge.rc:5060
 msgid " (Middle and right are identical)"
 msgstr " (Ở giữa và bên phải giống hệt nhau)"
 
 #. IDS_MIDDLEONLY_DIFF
-#: Merge.rc:5062
+#: Merge.rc:5061
 msgid " (Left and right are identical)"
 msgstr " (Bên trái và bên phải giống hệt nhau)"
 
 #. IDS_RIGHTONLY_DIFF
-#: Merge.rc:5063
+#: Merge.rc:5062
 msgid " (Left and middle are identical)"
 msgstr " (Bên trái và ở giữa giống hệt nhau)"
 
 #. IDS_PATH_MISMATCH
-#: Merge.rc:5064
+#: Merge.rc:5063
 msgid " (paths differ)"
 msgstr ""
 
 #. IDS_TEXT_FILES_DIFF
-#: Merge.rc:5065
+#: Merge.rc:5064
 msgid "Text files are different"
 msgstr "Các tệp văn bản này khác nhau"
 
 #. IDS_IMAGE_FILES_SAME
-#: Merge.rc:5066
+#: Merge.rc:5065
 msgid "Image files are identical"
 msgstr "Các tệp hình ảnh giống hệt nhau"
 
 #. IDS_IMAGE_FILES_DIFF
-#: Merge.rc:5067
+#: Merge.rc:5066
 msgid "Image files are different"
 msgstr "Các tệp hình ảnh này khác nhau"
 
 #. IDS_EXPR_DIFF
-#: Merge.rc:5068
+#: Merge.rc:5067
 #, c-format
 msgid "Files are different (expr: %1)"
 msgstr "Các tệp này khác nhau (biểu thức: %1)"
 
 #. IDS_HASH_GROUP
-#: Merge.rc:5069
+#: Merge.rc:5068
 #, c-format
 msgid "Group%d"
 msgstr "Nhóm %d"
 
 #. IDS_RENAME_MOVE_DETECTION_DISALBED
-#: Merge.rc:5070
+#: Merge.rc:5069
 msgctxt "Options dialog|Compare|Folder|Detect renames and moves"
 msgid "Disabled"
 msgstr ""
 
 #. IDS_RENAME_MOVE_DETECTION_RENAME
-#: Merge.rc:5071
+#: Merge.rc:5070
 msgid "Detect renames"
 msgstr ""
 
 #. IDS_RENAME_MOVE_DETECTION_RENAME_MOVE
-#: Merge.rc:5072
+#: Merge.rc:5071
 msgid "Detect renames and moves"
 msgstr ""
 
 #. IDS_RENAME_MOVE_MERGE_MODE_RENAME
-#: Merge.rc:5073
+#: Merge.rc:5072
 msgid "Merge renames"
 msgstr ""
 
 #. IDS_RENAME_MOVE_MERGE_MODE_RENAME_MOVE
-#: Merge.rc:5074
+#: Merge.rc:5073
 msgid "Merge renames and moves"
 msgstr ""
 
 #. IDS_RENAMED
-#: Merge.rc:5075
+#: Merge.rc:5074
 msgid "Renamed"
 msgstr ""
 
 #. IDS_RENAMED_MOVED
-#: Merge.rc:5077
+#: Merge.rc:5076
 msgid "Renamed/Moved"
 msgstr ""
 
 #. IDS_RENAMED_MOVED_ITEMS
-#: Merge.rc:5078
+#: Merge.rc:5077
 #, c-format
 msgid "(%1 items)"
 msgstr ""
 
 #. IDS_RENAMED_MOVED_RESULT
-#: Merge.rc:5079
+#: Merge.rc:5078
 #, c-format
 msgid "%1 (set %2): "
 msgstr ""
 
 #. IDS_SWITCH_FLAT_MODE
-#: Merge.rc:5080
+#: Merge.rc:5079
 msgid "Some moved items have been merged.\nIn Tree Mode, these items may appear in positions that do not reflect the actual folder structure, which can be confusing.\nSwitch to Flat Mode?"
 msgstr ""
 
 #. IDS_ELAPSED_TIME
-#: Merge.rc:5086
+#: Merge.rc:5085
 #, c-format
 msgid "Elapsed time: %ld ms"
 msgstr "Thời gian trôi qua: %ld ms"
 
 #. IDS_STATUS_SELITEM1
-#: Merge.rc:5087
+#: Merge.rc:5086
 msgid "1 item selected"
 msgstr "Đã chọn 1 mục"
 
 #. IDS_STATUS_SELITEMS
-#: Merge.rc:5088
+#: Merge.rc:5087
 #, c-format
 msgid "%1 items selected"
 msgstr "Đã chọn %1 mục"
 
 #. IDS_COLDESC_FILENAME
-#: Merge.rc:5094
+#: Merge.rc:5093
 msgid "Filename or folder name."
 msgstr "Tên tệp hoặc tên thư mục."
 
 #. IDS_COLDESC_DIR
-#: Merge.rc:5095
+#: Merge.rc:5094
 msgid "Subfolder name when subfolders are included."
 msgstr "Tên thư mục con khi bao gồm các thư mục con."
 
 #. IDS_COLDESC_RESULT
-#: Merge.rc:5096
+#: Merge.rc:5095
 msgid "Comparison result, long form."
 msgstr "Kết quả so sánh, dạng dài."
 
 #. IDS_COLDESC_LTIMEM
-#: Merge.rc:5101
+#: Merge.rc:5100
 msgid "Left side modification date."
 msgstr "Ngày sửa đổi bên trái."
 
 #. IDS_COLDESC_RTIMEM
-#: Merge.rc:5102
+#: Merge.rc:5101
 msgid "Right side modification date."
 msgstr "Ngày sửa đổi bên phải."
 
 #. IDS_COLDESC_MTIMEM
-#: Merge.rc:5103
+#: Merge.rc:5102
 msgid "Middle side modification date."
 msgstr "Ngày sửa đổi ở giữa."
 
 #. IDS_COLDESC_EXTENSION
-#: Merge.rc:5104
+#: Merge.rc:5103
 msgid "File's extension."
 msgstr "Phần mở rộng của tệp."
 
 #. IDS_COLDESC_LSIZE
-#: Merge.rc:5105
+#: Merge.rc:5104
 msgid "Left file size in bytes."
 msgstr "Kích cỡ tệp bên trái tính bằng byte."
 
 #. IDS_COLDESC_RSIZE
-#: Merge.rc:5106
+#: Merge.rc:5105
 msgid "Right file size in bytes."
 msgstr "Kích cỡ tệp bên phải tính bằng byte."
 
 #. IDS_COLDESC_MSIZE
-#: Merge.rc:5107
+#: Merge.rc:5106
 msgid "Middle file size in bytes."
 msgstr "Kích cỡ tệp ở giữa tính bằng byte."
 
 #. IDS_COLDESC_LSIZE_SHORT
-#: Merge.rc:5108
+#: Merge.rc:5107
 msgid "Left file size abbreviated."
 msgstr "Kích cỡ tệp bên trái viết tắt."
 
 #. IDS_COLDESC_RSIZE_SHORT
-#: Merge.rc:5109
+#: Merge.rc:5108
 msgid "Right file size abbreviated."
 msgstr "Kích cỡ tệp bên phải viết tắt."
 
 #. IDS_COLDESC_MSIZE_SHORT
-#: Merge.rc:5110
+#: Merge.rc:5109
 msgid "Middle file size abbreviated."
 msgstr "Kích cỡ tệp ở giữa viết tắt."
 
 #. IDS_COLDESC_LTIMEC
-#: Merge.rc:5116
+#: Merge.rc:5115
 msgid "Left side creation time."
 msgstr "Thời gian tạo bên trái."
 
 #. IDS_COLDESC_RTIMEC
-#: Merge.rc:5117
+#: Merge.rc:5116
 msgid "Right side creation time."
 msgstr "Thời gian tạo bên phải."
 
 #. IDS_COLDESC_MTIMEC
-#: Merge.rc:5118
+#: Merge.rc:5117
 msgid "Middle side creation time."
 msgstr "Thời gian tạo ở giữa."
 
 #. IDS_COLDESC_NEWER
-#: Merge.rc:5119
+#: Merge.rc:5118
 msgid "Tells which side has newer modification date."
 msgstr "Cho biết bên nào có ngày sửa đổi mới hơn."
 
 #. IDS_COLDESC_LVERSION
-#: Merge.rc:5120
+#: Merge.rc:5119
 msgid "Left side file version, only for some file types."
 msgstr "Phiên bản tệp bên trái, chỉ dành cho một số loại tệp."
 
 #. IDS_COLDESC_RVERSION
-#: Merge.rc:5121
+#: Merge.rc:5120
 msgid "Right side file version, only for some file types."
 msgstr "Phiên bản tệp bên phải, chỉ dành cho một số loại tệp."
 
 #. IDS_COLDESC_MVERSION
-#: Merge.rc:5126
+#: Merge.rc:5125
 msgid "Middle side file version, only for some file types."
 msgstr "Phiên bản tệp ở giữa, chỉ dành cho một số loại tệp."
 
 #. IDS_COLDESC_RESULT_ABBR
-#: Merge.rc:5127
+#: Merge.rc:5126
 msgid "Short comparison result."
 msgstr "Kết quả so sánh ngắn."
 
 #. IDS_COLDESC_LATTRIBUTES
-#: Merge.rc:5128
+#: Merge.rc:5127
 msgid "Left side attributes."
 msgstr "Thuộc tính bên trái."
 
 #. IDS_COLDESC_RATTRIBUTES
-#: Merge.rc:5129
+#: Merge.rc:5128
 msgid "Right side attributes."
 msgstr "Thuộc tính bên phải."
 
 #. IDS_COLDESC_MATTRIBUTES
-#: Merge.rc:5130
+#: Merge.rc:5129
 msgid "Middle side attributes."
 msgstr "Thuộc tính ở giữa."
 
 #. IDS_COLDESC_LEOL_TYPE
-#: Merge.rc:5131
+#: Merge.rc:5130
 msgid "Left side file EOL type."
 msgstr "Loại EOL tệp bên trái."
 
 #. IDS_COLDESC_REOL_TYPE
-#: Merge.rc:5132
+#: Merge.rc:5131
 msgid "Right side file EOL type."
 msgstr "Loại EOL tệp bên phải."
 
 #. IDS_COLDESC_MEOL_TYPE
-#: Merge.rc:5133
+#: Merge.rc:5132
 msgid "Middle side file EOL type."
 msgstr "Loại EOL tệp ở giữa."
 
 #. IDS_COLDESC_LENCODING
-#: Merge.rc:5139
+#: Merge.rc:5138
 msgid "Left side encoding."
 msgstr "Biên mã bên trái."
 
 #. IDS_COLDESC_RENCODING
-#: Merge.rc:5140
+#: Merge.rc:5139
 msgid "Right side encoding."
 msgstr "Biên mã bên phải."
 
 #. IDS_COLDESC_MENCODING
-#: Merge.rc:5141
+#: Merge.rc:5140
 msgid "Middle side encoding."
 msgstr "Biên mã ở giữa."
 
 #. IDS_COLDESC_NIDIFFS
-#: Merge.rc:5142
+#: Merge.rc:5141
 msgid "Number of ignored differences in file. Ignored and cannot be merged."
 msgstr ""
 "Số lượng khác biệt bị bỏ qua trong tệp. Đã bị bỏ qua và không thể trộn."
 
 #. IDS_COLDESC_NSDIFFS
-#: Merge.rc:5143
+#: Merge.rc:5142
 msgid "Number of differences in file (excluding ignored)."
 msgstr "Số lượng khác biệt trong tệp (không bao gồm các mục bị bỏ qua)."
 
 #. IDS_COLDESC_BINARY
-#: Merge.rc:5144
+#: Merge.rc:5143
 msgid "Shows an asterisk (*) if the file is binary."
 msgstr "Hiển thị dấu sao (*) nếu tệp là nhị phân."
 
 #. IDS_COLDESC_UNPACKER
-#: Merge.rc:5145
+#: Merge.rc:5144
 msgid "Unpacker plugin name or pipeline."
 msgstr "Tên hoặc ống dẫn của trình cắm bung gói."
 
 #. IDS_COLDESC_PREDIFFER
-#: Merge.rc:5146
+#: Merge.rc:5145
 msgid "Prediffer plugin name or pipeline."
 msgstr "Tên hoặc ống dẫn của trình cắm tiền so sánh."
 
 #. IDS_DIRECTORY_REPORT_TITLE
-#: Merge.rc:5152
+#: Merge.rc:5151
 #, c-format
 msgid "Compare %1 with %2"
 msgstr "So sánh %1 với %2"
 
 #. IDS_DIRECTORY_REPORT_TITLE3
-#: Merge.rc:5153
+#: Merge.rc:5152
 #, c-format
 msgid "Compare %1 with %2 and %3"
 msgstr "So sánh %1 với %2 và %3"
 
 #. IDS_REPORT_COMMALIST
-#: Merge.rc:5154
+#: Merge.rc:5153
 msgid "Comma-separated list"
 msgstr "Danh sách ngăn cách bằng dấu phẩy"
 
 #. IDS_REPORT_TABLIST
-#: Merge.rc:5155
+#: Merge.rc:5154
 msgid "Tab-separated list"
 msgstr "Danh sách ngăn cách bằng phím Tab"
 
 #. IDS_REPORT_SIMPLEHTML
-#: Merge.rc:5156
+#: Merge.rc:5155
 msgid "Simple HTML"
 msgstr "HTML đơn giản"
 
 #. IDS_REPORT_SIMPLEXML
-#: Merge.rc:5157
+#: Merge.rc:5156
 msgid "Simple XML"
 msgstr "XML đơn giản"
 
-#: Merge.rc:5159
+#: Merge.rc:5158
 msgid "Report file already exists. Overwrite?"
 msgstr "Đã tồn tại tệp báo cáo. Có ghi đè không?"
 
 #. IDS_REPORT_ERROR
-#: Merge.rc:5164
+#: Merge.rc:5163
 #, c-format
 msgid ""
 "Error creating the report:\n"
@@ -7215,27 +7210,27 @@ msgstr ""
 "%1"
 
 #. IDS_REPORT_SUCCESS
-#: Merge.rc:5165
+#: Merge.rc:5164
 msgid "Report created successfully."
 msgstr "Báo cáo đã được tạo thành công."
 
 #. IDS_SYNCPOINT_LASTBLOCK
-#: Merge.rc:5171
+#: Merge.rc:5170
 msgid "Cannot add a synchronization point at this line."
 msgstr "Không thể thêm điểm đồng bộ hoá tại dòng này."
 
 #. IDS_FILE_TO_ITSELF
-#: Merge.rc:5177
+#: Merge.rc:5176
 msgid "Same file is opened in both panes."
 msgstr "Cùng một tệp đang được mở ở cả hai khung."
 
 #. IDS_FILESSAME
-#: Merge.rc:5178
+#: Merge.rc:5177
 msgid "Selected files are identical."
 msgstr "Các tệp được chọn giống hệt nhau."
 
 #. IDS_FILESSAME_CURCFG
-#: Merge.rc:5179
+#: Merge.rc:5178
 msgid ""
 "Selected files are identical (with current settings).\r\n"
 "Checking binary identity..."
@@ -7244,7 +7239,7 @@ msgstr ""
 "Đang kiểm tra tính đồng nhất nhị phân..."
 
 #. IDS_FILESSAME_BINERROR
-#: Merge.rc:5180
+#: Merge.rc:5179
 msgid ""
 "Selected files are identical (with current settings).\r\n"
 "But binary comparison failed."
@@ -7253,12 +7248,12 @@ msgstr ""
 "Nhưng không so sánh nhị phân được."
 
 #. IDS_FILESSAME_BINSAME
-#: Merge.rc:5181
+#: Merge.rc:5180
 msgid "Selected files are identical (binary match)."
 msgstr "Các tệp được chọn giống hệt nhau (khớp về mặt nhị phân)."
 
 #. IDS_FILESSAME_BINDIFF
-#: Merge.rc:5182
+#: Merge.rc:5181
 msgid ""
 "Selected files are identical (with current settings).\r\n"
 "But differ at the binary level."
@@ -7267,19 +7262,19 @@ msgstr ""
 "Nhưng khác nhau ở cấp độ nhị phân."
 
 #. IDS_FILEERROR
-#: Merge.rc:5183
+#: Merge.rc:5182
 msgid "An error occurred while comparing files."
 msgstr "Đã xảy ra lỗi khi so sánh các tệp."
 
 #. IDS_TEMP_FILEERROR
-#: Merge.rc:5184
+#: Merge.rc:5183
 msgid "Could not create temporary files. Check your temporary path settings."
 msgstr ""
 "Không thể tạo các tệp tạm thời. Hãy kiểm tra các thiết đặt đường dẫn tạm "
 "thời của bạn."
 
 #. IDS_SUGGEST_IGNOREEOL
-#: Merge.rc:5185
+#: Merge.rc:5184
 msgid ""
 "Files use different EOL.\n"
 "\n"
@@ -7296,17 +7291,17 @@ msgstr ""
 "Tuỳ chọn."
 
 #. IDS_INVALID_DIRECTORY
-#: Merge.rc:5186
+#: Merge.rc:5185
 msgid "Selected folder is invalid."
 msgstr "Thư mục được chọn không hợp lệ."
 
 #. IDS_CANNOT_OPEN_BINARYFILE
-#: Merge.rc:5187
+#: Merge.rc:5186
 msgid "Cannot open a binary file in Editor."
 msgstr "Không thể mở tệp nhị phân trong trình chỉnh sửa."
 
 #. IDS_CREATE_PAIR_FOLDER
-#: Merge.rc:5188
+#: Merge.rc:5187
 #, c-format
 msgid ""
 "Create matching folder:\n"
@@ -7318,41 +7313,41 @@ msgstr ""
 "ở phía bên kia và mở ra không?"
 
 #. IDS_CONFIRM_COPY_ALL_DIFFS
-#: Merge.rc:5189
+#: Merge.rc:5188
 msgid "Copy all differences to other file?"
 msgstr "Có chép tất cả khác biệt sang tệp kia không?"
 
 #. IDS_MOVE_TO_NEXTFILE
-#: Merge.rc:5194
+#: Merge.rc:5193
 msgid "Move to next file?"
 msgstr "Có di chuyển đến tệp tiếp theo không?"
 
 #. IDS_MOVE_TO_PREVFILE
-#: Merge.rc:5195
+#: Merge.rc:5194
 msgid "Move to previous file?"
 msgstr "Có di chuyển đến tệp trước đó không?"
 
 #. IDS_MOVE_TO_NEXTPAGE
-#: Merge.rc:5196
+#: Merge.rc:5195
 msgid "Move to next page?"
 msgstr "Có di chuyển đến trang tiếp theo không?"
 
 #. IDS_MOVE_TO_PREVPAGE
-#: Merge.rc:5197
+#: Merge.rc:5196
 msgid "Move to previous page?"
 msgstr "Có di chuyển đến trang trước đó không?"
 
 #. IDS_MOVE_TO_FIRSTFILE
-#: Merge.rc:5198
+#: Merge.rc:5197
 msgid "Move to first file?"
 msgstr "Có di chuyển đến tệp đầu tiên không?"
 
 #. IDS_MOVE_TO_LASTFILE
-#: Merge.rc:5199
+#: Merge.rc:5198
 msgid "Move to last file?"
 msgstr "Có di chuyển đến tệp cuối cùng không?"
 
-#: Merge.rc:5206
+#: Merge.rc:5205
 #, c-format
 msgid ""
 "Different codepages: left (cp%d), right (cp%d).\n"
@@ -7365,51 +7360,51 @@ msgstr ""
 "(trộn an toàn hơn) không?\n"
 "(Khuyên dùng: trang mã Windows mặc định)"
 
-#: Merge.rc:5208
+#: Merge.rc:5207
 msgid "Information lost due to encoding errors: both files"
 msgstr "Thông tin bị mất do lỗi biên mã: cả hai tệp"
 
-#: Merge.rc:5210
+#: Merge.rc:5209
 msgid "Information lost due to encoding errors: first file"
 msgstr "Thông tin bị mất do lỗi biên mã: tệp thứ nhất"
 
-#: Merge.rc:5212
+#: Merge.rc:5211
 msgid "Information lost due to encoding errors: second file"
 msgstr "Thông tin bị mất do lỗi biên mã: tệp thứ hai"
 
-#: Merge.rc:5214
+#: Merge.rc:5213
 msgid "Information lost due to encoding errors: third file"
 msgstr "Thông tin bị mất do lỗi biên mã: tệp thứ ba"
 
 #. IDS_LINEDIFF_NODIFF
-#: Merge.rc:5220
+#: Merge.rc:5219
 msgid "No difference"
 msgstr "Không có khác biệt"
 
 #. IDS_LINEDIFF_NODIFF_CAPTION
-#: Merge.rc:5221
+#: Merge.rc:5220
 msgid "Line difference"
 msgstr "Khác biệt dòng"
 
 #. IDS_NUM_REPLACED
-#: Merge.rc:5227
+#: Merge.rc:5226
 #, c-format
 msgid "Replaced %1 string(s)."
 msgstr "Đã thay thế %1 xâu."
 
 #. IDS_EDIT_TEXT_NOT_FOUND
-#: Merge.rc:5228
+#: Merge.rc:5227
 #, c-format
 msgid "Cannot find string \"%s\"."
 msgstr "Không thể tìm thấy xâu \"%s\"."
 
 #. IDS_MERGE_MODE
-#: Merge.rc:5234
+#: Merge.rc:5233
 msgid "Entering Merge Mode. Press F9 to turn off."
 msgstr "Đang vào chế độ trộn. Nhấn F9 để tắt."
 
 #. IDS_AUTO_MERGE
-#: Merge.rc:5240
+#: Merge.rc:5239
 #, c-format
 msgid ""
 "Automatic merges: %1\n"
@@ -7419,89 +7414,89 @@ msgstr ""
 "Xung đột chưa được giải quyết: %2"
 
 #. IDS_CODEPAGE_MERGED
-#: Merge.rc:5241
+#: Merge.rc:5240
 msgid "Codepage change merged."
 msgstr "Đã trộn thay đổi về trang mã."
 
 #. IDS_CODEPAGE_CONFLICT
-#: Merge.rc:5242
+#: Merge.rc:5241
 msgid "Codepage changes are conflicting."
 msgstr "Các thay đổi trang mã đang bị xung đột."
 
 #. IDS_EOL_MERGED
-#: Merge.rc:5243
+#: Merge.rc:5242
 msgid "EOL change merged."
 msgstr "Đã trộn thay đổi EOL."
 
 #. IDS_EOL_CONFLICT
-#: Merge.rc:5244
+#: Merge.rc:5243
 msgid "EOL changes are conflicting."
 msgstr "Các thay đổi EOL đang bị xung đột."
 
 #. IDS_LOCBAR_CAPTION
-#: Merge.rc:5250
+#: Merge.rc:5249
 msgid "Location Pane"
 msgstr "Khung vị trí"
 
 #. IDS_DIFFBAR_CAPTION
-#: Merge.rc:5251
+#: Merge.rc:5250
 msgid "Diff Pane"
 msgstr "Khung khác biệt"
 
 #. IDS_DIFF_SUCCEEDED
-#: Merge.rc:5258
+#: Merge.rc:5257
 msgid "Patch file written."
 msgstr "Tệp bản vá đã được ghi."
 
 #. IDS_DIFF_FILEOVERWRITE
-#: Merge.rc:5259
+#: Merge.rc:5258
 msgid "Patch file already exists. Overwrite?"
 msgstr "Đã tồn tại tệp bản vá. Có ghi đè không?"
 
 #. IDS_DIFF_SELECTEDFILES
-#: Merge.rc:5260
+#: Merge.rc:5259
 #, c-format
 msgid "[%1 files selected]"
 msgstr "[đã chọn %1 tệp]"
 
 #. IDS_DIFF_NORMAL
-#: Merge.rc:5261
+#: Merge.rc:5260
 msgid "Normal"
 msgstr "Bình thường"
 
 #. IDS_DIFF_CONTEXT
-#: Merge.rc:5262
+#: Merge.rc:5261
 msgid "Context"
 msgstr "Ngữ cảnh"
 
 #. IDS_DIFF_UNIFIED
-#: Merge.rc:5263
+#: Merge.rc:5262
 msgid "Unified"
 msgstr "Thống nhất"
 
 #. IDS_FILEWRITE_ERROR
-#: Merge.rc:5265
+#: Merge.rc:5264
 #, c-format
 msgid "Could not write to file %1."
 msgstr "Không thể ghi vào tệp %1."
 
 #. IDS_PATH_NOT_ABSOLUTE
-#: Merge.rc:5266
+#: Merge.rc:5265
 #, c-format
 msgid "Output path is not absolute: %1"
 msgstr "Đường dẫn đầu ra không phải là tuyệt đối: %1"
 
 #. IDS_MUST_SPECIFY_OUTPUT
-#: Merge.rc:5267
+#: Merge.rc:5266
 msgid "Specify an output file."
 msgstr "Chỉ định một tệp đầu ra."
 
-#: Merge.rc:5269
+#: Merge.rc:5268
 msgid "Cannot create patch from binary files."
 msgstr "Không thể tạo bản vá từ các tệp nhị phân."
 
 #. IDS_SAVEFILES_FORPATCH
-#: Merge.rc:5270
+#: Merge.rc:5269
 msgid ""
 "Save all files first.\n"
 "\n"
@@ -7512,22 +7507,22 @@ msgstr ""
 "Việc tạo bản vá yêu cầu không có thay đổi nào chưa được lưu."
 
 #. IDS_FOLDER_NOTEXIST
-#: Merge.rc:5271
+#: Merge.rc:5270
 msgid "Folder does not exist."
 msgstr "Thư mục không tồn tại."
 
 #. IDS_ARCHIVE_SUCCEEDED
-#: Merge.rc:5277
+#: Merge.rc:5276
 msgid "Archive file written."
 msgstr ""
 
 #. IDS_ARCHIVE_SAVEFILES
-#: Merge.rc:5278
+#: Merge.rc:5277
 msgid "Save all files first.\n\nCreating an archive requires no unsaved changes."
 msgstr ""
 
 #. IDS_NO_ZIP_SUPPORT
-#: Merge.rc:5283
+#: Merge.rc:5282
 msgid ""
 "Archive support not enabled.\n"
 "7-Zip and/or Merge7z*.dll not found.\n"
@@ -7538,37 +7533,37 @@ msgstr ""
 "Xem tài liệu hướng dẫn để biết về hỗ trợ lưu trữ."
 
 #. IDS_OPT_EXPORT_CAPTION
-#: Merge.rc:5284
+#: Merge.rc:5283
 msgid "Select file for export"
 msgstr "Chọn tệp để xuất"
 
 #. IDS_OPT_IMPORT_CAPTION
-#: Merge.rc:5285
+#: Merge.rc:5284
 msgid "Select file for import"
 msgstr "Chọn tệp để nhập"
 
 #. IDS_OPT_IMPORT_DONE
-#: Merge.rc:5286
+#: Merge.rc:5285
 msgid "Options imported from file."
 msgstr "Các tuỳ chọn đã được nhập từ tệp."
 
 #. IDS_OPT_EXPORT_DONE
-#: Merge.rc:5287
+#: Merge.rc:5286
 msgid "Options exported to file."
 msgstr "Các tuỳ chọn đã được xuất ra tệp."
 
 #. IDS_OPT_IMPORT_ERR
-#: Merge.rc:5288
+#: Merge.rc:5287
 msgid "Failed to import options from file."
 msgstr "Không thể nhập tuỳ chọn từ tệp."
 
 #. IDS_OPT_EXPORT_ERR
-#: Merge.rc:5289
+#: Merge.rc:5288
 msgid "Failed to write options to file."
 msgstr "Không thể ghi tuỳ chọn vào tệp."
 
 #. IDS_CLOSEALL_WINDOWS
-#: Merge.rc:5290
+#: Merge.rc:5289
 msgid ""
 "Close multiple compare windows?\n"
 "\n"
@@ -7579,34 +7574,34 @@ msgstr ""
 "Tiếp tục nhé?"
 
 #. IDS_EOL_BIN
-#: Merge.rc:5300
+#: Merge.rc:5299
 msgctxt "EOL Type"
 msgid "Binary"
 msgstr "Nhị phân"
 
 #. IDS_MARKER_COLOR_FMT
-#: Merge.rc:5305
+#: Merge.rc:5304
 #, c-format
 msgid "Marker Color %d"
 msgstr "Màu dấu mốc %d"
 
 #. IDS_MARKER_NEW_PATTERN
-#: Merge.rc:5306
+#: Merge.rc:5305
 msgid "New Pattern"
 msgstr "Mẫu mới"
 
 #. IDS_PLUGINSLIST_TYPE
-#: Merge.rc:5312
+#: Merge.rc:5311
 msgid "Type"
 msgstr "Loại"
 
 #. IDS_PLUGINS_TYPE_EDITSCRIPT
-#: Merge.rc:5316
+#: Merge.rc:5315
 msgid "Editor script"
 msgstr "Kịch bản chỉnh sửa"
 
 #. ID_SELECTLINEDIFF
-#: Merge.rc:5322
+#: Merge.rc:5321
 msgid ""
 "\n"
 "Difference in Current Line (F4)"
@@ -7615,7 +7610,7 @@ msgstr ""
 "Khác biệt trong dòng hiện tại (F4)"
 
 #. ID_OPTIONS
-#: Merge.rc:5323
+#: Merge.rc:5322
 msgid ""
 "\n"
 "Options"
@@ -7624,7 +7619,7 @@ msgstr ""
 "Tuỳ chọn"
 
 #. ID_REFRESH
-#: Merge.rc:5324
+#: Merge.rc:5323
 msgid ""
 "\n"
 "Refresh (F5)"
@@ -7633,7 +7628,7 @@ msgstr ""
 "Làm mới (F5)"
 
 #. ID_PREVDIFF
-#: Merge.rc:5330
+#: Merge.rc:5329
 msgid ""
 "\n"
 "Previous Difference (Alt+Up)"
@@ -7642,7 +7637,7 @@ msgstr ""
 "Khác biệt trước đó (Alt+Lên)"
 
 #. ID_NEXTDIFF
-#: Merge.rc:5331
+#: Merge.rc:5330
 msgid ""
 "\n"
 "Next Difference (Alt+Down)"
@@ -7651,7 +7646,7 @@ msgstr ""
 "Khác biệt tiếp theo (Alt+Xuống)"
 
 #. ID_PREVCONFLICT
-#: Merge.rc:5332
+#: Merge.rc:5331
 msgid ""
 "\n"
 "Previous Conflict (Alt+Shift+Up)"
@@ -7660,7 +7655,7 @@ msgstr ""
 "Xung đột trước đó (Alt+Shift+Lên)"
 
 #. ID_NEXTCONFLICT
-#: Merge.rc:5333
+#: Merge.rc:5332
 msgid ""
 "\n"
 "Next Conflict (Alt+Shift+Down)"
@@ -7669,7 +7664,7 @@ msgstr ""
 "Xung đột tiếp theo (Alt+Shift+Xuống)"
 
 #. ID_FIRSTDIFF
-#: Merge.rc:5338
+#: Merge.rc:5337
 msgid ""
 "\n"
 "First Difference (Alt+Home)"
@@ -7678,7 +7673,7 @@ msgstr ""
 "Khác biệt đầu tiên (Alt+Home)"
 
 #. ID_CURDIFF
-#: Merge.rc:5339
+#: Merge.rc:5338
 msgid ""
 "\n"
 "Current Difference (Alt+Enter)"
@@ -7687,7 +7682,7 @@ msgstr ""
 "Khác biệt hiện tại (Alt+Enter)"
 
 #. ID_LASTDIFF
-#: Merge.rc:5340
+#: Merge.rc:5339
 msgid ""
 "\n"
 "Last Difference (Alt+End)"
@@ -7696,7 +7691,7 @@ msgstr ""
 "Khác biệt cuối cùng (Alt+End)"
 
 #. ID_L2R
-#: Merge.rc:5341
+#: Merge.rc:5340
 msgid ""
 "\n"
 "Copy to Right (Alt+Right)"
@@ -7705,7 +7700,7 @@ msgstr ""
 "Chép sang bên phải (Alt+Phải)"
 
 #. ID_R2L
-#: Merge.rc:5342
+#: Merge.rc:5341
 msgid ""
 "\n"
 "Copy to Left (Alt+Left)"
@@ -7714,7 +7709,7 @@ msgstr ""
 "Chép sang bên trái (Alt+Trái)"
 
 #. ID_L2RNEXT
-#: Merge.rc:5343
+#: Merge.rc:5342
 msgid ""
 "\n"
 "Copy to Right and Advance (Ctrl+Alt+Right)"
@@ -7723,7 +7718,7 @@ msgstr ""
 "Chép sang bên phải và tiến tiếp (Ctrl+Alt+Phải)"
 
 #. ID_R2LNEXT
-#: Merge.rc:5344
+#: Merge.rc:5343
 msgid ""
 "\n"
 "Copy to Left and Advance (Ctrl+Alt+Left)"
@@ -7732,7 +7727,7 @@ msgstr ""
 "Chép sang bên trái và tiến tiếp (Ctrl+Alt+Trái)"
 
 #. ID_ALL_RIGHT
-#: Merge.rc:5345
+#: Merge.rc:5344
 msgid ""
 "\n"
 "Copy All to Right"
@@ -7741,7 +7736,7 @@ msgstr ""
 "Chép tất cả sang bên phải"
 
 #. ID_ALL_LEFT
-#: Merge.rc:5346
+#: Merge.rc:5345
 msgid ""
 "\n"
 "Copy All to Left"
@@ -7750,7 +7745,7 @@ msgstr ""
 "Chép tất cả sang bên trái"
 
 #. ID_AUTO_MERGE
-#: Merge.rc:5347
+#: Merge.rc:5346
 msgid ""
 "\n"
 "Auto Merge (Ctrl+Alt+M)"
@@ -7759,7 +7754,7 @@ msgstr ""
 "Tự động trộn (Ctrl+Alt+M)"
 
 #. ID_FIRSTFILE
-#: Merge.rc:5348
+#: Merge.rc:5347
 msgid ""
 "\n"
 "First File"
@@ -7768,7 +7763,7 @@ msgstr ""
 "Tệp đầu tiên"
 
 #. ID_NEXTFILE
-#: Merge.rc:5349
+#: Merge.rc:5348
 msgid ""
 "\n"
 "Next File (Ctrl+F8)"
@@ -7777,7 +7772,7 @@ msgstr ""
 "Tệp tiếp theo (Ctrl+F8)"
 
 #. ID_LASTFILE
-#: Merge.rc:5350
+#: Merge.rc:5349
 msgid ""
 "\n"
 "Last File"
@@ -7786,7 +7781,7 @@ msgstr ""
 "Tệp cuối cùng"
 
 #. ID_PREVFILE
-#: Merge.rc:5351
+#: Merge.rc:5350
 msgid ""
 "\n"
 "Previous File (Ctrl+F7)"
@@ -7795,144 +7790,144 @@ msgstr ""
 "Tệp trước đó (Ctrl+F7)"
 
 #. IDS_UNPACK_AUTO
-#: Merge.rc:5358
+#: Merge.rc:5357
 msgid "Adapted unpacker applied to both files (one needs extension)."
 msgstr ""
 "Trình bung gói thích ứng đã áp dụng cho cả hai tệp (một tệp cần phần mở "
 "rộng)."
 
 #. IDS_NO_PREDIFFER
-#: Merge.rc:5359
+#: Merge.rc:5358
 msgid "No Prediffer (Normal)"
 msgstr "Không dùng trình tiền so sánh (bình thường)"
 
 #. IDS_SUGGESTED_PLUGINS
-#: Merge.rc:5360
+#: Merge.rc:5359
 msgid "Suggested Plugins"
 msgstr "Trình cắm được đề xuất"
 
 #. IDS_NOT_SUGGESTED_PLUGINS
-#: Merge.rc:5361
+#: Merge.rc:5360
 msgid "All Plugins"
 msgstr "Tất cả trình cắm"
 
 #. IDS_PRIVATEBUILD_FMT
-#: Merge.rc:5367
+#: Merge.rc:5366
 #, c-format
 msgid "Private Build: %1"
 msgstr "Bản dựng riêng: %1"
 
 #. IDS_ALLRIGHTS_RESERVED
-#: Merge.rc:5368
+#: Merge.rc:5367
 msgid " - All rights reserved."
 msgstr " - Bảo lưu mọi quyền."
 
 #. IDS_TITLE_PLUGINS_SETTINGS
-#: Merge.rc:5374
+#: Merge.rc:5373
 msgid "Plugin Settings"
 msgstr "Thiết đặt trình cắm"
 
 #. IDS_NO_SCT_SCRIPTS
-#: Merge.rc:5376
+#: Merge.rc:5375
 msgid "WSH not found - .sct scripts disabled"
 msgstr "Không tìm thấy WSH - các kịch bản .sct đã bị vô hiệu hoá"
 
 #. IDS_LOCBAR_GOTOLINE_FMT
-#: Merge.rc:5384
+#: Merge.rc:5383
 #, c-format
 msgid "G&o to Line %1"
 msgstr "Đi tới dòng %1"
 
 #. IDS_GOTO_MOVED_LINE
-#: Merge.rc:5390
+#: Merge.rc:5389
 msgid "Go to Moved Line\tCtrl+Shift+G"
 msgstr "Đi tới dòng đã di chuyển\tCtrl+Shift+G"
 
 #. IDS_AUTOCOMPLETE_DISABLED
-#: Merge.rc:5396
+#: Merge.rc:5395
 msgctxt "Options dialog|General|Open dialog Auto completion"
 msgid "Disabled"
 msgstr "Đã tắt"
 
 #. IDS_AUTOCOMPLETE_FILE_SYS
-#: Merge.rc:5397
+#: Merge.rc:5396
 msgid "From file system"
 msgstr "Từ hệ thống tệp"
 
 #. IDS_AUTOCOMPLETE_MRU
-#: Merge.rc:5398
+#: Merge.rc:5397
 msgid "From Most Recently Used list"
 msgstr "Từ danh sách dùng gần đây nhất"
 
 #. IDS_COLORSCHEME_PLAIN
-#: Merge.rc:5404
+#: Merge.rc:5403
 msgid "No Highlighting"
 msgstr "Không tô sáng"
 
 #. IDS_COLORSCHEME_PO
-#: Merge.rc:5439
+#: Merge.rc:5438
 msgid "Portable Object"
 msgstr "Đối tượng di động (PO)"
 
 #. IDS_COLORSCHEME_RSRC
-#: Merge.rc:5444
+#: Merge.rc:5443
 msgid "Resources"
 msgstr "Tài nguyên"
 
 #. IDS_COLORSCHEME_SH
-#: Merge.rc:5448
+#: Merge.rc:5447
 msgid "Shell"
 msgstr "Hệ vỏ (shell)"
 
 #. IDS_CLOSE_LEFT_TABS
-#: Merge.rc:5469
+#: Merge.rc:5468
 msgid "Close &Left Tabs"
 msgstr "Đóng các thẻ bên trái"
 
 #. IDS_CLOSE_RIGHT_TABS
-#: Merge.rc:5470
+#: Merge.rc:5469
 msgid "Close R&ight Tabs"
 msgstr "Đóng các thẻ bên phải"
 
 #. IDS_CLOSE_OTHER_TABS
-#: Merge.rc:5471
+#: Merge.rc:5470
 msgid "Close &Other Tabs"
 msgstr "Đóng các thẻ khác"
 
 #. IDS_TABBAR_AUTO_MAXWIDTH
-#: Merge.rc:5472
+#: Merge.rc:5471
 msgid "Enable &Auto Max Width"
 msgstr "Bật tự động mở tối đa chiều rộng"
 
 #. IDS_WEBPAGE_MENU
-#: Merge.rc:5482
+#: Merge.rc:5481
 msgid "We&bpage"
 msgstr "Trang web"
 
 #. IDS_VIEW_WRAP_TEXT
-#: Merge.rc:5487
+#: Merge.rc:5486
 msgid "W&rap Text"
 msgstr "Tự &ngắt dòng văn bản"
 
 #. IDS_NOTINSTALLED
-#: Merge.rc:5492
+#: Merge.rc:5491
 #, c-format
 msgid "%1 is not installed."
 msgstr "%1 chưa được cài đặt."
 
 #. IDS_CREATE_FOLDER
-#: Merge.rc:5497
+#: Merge.rc:5496
 #, c-format
 msgid "%1 does not exist. Create it?"
 msgstr "Không tồn tại %1. Có tạo nó không?"
 
 #. IDS_CREATE_FOLDER_ERROR
-#: Merge.rc:5498
+#: Merge.rc:5497
 msgid "Failed to create folder."
 msgstr "Không thể tạo thư mục."
 
 #. IDC_EXT_EDITOR_PATH
-#: Merge.rc:5503
+#: Merge.rc:5502
 msgid ""
 "Parameters:\n"
 "$file: Current file path\n"
@@ -7943,492 +7938,492 @@ msgstr ""
 "$linenum: Số dòng tại con trỏ hiện tại"
 
 #. IDS_DIFF_ALGORITHM_DEFAULT
-#: Merge.rc:5508
+#: Merge.rc:5507
 msgid "default"
 msgstr "mặc định"
 
 #. IDS_DIFF_ALGORITHM_MINIMAL
-#: Merge.rc:5509
+#: Merge.rc:5508
 msgid "minimal"
 msgstr "tối thiểu"
 
 #. IDS_DIFF_ALGORITHM_PATIENCE
-#: Merge.rc:5510
+#: Merge.rc:5509
 msgid "patience"
 msgstr "kiên nhẫn"
 
 #. IDS_DIFF_ALGORITHM_HISTOGRAM
-#: Merge.rc:5511
+#: Merge.rc:5510
 msgid "histogram"
 msgstr "biểu đồ tần suất"
 
 #. IDS_DIFF_ALGORITHM_NONE
-#: Merge.rc:5512
+#: Merge.rc:5511
 msgid "none"
 msgstr "không"
 
 #. IDS_RENDERING_MODE_GDI
-#: Merge.rc:5517
+#: Merge.rc:5516
 msgid "GDI"
 msgstr "GDI"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_DEFAULT
-#: Merge.rc:5518
+#: Merge.rc:5517
 msgid "DirectWrite Default"
 msgstr "DirectWrite Mặc định"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_ALIASED
-#: Merge.rc:5519
+#: Merge.rc:5518
 msgid "DirectWrite Aliased"
 msgstr "DirectWrite Răng cưa"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_GDI_CLASSIC
-#: Merge.rc:5520
+#: Merge.rc:5519
 msgid "DirectWrite GDI Classic"
 msgstr "DirectWrite GDI Cổ điển"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_GDI_NATURAL
-#: Merge.rc:5521
+#: Merge.rc:5520
 msgid "DirectWrite GDI Natural"
 msgstr "DirectWrite GDI Tự nhiên"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_NATURAL
-#: Merge.rc:5522
+#: Merge.rc:5521
 msgid "DirectWrite Natural"
 msgstr "DirectWrite Tự nhiên"
 
 #. IDS_RENDERING_MODE_DIRECTWRITE_NATURAL_SYMMETRIC
-#: Merge.rc:5523
+#: Merge.rc:5522
 msgid "DirectWrite Natural Symmetric"
 msgstr "DirectWrite Tự nhiên Đối xứng"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_DISABLED
-#: Merge.rc:5528
+#: Merge.rc:5527
 msgctxt "Options dialog|General|Close windows with Esc"
 msgid "Disabled"
 msgstr "Vô hiệu hoá"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_1
-#: Merge.rc:5529
+#: Merge.rc:5528
 msgid "MDI child window or main window"
 msgstr "Cửa sổ con MDI hoặc cửa sổ chính"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_2
-#: Merge.rc:5530
+#: Merge.rc:5529
 msgid "MDI child window only"
 msgstr "Chỉ cửa sổ con MDI"
 
 #. IDS_CLOSE_WINDOWS_WITH_ESC_3
-#: Merge.rc:5531
+#: Merge.rc:5530
 msgid "Close main window if only one MDI child window"
 msgstr "Đóng cửa sổ chính nếu chỉ còn một cửa sổ con MDI"
 
 #. IDS_DIFF_GROUP
-#: Merge.rc:5536
+#: Merge.rc:5535
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Diff"
 msgstr "Khác biệt"
 
 #. IDS_DIFF_HIGHLIGHT
-#: Merge.rc:5537
+#: Merge.rc:5536
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Highlight"
 msgstr "Tô sáng"
 
 #. IDS_DIFF_BLINK
-#: Merge.rc:5538
+#: Merge.rc:5537
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Blink"
 msgstr "Nhấp nháy"
 
 #. IDS_DIFF_BLOCKSIZE
-#: Merge.rc:5539
+#: Merge.rc:5538
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Block Size"
 msgstr "Kích cỡ khối"
 
 #. IDS_DIFF_BLOCKALPHA
-#: Merge.rc:5540
+#: Merge.rc:5539
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Block Alpha"
 msgstr "Am-pha khối"
 
 #. IDS_DIFF_CDTHRESHOLD
-#: Merge.rc:5541
+#: Merge.rc:5540
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "CD Threshold"
 msgstr "Ngưỡng CD"
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION
-#: Merge.rc:5542
+#: Merge.rc:5541
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Ins/Del Detection"
 msgstr "Phát hiện thêm/xoá"
 
 #. IDS_OVERLAY_MODE_NONE
-#: Merge.rc:5543 Merge.rc:5548
+#: Merge.rc:5542 Merge.rc:5547
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "None"
 msgstr "Không có"
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION_VERTICAL
-#: Merge.rc:5544
+#: Merge.rc:5543
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Vertical"
 msgstr "Chiều dọc"
 
 #. IDS_DIFF_INSERTION_DELETION_DETECTION_HORIZONTAL
-#: Merge.rc:5545
+#: Merge.rc:5544
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Horizontal"
 msgstr "Chiều ngang"
 
 #. IDS_OVERLAY_GROUP
-#: Merge.rc:5546
+#: Merge.rc:5545
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Overlay"
 msgstr "Lớp phủ"
 
 #. IDS_OVERLAY_ALPHA
-#: Merge.rc:5547
+#: Merge.rc:5546
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha"
 msgstr "Am-pha"
 
 #. IDS_OVERLAY_MODE_XOR
-#: Merge.rc:5549
+#: Merge.rc:5548
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "XOR"
 msgstr "XOR"
 
 #. IDS_OVERLAY_MODE_ALPHA
-#: Merge.rc:5550
+#: Merge.rc:5549
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha Blend"
 msgstr "Pha trộn am-pha"
 
 #. IDS_OVERLAY_MODE_ALPHA_ANIMATION
-#: Merge.rc:5551
+#: Merge.rc:5550
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Alpha Animation"
 msgstr "Hoạt ảnh am-pha"
 
 #. IDS_ZOOM
-#: Merge.rc:5552
+#: Merge.rc:5551
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Zoom"
 msgstr "Thu phóng"
 
 #. IDS_PAGE
-#: Merge.rc:5553
+#: Merge.rc:5552
 msgctxt "ImgMergeFrame|LocationPane"
 msgid "Page:"
 msgstr "Trang:"
 
 #. IDS_IMGCMP_STATUS_PT_RGBA_FMT
-#: Merge.rc:5554
+#: Merge.rc:5553
 #, c-format
 msgid "Pt: (%d, %d)  RGBA: (%d, %d, %d, %d)  "
 msgstr "Điểm: (%d, %d)  RGBA: (%d, %d, %d, %d)  "
 
 #. IDS_IMGCMP_STATUS_DIST1_FMT
-#: Merge.rc:5555
+#: Merge.rc:5554
 #, c-format
 msgid "Dist: %g  "
 msgstr "Kh.cách: %g  "
 
 #. IDS_IMGCMP_STATUS_DIST2_FMT
-#: Merge.rc:5556
+#: Merge.rc:5555
 #, c-format
 msgid "Dist: %g, %g  "
 msgstr "Kh.cách: %g, %g  "
 
 #. IDS_IMGCMP_STATUS_PAGE_ZOOM_SIZE_BPP_FMT
-#: Merge.rc:5557
+#: Merge.rc:5556
 #, c-format
 msgid "Page: %d/%d  Zoom: %d%%  %dx%dpx  %dbpp  "
 msgstr "Trang: %d/%d  T.phóng: %d%%  %dx%dpx  %dbpp  "
 
 #. IDS_IMGCMP_STATUS_RC_FMT
-#: Merge.rc:5558
+#: Merge.rc:5557
 #, c-format
 msgid "Rc: (%d, %d)  "
 msgstr "Rc: (%d, %d)  "
 
 #. IDS_IMGCMP_STATUS_FLIPPED_FMT
-#: Merge.rc:5559
+#: Merge.rc:5558
 #, c-format
 msgid "Flipped: %s  "
 msgstr "Đã lật: %s  "
 
 #. IDS_IMGCMP_STATUS_ROTATED_FMT
-#: Merge.rc:5560
+#: Merge.rc:5559
 #, c-format
 msgid "Rotated: %d  "
 msgstr "Đã xoay: %d  "
 
 #. IDS_IMGCMP_REPORT_ALLPAGES
-#: Merge.rc:5561
+#: Merge.rc:5560
 msgid "All pages"
 msgstr "Tất cả các trang"
 
 #. IDS_IGNSUB_STR1
-#: Merge.rc:5566
+#: Merge.rc:5565
 msgid "<Edit here>"
 msgstr "<Sửa ở đây>"
 
 #. IDS_IGNSUB_STR2
-#: Merge.rc:5567
+#: Merge.rc:5566
 msgid "No differences found to select"
 msgstr "Không tìm thấy khác biệt nào để chọn"
 
 #. IDS_IGNSUB_STR3
-#: Merge.rc:5568
+#: Merge.rc:5567
 msgid "No differences found to add as substitution filter"
 msgstr "Không tìm thấy khác biệt nào để thêm vào bộ lọc thay thế"
 
 #. IDS_IGNSUB_STR4
-#: Merge.rc:5569
+#: Merge.rc:5568
 msgid "The pair is already in the Substitution Filters list"
 msgstr "Cặp này đã có trong danh sách bộ lọc thay thế"
 
 #. IDS_IGNSUB_STR5
-#: Merge.rc:5570
+#: Merge.rc:5569
 msgid "Add this change to Substitution Filters?"
 msgstr "Có thêm thay đổi này vào bộ lọc thay thế không?"
 
 #. IDS_OCRRESULT_TEXTONLY
-#: Merge.rc:5575
+#: Merge.rc:5574
 msgid "Text only"
 msgstr "Chỉ văn bản"
 
 #. IDS_OCRRESULT_POS_LINE
-#: Merge.rc:5576
+#: Merge.rc:5575
 msgid "Line-by-line position and text"
 msgstr "Vị trí và văn bản theo từng dòng"
 
 #. IDS_OCRRESULT_POS_WORD
-#: Merge.rc:5577
+#: Merge.rc:5576
 msgid "Word-by-word position and text"
 msgstr "Vị trí và văn bản theo từng từ"
 
 #. IDS_USERDATAFOLDER_APPDATA
-#: Merge.rc:5582
+#: Merge.rc:5581
 msgid "AppData (Roaming) folder"
 msgstr "Thư mục AppData (Roaming)"
 
 #. IDS_USERDATAFOLDER_INSTALL
-#: Merge.rc:5583
+#: Merge.rc:5582
 msgid "Install folder"
 msgstr "Thư mục cài đặt"
 
 #. IDS_USERDATAFOLDER_DOCUMENTS
-#: Merge.rc:5584
+#: Merge.rc:5583
 msgid "Documents folder"
 msgstr "Thư mục tài liệu"
 
 #. IDS_SINGLEINSTANCE_DISABLED
-#: Merge.rc:5589
+#: Merge.rc:5588
 msgctxt "Options dialog|General|Single instance mode"
 msgid "Disabled"
 msgstr "Đã tắt"
 
 #. IDS_SINGLEINSTANCE_STR1
-#: Merge.rc:5590
+#: Merge.rc:5589
 msgid "Allow only one instance to run"
 msgstr "Chỉ cho phép một hiện thể chạy"
 
 #. IDS_CLIPBOARD_HISTORY
-#: Merge.rc:5591
+#: Merge.rc:5590
 msgid "Clipboard &History"
 msgstr ""
 
 #. IDS_SINGLEINSTANCE_STR2
-#: Merge.rc:5592
+#: Merge.rc:5591
 msgid "Allow only one instance; wait for termination"
 msgstr "Chỉ cho phép một hiện thể; chờ cho đến khi kết thúc"
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_DISABLED
-#: Merge.rc:5597
+#: Merge.rc:5596
 msgctxt "Options dialog|General|Auto-reload modified files"
 msgid "Disabled"
 msgstr "Đã tắt"
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_STR1
-#: Merge.rc:5598
+#: Merge.rc:5597
 msgid "Only on window activated"
 msgstr "Chỉ khi cửa sổ được kích hoạt"
 
 #. IDS_AUTO_RELOAD_MODIFIED_FILES_STR2
-#: Merge.rc:5599
+#: Merge.rc:5598
 msgid "Immediately"
 msgstr "Ngay lập tức"
 
 #. IDS_PLUGIN_ALL
-#: Merge.rc:5604
+#: Merge.rc:5603
 msgid "Al&l"
 msgstr "Tất cả"
 
 #. IDS_PLUGIN_OTHERS
-#: Merge.rc:5605
+#: Merge.rc:5604
 msgid "&Others"
 msgstr "&Khác"
 
-#: Merge.rc:5607
+#: Merge.rc:5606
 #, c-format
 msgid "Missing plugin name in pipeline: %1"
 msgstr "Thiếu tên trình cắm trong ống dẫn: %1"
 
-#: Merge.rc:5609
+#: Merge.rc:5608
 #, c-format
 msgid "Missing quote in plugin pipeline: %1"
 msgstr "Thiếu dấu ngoặc kép trong ống dẫn trình cắm: %1"
 
 #. IDS_PLUGIN_NAME_ALREADY_EXISTS
-#: Merge.rc:5610
+#: Merge.rc:5609
 #, c-format
 msgid "Plugin name '%1' already exists."
 msgstr "Tên trình cắm '%1' đã tồn tại."
 
 #. IDS_PLUGIN_TITLE1
-#: Merge.rc:5611
+#: Merge.rc:5610
 msgid "Specify plugin arguments"
 msgstr "Chỉ định đối số trình cắm"
 
-#: Merge.rc:5613
+#: Merge.rc:5612
 #, c-format
 msgid "Plugin not found or invalid: %1"
 msgstr "Không thấy trình cắm hoặc không hợp lệ: %1"
 
 #. IDS_PLUGIN_NOT_UNPACK
-#: Merge.rc:5614
+#: Merge.rc:5613
 #, c-format
 msgid "'%1' is not an unpacker plugin"
 msgstr "'%1' không phải là trình cắm bung gói"
 
 #. IDS_PLUGIN_NOT_PREDIFF
-#: Merge.rc:5615
+#: Merge.rc:5614
 #, c-format
 msgid "'%1' is not a prediffer plugin"
 msgstr "'%1' không phải là trình cắm tiền so sánh"
 
-#: Merge.rc:5617
+#: Merge.rc:5616
 #, c-format
 msgid "Error prediffing '%1' with '%2'. Prediffing disabled."
 msgstr ""
 "Lỗi khi xử lí tiền so sánh '%1' với '%2'. Đã tắt tính năng tiền so sánh."
 
 #. IDS_PLUGIN_CIRCULAR_REFERENCE
-#: Merge.rc:5618
+#: Merge.rc:5617
 #, c-format
 msgid "Circular reference in plugin pipeline: %1"
 msgstr "Tham chiếu vòng tròn trong ống dẫn trình cắm: %1"
 
 #. IDS_PLUGIN_TYPE1
-#: Merge.rc:5619
+#: Merge.rc:5618
 msgid "URL Handler"
 msgstr "Trình xử lý URL"
 
 #. IDS_PLUGIN_TYPE2
-#: Merge.rc:5620
+#: Merge.rc:5619
 msgid "File Unpacker"
 msgstr "Trình bung gói tệp"
 
 #. IDS_PLUGIN_TYPE3
-#: Merge.rc:5621
+#: Merge.rc:5620
 msgid "File or Folder Unpacker"
 msgstr "Trình bung gói tệp hoặc thư mục"
 
 #. IDS_PLUGIN_TYPE5
-#: Merge.rc:5623
+#: Merge.rc:5622
 msgid "Alias for Unpacker"
 msgstr "Bí danh cho trình bung gói"
 
 #. IDS_PLUGIN_TYPE6
-#: Merge.rc:5624
+#: Merge.rc:5623
 msgid "Alias for Prediffer"
 msgstr "Bí danh cho trình tiền so sánh"
 
 #. IDS_PLUGIN_TYPE7
-#: Merge.rc:5625
+#: Merge.rc:5624
 msgid "Alias for Editor script"
 msgstr "Bí danh cho kịch bản chỉnh sửa"
 
 #. IDS_PLUGIN_ALIAS_DESC
-#: Merge.rc:5626
+#: Merge.rc:5625
 #, c-format
 msgid "Alias for plugin pipeline '%1'"
 msgstr "Bí danh cho ống dẫn trình cắm '%1'"
 
 #. IDS_PLUGIN_NEW_DESC
-#: Merge.rc:5627
+#: Merge.rc:5626
 msgid "New plugin description"
 msgstr "Mô tả trình cắm mới"
 
 #. IDS_PLUGIN_TARGETS_ALL
-#: Merge.rc:5628
+#: Merge.rc:5627
 msgid "All"
 msgstr "Tất cả"
 
 #. IDS_PLUGIN_TARGETS_1ST
-#: Merge.rc:5629
+#: Merge.rc:5628
 msgid "1st"
 msgstr "Thứ nhất"
 
 #. IDS_PLUGIN_TARGETS_2ND
-#: Merge.rc:5630
+#: Merge.rc:5629
 msgid "2nd"
 msgstr "Thứ 2"
 
 #. IDS_PLUGIN_TARGETS_3RD
-#: Merge.rc:5631
+#: Merge.rc:5630
 msgid "3rd"
 msgstr "Thứ 3"
 
 #. IDS_PLUGIN_TARGETS_1ST_2ND
-#: Merge.rc:5632
+#: Merge.rc:5631
 msgid "1st and 2nd"
 msgstr "Thứ nhất và thứ 2"
 
 #. IDS_PLUGIN_TARGETS_1ST_3RD
-#: Merge.rc:5633
+#: Merge.rc:5632
 msgid "1st and 3rd"
 msgstr "Thứ nhất và thứ 3"
 
 #. IDS_PLUGIN_TARGETS_2ND_3RD
-#: Merge.rc:5634
+#: Merge.rc:5633
 msgid "2nd and 3rd"
 msgstr "Thứ 2 và thứ 3"
 
 #. IDS_PLUGIN_CTRL_CLICK
-#: Merge.rc:5635
+#: Merge.rc:5634
 msgid "(Ctrl+Click to add to pipeline)"
 msgstr ""
 
 #. IDS_FILTER_APPLIED
-#: Merge.rc:5640
+#: Merge.rc:5639
 msgid "Filter applied"
 msgstr "Đã áp dụng bộ lọc"
 
 #. IDS_FILTERMENU_COMPARE
-#: Merge.rc:5645
+#: Merge.rc:5644
 #, c-format
 msgid "Compare %1"
 msgstr "So sánh %1"
 
 #. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN2
-#: Merge.rc:5647
+#: Merge.rc:5646
 msgid "&Filter by This Column..."
 msgstr ""
 
 #. IDS_CLIPBOARDHISTORY_TIME
-#: Merge.rc:5652
+#: Merge.rc:5651
 #, c-format
 msgid "Clipboard at %s"
 msgstr "Bảng tạm lúc %s"
 
 #. IDS_CLIPBOARDHISTORY_DISABLED
-#: Merge.rc:5653
+#: Merge.rc:5652
 msgid ""
 "Clipboard history disabled.\r\n"
 "Enable: Windows logo key + V, then Turn on."
@@ -8436,115 +8431,115 @@ msgstr ""
 "Lịch sử bảng tạm đã bị tắt.\r\n"
 "Bật: Phím Windows + V, sau đó chọn Bật (Turn on)."
 
-#: Merge.rc:5655
+#: Merge.rc:5654
 msgid "This system does not support clipboard history."
 msgstr "Hệ thống này không hỗ trợ lịch sử bảng tạm."
 
-#: Merge.rc:5657
+#: Merge.rc:5656
 msgid "32-bit WinMerge does not support Clipboard Compare"
 msgstr "WinMerge phiên bản 32-bit không hỗ trợ So sánh bảng tạm"
 
 #. IDS_WEBVIEW2_RUNTIME_NOT_INSTALLED
-#: Merge.rc:5662
+#: Merge.rc:5661
 msgid "WebView2 runtime not installed. Download it?"
 msgstr "Chưa cài đặt thời gian chạy (runtime) WebView2. Có tải xuống không?"
 
 #. IDS_JUMPLIST_NEW_TEXT_COMPARE
-#: Merge.rc:5667
+#: Merge.rc:5666
 msgid "New Text Compare"
 msgstr "So sánh văn bản mới"
 
 #. IDS_JUMPLIST_NEW_TABLE_COMPARE
-#: Merge.rc:5668
+#: Merge.rc:5667
 msgid "New Table Compare"
 msgstr "So sánh bảng mới"
 
 #. IDS_JUMPLIST_NEW_BINARY_COMPARE
-#: Merge.rc:5669
+#: Merge.rc:5668
 msgid "New Binary Compare"
 msgstr "So sánh nhị phân mới"
 
 #. IDS_JUMPLIST_NEW_IMAGE_COMPARE
-#: Merge.rc:5670
+#: Merge.rc:5669
 msgid "New Image Compare"
 msgstr "So sánh hình ảnh mới"
 
 #. IDS_JUMPLIST_NEW_WEBPAGE_COMPARE
-#: Merge.rc:5671
+#: Merge.rc:5670
 msgid "New Webpage Compare"
 msgstr "So sánh trang web mới"
 
 #. IDS_JUMPLIST_NEW_FOLDER_COMPARE
-#: Merge.rc:5672
+#: Merge.rc:5671
 msgid "New Folder Compare"
 msgstr ""
 
 #. IDS_JUMPLIST_CLIPBOARD_COMPARE
-#: Merge.rc:5673
+#: Merge.rc:5672
 msgid "Clipboard Compare"
 msgstr "So sánh bảng tạm"
 
 #. IDS_PREVIEWBAR_PRINT
-#: Merge.rc:5678
+#: Merge.rc:5677
 msgid "&Print..."
 msgstr "In..."
 
 #. IDS_PREVIEWBAR_PREVPAGE
-#: Merge.rc:5680
+#: Merge.rc:5679
 msgid "Pre&v Page"
 msgstr "Trang trước"
 
 #. IDS_PREVIEWBAR_TWOPAGE
-#: Merge.rc:5681
+#: Merge.rc:5680
 msgid "&Two Page"
 msgstr "Hai trang"
 
 #. IDS_PREVIEWBAR_ONEPAGE
-#: Merge.rc:5682
+#: Merge.rc:5681
 msgid "&One Page"
 msgstr "Một trang"
 
 #. IDS_PREVIEWBAR_ZOOMIN
-#: Merge.rc:5683
+#: Merge.rc:5682
 msgid "Zoom &In"
 msgstr "Phóng to"
 
 #. IDS_PREVIEWBAR_ZOOMOUT
-#: Merge.rc:5684
+#: Merge.rc:5683
 msgid "Zoom &Out"
 msgstr "Thu nhỏ"
 
 #. IDS_WEBPAGE_COMPARING
-#: Merge.rc:5690
+#: Merge.rc:5689
 msgid "Comparing..."
 msgstr "Đang so sánh..."
 
 #. IDS_WEBPAGE_ZOOM
-#: Merge.rc:5691
+#: Merge.rc:5690
 msgid "Zoom:"
 msgstr "Thu phóng:"
 
 #. IDS_COPY_GRANULARITY_DIFFHUNK
-#: Merge.rc:5696
+#: Merge.rc:5695
 msgid "Diff hunk"
 msgstr "Khối khác biệt"
 
 #. IDS_COPY_GRANULARITY_INLINE
-#: Merge.rc:5697
+#: Merge.rc:5696
 msgid "Inline diff"
 msgstr "Khác biệt trên dòng"
 
 #. IDS_COPY_GRANULARITY_LINE
-#: Merge.rc:5698
+#: Merge.rc:5697
 msgid "Line"
 msgstr "Dòng"
 
-#: Merge.rc:5699
+#: Merge.rc:5698
 msgid "Character"
 msgstr "Kí tự"
 
 #. ID_MICE_PREVDIFF
-#: Merge.rc:5704
+#: Merge.rc:5703
 msgid ""
 "\n"
 "Previous Difference (Alt+Up)\n"
@@ -8557,7 +8552,7 @@ msgstr ""
 "(Alt+Cuộn lên)"
 
 #. ID_MICE_NEXTDIFF
-#: Merge.rc:5705
+#: Merge.rc:5704
 msgid ""
 "\n"
 "Next Difference (Alt+Down)\n"
@@ -8570,7 +8565,7 @@ msgstr ""
 "(Alt+Cuộn xuống)"
 
 #. ID_MICE_L2R
-#: Merge.rc:5706
+#: Merge.rc:5705
 msgid ""
 "\n"
 "Copy to Right (Alt+Right)\n"
@@ -8585,7 +8580,7 @@ msgstr ""
 "(Alt+Shift+Cuộn xuống)"
 
 #. ID_MICE_R2L
-#: Merge.rc:5707
+#: Merge.rc:5706
 msgid ""
 "\n"
 "Copy to Left (Alt+Left)\n"
@@ -8600,7 +8595,7 @@ msgstr ""
 "(Alt+Shift+Cuộn lên)"
 
 #. ID_MICE_L2RNEXT
-#: Merge.rc:5708
+#: Merge.rc:5707
 msgid ""
 "\n"
 "Copy to Right and Advance (Ctrl+Alt+Right)\n"
@@ -8613,7 +8608,7 @@ msgstr ""
 "(Ctrl+Alt+Shift+Cuộn xuống)"
 
 #. ID_MICE_R2LNEXT
-#: Merge.rc:5709
+#: Merge.rc:5708
 msgid ""
 "\n"
 "Copy to Left and Advance (Ctrl+Alt+Left)\n"
@@ -8626,282 +8621,282 @@ msgstr ""
 "(Ctrl+Alt+Shift+Cuộn lên)"
 
 #. IDS_LOG_COMPARING_2
-#: Merge.rc:5719
+#: Merge.rc:5718
 #, c-format
 msgid "Comparing %1 with %2"
 msgstr "Đang so sánh %1 với %2"
 
 #. IDS_LOG_COMPARING_3
-#: Merge.rc:5720
+#: Merge.rc:5719
 #, c-format
 msgid "Comparing %1 with %2 and %3"
 msgstr "Đang so sánh %1 với %2 và %3"
 
 #. IDS_LOG_COMPARE_COMPLETED
-#: Merge.rc:5721
+#: Merge.rc:5720
 msgid "Comparison completed"
 msgstr "So sánh hoàn tất"
 
 #. IDS_LOG_COMPARE_ERROR_2
-#: Merge.rc:5722
+#: Merge.rc:5721
 #, c-format
 msgid "Failed to compare %1 with %2: "
 msgstr "Không thể so sánh %1 với %2: "
 
 #. IDS_LOG_COMPARE_ERROR_3
-#: Merge.rc:5723
+#: Merge.rc:5722
 #, c-format
 msgid "Failed to compare %1 with %2 and %3: "
 msgstr "Không thể so sánh %1 với %2 và %3: "
 
 #. IDS_LOG_FILE_SAVED
-#: Merge.rc:5724
+#: Merge.rc:5723
 msgid "File saved"
 msgstr "Tệp đã được lưu"
 
 #. IDS_LOG_COPYING_FILES
-#: Merge.rc:5725
+#: Merge.rc:5724
 msgid "Copying files..."
 msgstr "Đang sao chép các tệp..."
 
 #. IDS_LOG_MOVING_FILES
-#: Merge.rc:5726
+#: Merge.rc:5725
 msgid "Moving files..."
 msgstr "Đang di chuyển các tệp..."
 
 #. IDS_LOG_DELETING_FILES
-#: Merge.rc:5727
+#: Merge.rc:5726
 msgid "Deleting files..."
 msgstr "Đang xoá các tệp..."
 
 #. IDS_LOG_RECYCLEBIN
-#: Merge.rc:5728
+#: Merge.rc:5727
 msgid "Recycle Bin"
 msgstr "Thùng rác"
 
 #. IDS_LOG_PERMANENTLY_DELETED
-#: Merge.rc:5729
+#: Merge.rc:5728
 msgid "Permanently deleted"
 msgstr "Đã xoá vĩnh viễn"
 
 #. IDS_LOG_FILEOPERATION_COMPLETED
-#: Merge.rc:5730
+#: Merge.rc:5729
 msgid "File operation completed successfully"
 msgstr "Thao tác tệp đã hoàn thành thành công"
 
 #. IDS_LOG_FILEOPERATION_CANCELED
-#: Merge.rc:5731
+#: Merge.rc:5730
 msgid "File operation canceled"
 msgstr "Thao tác tệp đã bị huỷ"
 
 #. IDS_FILTER_ERROR_NO_ERROR
-#: Merge.rc:5736
+#: Merge.rc:5735
 msgid "No error"
 msgstr "Không có lỗi"
 
 #. IDS_FILTER_ERROR_EMPTY_EXPRESSION
-#: Merge.rc:5737
+#: Merge.rc:5736
 msgid "Filter expression is empty"
 msgstr "Biểu thức bộ lọc trống"
 
 #. IDS_FILTER_ERROR_UNKNOWN_CHAR
-#: Merge.rc:5738
+#: Merge.rc:5737
 msgid "Unknown character in filter expression"
 msgstr "Kí tự không xác định trong biểu thức bộ lọc"
 
 #. IDS_FILTER_ERROR_UNTERMINATED_STRING
-#: Merge.rc:5739
+#: Merge.rc:5738
 msgid "Unterminated string literal"
 msgstr "Chuỗi văn bản chưa được kết thúc"
 
 #. IDS_FILTER_ERROR_SYNTAX_ERROR
-#: Merge.rc:5740
+#: Merge.rc:5739
 msgid "Syntax error in filter expression"
 msgstr "Lỗi cú pháp trong biểu thức bộ lọc"
 
 #. IDS_FILTER_ERROR_PARSE_FAILURE
-#: Merge.rc:5741
+#: Merge.rc:5740
 msgid "Failed to parse filter expression"
 msgstr "Không thể phân tích cú pháp biểu thức bộ lọc"
 
 #. IDS_FILTER_ERROR_INVALID_LITERAL
-#: Merge.rc:5742
+#: Merge.rc:5741
 msgid "Invalid literal value"
 msgstr "Giá trị hằng nguyên văn không hợp lệ"
 
 #. IDS_FILTER_ERROR_INVALID_REGULAR_EXPRESSION
-#: Merge.rc:5743
+#: Merge.rc:5742
 msgid "Invalid regular expression"
 msgstr "Biểu thức chính quy không hợp lệ"
 
 #. IDS_FILTER_ERROR_UNDEFINED_IDENTIFIER
-#: Merge.rc:5744
+#: Merge.rc:5743
 msgid "Undefined identifier"
 msgstr "Định danh chưa được định nghĩa"
 
 #. IDS_FILTER_ERROR_INVALID_ARGUMENT_COUNT
-#: Merge.rc:5745
+#: Merge.rc:5744
 msgid "Invalid number of arguments"
 msgstr "Số lượng đối số không hợp lệ"
 
 #. IDS_FILTER_ERROR_FILTER_NAME_NOT_FOUND
-#: Merge.rc:5746
+#: Merge.rc:5745
 msgid "Filter name not found"
 msgstr "Không tìm thấy tên bộ lọc"
 
 #. IDS_FILTER_ERROR_DIVIDE_BY_ZERO
-#: Merge.rc:5747
+#: Merge.rc:5746
 msgid "Division by zero in filter expression"
 msgstr "Lỗi chia cho số không trong biểu thức bộ lọc"
 
 #. IDS_FILTER_ERROR_UNKNOWN_ERROR
-#: Merge.rc:5748
+#: Merge.rc:5747
 msgid "Unknown error"
 msgstr "Lỗi không xác định"
 
 #. IDS_FILTER_ERROR_INVALID_PROPERTY_NAME
-#: Merge.rc:5749
+#: Merge.rc:5748
 msgid "Invalid property name"
 msgstr "Tên thuộc tính không hợp lệ"
 
 #. IDS_FILTER_ERROR_INVALID_DIRECTIVE
-#: Merge.rc:5750
+#: Merge.rc:5749
 msgid "Invalid directive"
 msgstr ""
 
 #. IDS_FILTER_OP_EQUALS
-#: Merge.rc:5755
+#: Merge.rc:5754
 msgid "Equals"
 msgstr "Bằng"
 
 #. IDS_FILTER_OP_NOT_EQUALS
-#: Merge.rc:5756
+#: Merge.rc:5755
 msgid "Does not equal"
 msgstr "Không bằng"
 
 #. IDS_FILTER_OP_LESS_THAN
-#: Merge.rc:5757
+#: Merge.rc:5756
 msgid "Less than"
 msgstr "Nhỏ hơn"
 
 #. IDS_FILTER_OP_LESS_EQUAL
-#: Merge.rc:5758
+#: Merge.rc:5757
 msgid "Less than or equal to"
 msgstr "Nhỏ hơn hoặc bằng"
 
 #. IDS_FILTER_OP_GREATER_EQUAL
-#: Merge.rc:5759
+#: Merge.rc:5758
 msgid "Greater than or equal to"
 msgstr "Lớn hơn hoặc bằng"
 
 #. IDS_FILTER_OP_GREATER_THAN
-#: Merge.rc:5760
+#: Merge.rc:5759
 msgid "Greater than"
 msgstr "Lớn hơn"
 
 #. IDS_FILTER_OP_BETWEEN
-#: Merge.rc:5761
+#: Merge.rc:5760
 msgid "Between"
 msgstr "Ở giữa"
 
 #. IDS_FILTER_OP_NOT_BETWEEN
-#: Merge.rc:5762
+#: Merge.rc:5761
 msgid "Not Between"
 msgstr "Không ở giữa"
 
 #. IDS_FILTER_OP_CONTAINS
-#: Merge.rc:5763
+#: Merge.rc:5762
 msgid "Contains"
 msgstr "Chứa"
 
 #. IDS_FILTER_OP_NOT_CONTAINS
-#: Merge.rc:5764
+#: Merge.rc:5763
 msgid "Not Contains"
 msgstr "Không chứa"
 
 #. IDS_FILTER_OP_RECONTAINS
-#: Merge.rc:5765
+#: Merge.rc:5764
 msgid "Contains (regex)"
 msgstr "Chứa (biểu thức chính quy)"
 
 #. IDS_FILTER_OP_NOT_RECONTAINS
-#: Merge.rc:5766
+#: Merge.rc:5765
 msgid "Not Contains (regex)"
 msgstr "Không chứa (biểu thức chính quy)"
 
 #. IDS_FILTER_OP_LIKE
-#: Merge.rc:5767
+#: Merge.rc:5766
 msgid "Match (wildcard)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_LIKE
-#: Merge.rc:5768
+#: Merge.rc:5767
 msgid "Not match (wildcard)"
 msgstr ""
 
 #. IDS_FILTER_OP_MATCHES
-#: Merge.rc:5769
+#: Merge.rc:5768
 msgid "Match (regex)"
 msgstr ""
 
 #. IDS_FILTER_OP_NOT_MATCHES
-#: Merge.rc:5770
+#: Merge.rc:5769
 msgid "Not match (regex)"
 msgstr ""
 
 #. IDS_COLORMODE_LIGHT
-#: Merge.rc:5775
+#: Merge.rc:5774
 msgid "Light"
 msgstr "Sáng"
 
 #. IDS_COLORMODE_DARK
-#: Merge.rc:5776
+#: Merge.rc:5775
 msgid "Dark"
 msgstr "Tối"
 
 #. IDS_COLORMODE_FOLLOWSYSTEM
-#: Merge.rc:5777
+#: Merge.rc:5776
 msgid "Follow system"
 msgstr "Theo hệ thống"
 
 #. IDS_EXAMPLE
-#: Merge.rc:5782
+#: Merge.rc:5781
 #, c-format
 msgid "e.g. %1"
 msgstr ""
 
 #. IDS_DETECTED_PREVIOUS_CRASH
-#: Merge.rc:5787
+#: Merge.rc:5786
 msgid "WinMerge detected a previous crash. Please report this if possible."
 msgstr ""
 
 #. IDS_REGEX_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5792
+#: Merge.rc:5791
 msgid "# Regex replacement list\r\n# Format: regex<TAB>replacement\r\n# Backreferences like $1, $2 are supported\r\n\r\n(\\d{4})-(\\d{2})-(\\d{2})\t$1_$2_$3\r\n"
 msgstr ""
 
 #. IDS_STRING_REPLACE_LIST_TEMPLATE
-#: Merge.rc:5793
+#: Merge.rc:5792
 msgid "# Replacement list\r\n# Format: search<TAB>replacement\r\n# Lines starting with # are ignored\r\n\r\nfrom1\tto1\r\nfrom2\tto2\r\n"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_ONLY
-#: Merge.rc:5798
+#: Merge.rc:5797
 msgid "Built-in only"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_BUILT_IN_FIRST
-#: Merge.rc:5799
+#: Merge.rc:5798
 msgid "Built-in first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_FIRST
-#: Merge.rc:5800
+#: Merge.rc:5799
 msgid "Tree-sitter first"
 msgstr ""
 
 #. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_ONLY
-#: Merge.rc:5801
+#: Merge.rc:5800
 msgid "Tree-sitter only"
 msgstr ""
 


### PR DESCRIPTION
Make the merge mode status indicator clickable and reduce its width to provide more space for plugin information.

* Show `↑↓` when merge mode is enabled
* Make the merge mode status pane clickable
* Move merge mode UI handling from `CMergeApp` to `CMainFrame`
* Reduce the merge mode status pane width
* Expand the plugin status pane
* Remove the unused "Merge" status string
