### PR TITLE
Fix cursor movement and scrolling across gaps created by the display …

### DIFF
--- a/Externals/crystaledit/editlib/ccrystaltextview.cpp
+++ b/Externals/crystaledit/editlib/ccrystaltextview.cpp
@@ -3642,7 +3642,7 @@ OnPrint (CDC * pdc, CPrintInfo * pInfo)
 // CCrystalTextView message handlers
 
 int CCrystalTextView::
-GetLineCount ()
+GetLineCount () const
 {
   if (m_pTextBuffer == nullptr)
     return 1;                   //  Single empty line

--- a/Externals/crystaledit/editlib/ccrystaltextview.h
+++ b/Externals/crystaledit/editlib/ccrystaltextview.h
@@ -201,7 +201,7 @@ public :
     };
 
     virtual void ResetView ();
-    virtual int GetLineCount ();
+    virtual int GetLineCount () const;
     virtual void OnUpdateCaret ();
     bool IsTextBufferInitialized () const;
     CString GetTextBufferEol (int nLine) const;
@@ -264,6 +264,9 @@ protected :
     virtual void PrintFooter (CDC * pdc, int nPageNum);
     virtual void GetPrintHeaderText (int nPageNum, CString & text);
     virtual void GetPrintFooterText (int nPageNum, CString & text);
+
+    int GetPreviousVisibleLine(int y) const;
+    int GetNextVisibleLine(int y) const;
 
     //  Keyboard handlers
     void MoveLeft (bool bSelect);

--- a/Externals/crystaledit/editlib/ccrystaltextview.h
+++ b/Externals/crystaledit/editlib/ccrystaltextview.h
@@ -265,8 +265,8 @@ protected :
     virtual void GetPrintHeaderText (int nPageNum, CString & text);
     virtual void GetPrintFooterText (int nPageNum, CString & text);
 
-    int GetPreviousVisibleLine(int y) const;
-    int GetNextVisibleLine(int y) const;
+    int GetPreviousVisibleLine (int y) const;
+    int GetNextVisibleLine (int y) const;
 
     //  Keyboard handlers
     void MoveLeft (bool bSelect);

--- a/Externals/crystaledit/editlib/ccrystaltextview2.cpp
+++ b/Externals/crystaledit/editlib/ccrystaltextview2.cpp
@@ -71,8 +71,12 @@ static const UINT_PTR CRYSTAL_RECALC_HSCROLLBAR = 1003;
 int CCrystalTextView::
 GetPreviousVisibleLine (int y) const
 {
-  if (y < 0)
+  const int nLineCount = GetLineCount ();
+  if (y <= 0)
     return -1;
+  if (y > nLineCount)
+    y = nLineCount;
+
   do { --y; } while (y > 0 && !GetLineVisible (y));
   return GetLineVisible (y) ? y : -1;
 }
@@ -83,6 +87,9 @@ GetNextVisibleLine (int y) const
   const int nLineCount = GetLineCount ();
   if (y >= nLineCount - 1)
     return -1;
+  if (y < -1)
+    y = -1;
+
   do { ++y; } while (y < nLineCount - 1 && !GetLineVisible (y));
   return GetLineVisible (y) ? y : -1;
 }

--- a/Externals/crystaledit/editlib/ccrystaltextview2.cpp
+++ b/Externals/crystaledit/editlib/ccrystaltextview2.cpp
@@ -68,6 +68,25 @@ static const UINT_PTR CRYSTAL_RECALC_HSCROLLBAR = 1003;
 /////////////////////////////////////////////////////////////////////////////
 // CCrystalTextView
 
+int CCrystalTextView::
+GetPreviousVisibleLine (int y) const
+{
+  if (y < 0)
+    return -1;
+  do { --y; } while (y > 0 && !GetLineVisible (y));
+  return GetLineVisible (y) ? y : -1;
+}
+
+int CCrystalTextView::
+GetNextVisibleLine (int y) const
+{
+  const int nLineCount = GetLineCount ();
+  if (y >= nLineCount - 1)
+    return -1;
+  do { ++y; } while (y < nLineCount - 1 && !GetLineVisible (y));
+  return GetLineVisible (y) ? y : -1;
+}
+
 void CCrystalTextView::
 MoveLeft (bool bSelect)
 {
@@ -80,9 +99,10 @@ MoveLeft (bool bSelect)
     {
       if (m_ptCursorPos.x == 0)
         {
-          if (m_ptCursorPos.y > 0)
+          const int y = GetPreviousVisibleLine (m_ptCursorPos.y);
+          if (y >= 0)
             {
-              m_ptCursorPos.y--;
+              m_ptCursorPos.y = y;
               m_ptCursorPos.x = GetLineLength (m_ptCursorPos.y);
             }
         }
@@ -113,9 +133,10 @@ MoveRight (bool bSelect)
     {
       if (m_ptCursorPos.x == nLineLength)
         {
-          if (m_ptCursorPos.y < GetLineCount () - 1)
+          const int y = GetNextVisibleLine (m_ptCursorPos.y);
+          if (y >= 0)
             {
-              m_ptCursorPos.y++;
+              m_ptCursorPos.y = y;
               m_ptCursorPos.x = 0;
             }
         }
@@ -418,8 +439,11 @@ MovePgDn (bool bSelect)
 void CCrystalTextView::
 MoveCtrlHome (bool bSelect)
 {
+  int y = !GetLineVisible (0) ? GetNextVisibleLine (0) : 0;
+  if (y < 0)
+    return;
   m_ptCursorPos.x = 0;
-  m_ptCursorPos.y = 0;
+  m_ptCursorPos.y = y;
   m_nIdealCharPos = CalculateActualOffset (m_ptCursorPos.y, m_ptCursorPos.x);
   EnsureVisible (m_ptCursorPos);
   if (!bSelect)
@@ -431,7 +455,11 @@ MoveCtrlHome (bool bSelect)
 void CCrystalTextView::
 MoveCtrlEnd (bool bSelect)
 {
-  m_ptCursorPos.y = GetLineCount () - 1;
+  int y = GetLineCount () - 1;
+  y = !GetLineVisible (y) ? GetPreviousVisibleLine (y) : y;
+  if (y < 0)
+    return;
+  m_ptCursorPos.y = y;
   m_ptCursorPos.x = GetLineLength (m_ptCursorPos.y);
   m_nIdealCharPos = CalculateActualOffset (m_ptCursorPos.y, m_ptCursorPos.x);
   EnsureVisible (m_ptCursorPos);
@@ -446,7 +474,10 @@ ScrollUp ()
 {
   if (m_nTopLine > 0)
     {
-      ScrollToLine (m_nTopLine - 1);
+      const int nTopLine = GetPreviousVisibleLine (m_nTopLine);
+      if (nTopLine < 0)
+        return;
+      ScrollToLine (nTopLine);
       UpdateCaret ();
       UpdateSiblingScrollPos (false);
     }
@@ -457,7 +488,10 @@ ScrollDown ()
 {
   if (m_nTopLine < GetLineCount () - 1)
     {
-      ScrollToLine (m_nTopLine + 1);
+      const int nTopLine = GetNextVisibleLine (m_nTopLine);
+      if (nTopLine < 0)
+        return;
+      ScrollToLine (nTopLine);
       UpdateCaret ();
       UpdateSiblingScrollPos (false);
     }


### PR DESCRIPTION
Fix cursor movement and scrolling across gaps created by the display filter.

* Skip hidden lines when moving left/right at line boundaries.
* Skip hidden lines with Ctrl+Home and Ctrl+End.
* Skip hidden lines when scrolling up/down.

Fixes #3601.
