### PR TITLE
Add local LLM and custom OpenAI-compatible API support

### DIFF
--- a/Plugins/Strings.rc
+++ b/Plugins/Strings.rc
@@ -338,6 +338,10 @@ BEGIN
                             "API key changed. Restart to apply."
     IDS_PLUGIN_EDITORADDIN_STR10
                             "Provider"
+    IDS_PLUGIN_EDITORADDIN_STR11
+                            "Base URL"
+    IDS_PLUGIN_EDITORADDIN_STR12
+                            "(pick a preset to fill in the field above)"
 END
 
 #endif    // English (United States) resources

--- a/Plugins/dlls/AI.sct
+++ b/Plugins/dlls/AI.sct
@@ -395,7 +395,7 @@ function getProviderConfig(providerName) {
     "LM Studio": { "baseUrl": "http://localhost:1234/v1", "defaultModel": "local-model", "apiKeyEnvName": "LMSTUDIO_API_KEY", "requiresApiKey": false },
     "LocalAI": { "baseUrl": "http://localhost:8080/v1", "defaultModel": "gpt-oss-20b", "apiKeyEnvName": "LOCALAI_API_KEY", "requiresApiKey": false },
     "vLLM": { "baseUrl": "http://localhost:8000/v1", "defaultModel": "Qwen/Qwen3-8B-Instruct", "apiKeyEnvName": "VLLM_API_KEY", "requiresApiKey": false },
-    "Custom (OpenAI-compatible)": { "baseUrl": "http://localhost:8080/v1", "defaultModel": "default", "apiKeyEnvName": "CUSTOM_API_KEY", "requiresApiKey": false }
+    "Custom (OpenAI-compatible)": { "baseUrl": "http://localhost:8080/v1", "defaultModel": "default", "apiKeyEnvName": "CUSTOM_API_KEY", "requiresApiKey": true }
   };
   return configs[providerName] || configs["OpenAI"];
 }

--- a/Plugins/dlls/AI.sct
+++ b/Plugins/dlls/AI.sct
@@ -36,9 +36,14 @@ var mergeApp;
 
 function getProviderConfig(providerName) {
   var configs = {
-    "OpenAI": { "baseUrl": "https://api.openai.com/v1", "defaultModel": "gpt-3.5-turbo", "apiKeyEnvName": "OPENAI_API_KEY" },
-    "MiniMax": { "baseUrl": "https://api.minimax.io/v1", "defaultModel": "MiniMax-M3", "apiKeyEnvName": "MINIMAX_API_KEY" },
-    "MiniMax (China)": { "baseUrl": "https://api.minimaxi.com/v1", "defaultModel": "MiniMax-M3", "apiKeyEnvName": "MINIMAX_API_KEY" }
+    "OpenAI": { "baseUrl": "https://api.openai.com/v1", "defaultModel": "gpt-5.6", "apiKeyEnvName": "OPENAI_API_KEY", "requiresApiKey": true },
+    "MiniMax": { "baseUrl": "https://api.minimax.io/v1", "defaultModel": "MiniMax-M3", "apiKeyEnvName": "MINIMAX_API_KEY", "requiresApiKey": true },
+    "MiniMax (China)": { "baseUrl": "https://api.minimaxi.com/v1", "defaultModel": "MiniMax-M3", "apiKeyEnvName": "MINIMAX_API_KEY", "requiresApiKey": true },
+    "Ollama": { "baseUrl": "http://localhost:11434/v1", "defaultModel": "llama3.3", "apiKeyEnvName": "OLLAMA_API_KEY", "requiresApiKey": false },
+    "LM Studio": { "baseUrl": "http://localhost:1234/v1", "defaultModel": "local-model", "apiKeyEnvName": "LMSTUDIO_API_KEY", "requiresApiKey": false },
+    "LocalAI": { "baseUrl": "http://localhost:8080/v1", "defaultModel": "gpt-oss-20b", "apiKeyEnvName": "LOCALAI_API_KEY", "requiresApiKey": false },
+    "vLLM": { "baseUrl": "http://localhost:8000/v1", "defaultModel": "Qwen/Qwen3-8B-Instruct", "apiKeyEnvName": "VLLM_API_KEY", "requiresApiKey": false },
+    "Custom (OpenAI-compatible)": { "baseUrl": "http://localhost:8080/v1", "defaultModel": "default", "apiKeyEnvName": "CUSTOM_API_KEY", "requiresApiKey": true }
   };
   return configs[providerName] || configs["OpenAI"];
 }
