### PR TITLE
Update Brazilian.po

### DIFF
--- a/Translations/WinMerge/Brazilian.po
+++ b/Translations/WinMerge/Brazilian.po
@@ -2,7 +2,7 @@
 # Released under the "GNU General Public License"
 #
 # Translators:
-# * Wender Firmino <wender at pta.com.br>
+# * Wender Firmino <wender at pta.com.br>, 
 # * Leonardo Peixoto <ljpeixoto at gmail.com>
 # * Felipe Periard Lopes <felipefplzx at gmail.com>
 # * Marcello Oliveira <marcello.mco at gmail.com>
@@ -13,7 +13,7 @@ msgstr ""
 "Project-Id-Version: WinMerge\n"
 "Report-Msgid-Bugs-To: https://github.com/WinMerge/winmerge/issues/\n"
 "POT-Creation-Date: 2023-03-13 09:30-0300\n"
-"PO-Revision-Date: 2026-09-01 22:40-0300\n"
+"PO-Revision-Date: 2026-09-06 19:50-0300\n"
 "Last-Translator: Marcello <marcello.mco@gmail.com>\n"
 "Language-Team: Felipe\n"
 "Language: pt_BR\n"
@@ -1561,7 +1561,7 @@ msgstr "Di&vidir"
 #. IDR_MERGEDOCTYPE, ID_WINDOW_PRESERVE_SPLITTER_RATIOS
 #: Merge.rc:934
 msgid "P&reserve Splitter Position"
-msgstr ""
+msgstr "P&reservar Posição do Separador"
 
 #. IDR_POPUP_DIRVIEW, ID_MERGE_COMPARE
 #: Merge.rc:953


### PR DESCRIPTION
Added translation for "Add an option to remember and restore splitter positions for text, image, web page, and binary comparisons. (#3611)".

### Summary
Briefly describe what this PR changes.

(Optional) Fixes #<issue-number>
