### PR TITLE
Fix issue #3579: Preserve the sort order for columns that can be safely sorted while folder comparison is running.

### DIFF
--- a/Src/DirView.cpp
+++ b/Src/DirView.cpp
@@ -1332,7 +1332,7 @@ void CDirView::SortColumnsAppropriately()
 		GetDocument()->m_diffThread.GetThreadState() == CDiffThread::THREAD_COMPARING;
 
 	// Do not sort by columns whose values are updated asynchronously,
-	// as this may violate the strict weak ordering required by std::sort.
+	// as this may violate the strict weak ordering required by std::stable_sort.
 	if (comparing && !m_pColItems->IsColSortableWhileComparing(sortCol))
 		return;
 	

--- a/Src/DirView.cpp
+++ b/Src/DirView.cpp
@@ -1324,16 +1324,18 @@ void CDirView::OnColumnClick(NMHDR *pNMHDR, LRESULT *pResult)
 
 void CDirView::SortColumnsAppropriately()
 {
-	// Do not sort while comparing.
-	// Compare-result columns are updated asynchronously and may
-	// violate strict weak ordering required by std::sort.
-	if (GetDocument()->m_diffThread.GetThreadState() == CDiffThread::THREAD_COMPARING)
-		return;
-	
 	int sortCol = GetOptionsMgr()->GetInt((GetDocument()->m_nDirs < 3) ? OPT_DIRVIEW_SORT_COLUMN : OPT_DIRVIEW_SORT_COLUMN3);
 	if (sortCol < 0 || sortCol >= m_pColItems->GetColCount())
 		return;
 
+	const bool comparing =
+		GetDocument()->m_diffThread.GetThreadState() == CDiffThread::THREAD_COMPARING;
+
+	// Do not sort by columns whose values are updated asynchronously,
+	// as this may violate the strict weak ordering required by std::sort.
+	if (comparing && !m_pColItems->IsColSortableWhileComparing(sortCol))
+		return;
+	
 	bool bSortAscending = GetOptionsMgr()->GetBool(OPT_DIRVIEW_SORT_ASCENDING);
 	m_ctlSortHeader.SetSortImage(m_pColItems->ColLogToPhys(sortCol), bSortAscending);
 	//sort using static CompareFunc comparison function

--- a/Src/DirViewColItems.cpp
+++ b/Src/DirViewColItems.cpp
@@ -1823,7 +1823,10 @@ DirViewColItems::IsColStatusAbbr(int col) const
 bool
 DirViewColItems::IsColSortableWhileComparing(int col) const
 {
-	decltype(ColFileNameSort) *sortFuncs[] = { ColFileNameSort, ColPathSort, ColTimeSort, ColExtSort, ColSizeSort, ColNewerSort, ColAttrSort, ColPropertySort, ColAllPropertySort };
+	if (col < 0 || col >= m_numcols)
+		return false;
+
+	decltype(ColFileNameSort) *sortFuncs[] = { ColFileNameSort, ColPathSort, ColTimeSort, ColExtSort, ColSizeSort, ColNewerSort, ColAttrSort };
 	for (auto sortFunc : sortFuncs)
 	{
 		if (m_cols[col].sortfnc == sortFunc)

--- a/Src/DirViewColItems.cpp
+++ b/Src/DirViewColItems.cpp
@@ -1816,6 +1816,22 @@ DirViewColItems::IsColStatusAbbr(int col) const
 {
 	return IsColById(col, COLHDR_RESULT_ABBR);
 }
+/**
+ * @brief Return whether the column can be sorted while comparison results are being updated.
+ * Such columns must not depend on values that are updated asynchronously.
+ */
+bool
+DirViewColItems::IsColSortableWhileComparing(int col) const
+{
+	decltype(ColFileNameSort) *sortFuncs[] = { ColFileNameSort, ColPathSort, ColTimeSort, ColExtSort, ColSizeSort, ColNewerSort, ColAttrSort, ColPropertySort, ColAllPropertySort };
+	for (auto sortFunc : sortFuncs)
+	{
+		if (m_cols[col].sortfnc == sortFunc)
+			return true;
+	}
+	return false;
+}
+
 
 /**
  * @brief return whether column normally sorts ascending (dates do not)

--- a/Src/DirViewColItems.h
+++ b/Src/DirViewColItems.h
@@ -63,6 +63,7 @@ public:
 	bool IsColRmTime(int col) const;
 	bool IsColStatus(int col) const;
 	bool IsColStatusAbbr(int col) const;
+	bool IsColSortableWhileComparing(int col) const;
 	bool IsDefaultSortAscending(int col) const;
 	String GetColDisplayName(int col) const;
 	String GetColDescription(int col) const;


### PR DESCRIPTION
Preserve the sort order for columns that can be safely sorted while folder comparison is running.

Fix #3579