@@ -158,17 +163,23 @@ function setEnvVal(name, value) {
 }
 
 function getApiKey() {
-  var keyEnvName = regRead(REGKEY_PATH + "OpenAI.ApiKeyEnvName", "OPENAI_API_KEY");
+  var providerName = regRead(REGKEY_PATH + "OpenAI.Provider", "OpenAI");
+  var provider = getProviderConfig(providerName);
+  var keyEnvName = regRead(REGKEY_PATH + "OpenAI.ApiKeyEnvName", provider.apiKeyEnvName || "OPENAI_API_KEY");
   var apiKey = wsh.ExpandEnvironmentStrings("%" + keyEnvName + "%");
   if (apiKey === "" || apiKey === "%" + keyEnvName + "%") {
     try { apiKey = wsh.RegRead("HKEY_CURRENT_USER\\Environment\\" + keyEnvName); } catch (e) { apiKey = ""; }
-    if (apiKey === "") {
+    if (apiKey === "" && provider.requiresApiKey !== false) {
       var msg = mergeApp.Translate("Enter API key.\r\n- Registration with the selected provider may be required (fees may apply).\r\n- Key stored in env var %1.");
       msg = msg.replace("%1", keyEnvName);
       apiKey = mergeApp.InputBox(msg, "AIConvertText plugin", "");
       if (apiKey !== "")
         setEnvVal(keyEnvName, apiKey);
     }
+  }
+  // Local providers don't need an API key; use a dummy value.
+  if (apiKey === "" || apiKey === "%" + keyEnvName + "%") {
+    apiKey = "local";
   }
   return apiKey;
 }
@@ -211,11 +222,15 @@ function AIConvertText(Text) {
     throw new Error(30001, "Canceled");
   var providerName = regRead(REGKEY_PATH + "OpenAI.Provider", "OpenAI");
   var provider = getProviderConfig(providerName);
-  var apiUrl = provider.baseUrl + "/chat/completions";
+  var baseUrl = regRead(REGKEY_PATH + "OpenAI.BaseUrl", provider.baseUrl);
+  var apiUrl = baseUrl.replace(/\/$/, "") + "/chat/completions";
   var temperature = regRead(REGKEY_PATH + "OpenAI.Temperature", "1.00");
   var maxTokens = regRead(REGKEY_PATH + "OpenAI.MaxTokens", 4096);
   var model = regRead(REGKEY_PATH + "OpenAI.Model", provider.defaultModel);
   var body = '{"model": "' + model + '", "temperature": ' + Number(temperature) + ', "messages": [{"role": "system", "content": "' + quote(cmd) + '"}, {"role": "user", "content": "' + quote(Text) + '"}]}';
+  if (maxTokens > 0) {
+    body = body.replace(/\}$/, ', "max_tokens": ' + Number(maxTokens) + '}');
+  }
   var xh = new ActiveXObject("Msxml2.ServerXMLHTTP");
   xh.open("POST", apiUrl, false);
   xh.setRequestHeader("Content-Type", "application/json");
@@ -258,8 +273,9 @@ function exportSettingsToXMLFile(filepath) {
   var providerName = regRead(REGKEY_PATH + "OpenAI.Provider", "OpenAI");
   var provider = getProviderConfig(providerName);
   var key_defvalues = {
-    "OpenAI.ApiKeyEnvName": "OPENAI_API_KEY",
+    "OpenAI.ApiKeyEnvName": provider.apiKeyEnvName || "OPENAI_API_KEY",
     "OpenAI.Provider": "OpenAI",
+    "OpenAI.BaseUrl": provider.baseUrl,
     "OpenAI.Temperature": "1.00",
     "OpenAI.MaxTokens": 4096,
     "OpenAI.Model": provider.defaultModel
@@ -370,6 +386,20 @@ function saveSettingsToXMLFile(filepath, settings) {
   ts.Close();
 }
 
+function getProviderConfig(providerName) {
+  var configs = {
+    "OpenAI": { "baseUrl": "https://api.openai.com/v1", "defaultModel": "gpt-5.6", "apiKeyEnvName": "OPENAI_API_KEY", "requiresApiKey": true },
+    "MiniMax": { "baseUrl": "https://api.minimax.io/v1", "defaultModel": "MiniMax-M3", "apiKeyEnvName": "MINIMAX_API_KEY", "requiresApiKey": true },
+    "MiniMax (China)": { "baseUrl": "https://api.minimaxi.com/v1", "defaultModel": "MiniMax-M3", "apiKeyEnvName": "MINIMAX_API_KEY", "requiresApiKey": true },
+    "Ollama": { "baseUrl": "http://localhost:11434/v1", "defaultModel": "llama3.3", "apiKeyEnvName": "OLLAMA_API_KEY", "requiresApiKey": false },
+    "LM Studio": { "baseUrl": "http://localhost:1234/v1", "defaultModel": "local-model", "apiKeyEnvName": "LMSTUDIO_API_KEY", "requiresApiKey": false },
+    "LocalAI": { "baseUrl": "http://localhost:8080/v1", "defaultModel": "gpt-oss-20b", "apiKeyEnvName": "LOCALAI_API_KEY", "requiresApiKey": false },
+    "vLLM": { "baseUrl": "http://localhost:8000/v1", "defaultModel": "Qwen/Qwen3-8B-Instruct", "apiKeyEnvName": "VLLM_API_KEY", "requiresApiKey": false },
+    "Custom (OpenAI-compatible)": { "baseUrl": "http://localhost:8080/v1", "defaultModel": "default", "apiKeyEnvName": "CUSTOM_API_KEY", "requiresApiKey": false }
+  };
+  return configs[providerName] || configs["OpenAI"];
+}
+
 function getApiKey(keyEnvName) {
   var apiKey = wsh.ExpandEnvironmentStrings("%" + keyEnvName + "%");
   if (apiKey === "" || apiKey === "%" + keyEnvName + "%") {
@@ -382,40 +412,111 @@ function getApiKey(keyEnvName) {
   return apiKey;
 }
 
+// Common model names per provider, used only to populate the "pick a
+// preset" dropdown next to the free-text model field.
+function getModelPresets(providerName) {
+  var presets = {
+    "OpenAI": ["gpt-5.6", "gpt-5.6-terra", "gpt-5.6-luna", "gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano", "gpt-5.1-chat-latest", "gpt-4.1", "gpt-4.1-mini", "gpt-4.1-nano", "gpt-4o", "gpt-4o-mini", "gpt-3.5-turbo"],
+    "MiniMax": ["MiniMax-M3", "MiniMax-M2.7", "MiniMax-M2.7-highspeed"],
+    "MiniMax (China)": ["MiniMax-M3", "MiniMax-M2.7", "MiniMax-M2.7-highspeed"],
+    "Ollama": ["llama3.3", "llama3.2", "qwen3", "qwen3-coder", "qwen2.5", "gemma4", "gemma3", "deepseek-r1", "deepseek-v3.1", "phi4", "phi4-mini", "mistral", "gpt-oss:20b"],
+    "LM Studio": ["local-model", "llama3.3", "qwen3", "gemma4", "phi4", "mistral", "gpt-oss-20b"],
+    "LocalAI": ["gpt-oss-20b", "llama3.3", "qwen3", "gemma4", "phi4", "mistral"],
+    "vLLM": ["Qwen/Qwen3-8B-Instruct", "meta-llama/Llama-3.3-70B-Instruct", "mistralai/Mistral-7B-Instruct-v0.3", "microsoft/Phi-4", "google/gemma-4-9b-it"],
+    "Custom (OpenAI-compatible)": ["default", "local-model"]
+  };
+  return presets[providerName] || presets["OpenAI"];
+}
+
+// Rebuilds the preset dropdown for the given provider so it only lists
+// models that actually make sense for that provider.
+function populateModelPresets(providerName) {
+  while (cboModelPreset.options.length > 0) {
+    cboModelPreset.remove(0);
+  }
+  var placeholder = document.createElement("option");
+  placeholder.value = "";
+  placeholder.text = "${(pick a preset to fill in the field above)}";
+  cboModelPreset.add(placeholder);
+
+  var models = getModelPresets(providerName);
+  for (var i = 0; i < models.length; i++) {
+    var opt = document.createElement("option");
+    opt.value = models[i];
+    opt.text = models[i];
+    cboModelPreset.add(opt);
+  }
+  cboModelPreset.value = "";
+}
+
+// Shows/hides and enables/disables the API key controls depending on
+// whether the currently selected provider actually needs a key.
+function updateApiKeyVisibility(provider) {
+  var needsKey = provider.requiresApiKey !== false;
+  liApiKeyEnvNameLabel.style.display = needsKey ? "" : "none";
+  liApiKeyEnvName.style.display = needsKey ? "" : "none";
+  liApiKeyLabel.style.display = needsKey ? "" : "none";
+  liApiKey.style.display = needsKey ? "" : "none";
+  txtApiKeyEnvName.disabled = !needsKey;
+  txtApiKey.disabled = !needsKey;
+}
+
 function onload() {
   xmlFilePath = objHTA.commandLine.split('"')[3];
   settings = loadSettingsFromXMLFile(xmlFilePath);
 
   var dpi = window.screen.deviceXDPI;
-  var w = 600 * dpi / 96, h = 500 * dpi / 96;
+  var w = 650 * dpi / 96, h = 550 * dpi / 96;
   window.resizeTo(w, h);
   window.moveTo((screen.width - w) / 2, (screen.height - h) / 2);
 
-  var provider = regRead(REGKEY_PATH + "OpenAI.Provider", "OpenAI");
-  cboProvider.value = provider;
+  var providerName = regRead(REGKEY_PATH + "OpenAI.Provider", "OpenAI");
+  cboProvider.value = providerName;
   if (cboProvider.selectedIndex < 0) {
     cboProvider.value = "OpenAI";
+    providerName = "OpenAI";
   }
+  var provider = getProviderConfig(providerName);
   var providerOption = cboProvider.options[cboProvider.selectedIndex];
-  var defaultModel = providerOption.getAttribute("defaultmodel");
-  var keyEnvName = regRead(REGKEY_PATH + "OpenAI.ApiKeyEnvName", "OPENAI_API_KEY");
+  var defaultModel = providerOption.getAttribute("defaultmodel") || provider.defaultModel;
+  var keyEnvName = regRead(REGKEY_PATH + "OpenAI.ApiKeyEnvName", provider.apiKeyEnvName);
   apiKey = getApiKey(keyEnvName);
 
   txtApiKeyEnvName.value = keyEnvName;
   txtApiKey.value = apiKey;
+  txtBaseUrl.value = regRead(REGKEY_PATH + "OpenAI.BaseUrl", provider.baseUrl);
   txtTemperature.value = regRead(REGKEY_PATH + "OpenAI.Temperature", "1.00");
   txtMaxTokens.value = regRead(REGKEY_PATH + "OpenAI.MaxTokens", 4096);
-  cboModel.value = regRead(REGKEY_PATH + "OpenAI.Model", defaultModel);
+  // Model is a free-text field; the preset dropdown next to it is just a
+  // per-provider shortcut list and is rebuilt for whichever provider is selected.
+  txtModel.value = regRead(REGKEY_PATH + "OpenAI.Model", defaultModel);
+  populateModelPresets(providerName);
+
+  updateApiKeyVisibility(provider);
+
   document.onkeydown = onkeydown;
 }
 
 function cboProvider_onchange() {
+  var providerName = cboProvider.value;
+  var provider = getProviderConfig(providerName);
   var providerOption = cboProvider.options[cboProvider.selectedIndex];
-  var provider = getProviderConfig(cboProvider.value);
-  cboModel.value = providerOption.getAttribute("defaultmodel");
+  txtModel.value = providerOption.getAttribute("defaultmodel") || provider.defaultModel;
+  populateModelPresets(providerName);
   txtApiKeyEnvName.value = provider.apiKeyEnvName;
   apiKey = getApiKey(provider.apiKeyEnvName);
   txtApiKey.value = apiKey;
+  txtBaseUrl.value = provider.baseUrl;
+  updateApiKeyVisibility(provider);
+}
+
+// Picking a preset from the dropdown just fills in the free-text model field;
+// the field itself is what actually gets saved, so any model name can be typed.
+function cboModelPreset_onchange() {
+  if (cboModelPreset.value !== "") {
+    txtModel.value = cboModelPreset.value;
+  }
+  cboModelPreset.value = "";
 }
 
 function onkeydown() {
@@ -428,6 +529,10 @@ function onkeydown() {
 }
 
 function btnOk_onclick() {
+  var providerName = cboProvider.value;
+  var provider = getProviderConfig(providerName);
+  var needsKey = provider.requiresApiKey !== false;
+
   var temperature = Number(txtTemperature.value);
   var maxTokens = Number(txtMaxTokens.value);
   if (isNaN(temperature)) {
@@ -439,24 +544,25 @@ function btnOk_onclick() {
   if (temperature > 2.0) {
     temperature = 2.0;
   }
-  if (isNaN(maxTokens)) {
+  if (isNaN(maxTokens) || maxTokens < 0) {
     maxTokens = 4096;
   }
-  if (cboModel.value === "gpt-3.5-turbo-16k") {
-    if (maxTokens < 0 || maxTokens > 16384) {
-      maxTokens = 16384;
-    }
-  } else {
-    if (maxTokens < 0 || maxTokens > 4096) {
-      maxTokens = 4096;
-    }
+  // Local / modern models often support larger contexts; allow up to 128k
+  if (maxTokens > 131072) {
+    maxTokens = 131072;
   }
+  var modelValue = txtModel.value.replace(/^\s+|\s+$/g, "");
+  if (modelValue === "") {
+    modelValue = provider.defaultModel;
+  }
+
   regWrite(REGKEY_PATH + "OpenAI.ApiKeyEnvName", txtApiKeyEnvName.value, "REG_SZ");
-  regWrite(REGKEY_PATH + "OpenAI.Provider", cboProvider.value, "REG_SZ");
+  regWrite(REGKEY_PATH + "OpenAI.Provider", providerName, "REG_SZ");
+  regWrite(REGKEY_PATH + "OpenAI.BaseUrl", txtBaseUrl.value.replace(/\/$/, ""), "REG_SZ");
   regWrite(REGKEY_PATH + "OpenAI.Temperature", temperature, "REG_SZ");
   regWrite(REGKEY_PATH + "OpenAI.MaxTokens", maxTokens, "REG_DWORD");
-  regWrite(REGKEY_PATH + "OpenAI.Model", cboModel.value, "REG_SZ");
-  if (txtApiKey.value !== apiKey) {
+  regWrite(REGKEY_PATH + "OpenAI.Model", modelValue, "REG_SZ");
+  if (needsKey && txtApiKey.value !== apiKey && txtApiKey.value !== "") {
     setEnvVal(txtApiKeyEnvName.value, txtApiKey.value);
     alert("${API key changed. Restart to apply.}");
   }
@@ -482,21 +588,32 @@ function btnCancel_onclick() {
         </li>
         <li>
           <select id="cboProvider" onchange="cboProvider_onchange();">
-            <option value="OpenAI" defaultmodel="gpt-3.5-turbo">OpenAI</option>
+            <option value="OpenAI" defaultmodel="gpt-5.6">OpenAI</option>
             <option value="MiniMax" defaultmodel="MiniMax-M3">MiniMax</option>
             <option value="MiniMax (China)" defaultmodel="MiniMax-M3">MiniMax (China)</option>
+            <option value="Ollama" defaultmodel="llama3.3">Ollama (local)</option>
+            <option value="LM Studio" defaultmodel="local-model">LM Studio (local)</option>
+            <option value="LocalAI" defaultmodel="gpt-oss-20b">LocalAI (local)</option>
+            <option value="vLLM" defaultmodel="Qwen/Qwen3-8B-Instruct">vLLM (local)</option>
+            <option value="Custom (OpenAI-compatible)" defaultmodel="default">Custom (OpenAI-compatible)</option>
           </select>
         </li>
         <li>
+          <label for="txtBaseUrl">${Base URL}:</label>
+        </li>
+        <li>
+          <input id="txtBaseUrl" type="text" style="width: 100%;" />
+        </li>
+        <li id="liApiKeyEnvNameLabel">
           <label for="txtApiKeyEnvName">${Environment variable name for API key}:</label>
         </li>
-        <li>
+        <li id="liApiKeyEnvName">
           <input id="txtApiKeyEnvName" type="text" />
         </li>
-        <li>
+        <li id="liApiKeyLabel">
           <label for="txtApiKey">${API key}:</label>
         </li>
-        <li>
+        <li id="liApiKey">
           <input id="txtApiKey" type="password" />
         </li>
         <li>
@@ -507,27 +624,19 @@ function btnCancel_onclick() {
         </li>
         <li>
           <label for="txtMaxTokens">${Maximum length}:</label>
+        </li>
         <li>
           <input id="txtMaxTokens" type="text" />
         </li>
         <li>
-          <label for="cboModel">${Model}:</label>
+          <label for="txtModel">${Model}:</label>
         </li>
         <li>
-          <select id="cboModel">
-            <option value="MiniMax-M3">MiniMax-M3</option>
-            <option value="gpt-5-mini">gpt-5-mini</option>
-            <option value="gpt-5-nano">gpt-5-nano</option>
-            <option value="gpt-5">gpt-5</option>
-            <option value="gpt-4.1-mini">gpt-4.1-mini</option>
-            <option value="gpt-4.1-nano">gpt-4.1-nano</option>
-            <option value="gpt-4.1">gpt-4.1</option>
-            <option value="gpt-4o-mini">gpt-4o-mini</option>
-            <option value="gpt-4o">gpt-4o</option>
-            <option value="gpt-4-turbo">gpt-4-turbo</option>
-            <option value="gpt-4">gpt-4</option>
-            <option value="gpt-3.5-turbo">gpt-3.5-turbo</option>
-            <option value="gpt-3.5-turbo-16k">gpt-3.5-turbo-16k</option>
+          <input id="txtModel" type="text" style="width: 100%;" />
+        </li>
+        <li>
+          <select id="cboModelPreset" onchange="cboModelPreset_onchange();">
+            <!-- populated dynamically by populateModelPresets() based on the selected provider -->
           </select>
         </li>
       </ul>

--- a/Plugins/dlls/AI.sct
+++ b/Plugins/dlls/AI.sct
@@ -177,9 +177,13 @@ function getApiKey() {
         setEnvVal(keyEnvName, apiKey);
     }
   }
-  // Local providers don't need an API key; use a dummy value.
   if (apiKey === "" || apiKey === "%" + keyEnvName + "%") {
-    apiKey = "local";
+    if (provider.requiresApiKey === false) {
+      // Local providers don't need an API key; use a dummy value.
+      apiKey = "local";
+    } else {
+      throw new Error(30001, "Canceled");
+    }
   }
   return apiKey;
 }


### PR DESCRIPTION
Add support for local LLMs and custom OpenAI-compatible APIs to the AIConvertText plugin.

- Add support for Ollama, LM Studio, LocalAI, and vLLM
- Add configurable Base URL
- Allow arbitrary model names
- Add model presets for each provider
- Hide API key settings for providers that do not require them
- Allow larger maximum output token values