### PR TITLE
Remember the image compare splitter position

### DIFF
--- a/Src/ImgMergeFrm.cpp
+++ b/Src/ImgMergeFrm.cpp
@@ -651,6 +651,8 @@ void CImgMergeFrame::LoadOptions()
 	RefreshOptions();
 
 	m_pImgMergeWindow->SetHorizontalSplit(GetOptionsMgr()->GetBool(OPT_SPLIT_HORIZONTALLY));
+	// After SetHorizontalSplit(): changing the orientation discards the position.
+	m_pImgMergeWindow->SetSplitterPosition(GetOptionsMgr()->GetInt(OPT_CMP_IMG_SPLITTER_POS));
 	m_pImgMergeWindow->SetShowDifferences(GetOptionsMgr()->GetBool(OPT_CMP_IMG_SHOWDIFFERENCES));
 	m_pImgMergeWindow->SetBlinkDifferences(GetOptionsMgr()->GetBool(OPT_CMP_IMG_BLINKDIFFERENCES));
 	m_pImgMergeWindow->SetOverlayMode(static_cast<IImgMergeWindow::OVERLAY_MODE>(GetOptionsMgr()->GetInt(OPT_CMP_IMG_OVERLAYMODE)));
@@ -673,6 +675,7 @@ void CImgMergeFrame::LoadOptions()
 
 void CImgMergeFrame::SaveOptions()
 {
+	GetOptionsMgr()->SaveOption(OPT_CMP_IMG_SPLITTER_POS, m_pImgMergeWindow->GetSplitterPosition());
 	GetOptionsMgr()->SaveOption(OPT_CMP_IMG_SHOWDIFFERENCES, m_pImgMergeWindow->GetShowDifferences());
 	GetOptionsMgr()->SaveOption(OPT_CMP_IMG_BLINKDIFFERENCES, m_pImgMergeWindow->GetBlinkDifferences());
 	GetOptionsMgr()->SaveOption(OPT_CMP_IMG_OVERLAYMODE, m_pImgMergeWindow->GetOverlayMode());

--- a/Src/OptionsDef.h
+++ b/Src/OptionsDef.h
@@ -274,6 +274,7 @@ inline const String OPT_CMP_IMG_OVERLAYANIMATIONINTERVAL {_T("Settings/ImageOver
 inline const String OPT_CMP_ENABLE_IMGCMP_IN_DIRCMP {_T("Settings/EnableImageCompareInFolderCompare"s)};
 inline const String OPT_CMP_IMG_OCR_RESULT_TYPE {_T("Settings/ImageOcrResultType"s)};
 inline const String OPT_CMP_IMG_PREFER_WIC_DECODER {_T("Settings/ImagePreferWICDecoder"s)};
+inline const String OPT_CMP_IMG_SPLITTER_POS {_T("Settings/ImageSplitterPosition"s)};
 
 // WebPage Compare options
 inline const String OPT_CMP_WEB_USERDATAFOLDER_TYPE {_T("Settings/WebPageUserDataFolderType"s)};

--- a/Src/OptionsInit.cpp
+++ b/Src/OptionsInit.cpp
@@ -192,6 +192,7 @@ void Init(COptionsMgr *pOptions)
 	pOptions->InitOption(OPT_CMP_IMG_OVERLAYANIMATIONINTERVAL, 1000, 200, 8000);
 	pOptions->InitOption(OPT_CMP_IMG_OCR_RESULT_TYPE, 0, 0, 2);
 	pOptions->InitOption(OPT_CMP_IMG_PREFER_WIC_DECODER, false);
+	pOptions->InitOption(OPT_CMP_IMG_SPLITTER_POS, 0, -65535, 65535);
 
 	pOptions->InitOption(OPT_CMP_WEB_USERDATAFOLDER_TYPE, 0, 0, 1);
 	pOptions->InitOption(OPT_CMP_WEB_USERDATAFOLDER_PERPANE, true);

--- a/Src/WinIMergeLib.h
+++ b/Src/WinIMergeLib.h
@@ -192,6 +192,8 @@ struct IImgMergeWindow
 	virtual int GetLastErrorCode() const = 0;
 	virtual bool GetPreferWICDecoder() const = 0;
 	virtual void SetPreferWICDecoder(bool preferWICDecoder) = 0;
+	virtual int  GetSplitterPosition() const = 0;
+	virtual void SetSplitterPosition(int position) = 0;
 };
 
 struct IImgToolWindow


### PR DESCRIPTION
Refs #3591. winmerge/winimerge#39 is merged; `Externals/winimerge` on master still points at 57ef929, so it needs a bump before this builds. No submodule change is included here.

Loads the splitter position in `CImgMergeFrame::LoadOptions()` and writes it back in `SaveOptions()`.

`Settings/ImageSplitterPosition` holds the smaller pane's size in pixels, signed to indicate which pane, so the range allows negative values.

`Src/WinIMergeLib.h` is the copy of the interface that `Src/ImgMergeFrm.h` includes, so the accessors are declared there as well as in `Externals/winimerge`.

Scoped to image compare, with no menu item. If it is more useful as a starting point for the wider Window > Keep Splitter Position design than as a merge, please treat it that way.