### PR TITLE
Update German.po

### DIFF
--- a/Translations/WinMerge/German.po
+++ b/Translations/WinMerge/German.po
@@ -14,7 +14,7 @@ msgstr ""
 "Project-Id-Version: WinMerge\n"
 "Report-Msgid-Bugs-To: https://github.com/WinMerge/winmerge/issues/\n"
 "POT-Creation-Date: \n"
-"PO-Revision-Date: 2026-09-01 18:15+0200\n"
+"PO-Revision-Date: 2026-09-06 14:06+0200\n"
 "Last-Translator: René Nicolaus <translation at havoc.de>\n"
 "Language-Team: German <winmerge-translate@lists.sourceforge.net>\n"
 "Language: de\n"
@@ -1744,7 +1744,7 @@ msgstr "&Teilen"
 #. IDR_MERGEDOCTYPE, ID_WINDOW_PRESERVE_SPLITTER_RATIOS
 #: Merge.rc:934
 msgid "P&reserve Splitter Position"
-msgstr ""
+msgstr "T&rennlinienposition beibehalten"
 
 #. IDR_POPUP_DIRVIEW, ID_MERGE_COMPARE
 #: Merge.rc:953


### PR DESCRIPTION
Updates the German translation for the string introduced in https://github.com/WinMerge/winmerge/commit/03067e934aa73c34fdc90e7547f1870212345070 ("Add an option to remember and restore splitter positions for text, image, web page, and binary comparisons. (https://github.com/WinMerge/winmerge/pull/3611)")