### PR TITLE
Add the FilterExpression support required by the upcoming ApplyLineFilter plugin.

### DIFF
--- a/Src/FilterEngine/FilterExpression.cpp
+++ b/Src/FilterEngine/FilterExpression.cpp
@@ -419,6 +419,40 @@ std::vector<String> FilterExpression::EvaluateKeys(const DIFFITEM& di)
 	}
 }
 
+static String ConvertString(const ValueType& value)
+{
+	if (const auto strVal = std::get_if<std::string>(&value))
+		return ucr::toTString(*strVal);
+	return ucr::toTString(ToStringValue(value));
+}
+
+String FilterExpression::TransformLine(const FilterEvalContext& ectxt)
+{
+	try
+	{
+		const auto result = rootNode->Evaluate(ectxt);
+		return ConvertString(result);
+	}
+	catch (const Poco::RegularExpressionException& e)
+	{
+		errorCode = FILTER_ERROR_INVALID_REGULAR_EXPRESSION;
+		errorPosition = -1;
+		errorMessage = e.message();
+		if (logger)
+			logger(0, "FilterExpression evaluation error: " + errorMessage);
+		return String();
+	}
+	catch (const std::exception& e)
+	{
+		errorCode = FILTER_ERROR_EVALUATION_FAILED;
+		errorPosition = -1;
+		errorMessage = e.what();
+		if (logger)
+			logger(0, "FilterExpression evaluation error: " + errorMessage);
+		return String();
+	}
+}
+
 bool FilterExpression::HasCaseSensitiveDirective(const String& expression)
 {
 	String directives = ExtractDirectives(expression);

--- a/Src/FilterEngine/FilterExpression.h
+++ b/Src/FilterEngine/FilterExpression.h
@@ -80,6 +80,7 @@ struct FilterExpression
 	bool Evaluate(const DIFFITEM& di) { FilterEvalContext ectxt{ this, &di }; return Evaluate(ectxt); }
 	bool Evaluate(const FilterEvalContext& ectxt);
 	std::vector<String> EvaluateKeys(const DIFFITEM& di);
+	String TransformLine(const FilterEvalContext& ectxt);
 	void UpdateTimestamp();
 	void Clear();
 	std::vector<std::string> GetPropertyNames() const;

--- a/Src/FilterEngine/FilterExpressionNodes.cpp
+++ b/Src/FilterEngine/FilterExpressionNodes.cpp
@@ -1604,7 +1604,7 @@ FieldNode::FieldNode(const FilterExpression* ctxt, const std::string& v) : ctxt(
 	auto [side, prefixlen] = ParseAttributeName(vl);
 	ValueType (*functmp)(int, const FilterEvalContext&) = nullptr;
 	const char* p = vl.c_str() + prefixlen;
-	bool singlePane = ctxt->ctxt->GetCompareDirs() == 1;
+	bool singlePane = ctxt->ctxt && ctxt->ctxt->GetCompareDirs() == 1;
 
 	// Handle dynamic column fields (column1, column2, etc.)
 	if (strncmp(p, "column", 6) == 0 && isdigit(p[6]))

--- a/Src/FilterEngine/FilterExpressionNodes.cpp
+++ b/Src/FilterEngine/FilterExpressionNodes.cpp
@@ -1604,13 +1604,14 @@ FieldNode::FieldNode(const FilterExpression* ctxt, const std::string& v) : ctxt(
 	auto [side, prefixlen] = ParseAttributeName(vl);
 	ValueType (*functmp)(int, const FilterEvalContext&) = nullptr;
 	const char* p = vl.c_str() + prefixlen;
+	bool singlePane = ctxt->ctxt->GetCompareDirs() == 1;
 
 	// Handle dynamic column fields (column1, column2, etc.)
 	if (strncmp(p, "column", 6) == 0 && isdigit(p[6]))
 	{
 		// Parse column number (Column1, Column2, etc.)
 		int columnIndex = atoi(p + 6) - 1;
-		if (prefixlen == 0)
+		if (prefixlen == 0 && !singlePane)
 		{
 			func = [columnIndex](const FilterEvalContext& ectxt) -> ValueType {
 				const int dirs = ectxt.expr->ctxt->GetCompareDirs();
@@ -1647,7 +1648,7 @@ FieldNode::FieldNode(const FilterExpression* ctxt, const std::string& v) : ctxt(
 		throw std::runtime_error("Invalid field name: " + std::string(v.begin(), v.end()));
 
 	// Set up the wrapper function based on side/prefix
-	if (prefixlen > 0)
+	if (prefixlen > 0 || singlePane)
 		func = [side, functmp](const FilterEvalContext& ectxt)-> ValueType { return functmp(side < 0 ? ectxt.expr->ctxt->GetCompareDirs() + side: side, ectxt); };
 	else
 	{
@@ -3993,11 +3994,11 @@ static auto columnOffsetAt(int index, const FilterEvalContext& ectxt, std::vecto
 	return std::monostate{};
 }
 
-void FunctionNode::SetLineAtFunc(int side, int prefixlen, ValueType (*proc)(int, const FilterEvalContext&, std::vector<ExprNode*>*))
+void FunctionNode::SetLineAtFunc(int side, int prefixlen, bool singlePane, ValueType (*proc)(int, const FilterEvalContext&, std::vector<ExprNode*>*))
 {
 	if (!args || args->size() != 1)
 		throw std::invalid_argument(functionName + " function requires 1 argument");
-	if (prefixlen == 0)
+	if (prefixlen == 0 && !singlePane)
 		func = [side, proc](const FilterEvalContext& ectxt, std::vector<ExprNode*>* args) -> ValueType
 		{
 			std::shared_ptr<std::vector<ValueType2>> values = std::make_shared<std::vector<ValueType2>>();
@@ -4011,11 +4012,11 @@ void FunctionNode::SetLineAtFunc(int side, int prefixlen, ValueType (*proc)(int,
 			{ return proc((side < 0) ? (ectxt.expr->ctxt->GetCompareDirs() - 1) : side, ectxt, args); };
 }
 
-void FunctionNode::SetColumnFunc(int side, int prefixlen)
+void FunctionNode::SetColumnFunc(int side, int prefixlen, bool singlePane)
 {
 	if (!args || args->size() != 1)
 		throw std::invalid_argument(functionName + " function requires 1 argument");
-	if (prefixlen == 0)
+	if (prefixlen == 0 && !singlePane)
 		func = [](const FilterEvalContext& ectxt, std::vector<ExprNode*>* args) -> ValueType
 		{
 			std::shared_ptr<std::vector<ValueType2>> values = std::make_shared<std::vector<ValueType2>>();
@@ -4029,11 +4030,11 @@ void FunctionNode::SetColumnFunc(int side, int prefixlen)
 			{ return columnFunc((side < 0) ? (ectxt.expr->ctxt->GetCompareDirs() - 1) : side, ectxt, args); };
 }
 
-void FunctionNode::SetColumnAtFunc(int side, int prefixlen, ValueType (*proc)(int, const FilterEvalContext&, std::vector<ExprNode*>*))
+void FunctionNode::SetColumnAtFunc(int side, int prefixlen, bool singlePane, ValueType (*proc)(int, const FilterEvalContext&, std::vector<ExprNode*>*))
 {
 	if (!args || args->size() != 2)
 		throw std::invalid_argument(functionName + " function requires 2 arguments");
-	if (prefixlen == 0)
+	if (prefixlen == 0 && !singlePane)
 		func = [side, proc](const FilterEvalContext& ectxt, std::vector<ExprNode*>* args) -> ValueType
 		{
 			std::shared_ptr<std::vector<ValueType2>> values = std::make_shared<std::vector<ValueType2>>();
@@ -4051,36 +4052,37 @@ FunctionNode::FunctionNode(const FilterExpression* ctxt, const std::string& name
 	: ctxt(ctxt), functionName(Poco::toLower(name)), args(args)
 {
 	auto [side, prefixlen] = ParseAttributeName(functionName);
+	bool singlePane = ctxt->ctxt->GetCompareDirs() == 1;
 
 	// Special handling for prop, lineat, lineoffsetat functions
 	if (functionName.compare(prefixlen, functionName.length() - prefixlen, "prop") == 0)
 	{
-		SetPropFunc(side, prefixlen);
+		SetPropFunc(side, prefixlen, singlePane);
 		return;
 	}
 	if (functionName.compare(prefixlen, functionName.length() - prefixlen, "lineat") == 0)
 	{
-		SetLineAtFunc(side, prefixlen, lineAt);
+		SetLineAtFunc(side, prefixlen, singlePane, lineAt);
 		return;
 	}
 	if (functionName.compare(prefixlen, functionName.length() - prefixlen, "lineoffsetat") == 0)
 	{
-		SetLineAtFunc(side, prefixlen, lineOffsetAt);
+		SetLineAtFunc(side, prefixlen, singlePane, lineOffsetAt);
 		return;
 	}
 	if (functionName.compare(prefixlen, functionName.length() - prefixlen, "columnat") == 0)
 	{
-		SetColumnAtFunc(side, prefixlen, columnAt);
+		SetColumnAtFunc(side, prefixlen, singlePane, columnAt);
 		return;
 	}
 	if (functionName.compare(prefixlen, functionName.length() - prefixlen, "columnoffsetat") == 0)
 	{
-		SetColumnAtFunc(side, prefixlen, columnOffsetAt);
+		SetColumnAtFunc(side, prefixlen, singlePane, columnOffsetAt);
 		return;
 	}
 	if (functionName.compare(prefixlen, functionName.length() - prefixlen, "column") == 0)
 	{
-		SetColumnFunc(side, prefixlen);
+		SetColumnFunc(side, prefixlen, singlePane);
 		return;
 	}
 

--- a/Src/FilterEngine/FilterExpressionNodes.h
+++ b/Src/FilterEngine/FilterExpressionNodes.h
@@ -121,10 +121,10 @@ struct FunctionNode : public ExprNode
 	virtual ~FunctionNode();
 	ExprNode* Optimize() override;
 	ValueType Evaluate(const FilterEvalContext& ectxt) const override;
-	void SetPropFunc(int side, int prefixlen);
-	void SetLineAtFunc(int side, int prefixlen, ValueType(*func)(int, const FilterEvalContext&, std::vector<ExprNode*>*));
-	void SetColumnFunc(int side, int prefixlen);
-	void SetColumnAtFunc(int side, int prefixlen, ValueType(*func)(int, const FilterEvalContext&, std::vector<ExprNode*>*));
+	void SetPropFunc(int side, int prefixlen, bool singlePane);
+	void SetLineAtFunc(int side, int prefixlen, bool singlePane, ValueType(*func)(int, const FilterEvalContext&, std::vector<ExprNode*>*));
+	void SetColumnFunc(int side, int prefixlen, bool singlePane);
+	void SetColumnAtFunc(int side, int prefixlen, bool singlePane, ValueType(*func)(int, const FilterEvalContext&, std::vector<ExprNode*>*));
 	const FilterExpression* ctxt;
 	std::string functionName;
 	std::vector<ExprNode*>* args;

--- a/Src/FilterEngine/FunctionNodeProperty.cpp
+++ b/Src/FilterEngine/FunctionNodeProperty.cpp
@@ -93,7 +93,7 @@ static auto propary(const String& name, const FilterEvalContext& ectxt) -> Value
 	return values;
 }
 
-void FunctionNode::SetPropFunc(int side, int prefixlen)
+void FunctionNode::SetPropFunc(int side, int prefixlen, bool singlePane)
 {
 	if (!args || args->size() != 1)
 		throw std::invalid_argument(functionName + " function requires 1 argument");
@@ -105,7 +105,7 @@ void FunctionNode::SetPropFunc(int side, int prefixlen)
 	const int propindex = propSys.GetPropertyIndex(propName);
 	if (propindex < 0)
 		throw InvalidPropertyNameError(strLit->value);
-	if (prefixlen == 0)
+	if (prefixlen == 0 && !singlePane)
 		func = [propName](const FilterEvalContext& ectxt, std::vector<ExprNode*>*) -> ValueType
 			{ return propary(propName, ectxt); };
 	else 

--- a/Testing/GoogleTest/FilterEngine/FilterExpression_test.cpp
+++ b/Testing/GoogleTest/FilterEngine/FilterExpression_test.cpp
@@ -4346,6 +4346,70 @@ TEST_P(FilterExpressionTest, BlockFunctions)
 	EXPECT_TRUE(fe.Evaluate(ectxt3));
 }
 
+TEST_P(FilterExpressionTest, TransformLine)
+{
+	PathContext paths(L"C:\\dev\\winmerge\\src");
+	CDiffContext ctxt(paths, 0);
+	DIFFITEM di;
+	CreateSimpleDiffItem(di);
+
+	FilterExpression fe;
+	fe.SetDiffContext(&ctxt);
+	fe.optimize = GetParam().optimize;
+	fe.diritem = false;
+
+	struct Provider : public ILineDataProvider
+	{
+		std::string GetLine(int pane, int lineIndex) const override
+		{
+			char buf[256];
+			sprintf_s(buf, "%*sLine %d", lineIndex, " ", lineIndex + 1);
+			return buf;
+		}
+
+		int GetLineCount() const override
+		{
+			return 10;
+		}
+
+		int GetColumnCount(int pane, int lineIndex) const override
+		{
+			return 0;
+		}
+
+		std::string GetColumn(int pane, int lineIndex, int columnIndex) const override
+		{
+			return "";
+		}
+
+		int GetRealLineNumber(int pane, int lineIndex) const override
+		{
+			return lineIndex;
+		}
+
+		unsigned GetLineFlags(int pane, int lineIndex) const override
+		{
+			return 0;
+		}
+
+		unsigned GetLineEol(int pane, int lineIndex) const override
+		{
+			return 1;
+		}
+	} provider;
+
+	auto pFilterSharedContext = std::make_unique<FilterSharedContext>();
+	FilterEvalContext ectxt{ &fe, &di, &provider, pFilterSharedContext.get() };
+
+	ectxt.lineIndex = 0;
+	pFilterSharedContext = std::make_unique<FilterSharedContext>(); ectxt.sharedContext = pFilterSharedContext.get();
+	EXPECT_TRUE(fe.Parse("replace(Line, \" \", \"\")"));
+	EXPECT_STREQ(_T("Line1"), fe.TransformLine(ectxt).c_str());
+
+	ectxt.lineIndex = 1;
+	EXPECT_STREQ(_T("Line2"), fe.TransformLine(ectxt).c_str());
+}
+
 TEST_P(FilterExpressionTest, StrFindAndRegexFindFunctions)
 {
 	PathContext paths(L"D:\\dev\\winmerge\\src", L"D:\\dev\\winmerge\\src");


### PR DESCRIPTION
Add the FilterExpression support required by the upcoming ApplyLineFilter plugin.

* Add `TransformLine()` to evaluate an expression and return the transformed line.
* Treat unqualified fields and functions as single-pane values when `GetCompareDirs() == 1`.
* Add tests for line transformation with a single-file comparison context.

This change provides the foundation for applying FilterExpression expressions to each line of a single input file.
