### PR TITLE
Set localization parameters for French, Italian, and Spanish manuals

### DIFF
--- a/Docs/Manual/French/xsl/html.xsl
+++ b/Docs/Manual/French/xsl/html.xsl
@@ -11,6 +11,13 @@
 <xsl:import href="../../Shared/xsl/html.xsl"/>
 
 <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  
+html/param.xsl  parameters
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->  
+<xsl:param name="chunker.output.encoding" select="'iso-8859-1'"/>
+<xsl:param name="l10n.gentext.language" select="'fr'"/>
+<xsl:param name="l10n.gentext.default.language" select="'fr'"/>
+
+<!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  
 Custom parameters
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->  
 <!-- Define suffix to appear after title text in head/title element of 

--- a/Docs/Manual/French/xsl/htmlhelp.xsl
+++ b/Docs/Manual/French/xsl/htmlhelp.xsl
@@ -13,6 +13,10 @@
 <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  
 html/param.xsl  parameters
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->  
-<xsl:param name="htmlhelp.title">WinMerge Help</xsl:param>
+<xsl:param name="chunker.output.encoding" select="'iso-8859-1'"/>
+<xsl:param name="l10n.gentext.language" select="'fr'"/>
+<xsl:param name="l10n.gentext.default.language" select="'fr'"/>
+<xsl:param name="htmlhelp.encoding" select="'iso-8859-1'"/>
+<xsl:param name="htmlhelp.title">Aide de WinMerge</xsl:param>
 
 </xsl:stylesheet>

--- a/Docs/Manual/Italian/xsl/html.xsl
+++ b/Docs/Manual/Italian/xsl/html.xsl
@@ -11,6 +11,13 @@
 <xsl:import href="../../Shared/xsl/html.xsl"/>
 
 <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  
+html/param.xsl  parameters
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->  
+<xsl:param name="chunker.output.encoding" select="'iso-8859-1'"/>
+<xsl:param name="l10n.gentext.language" select="'it'"/>
+<xsl:param name="l10n.gentext.default.language" select="'it'"/>
+
+<!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  
 Custom parameters
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->  
 <!-- Define suffix to appear after title text in head/title element of 

--- a/Docs/Manual/Italian/xsl/htmlhelp.xsl
+++ b/Docs/Manual/Italian/xsl/htmlhelp.xsl
@@ -13,6 +13,10 @@
 <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  
 html/param.xsl  parameters
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->  
-<xsl:param name="htmlhelp.title">WinMerge Help</xsl:param>
+<xsl:param name="chunker.output.encoding" select="'iso-8859-1'"/>
+<xsl:param name="l10n.gentext.language" select="'it'"/>
+<xsl:param name="l10n.gentext.default.language" select="'it'"/>
+<xsl:param name="htmlhelp.encoding" select="'iso-8859-1'"/>
+<xsl:param name="htmlhelp.title">Guida di WinMerge</xsl:param>
 
 </xsl:stylesheet>

--- a/Docs/Manual/Spanish/xsl/html.xsl
+++ b/Docs/Manual/Spanish/xsl/html.xsl
@@ -11,6 +11,13 @@
 <xsl:import href="../../Shared/xsl/html.xsl"/>
 
 <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  
+html/param.xsl  parameters
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->  
+<xsl:param name="chunker.output.encoding" select="'iso-8859-1'"/>
+<xsl:param name="l10n.gentext.language" select="'es'"/>
+<xsl:param name="l10n.gentext.default.language" select="'es'"/>
+
+<!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  
 Custom parameters
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->  
 <!-- Define suffix to appear after title text in head/title element of 

--- a/Docs/Manual/Spanish/xsl/htmlhelp.xsl
+++ b/Docs/Manual/Spanish/xsl/htmlhelp.xsl
@@ -13,6 +13,10 @@
 <!-- ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  
 html/param.xsl  parameters
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ -->  
-<xsl:param name="htmlhelp.title">WinMerge Help</xsl:param>
+<xsl:param name="chunker.output.encoding" select="'iso-8859-1'"/>
+<xsl:param name="l10n.gentext.language" select="'es'"/>
+<xsl:param name="l10n.gentext.default.language" select="'es'"/>
+<xsl:param name="htmlhelp.encoding" select="'iso-8859-1'"/>
+<xsl:param name="htmlhelp.title">Ayuda de WinMerge</xsl:param>
 
 </xsl:stylesheet>


### PR DESCRIPTION
Set the appropriate localization and encoding parameters for the French, Italian, and Spanish manuals.

Also translate the HTML Help title for each language.
