### PR TITLE
Add Azerbaijani translation

### DIFF
--- a/Translations/WinMerge/Azerbaijani.po
+++ b/Translations/WinMerge/Azerbaijani.po
@@ -1,0 +1,9232 @@
+# This file is from WinMerge <https://winmerge.org/>
+# Released under the "GNU General Public License"
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: WinMerge\n"
+"Report-Msgid-Bugs-To: https://github.com/WinMerge/winmerge/issues/\n"
+"POT-Creation-Date: 2026-09-05 20:56+0000\n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: Azerbaijani <winmerge-translate@lists.sourceforge.net>\n"
+"Language: az\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Poedit-Language: Azerbaijani\n"
+"X-Poedit-SourceCharset: UTF-8\n"
+"X-Poedit-Basepath: ../../Src/\n"
+
+#. LANGUAGE, SUBLANGUAGE
+#: Merge.rc:26 Merge.rc:59 Merge.rc:5837
+msgid "LANG_ENGLISH, SUBLANG_ENGLISH_US"
+msgstr "LANG_AZERI, SUBLANG_AZERI_LATIN"
+
+#. IDR_POPUP_MERGEVIEW, ID_COPY_TO_MIDDLE_R
+#: Merge.rc:79 Merge.rc:87
+msgid "Copy to Middle"
+msgstr "Ortaya köçür"
+
+#. IDR_POPUP_MERGEVIEW, ID_COPY_TO_RIGHT_M
+#: Merge.rc:80 Merge.rc:84
+msgid "C&opy to Right\tAlt+Right"
+msgstr "Sağa &köçür\tAlt+Right"
+
+#. IDR_POPUP_MERGEVIEW, ID_COPY_FROM_MIDDLE_R
+#: Merge.rc:81 Merge.rc:89
+msgid "Copy from Middle"
+msgstr "Ortadan köçür"
+
+#. IDR_POPUP_MERGEVIEW, ID_COPY_FROM_RIGHT_M
+#: Merge.rc:82 Merge.rc:86
+msgid "Copy fro&m Right\tAlt+Shift+Left"
+msgstr "Sağdan &köçür\tAlt+Shift+Left"
+
+#. IDR_POPUP_MERGEVIEW, ID_COPY_TO_LEFT_R
+#: Merge.rc:83 Merge.rc:88
+msgid "Cop&y to Left\tAlt+Left"
+msgstr "Sola &köçür\tAlt+Left"
+
+#. IDR_POPUP_MERGEVIEW, ID_COPY_FROM_LEFT_R
+#: Merge.rc:85 Merge.rc:90
+msgid "Copy &from Left\tAlt+Shift+Right"
+msgstr "Soldan &köçür\tAlt+Shift+Right"
+
+#. IDR_POPUP_MERGEVIEW, ID_COPY_LINES_TO_MIDDLE_R
+#: Merge.rc:92 Merge.rc:100
+msgid "Copy Selected Lines to Middle"
+msgstr "Seçilmiş sətirləri ortaya köçür"
+
+#. IDR_POPUP_MERGEVIEW, ID_COPY_LINES_TO_RIGHT_M
+#: Merge.rc:93 Merge.rc:97
+msgid "Copy Selected Lines to Right"
+msgstr "Seçilmiş sətirləri sağa köçür"
+
+#. IDR_POPUP_MERGEVIEW, ID_COPY_LINES_FROM_MIDDLE_R
+#: Merge.rc:94 Merge.rc:102
+msgid "Copy Selected Lines from Middle"
+msgstr "Seçilmiş sətirləri ortadan köçür"
+
+#. IDR_POPUP_MERGEVIEW, ID_COPY_LINES_FROM_RIGHT_M
+#: Merge.rc:95 Merge.rc:99
+msgid "Copy Selected Lines from Right"
+msgstr "Seçilmiş sətirləri sağdan köçür"
+
+#. IDR_POPUP_MERGEVIEW, ID_COPY_LINES_TO_LEFT_R
+#: Merge.rc:96 Merge.rc:101
+msgid "Copy Selected Lines to Left"
+msgstr "Seçilmiş sətirləri sola köçür"
+
+#. IDR_POPUP_MERGEVIEW, ID_COPY_LINES_FROM_LEFT_R
+#: Merge.rc:98 Merge.rc:103
+msgid "Copy Selected Lines from Left"
+msgstr "Seçilmiş sətirləri soldan köçür"
+
+#. IDR_POPUP_MERGEVIEW, ID_SEL_DIFF_COPY_1ST
+#: Merge.rc:105
+msgid "Copy Selected Diff (Left) to Clipboard\tCtrl+&1"
+msgstr "Seçilmiş fərqi (sol) mübadilə buferinə köçür\tCtrl+&1"
+
+#. IDR_POPUP_MERGEVIEW, ID_SEL_DIFF_COPY_2ND
+#: Merge.rc:106
+msgid "Copy Selected Diff (Right) to Clipboard\tCtrl+&2"
+msgstr "Seçilmiş fərqi (sağ) mübadilə buferinə köçür\tCtrl+&2"
+
+#. IDR_POPUP_MERGEVIEW, ID_SEL_DIFF_COPY_2ND_3WAY
+#: Merge.rc:107
+msgid "Copy Selected Diff (Middle) to Clipboard\tCtrl+&2"
+msgstr "Seçilmiş fərqi (orta) mübadilə buferinə köçür\tCtrl+&2"
+
+#. IDR_POPUP_MERGEVIEW, ID_SEL_DIFF_COPY_3RD
+#: Merge.rc:108
+msgid "Copy Selected Diff (Right) to Clipboard\tCtrl+&3"
+msgstr "Seçilmiş fərqi (sağ) mübadilə buferinə köçür\tCtrl+&3"
+
+#. IDR_MERGEDOCTYPE, ID_SELECTLINEDIFF
+#: Merge.rc:110 Merge.rc:700
+msgid "Select Line &Difference\tF4"
+msgstr "Sətir &fərqini seç\tF4"
+
+#. IDR_POPUP_MERGEVIEW
+#: Merge.rc:111
+msgid "Add to &Filters"
+msgstr "&Süzgəclərə əlavə et"
+
+#. IDR_POPUP_MERGEVIEW, ID_ADD_TO_DISPLAY_FILTERS
+#: Merge.rc:113
+msgid "Add to &Display Filter"
+msgstr "&Görüntü süzgəcinə əlavə et"
+
+#. IDR_POPUP_MERGEVIEW, ID_ADD_TO_LINE_FILTERS
+#: Merge.rc:114
+msgid "Add to &Line Filters"
+msgstr "&Sətir süzgəclərinə əlavə et"
+
+#. IDR_POPUP_MERGEVIEW, ID_ADD_TO_SUBSTITUTION_FILTERS
+#: Merge.rc:115
+msgid "Add to Substitution &Filters"
+msgstr "Əvəzetmə &süzgəclərinə əlavə et"
+
+#. IDR_POPUP_MERGEVIEW, ID_EDIT_UNDO
+#: Merge.rc:118
+msgid "&Undo"
+msgstr "&Geri al"
+
+#. IDR_POPUP_MERGEVIEW, ID_EDIT_REDO
+#: Merge.rc:119
+msgid "&Redo"
+msgstr "&Yenidən et"
+
+#. IDR_POPUP_MERGEVIEW, ID_EDIT_CUT
+#: Merge.rc:121
+msgid "Cu&t"
+msgstr "&Kəs"
+
+#. IDR_POPUP_DIRVIEW
+#: Merge.rc:122 Merge.rc:976
+msgid "&Copy"
+msgstr "&Köçür"
+
+#. IDR_POPUP_MERGEVIEW, ID_EDIT_PASTE
+#: Merge.rc:123
+msgid "&Paste"
+msgstr "&Yapışdır"
+
+#. IDR_MERGEDOCTYPE
+#: Merge.rc:125 Merge.rc:905 Merge.rc:912
+msgid "&Scripts"
+msgstr "&Skriptlər"
+
+#. IDS_NO_EDIT_SCRIPTS
+#: Merge.rc:127 Merge.rc:360 Merge.rc:471 Merge.rc:681 Merge.rc:686
+#: Merge.rc:895 Merge.rc:907 Merge.rc:914 Merge.rc:973 Merge.rc:1220
+#: Merge.rc:5386
+msgid "< Empty >"
+msgstr "< Boş >"
+
+#. IDR_POPUP_LOCATIONBAR, ID_EDIT_WMGOTO
+#: Merge.rc:130 Merge.rc:718 Merge.rc:1115
+msgid "&Go to...\tCtrl+G"
+msgstr "&Keç...\tCtrl+G"
+
+#. IDR_POPUP_LOCATIONBAR, ID_EDIT_GOTO_DEFINITION
+#: Merge.rc:131 Merge.rc:719 Merge.rc:1116
+msgid "Go to &Definition\tF12"
+msgstr "&Tərifə keç\tF12"
+
+#. IDR_POPUP_MERGEVIEW, ID_GOTO_MOVED_LINE_LM
+#: Merge.rc:132
+msgid "Go to Moved Line Between Left and Middle\tCtrl+Shift+G"
+msgstr "Sol və orta arasında yeri dəyişdirilmiş sətrə keç\tCtrl+Shift+G"
+
+#. IDR_POPUP_MERGEVIEW, ID_GOTO_MOVED_LINE_MR
+#: Merge.rc:133
+msgid "Go to Moved Line Between Middle and Right\tCtrl+Alt+G"
+msgstr "Orta və sağ arasında yeri dəyişdirilmiş sətrə keç\tCtrl+Alt+G"
+
+#. IDR_POPUP_MERGEVIEW
+#: Merge.rc:135
+msgid "Op&en"
+msgstr "&Aç"
+
+#. IDR_POPUP_DIRVIEW, ID_DIR_OPEN_RIGHT
+#: Merge.rc:137 Merge.rc:1014 Merge.rc:1021 Merge.rc:1028
+msgid "With &Registered Application"
+msgstr "&Əlaqələndirilmiş tətbiqlə"
+
+#. IDR_POPUP_DIRVIEW, ID_DIR_OPEN_RIGHT_WITHEDITOR
+#: Merge.rc:138 Merge.rc:1015 Merge.rc:1022 Merge.rc:1029
+msgid "With &External Editor\tCtrl+Alt+E"
+msgstr "&Xarici redaktorla\tCtrl+Alt+E"
+
+#. IDR_POPUP_DIRVIEW, ID_DIR_OPEN_RIGHT_WITH
+#: Merge.rc:139 Merge.rc:1016 Merge.rc:1023 Merge.rc:1030
+msgid "&With..."
+msgstr "&Bununla..."
+
+#. IDR_POPUP_DIRVIEW, ID_DIR_OPEN_RIGHT_PARENT_FOLDER
+#: Merge.rc:140 Merge.rc:1017 Merge.rc:1024 Merge.rc:1031
+msgid "Open &Parent Folder..."
+msgstr "&Üst qovluğu aç..."
+
+#. IDR_POPUP_IMG_CTXT, ID_FILE_SHELLMENU
+#: Merge.rc:142 Merge.rc:1284
+msgid "S&hell Menu"
+msgstr "&Örtük menyusu"
+
+#. IDR_POPUP_MERGEVIEWHEADER, ID_USE_FIRST_LINE_AS_HEADERS
+#: Merge.rc:150
+msgid "Use First Line as Headers"
+msgstr "İlk sətri başlıq kimi istifadə et"
+
+#. IDR_POPUP_MERGEVIEWHEADER, ID_AUTO_FIT_ALL_COLUMNS
+#: Merge.rc:151
+msgid "Auto-Fit All Columns"
+msgstr "Bütün sütunların enini avtomatik uyğunlaşdır"
+
+#. IDR_POPUP_MERGEVIEWHEADER
+#: Merge.rc:153
+msgid "&Ignore This Column"
+msgstr "Bu sütunu &nəzərə alma"
+
+#. IDR_POPUP_MERGEVIEWHEADER, ID_IGNORE_COLUMN_IN_COMPARISON
+#: Merge.rc:155
+msgid "In &All Panes"
+msgstr "&Bütün panellərdə"
+
+#. IDR_POPUP_MERGEVIEWHEADER, ID_IGNORE_COLUMN_IN_COMPARISON_THIS_PANE_ONLY
+#: Merge.rc:156
+msgid "In &This Pane Only (Column Not in Other Files)"
+msgstr "Yalnız &bu paneldə (sütun digər fayllarda yoxdur)"
+
+#. IDR_POPUP_MERGEVIEWHEADER, ID_IGNORE_COLUMN_IN_COMPARISON_CTRL_CLICK_TO_ADD_HINT
+#: Merge.rc:157
+msgid "(Ctrl+Click to add another column)"
+msgstr "(Başqa sütun əlavə etmək üçün Ctrl düyməsini basılı saxlayıb klikləyin)"
+
+#. IDR_POPUP_MERGEVIEWHEADER, ID_IGNORE_COLUMN_IN_COMPARISON_RESET
+#: Merge.rc:159
+msgid "&Reset All"
+msgstr "Hamısını &sıfırla"
+
+#. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN
+#: Merge.rc:161 Merge.rc:5657
+msgid "&Filter by This Column"
+msgstr "Bu sütuna görə &süz"
+
+#. IDR_POPUP_LINEFILTERMENU, ID_FILTERMENU_COLUMN_TEXT
+#: Merge.rc:163 Merge.rc:1890
+msgid "&Text..."
+msgstr "&Mətn..."
+
+#. IDR_POPUP_LINEFILTERMENU, ID_FILTERMENU_COLUMN_NUMBER
+#: Merge.rc:164 Merge.rc:1891
+msgid "&Number..."
+msgstr "&Ədəd..."
+
+#. IDR_POPUP_LINEFILTERMENU, ID_FILTERMENU_COLUMN_DATETIME
+#: Merge.rc:165 Merge.rc:1892
+msgid "&Date/Time..."
+msgstr "&Tarix/vaxt..."
+
+#. IDR_POPUP_WEBPAGEDIFFVIEW, ID_WEB_VIEWDIFFERENCES
+#: Merge.rc:174 Merge.rc:291
+msgid "View &Differences"
+msgstr "&Fərqləri göstər"
+
+#. IDR_POPUP_IMGMERGEVIEW
+#: Merge.rc:175
+msgid "Diff &Block Size"
+msgstr "Fərq &blokunun ölçüsü"
+
+#. IDR_POPUP_IMGMERGEVIEW
+#: Merge.rc:184
+msgid "&Ignore Color Difference"
+msgstr "Rəng fərqini &nəzərə alma"
+
+#. IDR_POPUP_IMGMERGEVIEW
+#: Merge.rc:194
+msgid "Ins&ertion/Deletion Detection"
+msgstr "Əlavəetmə/silmənin &aşkarlanması"
+
+#. IDR_MERGEDOCTYPE, ID_TOOLBAR_NONE
+#: Merge.rc:196 Merge.rc:229 Merge.rc:236 Merge.rc:380 Merge.rc:531
+#: Merge.rc:779
+msgid "&None"
+msgstr "&Heç biri"
+
+#. IDR_POPUP_IMGMERGEVIEW, ID_IMG_INSERTIONDELETIONDETECTION_VERTICAL
+#: Merge.rc:197
+msgid "&Vertical"
+msgstr "&Şaquli"
+
+#. IDR_POPUP_IMGMERGEVIEW, ID_IMG_INSERTIONDELETIONDETECTION_HORIZONTAL
+#: Merge.rc:198
+msgid "&Horizontal"
+msgstr "&Üfüqi"
+
+#. IDR_POPUP_IMG_CTXT, ID_IMG_CURPANE_PREVPAGE
+#: Merge.rc:201 Merge.rc:209 Merge.rc:1275
+msgid "&Previous Page"
+msgstr "&Əvvəlki səhifə"
+
+#. IDS_PREVIEWBAR_NEXTPAGE
+#: Merge.rc:202 Merge.rc:210 Merge.rc:1276 Merge.rc:5690
+msgid "&Next Page"
+msgstr "&Növbəti səhifə"
+
+#. IDR_POPUP_IMGMERGEVIEW
+#: Merge.rc:203
+msgid "&Active Pane"
+msgstr "&Aktiv panel"
+
+#. IDR_POPUP_IMG_CTXT, ID_IMG_CURPANE_ROTATE_RIGHT_90
+#: Merge.rc:205 Merge.rc:1270
+msgid "Rotate &Right 90deg"
+msgstr "&Sağa 90 dərəcə döndər"
+
+#. IDR_POPUP_IMG_CTXT, ID_IMG_CURPANE_ROTATE_LEFT_90
+#: Merge.rc:206 Merge.rc:1271
+msgid "Rotate &Left 90deg"
+msgstr "&Sola 90 dərəcə döndər"
+
+#. IDR_POPUP_IMG_CTXT, ID_IMG_CURPANE_FLIP_VERTICALLY
+#: Merge.rc:207 Merge.rc:1272
+msgid "Flip V&ertically"
+msgstr "&Şaquli çevir"
+
+#. IDR_POPUP_IMG_CTXT, ID_IMG_CURPANE_FLIP_HORIZONTALLY
+#: Merge.rc:208 Merge.rc:1273
+msgid "Flip H&orizontally"
+msgstr "&Üfüqi çevir"
+
+#. IDR_MERGEDOCTYPE
+#: Merge.rc:213 Merge.rc:727
+msgid "&Zoom"
+msgstr "&Miqyas"
+
+#. IDR_MERGEDOCTYPE, ID_VIEW_ZOOMIN
+#: Merge.rc:222 Merge.rc:729
+msgid "Zoom &In\tCtrl++"
+msgstr "&Böyüt\tCtrl++"
+
+#. IDR_MERGEDOCTYPE, ID_VIEW_ZOOMOUT
+#: Merge.rc:223 Merge.rc:730
+msgid "Zoom &Out\tCtrl+-"
+msgstr "&Kiçilt\tCtrl+-"
+
+#. IDR_MERGEDOCTYPE, ID_VIEW_ZOOMNORMAL, Zoom to normal
+#: Merge.rc:225 Merge.rc:732
+msgid "&Normal\tCtrl+*"
+msgstr "&Normal\tCtrl+*"
+
+#. IDR_POPUP_IMGMERGEVIEW
+#: Merge.rc:227
+msgid "&Overlay"
+msgstr "&Üst-üstə göstərmə"
+
+#. IDR_POPUP_IMGMERGEVIEW, ID_IMG_OVERLAY_ALPHABLEND
+#: Merge.rc:231
+msgid "&Alpha Blend"
+msgstr "&Alfa qarışdırma"
+
+#. IDR_POPUP_IMGMERGEVIEW, ID_IMG_OVERLAY_ALPHABLEND_ANIM
+#: Merge.rc:232
+msgid "Alpha &Blend Animation"
+msgstr "Alfa &qarışdırma animasiyası"
+
+#. IDR_POPUP_IMGMERGEVIEW
+#: Merge.rc:234
+msgid "Dragging &Mode"
+msgstr "Sürükləmə &rejimi"
+
+#. IDR_POPUP_IMG_CTXT, ID_IMG_DRAGGINGMODE_MOVE
+#: Merge.rc:237 Merge.rc:988 Merge.rc:1278
+msgid "&Move"
+msgstr "&Yerini dəyiş"
+
+#. IDR_POPUP_IMG_CTXT, ID_IMG_DRAGGINGMODE_ADJUST_OFFSET
+#: Merge.rc:238 Merge.rc:1279
+msgid "&Adjust Offset"
+msgstr "&Sürüşməni tənzimlə"
+
+#. IDR_POPUP_IMG_CTXT, ID_IMG_DRAGGINGMODE_VERTICAL_WIPE
+#: Merge.rc:239 Merge.rc:1280
+msgid "&Vertical Wipe"
+msgstr "&Şaquli keçid"
+
+#. IDR_POPUP_IMG_CTXT, ID_IMG_DRAGGINGMODE_HORIZONTAL_WIPE
+#: Merge.rc:240 Merge.rc:1281
+msgid "&Horizontal Wipe"
+msgstr "&Üfüqi keçid"
+
+#. IDR_POPUP_IMG_CTXT, ID_IMG_DRAGGINGMODE_RECTANGLE_SELECT
+#: Merge.rc:241 Merge.rc:1282
+msgid "Rectangle &Select"
+msgstr "Düzbucaqlı &seçim"
+
+#. IDR_POPUP_IMGMERGEVIEW, ID_IMG_USEBACKCOLOR
+#: Merge.rc:243
+msgid "&Set Background Color"
+msgstr "Fon rəngini &təyin et"
+
+#. IDR_POPUP_IMGMERGEVIEW
+#: Merge.rc:244
+msgid "&Vector Image Scaling"
+msgstr "&Vektor təsvirinin miqyaslanması"
+
+#. IDR_POPUP_IMGMERGEVIEW
+#: Merge.rc:253
+msgid "&Animation Settings"
+msgstr "&Animasiya parametrləri"
+
+#. IDR_POPUP_IMGMERGEVIEW
+#: Merge.rc:255
+msgid "&Blink Interval"
+msgstr "&Yanıb-sönmə intervalı"
+
+#. IDR_POPUP_IMGMERGEVIEW
+#: Merge.rc:268
+msgid "&Overlay Animation Interval"
+msgstr "&Üst-üstə göstərmə animasiyasının intervalı"
+
+#. IDR_POPUP_IMGMERGEVIEW, ID_IMG_COMPARE_EXTRACTED_TEXT
+#: Merge.rc:283
+msgid "Compare Extracted &Text from Images"
+msgstr "Şəkillərdən çıxarılmış &mətni müqayisə et"
+
+#. IDD_OPEN, IDOK
+#: Merge.rc:292 Merge.rc:2251
+msgid "Co&mpare"
+msgstr "&Müqayisə et"
+
+#. IDR_POPUP_WEBPAGE_COMPARE, ID_WEB_COMPARE_SCREENSHOTS
+#: Merge.rc:294 Merge.rc:1292
+msgid "&Screenshots"
+msgstr "&Ekran görüntüləri"
+
+#. IDR_POPUP_WEBPAGE_COMPARE, ID_WEB_COMPARE_FULLSIZE_SCREENSHOTS
+#: Merge.rc:295 Merge.rc:1293
+msgid "&Full Size Screenshots"
+msgstr "&Tam ölçülü ekran görüntüləri"
+
+#. IDR_POPUP_WEBPAGE_COMPARE, ID_WEB_COMPARE_HTMLS
+#: Merge.rc:296 Merge.rc:1294
+msgid "&HTMLs"
+msgstr "&HTML-lər"
+
+#. IDR_POPUP_WEBPAGE_COMPARE, ID_WEB_COMPARE_TEXTS
+#: Merge.rc:297 Merge.rc:1295
+msgid "&Texts"
+msgstr "&Mətnlər"
+
+#. IDR_POPUP_WEBPAGE_COMPARE, ID_WEB_COMPARE_RESOURCETREES
+#: Merge.rc:298 Merge.rc:1296
+msgid "&Resource Trees"
+msgstr "&Resurs ağacları"
+
+#. IDR_POPUP_RENAMEMOVE_MENU, ID_RENAME_MOVE_KEY_MENU_SIZE
+#: Merge.rc:300 Merge.rc:1832
+msgid "&Size"
+msgstr "&Ölçü"
+
+#. IDR_POPUP_WEBPAGEDIFFVIEW, ID_WEB_SIZE_FIT_TO_WINDOW
+#: Merge.rc:302
+msgid "Fit to Window"
+msgstr "Pəncərəyə sığdır"
+
+#. IDR_POPUP_WEBPAGEDIFFVIEW
+#: Merge.rc:309
+msgid "&Event Sync"
+msgstr "&Hadisələrin sinxronlaşdırılması"
+
+#. IDR_POPUP_WEBPAGE_SYNC_EVENTS, ID_WEB_SYNC_ENABLED
+#: Merge.rc:311 Merge.rc:1304
+msgid "&Enabled"
+msgstr "&Aktiv"
+
+#. IDR_POPUP_WEBPAGE_SYNC_EVENTS, ID_WEB_SYNC_SCROLL
+#: Merge.rc:313 Merge.rc:1306
+msgid "&Scroll"
+msgstr "&Sürüşdürmə"
+
+#. IDR_POPUP_WEBPAGE_SYNC_EVENTS, ID_WEB_SYNC_CLICK
+#: Merge.rc:314 Merge.rc:1307
+msgid "&Click"
+msgstr "&Klik"
+
+#. IDR_POPUP_WEBPAGE_SYNC_EVENTS, ID_WEB_SYNC_INPUT
+#: Merge.rc:315 Merge.rc:1308
+msgid "&Input"
+msgstr "&Daxiletmə"
+
+#. IDR_POPUP_WEBPAGE_SYNC_EVENTS, ID_WEB_SYNC_GOBACKFORWARD
+#: Merge.rc:316 Merge.rc:1309
+msgid "&Go Back/Forward"
+msgstr "&Geri/irəli keçid"
+
+#. IDR_POPUP_WEBPAGEDIFFVIEW
+#: Merge.rc:318
+msgid "Clear &Browsing Data"
+msgstr "&Baxış məlumatlarını təmizlə"
+
+#. IDR_POPUP_WEBPAGEDIFFVIEW, ID_WEB_CLEAR_DISK_CACHE
+#: Merge.rc:320
+msgid "&Disk Cache"
+msgstr "&Disk keşi"
+
+#. IDR_POPUP_WEBPAGEDIFFVIEW, ID_WEB_CLEAR_COOKIES
+#: Merge.rc:321
+msgid "&Cookies"
+msgstr "&Kukilər"
+
+#. IDR_POPUP_WEBPAGEDIFFVIEW, ID_WEB_CLEAR_BROWSING_HISTORY
+#: Merge.rc:322
+msgid "&Browsing History"
+msgstr "&Baxış tarixçəsi"
+
+#. IDR_POPUP_WEBPAGEDIFFVIEW, ID_WEB_CLEAR_ALL_PROFILE
+#: Merge.rc:323
+msgid "&All Profiles"
+msgstr "&Bütün profillər"
+
+#. IDR_MERGEDOCTYPE
+#: Merge.rc:330 Merge.rc:433 Merge.rc:610
+msgid "&File"
+msgstr "&Fayl"
+
+#. IDR_MERGEDOCTYPE
+#: Merge.rc:332 Merge.rc:435 Merge.rc:612
+msgid "&New"
+msgstr "&Yeni"
+
+#. IDR_POPUP_LINEFILTERMENU
+#: Merge.rc:334 Merge.rc:343 Merge.rc:437 Merge.rc:446 Merge.rc:614
+#: Merge.rc:623 Merge.rc:675 Merge.rc:967 Merge.rc:1194 Merge.rc:1207
+#: Merge.rc:1945
+msgid "&Text"
+msgstr "&Mətn"
+
+#. IDR_POPUP_COMPARE, ID_MERGE_COMPARE_TABLE
+#: Merge.rc:335 Merge.rc:344 Merge.rc:438 Merge.rc:447 Merge.rc:615
+#: Merge.rc:624 Merge.rc:676 Merge.rc:968 Merge.rc:1195 Merge.rc:1208
+msgid "T&able"
+msgstr "&Cədvəl"
+
+#. IDR_POPUP_COMPARE, ID_MERGE_COMPARE_HEX
+#: Merge.rc:336 Merge.rc:345 Merge.rc:439 Merge.rc:448 Merge.rc:616
+#: Merge.rc:625 Merge.rc:677 Merge.rc:969 Merge.rc:1196 Merge.rc:1209
+msgid "&Binary"
+msgstr "&İkilik"
+
+#. IDS_IMAGE_MENU
+#: Merge.rc:337 Merge.rc:346 Merge.rc:440 Merge.rc:449 Merge.rc:617
+#: Merge.rc:626 Merge.rc:678 Merge.rc:970 Merge.rc:1197 Merge.rc:1210
+#: Merge.rc:5488
+msgid "&Image"
+msgstr "&Şəkil"
+
+#. IDR_POPUP_COMPARE, ID_MERGE_COMPARE_WEBPAGE
+#: Merge.rc:338 Merge.rc:347 Merge.rc:441 Merge.rc:450 Merge.rc:618
+#: Merge.rc:627 Merge.rc:679 Merge.rc:971 Merge.rc:1198 Merge.rc:1211
+msgid "&Webpage"
+msgstr "&Veb-səhifə"
+
+#. IDR_POPUP_NEW, ID_FILE_NEW_FOLDER
+#: Merge.rc:339 Merge.rc:348 Merge.rc:442 Merge.rc:451 Merge.rc:619
+#: Merge.rc:628 Merge.rc:1199
+msgid "&Folder"
+msgstr "&Qovluq"
+
+#. IDR_MERGEDOCTYPE
+#: Merge.rc:341 Merge.rc:444 Merge.rc:621
+msgid "New (&3 panes)"
+msgstr "&Yeni (3 panel)"
+
+#. IDR_MERGEDOCTYPE, ID_FILE_OPEN
+#: Merge.rc:350 Merge.rc:453 Merge.rc:630
+msgid "&Open...\tCtrl+O"
+msgstr "&Aç...\tCtrl+O"
+
+#. IDR_MERGEDOCTYPE, ID_FILE_OPENCONFLICT
+#: Merge.rc:351 Merge.rc:454 Merge.rc:631
+msgid "Open Conflic&t File..."
+msgstr "&Ziddiyyətli faylı aç..."
+
+#. IDR_POPUP_EDITOR_HEADERBAR, ID_EDITOR_OPEN_CLIPBOARD
+#: Merge.rc:352 Merge.rc:455 Merge.rc:632 Merge.rc:1089
+msgid "Open C&lipboard"
+msgstr "&Mübadilə buferini aç"
+
+#. IDR_POPUP_PROJECT, ID_FILE_OPENPROJECT
+#: Merge.rc:354 Merge.rc:457 Merge.rc:634 Merge.rc:1236
+msgid "Open Pro&ject...\tCtrl+J"
+msgstr "&Layihəni aç...\tCtrl+J"
+
+#. IDD_OPEN, ID_SAVE_PROJECT
+#: Merge.rc:355 Merge.rc:458 Merge.rc:635 Merge.rc:1238 Merge.rc:2250
+msgid "Sa&ve Project..."
+msgstr "Layihəni &saxla..."
+
+#. IDR_MAINFRAME, ID_FILE_PROJECT_MRU_FIRST
+#: Merge.rc:357
+msgid "Recent Projects"
+msgstr "Son layihələr"
+
+#. IDR_MERGEDOCTYPE
+#: Merge.rc:358 Merge.rc:469 Merge.rc:684
+msgid "Recent F&iles or Folders"
+msgstr "Son &fayl və ya qovluqlar"
+
+#. IDR_MERGEDOCTYPE, ID_APP_EXIT
+#: Merge.rc:363 Merge.rc:474 Merge.rc:689
+msgid "E&xit\tCtrl+Q"
+msgstr "&Çıx\tCtrl+Q"
+
+#. IDR_MERGEDOCTYPE
+#: Merge.rc:365 Merge.rc:476 Merge.rc:691
+msgid "&Edit"
+msgstr "&Düzəliş"
+
+#. IDR_MERGEDOCTYPE, ID_EDIT_PASTE
+#: Merge.rc:367 Merge.rc:698
+msgid "&Paste\tCtrl+V"
+msgstr "&Yapışdır\tCtrl+V"
+
+#. IDR_MERGEDOCTYPE, ID_OPTIONS
+#: Merge.rc:369 Merge.rc:480 Merge.rc:721
+msgid "&Options...\tCtrl+,"
+msgstr "&Seçimlər...\tCtrl+,"
+
+#. IDR_MERGEDOCTYPE
+#: Merge.rc:371 Merge.rc:482 Merge.rc:723
+msgid "&View"
+msgstr "&Görünüş"
+
+#. IDR_MERGEDOCTYPE
+#: Merge.rc:373 Merge.rc:524 Merge.rc:772
+msgid "Ta&b Bar"
+msgstr "&Vərəq zolağı"
+
+#. IDR_MERGEDOCTYPE, ID_VIEW_TAB_BAR
+#: Merge.rc:375 Merge.rc:526 Merge.rc:774
+msgid "&View Tab Bar"
+msgstr "Vərəq zolağını &göstər"
+
+#. IDR_MERGEDOCTYPE, ID_VIEW_TAB_BAR_ON_TITLE_BAR
+#: Merge.rc:376 Merge.rc:527 Merge.rc:775
+msgid "&On Title Bar"
+msgstr "&Başlıq zolağında"
+
+#. IDR_MERGEDOCTYPE
+#: Merge.rc:378 Merge.rc:529 Merge.rc:777
+msgid "&Toolbar"
+msgstr "&Alətlər zolağı"
+
+#. IDR_MERGEDOCTYPE, ID_TOOLBAR_SMALL
+#: Merge.rc:381 Merge.rc:532 Merge.rc:780
+msgid "&Small"
+msgstr "&Kiçik"
+
+#. IDR_MERGEDOCTYPE, ID_TOOLBAR_MEDIUM
+#: Merge.rc:382 Merge.rc:533 Merge.rc:781
+msgid "&Medium"
+msgstr "&Orta"
+
+#. IDR_MERGEDOCTYPE, ID_TOOLBAR_BIG
+#: Merge.rc:383 Merge.rc:534 Merge.rc:782
+msgid "&Big"
+msgstr "&Böyük"
+
+#. IDR_MERGEDOCTYPE, ID_TOOLBAR_HUGE
+#: Merge.rc:384 Merge.rc:535 Merge.rc:783
+msgid "&Huge"
+msgstr "&Çox böyük"
+
+#. IDS_VIEW_MENU_BAR
+#: Merge.rc:386 Merge.rc:537 Merge.rc:785 Merge.rc:5725
+msgid "Men&u Bar"
+msgstr "&Menyu zolağı"
+
+#. IDR_DIRDOCTYPE, ID_VIEW_OUTPUT_BAR
+#: Merge.rc:387 Merge.rc:539
+msgid "&Output Pane"
+msgstr "&Çıxış paneli"
+
+#. IDR_MERGEDOCTYPE, ID_VIEW_STATUS_BAR
+#: Merge.rc:388 Merge.rc:540 Merge.rc:787
+msgid "&Status Bar"
+msgstr "&Vəziyyət zolağı"
+
+#. IDR_MERGEDOCTYPE
+#: Merge.rc:390 Merge.rc:563 Merge.rc:876
+msgid "&Tools"
+msgstr "&Alətlər"
+
+#. IDR_MERGEDOCTYPE, ID_TOOLS_FILTERS
+#: Merge.rc:392 Merge.rc:566 Merge.rc:878
+msgid "&Filters..."
+msgstr "&Süzgəclər..."
+
+#. IDR_MERGEDOCTYPE, ID_TOOLS_GENERATEPATCH
+#: Merge.rc:393 Merge.rc:567 Merge.rc:879
+msgid "&Generate Patch..."
+msgstr "&Yamaq yarat..."
+
+#. IDR_MERGEDOCTYPE
+#: Merge.rc:395 Merge.rc:570 Merge.rc:883
+msgid "&Plugins"
+msgstr "&Qoşmalar"
+
+#. IDD_PLUGINS_LIST, IDC_PLUGIN_SETTINGS
+#: Merge.rc:397 Merge.rc:572 Merge.rc:885 Merge.rc:2769 Merge.rc:3258
+msgid "P&lugin Settings..."
+msgstr "&Qoşma parametrləri..."
+
+#. IDR_MERGEDOCTYPE, ID_PREDIFFER_MANUAL
+#: Merge.rc:399 Merge.rc:574 Merge.rc:887
+msgid "Ma&nual Prediffer"
+msgstr "&Əl ilə ilkin müqayisə emalı"
+
+#. IDR_MERGEDOCTYPE, ID_PREDIFFER_AUTO
+#: Merge.rc:400 Merge.rc:575 Merge.rc:888
+msgid "A&utomatic Prediffer"
+msgstr "&Avtomatik ilkin müqayisə emalı"
+
+#. IDR_MERGEDOCTYPE, ID_UNPACK_MANUAL
+#: Merge.rc:402 Merge.rc:577 Merge.rc:890
+msgid "&Manual Unpacking"
+msgstr "&Əl ilə açma"
+
+#. IDR_MERGEDOCTYPE, ID_UNPACK_AUTO
+#: Merge.rc:403 Merge.rc:578 Merge.rc:891
+msgid "&Automatic Unpacking"
+msgstr "&Avtomatik açma"
+
+#. IDR_MERGEDOCTYPE, ID_RELOAD_PLUGINS
+#: Merge.rc:405 Merge.rc:582 Merge.rc:919
+msgid "&Reload Plugins"
+msgstr "Qoşmaları &yenidən yüklə"
+
+#. IDR_MERGEDOCTYPE
+#: Merge.rc:407 Merge.rc:584 Merge.rc:921
+msgid "&Window"
+msgstr "&Pəncərə"
+
+#. IDR_MERGEDOCTYPE, ID_FILE_CLOSE
+#: Merge.rc:409 Merge.rc:586 Merge.rc:923
+msgid "Cl&ose\tCtrl+W"
+msgstr "&Bağla\tCtrl+W"
+
+#. IDR_MERGEDOCTYPE, ID_WINDOW_CLOSEALL
+#: Merge.rc:410 Merge.rc:587 Merge.rc:924
+msgid "Clo&se All"
+msgstr "Hamısını &bağla"
+
+#. IDR_MERGEDOCTYPE, ID_NEXT_PANE
+#: Merge.rc:412 Merge.rc:589 Merge.rc:926
+msgid "Change &Pane\tF6"
+msgstr "&Paneli dəyiş\tF6"
+
+#. IDR_MERGEDOCTYPE, ID_WINDOW_TILE_HORZ
+#: Merge.rc:414 Merge.rc:591 Merge.rc:930
+msgid "Tile &Horizontally"
+msgstr "&Üfüqi düz"
+
+#. IDR_MERGEDOCTYPE, ID_WINDOW_TILE_VERT
+#: Merge.rc:415 Merge.rc:592 Merge.rc:931
+msgid "Tile &Vertically"
+msgstr "&Şaquli düz"
+
+#. IDR_MERGEDOCTYPE, ID_WINDOW_CASCADE
+#: Merge.rc:416 Merge.rc:593 Merge.rc:932
+msgid "&Cascade"
+msgstr "&Pilləli düz"
+
+#. IDS_MESSAGEBOX_HELP
+#: Merge.rc:418 Merge.rc:595 Merge.rc:936 Merge.rc:3533 Merge.rc:4549
+msgid "&Help"
+msgstr "&Kömək"
+
+#. IDR_MERGEDOCTYPE, ID_HELP_CONTENTS
+#: Merge.rc:420 Merge.rc:597 Merge.rc:938
+msgid "&WinMerge Help\tF1"
+msgstr "&WinMerge köməyi\tF1"
+
+#. IDR_MERGEDOCTYPE, ID_HELP_RELEASENOTES
+#: Merge.rc:422 Merge.rc:599 Merge.rc:940
+msgid "R&elease Notes"
+msgstr "&Buraxılış qeydləri"
+
+#. IDR_MERGEDOCTYPE, ID_HELP_TRANSLATIONS
+#: Merge.rc:423 Merge.rc:600 Merge.rc:941
+msgid "&Translations"
+msgstr "&Tərcümələr"
+
+#. IDR_MERGEDOCTYPE, ID_HELP_GETCONFIG
+#: Merge.rc:424 Merge.rc:601 Merge.rc:942
+msgid "C&onfiguration"
+msgstr "&Konfiqurasiya"
+
+#. IDR_MERGEDOCTYPE, ID_HELP_GNULICENSE
+#: Merge.rc:426 Merge.rc:603 Merge.rc:944
+msgid "&GNU General Public License"
+msgstr "&GNU Ümumi İctimai Lisenziyası"
+
+#. IDR_MERGEDOCTYPE, ID_APP_ABOUT
+#: Merge.rc:427 Merge.rc:604 Merge.rc:945
+msgid "&About WinMerge..."
+msgstr "WinMerge &haqqında..."
+
+#. IDR_MERGEDOCTYPE
+#: Merge.rc:460 Merge.rc:655
+msgid "&Read-Only"
+msgstr "&Yalnız oxumaq üçün"
+
+#. IDR_MERGEDOCTYPE, ID_FILE_LEFT_READONLY
+#: Merge.rc:462 Merge.rc:657
+msgid "L&eft Read-Only"
+msgstr "&Sol yalnız oxumaq üçün"
+
+#. IDR_MERGEDOCTYPE, ID_FILE_MIDDLE_READONLY
+#: Merge.rc:463 Merge.rc:658
+msgid "M&iddle Read-Only"
+msgstr "&Orta yalnız oxumaq üçün"
+
+#. IDR_MERGEDOCTYPE, ID_FILE_RIGHT_READONLY
+#: Merge.rc:464 Merge.rc:659
+msgid "Ri&ght Read-Only"
+msgstr "&Sağ yalnız oxumaq üçün"
+
+#. IDD_ENCODINGERROR, IDC_FILEENCODING
+#: Merge.rc:467 Merge.rc:672 Merge.rc:1071 Merge.rc:3396
+msgid "&File Encoding..."
+msgstr "Faylın &kodlaşdırılması..."
+
+#. IDR_POPUP_OUTPUTVIEW, ID_EDIT_SELECT_ALL
+#: Merge.rc:478 Merge.rc:701 Merge.rc:1388
+msgid "Select &All\tCtrl+A"
+msgstr "&Hamısını seç\tCtrl+A"
+
+#. IDR_DIRDOCTYPE, ID_OPTIONS_SHOWIDENTICAL
+#: Merge.rc:484
+msgid "Show &Identical Items"
+msgstr "&Eyni elementləri göstər"
+
+#. IDR_DIRDOCTYPE, ID_OPTIONS_SHOWDIFFERENT
+#: Merge.rc:485
+msgid "Show &Different Items"
+msgstr "&Fərqli elementləri göstər"
+
+#. IDR_DIRDOCTYPE, ID_OPTIONS_SHOWUNIQUELEFT
+#: Merge.rc:486
+msgid "Show L&eft Unique Items"
+msgstr "Yalnız &solda olan elementləri göstər"
+
+#. IDR_DIRDOCTYPE, ID_OPTIONS_SHOWUNIQUEMIDDLE
+#: Merge.rc:487
+msgid "Show Midd&le Unique Items"
+msgstr "Yalnız &ortada olan elementləri göstər"
+
+#. IDR_DIRDOCTYPE, ID_OPTIONS_SHOWUNIQUERIGHT
+#: Merge.rc:488
+msgid "Show Ri&ght Unique Items"
+msgstr "Yalnız &sağda olan elementləri göstər"
+
+#. IDR_DIRDOCTYPE, ID_OPTIONS_SHOWSKIPPED
+#: Merge.rc:489
+msgid "Show S&kipped Items"
+msgstr "&Ötürülmüş elementləri göstər"
+
+#. IDR_DIRDOCTYPE, ID_OPTIONS_SHOWBINARIES
+#: Merge.rc:490
+msgid "S&how Binary Files"
+msgstr "&İkilik faylları göstər"
+
+#. IDR_DIRDOCTYPE
+#: Merge.rc:491
+msgid "&3-way Compare"
+msgstr "&Üçtərəfli müqayisə"
+
+#. IDR_DIRDOCTYPE, ID_OPTIONS_SHOWDIFFERENTLEFTONLY
+#: Merge.rc:493
+msgid "Show &Left Only Different Items"
+msgstr "Yalnız &solda fərqli olan elementləri göstər"
+
+#. IDR_DIRDOCTYPE, ID_OPTIONS_SHOWDIFFERENTMIDDLEONLY
+#: Merge.rc:494
+msgid "Show &Middle Only Different Items"
+msgstr "Yalnız &ortada fərqli olan elementləri göstər"
+
+#. IDR_DIRDOCTYPE, ID_OPTIONS_SHOWDIFFERENTRIGHTONLY
+#: Merge.rc:495
+msgid "Show &Right Only Different Items"
+msgstr "Yalnız &sağda fərqli olan elementləri göstər"
+
+#. IDR_DIRDOCTYPE, ID_OPTIONS_SHOWMISSINGLEFTONLY
+#: Merge.rc:497
+msgid "Show L&eft Only Missing Items"
+msgstr "Yalnız s&olda çatışmayan elementləri göstər"
+
+#. IDR_DIRDOCTYPE, ID_OPTIONS_SHOWMISSINGMIDDLEONLY
+#: Merge.rc:498
+msgid "Show Mi&ddle Only Missing Items"
+msgstr "Yalnız o&rtada çatışmayan elementləri göstər"
+
+#. IDR_DIRDOCTYPE, ID_OPTIONS_SHOWMISSINGRIGHTONLY
+#: Merge.rc:499
+msgid "Show Rig&ht Only Missing Items"
+msgstr "Yalnız s&ağda çatışmayan elementləri göstər"
+
+#. IDR_DIRDOCTYPE, ID_VIEW_SHOWHIDDENITEMS
+#: Merge.rc:502
+msgid "Show Hidd&en Items"
+msgstr "&Gizli elementləri göstər"
+
+#. IDR_DIRDOCTYPE, ID_VIEW_TREEMODE
+#: Merge.rc:504
+msgid "Tree &Mode"
+msgstr "&Ağac rejimi"
+
+#. IDR_DIRDOCTYPE
+#: Merge.rc:505
+msgid "E&xpand Subfolders"
+msgstr "Alt qovluqları &genişləndir"
+
+#. IDR_DIRDOCTYPE, ID_VIEW_EXPAND_ALLSUBDIRS
+#: Merge.rc:507
+msgid "&All Subfolders"
+msgstr "&Bütün alt qovluqlar"
+
+#. IDR_DIRDOCTYPE, ID_VIEW_EXPAND_DIFFERENT_SUBDIRS
+#: Merge.rc:508
+msgid "&Different Subfolders"
+msgstr "&Fərqli alt qovluqlar"
+
+#. IDR_DIRDOCTYPE, ID_VIEW_EXPAND_IDENTICAL_SUBDIRS
+#: Merge.rc:509
+msgid "&Identical Subfolders"
+msgstr "&Eyni alt qovluqlar"
+
+#. IDR_DIRDOCTYPE, ID_VIEW_COLLAPSE_ALLSUBDIRS
+#: Merge.rc:511
+msgid "&Collapse All Subfolders"
+msgstr "Bütün alt qovluqları &yığ"
+
+#. IDR_DIRDOCTYPE, ID_VIEW_SHOW_EMPTY_FOLDERS
+#: Merge.rc:512
+msgid "Show &Empty Folders"
+msgstr "&Boş qovluqları göstər"
+
+#. IDR_MERGEDOCTYPE, ID_VIEW_SELECTFONT
+#: Merge.rc:514 Merge.rc:725
+msgid "Select &Font..."
+msgstr "&Şrift seç..."
+
+#. IDR_MERGEDOCTYPE, ID_VIEW_USEDEFAULTFONT
+#: Merge.rc:515 Merge.rc:726
+msgid "Use Default Font"
+msgstr "Standart şriftdən istifadə et"
+
+#. IDR_MERGEDOCTYPE
+#: Merge.rc:517 Merge.rc:764
+msgid "Sw&ap Panes"
+msgstr "Panellərin yerini &dəyiş"
+
+#. IDR_MERGEDOCTYPE, ID_SWAPPANES_SWAP12
+#: Merge.rc:519 Merge.rc:766
+msgid "Swap &1st | 2nd"
+msgstr "&Birinci ilə ikincinin yerini dəyiş"
+
+#. IDR_MERGEDOCTYPE, ID_SWAPPANES_SWAP23
+#: Merge.rc:520 Merge.rc:767
+msgid "Swap &2nd | 3rd"
+msgstr "&İkinci ilə üçüncünün yerini dəyiş"
+
+#. IDR_MERGEDOCTYPE, ID_SWAPPANES_SWAP13
+#: Merge.rc:521 Merge.rc:768
+msgid "Swap 1st | &3rd"
+msgstr "Birinci ilə &üçüncünün yerini dəyiş"
+
+#. IDR_MERGEDOCTYPE, ID_VIEW_DISPLAY_FILTER_BAR_MENU
+#: Merge.rc:538 Merge.rc:786
+msgid "Displa&y Filter Bar\tCtrl+Shift+L"
+msgstr "Görüntü &süzgəci zolağı\tCtrl+Shift+L"
+
+#. IDR_DIRDOCTYPE, ID_VIEW_DIR_STATISTICS
+#: Merge.rc:542
+msgid "Com&pare Statistics..."
+msgstr "Müqayisə &statistikası..."
+
+#. IDR_MERGEDOCTYPE, ID_REFRESH
+#: Merge.rc:544 Merge.rc:792
+msgid "Refresh\tF5"
+msgstr "Yenilə\tF5"
+
+#. IDR_POPUP_DIRVIEW, ID_RESCAN
+#: Merge.rc:545 Merge.rc:1063
+msgid "&Refresh Selected\tCtrl+F5"
+msgstr "Seçilmişləri &yenilə\tCtrl+F5"
+
+#. IDR_MERGEDOCTYPE
+#: Merge.rc:547 Merge.rc:794
+msgid "&Merge"
+msgstr "&Birləşdirmə"
+
+#. IDR_DIRDOCTYPE, ID_MERGE_COMPARE
+#: Merge.rc:549
+msgid "Co&mpare\tEnter"
+msgstr "&Müqayisə et\tEnter"
+
+#. IDR_MERGEDOCTYPE, ID_NEXTDIFF
+#: Merge.rc:551 Merge.rc:796
+msgid "&Next Difference\tAlt+Down"
+msgstr "&Növbəti fərq\tAlt+Down"
+
+#. IDR_MERGEDOCTYPE, ID_PREVDIFF
+#: Merge.rc:552 Merge.rc:797
+msgid "&Previous Difference\tAlt+Up"
+msgstr "&Əvvəlki fərq\tAlt+Up"
+
+#. IDR_MERGEDOCTYPE, ID_FIRSTDIFF
+#: Merge.rc:554 Merge.rc:802
+msgid "&First Difference\tAlt+Home"
+msgstr "&İlk fərq\tAlt+Home"
+
+#. IDR_MERGEDOCTYPE, ID_CURDIFF
+#: Merge.rc:555 Merge.rc:803
+msgid "&Current Difference\tAlt+Enter"
+msgstr "&Cari fərq\tAlt+Enter"
+
+#. IDR_MERGEDOCTYPE, ID_LASTDIFF
+#: Merge.rc:556 Merge.rc:804
+msgid "&Last Difference\tAlt+End"
+msgstr "&Son fərq\tAlt+End"
+
+#. IDR_MERGEDOCTYPE, ID_L2R
+#: Merge.rc:558 Merge.rc:859
+msgid "Copy to &Right\tAlt+Right"
+msgstr "&Sağa köçür\tAlt+Right"
+
+#. IDR_MERGEDOCTYPE, ID_R2L
+#: Merge.rc:559 Merge.rc:860
+msgid "Copy to L&eft\tAlt+Left"
+msgstr "So&la köçür\tAlt+Left"
+
+#. IDR_DIRDOCTYPE, ID_MERGE_DELETE
+#: Merge.rc:561
+msgid "&Delete\tDel"
+msgstr "&Sil\tDel"
+
+#. IDR_POPUP_DIRVIEW, ID_TOOLS_CUSTOMIZECOLUMNS
+#: Merge.rc:565 Merge.rc:1075
+msgid "&Customize Columns..."
+msgstr "Sütunları &fərdiləşdir..."
+
+#. IDR_MERGEDOCTYPE, ID_TOOLS_GENERATEREPORT
+#: Merge.rc:568 Merge.rc:880
+msgid "Generate &Report..."
+msgstr "&Hesabat yarat..."
+
+#. IDD_ENCODINGERROR, IDC_PLUGIN
+#: Merge.rc:580 Merge.rc:897 Merge.rc:3397
+msgid "&Edit with Unpacker..."
+msgstr "&Açma qoşması ilə redaktə et..."
+
+#. IDR_MERGEDOCTYPE, ID_FILE_SAVE
+#: Merge.rc:637
+msgid "&Save\tCtrl+S"
+msgstr "&Saxla\tCtrl+S"
+
+#. IDR_MERGEDOCTYPE
+#: Merge.rc:638
+msgid "Sav&e"
+msgstr "Sa&xla"
+
+#. IDR_POPUP_SAVE, ID_FILE_SAVE_LEFT
+#: Merge.rc:640 Merge.rc:1246
+msgid "Save &Left"
+msgstr "&Solu saxla"
+
+#. IDR_POPUP_SAVE, ID_FILE_SAVE_MIDDLE
+#: Merge.rc:641 Merge.rc:1247
+msgid "Save &Middle"
+msgstr "&Ortanı saxla"
+
+#. IDR_POPUP_SAVE, ID_FILE_SAVE_RIGHT
+#: Merge.rc:642 Merge.rc:1248
+msgid "Save &Right"
+msgstr "&Sağı saxla"
+
+#. IDR_MERGEDOCTYPE
+#: Merge.rc:644
+msgid "Save &As"
+msgstr "&Fərqli saxla"
+
+#. IDR_POPUP_SAVE, ID_FILE_SAVEAS_LEFT
+#: Merge.rc:646 Merge.rc:1250
+msgid "Save &Left As..."
+msgstr "&Solu fərqli saxla..."
+
+#. IDR_POPUP_SAVE, ID_FILE_SAVEAS_MIDDLE
+#: Merge.rc:647 Merge.rc:1251
+msgid "Save &Middle As..."
+msgstr "&Ortanı fərqli saxla..."
+
+#. IDR_POPUP_SAVE, ID_FILE_SAVEAS_RIGHT
+#: Merge.rc:648 Merge.rc:1252
+msgid "Save &Right As..."
+msgstr "&Sağı fərqli saxla..."
+
+#. IDR_MERGEDOCTYPE, ID_FILE_PRINT
+#: Merge.rc:651
+msgid "&Print...\tCtrl+P"
+msgstr "&Çap et...\tCtrl+P"
+
+#. IDR_MERGEDOCTYPE, ID_FILE_PAGE_SETUP
+#: Merge.rc:652
+msgid "Page Set&up..."
+msgstr "Səhifə &parametrləri..."
+
+#. IDR_MERGEDOCTYPE, ID_FILE_PRINT_PREVIEW
+#: Merge.rc:653
+msgid "Print Previe&w..."
+msgstr "Çapa &baxış..."
+
+#. IDR_MERGEDOCTYPE
+#: Merge.rc:662
+msgid "&Convert Line Endings to"
+msgstr "&Sətir sonlarını çevir"
+
+#. IDR_MERGEDOCTYPE, ID_FILE_MERGINGMODE
+#: Merge.rc:669
+msgid "Mer&ge Mode\tF9"
+msgstr "&Birləşdirmə rejimi\tF9"
+
+#. IDR_MERGEDOCTYPE, ID_RESCAN
+#: Merge.rc:671
+msgid "Reloa&d\tCtrl+F5"
+msgstr "&Yenidən yüklə\tCtrl+F5"
+
+#. IDR_MERGEDOCTYPE
+#: Merge.rc:673
+msgid "Reco&mpare As"
+msgstr "&Fərqli üsulla yenidən müqayisə et"
+
+#. IDR_POPUP_COMPARE, ID_MERGE_COMPARE_FOLDER
+#: Merge.rc:680 Merge.rc:972 Merge.rc:1212
+msgid "A&rchive"
+msgstr "&Arxiv"
+
+#. IDR_MERGEDOCTYPE, ID_EDIT_UNDO
+#: Merge.rc:693
+msgid "&Undo\tCtrl+Z"
+msgstr "&Geri al\tCtrl+Z"
+
+#. IDR_MERGEDOCTYPE, ID_EDIT_REDO
+#: Merge.rc:694
+msgid "&Redo\tCtrl+Y"
+msgstr "&Yenidən et\tCtrl+Y"
+
+#. IDR_MERGEDOCTYPE, ID_EDIT_CUT
+#: Merge.rc:696
+msgid "Cu&t\tCtrl+X"
+msgstr "&Kəs\tCtrl+X"
+
+#. IDR_POPUP_OUTPUTVIEW, ID_EDIT_COPY
+#: Merge.rc:697 Merge.rc:1387
+msgid "&Copy\tCtrl+C"
+msgstr "&Köçür\tCtrl+C"
+
+#. IDR_MERGEDOCTYPE, ID_EDIT_FIND
+#: Merge.rc:703
+msgid "F&ind...\tCtrl+F"
+msgstr "&Tap...\tCtrl+F"
+
+#. IDR_MERGEDOCTYPE, ID_EDIT_REPLACE
+#: Merge.rc:704
+msgid "Repla&ce...\tCtrl+H"
+msgstr "&Əvəz et...\tCtrl+H"
+
+#. IDR_MERGEDOCTYPE, ID_EDIT_MARK
+#: Merge.rc:705
+msgid "&Marker...\tCtrl+Shift+M"
+msgstr "&İşarələyici...\tCtrl+Shift+M"
+
+#. IDR_MERGEDOCTYPE
+#: Merge.rc:707
+msgid "Advanced"
+msgstr "Əlavə"
+
+#. IDR_MERGEDOCTYPE, ID_EDIT_COPY_LINENUMBERS
+#: Merge.rc:709
+msgid "&Copy With Line Numbers\tCtrl+Shift+C"
+msgstr "Sətir nömrələri ilə &köçür\tCtrl+Shift+C"
+
+#. IDR_MERGEDOCTYPE
+#: Merge.rc:711
+msgid "&Bookmarks"
+msgstr "&Əlfəcinlər"
+
+#. IDR_MERGEDOCTYPE, ID_EDIT_TOGGLE_BOOKMARK
+#: Merge.rc:713
+msgid "&Toggle Bookmark\tCtrl+F2"
+msgstr "Əlfəcini &əlavə et/sil\tCtrl+F2"
+
+#. IDR_MERGEDOCTYPE, ID_EDIT_GOTO_NEXT_BOOKMARK
+#: Merge.rc:714
+msgid "&Next Bookmark\tF2"
+msgstr "&Növbəti əlfəcin\tF2"
+
+#. IDR_MERGEDOCTYPE, ID_EDIT_GOTO_PREV_BOOKMARK
+#: Merge.rc:715
+msgid "&Previous Bookmark\tShift+F2"
+msgstr "&Əvvəlki əlfəcin\tShift+F2"
+
+#. IDR_MERGEDOCTYPE, ID_EDIT_CLEAR_ALL_BOOKMARKS
+#: Merge.rc:716
+msgid "&Clear All Bookmarks"
+msgstr "Bütün əlfəcinləri &təmizlə"
+
+#. IDR_MERGEDOCTYPE
+#: Merge.rc:734
+msgid "Syntax Highlight"
+msgstr "Sintaksisin vurğulanması"
+
+#. IDR_MERGEDOCTYPE
+#: Merge.rc:739
+msgid "&Diff Context"
+msgstr "&Fərqin konteksti"
+
+#. IDR_MERGEDOCTYPE, ID_VIEW_DIFFCONTEXT_ALL
+#: Merge.rc:741
+msgid "&All Lines"
+msgstr "&Bütün sətirlər"
+
+#. IDR_POPUP_LINEFILTERMENU, ID_FILTERMENU_LINE_CONTEXT_0
+#: Merge.rc:743 Merge.rc:2056
+msgid "&0 Lines"
+msgstr "0 &sətir"
+
+#. IDR_POPUP_LINEFILTERMENU, ID_FILTERMENU_LINE_CONTEXT_1
+#: Merge.rc:744 Merge.rc:2057
+msgid "&1 Line"
+msgstr "1 &sətir"
+
+#. IDR_POPUP_LINEFILTERMENU, ID_FILTERMENU_LINE_CONTEXT_3
+#: Merge.rc:745 Merge.rc:2058
+msgid "&3 Lines"
+msgstr "3 &sətir"
+
+#. IDR_POPUP_LINEFILTERMENU, ID_FILTERMENU_LINE_CONTEXT_5
+#: Merge.rc:746 Merge.rc:2059
+msgid "&5 Lines"
+msgstr "5 &sətir"
+
+#. IDR_POPUP_LINEFILTERMENU, ID_FILTERMENU_LINE_CONTEXT_7
+#: Merge.rc:747 Merge.rc:2060
+msgid "&7 Lines"
+msgstr "7 &sətir"
+
+#. IDR_MERGEDOCTYPE, ID_VIEW_DIFFCONTEXT_9
+#: Merge.rc:748
+msgid "&9 Lines"
+msgstr "9 &sətir"
+
+#. IDR_MERGEDOCTYPE, ID_VIEW_DIFFCONTEXT_TOGGLE
+#: Merge.rc:750
+msgid "&Toggle All and 0-9 Lines\tCtrl+D"
+msgstr "Bütün sətirlər və 0-9 sətir arasında &keçid et\tCtrl+D"
+
+#. IDR_MERGEDOCTYPE, ID_VIEW_DIFFCONTEXT_INVERT
+#: Merge.rc:752
+msgid "&Invert (Hide Different Lines)"
+msgstr "&Tərsinə çevir (fərqli sətirləri gizlət)"
+
+#. IDR_MERGEDOCTYPE, ID_VIEW_RESIZE_PANES
+#: Merge.rc:755
+msgid "&Lock Panes"
+msgstr "Panelləri &kilidlə"
+
+#. IDR_MERGEDOCTYPE, ID_VIEW_WHITESPACE
+#: Merge.rc:756
+msgid "&View Whitespace"
+msgstr "&Boşluq simvollarını göstər"
+
+#. IDR_MERGEDOCTYPE, ID_VIEW_EOL
+#: Merge.rc:757
+msgid "View E&OL"
+msgstr "&Sətir sonlarını göstər"
+
+#. IDR_MERGEDOCTYPE, ID_VIEW_LINEDIFFS
+#: Merge.rc:758
+msgid "Vie&w Line Differences"
+msgstr "Sətir &fərqlərini göstər"
+
+#. IDR_MERGEDOCTYPE, ID_VIEW_LINENUMBERS
+#: Merge.rc:759
+msgid "View Line &Numbers"
+msgstr "Sətir &nömrələrini göstər"
+
+#. IDR_MERGEDOCTYPE, ID_VIEW_SELMARGIN
+#: Merge.rc:760
+msgid "View &Margins"
+msgstr "&Kənar sahələri göstər"
+
+#. IDR_MERGEDOCTYPE, ID_VIEW_TOPMARGIN
+#: Merge.rc:761
+msgid "View To&p Margins"
+msgstr "&Üst kənar sahələri göstər"
+
+#. IDR_MERGEDOCTYPE, ID_VIEW_WORDWRAP
+#: Merge.rc:762
+msgid "W&rap Lines"
+msgstr "Sətirləri &bük"
+
+#. IDR_MERGEDOCTYPE, ID_VIEW_SPLITVERTICALLY
+#: Merge.rc:770
+msgid "Split V&ertically"
+msgstr "&Şaquli böl"
+
+#. IDR_MERGEDOCTYPE, ID_VIEW_DETAIL_BAR
+#: Merge.rc:788
+msgid "Diff &Pane"
+msgstr "&Fərq paneli"
+
+#. IDR_MERGEDOCTYPE, ID_VIEW_LOCATION_BAR
+#: Merge.rc:789
+msgid "Lo&cation Pane"
+msgstr "&Mövqe paneli"
+
+#. IDS_OUTPUTBAR_CAPTION
+#: Merge.rc:790 Merge.rc:5263
+msgid "Output Pane"
+msgstr "Çıxış paneli"
+
+#. IDR_MERGEDOCTYPE, ID_NEXTCONFLICT
+#: Merge.rc:799
+msgid "Ne&xt Conflict\tAlt+Shift+Down"
+msgstr "&Növbəti ziddiyyət\tAlt+Shift+Down"
+
+#. IDR_MERGEDOCTYPE, ID_PREVCONFLICT
+#: Merge.rc:800
+msgid "Pre&vious Conflict\tAlt+Shift+Up"
+msgstr "&Əvvəlki ziddiyyət\tAlt+Shift+Up"
+
+#. IDR_MERGEDOCTYPE
+#: Merge.rc:806
+msgid "A&dvanced"
+msgstr "&Əlavə"
+
+#. IDR_MERGEDOCTYPE, ID_NEXTDIFFLM
+#: Merge.rc:808
+msgid "Next Difference (Left/Middle)\tAlt+1"
+msgstr "Növbəti fərq (sol/orta)\tAlt+1"
+
+#. IDR_MERGEDOCTYPE, ID_PREVDIFFLM
+#: Merge.rc:809
+msgid "Previous Difference (Left/Middle)\tAlt+Shift+1"
+msgstr "Əvvəlki fərq (sol/orta)\tAlt+Shift+1"
+
+#. IDR_MERGEDOCTYPE, ID_NEXTDIFFLR
+#: Merge.rc:811
+msgid "Next Difference (Left/Right)\tAlt+2"
+msgstr "Növbəti fərq (sol/sağ)\tAlt+2"
+
+#. IDR_MERGEDOCTYPE, ID_PREVDIFFLR
+#: Merge.rc:812
+msgid "Previous Difference (Left/Right)\tAlt+Shift+2"
+msgstr "Əvvəlki fərq (sol/sağ)\tAlt+Shift+2"
+
+#. IDR_MERGEDOCTYPE, ID_NEXTDIFFMR
+#: Merge.rc:814
+msgid "Next Difference (Middle/Right)\tAlt+3"
+msgstr "Növbəti fərq (orta/sağ)\tAlt+3"
+
+#. IDR_MERGEDOCTYPE, ID_PREVDIFFMR
+#: Merge.rc:815
+msgid "Previous Difference (Middle/Right)\tAlt+Shift+3"
+msgstr "Əvvəlki fərq (orta/sağ)\tAlt+Shift+3"
+
+#. IDR_MERGEDOCTYPE, ID_NEXTDIFFLO
+#: Merge.rc:817
+msgid "Next Left-Only Difference\tAlt+7"
+msgstr "Yalnız soldakı növbəti fərq\tAlt+7"
+
+#. IDR_MERGEDOCTYPE, ID_PREVDIFFLO
+#: Merge.rc:818
+msgid "Previous Left-Only Difference\tAlt+Shift+7"
+msgstr "Yalnız soldakı əvvəlki fərq\tAlt+Shift+7"
+
+#. IDR_MERGEDOCTYPE, ID_NEXTDIFFMO
+#: Merge.rc:820
+msgid "Next Middle-Only Difference\tAlt+8"
+msgstr "Yalnız ortadakı növbəti fərq\tAlt+8"
+
+#. IDR_MERGEDOCTYPE, ID_PREVDIFFMO
+#: Merge.rc:821
+msgid "Previous Middle-Only Difference\tAlt+Shift+8"
+msgstr "Yalnız ortadakı əvvəlki fərq\tAlt+Shift+8"
+
+#. IDR_MERGEDOCTYPE, ID_NEXTDIFFRO
+#: Merge.rc:823
+msgid "Next Right-Only Difference\tAlt+9"
+msgstr "Yalnız sağdakı növbəti fərq\tAlt+9"
+
+#. IDR_MERGEDOCTYPE, ID_PREVDIFFRO
+#: Merge.rc:824
+msgid "Previous Right-Only Difference\tAlt+Shift+9"
+msgstr "Yalnız sağdakı əvvəlki fərq\tAlt+Shift+9"
+
+#. IDR_MERGEDOCTYPE
+#: Merge.rc:826
+msgid "Copy from &Left to"
+msgstr "&Soldan köçür:"
+
+#. IDD_LOAD_SAVE_CODEPAGE, IDC_AFFECTS_MIDDLE_BTN
+#: Merge.rc:828 Merge.rc:839 Merge.rc:844 Merge.rc:855 Merge.rc:1003
+#: Merge.rc:2820 Merge.rc:3149
+msgid "&Middle"
+msgstr "&Orta"
+
+#. IDD_LOAD_SAVE_CODEPAGE, IDC_AFFECTS_RIGHT_BTN
+#: Merge.rc:829 Merge.rc:834 Merge.rc:845 Merge.rc:850 Merge.rc:1004
+#: Merge.rc:2821 Merge.rc:3151
+msgid "&Right"
+msgstr "&Sağ"
+
+#. IDR_MERGEDOCTYPE
+#: Merge.rc:831
+msgid "Copy from &Middle to"
+msgstr "&Ortadan köçür:"
+
+#. IDD_LOAD_SAVE_CODEPAGE, IDC_AFFECTS_LEFT_BTN
+#: Merge.rc:833 Merge.rc:838 Merge.rc:849 Merge.rc:854 Merge.rc:1002
+#: Merge.rc:2819 Merge.rc:3147
+msgid "&Left"
+msgstr "&Sol"
+
+#. IDR_MERGEDOCTYPE
+#: Merge.rc:836
+msgid "Copy from &Right to"
+msgstr "&Sağdan köçür:"
+
+#. IDR_MERGEDOCTYPE
+#: Merge.rc:842
+msgid "Copy Selected Lines from Le&ft to"
+msgstr "Seçilmiş sətirləri &soldan köçür:"
+
+#. IDR_MERGEDOCTYPE
+#: Merge.rc:847
+msgid "Copy Selected Lines from Mi&ddle to"
+msgstr "Seçilmiş sətirləri &ortadan köçür:"
+
+#. IDR_MERGEDOCTYPE
+#: Merge.rc:852
+msgid "Copy Selected Lines from Ri&ght to"
+msgstr "Seçilmiş sətirləri s&ağdan köçür:"
+
+#. IDR_MERGEDOCTYPE, ID_COPY_FROM_LEFT
+#: Merge.rc:862
+msgid "Copy from Left\tAlt+Shift+Right"
+msgstr "Soldan köçür\tAlt+Shift+Right"
+
+#. IDR_MERGEDOCTYPE, ID_COPY_FROM_RIGHT
+#: Merge.rc:863
+msgid "Copy from Right\tAlt+Shift+Left"
+msgstr "Sağdan köçür\tAlt+Shift+Left"
+
+#. IDR_MERGEDOCTYPE, ID_L2RNEXT
+#: Merge.rc:865
+msgid "C&opy to Right and Advance\tCtrl+Alt+Right"
+msgstr "Sağa &köçür və irəlilə\tCtrl+Alt+Right"
+
+#. IDR_MERGEDOCTYPE, ID_R2LNEXT
+#: Merge.rc:866
+msgid "Copy &to Left and Advance\tCtrl+Alt+Left"
+msgstr "Sola &köçür və irəlilə\tCtrl+Alt+Left"
+
+#. IDR_MERGEDOCTYPE, ID_ALL_RIGHT
+#: Merge.rc:868
+msgid "Copy &All to Right"
+msgstr "&Hamısını sağa köçür"
+
+#. IDR_MERGEDOCTYPE, ID_ALL_LEFT
+#: Merge.rc:869
+msgid "Cop&y All to Left"
+msgstr "Hamısını so&la köçür"
+
+#. IDR_MERGEDOCTYPE, ID_AUTO_MERGE
+#: Merge.rc:871
+msgid "A&uto Merge\tCtrl+Alt+M"
+msgstr "&Avtomatik birləşdir\tCtrl+Alt+M"
+
+#. IDR_MERGEDOCTYPE, ID_ADD_SYNCPOINT
+#: Merge.rc:873
+msgid "Add &Synchronization Point\tAlt+S"
+msgstr "&Sinxronlaşdırma nöqtəsi əlavə et\tAlt+S"
+
+#. IDR_MERGEDOCTYPE, ID_CLEAR_SYNCPOINTS
+#: Merge.rc:874
+msgid "Clear Sync&hronization Points"
+msgstr "Sinxronlaşdırma nöqtələrini &təmizlə"
+
+#. IDR_MERGEDOCTYPE, ID_TOOLS_GENERATEARCHIVE
+#: Merge.rc:881
+msgid "Generate &Archive..."
+msgstr "&Arxiv yarat..."
+
+#. IDR_MERGEDOCTYPE
+#: Merge.rc:893
+msgid "Unpac&ker"
+msgstr "&Açma qoşması"
+
+#. IDR_MERGEDOCTYPE
+#: Merge.rc:899
+msgid "&Prediffer"
+msgstr "&İlkin müqayisə emalı qoşması"
+
+#. IDR_MERGEDOCTYPE, ID_APPLY_PREDIFFER
+#: Merge.rc:903
+msgid "Apply Pre&differ..."
+msgstr "&İlkin müqayisə emalını tətbiq et..."
+
+#. IDR_MERGEDOCTYPE, ID_TRANSFORM_WITH_SCRIPT
+#: Merge.rc:909
+msgid "&Transform with Editor Script..."
+msgstr "Redaktor skripti ilə &çevir..."
+
+#. IDR_MERGEDOCTYPE
+#: Merge.rc:910
+msgid "Scripts for &Copying"
+msgstr "&Köçürmə skriptləri"
+
+#. IDR_MERGEDOCTYPE, ID_SELECT_EDITOR_SCRIPT_FOR_COPYING
+#: Merge.rc:916
+msgid "Select &Editor Script..."
+msgstr "&Redaktor skripti seç..."
+
+#. IDR_MERGEDOCTYPE, ID_WINDOW_SPLIT
+#: Merge.rc:928
+msgid "Sp&lit"
+msgstr "&Böl"
+
+#. IDR_MERGEDOCTYPE, ID_WINDOW_PRESERVE_SPLITTER_RATIOS
+#: Merge.rc:934
+msgid "P&reserve Splitter Position"
+msgstr "Bölücünün mövqeyini &saxla"
+
+#. IDR_POPUP_DIRVIEW, ID_MERGE_COMPARE
+#: Merge.rc:953
+msgid "Comp&are"
+msgstr "&Müqayisə et"
+
+#. IDR_POPUP_DIRVIEW, ID_MERGE_COMPARE_WITH_MOVED_RENAMED
+#: Merge.rc:954
+msgid "Compar&e with Renamed/Moved Items"
+msgstr "Adı/yeri dəyişdirilmiş elementlərlə &müqayisə et"
+
+#. IDR_POPUP_DIRVIEW, ID_MERGE_COMPARE_IN_NEW_WINDOW
+#: Merge.rc:955
+msgid "Compare in New &Window"
+msgstr "Yeni &pəncərədə müqayisə et"
+
+#. IDR_POPUP_DIRVIEW, ID_MERGE_COMPARE_NONHORIZONTALLY
+#: Merge.rc:956 Merge.rc:963
+msgid "Compare Non-hor&izontally..."
+msgstr "&Üfüqi olmayan müqayisə..."
+
+#. IDR_POPUP_DIRVIEW
+#: Merge.rc:957
+msgid "Compare Non-hor&izontally"
+msgstr "&Üfüqi olmayan müqayisə"
+
+#. IDR_POPUP_DIRVIEW, ID_MERGE_COMPARE_LEFT1_LEFT2
+#: Merge.rc:959
+msgid "First &Left with Second Left"
+msgstr "Birinci &solu ikinci solla"
+
+#. IDR_POPUP_DIRVIEW, ID_MERGE_COMPARE_RIGHT1_RIGHT2
+#: Merge.rc:960
+msgid "First &Right with Second Right"
+msgstr "Birinci &sağı ikinci sağla"
+
+#. IDR_POPUP_DIRVIEW, ID_MERGE_COMPARE_LEFT1_RIGHT2
+#: Merge.rc:961
+msgid "&First Left with Second Right"
+msgstr "&Birinci solu ikinci sağla"
+
+#. IDR_POPUP_DIRVIEW, ID_MERGE_COMPARE_LEFT2_RIGHT1
+#: Merge.rc:962
+msgid "&Second Left with First Right"
+msgstr "&İkinci solu birinci sağla"
+
+#. IDR_POPUP_DIRVIEW
+#: Merge.rc:965
+msgid "Co&mpare As"
+msgstr "&Müqayisə üsulu"
+
+#. IDS_COPY_LEFT_TO_MIDDLE2
+#: Merge.rc:978 Merge.rc:990 Merge.rc:4863
+#, c-format
+msgid "Left to Middle (%1 of %2)"
+msgstr "Soldan ortaya (%1 / %2)"
+
+#. IDS_COPY_LEFT_TO_RIGHT2
+#: Merge.rc:979 Merge.rc:991 Merge.rc:4862
+#, c-format
+msgid "Left to Right (%1 of %2)"
+msgstr "Soldan sağa (%1 / %2)"
+
+#. IDS_MOVE_LEFT_TO2
+#: Merge.rc:980 Merge.rc:992 Merge.rc:1055 Merge.rc:4874 Merge.rc:4903
+#, c-format
+msgid "Left to... (%1 of %2)"
+msgstr "Soldan buraya... (%1 / %2)"
+
+#. IDS_COPY_MIDDLE_TO_LEFT2
+#: Merge.rc:981 Merge.rc:993 Merge.rc:4860
+#, c-format
+msgid "Middle to Left (%1 of %2)"
+msgstr "Ortadan sola (%1 / %2)"
+
+#. IDS_COPY_MIDDLE_TO_RIGHT2
+#: Merge.rc:982 Merge.rc:994 Merge.rc:4861
+#, c-format
+msgid "Middle to Right (%1 of %2)"
+msgstr "Ortadan sağa (%1 / %2)"
+
+#. IDS_MOVE_MIDDLE_TO2
+#: Merge.rc:983 Merge.rc:995 Merge.rc:1056 Merge.rc:4875 Merge.rc:4904
+#, c-format
+msgid "Middle to... (%1 of %2)"
+msgstr "Ortadan buraya... (%1 / %2)"
+
+#. IDS_COPY_RIGHT_TO_MIDDLE2
+#: Merge.rc:984 Merge.rc:996 Merge.rc:4859
+#, c-format
+msgid "Right to Middle (%1 of %2)"
+msgstr "Sağdan ortaya (%1 / %2)"
+
+#. IDS_COPY_RIGHT_TO_LEFT2
+#: Merge.rc:985 Merge.rc:997 Merge.rc:4858
+#, c-format
+msgid "Right to Left (%1 of %2)"
+msgstr "Sağdan sola (%1 / %2)"
+
+#. IDS_MOVE_RIGHT_TO2
+#: Merge.rc:986 Merge.rc:998 Merge.rc:1057 Merge.rc:4876 Merge.rc:4905
+#, c-format
+msgid "Right to... (%1 of %2)"
+msgstr "Sağdan buraya... (%1 / %2)"
+
+#. IDD_EDIT_MARKER, IDC_EDIT_MARKER_DELETE
+#: Merge.rc:1000 Merge.rc:2307
+msgid "&Delete"
+msgstr "&Sil"
+
+#. IDR_POPUP_DIRVIEW, ID_DIR_DEL_BOTH
+#: Merge.rc:1005
+msgid "&Both"
+msgstr "&Hər ikisi"
+
+#. IDR_POPUP_DIRVIEW, ID_DIR_DEL_ALL
+#: Merge.rc:1006
+msgid "&All"
+msgstr "&Hamısı"
+
+#. IDD_EDIT_REPLACE, IDC_EDIT_SCOPE_SELECTION
+#: Merge.rc:1007 Merge.rc:2290
+msgid "&Selection"
+msgstr "&Seçim"
+
+#. IDR_POPUP_DIRVIEW, ID_DIR_ITEM_RENAME
+#: Merge.rc:1009
+msgid "Re&name"
+msgstr "&Adını dəyiş"
+
+#. IDR_POPUP_DIRVIEW, ID_DIR_HIDE_FILENAMES
+#: Merge.rc:1010
+msgid "&Hide Items"
+msgstr "Elementləri &gizlət"
+
+#. IDR_POPUP_DIRVIEW
+#: Merge.rc:1012
+msgid "&Open Left"
+msgstr "&Solu aç"
+
+#. IDR_POPUP_DIRVIEW
+#: Merge.rc:1019
+msgid "Open Midd&le"
+msgstr "&Ortanı aç"
+
+#. IDR_POPUP_DIRVIEW
+#: Merge.rc:1026
+msgid "O&pen Right"
+msgstr "S&ağı aç"
+
+#. IDR_POPUP_DIRVIEW
+#: Merge.rc:1034
+msgid "Cop&y Paths"
+msgstr "&Yolları köçür"
+
+#. IDS_DEL_LEFT_FMT2
+#: Merge.rc:1036 Merge.rc:1045 Merge.rc:4891
+#, c-format
+msgid "Left (%1 of %2)"
+msgstr "Sol (%1 / %2)"
+
+#. IDS_DEL_MIDDLE_FMT2
+#: Merge.rc:1037 Merge.rc:1046 Merge.rc:4892
+#, c-format
+msgid "Middle (%1 of %2)"
+msgstr "Orta (%1 / %2)"
+
+#. IDS_DEL_RIGHT_FMT2
+#: Merge.rc:1038 Merge.rc:1047 Merge.rc:4893
+#, c-format
+msgid "Right (%1 of %2)"
+msgstr "Sağ (%1 / %2)"
+
+#. IDS_DEL_BOTH_FMT2
+#: Merge.rc:1039 Merge.rc:1048 Merge.rc:4894
+#, c-format
+msgid "Both (%1 of %2)"
+msgstr "Hər ikisi (%1 / %2)"
+
+#. IDS_DEL_ALL_FMT2
+#: Merge.rc:1040 Merge.rc:1049 Merge.rc:4899
+#, c-format
+msgid "All (%1 of %2)"
+msgstr "Hamısı (%1 / %2)"
+
+#. IDR_POPUP_DIRVIEW, ID_DIR_COPY_FILENAMES
+#: Merge.rc:1042
+msgid "Copy &Filenames"
+msgstr "&Fayl adlarını köçür"
+
+#. IDR_POPUP_DIRVIEW
+#: Merge.rc:1043
+msgid "Copy Items to Clip&board"
+msgstr "Elementləri mübadilə &buferinə köçür"
+
+#. IDR_POPUP_DIRVIEW, ID_DIR_COPY_ALL_DISP_COLUMNS
+#: Merge.rc:1051
+msgid "Copy All Di&splayed Columns"
+msgstr "Göstərilən bütün &sütunları köçür"
+
+#. IDR_POPUP_DIRVIEW
+#: Merge.rc:1053
+msgid "&Zip"
+msgstr "&Zip"
+
+#. IDS_COPY_BOTH_TO2
+#: Merge.rc:1058 Merge.rc:4877
+#, c-format
+msgid "Both to... (%1 of %2)"
+msgstr "Hər ikisini buraya... (%1 / %2)"
+
+#. IDS_COPY_ALL_TO2
+#: Merge.rc:1059 Merge.rc:4878
+#, c-format
+msgid "All to... (%1 of %2)"
+msgstr "Hamısını buraya... (%1 / %2)"
+
+#. IDS_COPY_DIFFERENCES_TO2
+#: Merge.rc:1060 Merge.rc:4879
+#, c-format
+msgid "Differences to... (%1 of %2)"
+msgstr "Fərqləri buraya... (%1 / %2)"
+
+#. IDR_POPUP_DIRVIEW, ID_DIR_SHELL_CONTEXT_MENU_LEFT
+#: Merge.rc:1065
+msgid "Left Shell Menu"
+msgstr "Sol örtük menyusu"
+
+#. IDR_POPUP_DIRVIEW, ID_DIR_SHELL_CONTEXT_MENU_MIDDLE
+#: Merge.rc:1066
+msgid "Middle Shell Menu"
+msgstr "Orta örtük menyusu"
+
+#. IDR_POPUP_DIRVIEW, ID_DIR_SHELL_CONTEXT_MENU_RIGHT
+#: Merge.rc:1067
+msgid "Right Shell Menu"
+msgstr "Sağ örtük menyusu"
+
+#. IDR_POPUP_DIRVIEW, ID_DIR_SHELL_CONTEXT_MENU_BOTH
+#: Merge.rc:1068
+msgid "Both Shell Menu"
+msgstr "Hər ikisinin örtük menyusu"
+
+#. IDR_POPUP_DIRVIEW, ID_DIR_SHELL_CONTEXT_MENU_ALL
+#: Merge.rc:1069
+msgid "All Shell Menu"
+msgstr "Hamısının örtük menyusu"
+
+#. IDR_POPUP_EDITOR_HEADERBAR, ID_EDITOR_COPY
+#: Merge.rc:1083
+msgid "Copy"
+msgstr "Köçür"
+
+#. IDR_POPUP_EDITOR_HEADERBAR, ID_EDITOR_COPY_PATH
+#: Merge.rc:1084
+msgid "&Copy Full Path"
+msgstr "Tam yolu &köçür"
+
+#. IDR_POPUP_EDITOR_HEADERBAR, ID_EDITOR_COPY_FILENAME
+#: Merge.rc:1085
+msgid "Copy &Filename"
+msgstr "&Fayl adını köçür"
+
+#. IDR_POPUP_EDITOR_HEADERBAR, ID_EDITOR_EDIT_CAPTION
+#: Merge.rc:1086
+msgid "&Edit Caption\tF2"
+msgstr "&Başlığı redaktə et\tF2"
+
+#. IDR_POPUP_EDITOR_HEADERBAR, ID_EDITOR_EDIT_PATH
+#: Merge.rc:1088
+msgid "Edit &Path\tCtrl+L"
+msgstr "&Yolu redaktə et\tCtrl+L"
+
+#. IDR_POPUP_EDITOR_HEADERBAR, ID_EDITOR_SELECT_FILE
+#: Merge.rc:1090
+msgid "&Open..."
+msgstr "&Aç..."
+
+#. IDR_POPUP_PLUGINS_SETTINGS
+#: Merge.rc:1096
+msgid "Unpacker Settings"
+msgstr "Açma qoşmasının parametrləri"
+
+#. IDS_USERCHOICE_NONE
+#: Merge.rc:1098 Merge.rc:1104 Merge.rc:1846 Merge.rc:1850 Merge.rc:2041
+#: Merge.rc:2045 Merge.rc:5388
+msgid "<None>"
+msgstr "<Heç biri>"
+
+#. IDS_USERCHOICE_AUTOMATIC
+#: Merge.rc:1099 Merge.rc:1105 Merge.rc:5389
+msgid "<Automatic>"
+msgstr "<Avtomatik>"
+
+#. IDD_OPEN, IDC_SELECT_PREDIFFER
+#: Merge.rc:1100 Merge.rc:1106 Merge.rc:2241 Merge.rc:2245
+msgid "&Select..."
+msgstr "&Seç..."
+
+#. IDR_POPUP_PLUGINS_SETTINGS
+#: Merge.rc:1102
+msgid "Prediffer Settings"
+msgstr "İlkin müqayisə emalının parametrləri"
+
+#. IDR_POPUP_LOCATIONBAR, ID_LOCBAR_GOTODIFF
+#: Merge.rc:1114
+msgid "G&o to Diff"
+msgstr "Fərqə &keç"
+
+#. IDR_POPUP_LOCATIONBAR, ID_LOCBAR_MOVECURSOR_ONCLICK
+#: Merge.rc:1118
+msgid "Move Cursor on &Click"
+msgstr "&Klikləyəndə kursoru daşı"
+
+#. IDR_POPUP_LOCATIONBAR, ID_DISPLAY_MOVED_NONE
+#: Merge.rc:1120
+msgid "&No Moved Blocks"
+msgstr "Yeri dəyişdirilmiş blokları &göstərmə"
+
+#. IDR_POPUP_LOCATIONBAR, ID_DISPLAY_MOVED_ALL
+#: Merge.rc:1121
+msgid "&All Moved Blocks"
+msgstr "Yeri dəyişdirilmiş &bütün bloklar"
+
+#. IDR_POPUP_PROJECT_DIFF_OPTIONS
+#: Merge.rc:1129 Merge.rc:1162
+msgid "W&hitespaces"
+msgstr "&Boşluq simvolları"
+
+#. IDR_POPUP_PROJECT_DIFF_OPTIONS, ID_PROJECT_DIFF_OPTIONS_WHITESPACE_COMPARE
+#: Merge.rc:1131 Merge.rc:1164
+msgid "Com&pare"
+msgstr "&Müqayisə et"
+
+#. IDR_POPUP_PROJECT_DIFF_OPTIONS, ID_PROJECT_DIFF_OPTIONS_WHITESPACE_IGNORE
+#: Merge.rc:1132 Merge.rc:1165
+msgid "I&gnore Changes"
+msgstr "Dəyişiklikləri &nəzərə alma"
+
+#. IDR_POPUP_PROJECT_DIFF_OPTIONS, ID_PROJECT_DIFF_OPTIONS_WHITESPACE_IGNOREALL
+#: Merge.rc:1133 Merge.rc:1166
+msgid "Ig&nore All"
+msgstr "&Heç birini nəzərə alma"
+
+#. IDR_POPUP_PROJECT_DIFF_OPTIONS, ID_PROJECT_DIFF_OPTIONS_IGNORE_BLANKLINES
+#: Merge.rc:1135 Merge.rc:1168
+msgid "Ignore Blan&k Lines"
+msgstr "&Boş sətirləri nəzərə alma"
+
+#. IDR_POPUP_PROJECT_DIFF_OPTIONS, ID_PROJECT_DIFF_OPTIONS_IGNORE_CASE
+#: Merge.rc:1136 Merge.rc:1169
+msgid "Ignore &Case"
+msgstr "Böyük-kiçik &hərf fərqini nəzərə alma"
+
+#. IDR_POPUP_PROJECT_DIFF_OPTIONS, ID_PROJECT_DIFF_OPTIONS_IGNORE_EOL
+#: Merge.rc:1137 Merge.rc:1170
+msgid "Igno&re EOL Differences (Windows/Unix/Mac)"
+msgstr "&Sətir sonu fərqlərini nəzərə alma (Windows/Unix/Mac)"
+
+#. IDR_POPUP_PROJECT_DIFF_OPTIONS, ID_PROJECT_DIFF_OPTIONS_IGNORE_CODEPAGE
+#: Merge.rc:1138 Merge.rc:1171
+msgid "Ignore Codepage &Differences"
+msgstr "Kod səhifəsi &fərqlərini nəzərə alma"
+
+#. IDR_POPUP_PROJECT_DIFF_OPTIONS, ID_PROJECT_DIFF_OPTIONS_IGNORE_NUMBERS
+#: Merge.rc:1139 Merge.rc:1172
+msgid "Ignore Num&bers"
+msgstr "&Ədədləri nəzərə alma"
+
+#. IDR_POPUP_PROJECT_DIFF_OPTIONS, ID_PROJECT_DIFF_OPTIONS_IGNORE_COMMENTS
+#: Merge.rc:1140 Merge.rc:1173
+msgid "Ignore C&omment Differences"
+msgstr "&Şərh fərqlərini nəzərə alma"
+
+#. IDR_POPUP_PROJECT_DIFF_OPTIONS, ID_PROJECT_DIFF_OPTIONS_IGNORE_MISSING_TRAILING_EOL
+#: Merge.rc:1141 Merge.rc:1174
+msgid "Ignore &Missing Trailing EOL"
+msgstr "&Sonda çatışmayan sətir sonunu nəzərə alma"
+
+#. IDR_POPUP_PROJECT_DIFF_OPTIONS, ID_PROJECT_DIFF_OPTIONS_IGNORE_LINE_BREAKS
+#: Merge.rc:1142 Merge.rc:1175
+msgid "Ignore Line &Breaks (Treat as Spaces)"
+msgstr "Sətir &bölünmələrini nəzərə alma (boşluq say)"
+
+#. IDD_PROPPAGE_COMPARE_FOLDER, IDC_RECURS_CHECK
+#: Merge.rc:1144 Merge.rc:3295
+msgid "&Include Subfolders"
+msgstr "Alt qovluqları &daxil et"
+
+#. IDR_POPUP_PROJECT_DIFF_OPTIONS
+#: Merge.rc:1145 Merge.rc:1177
+msgid "&Compare Method"
+msgstr "&Müqayisə üsulu"
+
+#. IDS_COMPMETHOD_FULL_CONTENTS
+#: Merge.rc:1147 Merge.rc:1179 Merge.rc:1373 Merge.rc:4643
+msgid "Full Contents"
+msgstr "Tam məzmun"
+
+#. IDS_COMPMETHOD_QUICK_CONTENTS
+#: Merge.rc:1148 Merge.rc:1180 Merge.rc:1374 Merge.rc:4644
+msgid "Quick Contents"
+msgstr "Sürətli məzmun"
+
+#. IDS_COMPMETHOD_BINARY_CONTENTS
+#: Merge.rc:1149 Merge.rc:1181 Merge.rc:1375 Merge.rc:4645
+msgid "Binary Contents"
+msgstr "İkilik məzmun"
+
+#. IDS_COMPMETHOD_MODDATE
+#: Merge.rc:1150 Merge.rc:1182 Merge.rc:1376 Merge.rc:4646
+msgid "Modified Date"
+msgstr "Dəyişdirilmə tarixi"
+
+#. IDS_COMPMETHOD_DATESIZE
+#: Merge.rc:1151 Merge.rc:1183 Merge.rc:1377 Merge.rc:4647
+msgid "Modified Date and Size"
+msgstr "Dəyişdirilmə tarixi və ölçü"
+
+#. IDS_COMPMETHOD_SIZE
+#: Merge.rc:1152 Merge.rc:1184 Merge.rc:1378 Merge.rc:4648
+msgid "Size"
+msgstr "Ölçü"
+
+#. IDS_COMPMETHOD_EXISTENCE
+#: Merge.rc:1153 Merge.rc:1185 Merge.rc:1379 Merge.rc:4649
+msgid "Existence"
+msgstr "Mövcudluq"
+
+#. IDR_POPUP_PROJECT, ID_LOAD_PROJECT
+#: Merge.rc:1237
+msgid "&Load Project..."
+msgstr "Layihəni &yüklə..."
+
+#. IDR_POPUP_PLUGIN_COMMAND_LINE_MENU, ID_PLUGIN_COMMAND_LINE_ARGALL
+#: Merge.rc:1317 Merge.rc:1346
+msgid "${*} - All Arguments"
+msgstr "${*} - Bütün arqumentlər"
+
+#. IDR_POPUP_PLUGIN_COMMAND_LINE_MENU, ID_PLUGIN_COMMAND_LINE_ARG1
+#: Merge.rc:1318 Merge.rc:1347
+msgid "${1} - First Argument"
+msgstr "${1} - Birinci arqument"
+
+#. IDR_POPUP_PLUGIN_COMMAND_LINE_MENU, ID_PLUGIN_COMMAND_LINE_ARG2
+#: Merge.rc:1319 Merge.rc:1348
+msgid "${2} - Second Argument"
+msgstr "${2} - İkinci arqument"
+
+#. IDR_POPUP_PLUGIN_COMMAND_LINE_MENU, ID_PLUGIN_COMMAND_LINE_ARG3
+#: Merge.rc:1320 Merge.rc:1349
+msgid "${3} - Third Argument"
+msgstr "${3} - Üçüncü arqument"
+
+#. IDR_POPUP_PLUGIN_COMMAND_LINE_MENU, ID_PLUGIN_COMMAND_LINE_ARG4
+#: Merge.rc:1321 Merge.rc:1350
+msgid "${4} - Fourth Argument"
+msgstr "${4} - Dördüncü arqument"
+
+#. IDR_POPUP_PLUGIN_COMMAND_LINE_MENU, ID_PLUGIN_COMMAND_LINE_ARG5
+#: Merge.rc:1322 Merge.rc:1351
+msgid "${5} - Fifth Argument"
+msgstr "${5} - Beşinci arqument"
+
+#. IDR_POPUP_PLUGIN_COMMAND_LINE_MENU, ID_PLUGIN_COMMAND_LINE_ARG6
+#: Merge.rc:1323 Merge.rc:1352
+msgid "${6} - Sixth Argument"
+msgstr "${6} - Altıncı arqument"
+
+#. IDR_POPUP_PLUGIN_COMMAND_LINE_MENU, ID_PLUGIN_COMMAND_LINE_ARG7
+#: Merge.rc:1324 Merge.rc:1353
+msgid "${7} - Seventh Argument"
+msgstr "${7} - Yeddinci arqument"
+
+#. IDR_POPUP_PLUGIN_COMMAND_LINE_MENU, ID_PLUGIN_COMMAND_LINE_ARG8
+#: Merge.rc:1325 Merge.rc:1354
+msgid "${8} - Eighth Argument"
+msgstr "${8} - Səkkizinci arqument"
+
+#. IDR_POPUP_PLUGIN_COMMAND_LINE_MENU, ID_PLUGIN_COMMAND_LINE_ARG9
+#: Merge.rc:1326 Merge.rc:1355
+msgid "${9} - Ninth Argument"
+msgstr "${9} - Doqquzuncu arqument"
+
+#. IDR_POPUP_PLUGIN_COMMAND_LINE_MENU, ID_PLUGIN_COMMAND_LINE_SRC_FILE
+#: Merge.rc:1334
+msgid "${SRC_FILE} - Source File"
+msgstr "${SRC_FILE} - Mənbə faylı"
+
+#. IDR_POPUP_PLUGIN_COMMAND_LINE_MENU, ID_PLUGIN_COMMAND_LINE_SRC_FOLDER
+#: Merge.rc:1335
+msgid "${SRC_FOLDER} - Source Folder"
+msgstr "${SRC_FOLDER} - Mənbə qovluğu"
+
+#. IDR_POPUP_PLUGIN_COMMAND_LINE_MENU, ID_PLUGIN_COMMAND_LINE_SRC_URL
+#: Merge.rc:1336
+msgid "${SRC_URL} - Source URL"
+msgstr "${SRC_URL} - Mənbə URL-i"
+
+#. IDR_POPUP_PLUGIN_COMMAND_LINE_MENU, ID_PLUGIN_COMMAND_LINE_SRC_URL_PROTOCOL
+#: Merge.rc:1337
+msgid "${SRC_URL_PROTOCOL} - Source URL Protocol"
+msgstr "${SRC_URL_PROTOCOL} - Mənbə URL-inin protokolu"
+
+#. IDR_POPUP_PLUGIN_COMMAND_LINE_MENU, ID_PLUGIN_COMMAND_LINE_SRC_URL_SUFFIX
+#: Merge.rc:1338
+msgid "${SRC_URL_SUFFIX} - Source URL Suffix"
+msgstr "${SRC_URL_SUFFIX} - Mənbə URL-inin sonluğu"
+
+#. IDR_POPUP_PLUGIN_COMMAND_LINE_MENU, ID_PLUGIN_COMMAND_LINE_DST_FILE
+#: Merge.rc:1339
+msgid "${DST_FILE} - Destination File"
+msgstr "${DST_FILE} - Təyinat faylı"
+
+#. IDR_POPUP_PLUGIN_COMMAND_LINE_MENU, ID_PLUGIN_COMMAND_LINE_DST_FOLDER
+#: Merge.rc:1340
+msgid "${DST_FOLDER} - Destination Folder"
+msgstr "${DST_FOLDER} - Təyinat qovluğu"
+
+#. IDR_POPUP_PLUGIN_COMMAND_LINE_MENU, ID_PLUGIN_COMMAND_LINE_DST_URL
+#: Merge.rc:1341
+msgid "${DST_URL} - Destination URL"
+msgstr "${DST_URL} - Təyinat URL-i"
+
+#. IDR_POPUP_PLUGIN_COMMAND_LINE_MENU, ID_PLUGIN_COMMAND_LINE_DST_URL_PROTOCOL
+#: Merge.rc:1342
+msgid "${DST_URL_PROTOCOL} - Destination URL Protocol"
+msgstr "${DST_URL_PROTOCOL} - Təyinat URL-inin protokolu"
+
+#. IDR_POPUP_PLUGIN_COMMAND_LINE_MENU, ID_PLUGIN_COMMAND_LINE_DST_URL_SUFFIX
+#: Merge.rc:1343
+msgid "${DST_URL_SUFFIX} - Destination URL Suffix"
+msgstr "${DST_URL_SUFFIX} - Təyinat URL-inin sonluğu"
+
+#. IDR_POPUP_PLUGIN_COMMAND_LINE_MENU, ID_PLUGIN_COMMAND_LINE_WINMERGE_HOME
+#: Merge.rc:1344
+msgid "${WINMERGE_HOME} - WinMerge Home Directory"
+msgstr "${WINMERGE_HOME} - WinMerge əsas qovluğu"
+
+#. IDR_POPUP_PLUGIN_COMMAND_LINE_MENU, ID_PLUGIN_COMMAND_LINE_SCRIPT_FILE
+#: Merge.rc:1345
+msgid "${SCRIPT_FILE} - Script File"
+msgstr "${SCRIPT_FILE} - Skript faylı"
+
+#. IDR_POPUP_PLUGIN_ADD_MENU, ID_PLUGIN_ADD_UNPACKER
+#: Merge.rc:1363
+msgid "Add &Unpacker Plugin..."
+msgstr "&Açma qoşması əlavə et..."
+
+#. IDR_POPUP_PLUGIN_ADD_MENU, ID_PLUGIN_ADD_PREDIFFER
+#: Merge.rc:1364
+msgid "Add &Prediffer Plugin..."
+msgstr "&İlkin müqayisə emalı qoşması əlavə et..."
+
+#. IDR_POPUP_PLUGIN_ADD_MENU, ID_PLUGIN_DUPLICATE
+#: Merge.rc:1365
+msgid "&Duplicate Plugin..."
+msgstr "Qoşmanın &surətini yarat..."
+
+#. IDR_POPUP_OUTPUTVIEW, ID_EDIT_CLEAR_ALL
+#: Merge.rc:1389
+msgid "Clear &All"
+msgstr "&Hamısını təmizlə"
+
+#. IDR_POPUP_LINEFILTERMENU, ID_FILTERMENU_MASK_CLEAR
+#: Merge.rc:1397 Merge.rc:1883
+msgid "&Clear All"
+msgstr "Hamısını &təmizlə"
+
+#. IDR_POPUP_FILTERMENU, ID_FILTERMENU_MASK_REMOVE_LAST
+#: Merge.rc:1398
+msgid "Remove Last Filter &Group"
+msgstr "Son süzgəc &qrupunu sil"
+
+#. IDR_POPUP_FILTERMENU, ID_FILTERMENU_MASK_ALL
+#: Merge.rc:1399
+msgid "R&eset to Default (*.*)"
+msgstr "Standart qiymətə &qaytar (*.*)"
+
+#. IDR_POPUP_FILTERMENU
+#: Merge.rc:1400
+msgid "Add E&xclude File"
+msgstr "İstisna ediləcək &fayl əlavə et"
+
+#. IDR_POPUP_FILTERMENU, ID_FILTERMENU_FILE_SYS
+#: Merge.rc:1402
+msgid "&System Files"
+msgstr "&Sistem faylları"
+
+#. IDR_POPUP_FILTERMENU, ID_FILTERMENU_FILE_BACKUP
+#: Merge.rc:1403
+msgid "&Editor Backup Files"
+msgstr "&Redaktorun ehtiyat nüsxə faylları"
+
+#. IDR_POPUP_FILTERMENU, ID_FILTERMENU_FILE_BIN
+#: Merge.rc:1404
+msgid "&Compiled Binary Files"
+msgstr "&Kompilyasiya edilmiş ikilik fayllar"
+
+#. IDR_POPUP_FILTERMENU, ID_FILTERMENU_FILE_LOG
+#: Merge.rc:1405
+msgid "&Log Files"
+msgstr "&Jurnal faylları"
+
+#. IDR_POPUP_FILTERMENU, ID_FILTERMENU_FILE_TEMP
+#: Merge.rc:1406
+msgid "&Temporary or Cache Files"
+msgstr "&Müvəqqəti və ya keş faylları"
+
+#. IDR_POPUP_FILTERMENU
+#: Merge.rc:1408
+msgid "Add Excl&ude Folder"
+msgstr "İstisna ediləcək &qovluq əlavə et"
+
+#. IDR_POPUP_FILTERMENU, ID_FILTERMENU_FOLDER_VCS
+#: Merge.rc:1410
+msgid "&Version Control"
+msgstr "&Versiyalara nəzarət"
+
+#. IDR_POPUP_FILTERMENU, ID_FILTERMENU_FOLDER_BUILD
+#: Merge.rc:1411
+msgid "&Build Artifacts"
+msgstr "&Yığma nəticələri"
+
+#. IDR_POPUP_FILTERMENU, ID_FILTERMENU_FOLDER_IDE
+#: Merge.rc:1412
+msgid "&IDE"
+msgstr "&IDE"
+
+#. IDR_POPUP_FILTERMENU
+#: Merge.rc:1415
+msgid "Add &File Condition"
+msgstr "&Fayl şərti əlavə et"
+
+#. IDR_POPUP_FILTERMENU
+#: Merge.rc:1417 Merge.rc:1596
+msgid "File &Size"
+msgstr "Faylın &ölçüsü"
+
+#. IDR_POPUP_FILTERMENU_DIFF_SIZE, ID_FILTERMENU_DIFF_SIZE_LT_1KB
+#: Merge.rc:1419 Merge.rc:1572 Merge.rc:1609 Merge.rc:1686 Merge.rc:1764
+msgid "Less than 1KB"
+msgstr "1KB-dan az"
+
+#. IDR_POPUP_FILTERMENU_DIFF_SIZE, ID_FILTERMENU_DIFF_SIZE_GE_1KB
+#: Merge.rc:1420 Merge.rc:1573 Merge.rc:1610 Merge.rc:1687 Merge.rc:1765
+msgid "1KB or more"
+msgstr "1KB və ya çox"
+
+#. IDR_POPUP_FILTERMENU_SIZE, ID_FILTERMENU_SIZE_LT_10KB
+#: Merge.rc:1421 Merge.rc:1574 Merge.rc:1688
+msgid "Less than 10KB"
+msgstr "10KB-dan az"
+
+#. IDR_POPUP_FILTERMENU_SIZE, ID_FILTERMENU_SIZE_GE_10KB
+#: Merge.rc:1422 Merge.rc:1575 Merge.rc:1689
+msgid "10KB or more"
+msgstr "10KB və ya çox"
+
+#. IDR_POPUP_FILTERMENU_SIZE, ID_FILTERMENU_SIZE_LT_100KB
+#: Merge.rc:1423 Merge.rc:1576 Merge.rc:1690
+msgid "Less than 100KB"
+msgstr "100KB-dan az"
+
+#. IDR_POPUP_FILTERMENU_SIZE, ID_FILTERMENU_SIZE_GE_100KB
+#: Merge.rc:1424 Merge.rc:1577 Merge.rc:1691
+msgid "100KB or more"
+msgstr "100KB və ya çox"
+
+#. IDR_POPUP_FILTERMENU_SIZE, ID_FILTERMENU_SIZE_LT_1MB
+#: Merge.rc:1425 Merge.rc:1578 Merge.rc:1692
+msgid "Less than 1MB"
+msgstr "1MB-dan az"
+
+#. IDR_POPUP_FILTERMENU_SIZE, ID_FILTERMENU_SIZE_GE_1MB
+#: Merge.rc:1426 Merge.rc:1579 Merge.rc:1693
+msgid "1MB or more"
+msgstr "1MB və ya çox"
+
+#. IDR_POPUP_FILTERMENU_SIZE, ID_FILTERMENU_SIZE_LT_10MB
+#: Merge.rc:1427 Merge.rc:1580 Merge.rc:1694
+msgid "Less than 10MB"
+msgstr "10MB-dan az"
+
+#. IDR_POPUP_FILTERMENU_SIZE, ID_FILTERMENU_SIZE_GE_10MB
+#: Merge.rc:1428 Merge.rc:1581 Merge.rc:1695
+msgid "10MB or more"
+msgstr "10MB və ya çox"
+
+#. IDR_POPUP_FILTERMENU_SIZE, ID_FILTERMENU_SIZE_LT_100MB
+#: Merge.rc:1429 Merge.rc:1582 Merge.rc:1696
+msgid "Less than 100MB"
+msgstr "100MB-dan az"
+
+#. IDR_POPUP_FILTERMENU_SIZE, ID_FILTERMENU_SIZE_GE_100MB
+#: Merge.rc:1430 Merge.rc:1583 Merge.rc:1697
+msgid "100MB or more"
+msgstr "100MB və ya çox"
+
+#. IDR_POPUP_FILTERMENU_SIZE, ID_FILTERMENU_SIZE_LT_1GB
+#: Merge.rc:1431 Merge.rc:1584 Merge.rc:1698
+msgid "Less than 1GB"
+msgstr "1GB-dan az"
+
+#. IDR_POPUP_FILTERMENU_SIZE, ID_FILTERMENU_SIZE_GE_1GB
+#: Merge.rc:1432 Merge.rc:1699
+msgid "1GB or more"
+msgstr "1GB və ya çox"
+
+#. IDR_POPUP_LINEFILTERMENU, ID_FILTERMENU_DIFF_LINE_LENGTH_RANGE
+#: Merge.rc:1433 Merge.rc:1510 Merge.rc:1562 Merge.rc:1568 Merge.rc:1585
+#: Merge.rc:1611 Merge.rc:1632 Merge.rc:1700 Merge.rc:1766 Merge.rc:1791
+#: Merge.rc:1994
+msgid "Custom Range..."
+msgstr "Xüsusi aralıq..."
+
+#. IDR_POPUP_FILTERMENU
+#: Merge.rc:1435 Merge.rc:1516 Merge.rc:1613
+msgid "&Last Modified"
+msgstr "&Son dəyişdirilmə"
+
+#. IDR_POPUP_FILTERMENU_DATE
+#: Merge.rc:1437 Merge.rc:1518 Merge.rc:1708
+msgid "&Hour"
+msgstr "&Saat"
+
+#. IDR_POPUP_FILTERMENU_DATE, ID_FILTERMENU_DATE_HOUR_BEFORE_1
+#: Merge.rc:1439 Merge.rc:1520 Merge.rc:1710
+msgid "More than 1 hour ago"
+msgstr "1 saatdan çox əvvəl"
+
+#. IDR_POPUP_FILTERMENU_DATE, ID_FILTERMENU_DATE_HOUR_WITHIN_1
+#: Merge.rc:1440 Merge.rc:1521 Merge.rc:1711
+msgid "Within 1 hour"
+msgstr "Son 1 saatda"
+
+#. IDR_POPUP_FILTERMENU_DATE
+#: Merge.rc:1442 Merge.rc:1523 Merge.rc:1713
+msgid "&Day"
+msgstr "&Gün"
+
+#. IDR_POPUP_FILTERMENU_DATE, ID_FILTERMENU_DATE_DAY_BEFORE_TODAY
+#: Merge.rc:1444 Merge.rc:1525 Merge.rc:1715
+msgid "Before today"
+msgstr "Bu gündən əvvəl"
+
+#. IDR_POPUP_FILTERMENU_DATE, ID_FILTERMENU_DATE_DAY_TODAY
+#: Merge.rc:1445 Merge.rc:1526 Merge.rc:1716
+msgid "Today"
+msgstr "Bu gün"
+
+#. IDR_POPUP_FILTERMENU_DATE, ID_FILTERMENU_DATE_DAY_BEFORE_YESTERDAY
+#: Merge.rc:1446 Merge.rc:1527 Merge.rc:1717
+msgid "Before yesterday"
+msgstr "Dünəndən əvvəl"
+
+#. IDR_POPUP_FILTERMENU_DATE, ID_FILTERMENU_DATE_DAY_YESTERDAY
+#: Merge.rc:1447 Merge.rc:1528 Merge.rc:1718
+msgid "Yesterday"
+msgstr "Dünən"
+
+#. IDR_POPUP_FILTERMENU_DATE, ID_FILTERMENU_DATE_DAY_SINCE_YESTERDAY
+#: Merge.rc:1448 Merge.rc:1529 Merge.rc:1719
+msgid "Since yesterday"
+msgstr "Dünəndən bəri"
+
+#. IDR_POPUP_FILTERMENU_DATE
+#: Merge.rc:1450 Merge.rc:1531 Merge.rc:1721
+msgid "&Week"
+msgstr "&Həftə"
+
+#. IDR_POPUP_FILTERMENU_DATE, ID_FILTERMENU_DATE_WEEK_BEFORE_THIS
+#: Merge.rc:1452 Merge.rc:1533 Merge.rc:1723
+msgid "Before this week"
+msgstr "Bu həftədən əvvəl"
+
+#. IDR_POPUP_FILTERMENU_DATE, ID_FILTERMENU_DATE_WEEK_THIS
+#: Merge.rc:1453 Merge.rc:1534 Merge.rc:1724
+msgid "This week"
+msgstr "Bu həftə"
+
+#. IDR_POPUP_FILTERMENU_DATE, ID_FILTERMENU_DATE_WEEK_BEFORE_LAST
+#: Merge.rc:1454 Merge.rc:1535 Merge.rc:1725
+msgid "Before last week"
+msgstr "Keçən həftədən əvvəl"
+
+#. IDR_POPUP_FILTERMENU_DATE, ID_FILTERMENU_DATE_WEEK_LAST
+#: Merge.rc:1455 Merge.rc:1536 Merge.rc:1726
+msgid "Last week"
+msgstr "Keçən həftə"
+
+#. IDR_POPUP_FILTERMENU_DATE, ID_FILTERMENU_DATE_WEEK_SINCE_LAST
+#: Merge.rc:1456 Merge.rc:1537 Merge.rc:1727
+msgid "Since last week"
+msgstr "Keçən həftədən bəri"
+
+#. IDR_POPUP_FILTERMENU_DATE
+#: Merge.rc:1458 Merge.rc:1539 Merge.rc:1729
+msgid "&Month"
+msgstr "&Ay"
+
+#. IDR_POPUP_FILTERMENU_DATE, ID_FILTERMENU_DATE_MONTH_BEFORE_THIS
+#: Merge.rc:1460 Merge.rc:1541 Merge.rc:1731
+msgid "Before this month"
+msgstr "Bu aydan əvvəl"
+
+#. IDR_POPUP_FILTERMENU_DATE, ID_FILTERMENU_DATE_MONTH_THIS
+#: Merge.rc:1461 Merge.rc:1542 Merge.rc:1732
+msgid "This month"
+msgstr "Bu ay"
+
+#. IDR_POPUP_FILTERMENU_DATE, ID_FILTERMENU_DATE_MONTH_BEFORE_LAST
+#: Merge.rc:1462 Merge.rc:1543 Merge.rc:1733
+msgid "Before last month"
+msgstr "Keçən aydan əvvəl"
+
+#. IDR_POPUP_FILTERMENU_DATE, ID_FILTERMENU_DATE_MONTH_LAST
+#: Merge.rc:1463 Merge.rc:1544 Merge.rc:1734
+msgid "Last month"
+msgstr "Keçən ay"
+
+#. IDR_POPUP_FILTERMENU_DATE, ID_FILTERMENU_DATE_MONTH_SINCE_LAST
+#: Merge.rc:1464 Merge.rc:1545 Merge.rc:1735
+msgid "Since last month"
+msgstr "Keçən aydan bəri"
+
+#. IDR_POPUP_FILTERMENU_DATE
+#: Merge.rc:1466 Merge.rc:1547 Merge.rc:1737
+msgid "&Year"
+msgstr "&İl"
+
+#. IDR_POPUP_FILTERMENU_DATE, ID_FILTERMENU_DATE_YEAR_BEFORE_THIS
+#: Merge.rc:1468 Merge.rc:1549 Merge.rc:1739
+msgid "Before this year"
+msgstr "Bu ildən əvvəl"
+
+#. IDR_POPUP_FILTERMENU_DATE, ID_FILTERMENU_DATE_YEAR_THIS
+#: Merge.rc:1469 Merge.rc:1550 Merge.rc:1740
+msgid "This year"
+msgstr "Bu il"
+
+#. IDR_POPUP_FILTERMENU_DATE, ID_FILTERMENU_DATE_YEAR_BEFORE_LAST
+#: Merge.rc:1470 Merge.rc:1551 Merge.rc:1741
+msgid "Before last year"
+msgstr "Keçən ildən əvvəl"
+
+#. IDR_POPUP_FILTERMENU_DATE, ID_FILTERMENU_DATE_YEAR_LAST
+#: Merge.rc:1471 Merge.rc:1552 Merge.rc:1742
+msgid "Last year"
+msgstr "Keçən il"
+
+#. IDR_POPUP_FILTERMENU_DATE, ID_FILTERMENU_DATE_YEAR_SINCE_LAST
+#: Merge.rc:1472 Merge.rc:1553 Merge.rc:1743
+msgid "Since last year"
+msgstr "Keçən ildən bəri"
+
+#. IDR_POPUP_LINEFILTERMENU, ID_FILTERMENU_LINE_MATCHNUMBER_RANGE
+#: Merge.rc:1474 Merge.rc:1555 Merge.rc:1745 Merge.rc:1910 Merge.rc:2068
+msgid "&Custom Range..."
+msgstr "&Xüsusi aralıq..."
+
+#. IDR_POPUP_FILTERMENU
+#: Merge.rc:1476 Merge.rc:1634
+msgid "&Attributes"
+msgstr "&Atributlar"
+
+#. IDR_POPUP_FILTERMENU_ATTR, ID_FILTERMENU_ATTR_READONLY
+#: Merge.rc:1478 Merge.rc:1652
+msgid "Read-only files"
+msgstr "Yalnız oxunan fayllar"
+
+#. IDR_POPUP_FILTERMENU_ATTR, ID_FILTERMENU_ATTR_NOT_READONLY
+#: Merge.rc:1479 Merge.rc:1653
+msgid "Not read-only files"
+msgstr "Yazıla bilən fayllar"
+
+#. IDR_POPUP_FILTERMENU_ATTR, ID_FILTERMENU_ATTR_HIDDEN
+#: Merge.rc:1480 Merge.rc:1654
+msgid "Hidden files"
+msgstr "Gizli fayllar"
+
+#. IDR_POPUP_FILTERMENU_ATTR, ID_FILTERMENU_ATTR_NOT_HIDDEN
+#: Merge.rc:1481 Merge.rc:1655
+msgid "Not hidden files"
+msgstr "Gizli olmayan fayllar"
+
+#. IDR_POPUP_FILTERMENU_ATTR, ID_FILTERMENU_ATTR_SYSTEM
+#: Merge.rc:1482 Merge.rc:1656
+msgid "System files"
+msgstr "Sistem faylları"
+
+#. IDR_POPUP_FILTERMENU_ATTR, ID_FILTERMENU_ATTR_NOT_SYSTEM
+#: Merge.rc:1483 Merge.rc:1657
+msgid "Not system files"
+msgstr "Sistem faylı olmayanlar"
+
+#. IDR_POPUP_FILTERMENU
+#: Merge.rc:1485
+msgid "File &Content"
+msgstr "Faylın &məzmunu"
+
+#. IDR_POPUP_FILTERMENU, ID_FILTERMENU_CONTENT_CONTAINS
+#: Merge.rc:1487
+msgid "Contains string..."
+msgstr "Mətni ehtiva edir..."
+
+#. IDR_POPUP_FILTERMENU, ID_FILTERMENU_CONTENT_NOT_CONTAINS
+#: Merge.rc:1488
+msgid "Does not contain string..."
+msgstr "Mətni ehtiva etmir..."
+
+#. IDR_POPUP_FILTERMENU, ID_FILTERMENU_CONTENT_FIRST_LINE_CONTAINS
+#: Merge.rc:1489
+msgid "First line contains string..."
+msgstr "İlk sətir mətni ehtiva edir..."
+
+#. IDR_POPUP_FILTERMENU, ID_FILTERMENU_CONTENT_FIRST_LINE_NOT_CONTAINS
+#: Merge.rc:1490
+msgid "First line does not contain string..."
+msgstr "İlk sətir mətni ehtiva etmir..."
+
+#. IDR_POPUP_FILTERMENU, ID_FILTERMENU_CONTENT_FIRST_10_CONTAINS
+#: Merge.rc:1491
+msgid "First 10 lines contain string..."
+msgstr "İlk 10 sətir mətni ehtiva edir..."
+
+#. IDR_POPUP_FILTERMENU, ID_FILTERMENU_CONTENT_FIRST_10_NOT_CONTAINS
+#: Merge.rc:1492
+msgid "First 10 lines do not contain string..."
+msgstr "İlk 10 sətir mətni ehtiva etmir..."
+
+#. IDR_POPUP_FILTERMENU, ID_FILTERMENU_CONTENT_LAST_10_CONTAINS
+#: Merge.rc:1493
+msgid "Last 10 lines contain string..."
+msgstr "Son 10 sətir mətni ehtiva edir..."
+
+#. IDR_POPUP_FILTERMENU, ID_FILTERMENU_CONTENT_LAST_10_NOT_CONTAINS
+#: Merge.rc:1494
+msgid "Last 10 lines do not contain string..."
+msgstr "Son 10 sətir mətni ehtiva etmir..."
+
+#. IDR_POPUP_FILTERMENU, ID_FILTERMENU_CONTENT_LAST_LINE_CONTAINS
+#: Merge.rc:1495
+msgid "Last line contains string..."
+msgstr "Son sətir mətni ehtiva edir..."
+
+#. IDR_POPUP_FILTERMENU, ID_FILTERMENU_CONTENT_LAST_LINE_NOT_CONTAINS
+#: Merge.rc:1496
+msgid "Last line does not contain string..."
+msgstr "Son sətir mətni ehtiva etmir..."
+
+#. IDR_POPUP_FILTERMENU
+#: Merge.rc:1498
+msgid "&Line Count"
+msgstr "&Sətir sayı"
+
+#. IDR_POPUP_LINEFILTERMENU, ID_FILTERMENU_DIFF_LINE_LENGTH_LT_10
+#: Merge.rc:1500 Merge.rc:1988
+msgid "Less than 10"
+msgstr "10-dan az"
+
+#. IDR_POPUP_LINEFILTERMENU, ID_FILTERMENU_DIFF_LINE_LENGTH_GE_10
+#: Merge.rc:1501 Merge.rc:1989
+msgid "10 or more"
+msgstr "10 və ya çox"
+
+#. IDR_POPUP_LINEFILTERMENU, ID_FILTERMENU_DIFF_LINE_LENGTH_LT_100
+#: Merge.rc:1502 Merge.rc:1990
+msgid "Less than 100"
+msgstr "100-dən az"
+
+#. IDR_POPUP_LINEFILTERMENU, ID_FILTERMENU_DIFF_LINE_LENGTH_GE_100
+#: Merge.rc:1503 Merge.rc:1991
+msgid "100 or more"
+msgstr "100 və ya çox"
+
+#. IDR_POPUP_LINEFILTERMENU, ID_FILTERMENU_DIFF_LINE_LENGTH_LT_1000
+#: Merge.rc:1504 Merge.rc:1992
+msgid "Less than 1000"
+msgstr "1000-dən az"
+
+#. IDR_POPUP_LINEFILTERMENU, ID_FILTERMENU_DIFF_LINE_LENGTH_GE_1000
+#: Merge.rc:1505 Merge.rc:1993
+msgid "1000 or more"
+msgstr "1000 və ya çox"
+
+#. IDR_POPUP_FILTERMENU, ID_FILTERMENU_LINES_LT_10000
+#: Merge.rc:1506
+msgid "Less than 10000"
+msgstr "10000-dən az"
+
+#. IDR_POPUP_FILTERMENU, ID_FILTERMENU_LINES_GE_10000
+#: Merge.rc:1507
+msgid "10000 or more"
+msgstr "10000 və ya çox"
+
+#. IDR_POPUP_FILTERMENU, ID_FILTERMENU_LINES_LT_100000
+#: Merge.rc:1508
+msgid "Less than 100000"
+msgstr "100000-dən az"
+
+#. IDR_POPUP_FILTERMENU, ID_FILTERMENU_LINES_GE_100000
+#: Merge.rc:1509
+msgid "100000 or more"
+msgstr "100000 və ya çox"
+
+#. IDR_POPUP_RENAMEMOVE_MENU, ID_RENAME_MOVE_KEY_MENU_PROPS
+#: Merge.rc:1512 Merge.rc:1639 Merge.rc:1818 Merge.rc:1835
+msgid "Additional &Properties..."
+msgstr "Əlavə &xassələr..."
+
+#. IDR_POPUP_FILTERMENU
+#: Merge.rc:1514
+msgid "Add F&older Condition"
+msgstr "&Qovluq şərti əlavə et"
+
+#. IDR_POPUP_FILTERMENU
+#: Merge.rc:1558
+msgid "&Files"
+msgstr "&Fayllar"
+
+#. IDR_POPUP_FILTERMENU, ID_FILTERMENU_FOLDER_FILES_EQ_0
+#: Merge.rc:1560
+msgid "0 files"
+msgstr "0 fayl"
+
+#. IDR_POPUP_FILTERMENU, ID_FILTERMENU_FOLDER_FILES_GE_1
+#: Merge.rc:1561
+msgid "1 file or more"
+msgstr "1 fayl və ya çox"
+
+#. IDR_POPUP_FILTERMENU
+#: Merge.rc:1564
+msgid "&Items"
+msgstr "&Elementlər"
+
+#. IDR_POPUP_FILTERMENU, ID_FILTERMENU_FOLDER_ITEMS_EQ_0
+#: Merge.rc:1566
+msgid "0 items"
+msgstr "0 element"
+
+#. IDR_POPUP_FILTERMENU, ID_FILTERMENU_FOLDER_ITEMS_GE_1
+#: Merge.rc:1567
+msgid "1 item or more"
+msgstr "1 element və ya çox"
+
+#. IDR_POPUP_FILTERMENU
+#: Merge.rc:1570
+msgid "&Total Size"
+msgstr "&Ümumi ölçü"
+
+#. IDR_POPUP_FILTERMENU, ID_FILTERMENU_FOLDER_STATS_RECURSIVE
+#: Merge.rc:1587
+msgid "&Recursive"
+msgstr "&Rekursiv"
+
+#. IDR_POPUP_LINEFILTERMENU, ID_FILTERMENU_CONDITION_ANY
+#: Merge.rc:1589 Merge.rc:1931
+msgid "Target: &Any (Left/Middle/Right)"
+msgstr "Hədəf: &istənilən (sol/orta/sağ)"
+
+#. IDR_POPUP_LINEFILTERMENU, ID_FILTERMENU_CONDITION_LEFT
+#: Merge.rc:1590 Merge.rc:1932
+msgid "Target: &Left"
+msgstr "Hədəf: &sol"
+
+#. IDR_POPUP_LINEFILTERMENU, ID_FILTERMENU_CONDITION_MIDDLE
+#: Merge.rc:1591 Merge.rc:1933
+msgid "Target: &Middle"
+msgstr "Hədəf: &orta"
+
+#. IDR_POPUP_LINEFILTERMENU, ID_FILTERMENU_CONDITION_RIGHT
+#: Merge.rc:1592 Merge.rc:1934
+msgid "Target: &Right"
+msgstr "Hədəf: s&ağ"
+
+#. IDR_POPUP_LINEFILTERMENU
+#: Merge.rc:1594 Merge.rc:1936
+msgid "Add &Difference Condition"
+msgstr "&Fərq şərti əlavə et"
+
+#. IDR_POPUP_LINEFILTERMENU, ID_FILTERMENU_DIFF_EOL_EQUAL
+#: Merge.rc:1598 Merge.rc:1615 Merge.rc:1636 Merge.rc:1753 Merge.rc:1774
+#: Merge.rc:1799 Merge.rc:1940 Merge.rc:1947 Merge.rc:1952 Merge.rc:1961
+#: Merge.rc:1981 Merge.rc:2004
+msgid "Equal"
+msgstr "Bərabərdir"
+
+#. IDR_POPUP_LINEFILTERMENU, ID_FILTERMENU_DIFF_EOL_NOT_EQUAL
+#: Merge.rc:1599 Merge.rc:1616 Merge.rc:1637 Merge.rc:1754 Merge.rc:1775
+#: Merge.rc:1800 Merge.rc:1941 Merge.rc:1948 Merge.rc:1953 Merge.rc:1962
+#: Merge.rc:1982 Merge.rc:2005
+msgid "Not Equal"
+msgstr "Bərabər deyil"
+
+#. IDR_POPUP_LINEFILTERMENU, ID_FILTERMENU_DIFF_LINE_LENGTH_LESS
+#: Merge.rc:1600 Merge.rc:1617 Merge.rc:1755 Merge.rc:1776 Merge.rc:1801
+#: Merge.rc:1954 Merge.rc:1963 Merge.rc:1983
+msgid "Less Than"
+msgstr "Kiçikdir"
+
+#. IDR_POPUP_LINEFILTERMENU, ID_FILTERMENU_DIFF_LINE_LENGTH_LESS_EQUAL
+#: Merge.rc:1601 Merge.rc:1618 Merge.rc:1756 Merge.rc:1777 Merge.rc:1802
+#: Merge.rc:1955 Merge.rc:1964 Merge.rc:1984
+msgid "Less Than or Equal to"
+msgstr "Kiçikdir və ya bərabərdir"
+
+#. IDR_POPUP_LINEFILTERMENU, ID_FILTERMENU_DIFF_LINE_LENGTH_GREATER
+#: Merge.rc:1602 Merge.rc:1619 Merge.rc:1757 Merge.rc:1778 Merge.rc:1803
+#: Merge.rc:1956 Merge.rc:1965 Merge.rc:1985
+msgid "Greater Than"
+msgstr "Böyükdür"
+
+#. IDR_POPUP_LINEFILTERMENU, ID_FILTERMENU_DIFF_LINE_LENGTH_GREATER_EQUAL
+#: Merge.rc:1603 Merge.rc:1620 Merge.rc:1758 Merge.rc:1779 Merge.rc:1804
+#: Merge.rc:1957 Merge.rc:1966 Merge.rc:1986
+msgid "Greater Than or Equal to"
+msgstr "Böyükdür və ya bərabərdir"
+
+#. IDR_POPUP_FILTERMENU_DIFF_SIZE, ID_FILTERMENU_DIFF_SIZE_LT_10B
+#: Merge.rc:1605 Merge.rc:1760
+msgid "Less than 10B"
+msgstr "10B-dan az"
+
+#. IDR_POPUP_FILTERMENU_DIFF_SIZE, ID_FILTERMENU_DIFF_SIZE_GE_10B
+#: Merge.rc:1606 Merge.rc:1761
+msgid "10B or more"
+msgstr "10B və ya çox"
+
+#. IDR_POPUP_FILTERMENU_DIFF_SIZE, ID_FILTERMENU_DIFF_SIZE_LT_100B
+#: Merge.rc:1607 Merge.rc:1762
+msgid "Less than 100B"
+msgstr "100B-dan az"
+
+#. IDR_POPUP_FILTERMENU_DIFF_SIZE, ID_FILTERMENU_DIFF_SIZE_GE_100B
+#: Merge.rc:1608 Merge.rc:1763
+msgid "100B or more"
+msgstr "100B və ya çox"
+
+#. IDR_POPUP_FILTERMENU_DIFF_DATE, ID_FILTERMENU_DIFF_DATE_LT_1SECOND
+#: Merge.rc:1622 Merge.rc:1781
+msgid "Less than 1 second"
+msgstr "1 saniyədən az"
+
+#. IDR_POPUP_FILTERMENU_DIFF_DATE, ID_FILTERMENU_DIFF_DATE_GE_1SECOND
+#: Merge.rc:1623 Merge.rc:1782
+msgid "1 second or more"
+msgstr "1 saniyə və ya çox"
+
+#. IDR_POPUP_FILTERMENU_DIFF_DATE, ID_FILTERMENU_DIFF_DATE_LT_1MINUTE
+#: Merge.rc:1624 Merge.rc:1783
+msgid "Less than 1 minute"
+msgstr "1 dəqiqədən az"
+
+#. IDR_POPUP_FILTERMENU_DIFF_DATE, ID_FILTERMENU_DIFF_DATE_GE_1MINUTE
+#: Merge.rc:1625 Merge.rc:1784
+msgid "1 minute or more"
+msgstr "1 dəqiqə və ya çox"
+
+#. IDR_POPUP_FILTERMENU_DIFF_DATE, ID_FILTERMENU_DIFF_DATE_LT_1HOUR
+#: Merge.rc:1626 Merge.rc:1785
+msgid "Less than 1 hour"
+msgstr "1 saatdan az"
+
+#. IDR_POPUP_FILTERMENU_DIFF_DATE, ID_FILTERMENU_DIFF_DATE_GE_1HOUR
+#: Merge.rc:1627 Merge.rc:1786
+msgid "1 hour or more"
+msgstr "1 saat və ya çox"
+
+#. IDR_POPUP_FILTERMENU_DIFF_DATE, ID_FILTERMENU_DIFF_DATE_LT_1DAY
+#: Merge.rc:1628 Merge.rc:1787
+msgid "Less than 1 day"
+msgstr "1 gündən az"
+
+#. IDR_POPUP_FILTERMENU_DIFF_DATE, ID_FILTERMENU_DIFF_DATE_GE_1DAY
+#: Merge.rc:1629 Merge.rc:1788
+msgid "1 day or more"
+msgstr "1 gün və ya çox"
+
+#. IDR_POPUP_FILTERMENU_DIFF_DATE, ID_FILTERMENU_DIFF_DATE_LT_1WEEK
+#: Merge.rc:1630 Merge.rc:1789
+msgid "Less than 1 week"
+msgstr "1 həftədən az"
+
+#. IDR_POPUP_FILTERMENU_DIFF_DATE, ID_FILTERMENU_DIFF_DATE_GE_1WEEK
+#: Merge.rc:1631 Merge.rc:1790
+msgid "1 week or more"
+msgstr "1 həftə və ya çox"
+
+#. IDR_POPUP_LINEFILTERMENU, ID_FILTERMENU_CONDITION_DIFF_LEFT_RIGHT
+#: Merge.rc:1641 Merge.rc:2008
+msgid "Target: &Left and Right"
+msgstr "Hədəf: &sol və sağ"
+
+#. IDR_POPUP_LINEFILTERMENU, ID_FILTERMENU_CONDITION_DIFF_LEFT_MIDDLE
+#: Merge.rc:1642 Merge.rc:2009
+msgid "Target: Left and &Middle"
+msgstr "Hədəf: sol və &orta"
+
+#. IDR_POPUP_LINEFILTERMENU, ID_FILTERMENU_CONDITION_DIFF_MIDDLE_RIGHT
+#: Merge.rc:1643 Merge.rc:2010
+msgid "Target: Middle and &Right"
+msgstr "Hədəf: orta və &sağ"
+
+#. IDR_POPUP_LINEFILTERMENU, ID_FILTERMENU_CONDITION_DIFF_ALL
+#: Merge.rc:1644 Merge.rc:2011
+msgid "Target: &All"
+msgstr "Hədəf: &hamısı"
+
+#. IDR_POPUP_FILTERMENU_BINARY, ID_FILTERMENU_BINARY_ONLY
+#: Merge.rc:1665
+msgid "Binary files only"
+msgstr "Yalnız ikilik fayllar"
+
+#. IDR_POPUP_FILTERMENU_BINARY, ID_FILTERMENU_TEXT_ONLY
+#: Merge.rc:1666
+msgid "Text files only"
+msgstr "Yalnız mətn faylları"
+
+#. IDS_EOL_NONE
+#: Merge.rc:1677 Merge.rc:1928 Merge.rc:5315
+msgid "None"
+msgstr "Heç biri"
+
+#. IDS_EOL_MIXED
+#: Merge.rc:1678 Merge.rc:5310
+msgid "Mixed"
+msgstr "Qarışıq"
+
+#. IDR_POPUP_ADDCMPMENU, ID_ADDCMPMENU_CLEAR
+#: Merge.rc:1812
+msgid "&Clear conditions"
+msgstr "Şərtləri &təmizlə"
+
+#. IDR_POPUP_ADDCMPMENU, ID_ADDCMPMENU_CMP_SIZE
+#: Merge.rc:1814
+msgid "Compare &Size"
+msgstr "&Ölçünü müqayisə et"
+
+#. IDR_POPUP_ADDCMPMENU, ID_ADDCMPMENU_CMP_DATE
+#: Merge.rc:1815
+msgid "Compare &Date"
+msgstr "&Tarixi müqayisə et"
+
+#. IDR_POPUP_ADDCMPMENU, ID_ADDCMPMENU_CMP_ATTR
+#: Merge.rc:1816
+msgid "Compare &Attributes"
+msgstr "&Atributları müqayisə et"
+
+#. IDR_POPUP_ADDCMPMENU, ID_ADDCMPMENU_CMP_CONTENTS
+#: Merge.rc:1817
+msgid "Compare C&ontents"
+msgstr "&Məzmunu müqayisə et"
+
+#. IDR_POPUP_RENAMEMOVE_MENU, ID_RENAME_MOVE_KEY_MENU_CLEAR
+#: Merge.rc:1826
+msgid "&Clear Keys"
+msgstr "Açarları &təmizlə"
+
+#. IDR_POPUP_RENAMEMOVE_MENU, ID_RENAME_MOVE_KEY_MENU_NAME
+#: Merge.rc:1828
+msgid "&Name"
+msgstr "&Ad"
+
+#. IDR_POPUP_RENAMEMOVE_MENU, ID_RENAME_MOVE_KEY_MENU_BASENAME
+#: Merge.rc:1829
+msgid "&Base name (without extension)"
+msgstr "&Əsas ad (uzantısız)"
+
+#. IDR_POPUP_RENAMEMOVE_MENU, ID_RENAME_MOVE_KEY_MENU_NORMALIZED_NAME
+#: Merge.rc:1830
+msgid "Normalized &Unicode Name"
+msgstr "Normallaşdırılmış &Unicode adı"
+
+#. IDR_POPUP_RENAMEMOVE_MENU, ID_RENAME_MOVE_KEY_MENU_RELPATH
+#: Merge.rc:1831
+msgid "&Relative Path"
+msgstr "&Nisbi yol"
+
+#. IDR_POPUP_RENAMEMOVE_MENU, ID_RENAME_MOVE_KEY_MENU_DATE
+#: Merge.rc:1833
+msgid "&Date"
+msgstr "&Tarix"
+
+#. IDR_POPUP_RENAMEMOVE_MENU, ID_RENAME_MOVE_KEY_MENU_HASH_MD5
+#: Merge.rc:1834
+msgid "&Hash (MD5)"
+msgstr "&Heş (MD5)"
+
+#. IDR_POPUP_RENAMEMOVE_MENU, ID_RENAME_MOVE_KEY_MENU_FUNC_REPLACE
+#: Merge.rc:1837
+msgid "Insert &replace() Function"
+msgstr "&replace() funksiyasını daxil et"
+
+#. IDR_POPUP_RENAMEMOVE_MENU, ID_RENAME_MOVE_KEY_MENU_FUNC_REGEXREPLACE
+#: Merge.rc:1838
+msgid "Insert rege&xReplace() Function"
+msgstr "rege&xReplace() funksiyasını daxil et"
+
+#. IDR_POPUP_LINEFILTERMENU
+#: Merge.rc:1839 Merge.rc:2034
+msgid "Replace &Lists"
+msgstr "&Əvəzetmə siyahıları"
+
+#. IDR_POPUP_LINEFILTERMENU, ID_FILTERMENU_CREATE_REPLACELIST
+#: Merge.rc:1841 Merge.rc:2036
+msgid "&Create String Replace List and Insert..."
+msgstr "&Mətn əvəzetmə siyahısı yarat və daxil et..."
+
+#. IDR_POPUP_LINEFILTERMENU, ID_FILTERMENU_CREATE_REGEXREPLACELIST
+#: Merge.rc:1842 Merge.rc:2037
+msgid "Create &Regex Replace List and Insert..."
+msgstr "&Müntəzəm ifadə əvəzetmə siyahısı yarat və daxil et..."
+
+#. IDR_POPUP_LINEFILTERMENU
+#: Merge.rc:1844 Merge.rc:2039
+msgid "&String Replace Lists"
+msgstr "&Mətn əvəzetmə siyahıları"
+
+#. IDR_POPUP_LINEFILTERMENU
+#: Merge.rc:1848 Merge.rc:2043
+msgid "Re&gex Replace Lists"
+msgstr "Müntəzəm &ifadə əvəzetmə siyahıları"
+
+#. IDR_POPUP_LINEFILTERMENU, ID_FILTERMENU_STRING_REPLACE_LISTS_FOLDER
+#: Merge.rc:1853 Merge.rc:2048
+msgid "Open String Replace Lists Folder..."
+msgstr "Mətn əvəzetmə siyahıları qovluğunu aç..."
+
+#. IDR_POPUP_LINEFILTERMENU, ID_FILTERMENU_REGEX_REPLACE_LISTS_FOLDER
+#: Merge.rc:1854 Merge.rc:2049
+msgid "Open Regex Replace Lists Folder..."
+msgstr "Müntəzəm ifadə əvəzetmə siyahıları qovluğunu aç..."
+
+#. IDD_FILTERS_CONDITION, IDC_CONDITION_MATCHCASE
+#: Merge.rc:1856 Merge.rc:2084 Merge.rc:2266 Merge.rc:2285 Merge.rc:2313
+#: Merge.rc:2860
+msgid "Match &case"
+msgstr "Böyük-kiçik &hərf fərqini nəzərə al"
+
+#. IDR_POPUP_RENAMEMOVE_MENU
+#: Merge.rc:1858
+msgid "Text &Normalization"
+msgstr "Mətnin &normallaşdırılması"
+
+#. IDR_POPUP_LINEFILTERMENU, ID_FILTERMENU_FUNC_TOLOWER
+#: Merge.rc:1860 Merge.rc:2019
+msgid "&Lowercase"
+msgstr "&Kiçik hərflər"
+
+#. IDR_POPUP_LINEFILTERMENU, ID_FILTERMENU_FUNC_TOUPPER
+#: Merge.rc:1861 Merge.rc:2020
+msgid "&Uppercase"
+msgstr "&Böyük hərflər"
+
+#. IDR_POPUP_LINEFILTERMENU, ID_FILTERMENU_FUNC_TOHALFWIDTH
+#: Merge.rc:1862 Merge.rc:2021
+msgid "&Half-width"
+msgstr "&Yarım enli"
+
+#. IDR_POPUP_LINEFILTERMENU, ID_FILTERMENU_FUNC_TOFULLWIDTH
+#: Merge.rc:1863 Merge.rc:2022
+msgid "&Full-width"
+msgstr "&Tam enli"
+
+#. IDR_POPUP_LINEFILTERMENU
+#: Merge.rc:1864 Merge.rc:2024
+msgid "&Chinese Conversion"
+msgstr "&Çin yazısının çevrilməsi"
+
+#. IDR_POPUP_LINEFILTERMENU, ID_FILTERMENU_FUNC_TOSIMPLIFIEDCHINESE
+#: Merge.rc:1866 Merge.rc:2026
+msgid "&Simplified Chinese"
+msgstr "&Sadələşdirilmiş Çin yazısı"
+
+#. IDR_POPUP_LINEFILTERMENU, ID_FILTERMENU_FUNC_TOTRADITIONALCHINESE
+#: Merge.rc:1867 Merge.rc:2027
+msgid "&Traditional Chinese"
+msgstr "&Ənənəvi Çin yazısı"
+
+#. IDR_POPUP_LINEFILTERMENU
+#: Merge.rc:1869 Merge.rc:2029
+msgid "&Japanese Conversion"
+msgstr "&Yapon yazısının çevrilməsi"
+
+#. IDR_POPUP_LINEFILTERMENU, ID_FILTERMENU_FUNC_TOHIRAGANA
+#: Merge.rc:1871 Merge.rc:2031
+msgid "&Hiragana"
+msgstr "&Hiraqana"
+
+#. IDR_POPUP_LINEFILTERMENU, ID_FILTERMENU_FUNC_TOKATAKANA
+#: Merge.rc:1872 Merge.rc:2032
+msgid "&Katakana"
+msgstr "&Katakana"
+
+#. IDR_POPUP_LINEFILTERMENU, ID_FILTERMENU_FUNC_NORMALIZEUNICODE
+#: Merge.rc:1874 Merge.rc:2023
+msgid "Normalize &Unicode"
+msgstr "&Unicode-u normallaşdır"
+
+#. IDR_POPUP_LINEFILTERMENU
+#: Merge.rc:1885
+msgid "Add L&ine Condition"
+msgstr "&Sətir şərti əlavə et"
+
+#. IDR_POPUP_LINEFILTERMENU, ID_FILTERMENU_LINE_RANGE
+#: Merge.rc:1887
+msgid "L&ine Text..."
+msgstr "Sətrin &mətni..."
+
+#. IDR_POPUP_LINEFILTERMENU
+#: Merge.rc:1888 Merge.rc:1943
+msgid "&Column"
+msgstr "&Sütun"
+
+#. IDR_POPUP_LINEFILTERMENU, ID_FILTERMENU_COLUMN_1
+#: Merge.rc:1893 Merge.rc:1968
+msgid "Column: &1"
+msgstr "&Sütun: 1"
+
+#. IDR_POPUP_LINEFILTERMENU, ID_FILTERMENU_COLUMN_2
+#: Merge.rc:1894 Merge.rc:1969
+msgid "Column: &2"
+msgstr "&Sütun: 2"
+
+#. IDR_POPUP_LINEFILTERMENU, ID_FILTERMENU_COLUMN_3
+#: Merge.rc:1895 Merge.rc:1970
+msgid "Column: &3"
+msgstr "&Sütun: 3"
+
+#. IDR_POPUP_LINEFILTERMENU, ID_FILTERMENU_COLUMN_4
+#: Merge.rc:1896 Merge.rc:1971
+msgid "Column: &4"
+msgstr "&Sütun: 4"
+
+#. IDR_POPUP_LINEFILTERMENU, ID_FILTERMENU_COLUMN_5
+#: Merge.rc:1897 Merge.rc:1972
+msgid "Column: &5"
+msgstr "&Sütun: 5"
+
+#. IDR_POPUP_LINEFILTERMENU, ID_FILTERMENU_COLUMN_6
+#: Merge.rc:1898 Merge.rc:1973
+msgid "Column: &6"
+msgstr "&Sütun: 6"
+
+#. IDR_POPUP_LINEFILTERMENU, ID_FILTERMENU_COLUMN_7
+#: Merge.rc:1899 Merge.rc:1974
+msgid "Column: &7"
+msgstr "&Sütun: 7"
+
+#. IDR_POPUP_LINEFILTERMENU, ID_FILTERMENU_COLUMN_8
+#: Merge.rc:1900 Merge.rc:1975
+msgid "Column: &8"
+msgstr "&Sütun: 8"
+
+#. IDR_POPUP_LINEFILTERMENU, ID_FILTERMENU_COLUMN_9
+#: Merge.rc:1901 Merge.rc:1976
+msgid "Column: &9"
+msgstr "&Sütun: 9"
+
+#. IDR_POPUP_LINEFILTERMENU, ID_FILTERMENU_COLUMN_10
+#: Merge.rc:1902 Merge.rc:1977
+msgid "Column: 1&0"
+msgstr "&Sütun: 10"
+
+#. IDR_POPUP_LINEFILTERMENU, ID_FILTERMENU_LINE_LENGTH_RANGE
+#: Merge.rc:1904
+msgid "Line L&ength..."
+msgstr "Sətrin &uzunluğu..."
+
+#. IDR_POPUP_LINEFILTERMENU, ID_FILTERMENU_WORD_COUNT_RANGE
+#: Merge.rc:1905
+msgid "&Word Count..."
+msgstr "&Söz sayı..."
+
+#. IDR_POPUP_LINEFILTERMENU
+#: Merge.rc:1906
+msgid "Line &Number"
+msgstr "Sətrin &nömrəsi"
+
+#. IDR_POPUP_LINEFILTERMENU, ID_FILTERMENU_LINE_ODD_LINES
+#: Merge.rc:1908
+msgid "&Odd Lines"
+msgstr "&Tək sətirlər"
+
+#. IDR_POPUP_LINEFILTERMENU, ID_FILTERMENU_LINE_EVEN_LINES
+#: Merge.rc:1909
+msgid "&Even Lines"
+msgstr "&Cüt sətirlər"
+
+#. IDR_POPUP_LINEFILTERMENU
+#: Merge.rc:1912 Merge.rc:1996
+msgid "Line &Status"
+msgstr "Sətrin &vəziyyəti"
+
+#. IDS_DIFFERENT
+#: Merge.rc:1914 Merge.rc:1998 Merge.rc:2876 Merge.rc:3046 Merge.rc:3087
+#: Merge.rc:5069
+msgid "Different"
+msgstr "Fərqli"
+
+#. IDS_IDENTICAL
+#: Merge.rc:1915 Merge.rc:1999 Merge.rc:2875 Merge.rc:3065 Merge.rc:3126
+#: Merge.rc:5059
+msgid "Identical"
+msgstr "Eyni"
+
+#. IDR_POPUP_LINEFILTERMENU, ID_FILTERMENU_LINE_TRIVIAL
+#: Merge.rc:1916 Merge.rc:2000
+msgid "Trivial"
+msgstr "Əhəmiyyətsiz"
+
+#. IDR_POPUP_LINEFILTERMENU, ID_FILTERMENU_LINE_EXISTS
+#: Merge.rc:1918
+msgid "Exists"
+msgstr "Mövcuddur"
+
+#. IDR_POPUP_LINEFILTERMENU, ID_FILTERMENU_LINE_MISSING
+#: Merge.rc:1919
+msgid "Missing"
+msgstr "Çatışmır"
+
+#. IDS_MOVED
+#: Merge.rc:1920 Merge.rc:5087
+msgid "Moved"
+msgstr "Yeri dəyişdirilib"
+
+#. IDR_POPUP_LINEFILTERMENU, ID_FILTERMENU_LINE_BOOKMARKED
+#: Merge.rc:1921
+msgid "Bookmarked"
+msgstr "Əlfəcin qoyulub"
+
+#. IDR_POPUP_LINEFILTERMENU
+#: Merge.rc:1923 Merge.rc:2002
+msgid "&EOL"
+msgstr "&Sətir sonu"
+
+#. IDR_POPUP_LINEFILTERMENU
+#: Merge.rc:1938
+msgid "L&ine Text"
+msgstr "Sətrin &mətni"
+
+#. IDR_POPUP_LINEFILTERMENU
+#: Merge.rc:1950
+msgid "&Number"
+msgstr "&Ədəd"
+
+#. IDR_POPUP_LINEFILTERMENU
+#: Merge.rc:1959
+msgid "&Date/Time"
+msgstr "&Tarix/vaxt"
+
+#. IDR_POPUP_LINEFILTERMENU
+#: Merge.rc:1979
+msgid "Line L&ength"
+msgstr "Sətrin &uzunluğu"
+
+#. IDR_POPUP_LINEFILTERMENU
+#: Merge.rc:2013
+msgid "&Transform Line/Column"
+msgstr "Sətri/sütunu &çevir"
+
+#. IDR_POPUP_LINEFILTERMENU, ID_FILTERMENU_FUNC_TRIM
+#: Merge.rc:2015
+msgid "&Trim"
+msgstr "Kənar boşluqları &sil"
+
+#. IDR_POPUP_LINEFILTERMENU, ID_FILTERMENU_FUNC_NORM_SPACE
+#: Merge.rc:2016
+msgid "Normalize &Whitespace"
+msgstr "&Boşluq simvollarını normallaşdır"
+
+#. IDD_EDIT_REPLACE, IDC_EDIT_REPLACE
+#: Merge.rc:2017 Merge.rc:2294
+msgid "&Replace"
+msgstr "&Əvəz et"
+
+#. IDR_POPUP_LINEFILTERMENU, ID_FILTERMENU_FUNC_REGEXREPLACE
+#: Merge.rc:2018
+msgid "Reg&ex Replace"
+msgstr "&Müntəzəm ifadə ilə əvəz et"
+
+#. IDR_POPUP_LINEFILTERMENU
+#: Merge.rc:2052
+msgid "&Refine Current Filter"
+msgstr "Cari süzgəci &dəqiqləşdir"
+
+#. IDR_POPUP_LINEFILTERMENU
+#: Merge.rc:2054
+msgid "Add Con&text Lines"
+msgstr "&Kontekst sətirləri əlavə et"
+
+#. IDR_POPUP_LINEFILTERMENU
+#: Merge.rc:2062
+msgid "Filter by &Occurrence"
+msgstr "&Təkrarlanmasına görə süz"
+
+#. IDR_POPUP_LINEFILTERMENU, ID_FILTERMENU_LINE_MATCHNUMBER_EQ_1
+#: Merge.rc:2064
+msgid "&First"
+msgstr "&İlk"
+
+#. IDR_POPUP_LINEFILTERMENU, ID_FILTERMENU_LINE_MATCHNUMBER_EQ_LAST
+#: Merge.rc:2065
+msgid "&Last"
+msgstr "&Son"
+
+#. IDR_POPUP_LINEFILTERMENU, ID_FILTERMENU_LINE_MATCHNUMBER_LE_5
+#: Merge.rc:2066
+msgid "First &5 Matches"
+msgstr "İlk 5 &uyğunluq"
+
+#. IDR_POPUP_LINEFILTERMENU, ID_FILTERMENU_LINE_MATCHNUMBER_GT_5
+#: Merge.rc:2067
+msgid "After First &5"
+msgstr "İlk 5 uyğunluqdan &sonra"
+
+#. IDR_POPUP_LINEFILTERMENU, ID_FILTERMENU_LINE_OCCURRENCE_BY_BLOCK
+#: Merge.rc:2070
+msgid "By &Block"
+msgstr "&Bloka görə"
+
+#. IDR_POPUP_LINEFILTERMENU
+#: Merge.rc:2072
+msgid "&Range"
+msgstr "&Aralıq"
+
+#. IDR_POPUP_LINEFILTERMENU, ID_FILTERMENU_LINE_MATCHINSIDE
+#: Merge.rc:2074 Merge.rc:2080
+msgid "&Inside..."
+msgstr "&Daxilində..."
+
+#. IDR_POPUP_LINEFILTERMENU, ID_FILTERMENU_LINE_MATCHOUTSIDE
+#: Merge.rc:2075 Merge.rc:2081
+msgid "&Outside..."
+msgstr "&Xaricində..."
+
+#. IDR_POPUP_LINEFILTERMENU
+#: Merge.rc:2078
+msgid "Create &Range"
+msgstr "&Aralıq yarat"
+
+#. IDR_POPUP_LINEFILTERMENU, ID_FILTERMENU_OPERATOR_AND
+#: Merge.rc:2086
+msgid "Combine: A&ND"
+msgstr "Birləşdirmə: &VƏ"
+
+#. IDR_POPUP_LINEFILTERMENU, ID_FILTERMENU_OPERATOR_OR
+#: Merge.rc:2087
+msgid "Combine: &OR"
+msgstr "Birləşdirmə: VƏ &YA"
+
+#. IDD_ABOUTBOX
+#: Merge.rc:2203
+msgid "About WinMerge"
+msgstr "WinMerge haqqında"
+
+#. IDD_ABOUTBOX, IDC_WWW
+#: Merge.rc:2207
+msgid "Visit the WinMerge Homepage!"
+msgstr "WinMerge ana səhifəsinə keçin!"
+
+#. IDD_PLUGINS_EDITPLUGIN, IDOK
+#: Merge.rc:2209 Merge.rc:2351 Merge.rc:2706 Merge.rc:2730 Merge.rc:2744
+#: Merge.rc:2772 Merge.rc:2863 Merge.rc:2892 Merge.rc:2908 Merge.rc:2969
+#: Merge.rc:2987 Merge.rc:3005 Merge.rc:3023 Merge.rc:3035 Merge.rc:3199
+#: Merge.rc:3259 Merge.rc:3395 Merge.rc:3437 Merge.rc:3480 Merge.rc:3530
+msgid "OK"
+msgstr "Tamam"
+
+#. IDD_ABOUTBOX, IDC_OPEN_CONTRIBUTORS
+#: Merge.rc:2210
+msgid "Contributors"
+msgstr "Töhfə verənlər"
+
+#. IDD_SELECT_FILES_OR_FOLDERS
+#: Merge.rc:2216 Merge.rc:3403
+msgid "Select Files or Folders"
+msgstr "Fayl və ya qovluq seçin"
+
+#. IDD_OPEN, IDC_FILES_DIRS_GROUP0
+#: Merge.rc:2220
+msgid "&1st File or Folder"
+msgstr "&Birinci fayl və ya qovluq"
+
+#. IDD_OPEN, IDC_PATH0_READONLY
+#: Merge.rc:2222
+msgid "Re&ad-only"
+msgstr "&Yalnız oxumaq üçün"
+
+#. IDD_OPEN, IDC_SWAP01_STATIC
+#: Merge.rc:2224
+msgid "Swap 1st | 2nd"
+msgstr "Birinci ilə ikincinin yerini dəyiş"
+
+#. IDD_ARCHIVE, IDC_ARCHIVE_BROWSE
+#: Merge.rc:2225 Merge.rc:2581 Merge.rc:2688 Merge.rc:3000 Merge.rc:3018
+msgid "&Browse..."
+msgstr "&Gözdən keçir..."
+
+#. IDD_OPEN, IDC_FILES_DIRS_GROUP1
+#: Merge.rc:2226
+msgid "&2nd File or Folder"
+msgstr "&İkinci fayl və ya qovluq"
+
+#. IDD_OPEN, IDC_PATH1_READONLY
+#: Merge.rc:2228
+msgid "Rea&d-only"
+msgstr "Yalnız &oxumaq üçün"
+
+#. IDD_OPEN, IDC_SWAP12_STATIC
+#: Merge.rc:2230
+msgid "Swap 2nd | 3rd"
+msgstr "İkinci ilə üçüncünün yerini dəyiş"
+
+#. IDD_PROPPAGE_SYSTEM, IDC_FILTER_USER_BROWSE
+#: Merge.rc:2231 Merge.rc:2586
+msgid "B&rowse..."
+msgstr "G&özdən keçir..."
+
+#. IDD_OPEN, IDC_FILES_DIRS_GROUP2
+#: Merge.rc:2232
+msgid "&3rd File or Folder (Optional)"
+msgstr "&Üçüncü fayl və ya qovluq (istəyə bağlı)"
+
+#. IDD_OPEN, IDC_PATH2_READONLY
+#: Merge.rc:2234
+msgid "Read-o&nly"
+msgstr "Yalnız oxumaq &üçün"
+
+#. IDD_OPEN, IDC_SWAP02_STATIC
+#: Merge.rc:2236
+msgid "Swap 1st | 3rd"
+msgstr "Birinci ilə üçüncünün yerini dəyiş"
+
+#. IDD_PROPPAGE_BACKUPS, IDC_BACKUP_BROWSE
+#: Merge.rc:2237 Merge.rc:2980 Merge.rc:3215
+msgid "Browse..."
+msgstr "Gözdən keçir..."
+
+#. IDD_OPEN, IDC_FILES_DIRS_GROUP3
+#: Merge.rc:2239
+msgid " Folder: Filter"
+msgstr " Qovluq: süzgəc"
+
+#. IDD_OPEN, IDC_RECURS_CHECK
+#: Merge.rc:2242
+msgid "&Include subfolders"
+msgstr "Alt qovluqları &daxil et"
+
+#. IDD_OPEN, IDC_FILES_DIRS_GROUP5
+#: Merge.rc:2243
+msgid " File: Prediffer Plugin"
+msgstr " Fayl: ilkin müqayisə emalı qoşması"
+
+#. IDD_OPEN, IDC_FILES_DIRS_GROUP4
+#: Merge.rc:2247
+msgid " File: Unpacker Plugin"
+msgstr " Fayl: açma qoşması"
+
+#. IDD_OPEN, IDC_SELECT_UNPACKER
+#: Merge.rc:2249
+msgid "Se&lect..."
+msgstr "&Seç..."
+
+#. IDD_PLUGINS_EDITPLUGIN, IDCANCEL
+#: Merge.rc:2252 Merge.rc:2272 Merge.rc:2296 Merge.rc:2317 Merge.rc:2352
+#: Merge.rc:2707 Merge.rc:2731 Merge.rc:2745 Merge.rc:2773 Merge.rc:2826
+#: Merge.rc:2864 Merge.rc:2893 Merge.rc:2909 Merge.rc:2970 Merge.rc:2988
+#: Merge.rc:3006 Merge.rc:3024 Merge.rc:3036 Merge.rc:3200 Merge.rc:3260
+#: Merge.rc:3420 Merge.rc:3438 Merge.rc:3481 Merge.rc:3531
+msgid "Cancel"
+msgstr "Ləğv et"
+
+#. IDD_OPEN, IDC_OPEN_STATUS
+#: Merge.rc:2253
+msgid "Status:"
+msgstr "Vəziyyət:"
+
+#. IDD_PLUGINS_LIST, ID_HELP
+#: Merge.rc:2254 Merge.rc:2353 Merge.rc:3261
+msgid "Help"
+msgstr "Kömək"
+
+#. IDD_OPEN, IDC_OPTIONS
+#: Merge.rc:2255
+msgid "&Options..."
+msgstr "&Seçimlər..."
+
+#. IDD_EDIT_FIND
+#: Merge.rc:2260
+msgid "Find"
+msgstr "Tap"
+
+#. IDD_EDIT_MARKER, IDC_STATIC
+#: Merge.rc:2263 Merge.rc:2280 Merge.rc:2308
+msgid "Fi&nd what:"
+msgstr "&Axtarılan mətn:"
+
+#. IDD_EDIT_MARKER, IDC_EDIT_WHOLE_WORD
+#: Merge.rc:2265 Merge.rc:2284 Merge.rc:2312
+msgid "Match &whole word only"
+msgstr "Yalnız &bütöv sözləri tap"
+
+#. IDD_EDIT_MARKER, IDC_EDIT_REGEXP
+#: Merge.rc:2267 Merge.rc:2286 Merge.rc:2314
+msgid "Regular &expression"
+msgstr "Müntəzəm &ifadə"
+
+#. IDD_EDIT_FIND, IDC_FINDDLG_DONTWRAP
+#: Merge.rc:2268
+msgid "D&on't wrap end of file"
+msgstr "Faylın sonunda əvvələ &qayıtma"
+
+#. IDD_EDIT_FIND, IDC_FINDDLG_DONTCLOSE
+#: Merge.rc:2269
+msgid "&Don't close this dialog"
+msgstr "Bu dialoqu &bağlama"
+
+#. IDD_EDIT_REPLACE, IDC_EDIT_SKIP
+#: Merge.rc:2270 Merge.rc:2292
+msgid "&Find Next"
+msgstr "&Növbətini tap"
+
+#. IDD_EDIT_FIND, IDC_EDIT_FINDPREV
+#: Merge.rc:2271
+msgid "Find &Prev"
+msgstr "&Əvvəlkini tap"
+
+#. IDD_EDIT_REPLACE
+#: Merge.rc:2277
+msgid "Replace"
+msgstr "Əvəz et"
+
+#. IDD_EDIT_REPLACE, IDC_STATIC
+#: Merge.rc:2282
+msgid "Re&place with:"
+msgstr "&Əvəz edən mətn:"
+
+#. IDD_EDIT_REPLACE, IDC_EDIT_SCOPE_DONT_WRAP
+#: Merge.rc:2287
+msgid "&Don't wrap at end of file"
+msgstr "Faylın sonunda əvvələ &qayıtma"
+
+#. IDD_EDIT_REPLACE, IDC_STATIC
+#: Merge.rc:2289
+msgid "Replace in"
+msgstr "Əvəzetmə sahəsi"
+
+#. IDD_EDIT_REPLACE, IDC_EDIT_SCOPE_WHOLE_FILE
+#: Merge.rc:2291
+msgid "Wh&ole file"
+msgstr "&Bütün fayl"
+
+#. IDD_EDIT_REPLACE, IDC_EDIT_FINDPREV
+#: Merge.rc:2293
+msgid "Find Pre&v"
+msgstr "&Əvvəlkini tap"
+
+#. IDD_EDIT_REPLACE, IDC_EDIT_REPLACE_ALL
+#: Merge.rc:2295
+msgid "Replace &All"
+msgstr "&Hamısını əvəz et"
+
+#. IDS_OPTIONSPG_MARKERCOLORS
+#: Merge.rc:2301 Merge.rc:4569
+msgid "Markers"
+msgstr "İşarələyicilər"
+
+#. IDD_EDIT_MARKER, IDC_EDIT_MARKERS_ENABLED
+#: Merge.rc:2304
+msgid "Enable &markers"
+msgstr "&İşarələyiciləri aktivləşdir"
+
+#. IDD_FILTERS_LINEFILTERS, IDC_LFILTER_ADDBTN
+#: Merge.rc:2306 Merge.rc:2328
+msgid "New"
+msgstr "Yeni"
+
+#. IDD_EDIT_MARKER, IDC_STATIC
+#: Merge.rc:2310
+msgid "&Background color:"
+msgstr "&Fon rəngi:"
+
+#. IDS_MESSAGEBOX_OK
+#: Merge.rc:2315 Merge.rc:3161 Merge.rc:3419 Merge.rc:4531
+msgid "&Ok"
+msgstr "&Tamam"
+
+#. IDD_PLUGINS_EDITPLUGIN
+#: Merge.rc:2316 Merge.rc:2800 Merge.rc:3532
+msgid "&Apply"
+msgstr "&Tətbiq et"
+
+#. IDD_FILTERS_LINEFILTERS
+#: Merge.rc:2322
+msgid "Line Filters"
+msgstr "Sətir süzgəcləri"
+
+#. IDD_FILTERS_LINEFILTERS, IDC_IGNOREREGEXP
+#: Merge.rc:2325
+msgid "Enable Line Filters"
+msgstr "Sətir süzgəclərini aktivləşdir"
+
+#. IDD_FILTERS_LINEFILTERS, IDC_STATIC
+#: Merge.rc:2326
+msgid "Regular Expressions (one per line):"
+msgstr "Müntəzəm ifadələr (hər sətirdə biri):"
+
+#. IDD_PLUGINS_LIST, IDC_PLUGIN_EDIT
+#: Merge.rc:2329 Merge.rc:3256
+msgid "Edit"
+msgstr "Redaktə et"
+
+#. IDD_PLUGINS_LIST, IDC_PLUGIN_REMOVE
+#: Merge.rc:2330 Merge.rc:2342 Merge.rc:3257
+msgid "Remove"
+msgstr "Sil"
+
+#. IDD_FILTERS_SUBSTITUTIONFILTERS
+#: Merge.rc:2335
+msgid "Substitution Filters"
+msgstr "Əvəzetmə süzgəcləri"
+
+#. IDD_FILTERS_SUBSTITUTIONFILTERS, IDC_STATIC
+#: Merge.rc:2338
+msgid "Changes to the listed pairs below will be ignored or marked as insignificant. Patches are unaffected."
+msgstr "Aşağıda sadalanan cütlərdəki dəyişikliklər nəzərə alınmayacaq və ya əhəmiyyətsiz kimi işarələnəcək. Bu, yamaqlara təsir etmir."
+
+#. IDD_FILTERS_SUBSTITUTIONFILTERS, IDC_IGNORED_SUSBSTITUTIONS_ENABLED
+#: Merge.rc:2339
+msgid "Enable"
+msgstr "Aktivləşdir"
+
+#. IDD_PLUGINS_LIST, IDC_PLUGIN_ADD
+#: Merge.rc:2341 Merge.rc:3255
+msgid "Add"
+msgstr "Əlavə et"
+
+#. IDD_FILTERS_SUBSTITUTIONFILTERS, IDC_LFILTER_CLEARBTN
+#: Merge.rc:2343
+msgid "Clear"
+msgstr "Təmizlə"
+
+#. IDD_PREFERENCES
+#: Merge.rc:2348
+msgid "Options"
+msgstr "Seçimlər"
+
+#. IDD_PREFERENCES, IDC_TREEOPT_IMPORT
+#: Merge.rc:2357
+msgid "Import..."
+msgstr "İdxal et..."
+
+#. IDD_PREFERENCES, IDC_TREEOPT_EXPORT
+#: Merge.rc:2358
+msgid "Export..."
+msgstr "İxrac et..."
+
+#. IDS_OPTIONSPG_GENCOMPARE
+#: Merge.rc:2363 Merge.rc:4559 Merge.rc:4562 Merge.rc:4579
+msgid "General"
+msgstr "Ümumi"
+
+#. IDD_PROPPAGE_GENERAL, IDC_SCROLL_CHECK
+#: Merge.rc:2366
+msgid "Automatically &scroll to first difference"
+msgstr "Avtomatik olaraq ilk fərqə &keç"
+
+#. IDD_PROPPAGE_GENERAL, IDC_SCROLL_TO_FIRST_INLINE_DIFF_CHECK
+#: Merge.rc:2368
+msgid "Automatically s&croll to first inline difference"
+msgstr "Avtomatik olaraq ilk sətirdaxili fərqə &keç"
+
+#. IDD_PROPPAGE_GENERAL, IDC_STATIC
+#: Merge.rc:2370
+msgid "Cl&ose windows with 'Esc':"
+msgstr "Pəncərələri 'Esc' ilə &bağla:"
+
+#. IDD_PROPPAGE_GENERAL, IDC_VERIFY_OPEN_PATHS
+#: Merge.rc:2372
+msgid "&Automatically verify paths in Open dialog"
+msgstr "Açma dialoqunda yolları &avtomatik yoxla"
+
+#. IDD_PROPPAGE_GENERAL, IDC_STATIC
+#: Merge.rc:2374
+msgid "Single instance mode:"
+msgstr "Tək nüsxə rejimi:"
+
+#. IDD_PROPPAGE_GENERAL, IDC_ASK_MULTIWINDOW_CLOSE
+#: Merge.rc:2376
+msgid "As&k when closing multiple windows"
+msgstr "Bir neçə pəncərəni bağlayarkən &soruş"
+
+#. IDD_PROPPAGE_GENERAL, IDC_PRESERVE_FILETIME
+#: Merge.rc:2378
+msgid "&Preserve file time in file compare"
+msgstr "Fayl müqayisəsində faylın vaxtını &saxla"
+
+#. IDD_PROPPAGE_GENERAL, IDC_STARTUP_FOLDER_SELECT
+#: Merge.rc:2380
+msgid "Show \"Select Files or Folders\" dialog on startup"
+msgstr "Başlanğıcda \"Fayl və ya qovluq seçin\" dialoqunu göstər"
+
+#. IDD_PROPPAGE_GENERAL, IDC_CLOSE_WITH_OK
+#: Merge.rc:2382
+msgid "Close \"Select Files or Folders\" dialog on clicking Compare button"
+msgstr "Müqayisə et düyməsinə klikləyəndə \"Fayl və ya qovluq seçin\" dialoqunu bağla"
+
+#. IDD_PROPPAGE_GENERAL, IDC_STATIC
+#: Merge.rc:2384
+msgid "Op&en dialog Auto completion:"
+msgstr "&Açma dialoqunda avtomatik tamamlama:"
+
+#. IDD_PROPPAGE_GENERAL, IDC_STATIC
+#: Merge.rc:2386
+msgid "Auto-&reload modified files:"
+msgstr "Dəyişdirilmiş faylları avtomatik &yenidən yüklə:"
+
+#. IDD_PROPPAGE_GENERAL, IDC_STATIC
+#: Merge.rc:2388
+msgid "Language:"
+msgstr "Dil:"
+
+#. IDD_PROPPAGE_COMPARE_WEBPAGE, IDC_COMPARE_DEFAULTS
+#: Merge.rc:2390 Merge.rc:2570 Merge.rc:2592 Merge.rc:2623 Merge.rc:2642
+#: Merge.rc:2659 Merge.rc:2667 Merge.rc:2705 Merge.rc:2729 Merge.rc:2928
+#: Merge.rc:2939 Merge.rc:2948 Merge.rc:3219 Merge.rc:3254 Merge.rc:3317
+#: Merge.rc:3342 Merge.rc:3356 Merge.rc:3371 Merge.rc:3387
+msgid "Defaults"
+msgstr "Standart qiymətlər"
+
+#. IDS_OPTIONSPG_COLORS
+#: Merge.rc:2395 Merge.rc:2411 Merge.rc:2538 Merge.rc:2563 Merge.rc:4565
+msgid "Colors"
+msgstr "Rənglər"
+
+#. IDD_PROPPAGE_COLOR_SCHEMES, IDC_STATIC
+#: Merge.rc:2398
+msgid "Color &mode:"
+msgstr "Rəng &rejimi:"
+
+#. IDD_PROPPAGE_COLOR_SCHEMES, IDC_STATIC
+#: Merge.rc:2400
+msgid "&Light mode scheme:"
+msgstr "&Açıq rejimin sxemi:"
+
+#. IDD_PROPPAGE_COLOR_SCHEMES, IDC_STATIC
+#: Merge.rc:2402
+msgid "&Dark mode scheme:"
+msgstr "&Tünd rejimin sxemi:"
+
+#. IDD_PROPPAGE_COLOR_SCHEMES, IDC_STATIC
+#: Merge.rc:2404
+msgid "Your custom schemes"
+msgstr "Xüsusi sxemləriniz"
+
+#. IDD_PROPPAGE_COLOR_SCHEMES, IDC_COLOR_SCHEME_SAVE
+#: Merge.rc:2405
+msgid "&Save current scheme..."
+msgstr "Cari sxemi &saxla..."
+
+#. IDD_PROPPAGE_COLOR_SCHEMES, IDC_COLOR_SCHEME_DELETE
+#: Merge.rc:2406
+msgid "Delete &current scheme..."
+msgstr "&Cari sxemi sil..."
+
+#. IDD_PROPPAGE_COLORS_DIR, IDC_BACKGROUND_COLUMN_LABEL
+#: Merge.rc:2414 Merge.rc:2509 Merge.rc:2529 Merge.rc:2543
+msgid "Background"
+msgstr "Fon"
+
+#. IDD_PROPPAGE_COLORS_WINMERGE, IDC_STATIC
+#: Merge.rc:2415
+msgid "Deleted"
+msgstr "Silinmiş"
+
+#. IDS_OPTIONSPG_TEXTCOLORS
+#: Merge.rc:2416 Merge.rc:2478 Merge.rc:2510 Merge.rc:2544 Merge.rc:4567
+msgid "Text"
+msgstr "Mətn"
+
+#. IDD_PROPPAGE_COLORS_WINMERGE, IDC_STATIC
+#: Merge.rc:2417
+msgid "Difference:"
+msgstr "Fərq:"
+
+#. IDD_PROPPAGE_COLORS_WINMERGE, IDC_STATIC
+#: Merge.rc:2422
+msgid "Selected Difference:"
+msgstr "Seçilmiş fərq:"
+
+#. IDD_PROPPAGE_COLORS_WINMERGE, IDC_STATIC
+#: Merge.rc:2427
+msgid "Ignored Difference:"
+msgstr "Nəzərə alınmayan fərq:"
+
+#. IDD_PROPPAGE_COLORS_WINMERGE, IDC_STATIC
+#: Merge.rc:2432
+msgid "Moved:"
+msgstr "Yeri dəyişdirilmiş:"
+
+#. IDD_PROPPAGE_COLORS_WINMERGE, IDC_STATIC
+#: Merge.rc:2437
+msgid "Selected Moved:"
+msgstr "Seçilmiş yeri dəyişdirilmiş:"
+
+#. IDD_PROPPAGE_COLORS_WINMERGE, IDC_STATIC
+#: Merge.rc:2442
+msgid "Same As Next (3 panes):"
+msgstr "Növbəti ilə eyni (3 panel):"
+
+#. IDD_PROPPAGE_COLORS_WINMERGE, IDC_STATIC
+#: Merge.rc:2447
+msgid "Same As Next (Selected):"
+msgstr "Növbəti ilə eyni (seçilmiş):"
+
+#. IDD_PROPPAGE_COLORS_WINMERGE, IDC_STATIC
+#: Merge.rc:2452
+msgid "Word Difference:"
+msgstr "Söz fərqi:"
+
+#. IDD_PROPPAGE_COLORS_WINMERGE, IDC_STATIC
+#: Merge.rc:2457
+msgid "Selected Word Diff:"
+msgstr "Seçilmiş söz fərqi:"
+
+#. IDD_INPUTBOX
+#: Merge.rc:2466 Merge.rc:2501 Merge.rc:2522 Merge.rc:3432
+msgid "Dialog"
+msgstr "Dialoq"
+
+#. IDD_PROPPAGE_COLORS_SYNTAX, IDC_STATIC
+#: Merge.rc:2469
+msgid "Keywords:"
+msgstr "Açar sözlər:"
+
+#. IDD_PROPPAGE_COLORS_SYNTAX, IDC_STATIC
+#: Merge.rc:2470
+msgid "Function names:"
+msgstr "Funksiya adları:"
+
+#. IDD_PROPPAGE_COLORS_SYNTAX, IDC_STATIC
+#: Merge.rc:2471
+msgid "Comments:"
+msgstr "Şərhlər:"
+
+#. IDD_PROPPAGE_COLORS_SYNTAX, IDC_STATIC
+#: Merge.rc:2472
+msgid "Numbers:"
+msgstr "Ədədlər:"
+
+#. IDD_PROPPAGE_COLORS_SYNTAX, IDC_STATIC
+#: Merge.rc:2473
+msgid "Operators:"
+msgstr "Operatorlar:"
+
+#. IDD_PROPPAGE_COLORS_SYNTAX, IDC_STATIC
+#: Merge.rc:2474
+msgid "Strings:"
+msgstr "Mətn sətirləri:"
+
+#. IDD_PROPPAGE_COLORS_SYNTAX, IDC_STATIC
+#: Merge.rc:2475
+msgid "Preprocessor:"
+msgstr "Ön emalçı:"
+
+#. IDD_PROPPAGE_COLORS_SYNTAX, IDC_STATIC
+#: Merge.rc:2476
+msgid "User 1:"
+msgstr "İstifadəçi 1:"
+
+#. IDD_PROPPAGE_COLORS_SYNTAX, IDC_STATIC
+#: Merge.rc:2477
+msgid "User 2:"
+msgstr "İstifadəçi 2:"
+
+#. IDD_PROPPAGE_COLORS_SYNTAX, IDC_SCOLOR_USER2_BOLD
+#: Merge.rc:2480 Merge.rc:2482 Merge.rc:2484 Merge.rc:2486 Merge.rc:2488
+#: Merge.rc:2490 Merge.rc:2492 Merge.rc:2494 Merge.rc:2496
+msgid "Bold"
+msgstr "Qalın"
+
+#. IDD_PROPPAGE_COLORS_TEXT, IDC_DEFAULT_STANDARD_COLORS
+#: Merge.rc:2504
+msgid "&Use customized text colors"
+msgstr "Fərdiləşdirilmiş mətn rənglərindən &istifadə et"
+
+#. IDD_PROPPAGE_COLORS_TEXT, IDC_WHITESPACE_COLOR_LABEL
+#: Merge.rc:2506
+msgid "Whitespace:"
+msgstr "Boşluq simvolları:"
+
+#. IDD_PROPPAGE_COLORS_TEXT, IDC_TEXT_COLOR_LABEL
+#: Merge.rc:2507
+msgid "Regular text:"
+msgstr "Adi mətn:"
+
+#. IDD_PROPPAGE_COLORS_TEXT, IDC_SELECTION_COLOR_LABEL
+#: Merge.rc:2508
+msgid "Selection:"
+msgstr "Seçim:"
+
+#. IDD_PROPPAGE_COLORS_DIR, IDC_STATIC
+#: Merge.rc:2516 Merge.rc:2557
+msgid "Margin:"
+msgstr "Kənar sahə:"
+
+#. IDD_PROPPAGE_COLORS_MARKER, IDC_MARKER0_COLOR_LABEL
+#: Merge.rc:2525
+msgid "Search Marker:"
+msgstr "Axtarış işarələyicisi:"
+
+#. IDD_PROPPAGE_COLORS_MARKER, IDC_MARKER1_COLOR_LABEL
+#: Merge.rc:2526
+msgid "User Defined Marker 1:"
+msgstr "İstifadəçinin təyin etdiyi işarələyici 1:"
+
+#. IDD_PROPPAGE_COLORS_MARKER, IDC_MARKER2_COLOR_LABEL
+#: Merge.rc:2527
+msgid "User Defined Marker 2:"
+msgstr "İstifadəçinin təyin etdiyi işarələyici 2:"
+
+#. IDD_PROPPAGE_COLORS_MARKER, IDC_MARKER3_COLOR_LABEL
+#: Merge.rc:2528
+msgid "User Defined Marker 3:"
+msgstr "İstifadəçinin təyin etdiyi işarələyici 3:"
+
+#. IDD_PROPPAGE_COLORS_DIR, IDC_USE_DIR_COMPARE_COLORS
+#: Merge.rc:2541
+msgid "&Use folder compare colors"
+msgstr "Qovluq müqayisəsinin rənglərindən &istifadə et"
+
+#. IDD_PROPPAGE_COLORS_DIR, IDC_STATIC
+#: Merge.rc:2545
+msgid "Items equal:"
+msgstr "Eyni elementlər:"
+
+#. IDD_PROPPAGE_COLORS_DIR, IDC_STATIC
+#: Merge.rc:2548
+msgid "Items different:"
+msgstr "Fərqli elementlər:"
+
+#. IDD_PROPPAGE_COLORS_DIR, IDC_STATIC
+#: Merge.rc:2551
+msgid "Items missing:"
+msgstr "Çatışmayan elementlər:"
+
+#. IDD_PROPPAGE_COLORS_DIR, IDC_STATIC
+#: Merge.rc:2554
+msgid "Items filtered:"
+msgstr "Süzülmüş elementlər:"
+
+#. IDD_PROPPAGE_COLORS_SYSTEM, IDC_SYSCOLOR_HOOK_ENABLED
+#: Merge.rc:2566
+msgid "&Use custom system colors"
+msgstr "Xüsusi sistem rənglərindən &istifadə et"
+
+#. IDS_PRPCAT_SYSTEM
+#: Merge.rc:2575 Merge.rc:4571 Merge.rc:4572 Merge.rc:5018
+msgid "System"
+msgstr "Sistem"
+
+#. IDD_PROPPAGE_SYSTEM, IDC_USE_RECYCLE_BIN
+#: Merge.rc:2578
+msgid "&Use Recycle Bin"
+msgstr "&Zibil qutusundan istifadə et"
+
+#. IDD_PROPPAGE_SYSTEM, IDC_STATIC
+#: Merge.rc:2579
+msgid "&External editor:"
+msgstr "&Xarici redaktor:"
+
+#. IDD_PROPPAGE_SYSTEM, IDC_STATIC
+#: Merge.rc:2582
+msgid "&Store user data in:"
+msgstr "İstifadəçi məlumatlarını burada &saxla:"
+
+#. IDD_PROPPAGE_SYSTEM, IDC_STATIC
+#: Merge.rc:2584
+msgid "&Filter folder:"
+msgstr "&Süzgəc qovluğu:"
+
+#. IDD_PROPPAGE_SYSTEM, IDC_STATIC
+#: Merge.rc:2587
+msgid "Temporary files folder"
+msgstr "Müvəqqəti fayllar qovluğu"
+
+#. IDD_PROPPAGE_SYSTEM, IDC_TMPFOLDER_SYSTEM
+#: Merge.rc:2588
+msgid "S&ystem temp folder"
+msgstr "&Sistemin müvəqqəti qovluğu"
+
+#. IDD_PROPPAGE_SYSTEM, IDC_STATIC
+#: Merge.rc:2589
+msgid "C&ustom folder:"
+msgstr "&Xüsusi qovluq:"
+
+#. IDD_GENERATE_PATCH, IDC_DIFF_BROWSE_FILE2
+#: Merge.rc:2591 Merge.rc:2691
+msgid "Br&owse..."
+msgstr "&Gözdən keçir..."
+
+#. IDS_OPTIONSPG_COMPARE
+#: Merge.rc:2597 Merge.rc:4560
+msgid "Compare"
+msgstr "Müqayisə"
+
+#. IDD_PROPPAGE_COMPARE, IDC_STATIC
+#: Merge.rc:2600
+msgid "Whitespaces"
+msgstr "Boşluq simvolları"
+
+#. IDD_PROPPAGE_COMPARE, IDC_WHITESPACE
+#: Merge.rc:2601
+msgid "&Compare"
+msgstr "&Müqayisə et"
+
+#. IDD_PROPPAGE_COMPARE, IDC_WHITE_CHANGE
+#: Merge.rc:2602
+msgid "&Ignore change"
+msgstr "Dəyişikliyi &nəzərə alma"
+
+#. IDD_PROPPAGE_COMPARE, IDC_ALL_WHITE
+#: Merge.rc:2603
+msgid "I&gnore all"
+msgstr "&Heç birini nəzərə alma"
+
+#. IDD_PROPPAGE_COMPARE, IDC_IGNBLANKS_CHECK
+#: Merge.rc:2604
+msgid "Ignore blan&k lines"
+msgstr "&Boş sətirləri nəzərə alma"
+
+#. IDD_PROPPAGE_COMPARE, IDC_IGNCASE_CHECK
+#: Merge.rc:2605
+msgid "Ignore &case"
+msgstr "Böyük-kiçik &hərf fərqini nəzərə alma"
+
+#. IDD_PROPPAGE_COMPARE, IDC_EOL_SENSITIVE
+#: Merge.rc:2606
+msgid "Igno&re EOL differences (Windows/Unix/Mac)"
+msgstr "&Sətir sonu fərqlərini nəzərə alma (Windows/Unix/Mac)"
+
+#. IDD_PROPPAGE_COMPARE, IDC_IGNORE_NUMBERS
+#: Merge.rc:2608
+msgid "Ignore num&bers"
+msgstr "&Ədədləri nəzərə alma"
+
+#. IDD_PROPPAGE_COMPARE, IDC_CP_SENSITIVE
+#: Merge.rc:2609
+msgid "Ignore codepage &differences"
+msgstr "Kod səhifəsi &fərqlərini nəzərə alma"
+
+#. IDD_PROPPAGE_COMPARE, IDC_FILTERCOMMENTS_CHECK
+#: Merge.rc:2610
+msgid "Ignore c&omment differences"
+msgstr "&Şərh fərqlərini nəzərə alma"
+
+#. IDD_PROPPAGE_COMPARE, IDC_IGNEOFEOL_CHECK
+#: Merge.rc:2612
+msgid "Ignore &missing trailing EOL"
+msgstr "&Sonda çatışmayan sətir sonunu nəzərə alma"
+
+#. IDD_PROPPAGE_COMPARE, IDC_IGNLBRKS_CHECK
+#: Merge.rc:2614
+msgid "Ignore line &breaks (treat as spaces)"
+msgstr "Sətir &bölünmələrini nəzərə alma (boşluq say)"
+
+#. IDD_PROPPAGE_COMPARE, IDC_MOVED_BLOCKS
+#: Merge.rc:2616
+msgid "E&nable moved block detection"
+msgstr "Yeri dəyişdirilmiş blokların aşkarlanmasını &aktivləşdir"
+
+#. IDD_PROPPAGE_COMPARE, IDC_ALIGN_SIMILAR_LINES
+#: Merge.rc:2617
+msgid "Align &similar lines"
+msgstr "&Oxşar sətirləri uyğunlaşdır"
+
+#. IDD_PROPPAGE_COMPARE, IDC_STATIC
+#: Merge.rc:2618
+msgid "Diff &algorithm:"
+msgstr "&Fərq alqoritmi:"
+
+#. IDD_PROPPAGE_COMPARE, IDC_INDENT_HEURISTIC
+#: Merge.rc:2620
+msgid "Enable indent &heuristic"
+msgstr "Girinti &evristikasını aktivləşdir"
+
+#. IDD_PROPPAGE_COMPARE, IDC_COMPLETELY_BLANK_OUT_IGNORED_DIFFERENCES
+#: Merge.rc:2621
+msgid "Completely unhighlight the ignored differences"
+msgstr "Nəzərə alınmayan fərqlərin vurğulanmasını tamamilə söndür"
+
+#. IDS_OPTIONSPG_EDITOR
+#: Merge.rc:2628 Merge.rc:4561
+msgid "Editor"
+msgstr "Redaktor"
+
+#. IDD_PROPPAGE_EDITOR, IDC_HILITE_CHECK
+#: Merge.rc:2631
+msgid "&Highlight syntax"
+msgstr "Sintaksisi &vurğula"
+
+#. IDD_PROPPAGE_EDITOR, IDC_STATIC
+#: Merge.rc:2632
+msgid "Highlight &mode:"
+msgstr "Vurğulama &rejimi:"
+
+#. IDD_PROPPAGE_EDITOR, IDC_MIXED_EOL
+#: Merge.rc:2634
+msgid "&Preserve original EOL"
+msgstr "İlkin sətir sonunu &saxla"
+
+#. IDD_PROPPAGE_EDITOR, IDC_STATIC
+#: Merge.rc:2635
+msgid "Tabs"
+msgstr "Tabulyasiya"
+
+#. IDD_PROPPAGE_EDITOR, IDC_STATIC
+#: Merge.rc:2636
+msgid "&Tab size:"
+msgstr "&Tabulyasiya ölçüsü:"
+
+#. IDD_PROPPAGE_EDITOR, IDC_PROP_INSERT_TABS
+#: Merge.rc:2638
+msgid "&Insert tabs"
+msgstr "&Tabulyasiya daxil et"
+
+#. IDD_PROPPAGE_EDITOR, IDC_PROP_INSERT_SPACES
+#: Merge.rc:2639
+msgid "Insert &spaces"
+msgstr "&Boşluq daxil et"
+
+#. IDD_PROPPAGE_EDITOR, IDC_STATIC
+#: Merge.rc:2640
+msgid "&Rendering mode:"
+msgstr "&Təsvir rejimi:"
+
+#. IDD_PROPPAGE_EDITOR_COMPAREMERGE, IDC_AUTOMRESCAN_CHECK
+#: Merge.rc:2649
+msgid "&Automatic rescan"
+msgstr "&Avtomatik yenidən yoxlama"
+
+#. IDD_PROPPAGE_EDITOR_COMPAREMERGE, IDC_STATIC
+#: Merge.rc:2650
+msgid "Copy &granularity for selected differences:"
+msgstr "Seçilmiş fərqlər üçün köçürmənin &dəqiqlik səviyyəsi:"
+
+#. IDD_PROPPAGE_EDITOR_COMPAREMERGE, IDC_LINE_COLORING_GROUP
+#: Merge.rc:2652
+msgid "Line Difference Coloring"
+msgstr "Sətir fərqlərinin rənglənməsi"
+
+#. IDD_PROPPAGE_EDITOR_COMPAREMERGE, IDC_VIEW_LINE_DIFFERENCES
+#: Merge.rc:2653
+msgid "View line differences"
+msgstr "Sətir fərqlərini göstər"
+
+#. IDD_PROPPAGE_EDITOR_COMPAREMERGE, IDC_EDITOR_CHARLEVEL
+#: Merge.rc:2654
+msgid "&Character-level"
+msgstr "&Simvol səviyyəsində"
+
+#. IDD_PROPPAGE_EDITOR_COMPAREMERGE, IDC_EDITOR_WORDLEVEL
+#: Merge.rc:2655
+msgid "&Word-level:"
+msgstr "&Söz səviyyəsində:"
+
+#. IDD_PROPPAGE_EDITOR_COMPAREMERGE, IDC_STATIC
+#: Merge.rc:2657
+msgid "W&ord break characters:"
+msgstr "Söz &ayırıcı simvollar:"
+
+#. IDD_PROPPAGE_MESSAGEBOXES, IDC_STATIC
+#: Merge.rc:2674
+msgid "Some messages can be hidden by the user. Press Reset to make all messages visible again."
+msgstr "İstifadəçi bəzi bildirişləri gizlədə bilər. Bütün bildirişləri yenidən göstərmək üçün Sıfırla düyməsinə basın."
+
+#. IDD_SELECT_FILES_OR_FOLDERS, IDC_RESET
+#: Merge.rc:2675 Merge.rc:3418
+msgid "Reset"
+msgstr "Sıfırla"
+
+#. IDD_GENERATE_PATCH
+#: Merge.rc:2681
+msgid "Patch Generator"
+msgstr "Yamaq yaradıcısı"
+
+#. IDD_ARCHIVE, IDC_STATIC
+#: Merge.rc:2684 Merge.rc:2996 Merge.rc:3014
+msgid "Comparisons to include:"
+msgstr "Daxil ediləcək müqayisələr:"
+
+#. IDD_GENERATE_PATCH, IDC_STATIC
+#: Merge.rc:2686
+msgid "File&1:"
+msgstr "&Birinci fayl:"
+
+#. IDD_GENERATE_PATCH, IDC_STATIC
+#: Merge.rc:2689
+msgid "File&2:"
+msgstr "&İkinci fayl:"
+
+#. IDD_GENERATE_PATCH, IDC_DIFF_SWAPFILES
+#: Merge.rc:2692
+msgid "&Swap"
+msgstr "Yerini &dəyiş"
+
+#. IDD_ARCHIVE, IDC_ARCHIVE_COPYCLIPBOARD
+#: Merge.rc:2693 Merge.rc:2985 Merge.rc:3001 Merge.rc:3022
+msgid "&Copy to clipboard"
+msgstr "Mübadilə buferinə &köçür"
+
+#. IDD_GENERATE_PATCH, IDC_DIFF_APPENDFILE
+#: Merge.rc:2694
+msgid "&Append to existing file"
+msgstr "Mövcud faylın sonuna &əlavə et"
+
+#. IDD_GENERATE_PATCH, IDC_STATIC
+#: Merge.rc:2695
+msgid "&Result:"
+msgstr "&Nəticə:"
+
+#. IDD_GENERATE_PATCH, IDC_DIFF_BROWSE_RESULT
+#: Merge.rc:2697
+msgid "Bro&wse..."
+msgstr "&Gözdən keçir..."
+
+#. IDD_GENERATE_PATCH, IDC_STATIC
+#: Merge.rc:2698
+msgid "&Format"
+msgstr "&Format"
+
+#. IDD_GENERATE_PATCH, IDC_STATIC
+#: Merge.rc:2699
+msgid "St&yle:"
+msgstr "&Üslub:"
+
+#. IDD_GENERATE_PATCH, IDC_STATIC
+#: Merge.rc:2701
+msgid "&Context:"
+msgstr "&Kontekst:"
+
+#. IDD_GENERATE_PATCH, IDC_DIFF_INCLCMDLINE
+#: Merge.rc:2703
+msgid "Inclu&de command line"
+msgstr "Əmr sətrini &daxil et"
+
+#. IDD_GENERATE_PATCH, IDC_DIFF_OPENTOEDITOR
+#: Merge.rc:2704
+msgid "Open in e&xternal editor"
+msgstr "&Xarici redaktorda aç"
+
+#. IDD_DIRCOLS
+#: Merge.rc:2721
+msgid "Display Columns"
+msgstr "Göstərilən sütunlar"
+
+#. IDD_DIRCOLS, IDC_UP
+#: Merge.rc:2725
+msgid "Move &Up"
+msgstr "&Yuxarı daşı"
+
+#. IDD_DIRCOLS, IDC_DOWN
+#: Merge.rc:2726
+msgid "Move &Down"
+msgstr "&Aşağı daşı"
+
+#. IDD_DIRCOLS, IDC_COLDLG_ADDITIONAL_PROPERTIES
+#: Merge.rc:2728
+msgid "&Additional Properties"
+msgstr "&Əlavə xassələr"
+
+#. IDD_DIRADDITIONALPROPS
+#: Merge.rc:2736
+msgid "Additional Properties"
+msgstr "Əlavə xassələr"
+
+#. IDD_PLUGINS_SELECTPLUGIN
+#: Merge.rc:2750
+msgid "Select Plugin"
+msgstr "Qoşma seçin"
+
+#. IDD_PLUGINS_EDITPLUGIN, IDC_STATIC
+#: Merge.rc:2753 Merge.rc:3448
+msgid "Plugin &name:"
+msgstr "Qoşmanın &adı:"
+
+#. IDD_PLUGINS_SELECTPLUGIN, IDC_STATIC
+#: Merge.rc:2755
+msgid "&Target files:"
+msgstr "&Hədəf fayllar:"
+
+#. IDD_PLUGINS_EDITPLUGIN, IDC_STATIC
+#: Merge.rc:2757 Merge.rc:3450
+msgid "Extensions list:"
+msgstr "Uzantı siyahısı:"
+
+#. IDD_PLUGINS_EDITPLUGIN, IDC_STATIC
+#: Merge.rc:2759 Merge.rc:3452
+msgid "Description:"
+msgstr "Təsvir:"
+
+#. IDD_PLUGINS_EDITPLUGIN, IDC_STATIC
+#: Merge.rc:2761 Merge.rc:3454
+msgid "Default arguments:"
+msgstr "Standart arqumentlər:"
+
+#. IDD_PLUGINS_SELECTPLUGIN, IDC_PLUGIN_ALLOW_ALL
+#: Merge.rc:2763
+msgid "Display all plugins (Ignore extension)"
+msgstr "Bütün qoşmaları göstər (uzantını nəzərə alma)"
+
+#. IDD_PLUGINS_SELECTPLUGIN, IDC_PLUGIN_OPEN_IN_SAME_FRAME_TYPE
+#: Merge.rc:2765
+msgid "&Open files in same window type after unpacking"
+msgstr "Açıldıqdan sonra faylları eyni növ pəncərədə &aç"
+
+#. IDD_PLUGINS_EDITPLUGIN, IDC_PLUGIN_PIPELINE_STATIC
+#: Merge.rc:2767 Merge.rc:3462
+msgid "&Plugin pipeline:"
+msgstr "&Qoşma ardıcıllığı:"
+
+#. IDD_PLUGINS_SELECTPLUGIN, IDC_PLUGIN_ALIAS
+#: Merge.rc:2770
+msgid "&Alias..."
+msgstr "&Ləqəb..."
+
+#. IDD_DIRCOMP_PROGRESS, IDC_COMPARISON_STOP
+#: Merge.rc:2780
+msgid "Stop"
+msgstr "Dayandır"
+
+#. IDD_DIRCOMP_PROGRESS, IDC_COMPARISON_PAUSE
+#: Merge.rc:2781
+msgid "Pause"
+msgstr "Fasilə ver"
+
+#. IDD_DIRCOMP_PROGRESS, IDC_COMPARISON_CONTINUE
+#: Merge.rc:2782
+msgid "Continue"
+msgstr "Davam et"
+
+#. IDD_PROPPAGE_COMPARE_FOLDER, IDC_STATIC
+#: Merge.rc:2784 Merge.rc:3305
+msgid "C&PU cores to use:"
+msgstr "İstifadə ediləcək &CPU nüvələri:"
+
+#. IDD_DIRCOMP_PROGRESS, IDC_STATIC
+#: Merge.rc:2785
+msgid "Items total:"
+msgstr "Ümumi element sayı:"
+
+#. IDD_DIRCOMP_PROGRESS, IDC_STATIC
+#: Merge.rc:2786
+msgid "Items compared:"
+msgstr "Müqayisə edilmiş elementlər:"
+
+#. IDS_PREVIEWBAR_CLOSE
+#: Merge.rc:2801 Merge.rc:3178 Merge.rc:5696
+msgid "&Close"
+msgstr "&Bağla"
+
+#. IDD_WMGOTO
+#: Merge.rc:2812
+msgid "Go to"
+msgstr "Keç"
+
+#. IDD_WMGOTO, IDC_STATIC
+#: Merge.rc:2815
+msgid "G&o to:"
+msgstr "&Keç:"
+
+#. IDD_WMGOTO, IDC_STATIC
+#: Merge.rc:2818
+msgid "File"
+msgstr "Fayl"
+
+#. IDD_WMGOTO, IDC_STATIC
+#: Merge.rc:2822
+msgid "Go to what"
+msgstr "Keçid hədəfi"
+
+#. IDD_WMGOTO, IDC_WMGOTO_TOLINE
+#: Merge.rc:2823
+msgid "Li&ne"
+msgstr "&Sətir"
+
+#. IDD_WMGOTO, IDC_WMGOTO_TODIFF
+#: Merge.rc:2824
+msgid "&Difference"
+msgstr "&Fərq"
+
+#. IDD_WMGOTO, IDOK
+#: Merge.rc:2825
+msgid "&Go to"
+msgstr "&Keç"
+
+#. IDS_PROJECT_ITEM_FILE_FILTER
+#: Merge.rc:2831 Merge.rc:4682
+msgid "File Filters"
+msgstr "Fayl süzgəcləri"
+
+#. IDD_FILTERS_FILEFILTERS, IDC_STATIC
+#: Merge.rc:2834
+msgid "&Mask / Filter Expression"
+msgstr "&Maska / süzgəc ifadəsi"
+
+#. IDD_FILTERS_FILEFILTERS, IDC_STATIC
+#: Merge.rc:2837
+msgid "Preset &Filters"
+msgstr "Hazır &süzgəclər"
+
+#. IDD_FILTERS_FILEFILTERS, IDC_FILTERFILE_TEST_BTN
+#: Merge.rc:2839
+msgid "Test..."
+msgstr "Yoxla..."
+
+#. IDD_FILTERS_FILEFILTERS, IDC_FILTERFILE_INSTALL
+#: Merge.rc:2840
+msgid "Install..."
+msgstr "Quraşdır..."
+
+#. IDD_FILTERS_FILEFILTERS, IDC_FILTERFILE_NEWBTN
+#: Merge.rc:2841
+msgid "New..."
+msgstr "Yeni..."
+
+#. IDD_FILTERS_FILEFILTERS, IDC_FILTERFILE_EDITBTN
+#: Merge.rc:2842
+msgid "Edit..."
+msgstr "Redaktə et..."
+
+#. IDD_FILTERS_FILEFILTERS, IDC_FILTERFILE_DELETEBTN
+#: Merge.rc:2843
+msgid "Delete..."
+msgstr "Sil..."
+
+#. IDD_FILTERS_CONDITION
+#: Merge.rc:2848
+msgid "Filter Condition"
+msgstr "Süzgəc şərti"
+
+#. IDD_FILTERS_CONDITION, IDC_STATIC
+#: Merge.rc:2851
+msgid "&Left-hand side:"
+msgstr "&Sol tərəf:"
+
+#. IDD_FILTERS_CONDITION, IDC_STATIC
+#: Merge.rc:2853
+msgid "&Operator:"
+msgstr "&Operator:"
+
+#. IDD_FILTERS_CONDITION, IDC_STATIC
+#: Merge.rc:2855
+msgid "&Right-hand side:"
+msgstr "S&ağ tərəf:"
+
+#. IDD_FILTERS_CONDITION, IDC_STATIC
+#: Merge.rc:2861
+msgid "Expression:"
+msgstr "İfadə:"
+
+#. IDD_COMPARISON_RESULT_FILTER
+#: Merge.rc:2869
+msgid "Filter by Comparison Result"
+msgstr "Müqayisə nəticəsinə görə süz"
+
+#. IDD_COMPARISON_RESULT_FILTER, IDC_RADIO_INCLUDE
+#: Merge.rc:2872
+msgid "&Include"
+msgstr "&Daxil et"
+
+#. IDD_COMPARISON_RESULT_FILTER, IDC_RADIO_EXCLUDE
+#: Merge.rc:2873
+msgid "&Exclude"
+msgstr "&İstisna et"
+
+#. IDD_COMPARISON_RESULT_FILTER, IDC_STATIC
+#: Merge.rc:2874
+msgid "Comparison Results"
+msgstr "Müqayisə nəticələri"
+
+#. IDD_COMPARISON_RESULT_FILTER, IDC_CHECK_LEFT_ONLY
+#: Merge.rc:2877
+msgid "Left only"
+msgstr "Yalnız solda"
+
+#. IDD_COMPARISON_RESULT_FILTER, IDC_CHECK_RIGHT_ONLY
+#: Merge.rc:2878
+msgid "Right only"
+msgstr "Yalnız sağda"
+
+#. IDD_COMPARISON_RESULT_FILTER, IDC_CHECK_SKIPPED
+#: Merge.rc:2879
+msgid "Skipped"
+msgstr "Ötürülüb"
+
+#. IDD_COMPARISON_RESULT_FILTER, IDC_CHECK_MIDDLE_ONLY
+#: Merge.rc:2880
+msgid "Middle only"
+msgstr "Yalnız ortada"
+
+#. IDD_COMPARISON_RESULT_FILTER, IDC_CHECK_LEFT_ONLY_DIFFERENT
+#: Merge.rc:2881
+msgid "Left only (different)"
+msgstr "Yalnız solda (fərqli)"
+
+#. IDD_COMPARISON_RESULT_FILTER, IDC_CHECK_MIDDLE_ONLY_DIFFERENT
+#: Merge.rc:2883
+msgid "Middle only (different)"
+msgstr "Yalnız ortada (fərqli)"
+
+#. IDD_COMPARISON_RESULT_FILTER, IDC_CHECK_RIGHT_ONLY_DIFFERENT
+#: Merge.rc:2885
+msgid "Right only (different)"
+msgstr "Yalnız sağda (fərqli)"
+
+#. IDD_COMPARISON_RESULT_FILTER, IDC_CHECK_LEFT_ONLY_MISSING
+#: Merge.rc:2887
+msgid "Left only (missing)"
+msgstr "Yalnız solda (çatışmır)"
+
+#. IDD_COMPARISON_RESULT_FILTER, IDC_CHECK_MIDDLE_ONLY_MISSING
+#: Merge.rc:2888
+msgid "Middle only (missing)"
+msgstr "Yalnız ortada (çatışmır)"
+
+#. IDD_COMPARISON_RESULT_FILTER, IDC_CHECK_RIGHT_ONLY_MISSING
+#: Merge.rc:2890
+msgid "Right only (missing)"
+msgstr "Yalnız sağda (çatışmır)"
+
+#. IDD_FILTERS_MATCHINSIDE
+#: Merge.rc:2898
+msgid "Match Inside/Outside Filter Expressions"
+msgstr "Süzgəc ifadələrinin daxilində/xaricində uyğunlaşdır"
+
+#. IDD_FILTERS_MATCHINSIDE, IDC_STATIC
+#: Merge.rc:2901
+msgid "&Start filter:"
+msgstr "&Başlanğıc süzgəci:"
+
+#. IDD_FILTERS_MATCHINSIDE, IDC_STATIC
+#: Merge.rc:2904
+msgid "&End filter:"
+msgstr "&Son süzgəc:"
+
+#. IDD_FILTERS_MATCHINSIDE, IDC_STATIC
+#: Merge.rc:2907
+msgid "Lines between start and end filter matches will be included."
+msgstr "Başlanğıc və son süzgəc uyğunluqları arasındakı sətirlər daxil ediləcək."
+
+#. IDS_OPTIONSPG_CODEPAGE
+#: Merge.rc:2914 Merge.rc:3143 Merge.rc:4573
+msgid "Codepage"
+msgstr "Kod səhifəsi"
+
+#. IDD_PROPPAGE_CODEPAGE, IDC_STATIC
+#: Merge.rc:2917
+msgid "Default Codepage"
+msgstr "Standart kod səhifəsi"
+
+#. IDD_PROPPAGE_CODEPAGE, IDC_STATIC
+#: Merge.rc:2918
+msgid "Select the default codepage for non-Unicode files:"
+msgstr "Unicode olmayan fayllar üçün standart kod səhifəsini seçin:"
+
+#. IDD_PROPPAGE_CODEPAGE, IDC_CP_SYSTEM
+#: Merge.rc:2919
+msgid "System codepage"
+msgstr "Sistemin kod səhifəsi"
+
+#. IDD_PROPPAGE_CODEPAGE, IDC_CP_UI
+#: Merge.rc:2920
+msgid "According to WinMerge User Interface"
+msgstr "WinMerge istifadəçi interfeysinə uyğun"
+
+#. IDD_PROPPAGE_CODEPAGE, IDC_CP_CUSTOM
+#: Merge.rc:2921
+msgid "Custom codepage:"
+msgstr "Xüsusi kod səhifəsi:"
+
+#. IDD_PROPPAGE_CODEPAGE, IDC_DETECT_CODEPAGE
+#: Merge.rc:2923
+msgid "Detect codepage for: .html, .rc, .xml\nRestart required."
+msgstr "Bu faylların kod səhifəsini aşkar et: .html, .rc, .xml\nYenidən başlatmaq lazımdır."
+
+#. IDD_PROPPAGE_CODEPAGE, IDC_DETECT_CODEPAGE2
+#: Merge.rc:2925
+msgid "Detect codepage for files with mlang.dll\nRestart required."
+msgstr "Faylların kod səhifəsini mlang.dll ilə aşkar et\nYenidən başlatmaq lazımdır."
+
+#. IDS_OPTIONSPG_ARCHIVE
+#: Merge.rc:2933 Merge.rc:4574
+msgid "Archive Support"
+msgstr "Arxiv dəstəyi"
+
+#. IDD_PROPPAGE_ARCHIVE, IDC_ARCHIVE_ENABLE
+#: Merge.rc:2936
+msgid "&Enable archive file support"
+msgstr "Arxiv fayllarının dəstəyini &aktivləşdir"
+
+#. IDD_PROPPAGE_ARCHIVE, IDC_ARCHIVE_DETECTTYPE
+#: Merge.rc:2937
+msgid "&Detect archive type from file signature"
+msgstr "Arxiv növünü fayl imzasından &aşkar et"
+
+#. IDD_PROPPAGE_PROJECT, IDC_STATIC
+#: Merge.rc:2946
+msgid "Items saved to or restored from the project file:"
+msgstr "Layihə faylında saxlanan və ya ondan bərpa edilən elementlər:"
+
+#. IDD_SAVECLOSING
+#: Merge.rc:2953
+msgid "Save Modified Files?"
+msgstr "Dəyişdirilmiş fayllar saxlansın?"
+
+#. IDD_SAVECLOSING, IDC_SAVECLOSING_LEFTFRAME
+#: Merge.rc:2956
+msgid "Left side file"
+msgstr "Sol tərəfdəki fayl"
+
+#. IDD_SAVECLOSING, IDC_SAVECLOSING_SAVELEFT
+#: Merge.rc:2958
+msgid "&Save changes"
+msgstr "Dəyişiklikləri &saxla"
+
+#. IDD_SAVECLOSING, IDC_SAVECLOSING_DISCARDLEFT
+#: Merge.rc:2959
+msgid "&Discard changes"
+msgstr "Dəyişiklikləri &ləğv et"
+
+#. IDD_SAVECLOSING, IDC_SAVECLOSING_MIDDLEFRAME
+#: Merge.rc:2960
+msgid "Middle side file"
+msgstr "Orta tərəfdəki fayl"
+
+#. IDD_SAVECLOSING, IDC_SAVECLOSING_SAVEMIDDLE
+#: Merge.rc:2962
+msgid "Sa&ve changes"
+msgstr "Dəyişiklikləri sa&xla"
+
+#. IDD_SAVECLOSING, IDC_SAVECLOSING_DISCARDMIDDLE
+#: Merge.rc:2963
+msgid "Discard c&hanges"
+msgstr "Dəyişiklikləri lə&ğv et"
+
+#. IDD_SAVECLOSING, IDC_SAVECLOSING_RIGHTFRAME
+#: Merge.rc:2964
+msgid "Right side file"
+msgstr "Sağ tərəfdəki fayl"
+
+#. IDD_SAVECLOSING, IDC_SAVECLOSING_SAVERIGHT
+#: Merge.rc:2966
+msgid "S&ave changes"
+msgstr "Dəyişiklikləri s&axla"
+
+#. IDD_SAVECLOSING, IDC_SAVECLOSING_DISCARDRIGHT
+#: Merge.rc:2967
+msgid "Dis&card changes"
+msgstr "Dəyişiklikləri ləğv &et"
+
+#. IDD_SAVECLOSING, IDC_SAVECLOSING_DISCARDALL
+#: Merge.rc:2968
+msgid "Disca&rd All"
+msgstr "Hamısını &ləğv et"
+
+#. IDD_DIRCMP_REPORT
+#: Merge.rc:2975
+msgid "Folder Compare Report"
+msgstr "Qovluq müqayisəsi hesabatı"
+
+#. IDD_FILECMP_REPORT, IDC_STATIC
+#: Merge.rc:2978 Merge.rc:2998
+msgid "Report &file:"
+msgstr "Hesabat &faylı:"
+
+#. IDD_DIRCMP_REPORT, IDC_STATIC
+#: Merge.rc:2981
+msgid "&Style:"
+msgstr "&Üslub:"
+
+#. IDD_DIRCMP_REPORT, IDC_REPORT_INCLUDEFILECMPREPORT
+#: Merge.rc:2983
+msgid "&Include file compare report"
+msgstr "Fayl müqayisəsi hesabatını &daxil et"
+
+#. IDD_FILECMP_REPORT, IDC_REPORT_OPENREPORTFILE
+#: Merge.rc:2986 Merge.rc:3002
+msgid "Open report after &generating"
+msgstr "Hesabatı yaratdıqdan sonra &aç"
+
+#. IDD_FILECMP_REPORT
+#: Merge.rc:2993
+msgid "File Compare Report"
+msgstr "Fayl müqayisəsi hesabatı"
+
+#. IDD_FILECMP_REPORT, IDC_REPORT_INCLUDE_ALL_IMAGE_PAGES
+#: Merge.rc:3003
+msgid "&Include all image pages"
+msgstr "Şəklin bütün səhifələrini &daxil et"
+
+#. IDD_FILECMP_REPORT, IDC_REPORT_INFO
+#: Merge.rc:3004
+msgid "\\u24D8 The report uses the current comparison settings."
+msgstr "\\u24D8 Hesabatda cari müqayisə parametrləri istifadə olunur."
+
+#. IDD_ARCHIVE
+#: Merge.rc:3011
+msgid "Archive Generator"
+msgstr "Arxiv yaradıcısı"
+
+#. IDD_ARCHIVE, IDC_STATIC
+#: Merge.rc:3016
+msgid "Archive &file:"
+msgstr "Arxiv &faylı:"
+
+#. IDD_ARCHIVE, IDC_ARCHIVE_REPORT
+#: Merge.rc:3019
+msgid "Include &report"
+msgstr "&Hesabatı daxil et"
+
+#. IDD_ARCHIVE, IDC_ARCHIVE_PATCH
+#: Merge.rc:3020
+msgid "Include &patch"
+msgstr "&Yamağı daxil et"
+
+#. IDD_ARCHIVE, IDC_ARCHIVE_PROJECT
+#: Merge.rc:3021
+msgid "Include pro&ject"
+msgstr "&Layihəni daxil et"
+
+#. IDD_FILTERS_FILEFILTERS_SHARED
+#: Merge.rc:3029
+msgid "Shared or Private Filter"
+msgstr "Ümumi və ya şəxsi süzgəc"
+
+#. IDD_FILTERS_FILEFILTERS_SHARED, IDC_STATIC
+#: Merge.rc:3032
+msgid "What type of filter do you want?"
+msgstr "Hansı növ süzgəc istəyirsiniz?"
+
+#. IDD_FILTERS_FILEFILTERS_SHARED, IDC_SHARED
+#: Merge.rc:3033
+msgid "Shared Filter (for all users)"
+msgstr "Ümumi süzgəc (bütün istifadəçilər üçün)"
+
+#. IDD_FILTERS_FILEFILTERS_SHARED, IDC_PRIVATE
+#: Merge.rc:3034
+msgid "Private Filter (current user only)"
+msgstr "Şəxsi süzgəc (yalnız cari istifadəçi üçün)"
+
+#. IDD_COMPARE_STATISTICS3
+#: Merge.rc:3041 Merge.rc:3082
+msgid "Compare Statistics"
+msgstr "Müqayisə statistikası"
+
+#. IDD_COMPARE_STATISTICS3, IDC_STATIC
+#: Merge.rc:3044 Merge.rc:3085
+msgid "Folders:"
+msgstr "Qovluqlar:"
+
+#. IDD_COMPARE_STATISTICS3, IDC_STATIC
+#: Merge.rc:3045 Merge.rc:3086
+msgid "Files:"
+msgstr "Fayllar:"
+
+#. IDD_COMPARE_STATISTICS3, IDC_STATIC
+#: Merge.rc:3051 Merge.rc:3070 Merge.rc:3092 Merge.rc:3131
+msgid "Binary:"
+msgstr "İkilik:"
+
+#. IDD_COMPARE_STATISTICS3, IDC_STATIC
+#: Merge.rc:3054 Merge.rc:3095
+msgid "Unique"
+msgstr "Yalnız bir tərəfdə"
+
+#. IDD_COMPARE_STATISTICS3, IDC_STATIC
+#: Merge.rc:3055 Merge.rc:3096
+msgid "Left:"
+msgstr "Sol:"
+
+#. IDD_COMPARE_STATISTICS3, IDC_STATIC
+#: Merge.rc:3060 Merge.rc:3106
+msgid "Right:"
+msgstr "Sağ:"
+
+#. IDD_COMPARE_STATISTICS3, IDC_STATIC
+#: Merge.rc:3074 Merge.rc:3135
+msgid "Total:"
+msgstr "Cəmi:"
+
+#. IDD_COMPARE_STATISTICS3, IDOK
+#: Merge.rc:3077 Merge.rc:3138
+msgid "Close"
+msgstr "Bağla"
+
+#. IDD_COMPARE_STATISTICS3, IDC_STATIC
+#: Merge.rc:3101
+msgid "Middle:"
+msgstr "Orta:"
+
+#. IDD_COMPARE_STATISTICS3, IDC_STATIC
+#: Merge.rc:3111
+msgid "Missing Left:"
+msgstr "Solda çatışmır:"
+
+#. IDD_COMPARE_STATISTICS3, IDC_STATIC
+#: Merge.rc:3116
+msgid "Missing Middle:"
+msgstr "Ortada çatışmır:"
+
+#. IDD_COMPARE_STATISTICS3, IDC_STATIC
+#: Merge.rc:3121
+msgid "Missing Right:"
+msgstr "Sağda çatışmır:"
+
+#. IDD_LOAD_SAVE_CODEPAGE, IDC_AFFECTS_GROUP
+#: Merge.rc:3146
+msgid "Affects"
+msgstr "Təsir edir"
+
+#. IDD_LOAD_SAVE_CODEPAGE, IDC_RIGHT_FILES_LABEL
+#: Merge.rc:3148 Merge.rc:3150 Merge.rc:3152
+msgid "(Affects)"
+msgstr "(Təsir edir)"
+
+#. IDD_LOAD_SAVE_CODEPAGE, IDC_LOADING_GROUP
+#: Merge.rc:3153
+msgid "Select Codepage for"
+msgstr "Kod səhifəsinin tətbiq sahəsi"
+
+#. IDD_LOAD_SAVE_CODEPAGE, IDC_LOAD_FILES_LABEL
+#: Merge.rc:3154
+msgid "&File Loading:"
+msgstr "Faylın &yüklənməsi:"
+
+#. IDD_LOAD_SAVE_CODEPAGE, IDC_SAVE_FILES_LABEL
+#: Merge.rc:3156
+msgid "File &Saving:"
+msgstr "Faylın &saxlanması:"
+
+#. IDD_LOAD_SAVE_CODEPAGE, IDC_LOAD_SAVE_SAME_CODEPAGE
+#: Merge.rc:3159
+msgid "&Use same codepage for both"
+msgstr "Hər ikisi üçün &eyni kod səhifəsindən istifadə et"
+
+#. IDS_MESSAGEBOX_CANCEL
+#: Merge.rc:3162 Merge.rc:4532
+msgid "&Cancel"
+msgstr "&Ləğv et"
+
+#. IDD_FILTERS_FILEFILTERS_TEST
+#: Merge.rc:3167
+msgid "Test Filter"
+msgstr "Süzgəci yoxla"
+
+#. IDD_FILTERS_FILEFILTERS_TEST, IDC_HEADER
+#: Merge.rc:3170
+msgid "Testing filter:"
+msgstr "Yoxlanılan süzgəc:"
+
+#. IDD_FILTERS_FILEFILTERS_TEST, IDC_PROMPT_LABEL
+#: Merge.rc:3172
+msgid "&Enter text to test:"
+msgstr "Yoxlamaq üçün mətni &daxil edin:"
+
+#. IDD_FILTERS_FILEFILTERS_TEST, IDC_IS_DIRECTORY
+#: Merge.rc:3174
+msgid "&Folder Name"
+msgstr "&Qovluğun adı"
+
+#. IDD_FILTERS_FILEFILTERS_TEST, IDC_STATIC
+#: Merge.rc:3175
+msgid "Result:"
+msgstr "Nəticə:"
+
+#. IDD_FILTERS_FILEFILTERS_TEST, IDC_TEST_BTN
+#: Merge.rc:3177
+msgid "&Test"
+msgstr "&Yoxla"
+
+#. IDS_OPTIONSPG_TABLECOMPARE
+#: Merge.rc:3183 Merge.rc:3322 Merge.rc:4588
+msgid "Table"
+msgstr "Cədvəl"
+
+#. IDD_OPEN_TABLE, IDC_STATIC
+#: Merge.rc:3186
+msgid "File type"
+msgstr "Fayl növü"
+
+#. IDD_OPEN_TABLE, IDC_COMPARETABLE_CSV
+#: Merge.rc:3187
+msgid "&CSV"
+msgstr "&CSV"
+
+#. IDD_OPEN_TABLE, IDC_COMPARETABLE_TSV
+#: Merge.rc:3188
+msgid "&TSV"
+msgstr "&TSV"
+
+#. IDD_OPEN_TABLE, IDC_COMPARETABLE_DSV
+#: Merge.rc:3189
+msgid "Custom &Delimiter-Separated Values"
+msgstr "Xüsusi &ayırıcı ilə ayrılmış qiymətlər"
+
+#. IDD_PROPPAGE_COMPARE_TABLE, IDC_STATIC
+#: Merge.rc:3191 Merge.rc:3193 Merge.rc:3328 Merge.rc:3336
+msgid "D&elimiter character:"
+msgstr "&Ayırıcı simvol:"
+
+#. IDD_PROPPAGE_COMPARE_TABLE, IDC_COMPARETABLE_ALLOWNEWLINE
+#: Merge.rc:3195 Merge.rc:3338
+msgid "&Allow newlines in quotes"
+msgstr "Dırnaq daxilində yeni sətirlərə &icazə ver"
+
+#. IDD_PROPPAGE_COMPARE_TABLE, IDC_STATIC
+#: Merge.rc:3197 Merge.rc:3340
+msgid "&Quote character:"
+msgstr "&Dırnaq simvolu:"
+
+#. IDS_OPTIONSPG_BACKUPS
+#: Merge.rc:3205 Merge.rc:4576
+msgid "Backup Files"
+msgstr "Ehtiyat nüsxə faylları"
+
+#. IDD_PROPPAGE_BACKUPS, IDC_STATIC
+#: Merge.rc:3208
+msgid "Create backup files for:"
+msgstr "Bu əməliyyatlar üçün ehtiyat nüsxə faylları yarat:"
+
+#. IDD_PROPPAGE_BACKUPS, IDC_BACKUP_FOLDERCMP
+#: Merge.rc:3209
+msgid "&Folder compare"
+msgstr "&Qovluq müqayisəsi"
+
+#. IDD_PROPPAGE_BACKUPS, IDC_BACKUP_FILECMP
+#: Merge.rc:3210
+msgid "Fil&e compare"
+msgstr "&Fayl müqayisəsi"
+
+#. IDD_PROPPAGE_BACKUPS, IDC_STATIC
+#: Merge.rc:3211
+msgid "Create backup files in:"
+msgstr "Ehtiyat nüsxə fayllarını burada yarat:"
+
+#. IDD_PROPPAGE_BACKUPS, IDC_BACKUP_ORIGFOLD
+#: Merge.rc:3212
+msgid "&Original file's folder"
+msgstr "&İlkin faylın qovluğu"
+
+#. IDD_PROPPAGE_BACKUPS, IDC_BACKUP_GLOBALFOLD
+#: Merge.rc:3213
+msgid "&Global backup folder:"
+msgstr "&Ümumi ehtiyat nüsxə qovluğu:"
+
+#. IDD_PROPPAGE_BACKUPS, IDC_STATIC
+#: Merge.rc:3216
+msgid "Backup filename:"
+msgstr "Ehtiyat nüsxə faylının adı:"
+
+#. IDD_PROPPAGE_BACKUPS, IDC_BACKUP_APPEND_BAK
+#: Merge.rc:3217
+msgid "&Append .bak extension"
+msgstr ".bak uzantısı &əlavə et"
+
+#. IDD_PROPPAGE_BACKUPS, IDC_BACKUP_APPEND_TIME
+#: Merge.rc:3218
+msgid "A&ppend timestamp"
+msgstr "Vaxt &nişanı əlavə et"
+
+#. IDS_CONFIRM_COPY_CAPTION
+#: Merge.rc:3224 Merge.rc:4926
+msgid "Confirm Copy"
+msgstr "Köçürməni təsdiqlə"
+
+#. IDD_CONFIRM_COPY, IDC_FLDCONFIRM_QUERY
+#: Merge.rc:3228
+msgid "Are you sure you want to copy XXX items?"
+msgstr "XXX elementi köçürmək istədiyinizə əminsiniz?"
+
+#. IDD_CONFIRM_COPY, IDC_FLDCONFIRM_FROM_TEXT
+#: Merge.rc:3229
+msgid "From left"
+msgstr "Soldan"
+
+#. IDD_CONFIRM_COPY, IDC_FLDCONFIRM_TO_TEXT
+#: Merge.rc:3231
+msgid "To right"
+msgstr "Sağa"
+
+#. IDS_MESSAGEBOX_DONT_ASK_AGAIN
+#: Merge.rc:3233 Merge.rc:4551
+msgid "Don't ask this &question again."
+msgstr "Bu &sualı bir daha vermə."
+
+#. IDD_CONFIRM_COPY, IDYES
+#: Merge.rc:3235
+msgid "Yes"
+msgstr "Bəli"
+
+#. IDD_CONFIRM_COPY, IDNO
+#: Merge.rc:3236
+msgid "No"
+msgstr "Xeyr"
+
+#. IDS_PROJECT_ITEM_PLUGIN
+#: Merge.rc:3241 Merge.rc:4684
+msgid "Plugins"
+msgstr "Qoşmalar"
+
+#. IDD_PLUGINS_LIST, IDC_PLUGINS_ENABLE
+#: Merge.rc:3244
+msgid "&Enable plugins"
+msgstr "Qoşmaları &aktivləşdir"
+
+#. IDD_PLUGINS_EDITPLUGIN, IDC_STATIC
+#: Merge.rc:3245 Merge.rc:3446
+msgid "Plugin &type:"
+msgstr "Qoşmanın &növü:"
+
+#. IDD_PLUGINS_LIST, IDC_STATIC
+#: Merge.rc:3248
+msgid "File filters:"
+msgstr "Fayl süzgəcləri:"
+
+#. IDD_PLUGINS_LIST, IDC_STATIC
+#: Merge.rc:3250
+msgid "&Plugin arguments:"
+msgstr "Qoşmanın &arqumentləri:"
+
+#. IDD_PLUGINS_EDITPLUGIN, IDC_PLUGIN_AUTOMATIC
+#: Merge.rc:3252 Merge.rc:3467
+msgid "Enable &automatic unpacking/prediffing"
+msgstr "&Avtomatik açmanı/ilkin müqayisə emalını aktivləşdir"
+
+#. IDS_OPTIONSPG_SHELL
+#: Merge.rc:3266 Merge.rc:4577
+msgid "Shell Integration"
+msgstr "Örtüklə inteqrasiya"
+
+#. IDD_PROPPAGE_SHELL, IDC_STATIC
+#: Merge.rc:3269
+msgid "Explorer"
+msgstr "Explorer"
+
+#. IDD_PROPPAGE_SHELL, IDC_EXPLORER_CONTEXT
+#: Merge.rc:3270
+msgid "&Add to context menu"
+msgstr "Kontekst menyusuna &əlavə et"
+
+#. IDD_PROPPAGE_SHELL, IDC_EXPLORER_ADVANCED
+#: Merge.rc:3271
+msgid "E&nable advanced menu"
+msgstr "Genişləndirilmiş menyunu &aktivləşdir"
+
+#. IDD_PROPPAGE_SHELL, IDC_EXPLORER_COMPARE_AS
+#: Merge.rc:3272
+msgid "Enable &Compare As menu"
+msgstr "&Müqayisə üsulu menyusunu aktivləşdir"
+
+#. IDD_PROPPAGE_SHELL, IDC_REGISTER_SHELLEXTENSION
+#: Merge.rc:3273
+msgid "&Register Shell Extension"
+msgstr "Örtük genişlənməsini &qeydiyyata al"
+
+#. IDD_PROPPAGE_SHELL, IDC_UNREGISTER_SHELLEXTENSION
+#: Merge.rc:3274
+msgid "&Unregister Shell Extension"
+msgstr "Örtük genişlənməsini qeydiyyatdan &çıxar"
+
+#. IDD_PROPPAGE_SHELL, IDC_REGISTER_SHELLEXTENSION_PERUSER
+#: Merge.rc:3275
+msgid "Register Shell Extension for Current User &Only"
+msgstr "Örtük genişlənməsini &yalnız cari istifadəçi üçün qeydiyyata al"
+
+#. IDD_PROPPAGE_SHELL, IDC_UNREGISTER_SHELLEXTENSION_PERUSER
+#: Merge.rc:3276
+msgid "Unregister Shell Extension for Current User On&ly"
+msgstr "Örtük genişlənməsini yalnız cari istifadəçi üçün qeydiyyatdan &çıxar"
+
+#. IDD_PROPPAGE_SHELL, IDC_REGISTER_WINMERGECONTEXTMENU
+#: Merge.rc:3277
+msgid "Register Shell Extension for &Windows 11"
+msgstr "Örtük genişlənməsini &Windows 11 üçün qeydiyyata al"
+
+#. IDD_PROPPAGE_SHELL, IDC_UNREGISTER_WINMERGECONTEXTMENU
+#: Merge.rc:3278
+msgid "Unregister Shell Extension for W&indows 11"
+msgstr "Örtük genişlənməsini W&indows 11 üçün qeydiyyatdan çıxar"
+
+#. IDD_PROPPAGE_SHELL, IDC_STATIC
+#: Merge.rc:3279
+msgid "Jump List"
+msgstr "Keçid siyahısı"
+
+#. IDD_PROPPAGE_SHELL, IDC_CLEAR_ALL_RECENT_ITEMS
+#: Merge.rc:3281
+msgid "Clear all recent items"
+msgstr "Bütün son elementləri təmizlə"
+
+#. IDS_OPTIONSPG_FOLDERCOMPARE
+#: Merge.rc:3286 Merge.rc:4585
+msgctxt "Options dialog|Categories"
+msgid "Folder"
+msgstr "Qovluq"
+
+#. IDD_PROPPAGE_COMPARE_FOLDER, IDC_STATIC
+#: Merge.rc:3289
+msgid "&Compare method:"
+msgstr "&Müqayisə üsulu:"
+
+#. IDD_PROPPAGE_COMPARE_FOLDER, IDC_COMPARE_STOPFIRST
+#: Merge.rc:3291
+msgid "S&top after first difference"
+msgstr "İlk fərqdən sonra &dayan"
+
+#. IDD_PROPPAGE_COMPARE_FOLDER, IDC_IGNORE_SMALLTIMEDIFF
+#: Merge.rc:3293
+msgid "Ign&ore time differences less than 3 seconds"
+msgstr "3 saniyədən az vaxt fərqini &nəzərə alma"
+
+#. IDD_PROPPAGE_COMPARE_FOLDER, IDC_STATIC
+#: Merge.rc:3296
+msgid "Expand subfolders &after comparison:"
+msgstr "Alt qovluqları müqayisədən &sonra genişləndir:"
+
+#. IDD_PROPPAGE_COMPARE_FOLDER, IDC_COMPARE_WALKSUBDIRS
+#: Merge.rc:3298
+msgid "Include &unique subfolders contents"
+msgstr "Yalnız bir tərəfdəki alt qovluqların məzmununu &daxil et"
+
+#. IDD_PROPPAGE_COMPARE_FOLDER, IDC_IGNORE_REPARSEPOINTS
+#: Merge.rc:3300
+msgid "Ignore &reparse points"
+msgstr "Yenidən emal nöqtələrini &nəzərə alma"
+
+#. IDD_PROPPAGE_COMPARE_FOLDER, IDC_STATIC
+#: Merge.rc:3301
+msgid "Switch to &quick compare when size exceeds (MB):"
+msgstr "Ölçü bu həddi aşdıqda &sürətli müqayisəyə keç (MB):"
+
+#. IDD_PROPPAGE_COMPARE_FOLDER, IDC_STATIC
+#: Merge.rc:3303
+msgid "Switch to &binary compare when size exceeds (MB):"
+msgstr "Ölçü bu həddi aşdıqda &ikilik müqayisəyə keç (MB):"
+
+#. IDD_PROPPAGE_COMPARE_FOLDER, IDC_STATIC
+#: Merge.rc:3307
+msgid "Additional comparison condi&tions:"
+msgstr "Əlavə müqayisə &şərtləri:"
+
+#. IDD_PROPPAGE_COMPARE_FOLDER, IDC_STATIC
+#: Merge.rc:3310
+msgid "&Rename/move detection:"
+msgstr "&Ad/yer dəyişikliyinin aşkarlanması:"
+
+#. IDD_PROPPAGE_COMPARE_FOLDER, IDC_STATIC
+#: Merge.rc:3312
+msgid "Rename/move detection &keys:"
+msgstr "Ad/yer dəyişikliyinin aşkarlanması üçün &açarlar:"
+
+#. IDD_PROPPAGE_COMPARE_FOLDER, IDC_STATIC
+#: Merge.rc:3315
+msgid "M&erge renames and moves:"
+msgstr "Ad və yer dəyişikliklərini &birləşdir:"
+
+#. IDD_PROPPAGE_COMPARE_TABLE, IDC_STATIC
+#: Merge.rc:3326 Merge.rc:3331 Merge.rc:3334
+msgid "File patterns:"
+msgstr "Fayl nümunələri:"
+
+#. IDD_PROPPAGE_COMPARE_TABLE, IDC_STATIC
+#: Merge.rc:3333
+msgid "Custom Delimiter-Separated Values"
+msgstr "Xüsusi ayırıcı ilə ayrılmış qiymətlər"
+
+#. IDS_OPTIONSPG_BINARYCOMPARE
+#: Merge.rc:3347 Merge.rc:4587
+msgctxt "Options dialog|Categories"
+msgid "Binary"
+msgstr "İkilik"
+
+#. IDD_PROPPAGE_COMPARE_BINARY, IDC_STATIC
+#: Merge.rc:3350
+msgid "Binary file &patterns:"
+msgstr "İkilik fayl &nümunələri:"
+
+#. IDD_PROPPAGE_COMPARE_BINARY, IDC_STATIC
+#: Merge.rc:3352
+msgid "Frhed settings"
+msgstr "Frhed parametrləri"
+
+#. IDD_PROPPAGE_COMPARE_BINARY, IDC_COMPAREBINARY_VIEWSETTINGS
+#: Merge.rc:3353
+msgid "View &Settings..."
+msgstr "Görünüş &parametrləri..."
+
+#. IDD_PROPPAGE_COMPARE_BINARY, IDC_COMPAREBINARY_BINARYMODE
+#: Merge.rc:3354
+msgid "&Binary Mode..."
+msgstr "&İkilik rejim..."
+
+#. IDD_PROPPAGE_COMPARE_BINARY, IDC_COMPAREBINARY_CHARACTERSET
+#: Merge.rc:3355
+msgid "&Character Set..."
+msgstr "&Simvol dəsti..."
+
+#. IDS_PRPCAT_IMAGE
+#: Merge.rc:3361 Merge.rc:4586 Merge.rc:5026
+msgid "Image"
+msgstr "Şəkil"
+
+#. IDD_PROPPAGE_COMPARE_IMAGE, IDC_STATIC
+#: Merge.rc:3364
+msgid "Image file &patterns:"
+msgstr "Şəkil faylı &nümunələri:"
+
+#. IDD_PROPPAGE_COMPARE_IMAGE, IDC_ENABLE_IMGCMP_IN_DIRCMP
+#: Merge.rc:3366
+msgid "&Enable image compare in folder compare"
+msgstr "Qovluq müqayisəsində şəkil müqayisəsini &aktivləşdir"
+
+#. IDD_PROPPAGE_COMPARE_IMAGE, IDC_COMPAREIMAGE_PREFER_WIC_DECODER
+#: Merge.rc:3368
+msgid "&Prefer WIC Decoder"
+msgstr "&WIC dekoderinə üstünlük ver"
+
+#. IDD_PROPPAGE_COMPARE_IMAGE, IDC_STATIC
+#: Merge.rc:3369
+msgid "OCR result:"
+msgstr "OCR nəticəsi:"
+
+#. IDS_OPTIONSPG_WEBPAGECOMPARE
+#: Merge.rc:3376 Merge.rc:4589
+msgid "Webpage"
+msgstr "Veb-səhifə"
+
+#. IDD_PROPPAGE_COMPARE_WEBPAGE, IDC_STATIC
+#: Merge.rc:3379
+msgid "URL pattern to &include (Regular expression):"
+msgstr "&Daxil ediləcək URL nümunəsi (müntəzəm ifadə):"
+
+#. IDD_PROPPAGE_COMPARE_WEBPAGE, IDC_STATIC
+#: Merge.rc:3381
+msgid "URL pattern to &exclude (Regular expression):"
+msgstr "&İstisna ediləcək URL nümunəsi (müntəzəm ifadə):"
+
+#. IDD_PROPPAGE_COMPARE_WEBPAGE, IDC_STATIC
+#: Merge.rc:3383
+msgid "&User data folder location:"
+msgstr "&İstifadəçi məlumatları qovluğunun yeri:"
+
+#. IDD_PROPPAGE_COMPARE_WEBPAGE, IDC_COMPAREWEBPAGE_USERDATAFOLDER_PERPANE
+#: Merge.rc:3385
+msgid "&Separate user data folders for each pane"
+msgstr "Hər panel üçün &ayrı istifadəçi məlumatları qovluqları"
+
+#. IDD_ENCODINGERROR, IDC_HEXVIEW
+#: Merge.rc:3398
+msgid "&Hex View"
+msgstr "&Onaltılıq görünüş"
+
+#. IDD_PLUGINS_EDITPLUGIN
+#: Merge.rc:3443
+msgid "Edit Plugin"
+msgstr "Qoşmanı redaktə et"
+
+#. IDD_PLUGINS_EDITPLUGIN, IDC_STATIC
+#: Merge.rc:3456
+msgid "&Category:"
+msgstr "&Kateqoriya:"
+
+#. IDD_PLUGINS_EDITPLUGIN, IDC_PLUGIN_MENUCAPTION_STATIC
+#: Merge.rc:3458
+msgid "&Menu caption:"
+msgstr "&Menyu başlığı:"
+
+#. IDD_PLUGINS_EDITPLUGIN, IDC_PLUGIN_WINDOWTYPE_STATIC
+#: Merge.rc:3460
+msgid "&Window type:"
+msgstr "&Pəncərə növü:"
+
+#. IDD_PLUGINS_EDITPLUGIN, IDC_PLUGIN_UNPACKEDFILEEXTENSION_STATIC
+#: Merge.rc:3465
+msgid "&Unpacked file extension:"
+msgstr "&Açılmış faylın uzantısı:"
+
+#. IDD_PLUGINS_EDITPLUGIN, IDC_PLUGIN_ARGUMENTSREQUIRED
+#: Merge.rc:3469
+msgid "&Require arguments"
+msgstr "Arqumentləri &tələb et"
+
+#. IDD_PLUGINS_EDITPLUGIN, IDC_PLUGIN_GENERATESCRIPT
+#: Merge.rc:3470
+msgid "&Generate editor script"
+msgstr "Redaktor skripti &yarat"
+
+#. IDD_PLUGINS_EDITPLUGIN, IDC_PLUGIN_COMMAND_LINE_STATIC
+#: Merge.rc:3473
+msgid "Command &line:"
+msgstr "Əmr &sətri:"
+
+#. IDD_PLUGINS_EDITPLUGIN, IDC_PLUGIN_SCRIPT_FILEEXTENSION_STATIC
+#: Merge.rc:3476
+msgid "&Script file extension:"
+msgstr "&Skript faylının uzantısı:"
+
+#. IDD_PLUGINS_EDITPLUGIN, IDC_PLUGIN_SCRIPT_BODY_STATIC
+#: Merge.rc:3478
+msgid "Script &body:"
+msgstr "Skriptin &mətni:"
+
+#. IDD_PLUGINS_EDITPLUGIN
+#: Merge.rc:3487
+msgid "Font"
+msgstr "Şrift"
+
+#. IDD_PLUGINS_EDITPLUGIN
+#: Merge.rc:3490
+msgid "&Font:"
+msgstr "&Şrift:"
+
+#. IDD_PLUGINS_EDITPLUGIN
+#: Merge.rc:3496
+msgid "Font st&yle:"
+msgstr "Şriftin &üslubu:"
+
+#. IDD_PLUGINS_EDITPLUGIN
+#: Merge.rc:3502
+msgid "&Size:"
+msgstr "&Ölçü:"
+
+#. IDD_PLUGINS_EDITPLUGIN
+#: Merge.rc:3508
+msgid "Effects"
+msgstr "Effektlər"
+
+#. IDD_PLUGINS_EDITPLUGIN
+#: Merge.rc:3509
+msgid "Stri&keout"
+msgstr "&Üstündən xətt"
+
+#. IDD_PLUGINS_EDITPLUGIN
+#: Merge.rc:3510
+msgid "&Underline"
+msgstr "&Altından xətt"
+
+#. IDD_PLUGINS_EDITPLUGIN
+#: Merge.rc:3512
+msgid "&Color:"
+msgstr "&Rəng:"
+
+#. IDD_PLUGINS_EDITPLUGIN
+#: Merge.rc:3517
+msgid "Sample"
+msgstr "Nümunə"
+
+#. IDD_PLUGINS_EDITPLUGIN
+#: Merge.rc:3518
+msgid "AaBbYyZz"
+msgstr "AaBbYyZz"
+
+#. IDD_PLUGINS_EDITPLUGIN
+#: Merge.rc:3522
+msgid "Sc&ript:"
+msgstr "&Yazı sistemi:"
+
+#. IDD_PLUGINS_EDITPLUGIN, IDC_MANAGE_LINK
+#: Merge.rc:3527
+msgid "<A>Show more fonts</A>"
+msgstr "<A>Daha çox şrift göstər</A>"
+
+#. ID_INDICATOR_EXT
+#: Merge.rc:4477
+msgid "EXT"
+msgstr "GEN"
+
+#. ID_INDICATOR_CAPS
+#: Merge.rc:4478
+msgid "CAP"
+msgstr "BÖY"
+
+#. ID_INDICATOR_NUM
+#: Merge.rc:4479
+msgid "NUM"
+msgstr "ƏDƏD"
+
+#. ID_INDICATOR_SCRL
+#: Merge.rc:4480
+msgid "SCRL"
+msgstr "SÜR"
+
+#. ID_INDICATOR_OVR
+#: Merge.rc:4481
+msgid "OVR"
+msgstr "ÜST"
+
+#. ID_INDICATOR_REC
+#: Merge.rc:4482
+msgid "REC"
+msgstr "QEYD"
+
+#. ID_FILE_NEW
+#: Merge.rc:4488
+msgid "\nNew Documents (Ctrl+N)"
+msgstr "\nYeni sənədlər (Ctrl+N)"
+
+#. ID_FILE_OPEN
+#: Merge.rc:4489
+msgid "\nOpen (Ctrl+O)"
+msgstr "\nAç (Ctrl+O)"
+
+#. ID_FILE_SAVE
+#: Merge.rc:4490
+msgid "\nSave (Ctrl+S)"
+msgstr "\nSaxla (Ctrl+S)"
+
+#. IDS_UNK_ERROR_READING_PROJECT
+#: Merge.rc:4496
+msgid "Unknown error opening project file."
+msgstr "Layihə faylını açarkən naməlum xəta baş verdi."
+
+#. IDS_UNK_ERROR_SAVING_PROJECT
+#: Merge.rc:4497
+msgid "Unknown error saving project file."
+msgstr "Layihə faylını saxlayarkən naməlum xəta baş verdi."
+
+#. IDS_PROJFILE_LOAD_SUCCESS
+#: Merge.rc:4502
+msgid "Project file loaded."
+msgstr "Layihə faylı yükləndi."
+
+#. IDS_PROJFILE_SAVE_SUCCESS
+#: Merge.rc:4503
+msgid "Project file saved."
+msgstr "Layihə faylı saxlandı."
+
+#. IDS_PROJFILE_CONTAIN_PLUGIN_ARGS
+#: Merge.rc:4504
+#, c-format
+msgid "This project file contains plugins with custom arguments:\n\n%1\nThese arguments may affect plugin behavior or execute external programs.\n\nDo you want to open this project file?"
+msgstr "Bu layihə faylında xüsusi arqumentli qoşmalar var:\n\n%1\nBu arqumentlər qoşmanın işinə təsir edə və ya xarici proqramları işə sala bilər.\n\nBu layihə faylını açmaq istəyirsiniz?"
+
+#. ID_EDIT_UNDO
+#: Merge.rc:4510
+msgid "\nUndo (Ctrl+Z)"
+msgstr "\nGeri al (Ctrl+Z)"
+
+#. ID_EDIT_REDO
+#: Merge.rc:4511
+msgid "\nRedo (Ctrl+Y)"
+msgstr "\nYenidən et (Ctrl+Y)"
+
+#. IDR_MERGEDOCTYPE
+#: Merge.rc:4518
+msgid "\nFileCompare\n\n\n\nWinMerge.FileCompare\nWinMerge File Compare"
+msgstr "\nFayl müqayisəsi\n\n\n\nWinMerge.FileCompare\nWinMerge fayl müqayisəsi"
+
+#. IDR_DIRDOCTYPE
+#: Merge.rc:4519
+msgid "\nFolderCompare\n\n\n\nWinMerge.FolderCompare\nWinMerge Folder Compare"
+msgstr "\nQovluq müqayisəsi\n\n\n\nWinMerge.FolderCompare\nWinMerge qovluq müqayisəsi"
+
+#. IDS_SPLASH_GPLTEXT
+#: Merge.rc:4525
+msgid "WinMerge comes with ABSOLUTELY NO WARRANTY. It is free software and can be redistributed under the conditions of the GNU General Public License - see the Help menu for details."
+msgstr "WinMerge heç bir zəmanət olmadan təqdim edilir. Bu, azad proqram təminatıdır və GNU Ümumi İctimai Lisenziyasının şərtləri ilə yenidən yayıla bilər. Ətraflı məlumat üçün Kömək menyusuna baxın."
+
+#. IDS_MESSAGEBOX_ABORT
+#: Merge.rc:4533
+msgid "&Abort"
+msgstr "&Dayandır"
+
+#. IDS_MESSAGEBOX_RETRY
+#: Merge.rc:4534
+msgid "&Retry"
+msgstr "&Yenidən cəhd et"
+
+#. IDS_MESSAGEBOX_IGNORE
+#: Merge.rc:4535
+msgid "&Ignore"
+msgstr "&Nəzərə alma"
+
+#. IDS_MESSAGEBOX_IGNOREALL
+#: Merge.rc:4536
+msgid "Ignore &all"
+msgstr "&Heç birini nəzərə alma"
+
+#. IDS_MESSAGEBOX_YES
+#: Merge.rc:4537
+msgid "&Yes"
+msgstr "&Bəli"
+
+#. IDS_MESSAGEBOX_YES_TO_ALL
+#: Merge.rc:4543
+msgid "Yes to &all"
+msgstr "&Hamısına bəli"
+
+#. IDS_MESSAGEBOX_NO
+#: Merge.rc:4544
+msgid "&No"
+msgstr "&Xeyr"
+
+#. IDS_MESSAGEBOX_NO_TO_ALL
+#: Merge.rc:4545
+msgid "No to a&ll"
+msgstr "Hamısına &xeyr"
+
+#. IDS_MESSAGEBOX_CONTINUE
+#: Merge.rc:4546
+msgid "&Continue"
+msgstr "&Davam et"
+
+#. IDS_MESSAGEBOX_SKIP
+#: Merge.rc:4547
+msgid "&Skip"
+msgstr "&Ötür"
+
+#. IDS_MESSAGEBOX_SKIPALL
+#: Merge.rc:4548
+msgid "Skip &all"
+msgstr "&Hamısını ötür"
+
+#. IDS_MESSAGEBOX_DONT_DISPLAY_AGAIN
+#: Merge.rc:4550
+msgid "Don't display this &message again."
+msgstr "Bu &bildirişi bir daha göstərmə."
+
+#: Merge.rc:4553
+msgid "To make this message box visible, press Reset on the Message Boxes page in Options."
+msgstr "Bu bildiriş pəncərəsini göstərmək üçün Seçimlər bölməsinin Bildiriş pəncərələri səhifəsində Sıfırla düyməsinə basın."
+
+#. IDS_OPTIONSPG_EDITOR_COMPAREMERGE
+#: Merge.rc:4563
+msgid "Compare/Merge"
+msgstr "Müqayisə/birləşdirmə"
+
+#. IDS_OPTIONSPG_SYNTAXCOLORS
+#: Merge.rc:4564 Merge.rc:4568
+msgid "Syntax"
+msgstr "Sintaksis"
+
+#. IDS_OPTIONSPG_COLOR_SCHEMES
+#: Merge.rc:4566
+msgid "Color Schemes"
+msgstr "Rəng sxemləri"
+
+#. IDS_OPTIONSPG_DIRCOLORS
+#: Merge.rc:4570
+msgid "Folder Compare"
+msgstr "Qovluq müqayisəsi"
+
+#. IDS_OPTIONSPG_PROJECT
+#: Merge.rc:4575
+msgid "Project"
+msgstr "Layihə"
+
+#. IDS_COLHDR_NSDIFFS
+#: Merge.rc:4578 Merge.rc:5001
+msgid "Differences"
+msgstr "Fərqlər"
+
+#. IDS_OPTIONSPG_MESSAGEBOXES
+#: Merge.rc:4580
+msgid "Message Boxes"
+msgstr "Bildiriş pəncərələri"
+
+#. IDS_TO
+#: Merge.rc:4595
+msgid "To:"
+msgstr "Hara:"
+
+#. IDS_FROM_LEFT
+#: Merge.rc:4596
+msgid "From left:"
+msgstr "Soldan:"
+
+#. IDS_TO_LEFT
+#: Merge.rc:4597
+msgid "To left:"
+msgstr "Sola:"
+
+#. IDS_FROM_RIGHT
+#: Merge.rc:4598
+msgid "From right:"
+msgstr "Sağdan:"
+
+#. IDS_TO_RIGHT
+#: Merge.rc:4599
+msgid "To right:"
+msgstr "Sağa:"
+
+#. IDS_FROM_MIDDLE
+#: Merge.rc:4600
+msgid "From middle:"
+msgstr "Ortadan:"
+
+#. IDS_TO_MIDDLE
+#: Merge.rc:4601
+msgid "To middle:"
+msgstr "Ortaya:"
+
+#. IDS_VERSION_FMT
+#: Merge.rc:4607
+#, c-format
+msgid "Version %1"
+msgstr "Versiya %1"
+
+#. IDS_OPTIONS_TITLE
+#: Merge.rc:4613
+#, c-format
+msgid "Options (%1)"
+msgstr "Seçimlər (%1)"
+
+#. IDS_MESSAGE_BOX_ARE_RESET
+#: Merge.rc:4614
+msgid "All message boxes are now displayed again."
+msgstr "Bütün bildiriş pəncərələri yenidən göstərilir."
+
+#: Merge.rc:4616
+#, c-format
+msgid "Tab size value is out of range. Please use 1 - %1."
+msgstr "Tabulyasiya ölçüsü icazə verilən aralıqdan kənardadır. 1 - %1 aralığında qiymət daxil edin."
+
+#. IDS_PROJECT_OPEN
+#: Merge.rc:4622 Merge.rc:4679
+msgid "Open"
+msgstr "Aç"
+
+#. IDS_PROGRAMFILES
+#: Merge.rc:4623
+msgid "Programs|*.exe;*.bat;*.cmd|All Files (*.*)|*.*||"
+msgstr "Proqramlar|*.exe;*.bat;*.cmd|Bütün fayllar (*.*)|*.*||"
+
+#. IDS_ALLFILES
+#: Merge.rc:4624
+msgid "All Files (*.*)|*.*||"
+msgstr "Bütün fayllar (*.*)|*.*||"
+
+#. IDS_PROJECTFILES
+#: Merge.rc:4625
+msgid "WinMerge Project Files (*.WinMerge)|*.WinMerge||"
+msgstr "WinMerge layihə faylları (*.WinMerge)|*.WinMerge||"
+
+#. IDS_INIFILES
+#: Merge.rc:4627
+msgid "Options files (*.ini)|*.ini|All Files (*.*)|*.*||"
+msgstr "Seçim faylları (*.ini)|*.ini|Bütün fayllar (*.*)|*.*||"
+
+#. IDS_REPLACELIST_FILES
+#: Merge.rc:4628
+msgid "Tab-Separated Values (*.tsv;*.txt)|*.tsv;*.txt|All Files (*.*)|*.*||"
+msgstr "Tabulyasiya ilə ayrılmış qiymətlər (*.tsv;*.txt)|*.tsv;*.txt|Bütün fayllar (*.*)|*.*||"
+
+#. IDS_ARCHIVEFILES
+#: Merge.rc:4629
+msgid "ZIP Files (*.zip)|*.zip|7z Files (*.7z)|*.7z|TAR Files (*.tar)|*.tar|All Files (*.*)|*.*||"
+msgstr "ZIP faylları (*.zip)|*.zip|7z faylları (*.7z)|*.7z|TAR faylları (*.tar)|*.tar|Bütün fayllar (*.*)|*.*||"
+
+#. IDS_TEXT_REPORT_FILES
+#: Merge.rc:4635
+msgid "Text Files (*.csv;*.asc;*.rpt;*.txt)|*.csv;*.asc;*.rpt;*.txt|All Files (*.*)|*.*||"
+msgstr "Mətn faylları (*.csv;*.asc;*.rpt;*.txt)|*.csv;*.asc;*.rpt;*.txt|Bütün fayllar (*.*)|*.*||"
+
+#. IDS_HTML_REPORT_FILES
+#: Merge.rc:4636
+msgid "HTML Files (*.htm,*.html)|*.htm;*.html|All Files (*.*)|*.*||"
+msgstr "HTML faylları (*.htm,*.html)|*.htm;*.html|Bütün fayllar (*.*)|*.*||"
+
+#. IDS_XML_REPORT_FILES
+#: Merge.rc:4637
+msgid "XML Files (*.xml)|*.xml|All Files (*.*)|*.*||"
+msgstr "XML faylları (*.xml)|*.xml|Bütün fayllar (*.*)|*.*||"
+
+#. IDS_EXPANDSUBDIRS_DONOTEXPAND
+#: Merge.rc:4655
+msgid "Do not expand"
+msgstr "Genişləndirmə"
+
+#. IDS_EXPANDSUBDIRS_ALL
+#: Merge.rc:4656
+msgid "Expand all subfolders"
+msgstr "Bütün alt qovluqları genişləndir"
+
+#. IDS_EXPANDSUBDIRS_DIFFERENT
+#: Merge.rc:4657
+msgid "Expand different subfolders"
+msgstr "Fərqli alt qovluqları genişləndir"
+
+#. IDS_EXPANDSUBDIRS_IDENTICAL
+#: Merge.rc:4658
+msgid "Expand identical subfolders"
+msgstr "Eyni alt qovluqları genişləndir"
+
+#. IDS_SYNTAXTABLE_FILETYPE
+#: Merge.rc:4664
+msgid "File Type"
+msgstr "Fayl növü"
+
+#. IDS_COLHDR_EXTENSION
+#: Merge.rc:4665 Merge.rc:4958
+msgid "Extension"
+msgstr "Uzantı"
+
+#. IDS_PRPCAT_MESSAGE
+#: Merge.rc:4671 Merge.rc:5030
+msgid "Message"
+msgstr "Bildiriş"
+
+#. IDS_MESSAGEBOX_ANSWER
+#: Merge.rc:4672
+msgid "Answer"
+msgstr "Cavab"
+
+#. IDS_PROJECT_ITEM
+#: Merge.rc:4678
+msgid "Item"
+msgstr "Element"
+
+#. IDS_PROJECT_LOAD
+#: Merge.rc:4680
+msgid "Load"
+msgstr "Yüklə"
+
+#. IDS_PROJECT_SAVE
+#: Merge.rc:4681
+msgid "Save"
+msgstr "Saxla"
+
+#. IDS_PROJECT_ITEM_INCLUDE_SUBFOLDERS
+#: Merge.rc:4683
+msgid "Include Subfolders"
+msgstr "Alt qovluqları daxil et"
+
+#. IDS_PROJECT_ITEM_COMPARE_OPTIONS
+#: Merge.rc:4685
+msgid "Compare Options"
+msgstr "Müqayisə seçimləri"
+
+#. IDS_PROJECT_ITEM_HIDDEN_ITEMS
+#: Merge.rc:4686
+msgid "Hidden Items"
+msgstr "Gizli elementlər"
+
+#. IDS_PLUGINSLIST_NAME
+#: Merge.rc:4692 Merge.rc:5322
+msgid "Name"
+msgstr "Ad"
+
+#. IDS_FILTERFILE_PATHTITLE
+#: Merge.rc:4693
+msgid "Location"
+msgstr "Mövqe"
+
+#. IDS_FILTER_TITLE
+#: Merge.rc:4694
+msgid "Filters"
+msgstr "Süzgəclər"
+
+#. IDS_FILTER_PREFIX
+#: Merge.rc:4695
+msgid "[F] "
+msgstr "[S] "
+
+#. IDS_PLUGINSLIST_DESC
+#: Merge.rc:4696 Merge.rc:5324
+msgid "Description"
+msgstr "Təsvir"
+
+#. IDS_FILEFILTER_SAVENEW
+#: Merge.rc:4697
+msgid "Select Filename for New Filter"
+msgstr "Yeni süzgəc üçün fayl adı seçin"
+
+#. IDS_FILEFILTER_FILEMASK
+#: Merge.rc:4698
+msgid "File Filters (*.flt)|*.flt|All Files (*.*)|*.*||"
+msgstr "Fayl süzgəcləri (*.flt)|*.flt|Bütün fayllar (*.*)|*.*||"
+
+#: Merge.rc:4700
+#, c-format
+msgid "Cannot find filter template!\n\nCopy %1 to WinMerge/Filters Folder:\n%2."
+msgstr "Süzgəc şablonu tapılmadı!\n\n%1 faylını WinMerge/Filters qovluğuna köçürün:\n%2."
+
+#: Merge.rc:4702
+#, c-format
+msgid "Cannot copy filter template:\n%1\n\nMake sure the folder exists and is writable."
+msgstr "Süzgəc şablonunu köçürmək mümkün olmadı:\n%1\n\nQovluğun mövcud və yazıla bilən olduğundan əmin olun."
+
+#: Merge.rc:4704
+msgid "User's filter folder is not defined!\n\nSelect filter folder in Options/System."
+msgstr "İstifadəçinin süzgəc qovluğu təyin edilməyib!\n\nSeçimlər/Sistem bölməsində süzgəc qovluğu seçin."
+
+#: Merge.rc:4706
+#, c-format
+msgid "Failed to delete filter:\n%1\n\nFile may be read-only."
+msgstr "Süzgəci silmək mümkün olmadı:\n%1\n\nFayl yalnız oxumaq üçün ola bilər."
+
+#. IDS_FILEFILTER_INSTALL
+#: Merge.rc:4707
+msgid "Locate Filter File to Install"
+msgstr "Quraşdırılacaq süzgəc faylını seçin"
+
+#: Merge.rc:4709
+msgid "Installing filter file failed.\n\nCould not copy new filter to folder."
+msgstr "Süzgəc faylını quraşdırmaq mümkün olmadı.\n\nYeni süzgəci qovluğa köçürmək mümkün olmadı."
+
+#. IDS_FILEFILTER_OVERWRITE
+#: Merge.rc:4710
+msgid "Filter file exists. Overwrite?"
+msgstr "Süzgəc faylı mövcuddur. Üzərinə yazılsın?"
+
+#. IDS_FILTERLINE_REGEXP
+#: Merge.rc:4716
+msgid "Regular expression"
+msgstr "Müntəzəm ifadə"
+
+#. IDS_FILTERCHANGED
+#: Merge.rc:4722
+msgid "Filters updated. Refresh all open folder compares?\n\nSelect 'No' to refresh later."
+msgstr "Süzgəclər yeniləndi. Bütün açıq qovluq müqayisələri yenilənsin?\n\nDaha sonra yeniləmək üçün 'Xeyr' seçin."
+
+#. IDS_DIRECTORY_WINDOW_TITLE
+#: Merge.rc:4728
+msgid "Folder Comparison Results"
+msgstr "Qovluq müqayisəsinin nəticələri"
+
+#. IDS_FILE_COMPARISON_TITLE
+#: Merge.rc:4729
+msgid "File Comparison"
+msgstr "Fayl müqayisəsi"
+
+#. IDS_EMPTY_LEFT_FILE
+#: Merge.rc:4730
+msgid "Untitled Left"
+msgstr "Adsız sol"
+
+#. IDS_EMPTY_MIDDLE_FILE
+#: Merge.rc:4731
+msgid "Untitled Middle"
+msgstr "Adsız orta"
+
+#. IDS_EMPTY_RIGHT_FILE
+#: Merge.rc:4732
+msgid "Untitled Right"
+msgstr "Adsız sağ"
+
+#. IDS_CONFLICT_BASE_FILE
+#: Merge.rc:4733
+msgid "Base File"
+msgstr "Əsas fayl"
+
+#. IDS_CONFLICT_THEIRS_FILE
+#: Merge.rc:4734
+msgid "Theirs File"
+msgstr "Onların faylı"
+
+#. IDS_CONFLICT_MINE_FILE
+#: Merge.rc:4735
+msgid "Mine File"
+msgstr "Mənim faylım"
+
+#. IDS_SELFCOMPARE_ORIGINAL_FILE
+#: Merge.rc:4736
+msgid "Original File"
+msgstr "İlkin fayl"
+
+#. IDS_LINE_STATUS_INFO_EOL
+#: Merge.rc:4742
+#, c-format
+msgid "Ln: %s  Col: %d/%d  Ch: %d/%d  EOL: %s"
+msgstr "Sət: %s  Süt: %d/%d  Sim: %d/%d  Sətir sonu: %s"
+
+#. IDS_EMPTY_LINE_STATUS_INFO
+#: Merge.rc:4743
+#, c-format
+msgid "Line: %s"
+msgstr "Sətir: %s"
+
+#. IDS_LINE_STATUS_INFO
+#: Merge.rc:4744
+#, c-format
+msgid "Ln: %s  Col: %d/%d  Ch: %d/%d"
+msgstr "Sət: %s  Süt: %d/%d  Sim: %d/%d"
+
+#. IDS_LINE_STATUS_INFO_SEL
+#: Merge.rc:4745
+#, c-format
+msgid "  Sel: %d | %d"
+msgstr "  Seç: %d | %d"
+
+#. IDS_DIFF_NUMBER_STATUS_FMT
+#: Merge.rc:4746
+#, c-format
+msgid "Difference %1 of %2"
+msgstr "Fərq %1 / %2"
+
+#. IDS_NO_DIFF_SEL_FMT
+#: Merge.rc:4747
+#, c-format
+msgid "%1 Differences Found"
+msgstr "%1 fərq tapıldı"
+
+#. IDS_1_DIFF_FOUND
+#: Merge.rc:4748
+msgid "1 Difference Found"
+msgstr "1 fərq tapıldı"
+
+#. IDS_NO_ERR_SEL_FMT
+#: Merge.rc:4749
+#, c-format
+msgid "%1 Errors Found"
+msgstr "%1 xəta tapıldı"
+
+#. IDS_1_ERR_FOUND
+#: Merge.rc:4750
+msgid "1 Error Found"
+msgstr "1 xəta tapıldı"
+
+#. IDS_STATUSBAR_READONLY, Abbreviation from "Read Only"
+#: Merge.rc:4751
+msgid "RO"
+msgstr "YO"
+
+#. IDS_DIRVIEW_STATUS_FMT_FOCUS
+#: Merge.rc:4757
+#, c-format
+msgid "Item %1 of %2"
+msgstr "Element %1 / %2"
+
+#. IDS_DIRVIEW_STATUS_FMT_NOFOCUS
+#: Merge.rc:4758
+#, c-format
+msgid "Items: %1"
+msgstr "Elementlər: %1"
+
+#. IDS_DIRVIEW_STATUS_COMPARING
+#: Merge.rc:4759
+msgid "Comparing items..."
+msgstr "Elementlər müqayisə edilir..."
+
+#. IDS_ITEMS_PER_SEC
+#: Merge.rc:4760
+#, c-format
+msgid "%.1f[items/sec]"
+msgstr "%.1f[element/san]"
+
+#. IDS_ERROR_INCOMPARABLE
+#: Merge.rc:4766
+msgid "Select two existing folders/files to compare."
+msgstr "Müqayisə etmək üçün mövcud olan iki qovluq/fayl seçin."
+
+#. IDS_DIRSEL_TAG
+#: Merge.rc:4767
+msgid "Folder Selection"
+msgstr "Qovluq seçimi"
+
+#. IDS_OPEN_FILESDIRS
+#: Merge.rc:4768
+msgid "Select two (or three) folders/files to compare."
+msgstr "Müqayisə etmək üçün iki (və ya üç) qovluq/fayl seçin."
+
+#. IDS_OPEN_LEFTINVALID
+#: Merge.rc:4769
+msgid "Left (1st) path is invalid!"
+msgstr "Sol (birinci) yol yanlışdır!"
+
+#. IDS_OPEN_MIDDLEINVALID
+#: Merge.rc:4770
+msgid "Middle (2nd) path is invalid!"
+msgstr "Orta (ikinci) yol yanlışdır!"
+
+#. IDS_OPEN_RIGHTINVALID2
+#: Merge.rc:4771
+msgid "Right (2nd) path is invalid!"
+msgstr "Sağ (ikinci) yol yanlışdır!"
+
+#. IDS_OPEN_RIGHTINVALID3
+#: Merge.rc:4772
+msgid "Right (3rd) path is invalid!"
+msgstr "Sağ (üçüncü) yol yanlışdır!"
+
+#. IDS_OPEN_BOTHINVALID
+#: Merge.rc:4773
+msgid "Both paths are invalid!"
+msgstr "Hər iki yol yanlışdır!"
+
+#: Merge.rc:4775
+msgid "Left (1st) and Middle (2nd) paths are invalid!"
+msgstr "Sol (birinci) və orta (ikinci) yollar yanlışdır!"
+
+#. IDS_OPEN_LEFTRIGHTINVALID
+#: Merge.rc:4776
+msgid "Left (1st) and Right (3rd) paths are invalid!"
+msgstr "Sol (birinci) və sağ (üçüncü) yollar yanlışdır!"
+
+#: Merge.rc:4778
+msgid "Middle (2nd) and Right (3rd) paths are invalid!"
+msgstr "Orta (ikinci) və sağ (üçüncü) yollar yanlışdır!"
+
+#. IDS_OPEN_ALLINVALID
+#: Merge.rc:4779
+msgid "All paths are invalid!"
+msgstr "Bütün yollar yanlışdır!"
+
+#. IDS_OPEN_UNPACKERDISABLED
+#: Merge.rc:4780
+msgid "Only enabled for file comparisons"
+msgstr "Yalnız fayl müqayisələri üçün aktivdir"
+
+#. IDS_OPEN_MISMATCH
+#: Merge.rc:4781
+msgid "Cannot compare file and folder!"
+msgstr "Fayl ilə qovluğu müqayisə etmək mümkün deyil!"
+
+#. IDS_ERROR_FILE_NOT_FOUND
+#: Merge.rc:4787
+#, c-format
+msgid "File not found: %1"
+msgstr "Fayl tapılmadı: %1"
+
+#. IDS_ERROR_FOLDER_NOT_FOUND
+#: Merge.rc:4788
+#, c-format
+msgid "Folder not found: %1"
+msgstr "Qovluq tapılmadı: %1"
+
+#. IDS_ERROR_FILE_NOT_UNPACKED
+#: Merge.rc:4789
+#, c-format
+msgid "File not unpacked: %1"
+msgstr "Fayl açılmadı: %1"
+
+#. IDS_ERROR_FILEOPEN
+#: Merge.rc:4790
+#, c-format
+msgid "Cannot open file\n%1\n\n%2"
+msgstr "Faylı açmaq mümkün olmadı\n%1\n\n%2"
+
+#. IDS_ERROR_CONF_RESOLVE
+#: Merge.rc:4791
+msgid "Failed to parse conflict file."
+msgstr "Ziddiyyətli faylı təhlil etmək mümkün olmadı."
+
+#. IDS_NOT_CONFLICT_FILE
+#: Merge.rc:4792
+#, c-format
+msgid "The file\n%1\nis not a conflict file."
+msgstr "Bu fayl\n%1\nziddiyyətli fayl deyil."
+
+#. IDS_COMPARE_LARGE_FILES
+#: Merge.rc:4793
+msgid "Comparing large files requires significant memory.\nShow only comparison results (not file contents)?"
+msgstr "Böyük faylların müqayisəsi çox yaddaş tələb edir.\nYalnız müqayisə nəticələri göstərilsin (fayl məzmunu olmadan)?"
+
+#. IDS_SAVE_AS_TITLE
+#: Merge.rc:4799
+msgid "Save As"
+msgstr "Fərqli saxla"
+
+#. IDS_SAVE_FMT
+#: Merge.rc:4800
+#, c-format
+msgid "Save changes to %1?"
+msgstr "%1 faylındakı dəyişikliklər saxlansın?"
+
+#. IDS_SAVEREADONLY_FMT
+#: Merge.rc:4801
+#, c-format
+msgid "%1 is read-only. Override? Or 'No' to save as new filename?"
+msgstr "%1 yalnız oxumaq üçündür. Üzərinə yazılsın? Yeni fayl adı ilə saxlamaq üçün 'Xeyr' seçin."
+
+#. IDS_ERROR_BACKUP
+#: Merge.rc:4802
+msgid "Error backing up file"
+msgstr "Faylın ehtiyat nüsxəsini yaradarkən xəta baş verdi"
+
+#: Merge.rc:4804
+#, c-format
+msgid "Unable to backup original file:\n%1\n\nContinue anyway?"
+msgstr "İlkin faylın ehtiyat nüsxəsini yaratmaq mümkün olmadı:\n%1\n\nYenə də davam edilsin?"
+
+#. IDS_FILESAVE_FAILED
+#: Merge.rc:4805
+#, c-format
+msgid "Saving file failed.\n%1\n%2\n\t- Use different filename (OK)\n\t- Abort (Cancel)?"
+msgstr "Faylı saxlamaq mümkün olmadı.\n%1\n%2\n\t- Başqa fayl adından istifadə edilsin (Tamam)\n\t- Dayandırılsın (Ləğv et)?"
+
+#: Merge.rc:4807
+#, c-format
+msgid "Plugin '%2' cannot pack changes to left file into '%1'.\n\nOriginal unchanged. Save unpacked version?"
+msgstr "'%2' qoşması sol fayldakı dəyişiklikləri '%1' daxilində qablaşdıra bilmir.\n\nİlkin fayl dəyişməyib. Açılmış versiya saxlansın?"
+
+#: Merge.rc:4809
+#, c-format
+msgid "Plugin '%2' cannot pack changes to middle file into '%1'.\n\nOriginal unchanged. Save unpacked version?"
+msgstr "'%2' qoşması orta fayldakı dəyişiklikləri '%1' daxilində qablaşdıra bilmir.\n\nİlkin fayl dəyişməyib. Açılmış versiya saxlansın?"
+
+#: Merge.rc:4811
+#, c-format
+msgid "Plugin '%2' cannot pack changes to right file into '%1'.\n\nOriginal unchanged. Save unpacked version?"
+msgstr "'%2' qoşması sağ fayldakı dəyişiklikləri '%1' daxilində qablaşdıra bilmir.\n\nİlkin fayl dəyişməyib. Açılmış versiya saxlansın?"
+
+#. IDS_FILECHANGED_ONDISK
+#: Merge.rc:4812
+#, c-format
+msgid "Another application updated\n%1\nsince WinMerge loaded it.\n\nOverwrite?"
+msgstr "Başqa tətbiq\n%1\nfaylını WinMerge yüklədikdən sonra yeniləyib.\n\nÜzərinə yazılsın?"
+
+#. IDS_SAVEREADONLY_MULTI
+#: Merge.rc:4813
+#, c-format
+msgid "%1\nis read-only. Override?"
+msgstr "%1\nyalnız oxumaq üçündür. Üzərinə yazılsın?"
+
+#. IDS_FILECHANGED_RESCAN
+#: Merge.rc:4814
+#, c-format
+msgid "Another application updated\n%1\nsince last scan.\n\nReload?"
+msgstr "Başqa tətbiq\n%1\nfaylını son yoxlamadan sonra yeniləyib.\n\nYenidən yüklənsin?"
+
+#. IDS_SAVE_LEFT_AS
+#: Merge.rc:4815
+msgid "Save Left File As"
+msgstr "Sol faylı fərqli saxla"
+
+#. IDS_SAVE_MIDDLE_AS
+#: Merge.rc:4816
+msgid "Save Middle File As"
+msgstr "Orta faylı fərqli saxla"
+
+#. IDS_SAVE_RIGHT_AS
+#: Merge.rc:4817
+msgid "Save Right File As"
+msgstr "Sağ faylı fərqli saxla"
+
+#. IDS_FILE_DISAPPEARED
+#: Merge.rc:4822
+#, c-format
+msgid "File\n%1\nnot found. Save a copy to continue."
+msgstr "Fayl\n%1\ntapılmadı. Davam etmək üçün surətini saxlayın."
+
+#. IDS_VIEWS_OUTOFSYNC
+#: Merge.rc:4828
+msgid "Cannot merge unsynched documents.\n\nRefresh before continuing."
+msgstr "Sinxronlaşdırılmamış sənədləri birləşdirmək mümkün deyil.\n\nDavam etməzdən əvvəl yeniləyin."
+
+#. IDS_BREAK_ON_WHITESPACE
+#: Merge.rc:4833
+msgid "Break at whitespace"
+msgstr "Boşluq simvollarında böl"
+
+#. IDS_BREAK_ON_PUNCTUATION
+#: Merge.rc:4834
+msgid "Break at whitespace or punctuation"
+msgstr "Boşluq və ya durğu işarələrində böl"
+
+#. IDS_L2M
+#: Merge.rc:4840
+msgid "Copy to &Middle\tAlt+Right"
+msgstr "&Ortaya köçür\tAlt+Right"
+
+#. IDS_R2M
+#: Merge.rc:4841
+msgid "Copy to &Middle\tAlt+Left"
+msgstr "&Ortaya köçür\tAlt+Left"
+
+#. IDS_COPY_FROM_MIDDLE_R
+#: Merge.rc:4842
+msgid "Copy from Middle\tAlt+Shift+Right"
+msgstr "Ortadan köçür\tAlt+Shift+Right"
+
+#. IDS_COPY_FROM_MIDDLE_L
+#: Merge.rc:4843
+msgid "Copy from Middle\tAlt+Shift+Left"
+msgstr "Ortadan köçür\tAlt+Shift+Left"
+
+#. IDS_L2MNEXT
+#: Merge.rc:4844
+msgid "Copy to Middle and Advance\tCtrl+Alt+Right"
+msgstr "Ortaya köçür və irəlilə\tCtrl+Alt+Right"
+
+#. IDS_R2MNEXT
+#: Merge.rc:4845
+msgid "Copy to Middle and Advance\tCtrl+Alt+Left"
+msgstr "Ortaya köçür və irəlilə\tCtrl+Alt+Left"
+
+#. IDS_ALL_MIDDLE
+#: Merge.rc:4846
+msgid "Copy All to Middle"
+msgstr "Hamısını ortaya köçür"
+
+#. IDS_COPY_RIGHT_TO_LEFT
+#: Merge.rc:4852
+#, c-format
+msgid "Right to Left (%1)"
+msgstr "Sağdan sola (%1)"
+
+#. IDS_COPY_RIGHT_TO_MIDDLE
+#: Merge.rc:4853
+#, c-format
+msgid "Right to Middle (%1)"
+msgstr "Sağdan ortaya (%1)"
+
+#. IDS_COPY_MIDDLE_TO_LEFT
+#: Merge.rc:4854
+#, c-format
+msgid "Middle to Left (%1)"
+msgstr "Ortadan sola (%1)"
+
+#. IDS_COPY_MIDDLE_TO_RIGHT
+#: Merge.rc:4855
+#, c-format
+msgid "Middle to Right (%1)"
+msgstr "Ortadan sağa (%1)"
+
+#. IDS_COPY_LEFT_TO_RIGHT
+#: Merge.rc:4856
+#, c-format
+msgid "Left to Right (%1)"
+msgstr "Soldan sağa (%1)"
+
+#. IDS_COPY_LEFT_TO_MIDDLE
+#: Merge.rc:4857
+#, c-format
+msgid "Left to Middle (%1)"
+msgstr "Soldan ortaya (%1)"
+
+#. IDS_MOVE_LEFT_TO
+#: Merge.rc:4868 Merge.rc:4900
+#, c-format
+msgid "Left to... (%1)"
+msgstr "Soldan buraya... (%1)"
+
+#. IDS_MOVE_MIDDLE_TO
+#: Merge.rc:4869 Merge.rc:4901
+#, c-format
+msgid "Middle to... (%1)"
+msgstr "Ortadan buraya... (%1)"
+
+#. IDS_MOVE_RIGHT_TO
+#: Merge.rc:4870 Merge.rc:4902
+#, c-format
+msgid "Right to... (%1)"
+msgstr "Sağdan buraya... (%1)"
+
+#. IDS_COPY_BOTH_TO
+#: Merge.rc:4871
+#, c-format
+msgid "Both to... (%1)"
+msgstr "Hər ikisini buraya... (%1)"
+
+#. IDS_COPY_ALL_TO
+#: Merge.rc:4872
+#, c-format
+msgid "All to... (%1)"
+msgstr "Hamısını buraya... (%1)"
+
+#. IDS_COPY_DIFFERENCES_TO
+#: Merge.rc:4873
+#, c-format
+msgid "Differences to... (%1)"
+msgstr "Fərqləri buraya... (%1)"
+
+#. IDS_ONLYDIFFITEMS_CONFIRM
+#: Merge.rc:4880
+msgid "Some selected items are identical or skipped.\nProcess only items with differences?"
+msgstr "Bəzi seçilmiş elementlər eynidir və ya ötürülüb.\nYalnız fərqli elementlər emal edilsin?"
+
+#. IDS_DEL_LEFT_FMT
+#: Merge.rc:4886
+#, c-format
+msgid "Left (%1)"
+msgstr "Sol (%1)"
+
+#. IDS_DEL_MIDDLE_FMT
+#: Merge.rc:4887
+#, c-format
+msgid "Middle (%1)"
+msgstr "Orta (%1)"
+
+#. IDS_DEL_RIGHT_FMT
+#: Merge.rc:4888
+#, c-format
+msgid "Right (%1)"
+msgstr "Sağ (%1)"
+
+#. IDS_DEL_BOTH_FMT
+#: Merge.rc:4889
+#, c-format
+msgid "Both (%1)"
+msgstr "Hər ikisi (%1)"
+
+#. IDS_DEL_ALL_FMT
+#: Merge.rc:4890
+#, c-format
+msgid "All (%1)"
+msgstr "Hamısı (%1)"
+
+#. IDS_SELECT_DEST_LEFT
+#: Merge.rc:4906
+msgid "Left Side - Select Destination Folder:"
+msgstr "Sol tərəf - təyinat qovluğunu seçin:"
+
+#. IDS_SELECT_DEST_MIDDLE
+#: Merge.rc:4907
+msgid "Middle Side - Select Destination Folder:"
+msgstr "Orta tərəf - təyinat qovluğunu seçin:"
+
+#. IDS_SELECT_DEST_RIGHT
+#: Merge.rc:4908
+msgid "Right Side - Select Destination Folder:"
+msgstr "Sağ tərəf - təyinat qovluğunu seçin:"
+
+#. IDS_FILES_AFFECTED_FMT
+#: Merge.rc:4909
+#, c-format
+msgid "(%1 Files Affected)"
+msgstr "(%1 fayla təsir edir)"
+
+#. IDS_FILES_AFFECTED_FMT2
+#: Merge.rc:4910
+#, c-format
+msgid "(%1 of %2 Files Affected)"
+msgstr "(%1 / %2 fayla təsir edir)"
+
+#. IDS_CONFIRM_DELETE_SINGLE
+#: Merge.rc:4916
+#, c-format
+msgid "Are you sure you want to delete\n\n%1 ?"
+msgstr "Bunu silmək istədiyinizə əminsiniz?\n\n%1 ?"
+
+#. IDS_CONFIRM_SINGLE_COPY
+#: Merge.rc:4917
+msgid "Are you sure you want to copy?"
+msgstr "Köçürmək istədiyinizə əminsiniz?"
+
+#. IDS_CONFIRM_MULTIPLE_COPY
+#: Merge.rc:4918
+#, c-format
+msgid "Are you sure you want to copy %d items?"
+msgstr "%d elementi köçürmək istədiyinizə əminsiniz?"
+
+#. IDS_DIRCMP_NOTSYNC
+#: Merge.rc:4919
+#, c-format
+msgid "Operation aborted!\n\nFolder contents changed, path\n%1\nnot found.\n\nRefresh the compare."
+msgstr "Əməliyyat dayandırıldı!\n\nQovluğun məzmunu dəyişib, yol\n%1\ntapılmadı.\n\nMüqayisəni yeniləyin."
+
+#. IDS_CONFIRM_SINGLE_MOVE
+#: Merge.rc:4924
+msgid "Are you sure you want to move?"
+msgstr "Yerini dəyişmək istədiyinizə əminsiniz?"
+
+#. IDS_CONFIRM_MULTIPLE_MOVE
+#: Merge.rc:4925
+#, c-format
+msgid "Are you sure you want to move %d items?"
+msgstr "%d elementin yerini dəyişmək istədiyinizə əminsiniz?"
+
+#. IDS_CONFIRM_MOVE_CAPTION
+#: Merge.rc:4927
+msgid "Confirm Move"
+msgstr "Yerdəyişməni təsdiqlə"
+
+#: Merge.rc:4929
+msgid "Close the folder comparison window?"
+msgstr "Qovluq müqayisəsi pəncərəsi bağlansın?"
+
+#: Merge.rc:4931
+msgid "Close the folder comparison window, which took a long time?"
+msgstr "Uzun vaxt aparmış qovluq müqayisəsinin pəncərəsi bağlansın?"
+
+#. IDS_ERROR_INVALID_DIR_FILE_NAME
+#: Merge.rc:4932
+msgid "The file or folder name is invalid."
+msgstr "Fayl və ya qovluq adı yanlışdır."
+
+#. IDS_ERROR_EXECUTE_FILE
+#: Merge.rc:4938
+#, c-format
+msgid "Failed to execute external editor: %1"
+msgstr "Xarici redaktoru işə salmaq mümkün olmadı: %1"
+
+#. IDS_UNKNOWN_ARCHIVE_FORMAT
+#: Merge.rc:4944
+msgid "Unknown archive format"
+msgstr "Naməlum arxiv formatı"
+
+#: Merge.rc:4946
+msgid "Failed to extract archive.\nCompare as text file?"
+msgstr "Arxivi açmaq mümkün olmadı.\nMətn faylı kimi müqayisə edilsin?"
+
+#. IDS_COLHDR_FILENAME
+#: Merge.rc:4952
+msgid "Filename"
+msgstr "Faylın adı"
+
+#. IDS_COLHDR_DIR
+#: Merge.rc:4953
+msgctxt "DirView|ColumnHeader"
+msgid "Folder"
+msgstr "Qovluq"
+
+#. IDS_COLHDR_RESULT
+#: Merge.rc:4954
+msgid "Comparison Result"
+msgstr "Müqayisənin nəticəsi"
+
+#. IDS_COLHDR_LTIMEM
+#: Merge.rc:4955
+msgid "Left Date"
+msgstr "Solun tarixi"
+
+#. IDS_COLHDR_RTIMEM
+#: Merge.rc:4956
+msgid "Right Date"
+msgstr "Sağın tarixi"
+
+#. IDS_COLHDR_MTIMEM
+#: Merge.rc:4957
+msgid "Middle Date"
+msgstr "Ortanın tarixi"
+
+#. IDS_COLHDR_LSIZE
+#: Merge.rc:4959
+msgid "Left Size"
+msgstr "Solun ölçüsü"
+
+#. IDS_COLHDR_RSIZE
+#: Merge.rc:4960
+msgid "Right Size"
+msgstr "Sağın ölçüsü"
+
+#. IDS_COLHDR_MSIZE
+#: Merge.rc:4965
+msgid "Middle Size"
+msgstr "Ortanın ölçüsü"
+
+#. IDS_COLHDR_RSIZE_SHORT
+#: Merge.rc:4966
+msgid "Right Size (Short)"
+msgstr "Sağın ölçüsü (qısa)"
+
+#. IDS_COLHDR_LSIZE_SHORT
+#: Merge.rc:4967
+msgid "Left Size (Short)"
+msgstr "Solun ölçüsü (qısa)"
+
+#. IDS_COLHDR_MSIZE_SHORT
+#: Merge.rc:4968
+msgid "Middle Size (Short)"
+msgstr "Ortanın ölçüsü (qısa)"
+
+#. IDS_COLHDR_LTIMEC
+#: Merge.rc:4974
+msgid "Left Creation Time"
+msgstr "Solun yaradılma vaxtı"
+
+#. IDS_COLHDR_RTIMEC
+#: Merge.rc:4975
+msgid "Right Creation Time"
+msgstr "Sağın yaradılma vaxtı"
+
+#. IDS_COLHDR_MTIMEC
+#: Merge.rc:4976
+msgid "Middle Creation Time"
+msgstr "Ortanın yaradılma vaxtı"
+
+#. IDS_COLHDR_NEWER
+#: Merge.rc:4977
+msgid "Newer File"
+msgstr "Daha yeni fayl"
+
+#. IDS_COLHDR_LVERSION
+#: Merge.rc:4978
+msgid "Left File Version"
+msgstr "Sol faylın versiyası"
+
+#. IDS_COLHDR_RVERSION
+#: Merge.rc:4979
+msgid "Right File Version"
+msgstr "Sağ faylın versiyası"
+
+#. IDS_COLHDR_MVERSION
+#: Merge.rc:4980
+msgid "Middle File Version"
+msgstr "Orta faylın versiyası"
+
+#. IDS_COLHDR_RESULT_ABBR
+#: Merge.rc:4981
+msgid "Short Result"
+msgstr "Qısa nəticə"
+
+#. IDS_COLHDR_LATTRIBUTES
+#: Merge.rc:4982
+msgid "Left Attributes"
+msgstr "Solun atributları"
+
+#. IDS_COLHDR_RATTRIBUTES
+#: Merge.rc:4983
+msgid "Right Attributes"
+msgstr "Sağın atributları"
+
+#. IDS_COLHDR_MATTRIBUTES
+#: Merge.rc:4984
+msgid "Middle Attributes"
+msgstr "Ortanın atributları"
+
+#. IDS_COLHDR_LEOL_TYPE
+#: Merge.rc:4989
+msgid "Left EOL"
+msgstr "Solun sətir sonu"
+
+#. IDS_COLHDR_MEOL_TYPE
+#: Merge.rc:4990
+msgid "Middle EOL"
+msgstr "Ortanın sətir sonu"
+
+#. IDS_COLHDR_REOL_TYPE
+#: Merge.rc:4991
+msgid "Right EOL"
+msgstr "Sağın sətir sonu"
+
+#. IDS_COLHDR_LENCODING
+#: Merge.rc:4997
+msgid "Left Encoding"
+msgstr "Solun kodlaşdırılması"
+
+#. IDS_COLHDR_RENCODING
+#: Merge.rc:4998
+msgid "Right Encoding"
+msgstr "Sağın kodlaşdırılması"
+
+#. IDS_COLHDR_MENCODING
+#: Merge.rc:4999
+msgid "Middle Encoding"
+msgstr "Ortanın kodlaşdırılması"
+
+#. IDS_COLHDR_NIDIFFS
+#: Merge.rc:5000
+msgid "Ignored Diff"
+msgstr "Nəzərə alınmayan fərq"
+
+#. IDS_COLHDR_BINARY
+#: Merge.rc:5002
+msgctxt "DirView|ColumnHeader"
+msgid "Binary"
+msgstr "İkilik"
+
+#. IDS_PLUGINS_TYPE_UNPACKER
+#: Merge.rc:5003 Merge.rc:5325
+msgid "Unpacker"
+msgstr "Açma qoşması"
+
+#. IDS_PLUGIN_TYPE4
+#: Merge.rc:5004 Merge.rc:5326 Merge.rc:5633
+msgid "Prediffer"
+msgstr "İlkin müqayisə emalı qoşması"
+
+#. IDS_COLHDR_LEFT
+#: Merge.rc:5005
+msgid "Left"
+msgstr "Sol"
+
+#. IDS_COLHDR_MIDDLE
+#: Merge.rc:5006
+msgid "Middle"
+msgstr "Orta"
+
+#. IDS_COLHDR_RIGHT
+#: Merge.rc:5007
+msgid "Right"
+msgstr "Sağ"
+
+#. IDS_COLHDR_DIFF
+#: Merge.rc:5008
+msgid "Diff"
+msgstr "Fərq"
+
+#. IDS_COLHDR_LEFT_DUPLICATE
+#: Merge.rc:5009
+msgid "Left Duplicate Count"
+msgstr "Soldakı təkrarların sayı"
+
+#. IDS_COLHDR_RIGHT_DUPLICATE
+#: Merge.rc:5010
+msgid "Right Duplicate Count"
+msgstr "Sağdakı təkrarların sayı"
+
+#. IDS_COLHDR_MIDDLE_DUPLICATE
+#: Merge.rc:5011
+msgid "Middle Duplicate Count"
+msgstr "Ortadakı təkrarların sayı"
+
+#. IDS_COLHDR_MOVE
+#: Merge.rc:5012
+msgid "Move"
+msgstr "Yerdəyişmə"
+
+#. IDS_PRPCAT_AUDIO
+#: Merge.rc:5019
+msgid "Audio"
+msgstr "Səs"
+
+#. IDS_PRPCAT_CALENDAR
+#: Merge.rc:5020
+msgid "Calendar"
+msgstr "Təqvim"
+
+#. IDS_PRPCAT_COMMUNICATION
+#: Merge.rc:5021
+msgid "Communication"
+msgstr "Ünsiyyət"
+
+#. IDS_PRPCAT_CONTACT
+#: Merge.rc:5022
+msgid "Contact"
+msgstr "Əlaqə"
+
+#. IDS_PRPCAT_DEVICES
+#: Merge.rc:5023
+msgid "Devices"
+msgstr "Qurğular"
+
+#. IDS_PRPCAT_DOCUMENT
+#: Merge.rc:5024
+msgid "Document"
+msgstr "Sənəd"
+
+#. IDS_PRPCAT_HOME
+#: Merge.rc:5025
+msgid "Home"
+msgstr "Ev"
+
+#. IDS_PRPCAT_JOURNAL
+#: Merge.rc:5027
+msgid "Journal"
+msgstr "Jurnal"
+
+#. IDS_PRPCAT_LINK
+#: Merge.rc:5028
+msgid "Link"
+msgstr "Keçid"
+
+#. IDS_PRPCAT_MEDIA
+#: Merge.rc:5029
+msgid "Media"
+msgstr "Media"
+
+#. IDS_PRPCAT_MUSIC
+#: Merge.rc:5031
+msgid "Music"
+msgstr "Musiqi"
+
+#. IDS_PRPCAT_NOTE
+#: Merge.rc:5032
+msgid "Note"
+msgstr "Qeyd"
+
+#. IDS_PRPCAT_PHOTO
+#: Merge.rc:5033
+msgid "Photo"
+msgstr "Foto"
+
+#. IDS_PRPCAT_RECORDEDTV
+#: Merge.rc:5034
+msgid "RecordedTV"
+msgstr "Yazılmış televiziya yayımı"
+
+#. IDS_PRPCAT_SEARCH
+#: Merge.rc:5035
+msgid "Search"
+msgstr "Axtarış"
+
+#. IDS_PRPCAT_SECURITY
+#: Merge.rc:5036
+msgid "Security"
+msgstr "Təhlükəsizlik"
+
+#. IDS_PRPCAT_SOFTWARE
+#: Merge.rc:5037
+msgid "Software"
+msgstr "Proqram təminatı"
+
+#. IDS_PRPCAT_TASK
+#: Merge.rc:5038
+msgid "Task"
+msgstr "Tapşırıq"
+
+#. IDS_PRPCAT_VIDEO
+#: Merge.rc:5039
+msgid "Video"
+msgstr "Video"
+
+#. IDS_PRPCAT_HASH
+#: Merge.rc:5040
+msgid "Hash"
+msgstr "Heş"
+
+#. IDS_CANT_COMPARE_FILES
+#: Merge.rc:5046
+msgid "Unable to compare files"
+msgstr "Faylları müqayisə etmək mümkün olmadı"
+
+#. IDS_ABORTED_ITEM
+#: Merge.rc:5047
+msgid "Item aborted"
+msgstr "Elementin emalı dayandırıldı"
+
+#. IDS_FILE_SKIPPED
+#: Merge.rc:5048
+msgid "File skipped"
+msgstr "Fayl ötürüldü"
+
+#. IDS_DIR_SKIPPED
+#: Merge.rc:5049
+msgid "Folder skipped"
+msgstr "Qovluq ötürüldü"
+
+#. IDS_LEFT_ONLY_IN_FMT
+#: Merge.rc:5050
+#, c-format
+msgid "Left only: %1"
+msgstr "Yalnız solda: %1"
+
+#. IDS_MIDDLE_ONLY_IN_FMT
+#: Merge.rc:5051
+#, c-format
+msgid "Middle only: %1"
+msgstr "Yalnız ortada: %1"
+
+#. IDS_RIGHT_ONLY_IN_FMT
+#: Merge.rc:5052
+#, c-format
+msgid "Right only: %1"
+msgstr "Yalnız sağda: %1"
+
+#. IDS_DOES_NOT_EXIST_IN_FMT
+#: Merge.rc:5053
+#, c-format
+msgid "Does not exist in %1"
+msgstr "%1 daxilində yoxdur"
+
+#. IDS_BIN_FILES_SAME
+#: Merge.rc:5054
+msgid "Binary files are identical"
+msgstr "İkilik fayllar eynidir"
+
+#. IDS_BIN_FILES_DIFF
+#: Merge.rc:5060
+msgid "Binary files are different"
+msgstr "İkilik fayllar fərqlidir"
+
+#. IDS_FILES_ARE_DIFFERENT
+#: Merge.rc:5061
+msgid "Files are different"
+msgstr "Fayllar fərqlidir"
+
+#. IDS_FOLDERS_ARE_DIFFERENT
+#: Merge.rc:5062
+msgid "Folders are different"
+msgstr "Qovluqlar fərqlidir"
+
+#. IDS_LEFTONLY
+#: Merge.rc:5063
+msgid "Left Only"
+msgstr "Yalnız solda"
+
+#. IDS_RIGHTONLY
+#: Merge.rc:5064
+msgid "Right Only"
+msgstr "Yalnız sağda"
+
+#. IDS_MIDDLEONLY
+#: Merge.rc:5065
+msgid "Middle Only"
+msgstr "Yalnız ortada"
+
+#. IDS_NOITEMLEFT
+#: Merge.rc:5066
+msgid "No item in left"
+msgstr "Solda element yoxdur"
+
+#. IDS_NOITEMRIGHT
+#: Merge.rc:5067
+msgid "No item in right"
+msgstr "Sağda element yoxdur"
+
+#. IDS_NOITEMMIDDLE
+#: Merge.rc:5068
+msgid "No item in middle"
+msgstr "Ortada element yoxdur"
+
+#. IDS_CMPRES_ERROR
+#: Merge.rc:5070
+msgid "Error"
+msgstr "Xəta"
+
+#. IDS_TEXT_FILES_SAME
+#: Merge.rc:5071
+msgid "Text files are identical"
+msgstr "Mətn faylları eynidir"
+
+#. IDS_LEFTONLY_DIFF
+#: Merge.rc:5072
+msgid " (Middle and right are identical)"
+msgstr " (Orta və sağ eynidir)"
+
+#. IDS_MIDDLEONLY_DIFF
+#: Merge.rc:5073
+msgid " (Left and right are identical)"
+msgstr " (Sol və sağ eynidir)"
+
+#. IDS_RIGHTONLY_DIFF
+#: Merge.rc:5074
+msgid " (Left and middle are identical)"
+msgstr " (Sol və orta eynidir)"
+
+#. IDS_PATH_MISMATCH
+#: Merge.rc:5075
+msgid " (paths differ)"
+msgstr " (yollar fərqlidir)"
+
+#. IDS_TEXT_FILES_DIFF
+#: Merge.rc:5076
+msgid "Text files are different"
+msgstr "Mətn faylları fərqlidir"
+
+#. IDS_IMAGE_FILES_SAME
+#: Merge.rc:5077
+msgid "Image files are identical"
+msgstr "Şəkil faylları eynidir"
+
+#. IDS_IMAGE_FILES_DIFF
+#: Merge.rc:5078
+msgid "Image files are different"
+msgstr "Şəkil faylları fərqlidir"
+
+#. IDS_EXPR_DIFF
+#: Merge.rc:5079
+#, c-format
+msgid "Files are different (expr: %1)"
+msgstr "Fayllar fərqlidir (ifadə: %1)"
+
+#. IDS_HASH_GROUP
+#: Merge.rc:5080
+#, c-format
+msgid "Group%d"
+msgstr "Qrup%d"
+
+#. IDS_RENAME_MOVE_DETECTION_DISALBED
+#: Merge.rc:5081
+msgctxt "Options dialog|Compare|Folder|Detect renames and moves"
+msgid "Disabled"
+msgstr "Söndürülüb"
+
+#. IDS_RENAME_MOVE_DETECTION_RENAME
+#: Merge.rc:5082
+msgid "Detect renames"
+msgstr "Ad dəyişikliklərini aşkar et"
+
+#. IDS_RENAME_MOVE_DETECTION_RENAME_MOVE
+#: Merge.rc:5083
+msgid "Detect renames and moves"
+msgstr "Ad və yer dəyişikliklərini aşkar et"
+
+#. IDS_RENAME_MOVE_MERGE_MODE_RENAME
+#: Merge.rc:5084
+msgid "Merge renames"
+msgstr "Ad dəyişikliklərini birləşdir"
+
+#. IDS_RENAME_MOVE_MERGE_MODE_RENAME_MOVE
+#: Merge.rc:5085
+msgid "Merge renames and moves"
+msgstr "Ad və yer dəyişikliklərini birləşdir"
+
+#. IDS_RENAMED
+#: Merge.rc:5086
+msgid "Renamed"
+msgstr "Adı dəyişdirilib"
+
+#. IDS_RENAMED_MOVED
+#: Merge.rc:5088
+msgid "Renamed/Moved"
+msgstr "Adı/yeri dəyişdirilib"
+
+#. IDS_RENAMED_MOVED_ITEMS
+#: Merge.rc:5089
+#, c-format
+msgid "(%1 items)"
+msgstr "(%1 element)"
+
+#. IDS_RENAMED_MOVED_RESULT
+#: Merge.rc:5090
+#, c-format
+msgid "%1 (set %2): "
+msgstr "%1 (dəst %2): "
+
+#. IDS_SWITCH_FLAT_MODE
+#: Merge.rc:5091
+msgid "Some moved items have been merged.\nIn Tree Mode, these items may appear in positions that do not reflect the actual folder structure, which can be confusing.\nSwitch to Flat Mode?"
+msgstr "Yeri dəyişdirilmiş bəzi elementlər birləşdirilib.\nAğac rejimində bu elementlər qovluğun həqiqi quruluşunu əks etdirməyən mövqelərdə görünə bilər, bu da çaşqınlıq yarada bilər.\nDüz siyahı rejiminə keçilsin?"
+
+#. IDS_ELAPSED_TIME
+#: Merge.rc:5097
+#, c-format
+msgid "Elapsed time: %ld ms"
+msgstr "Keçən vaxt: %ld ms"
+
+#. IDS_STATUS_SELITEM1
+#: Merge.rc:5098
+msgid "1 item selected"
+msgstr "1 element seçilib"
+
+#. IDS_STATUS_SELITEMS
+#: Merge.rc:5099
+#, c-format
+msgid "%1 items selected"
+msgstr "%1 element seçilib"
+
+#. IDS_COLDESC_FILENAME
+#: Merge.rc:5105
+msgid "Filename or folder name."
+msgstr "Fayl və ya qovluq adı."
+
+#. IDS_COLDESC_DIR
+#: Merge.rc:5106
+msgid "Subfolder name when subfolders are included."
+msgstr "Alt qovluqlar daxil edildikdə alt qovluğun adı."
+
+#. IDS_COLDESC_RESULT
+#: Merge.rc:5107
+msgid "Comparison result, long form."
+msgstr "Müqayisə nəticəsinin uzun forması."
+
+#. IDS_COLDESC_LTIMEM
+#: Merge.rc:5112
+msgid "Left side modification date."
+msgstr "Sol tərəfin dəyişdirilmə tarixi."
+
+#. IDS_COLDESC_RTIMEM
+#: Merge.rc:5113
+msgid "Right side modification date."
+msgstr "Sağ tərəfin dəyişdirilmə tarixi."
+
+#. IDS_COLDESC_MTIMEM
+#: Merge.rc:5114
+msgid "Middle side modification date."
+msgstr "Orta tərəfin dəyişdirilmə tarixi."
+
+#. IDS_COLDESC_EXTENSION
+#: Merge.rc:5115
+msgid "File's extension."
+msgstr "Faylın uzantısı."
+
+#. IDS_COLDESC_LSIZE
+#: Merge.rc:5116
+msgid "Left file size in bytes."
+msgstr "Sol faylın baytla ölçüsü."
+
+#. IDS_COLDESC_RSIZE
+#: Merge.rc:5117
+msgid "Right file size in bytes."
+msgstr "Sağ faylın baytla ölçüsü."
+
+#. IDS_COLDESC_MSIZE
+#: Merge.rc:5118
+msgid "Middle file size in bytes."
+msgstr "Orta faylın baytla ölçüsü."
+
+#. IDS_COLDESC_LSIZE_SHORT
+#: Merge.rc:5119
+msgid "Left file size abbreviated."
+msgstr "Sol faylın qısaldılmış ölçüsü."
+
+#. IDS_COLDESC_RSIZE_SHORT
+#: Merge.rc:5120
+msgid "Right file size abbreviated."
+msgstr "Sağ faylın qısaldılmış ölçüsü."
+
+#. IDS_COLDESC_MSIZE_SHORT
+#: Merge.rc:5121
+msgid "Middle file size abbreviated."
+msgstr "Orta faylın qısaldılmış ölçüsü."
+
+#. IDS_COLDESC_LTIMEC
+#: Merge.rc:5127
+msgid "Left side creation time."
+msgstr "Sol tərəfin yaradılma vaxtı."
+
+#. IDS_COLDESC_RTIMEC
+#: Merge.rc:5128
+msgid "Right side creation time."
+msgstr "Sağ tərəfin yaradılma vaxtı."
+
+#. IDS_COLDESC_MTIMEC
+#: Merge.rc:5129
+msgid "Middle side creation time."
+msgstr "Orta tərəfin yaradılma vaxtı."
+
+#. IDS_COLDESC_NEWER
+#: Merge.rc:5130
+msgid "Tells which side has newer modification date."
+msgstr "Hansı tərəfin daha yeni dəyişdirilmə tarixinə malik olduğunu göstərir."
+
+#. IDS_COLDESC_LVERSION
+#: Merge.rc:5131
+msgid "Left side file version, only for some file types."
+msgstr "Sol tərəfdəki faylın versiyası, yalnız bəzi fayl növləri üçün."
+
+#. IDS_COLDESC_RVERSION
+#: Merge.rc:5132
+msgid "Right side file version, only for some file types."
+msgstr "Sağ tərəfdəki faylın versiyası, yalnız bəzi fayl növləri üçün."
+
+#. IDS_COLDESC_MVERSION
+#: Merge.rc:5137
+msgid "Middle side file version, only for some file types."
+msgstr "Orta tərəfdəki faylın versiyası, yalnız bəzi fayl növləri üçün."
+
+#. IDS_COLDESC_RESULT_ABBR
+#: Merge.rc:5138
+msgid "Short comparison result."
+msgstr "Qısa müqayisə nəticəsi."
+
+#. IDS_COLDESC_LATTRIBUTES
+#: Merge.rc:5139
+msgid "Left side attributes."
+msgstr "Sol tərəfin atributları."
+
+#. IDS_COLDESC_RATTRIBUTES
+#: Merge.rc:5140
+msgid "Right side attributes."
+msgstr "Sağ tərəfin atributları."
+
+#. IDS_COLDESC_MATTRIBUTES
+#: Merge.rc:5141
+msgid "Middle side attributes."
+msgstr "Orta tərəfin atributları."
+
+#. IDS_COLDESC_LEOL_TYPE
+#: Merge.rc:5142
+msgid "Left side file EOL type."
+msgstr "Sol tərəfdəki faylın sətir sonu növü."
+
+#. IDS_COLDESC_REOL_TYPE
+#: Merge.rc:5143
+msgid "Right side file EOL type."
+msgstr "Sağ tərəfdəki faylın sətir sonu növü."
+
+#. IDS_COLDESC_MEOL_TYPE
+#: Merge.rc:5144
+msgid "Middle side file EOL type."
+msgstr "Orta tərəfdəki faylın sətir sonu növü."
+
+#. IDS_COLDESC_LENCODING
+#: Merge.rc:5150
+msgid "Left side encoding."
+msgstr "Sol tərəfin kodlaşdırılması."
+
+#. IDS_COLDESC_RENCODING
+#: Merge.rc:5151
+msgid "Right side encoding."
+msgstr "Sağ tərəfin kodlaşdırılması."
+
+#. IDS_COLDESC_MENCODING
+#: Merge.rc:5152
+msgid "Middle side encoding."
+msgstr "Orta tərəfin kodlaşdırılması."
+
+#. IDS_COLDESC_NIDIFFS
+#: Merge.rc:5153
+msgid "Number of ignored differences in file. Ignored and cannot be merged."
+msgstr "Faylda nəzərə alınmayan fərqlərin sayı. Bunlar nəzərə alınmır və birləşdirilə bilməz."
+
+#. IDS_COLDESC_NSDIFFS
+#: Merge.rc:5154
+msgid "Number of differences in file (excluding ignored)."
+msgstr "Fayldakı fərqlərin sayı (nəzərə alınmayanlar xaric)."
+
+#. IDS_COLDESC_BINARY
+#: Merge.rc:5155
+msgid "Shows an asterisk (*) if the file is binary."
+msgstr "Fayl ikilikdirsə, ulduz (*) göstərir."
+
+#. IDS_COLDESC_UNPACKER
+#: Merge.rc:5156
+msgid "Unpacker plugin name or pipeline."
+msgstr "Açma qoşmasının adı və ya qoşma ardıcıllığı."
+
+#. IDS_COLDESC_PREDIFFER
+#: Merge.rc:5157
+msgid "Prediffer plugin name or pipeline."
+msgstr "İlkin müqayisə emalı qoşmasının adı və ya qoşma ardıcıllığı."
+
+#. IDS_DIRECTORY_REPORT_TITLE
+#: Merge.rc:5163
+#, c-format
+msgid "Compare %1 with %2"
+msgstr "%1 ilə %2 müqayisə edilsin"
+
+#. IDS_DIRECTORY_REPORT_TITLE3
+#: Merge.rc:5164
+#, c-format
+msgid "Compare %1 with %2 and %3"
+msgstr "%1 ilə %2 və %3 müqayisə edilsin"
+
+#. IDS_REPORT_COMMALIST
+#: Merge.rc:5165
+msgid "Comma-separated list"
+msgstr "Vergüllə ayrılmış siyahı"
+
+#. IDS_REPORT_TABLIST
+#: Merge.rc:5166
+msgid "Tab-separated list"
+msgstr "Tabulyasiya ilə ayrılmış siyahı"
+
+#. IDS_REPORT_SIMPLEHTML
+#: Merge.rc:5167
+msgid "Simple HTML"
+msgstr "Sadə HTML"
+
+#. IDS_REPORT_SIMPLEXML
+#: Merge.rc:5168
+msgid "Simple XML"
+msgstr "Sadə XML"
+
+#: Merge.rc:5170
+msgid "Report file already exists. Overwrite?"
+msgstr "Hesabat faylı artıq mövcuddur. Üzərinə yazılsın?"
+
+#. IDS_REPORT_ERROR
+#: Merge.rc:5175
+#, c-format
+msgid "Error creating the report:\n%1"
+msgstr "Hesabatı yaradarkən xəta baş verdi:\n%1"
+
+#. IDS_REPORT_SUCCESS
+#: Merge.rc:5176
+msgid "Report created successfully."
+msgstr "Hesabat yaradıldı."
+
+#. IDS_SYNCPOINT_LASTBLOCK
+#: Merge.rc:5182
+msgid "Cannot add a synchronization point at this line."
+msgstr "Bu sətrə sinxronlaşdırma nöqtəsi əlavə etmək mümkün deyil."
+
+#. IDS_FILE_TO_ITSELF
+#: Merge.rc:5188
+msgid "Same file is opened in both panes."
+msgstr "Hər iki paneldə eyni fayl açılıb."
+
+#. IDS_FILESSAME
+#: Merge.rc:5189
+msgid "Selected files are identical."
+msgstr "Seçilmiş fayllar eynidir."
+
+#. IDS_FILESSAME_CURCFG
+#: Merge.rc:5190
+msgid "Selected files are identical (with current settings).\r\nChecking binary identity..."
+msgstr "Seçilmiş fayllar eynidir (cari parametrlərlə).\r\nİkilik eynilik yoxlanılır..."
+
+#. IDS_FILESSAME_BINERROR
+#: Merge.rc:5191
+msgid "Selected files are identical (with current settings).\r\nBut binary comparison failed."
+msgstr "Seçilmiş fayllar eynidir (cari parametrlərlə).\r\nLakin ikilik müqayisə alınmadı."
+
+#. IDS_FILESSAME_BINSAME
+#: Merge.rc:5192
+msgid "Selected files are identical (binary match)."
+msgstr "Seçilmiş fayllar eynidir (ikilik uyğunluq)."
+
+#. IDS_FILESSAME_BINDIFF
+#: Merge.rc:5193
+msgid "Selected files are identical (with current settings).\r\nBut differ at the binary level."
+msgstr "Seçilmiş fayllar eynidir (cari parametrlərlə).\r\nLakin ikilik səviyyədə fərqlənir."
+
+#. IDS_FILEERROR
+#: Merge.rc:5194
+msgid "An error occurred while comparing files."
+msgstr "Faylları müqayisə edərkən xəta baş verdi."
+
+#. IDS_TEMP_FILEERROR
+#: Merge.rc:5195
+msgid "Could not create temporary files. Check your temporary path settings."
+msgstr "Müvəqqəti faylları yaratmaq mümkün olmadı. Müvəqqəti yol parametrlərini yoxlayın."
+
+#. IDS_SUGGEST_IGNOREEOL
+#: Merge.rc:5196
+msgid "Files use different EOL.\n\nTreat all EOL as equivalent?\n\nSet 'Ignore EOL differences (Windows/Unix/Mac)' in Compare section of Options."
+msgstr "Fayllarda fərqli sətir sonları istifadə olunur.\n\nBütün sətir sonları eyni sayılsın?\n\nSeçimlərin Müqayisə bölməsində 'Sətir sonu fərqlərini nəzərə alma (Windows/Unix/Mac)' seçimini aktivləşdirin."
+
+#. IDS_INVALID_DIRECTORY
+#: Merge.rc:5197
+msgid "Selected folder is invalid."
+msgstr "Seçilmiş qovluq yanlışdır."
+
+#. IDS_CANNOT_OPEN_BINARYFILE
+#: Merge.rc:5198
+msgid "Cannot open a binary file in Editor."
+msgstr "İkilik faylı redaktorda açmaq mümkün deyil."
+
+#. IDS_CREATE_PAIR_FOLDER
+#: Merge.rc:5199
+#, c-format
+msgid "Create matching folder:\n%1\non the other side and open?"
+msgstr "Uyğun qovluq:\n%1\ndigər tərəfdə yaradılsın və açılsın?"
+
+#. IDS_CONFIRM_COPY_ALL_DIFFS
+#: Merge.rc:5200
+msgid "Copy all differences to other file?"
+msgstr "Bütün fərqlər digər fayla köçürülsün?"
+
+#. IDS_MOVE_TO_NEXTFILE
+#: Merge.rc:5205
+msgid "Move to next file?"
+msgstr "Növbəti fayla keçilsin?"
+
+#. IDS_MOVE_TO_PREVFILE
+#: Merge.rc:5206
+msgid "Move to previous file?"
+msgstr "Əvvəlki fayla keçilsin?"
+
+#. IDS_MOVE_TO_NEXTPAGE
+#: Merge.rc:5207
+msgid "Move to next page?"
+msgstr "Növbəti səhifəyə keçilsin?"
+
+#. IDS_MOVE_TO_PREVPAGE
+#: Merge.rc:5208
+msgid "Move to previous page?"
+msgstr "Əvvəlki səhifəyə keçilsin?"
+
+#. IDS_MOVE_TO_FIRSTFILE
+#: Merge.rc:5209
+msgid "Move to first file?"
+msgstr "İlk fayla keçilsin?"
+
+#. IDS_MOVE_TO_LASTFILE
+#: Merge.rc:5210
+msgid "Move to last file?"
+msgstr "Son fayla keçilsin?"
+
+#: Merge.rc:5217
+#, c-format
+msgid "Different codepages: left (cp%d), right (cp%d).\nDisplay in codepage (better display) or default Windows codepage (safer merging)?\n(Recommended: default Windows codepage)"
+msgstr "Kod səhifələri fərqlidir: sol (cp%d), sağ (cp%d).\nFaylın kod səhifəsi ilə (daha yaxşı görünüş) və ya Windows standart kod səhifəsi ilə (daha etibarlı birləşdirmə) göstərilsin?\n(Tövsiyə: Windows standart kod səhifəsi)"
+
+#: Merge.rc:5219
+msgid "Information lost due to encoding errors: both files"
+msgstr "Kodlaşdırma xətalarına görə məlumat itirildi: hər iki fayl"
+
+#: Merge.rc:5221
+msgid "Information lost due to encoding errors: first file"
+msgstr "Kodlaşdırma xətalarına görə məlumat itirildi: birinci fayl"
+
+#: Merge.rc:5223
+msgid "Information lost due to encoding errors: second file"
+msgstr "Kodlaşdırma xətalarına görə məlumat itirildi: ikinci fayl"
+
+#: Merge.rc:5225
+msgid "Information lost due to encoding errors: third file"
+msgstr "Kodlaşdırma xətalarına görə məlumat itirildi: üçüncü fayl"
+
+#. IDS_LINEDIFF_NODIFF
+#: Merge.rc:5231
+msgid "No difference"
+msgstr "Fərq yoxdur"
+
+#. IDS_LINEDIFF_NODIFF_CAPTION
+#: Merge.rc:5232
+msgid "Line difference"
+msgstr "Sətir fərqi"
+
+#. IDS_NUM_REPLACED
+#: Merge.rc:5238
+#, c-format
+msgid "Replaced %1 string(s)."
+msgstr "%1 mətn sətri əvəz edildi."
+
+#. IDS_EDIT_TEXT_NOT_FOUND
+#: Merge.rc:5239
+#, c-format
+msgid "Cannot find string \"%s\"."
+msgstr "\"%s\" mətni tapılmadı."
+
+#. IDS_MERGE_MODE
+#: Merge.rc:5245
+msgid "Entering Merge Mode. Press F9 to turn off."
+msgstr "Birləşdirmə rejiminə keçilir. Söndürmək üçün F9 düyməsinə basın."
+
+#. IDS_AUTO_MERGE
+#: Merge.rc:5251
+#, c-format
+msgid "Automatic merges: %1\nUnresolved conflicts: %2"
+msgstr "Avtomatik birləşdirmələr: %1\nHəll edilməmiş ziddiyyətlər: %2"
+
+#. IDS_CODEPAGE_MERGED
+#: Merge.rc:5252
+msgid "Codepage change merged."
+msgstr "Kod səhifəsi dəyişikliyi birləşdirildi."
+
+#. IDS_CODEPAGE_CONFLICT
+#: Merge.rc:5253
+msgid "Codepage changes are conflicting."
+msgstr "Kod səhifəsi dəyişiklikləri ziddiyyətlidir."
+
+#. IDS_EOL_MERGED
+#: Merge.rc:5254
+msgid "EOL change merged."
+msgstr "Sətir sonu dəyişikliyi birləşdirildi."
+
+#. IDS_EOL_CONFLICT
+#: Merge.rc:5255
+msgid "EOL changes are conflicting."
+msgstr "Sətir sonu dəyişiklikləri ziddiyyətlidir."
+
+#. IDS_LOCBAR_CAPTION
+#: Merge.rc:5261
+msgid "Location Pane"
+msgstr "Mövqe paneli"
+
+#. IDS_DIFFBAR_CAPTION
+#: Merge.rc:5262
+msgid "Diff Pane"
+msgstr "Fərq paneli"
+
+#. IDS_DIFF_SUCCEEDED
+#: Merge.rc:5269
+msgid "Patch file written."
+msgstr "Yamaq faylı yazıldı."
+
+#. IDS_DIFF_FILEOVERWRITE
+#: Merge.rc:5270
+msgid "Patch file already exists. Overwrite?"
+msgstr "Yamaq faylı artıq mövcuddur. Üzərinə yazılsın?"
+
+#. IDS_DIFF_SELECTEDFILES
+#: Merge.rc:5271
+#, c-format
+msgid "[%1 files selected]"
+msgstr "[%1 fayl seçilib]"
+
+#. IDS_DIFF_NORMAL
+#: Merge.rc:5272
+msgid "Normal"
+msgstr "Normal"
+
+#. IDS_DIFF_CONTEXT
+#: Merge.rc:5273
+msgid "Context"
+msgstr "Kontekst"
+
+#. IDS_DIFF_UNIFIED
+#: Merge.rc:5274
+msgid "Unified"
+msgstr "Birləşdirilmiş"
+
+#. IDS_FILEWRITE_ERROR
+#: Merge.rc:5276
+#, c-format
+msgid "Could not write to file %1."
+msgstr "%1 faylına yazmaq mümkün olmadı."
+
+#. IDS_PATH_NOT_ABSOLUTE
+#: Merge.rc:5277
+#, c-format
+msgid "Output path is not absolute: %1"
+msgstr "Çıxış yolu mütləq deyil: %1"
+
+#. IDS_MUST_SPECIFY_OUTPUT
+#: Merge.rc:5278
+msgid "Specify an output file."
+msgstr "Çıxış faylını göstərin."
+
+#: Merge.rc:5280
+msgid "Cannot create patch from binary files."
+msgstr "İkilik fayllardan yamaq yaratmaq mümkün deyil."
+
+#. IDS_SAVEFILES_FORPATCH
+#: Merge.rc:5281
+msgid "Save all files first.\n\nCreating a patch requires no unsaved changes."
+msgstr "Əvvəlcə bütün faylları saxlayın.\n\nYamaq yaratmaq üçün saxlanmamış dəyişikliklər olmamalıdır."
+
+#. IDS_FOLDER_NOTEXIST
+#: Merge.rc:5282
+msgid "Folder does not exist."
+msgstr "Qovluq mövcud deyil."
+
+#. IDS_ARCHIVE_SUCCEEDED
+#: Merge.rc:5288
+msgid "Archive file written."
+msgstr "Arxiv faylı yazıldı."
+
+#. IDS_ARCHIVE_SAVEFILES
+#: Merge.rc:5289
+msgid "Save all files first.\n\nCreating an archive requires no unsaved changes."
+msgstr "Əvvəlcə bütün faylları saxlayın.\n\nArxiv yaratmaq üçün saxlanmamış dəyişikliklər olmamalıdır."
+
+#. IDS_NO_ZIP_SUPPORT
+#: Merge.rc:5294
+msgid "Archive support not enabled.\n7-Zip and/or Merge7z*.dll not found.\nSee manual for archive support."
+msgstr "Arxiv dəstəyi aktiv deyil.\n7-Zip və/və ya Merge7z*.dll tapılmadı.\nArxiv dəstəyi üçün təlimata baxın."
+
+#. IDS_OPT_EXPORT_CAPTION
+#: Merge.rc:5295
+msgid "Select file for export"
+msgstr "İxrac üçün fayl seçin"
+
+#. IDS_OPT_IMPORT_CAPTION
+#: Merge.rc:5296
+msgid "Select file for import"
+msgstr "İdxal üçün fayl seçin"
+
+#. IDS_OPT_IMPORT_DONE
+#: Merge.rc:5297
+msgid "Options imported from file."
+msgstr "Seçimlər fayldan idxal edildi."
+
+#. IDS_OPT_EXPORT_DONE
+#: Merge.rc:5298
+msgid "Options exported to file."
+msgstr "Seçimlər fayla ixrac edildi."
+
+#. IDS_OPT_IMPORT_ERR
+#: Merge.rc:5299
+msgid "Failed to import options from file."
+msgstr "Seçimləri fayldan idxal etmək mümkün olmadı."
+
+#. IDS_OPT_EXPORT_ERR
+#: Merge.rc:5300
+msgid "Failed to write options to file."
+msgstr "Seçimləri fayla yazmaq mümkün olmadı."
+
+#. IDS_CLOSEALL_WINDOWS
+#: Merge.rc:5301
+msgid "Close multiple compare windows?\n\nContinue?"
+msgstr "Bir neçə müqayisə pəncərəsi bağlansın?\n\nDavam edilsin?"
+
+#. IDS_EOL_BIN
+#: Merge.rc:5311
+msgctxt "EOL Type"
+msgid "Binary"
+msgstr "İkilik"
+
+#. IDS_MARKER_COLOR_FMT
+#: Merge.rc:5316
+#, c-format
+msgid "Marker Color %d"
+msgstr "İşarələyici rəngi %d"
+
+#. IDS_MARKER_NEW_PATTERN
+#: Merge.rc:5317
+msgid "New Pattern"
+msgstr "Yeni nümunə"
+
+#. IDS_PLUGINSLIST_TYPE
+#: Merge.rc:5323
+msgid "Type"
+msgstr "Növ"
+
+#. IDS_PLUGINS_TYPE_EDITSCRIPT
+#: Merge.rc:5327
+msgid "Editor script"
+msgstr "Redaktor skripti"
+
+#. ID_SELECTLINEDIFF
+#: Merge.rc:5333
+msgid "\nDifference in Current Line (F4)"
+msgstr "\nCari sətirdəki fərq (F4)"
+
+#. ID_OPTIONS
+#: Merge.rc:5334
+msgid "\nOptions"
+msgstr "\nSeçimlər"
+
+#. ID_REFRESH
+#: Merge.rc:5335
+msgid "\nRefresh (F5)"
+msgstr "\nYenilə (F5)"
+
+#. ID_PREVDIFF
+#: Merge.rc:5341
+msgid "\nPrevious Difference (Alt+Up)"
+msgstr "\nƏvvəlki fərq (Alt+Up)"
+
+#. ID_NEXTDIFF
+#: Merge.rc:5342
+msgid "\nNext Difference (Alt+Down)"
+msgstr "\nNövbəti fərq (Alt+Down)"
+
+#. ID_PREVCONFLICT
+#: Merge.rc:5343
+msgid "\nPrevious Conflict (Alt+Shift+Up)"
+msgstr "\nƏvvəlki ziddiyyət (Alt+Shift+Up)"
+
+#. ID_NEXTCONFLICT
+#: Merge.rc:5344
+msgid "\nNext Conflict (Alt+Shift+Down)"
+msgstr "\nNövbəti ziddiyyət (Alt+Shift+Down)"
+
+#. ID_FIRSTDIFF
+#: Merge.rc:5349
+msgid "\nFirst Difference (Alt+Home)"
+msgstr "\nİlk fərq (Alt+Home)"
+
+#. ID_CURDIFF
+#: Merge.rc:5350
+msgid "\nCurrent Difference (Alt+Enter)"
+msgstr "\nCari fərq (Alt+Enter)"
+
+#. ID_LASTDIFF
+#: Merge.rc:5351
+msgid "\nLast Difference (Alt+End)"
+msgstr "\nSon fərq (Alt+End)"
+
+#. ID_L2R
+#: Merge.rc:5352
+msgid "\nCopy to Right (Alt+Right)"
+msgstr "\nSağa köçür (Alt+Right)"
+
+#. ID_R2L
+#: Merge.rc:5353
+msgid "\nCopy to Left (Alt+Left)"
+msgstr "\nSola köçür (Alt+Left)"
+
+#. ID_L2RNEXT
+#: Merge.rc:5354
+msgid "\nCopy to Right and Advance (Ctrl+Alt+Right)"
+msgstr "\nSağa köçür və irəlilə (Ctrl+Alt+Right)"
+
+#. ID_R2LNEXT
+#: Merge.rc:5355
+msgid "\nCopy to Left and Advance (Ctrl+Alt+Left)"
+msgstr "\nSola köçür və irəlilə (Ctrl+Alt+Left)"
+
+#. ID_ALL_RIGHT
+#: Merge.rc:5356
+msgid "\nCopy All to Right"
+msgstr "\nHamısını sağa köçür"
+
+#. ID_ALL_LEFT
+#: Merge.rc:5357
+msgid "\nCopy All to Left"
+msgstr "\nHamısını sola köçür"
+
+#. ID_AUTO_MERGE
+#: Merge.rc:5358
+msgid "\nAuto Merge (Ctrl+Alt+M)"
+msgstr "\nAvtomatik birləşdir (Ctrl+Alt+M)"
+
+#. ID_FIRSTFILE
+#: Merge.rc:5359
+msgid "\nFirst File"
+msgstr "\nİlk fayl"
+
+#. ID_NEXTFILE
+#: Merge.rc:5360
+msgid "\nNext File (Ctrl+F8)"
+msgstr "\nNövbəti fayl (Ctrl+F8)"
+
+#. ID_LASTFILE
+#: Merge.rc:5361
+msgid "\nLast File"
+msgstr "\nSon fayl"
+
+#. ID_PREVFILE
+#: Merge.rc:5362
+msgid "\nPrevious File (Ctrl+F7)"
+msgstr "\nƏvvəlki fayl (Ctrl+F7)"
+
+#. IDS_UNPACK_AUTO
+#: Merge.rc:5369
+msgid "Adapted unpacker applied to both files (one needs extension)."
+msgstr "Uyğunlaşdırılmış açma qoşması hər iki fayla tətbiq edildi (birinə uzantı lazımdır)."
+
+#. IDS_NO_PREDIFFER
+#: Merge.rc:5370
+msgid "No Prediffer (Normal)"
+msgstr "İlkin müqayisə emalı yoxdur (normal)"
+
+#. IDS_SUGGESTED_PLUGINS
+#: Merge.rc:5371
+msgid "Suggested Plugins"
+msgstr "Təklif edilən qoşmalar"
+
+#. IDS_NOT_SUGGESTED_PLUGINS
+#: Merge.rc:5372
+msgid "All Plugins"
+msgstr "Bütün qoşmalar"
+
+#. IDS_PRIVATEBUILD_FMT
+#: Merge.rc:5378
+#, c-format
+msgid "Private Build: %1"
+msgstr "Şəxsi yığma: %1"
+
+#. IDS_ALLRIGHTS_RESERVED
+#: Merge.rc:5379
+msgid " - All rights reserved."
+msgstr " - Bütün hüquqlar qorunur."
+
+#. IDS_TITLE_PLUGINS_SETTINGS
+#: Merge.rc:5385
+msgid "Plugin Settings"
+msgstr "Qoşma parametrləri"
+
+#. IDS_NO_SCT_SCRIPTS
+#: Merge.rc:5387
+msgid "WSH not found - .sct scripts disabled"
+msgstr "WSH tapılmadı - .sct skriptləri söndürülüb"
+
+#. IDS_LOCBAR_GOTOLINE_FMT
+#: Merge.rc:5395
+#, c-format
+msgid "G&o to Line %1"
+msgstr "%1 nömrəli sətrə &keç"
+
+#. IDS_GOTO_MOVED_LINE
+#: Merge.rc:5401
+msgid "Go to Moved Line\tCtrl+Shift+G"
+msgstr "Yeri dəyişdirilmiş sətrə keç\tCtrl+Shift+G"
+
+#. IDS_AUTOCOMPLETE_DISABLED
+#: Merge.rc:5407
+msgctxt "Options dialog|General|Open dialog Auto completion"
+msgid "Disabled"
+msgstr "Söndürülüb"
+
+#. IDS_AUTOCOMPLETE_FILE_SYS
+#: Merge.rc:5408
+msgid "From file system"
+msgstr "Fayl sistemindən"
+
+#. IDS_AUTOCOMPLETE_MRU
+#: Merge.rc:5409
+msgid "From Most Recently Used list"
+msgstr "Son istifadə edilənlər siyahısından"
+
+#. IDS_COLORSCHEME_PLAIN
+#: Merge.rc:5415
+msgid "No Highlighting"
+msgstr "Vurğulama yoxdur"
+
+#. IDS_COLORSCHEME_PO
+#: Merge.rc:5450
+msgid "Portable Object"
+msgstr "Daşına bilən obyekt"
+
+#. IDS_COLORSCHEME_RSRC
+#: Merge.rc:5455
+msgid "Resources"
+msgstr "Resurslar"
+
+#. IDS_COLORSCHEME_SH
+#: Merge.rc:5459
+msgid "Shell"
+msgstr "Örtük"
+
+#. IDS_CLOSE_LEFT_TABS
+#: Merge.rc:5480
+msgid "Close &Left Tabs"
+msgstr "&Soldakı vərəqləri bağla"
+
+#. IDS_CLOSE_RIGHT_TABS
+#: Merge.rc:5481
+msgid "Close R&ight Tabs"
+msgstr "S&ağdakı vərəqləri bağla"
+
+#. IDS_CLOSE_OTHER_TABS
+#: Merge.rc:5482
+msgid "Close &Other Tabs"
+msgstr "&Digər vərəqləri bağla"
+
+#. IDS_TABBAR_AUTO_MAXWIDTH
+#: Merge.rc:5483
+msgid "Enable &Auto Max Width"
+msgstr "&Avtomatik maksimum eni aktivləşdir"
+
+#. IDS_WEBPAGE_MENU
+#: Merge.rc:5493
+msgid "We&bpage"
+msgstr "&Veb-səhifə"
+
+#. IDS_VIEW_WRAP_TEXT
+#: Merge.rc:5498
+msgid "W&rap Text"
+msgstr "Mətni &bük"
+
+#. IDS_NOTINSTALLED
+#: Merge.rc:5503
+#, c-format
+msgid "%1 is not installed."
+msgstr "%1 quraşdırılmayıb."
+
+#. IDS_CREATE_FOLDER
+#: Merge.rc:5508
+#, c-format
+msgid "%1 does not exist. Create it?"
+msgstr "%1 mövcud deyil. Yaradılsın?"
+
+#. IDS_CREATE_FOLDER_ERROR
+#: Merge.rc:5509
+msgid "Failed to create folder."
+msgstr "Qovluğu yaratmaq mümkün olmadı."
+
+#. IDC_EXT_EDITOR_PATH
+#: Merge.rc:5514
+msgid "Parameters:\n$file: Current file path\n$linenum: Current cursor line number"
+msgstr "Parametrlər:\n$file: cari faylın yolu\n$linenum: kursorun cari sətir nömrəsi"
+
+#. IDS_DIFF_ALGORITHM_DEFAULT
+#: Merge.rc:5519
+msgid "default"
+msgstr "standart"
+
+#. IDS_DIFF_ALGORITHM_MINIMAL
+#: Merge.rc:5520
+msgid "minimal"
+msgstr "minimal"
+
+#. IDS_DIFF_ALGORITHM_PATIENCE
+#: Merge.rc:5521
+msgid "patience"
+msgstr "səbir"
+
+#. IDS_DIFF_ALGORITHM_HISTOGRAM
+#: Merge.rc:5522
+msgid "histogram"
+msgstr "histoqram"
+
+#. IDS_DIFF_ALGORITHM_NONE
+#: Merge.rc:5523
+msgid "none"
+msgstr "heç biri"
+
+#. IDS_RENDERING_MODE_GDI
+#: Merge.rc:5528
+msgid "GDI"
+msgstr "GDI"
+
+#. IDS_RENDERING_MODE_DIRECTWRITE_DEFAULT
+#: Merge.rc:5529
+msgid "DirectWrite Default"
+msgstr "DirectWrite standart"
+
+#. IDS_RENDERING_MODE_DIRECTWRITE_ALIASED
+#: Merge.rc:5530
+msgid "DirectWrite Aliased"
+msgstr "DirectWrite hamarlamasız"
+
+#. IDS_RENDERING_MODE_DIRECTWRITE_GDI_CLASSIC
+#: Merge.rc:5531
+msgid "DirectWrite GDI Classic"
+msgstr "DirectWrite GDI klassik"
+
+#. IDS_RENDERING_MODE_DIRECTWRITE_GDI_NATURAL
+#: Merge.rc:5532
+msgid "DirectWrite GDI Natural"
+msgstr "DirectWrite GDI təbii"
+
+#. IDS_RENDERING_MODE_DIRECTWRITE_NATURAL
+#: Merge.rc:5533
+msgid "DirectWrite Natural"
+msgstr "DirectWrite təbii"
+
+#. IDS_RENDERING_MODE_DIRECTWRITE_NATURAL_SYMMETRIC
+#: Merge.rc:5534
+msgid "DirectWrite Natural Symmetric"
+msgstr "DirectWrite təbii simmetrik"
+
+#. IDS_CLOSE_WINDOWS_WITH_ESC_DISABLED
+#: Merge.rc:5539
+msgctxt "Options dialog|General|Close windows with Esc"
+msgid "Disabled"
+msgstr "Söndürülüb"
+
+#. IDS_CLOSE_WINDOWS_WITH_ESC_1
+#: Merge.rc:5540
+msgid "MDI child window or main window"
+msgstr "MDI alt pəncərəsi və ya əsas pəncərə"
+
+#. IDS_CLOSE_WINDOWS_WITH_ESC_2
+#: Merge.rc:5541
+msgid "MDI child window only"
+msgstr "Yalnız MDI alt pəncərəsi"
+
+#. IDS_CLOSE_WINDOWS_WITH_ESC_3
+#: Merge.rc:5542
+msgid "Close main window if only one MDI child window"
+msgstr "Yalnız bir MDI alt pəncərəsi varsa, əsas pəncərəni bağla"
+
+#. IDS_DIFF_GROUP
+#: Merge.rc:5547
+msgctxt "ImgMergeFrame|LocationPane"
+msgid "Diff"
+msgstr "Fərq"
+
+#. IDS_DIFF_HIGHLIGHT
+#: Merge.rc:5548
+msgctxt "ImgMergeFrame|LocationPane"
+msgid "Highlight"
+msgstr "Vurğulama"
+
+#. IDS_DIFF_BLINK
+#: Merge.rc:5549
+msgctxt "ImgMergeFrame|LocationPane"
+msgid "Blink"
+msgstr "Yanıb-sönmə"
+
+#. IDS_DIFF_BLOCKSIZE
+#: Merge.rc:5550
+msgctxt "ImgMergeFrame|LocationPane"
+msgid "Block Size"
+msgstr "Blokun ölçüsü"
+
+#. IDS_DIFF_BLOCKALPHA
+#: Merge.rc:5551
+msgctxt "ImgMergeFrame|LocationPane"
+msgid "Block Alpha"
+msgstr "Blokun alfa qiyməti"
+
+#. IDS_DIFF_CDTHRESHOLD
+#: Merge.rc:5552
+msgctxt "ImgMergeFrame|LocationPane"
+msgid "CD Threshold"
+msgstr "Rəng fərqi həddi"
+
+#. IDS_DIFF_INSERTION_DELETION_DETECTION
+#: Merge.rc:5553
+msgctxt "ImgMergeFrame|LocationPane"
+msgid "Ins/Del Detection"
+msgstr "Əlavəetmə/silmənin aşkarlanması"
+
+#. IDS_OVERLAY_MODE_NONE
+#: Merge.rc:5554 Merge.rc:5559
+msgctxt "ImgMergeFrame|LocationPane"
+msgid "None"
+msgstr "Heç biri"
+
+#. IDS_DIFF_INSERTION_DELETION_DETECTION_VERTICAL
+#: Merge.rc:5555
+msgctxt "ImgMergeFrame|LocationPane"
+msgid "Vertical"
+msgstr "Şaquli"
+
+#. IDS_DIFF_INSERTION_DELETION_DETECTION_HORIZONTAL
+#: Merge.rc:5556
+msgctxt "ImgMergeFrame|LocationPane"
+msgid "Horizontal"
+msgstr "Üfüqi"
+
+#. IDS_OVERLAY_GROUP
+#: Merge.rc:5557
+msgctxt "ImgMergeFrame|LocationPane"
+msgid "Overlay"
+msgstr "Üst-üstə göstərmə"
+
+#. IDS_OVERLAY_ALPHA
+#: Merge.rc:5558
+msgctxt "ImgMergeFrame|LocationPane"
+msgid "Alpha"
+msgstr "Alfa"
+
+#. IDS_OVERLAY_MODE_XOR
+#: Merge.rc:5560
+msgctxt "ImgMergeFrame|LocationPane"
+msgid "XOR"
+msgstr "XOR"
+
+#. IDS_OVERLAY_MODE_ALPHA
+#: Merge.rc:5561
+msgctxt "ImgMergeFrame|LocationPane"
+msgid "Alpha Blend"
+msgstr "Alfa qarışdırma"
+
+#. IDS_OVERLAY_MODE_ALPHA_ANIMATION
+#: Merge.rc:5562
+msgctxt "ImgMergeFrame|LocationPane"
+msgid "Alpha Animation"
+msgstr "Alfa animasiyası"
+
+#. IDS_ZOOM
+#: Merge.rc:5563
+msgctxt "ImgMergeFrame|LocationPane"
+msgid "Zoom"
+msgstr "Miqyas"
+
+#. IDS_PAGE
+#: Merge.rc:5564
+msgctxt "ImgMergeFrame|LocationPane"
+msgid "Page:"
+msgstr "Səhifə:"
+
+#. IDS_IMGCMP_STATUS_PT_RGBA_FMT
+#: Merge.rc:5565
+#, c-format
+msgid "Pt: (%d, %d)  RGBA: (%d, %d, %d, %d)  "
+msgstr "Nöqtə: (%d, %d)  RGBA: (%d, %d, %d, %d)  "
+
+#. IDS_IMGCMP_STATUS_DIST1_FMT
+#: Merge.rc:5566
+#, c-format
+msgid "Dist: %g  "
+msgstr "Məsafə: %g  "
+
+#. IDS_IMGCMP_STATUS_DIST2_FMT
+#: Merge.rc:5567
+#, c-format
+msgid "Dist: %g, %g  "
+msgstr "Məsafə: %g, %g  "
+
+#. IDS_IMGCMP_STATUS_PAGE_ZOOM_SIZE_BPP_FMT
+#: Merge.rc:5568
+#, c-format
+msgid "Page: %d/%d  Zoom: %d%%  %dx%dpx  %dbpp  "
+msgstr "Səhifə: %d/%d  Miqyas: %d%%  %dx%dpx  %dbpp  "
+
+#. IDS_IMGCMP_STATUS_RC_FMT
+#: Merge.rc:5569
+#, c-format
+msgid "Rc: (%d, %d)  "
+msgstr "Düzbucaqlı: (%d, %d)  "
+
+#. IDS_IMGCMP_STATUS_FLIPPED_FMT
+#: Merge.rc:5570
+#, c-format
+msgid "Flipped: %s  "
+msgstr "Çevrilib: %s  "
+
+#. IDS_IMGCMP_STATUS_ROTATED_FMT
+#: Merge.rc:5571
+#, c-format
+msgid "Rotated: %d  "
+msgstr "Döndərilib: %d  "
+
+#. IDS_IMGCMP_REPORT_ALLPAGES
+#: Merge.rc:5572
+msgid "All pages"
+msgstr "Bütün səhifələr"
+
+#. IDS_IGNSUB_STR1
+#: Merge.rc:5577
+msgid "<Edit here>"
+msgstr "<Burada redaktə edin>"
+
+#. IDS_IGNSUB_STR2
+#: Merge.rc:5578
+msgid "No differences found to select"
+msgstr "Seçmək üçün fərq tapılmadı"
+
+#. IDS_IGNSUB_STR3
+#: Merge.rc:5579
+msgid "No differences found to add as substitution filter"
+msgstr "Əvəzetmə süzgəci kimi əlavə etmək üçün fərq tapılmadı"
+
+#. IDS_IGNSUB_STR4
+#: Merge.rc:5580
+msgid "The pair is already in the Substitution Filters list"
+msgstr "Cüt artıq əvəzetmə süzgəcləri siyahısındadır"
+
+#. IDS_IGNSUB_STR5
+#: Merge.rc:5581
+msgid "Add this change to Substitution Filters?"
+msgstr "Bu dəyişiklik əvəzetmə süzgəclərinə əlavə edilsin?"
+
+#. IDS_OCRRESULT_TEXTONLY
+#: Merge.rc:5586
+msgid "Text only"
+msgstr "Yalnız mətn"
+
+#. IDS_OCRRESULT_POS_LINE
+#: Merge.rc:5587
+msgid "Line-by-line position and text"
+msgstr "Sətir-sətir mövqe və mətn"
+
+#. IDS_OCRRESULT_POS_WORD
+#: Merge.rc:5588
+msgid "Word-by-word position and text"
+msgstr "Söz-söz mövqe və mətn"
+
+#. IDS_USERDATAFOLDER_APPDATA
+#: Merge.rc:5593
+msgid "AppData (Roaming) folder"
+msgstr "AppData (Roaming) qovluğu"
+
+#. IDS_USERDATAFOLDER_INSTALL
+#: Merge.rc:5594
+msgid "Install folder"
+msgstr "Quraşdırma qovluğu"
+
+#. IDS_USERDATAFOLDER_DOCUMENTS
+#: Merge.rc:5595
+msgid "Documents folder"
+msgstr "Sənədlər qovluğu"
+
+#. IDS_SINGLEINSTANCE_DISABLED
+#: Merge.rc:5600
+msgctxt "Options dialog|General|Single instance mode"
+msgid "Disabled"
+msgstr "Söndürülüb"
+
+#. IDS_SINGLEINSTANCE_STR1
+#: Merge.rc:5601
+msgid "Allow only one instance to run"
+msgstr "Yalnız bir nüsxənin işləməsinə icazə ver"
+
+#. IDS_CLIPBOARD_HISTORY
+#: Merge.rc:5602
+msgid "Clipboard &History"
+msgstr "Mübadilə buferinin &tarixçəsi"
+
+#. IDS_SINGLEINSTANCE_STR2
+#: Merge.rc:5603
+msgid "Allow only one instance; wait for termination"
+msgstr "Yalnız bir nüsxəyə icazə ver; onun bağlanmasını gözlə"
+
+#. IDS_AUTO_RELOAD_MODIFIED_FILES_DISABLED
+#: Merge.rc:5608
+msgctxt "Options dialog|General|Auto-reload modified files"
+msgid "Disabled"
+msgstr "Söndürülüb"
+
+#. IDS_AUTO_RELOAD_MODIFIED_FILES_STR1
+#: Merge.rc:5609
+msgid "Only on window activated"
+msgstr "Yalnız pəncərə aktivləşdirildikdə"
+
+#. IDS_AUTO_RELOAD_MODIFIED_FILES_STR2
+#: Merge.rc:5610
+msgid "Immediately"
+msgstr "Dərhal"
+
+#. IDS_PLUGIN_ALL
+#: Merge.rc:5615
+msgid "Al&l"
+msgstr "&Hamısı"
+
+#. IDS_PLUGIN_OTHERS
+#: Merge.rc:5616
+msgid "&Others"
+msgstr "&Digərləri"
+
+#: Merge.rc:5618
+#, c-format
+msgid "Missing plugin name in pipeline: %1"
+msgstr "Ardıcıllıqda qoşma adı çatışmır: %1"
+
+#: Merge.rc:5620
+#, c-format
+msgid "Missing quote in plugin pipeline: %1"
+msgstr "Qoşma ardıcıllığında dırnaq çatışmır: %1"
+
+#. IDS_PLUGIN_NAME_ALREADY_EXISTS
+#: Merge.rc:5621
+#, c-format
+msgid "Plugin name '%1' already exists."
+msgstr "'%1' qoşma adı artıq mövcuddur."
+
+#. IDS_PLUGIN_TITLE1
+#: Merge.rc:5622
+msgid "Specify plugin arguments"
+msgstr "Qoşmanın arqumentlərini göstərin"
+
+#: Merge.rc:5624
+#, c-format
+msgid "Plugin not found or invalid: %1"
+msgstr "Qoşma tapılmadı və ya yanlışdır: %1"
+
+#. IDS_PLUGIN_NOT_UNPACK
+#: Merge.rc:5625
+#, c-format
+msgid "'%1' is not an unpacker plugin"
+msgstr "'%1' açma qoşması deyil"
+
+#. IDS_PLUGIN_NOT_PREDIFF
+#: Merge.rc:5626
+#, c-format
+msgid "'%1' is not a prediffer plugin"
+msgstr "'%1' ilkin müqayisə emalı qoşması deyil"
+
+#: Merge.rc:5628
+#, c-format
+msgid "Error prediffing '%1' with '%2'. Prediffing disabled."
+msgstr "'%1' faylının '%2' ilə ilkin müqayisə emalında xəta baş verdi. İlkin müqayisə emalı söndürüldü."
+
+#. IDS_PLUGIN_CIRCULAR_REFERENCE
+#: Merge.rc:5629
+#, c-format
+msgid "Circular reference in plugin pipeline: %1"
+msgstr "Qoşma ardıcıllığında dairəvi istinad var: %1"
+
+#. IDS_PLUGIN_TYPE1
+#: Merge.rc:5630
+msgid "URL Handler"
+msgstr "URL emalçısı"
+
+#. IDS_PLUGIN_TYPE2
+#: Merge.rc:5631
+msgid "File Unpacker"
+msgstr "Fayl açma qoşması"
+
+#. IDS_PLUGIN_TYPE3
+#: Merge.rc:5632
+msgid "File or Folder Unpacker"
+msgstr "Fayl və ya qovluq açma qoşması"
+
+#. IDS_PLUGIN_TYPE5
+#: Merge.rc:5634
+msgid "Alias for Unpacker"
+msgstr "Açma qoşmasının ləqəbi"
+
+#. IDS_PLUGIN_TYPE6
+#: Merge.rc:5635
+msgid "Alias for Prediffer"
+msgstr "İlkin müqayisə emalı qoşmasının ləqəbi"
+
+#. IDS_PLUGIN_TYPE7
+#: Merge.rc:5636
+msgid "Alias for Editor script"
+msgstr "Redaktor skriptinin ləqəbi"
+
+#. IDS_PLUGIN_ALIAS_DESC
+#: Merge.rc:5637
+#, c-format
+msgid "Alias for plugin pipeline '%1'"
+msgstr "'%1' qoşma ardıcıllığının ləqəbi"
+
+#. IDS_PLUGIN_NEW_DESC
+#: Merge.rc:5638
+msgid "New plugin description"
+msgstr "Yeni qoşmanın təsviri"
+
+#. IDS_PLUGIN_TARGETS_ALL
+#: Merge.rc:5639
+msgid "All"
+msgstr "Hamısı"
+
+#. IDS_PLUGIN_TARGETS_1ST
+#: Merge.rc:5640
+msgid "1st"
+msgstr "Birinci"
+
+#. IDS_PLUGIN_TARGETS_2ND
+#: Merge.rc:5641
+msgid "2nd"
+msgstr "İkinci"
+
+#. IDS_PLUGIN_TARGETS_3RD
+#: Merge.rc:5642
+msgid "3rd"
+msgstr "Üçüncü"
+
+#. IDS_PLUGIN_TARGETS_1ST_2ND
+#: Merge.rc:5643
+msgid "1st and 2nd"
+msgstr "Birinci və ikinci"
+
+#. IDS_PLUGIN_TARGETS_1ST_3RD
+#: Merge.rc:5644
+msgid "1st and 3rd"
+msgstr "Birinci və üçüncü"
+
+#. IDS_PLUGIN_TARGETS_2ND_3RD
+#: Merge.rc:5645
+msgid "2nd and 3rd"
+msgstr "İkinci və üçüncü"
+
+#. IDS_PLUGIN_CTRL_CLICK
+#: Merge.rc:5646
+msgid "(Ctrl+Click to add to pipeline)"
+msgstr "(Ardıcıllığa əlavə etmək üçün Ctrl düyməsini basılı saxlayıb klikləyin)"
+
+#. IDS_FILTER_APPLIED
+#: Merge.rc:5651
+msgid "Filter applied"
+msgstr "Süzgəc tətbiq edildi"
+
+#. IDS_FILTERMENU_COMPARE
+#: Merge.rc:5656
+#, c-format
+msgid "Compare %1"
+msgstr "%1 müqayisə edilsin"
+
+#. IDS_FILTERMENU_FILTER_BY_THIS_COLUMN2
+#: Merge.rc:5658
+msgid "&Filter by This Column..."
+msgstr "Bu sütuna görə &süz..."
+
+#. IDS_CLIPBOARDHISTORY_TIME
+#: Merge.rc:5663
+#, c-format
+msgid "Clipboard at %s"
+msgstr "%s vaxtındakı mübadilə buferi"
+
+#. IDS_CLIPBOARDHISTORY_DISABLED
+#: Merge.rc:5664
+msgid "Clipboard history disabled.\r\nEnable: Windows logo key + V, then Turn on."
+msgstr "Mübadilə buferinin tarixçəsi söndürülüb.\r\nAktivləşdirmək üçün: Windows loqolu düymə + V, sonra Aktivləşdir seçin."
+
+#: Merge.rc:5666
+msgid "This system does not support clipboard history."
+msgstr "Bu sistem mübadilə buferinin tarixçəsini dəstəkləmir."
+
+#: Merge.rc:5668
+msgid "32-bit WinMerge does not support Clipboard Compare"
+msgstr "32 bitlik WinMerge mübadilə buferinin müqayisəsini dəstəkləmir"
+
+#. IDS_WEBVIEW2_RUNTIME_NOT_INSTALLED
+#: Merge.rc:5673
+msgid "WebView2 runtime not installed. Download it?"
+msgstr "WebView2 icra mühiti quraşdırılmayıb. Endirilsin?"
+
+#. IDS_JUMPLIST_NEW_TEXT_COMPARE
+#: Merge.rc:5678
+msgid "New Text Compare"
+msgstr "Yeni mətn müqayisəsi"
+
+#. IDS_JUMPLIST_NEW_TABLE_COMPARE
+#: Merge.rc:5679
+msgid "New Table Compare"
+msgstr "Yeni cədvəl müqayisəsi"
+
+#. IDS_JUMPLIST_NEW_BINARY_COMPARE
+#: Merge.rc:5680
+msgid "New Binary Compare"
+msgstr "Yeni ikilik müqayisə"
+
+#. IDS_JUMPLIST_NEW_IMAGE_COMPARE
+#: Merge.rc:5681
+msgid "New Image Compare"
+msgstr "Yeni şəkil müqayisəsi"
+
+#. IDS_JUMPLIST_NEW_WEBPAGE_COMPARE
+#: Merge.rc:5682
+msgid "New Webpage Compare"
+msgstr "Yeni veb-səhifə müqayisəsi"
+
+#. IDS_JUMPLIST_NEW_FOLDER_COMPARE
+#: Merge.rc:5683
+msgid "New Folder Compare"
+msgstr "Yeni qovluq müqayisəsi"
+
+#. IDS_JUMPLIST_CLIPBOARD_COMPARE
+#: Merge.rc:5684
+msgid "Clipboard Compare"
+msgstr "Mübadilə buferinin müqayisəsi"
+
+#. IDS_PREVIEWBAR_PRINT
+#: Merge.rc:5689
+msgid "&Print..."
+msgstr "&Çap et..."
+
+#. IDS_PREVIEWBAR_PREVPAGE
+#: Merge.rc:5691
+msgid "Pre&v Page"
+msgstr "&Əvvəlki səhifə"
+
+#. IDS_PREVIEWBAR_TWOPAGE
+#: Merge.rc:5692
+msgid "&Two Page"
+msgstr "&İki səhifə"
+
+#. IDS_PREVIEWBAR_ONEPAGE
+#: Merge.rc:5693
+msgid "&One Page"
+msgstr "&Bir səhifə"
+
+#. IDS_PREVIEWBAR_ZOOMIN
+#: Merge.rc:5694
+msgid "Zoom &In"
+msgstr "&Böyüt"
+
+#. IDS_PREVIEWBAR_ZOOMOUT
+#: Merge.rc:5695
+msgid "Zoom &Out"
+msgstr "&Kiçilt"
+
+#. IDS_WEBPAGE_COMPARING
+#: Merge.rc:5701
+msgid "Comparing..."
+msgstr "Müqayisə edilir..."
+
+#. IDS_WEBPAGE_ZOOM
+#: Merge.rc:5702
+msgid "Zoom:"
+msgstr "Miqyas:"
+
+#. IDS_COPY_GRANULARITY_DIFFHUNK
+#: Merge.rc:5707
+msgid "Diff hunk"
+msgstr "Fərq bloku"
+
+#. IDS_COPY_GRANULARITY_INLINE
+#: Merge.rc:5708
+msgid "Inline diff"
+msgstr "Sətirdaxili fərq"
+
+#. IDS_COPY_GRANULARITY_LINE
+#: Merge.rc:5709
+msgid "Line"
+msgstr "Sətir"
+
+#: Merge.rc:5710
+msgid "Character"
+msgstr "Simvol"
+
+#. ID_MICE_PREVDIFF
+#: Merge.rc:5715
+msgid "\nPrevious Difference (Alt+Up)\n(Right Button+Wheel Up)\n(Alt+Wheel Up)"
+msgstr "\nƏvvəlki fərq (Alt+Up)\n(Sağ düymə+Təkər yuxarı)\n(Alt+Təkər yuxarı)"
+
+#. ID_MICE_NEXTDIFF
+#: Merge.rc:5716
+msgid "\nNext Difference (Alt+Down)\n(Right Button+Wheel Down)\n(Alt+Wheel Down)"
+msgstr "\nNövbəti fərq (Alt+Down)\n(Sağ düymə+Təkər aşağı)\n(Alt+Təkər aşağı)"
+
+#. ID_MICE_L2R
+#: Merge.rc:5717
+msgid "\nCopy to Right (Alt+Right)\n(Right Button+Wheel Right)\n(Alt+Wheel Right)\n(Alt+Shift+Wheel Down)"
+msgstr "\nSağa köçür (Alt+Right)\n(Sağ düymə+Təkər sağa)\n(Alt+Təkər sağa)\n(Alt+Shift+Təkər aşağı)"
+
+#. ID_MICE_R2L
+#: Merge.rc:5718
+msgid "\nCopy to Left (Alt+Left)\n(Right Button+Wheel Left)\n(Alt+Wheel Left)\n(Alt+Shift+Wheel Up)"
+msgstr "\nSola köçür (Alt+Left)\n(Sağ düymə+Təkər sola)\n(Alt+Təkər sola)\n(Alt+Shift+Təkər yuxarı)"
+
+#. ID_MICE_L2RNEXT
+#: Merge.rc:5719
+msgid "\nCopy to Right and Advance (Ctrl+Alt+Right)\n(Ctrl+Alt+Wheel Right)\n(Ctrl+Alt+Shift+Wheel Down)"
+msgstr "\nSağa köçür və irəlilə (Ctrl+Alt+Right)\n(Ctrl+Alt+Təkər sağa)\n(Ctrl+Alt+Shift+Təkər aşağı)"
+
+#. ID_MICE_R2LNEXT
+#: Merge.rc:5720
+msgid "\nCopy to Left and Advance (Ctrl+Alt+Left)\n(Ctrl+Alt+Wheel Left)\n(Ctrl+Alt+Shift+Wheel Up)"
+msgstr "\nSola köçür və irəlilə (Ctrl+Alt+Left)\n(Ctrl+Alt+Təkər sola)\n(Ctrl+Alt+Shift+Təkər yuxarı)"
+
+#. IDS_LOG_COMPARING_2
+#: Merge.rc:5730
+#, c-format
+msgid "Comparing %1 with %2"
+msgstr "%1 ilə %2 müqayisə edilir"
+
+#. IDS_LOG_COMPARING_3
+#: Merge.rc:5731
+#, c-format
+msgid "Comparing %1 with %2 and %3"
+msgstr "%1 ilə %2 və %3 müqayisə edilir"
+
+#. IDS_LOG_COMPARE_COMPLETED
+#: Merge.rc:5732
+msgid "Comparison completed"
+msgstr "Müqayisə tamamlandı"
+
+#. IDS_LOG_COMPARE_ERROR_2
+#: Merge.rc:5733
+#, c-format
+msgid "Failed to compare %1 with %2: "
+msgstr "%1 ilə %2 müqayisə edilə bilmədi: "
+
+#. IDS_LOG_COMPARE_ERROR_3
+#: Merge.rc:5734
+#, c-format
+msgid "Failed to compare %1 with %2 and %3: "
+msgstr "%1 ilə %2 və %3 müqayisə edilə bilmədi: "
+
+#. IDS_LOG_FILE_SAVED
+#: Merge.rc:5735
+msgid "File saved"
+msgstr "Fayl saxlandı"
+
+#. IDS_LOG_COPYING_FILES
+#: Merge.rc:5736
+msgid "Copying files..."
+msgstr "Fayllar köçürülür..."
+
+#. IDS_LOG_MOVING_FILES
+#: Merge.rc:5737
+msgid "Moving files..."
+msgstr "Faylların yeri dəyişdirilir..."
+
+#. IDS_LOG_DELETING_FILES
+#: Merge.rc:5738
+msgid "Deleting files..."
+msgstr "Fayllar silinir..."
+
+#. IDS_LOG_RECYCLEBIN
+#: Merge.rc:5739
+msgid "Recycle Bin"
+msgstr "Zibil qutusu"
+
+#. IDS_LOG_PERMANENTLY_DELETED
+#: Merge.rc:5740
+msgid "Permanently deleted"
+msgstr "Həmişəlik silindi"
+
+#. IDS_LOG_FILEOPERATION_COMPLETED
+#: Merge.rc:5741
+msgid "File operation completed successfully"
+msgstr "Fayl əməliyyatı tamamlandı"
+
+#. IDS_LOG_FILEOPERATION_CANCELED
+#: Merge.rc:5742
+msgid "File operation canceled"
+msgstr "Fayl əməliyyatı ləğv edildi"
+
+#. IDS_FILTER_ERROR_NO_ERROR
+#: Merge.rc:5747
+msgid "No error"
+msgstr "Xəta yoxdur"
+
+#. IDS_FILTER_ERROR_EMPTY_EXPRESSION
+#: Merge.rc:5748
+msgid "Filter expression is empty"
+msgstr "Süzgəc ifadəsi boşdur"
+
+#. IDS_FILTER_ERROR_UNKNOWN_CHAR
+#: Merge.rc:5749
+msgid "Unknown character in filter expression"
+msgstr "Süzgəc ifadəsində naməlum simvol var"
+
+#. IDS_FILTER_ERROR_UNTERMINATED_STRING
+#: Merge.rc:5750
+msgid "Unterminated string literal"
+msgstr "Bağlanmamış mətn sabiti"
+
+#. IDS_FILTER_ERROR_SYNTAX_ERROR
+#: Merge.rc:5751
+msgid "Syntax error in filter expression"
+msgstr "Süzgəc ifadəsində sintaksis xətası"
+
+#. IDS_FILTER_ERROR_PARSE_FAILURE
+#: Merge.rc:5752
+msgid "Failed to parse filter expression"
+msgstr "Süzgəc ifadəsini təhlil etmək mümkün olmadı"
+
+#. IDS_FILTER_ERROR_INVALID_LITERAL
+#: Merge.rc:5753
+msgid "Invalid literal value"
+msgstr "Yanlış sabit qiymət"
+
+#. IDS_FILTER_ERROR_INVALID_REGULAR_EXPRESSION
+#: Merge.rc:5754
+msgid "Invalid regular expression"
+msgstr "Yanlış müntəzəm ifadə"
+
+#. IDS_FILTER_ERROR_UNDEFINED_IDENTIFIER
+#: Merge.rc:5755
+msgid "Undefined identifier"
+msgstr "Təyin edilməmiş identifikator"
+
+#. IDS_FILTER_ERROR_INVALID_ARGUMENT_COUNT
+#: Merge.rc:5756
+msgid "Invalid number of arguments"
+msgstr "Arqument sayı yanlışdır"
+
+#. IDS_FILTER_ERROR_FILTER_NAME_NOT_FOUND
+#: Merge.rc:5757
+msgid "Filter name not found"
+msgstr "Süzgəc adı tapılmadı"
+
+#. IDS_FILTER_ERROR_DIVIDE_BY_ZERO
+#: Merge.rc:5758
+msgid "Division by zero in filter expression"
+msgstr "Süzgəc ifadəsində sıfıra bölmə"
+
+#. IDS_FILTER_ERROR_UNKNOWN_ERROR
+#: Merge.rc:5759
+msgid "Unknown error"
+msgstr "Naməlum xəta"
+
+#. IDS_FILTER_ERROR_INVALID_PROPERTY_NAME
+#: Merge.rc:5760
+msgid "Invalid property name"
+msgstr "Yanlış xassə adı"
+
+#. IDS_FILTER_ERROR_INVALID_DIRECTIVE
+#: Merge.rc:5761
+msgid "Invalid directive"
+msgstr "Yanlış direktiv"
+
+#. IDS_FILTER_ERROR_INVALID_ARGUMENT
+#: Merge.rc:5762
+msgid "Invalid argument"
+msgstr "Yanlış arqument"
+
+#. IDS_FILTER_OP_EQUALS
+#: Merge.rc:5767
+msgid "Equals"
+msgstr "Bərabərdir"
+
+#. IDS_FILTER_OP_NOT_EQUALS
+#: Merge.rc:5768
+msgid "Does not equal"
+msgstr "Bərabər deyil"
+
+#. IDS_FILTER_OP_LESS_THAN
+#: Merge.rc:5769
+msgid "Less than"
+msgstr "Kiçikdir"
+
+#. IDS_FILTER_OP_LESS_EQUAL
+#: Merge.rc:5770
+msgid "Less than or equal to"
+msgstr "Kiçikdir və ya bərabərdir"
+
+#. IDS_FILTER_OP_GREATER_EQUAL
+#: Merge.rc:5771
+msgid "Greater than or equal to"
+msgstr "Böyükdür və ya bərabərdir"
+
+#. IDS_FILTER_OP_GREATER_THAN
+#: Merge.rc:5772
+msgid "Greater than"
+msgstr "Böyükdür"
+
+#. IDS_FILTER_OP_BETWEEN
+#: Merge.rc:5773
+msgid "Between"
+msgstr "Arasındadır"
+
+#. IDS_FILTER_OP_NOT_BETWEEN
+#: Merge.rc:5774
+msgid "Not Between"
+msgstr "Arasında deyil"
+
+#. IDS_FILTER_OP_CONTAINS
+#: Merge.rc:5775
+msgid "Contains"
+msgstr "Ehtiva edir"
+
+#. IDS_FILTER_OP_NOT_CONTAINS
+#: Merge.rc:5776
+msgid "Not Contains"
+msgstr "Ehtiva etmir"
+
+#. IDS_FILTER_OP_RECONTAINS
+#: Merge.rc:5777
+msgid "Contains (regex)"
+msgstr "Ehtiva edir (müntəzəm ifadə)"
+
+#. IDS_FILTER_OP_NOT_RECONTAINS
+#: Merge.rc:5778
+msgid "Not Contains (regex)"
+msgstr "Ehtiva etmir (müntəzəm ifadə)"
+
+#. IDS_FILTER_OP_LIKE
+#: Merge.rc:5779
+msgid "Match (wildcard)"
+msgstr "Uyğundur (şablon simvol)"
+
+#. IDS_FILTER_OP_NOT_LIKE
+#: Merge.rc:5780
+msgid "Not match (wildcard)"
+msgstr "Uyğun deyil (şablon simvol)"
+
+#. IDS_FILTER_OP_MATCHES
+#: Merge.rc:5781
+msgid "Match (regex)"
+msgstr "Uyğundur (müntəzəm ifadə)"
+
+#. IDS_FILTER_OP_NOT_MATCHES
+#: Merge.rc:5782
+msgid "Not match (regex)"
+msgstr "Uyğun deyil (müntəzəm ifadə)"
+
+#. IDS_COLORMODE_LIGHT
+#: Merge.rc:5787
+msgid "Light"
+msgstr "Açıq"
+
+#. IDS_COLORMODE_DARK
+#: Merge.rc:5788
+msgid "Dark"
+msgstr "Tünd"
+
+#. IDS_COLORMODE_FOLLOWSYSTEM
+#: Merge.rc:5789
+msgid "Follow system"
+msgstr "Sistemə uyğun"
+
+#. IDS_EXAMPLE
+#: Merge.rc:5794
+#, c-format
+msgid "e.g. %1"
+msgstr "məs., %1"
+
+#. IDS_DETECTED_PREVIOUS_CRASH
+#: Merge.rc:5799
+msgid "WinMerge detected a previous crash. Please report this if possible."
+msgstr "WinMerge əvvəlki qəza ilə bağlanmanı aşkar etdi. Mümkünsə, bu barədə məlumat verin."
+
+#. IDS_REGEX_REPLACE_LIST_TEMPLATE
+#: Merge.rc:5804
+msgid "# Regex replacement list\r\n# Format: regex<TAB>replacement\r\n# Backreferences like $1, $2 are supported\r\n\r\n(\\d{4})-(\\d{2})-(\\d{2})\t$1_$2_$3\r\n"
+msgstr "# Müntəzəm ifadə əvəzetmə siyahısı\r\n# Format: müntəzəm ifadə<TAB>əvəzetmə\r\n# $1, $2 kimi geri istinadlar dəstəklənir\r\n\r\n(\\d{4})-(\\d{2})-(\\d{2})\t$1_$2_$3\r\n"
+
+#. IDS_STRING_REPLACE_LIST_TEMPLATE
+#: Merge.rc:5805
+msgid "# Replacement list\r\n# Format: search<TAB>replacement\r\n# Lines starting with # are ignored\r\n\r\nfrom1\tto1\r\nfrom2\tto2\r\n"
+msgstr "# Əvəzetmə siyahısı\r\n# Format: axtarış<TAB>əvəzetmə\r\n# # ilə başlayan sətirlər nəzərə alınmır\r\n\r\nfrom1\tto1\r\nfrom2\tto2\r\n"
+
+#. IDS_HILITE_SYNTAX_MODE_BUILT_IN_ONLY
+#: Merge.rc:5810
+msgid "Built-in only"
+msgstr "Yalnız daxili"
+
+#. IDS_HILITE_SYNTAX_MODE_BUILT_IN_FIRST
+#: Merge.rc:5811
+msgid "Built-in first"
+msgstr "Əvvəlcə daxili"
+
+#. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_FIRST
+#: Merge.rc:5812
+msgid "Tree-sitter first"
+msgstr "Əvvəlcə Tree-sitter"
+
+#. IDS_HILITE_SYNTAX_MODE_TREE_SITTER_ONLY
+#: Merge.rc:5813
+msgid "Tree-sitter only"
+msgstr "Yalnız Tree-sitter"
+
+#. IDS_MDIBUTTONS_AUTOHIDE
+#: Merge.rc:5818
+msgid "&Auto-hide MDI buttons"
+msgstr "MDI düymələrini &avtomatik gizlət"
+
+#. IDS_MDIBUTTONS_ALWAYSSHOW
+#: Merge.rc:5819
+msgid "Always &show MDI buttons"
+msgstr "MDI düymələrini həmişə &göstər"
+
+#. IDS_MDIBUTTONS_ALWAYSHIDE
+#: Merge.rc:5820
+msgid "Always &hide MDI buttons"
+msgstr "MDI düymələrini həmişə &gizlət"
+
+#. IDS_PLUGIN_PROCESS_TYPE1
+#: Strings.rc:43
+msgid "Prettification"
+msgstr "Səliqəli formatlama"
+
+#. IDS_PLUGIN_PROCESS_TYPE2
+#: Strings.rc:44
+msgid "Content Extraction"
+msgstr "Məzmunun çıxarılması"
+
+#. IDS_PLUGIN_PROCESS_TYPE3
+#: Strings.rc:45
+msgid "Preview"
+msgstr "Ön baxış"
+
+#. IDS_PLUGIN_PROCESS_TYPE5
+#: Strings.rc:47
+msgid "Data Query"
+msgstr "Məlumat sorğusu"
+
+#. IDS_PLUGIN_PROCESS_TYPE6
+#: Strings.rc:48
+msgid "Validation"
+msgstr "Doğrulama"
+
+#. IDS_PLUGIN_PROCESS_TYPE7
+#: Strings.rc:53
+msgid "Decompilation"
+msgstr "Dekompilyasiya"
+
+#. IDS_PLUGIN_PROCESS_TYPE8
+#: Strings.rc:54
+msgid "URL Handling"
+msgstr "URL emalı"
+
+#. IDS_PLUGIN_PROCESS_TYPE9
+#: Strings.rc:55
+msgid "Decoding / Encoding"
+msgstr "Kodun açılması / kodlaşdırma"
+
+#. IDS_PLUGIN_MENU_CAPTION1
+#: Strings.rc:56
+msgid "Make Uppercase"
+msgstr "Böyük hərflərə çevir"
+
+#. IDS_PLUGIN_MENU_CAPTION2
+#: Strings.rc:57
+msgid "Make Lowercase"
+msgstr "Kiçik hərflərə çevir"
+
+#. IDS_PLUGIN_MENU_CAPTION3
+#: Strings.rc:58
+msgid "Remove Duplicate Lines"
+msgstr "Təkrarlanan sətirləri sil"
+
+#. IDS_PLUGIN_MENU_CAPTION4
+#: Strings.rc:59
+msgid "Count Duplicate Lines"
+msgstr "Təkrarlanan sətirləri say"
+
+#. IDS_PLUGIN_MENU_CAPTION5
+#: Strings.rc:60
+msgid "Sort Lines Ascending"
+msgstr "Sətirləri artan sıra ilə düz"
+
+#. IDS_PLUGIN_MENU_CAPTION6
+#: Strings.rc:61
+msgid "Sort Lines Descending"
+msgstr "Sətirləri azalan sıra ilə düz"
+
+#. IDS_PLUGIN_MENU_CAPTION7
+#: Strings.rc:62
+msgid "Reverse Columns"
+msgstr "Sütunları tərsinə düz"
+
+#. IDS_PLUGIN_MENU_CAPTION8
+#: Strings.rc:63
+msgid "Reverse Lines"
+msgstr "Sətirləri tərsinə düz"
+
+#. IDS_PLUGIN_MENU_CAPTION9
+#: Strings.rc:64
+msgid "Replace..."
+msgstr "Əvəz et..."
+
+#. IDS_PLUGIN_MENU_CAPTION10
+#: Strings.rc:65
+msgid "Apply Filter Command..."
+msgstr "Süzgəc əmrini tətbiq et..."
+
+#. IDS_PLUGIN_MENU_CAPTION11
+#: Strings.rc:66
+msgid "Tokenize..."
+msgstr "Hissələrə ayır..."
+
+#. IDS_PLUGIN_MENU_CAPTION12
+#: Strings.rc:67
+msgid "Trim Spaces"
+msgstr "Kənar boşluqları sil"
+
+#. IDS_PLUGIN_MENU_CAPTION13
+#: Strings.rc:68
+msgid "Select Columns..."
+msgstr "Sütunları seç..."
+
+#. IDS_PLUGIN_MENU_CAPTION14
+#: Strings.rc:73
+msgid "Select Lines..."
+msgstr "Sətirləri seç..."
+
+#. IDS_PLUGIN_MENU_CAPTION15
+#: Strings.rc:74
+msgid "Insert Date"
+msgstr "Tarix daxil et"
+
+#. IDS_PLUGIN_MENU_CAPTION16
+#: Strings.rc:75
+msgid "Insert Time"
+msgstr "Vaxt daxil et"
+
+#. IDS_PLUGIN_MENU_CAPTION17
+#: Strings.rc:76
+msgid "Apply Patch..."
+msgstr "Yamaq tətbiq et..."
+
+#. IDS_PLUGIN_MENU_CAPTION18
+#: Strings.rc:77
+msgid "Ignore Columns"
+msgstr "Sütunları nəzərə alma"
+
+#. IDS_PLUGIN_MENU_CAPTION19
+#: Strings.rc:78
+msgid "Ignore Comments (C-Family Languages)"
+msgstr "Şərhləri nəzərə alma (C ailəsinə aid dillər)"
+
+#. IDS_PLUGIN_MENU_CAPTION20
+#: Strings.rc:79
+msgid "Ignore CSV Fields"
+msgstr "CSV sahələrini nəzərə alma"
+
+#. IDS_PLUGIN_MENU_CAPTION21
+#: Strings.rc:80
+msgid "Ignore TSV Fields"
+msgstr "TSV sahələrini nəzərə alma"
+
+#. IDS_PLUGIN_MENU_CAPTION22
+#: Strings.rc:81
+msgid "Ignore Leading Line Numbers"
+msgstr "Əvvəldəki sətir nömrələrini nəzərə alma"
+
+#. IDS_PLUGIN_MENU_CAPTION23
+#: Strings.rc:82
+msgid "Apply Prediff Substitution Filters"
+msgstr "İlkin müqayisə əvəzetmə süzgəclərini tətbiq et"
+
+#. IDS_PLUGIN_MENU_CAPTION24
+#: Strings.rc:83
+msgid "Prettify HTML"
+msgstr "HTML-i səliqəli formatla"
+
+#. IDS_PLUGIN_MENU_CAPTION25
+#: Strings.rc:84
+msgid "Prettify JSON"
+msgstr "JSON-u səliqəli formatla"
+
+#. IDS_PLUGIN_MENU_CAPTION26
+#: Strings.rc:85
+msgid "Prettify XML"
+msgstr "XML-i səliqəli formatla"
+
+#. IDS_PLUGIN_MENU_CAPTION27
+#: Strings.rc:86
+msgid "Prettify YAML"
+msgstr "YAML-ı səliqəli formatla"
+
+#. IDS_PLUGIN_MENU_CAPTION28
+#: Strings.rc:87
+msgid "Prettify PO"
+msgstr "PO-nu səliqəli formatla"
+
+#. IDS_PLUGIN_MENU_CAPTION29
+#: Strings.rc:88
+msgid "Preview Graphviz"
+msgstr "Graphviz ön baxışı"
+
+#. IDS_PLUGIN_MENU_CAPTION30
+#: Strings.rc:93
+msgid "Preview Markdown"
+msgstr "Markdown ön baxışı"
+
+#. IDS_PLUGIN_MENU_CAPTION31
+#: Strings.rc:94
+msgid "Preview PlantUML"
+msgstr "PlantUML ön baxışı"
+
+#. IDS_PLUGIN_MENU_CAPTION32
+#: Strings.rc:95
+msgid "Query CSV Data..."
+msgstr "CSV məlumatlarını sorğula..."
+
+#. IDS_PLUGIN_MENU_CAPTION33
+#: Strings.rc:96
+msgid "Query TSV Data..."
+msgstr "TSV məlumatlarını sorğula..."
+
+#. IDS_PLUGIN_MENU_CAPTION34
+#: Strings.rc:97
+msgid "Query JSON Data..."
+msgstr "JSON məlumatlarını sorğula..."
+
+#. IDS_PLUGIN_MENU_CAPTION35
+#: Strings.rc:98
+msgid "Query YAML Data..."
+msgstr "YAML məlumatlarını sorğula..."
+
+#. IDS_PLUGIN_MENU_CAPTION36
+#: Strings.rc:99
+msgid "Validate HTML"
+msgstr "HTML-i doğrula"
+
+#. IDS_PLUGIN_MENU_CAPTION37
+#: Strings.rc:100
+msgid "Validate PO"
+msgstr "PO-nu doğrula"
+
+#. IDS_PLUGIN_MENU_CAPTION38
+#: Strings.rc:101
+msgid "Disassemble JVM Bytecode"
+msgstr "JVM bayt-kodunu disassemblə et"
+
+#. IDS_PLUGIN_MENU_CAPTION39
+#: Strings.rc:102
+msgid "Disassemble IL Code"
+msgstr "IL kodunu disassemblə et"
+
+#. IDS_PLUGIN_MENU_CAPTION40
+#: Strings.rc:103
+msgid "Disassemble Native Code"
+msgstr "Maşın kodunu disassemblə et"
+
+#. IDS_PLUGIN_MENU_CAPTION41
+#: Strings.rc:104
+msgid "Convert Text with AI..."
+msgstr "Mətni süni intellektlə çevir..."
+
+#. IDS_PLUGIN_MENU_CAPTION42
+#: Strings.rc:105
+msgid "Unescape Java properties files"
+msgstr "Java xassə fayllarındakı qaçış ardıcıllıqlarını aç"
+
+#. IDS_PLUGIN_MENU_CAPTION43
+#: Strings.rc:106
+msgid "Decompile Java (CFR)"
+msgstr "Java-nı dekompilyasiya et (CFR)"
+
+#. IDS_PLUGIN_DESCRIPTION1
+#: Strings.rc:111
+msgid "Make characters uppercase"
+msgstr "Simvolları böyük hərflərə çevir"
+
+#. IDS_PLUGIN_DESCRIPTION2
+#: Strings.rc:116
+msgid "Make characters lowercase"
+msgstr "Simvolları kiçik hərflərə çevir"
+
+#. IDS_PLUGIN_DESCRIPTION3
+#: Strings.rc:117
+msgid "Remove duplicate lines"
+msgstr "Təkrarlanan sətirləri sil"
+
+#. IDS_PLUGIN_DESCRIPTION4
+#: Strings.rc:118
+msgid "Count duplicate lines"
+msgstr "Təkrarlanan sətirləri say"
+
+#. IDS_PLUGIN_DESCRIPTION5
+#: Strings.rc:119
+msgid "Sort lines ascending"
+msgstr "Sətirləri artan sıra ilə düz"
+
+#. IDS_PLUGIN_DESCRIPTION6
+#: Strings.rc:120
+msgid "Sort lines descending"
+msgstr "Sətirləri azalan sıra ilə düz"
+
+#. IDS_PLUGIN_DESCRIPTION7
+#: Strings.rc:121
+msgid "Reverse columns"
+msgstr "Sütunları tərsinə düz"
+
+#. IDS_PLUGIN_DESCRIPTION8
+#: Strings.rc:122
+msgid "Reverse lines"
+msgstr "Sətirləri tərsinə düz"
+
+#. IDS_PLUGIN_DESCRIPTION9
+#: Strings.rc:123
+msgid "Replace text.\r\nUsage: Replace [-i] [-e] FIND REPLACE\r\n or: Replace -s\r\n FIND - text to find\r\n REPLACE - text to replace\r\n -i - ignore case (only for -e)\r\n -e - regex\r\n -s - use Substitution Filters"
+msgstr "Mətni əvəz et.\r\nİstifadə: Replace [-i] [-e] FIND REPLACE\r\n və ya: Replace -s\r\n FIND - axtarılan mətn\r\n REPLACE - əvəz edən mətn\r\n -i - böyük-kiçik hərf fərqini nəzərə alma (yalnız -e üçün)\r\n -e - müntəzəm ifadə\r\n -s - əvəzetmə süzgəclərindən istifadə et"
+
+#: Strings.rc:125
+#, c-format
+msgid "Apply filter. \r\nUsage: ExecFilterCommand COMMAND\r\n COMMAND - command to execute. %1 = filename."
+msgstr "Süzgəci tətbiq et. \r\nİstifadə: ExecFilterCommand COMMAND\r\n COMMAND - icra ediləcək əmr. %1 = faylın adı."
+
+#: Strings.rc:127
+msgid "Tokenize. \r\nUsage: Tokenize PATTERNS\r\n PATTERNS - regex (e.g. [^\\w]+)"
+msgstr "Hissələrə ayır. \r\nİstifadə: Tokenize PATTERNS\r\n PATTERNS - müntəzəm ifadə (məs., [^\\w]+)"
+
+#. IDS_PLUGIN_DESCRIPTION12
+#: Strings.rc:128
+msgid "Trim spaces"
+msgstr "Kənar boşluqları sil"
+
+#: Strings.rc:130
+msgid "Select columns.\r\nUsage: SelectColumns RANGES\r\n or: SelectColumns [-v] [-i] [-g] -e PATTERNS\r\n or: SelectColumns [-v] [-i] -F STRING\r\n RANGES - column ranges (-3,5-10,30-)\r\n PATTERNS - regex\r\n STRING - string to match literally\r\n -v - select non-matching\r\n -i - ignore case\r\n -g - enable global flag\r\n -e - use PATTERNS\r\n -F - use fixed string for matching"
+msgstr "Sütunları seç.\r\nİstifadə: SelectColumns RANGES\r\n və ya: SelectColumns [-v] [-i] [-g] -e PATTERNS\r\n və ya: SelectColumns [-v] [-i] -F STRING\r\n RANGES - sütun aralıqları (-3,5-10,30-)\r\n PATTERNS - müntəzəm ifadə\r\n STRING - olduğu kimi uyğunlaşdırılacaq mətn\r\n -v - uyğun gəlməyənləri seç\r\n -i - böyük-kiçik hərf fərqini nəzərə alma\r\n -g - qlobal bayrağı aktivləşdir\r\n -e - PATTERNS istifadə et\r\n -F - uyğunlaşdırma üçün sabit mətndən istifadə et"
+
+#: Strings.rc:132
+msgid "Select lines.\r\nUsage: SelectLines RANGES\r\n or: SelectLines [-v] [-i] -e PATTERNS\r\n or: SelectLines [-v] [-i] -F STRING\r\n RANGES - line ranges (-3,5-10,30-)\r\n PATTERNS - regex\r\n STRING - string to match literally\r\n -v - select non-matching\r\n -i - ignore case\r\n -e - use PATTERNS\r\n -F - use fixed string for matching"
+msgstr "Sətirləri seç.\r\nİstifadə: SelectLines RANGES\r\n və ya: SelectLines [-v] [-i] -e PATTERNS\r\n və ya: SelectLines [-v] [-i] -F STRING\r\n RANGES - sətir aralıqları (-3,5-10,30-)\r\n PATTERNS - müntəzəm ifadə\r\n STRING - olduğu kimi uyğunlaşdırılacaq mətn\r\n -v - uyğun gəlməyənləri seç\r\n -i - böyük-kiçik hərf fərqini nəzərə alma\r\n -e - PATTERNS istifadə et\r\n -F - uyğunlaşdırma üçün sabit mətndən istifadə et"
+
+#: Strings.rc:138
+msgid "HTML Prettier (tidy-html5).\r\nArguments: tidy command line options."
+msgstr "HTML formatlayıcısı (tidy-html5).\r\nArqumentlər: tidy əmr sətri seçimləri."
+
+#: Strings.rc:140
+msgid "JSON Prettier (jq).\r\nArguments: jq filter/command line options."
+msgstr "JSON formatlayıcısı (jq).\r\nArqumentlər: jq süzgəci/əmr sətri seçimləri."
+
+#: Strings.rc:142
+msgid "XML Prettier (tidy-html5).\r\nArguments: tidy command line options."
+msgstr "XML formatlayıcısı (tidy-html5).\r\nArqumentlər: tidy əmr sətri seçimləri."
+
+#: Strings.rc:144
+msgid "YAML Prettier (yq).\r\nArguments: yq filter/command line options."
+msgstr "YAML formatlayıcısı (yq).\r\nArqumentlər: yq süzgəci/əmr sətri seçimləri."
+
+#: Strings.rc:146
+msgid "PO Prettier (gettext msgcat).\r\nArguments: msgcat command line options."
+msgstr "PO formatlayıcısı (gettext msgcat).\r\nArqumentlər: msgcat əmr sətri seçimləri."
+
+#: Strings.rc:148
+msgid "Graphviz Previewer.\r\nArguments: dot command line options."
+msgstr "Graphviz ön baxış vasitəsi.\r\nArqumentlər: dot əmr sətri seçimləri."
+
+#: Strings.rc:150
+msgid "Markdown Previewer.\r\nArguments: md2html command line options."
+msgstr "Markdown ön baxış vasitəsi.\r\nArqumentlər: md2html əmr sətri seçimləri."
+
+#: Strings.rc:152
+msgid "PlantUML Previewer.\r\nArguments: plantuml.jar command line options."
+msgstr "PlantUML ön baxış vasitəsi.\r\nArqumentlər: plantuml.jar əmr sətri seçimləri."
+
+#: Strings.rc:154
+msgid "CSV Querier (q).\r\nArguments: SQL statement/q command line options."
+msgstr "CSV sorğu vasitəsi (q).\r\nArqumentlər: SQL ifadəsi/q əmr sətri seçimləri."
+
+#: Strings.rc:156
+msgid "TSV Querier (q).\r\nArguments: SQL statement/q command line options."
+msgstr "TSV sorğu vasitəsi (q).\r\nArqumentlər: SQL ifadəsi/q əmr sətri seçimləri."
+
+#: Strings.rc:158
+msgid "JSON Querier (jq).\r\nArguments: jq filter/command line options."
+msgstr "JSON sorğu vasitəsi (jq).\r\nArqumentlər: jq süzgəci/əmr sətri seçimləri."
+
+#: Strings.rc:164
+msgid "YAML Querier (yq).\r\nArguments: yq filter/command line options."
+msgstr "YAML sorğu vasitəsi (yq).\r\nArqumentlər: yq süzgəci/əmr sətri seçimləri."
+
+#: Strings.rc:166
+msgid "HTML Validator (tidy-html5).\r\nArguments: tidy command line options."
+msgstr "HTML doğrulayıcısı (tidy-html5).\r\nArqumentlər: tidy əmr sətri seçimləri."
+
+#: Strings.rc:168
+msgid "PO Validator (gettext msgfmt).\r\nArguments: msgfmt command line options."
+msgstr "PO doğrulayıcısı (gettext msgfmt).\r\nArqumentlər: msgfmt əmr sətri seçimləri."
+
+#: Strings.rc:170
+msgid "JVM bytecode disassembler (javap).\r\nArguments: javap command line options."
+msgstr "JVM bayt-kodu disassembleri (javap).\r\nArqumentlər: javap əmr sətri seçimləri."
+
+#: Strings.rc:172
+msgid "IL disassembler (ildasm).\r\nArguments: ildasm command line options."
+msgstr "IL disassembleri (ildasm).\r\nArqumentlər: ildasm əmr sətri seçimləri."
+
+#: Strings.rc:174
+msgid "Native code disassembler (dumpbin).\r\nArguments: dumpbin command line options."
+msgstr "Maşın kodu disassembleri (dumpbin).\r\nArqumentlər: dumpbin əmr sətri seçimləri."
+
+#: Strings.rc:176
+msgid "Content extractor (Apache Tika).\r\nArguments: tika-app.jar command line options."
+msgstr "Məzmun çıxarma vasitəsi (Apache Tika).\r\nArqumentlər: tika-app.jar əmr sətri seçimləri."
+
+#. IDS_PLUGIN_DESCRIPTION41
+#: Strings.rc:177
+msgid "Apply patch (GNU patch)"
+msgstr "Yamaq tətbiq et (GNU patch)"
+
+#. IDS_PLUGIN_DESCRIPTION42
+#: Strings.rc:178
+msgid "Display MS Excel text content"
+msgstr "MS Excel mətn məzmununu göstər"
+
+#. IDS_PLUGIN_DESCRIPTION43
+#: Strings.rc:179
+msgid "Display MS PowerPoint text content"
+msgstr "MS PowerPoint mətn məzmununu göstər"
+
+#. IDS_PLUGIN_DESCRIPTION44
+#: Strings.rc:180
+msgid "Display MS Visio text content"
+msgstr "MS Visio mətn məzmununu göstər"
+
+#. IDS_PLUGIN_DESCRIPTION45
+#: Strings.rc:181
+msgid "Display MS Word text content"
+msgstr "MS Word mətn məzmununu göstər"
+
+#: Strings.rc:183
+msgid "Ignore columns - list from plugin name/argument"
+msgstr "Sütunları nəzərə alma - siyahı qoşmanın adından/arqumentindən alınır"
+
+#: Strings.rc:185
+msgid "Ignore C, C++, PHP, and JavaScript comments (//... and /* ... */)."
+msgstr "C, C++, PHP və JavaScript şərhlərini (//... və /* ... */) nəzərə alma."
+
+#: Strings.rc:187
+msgid "Ignore fields - list from plugin name/argument"
+msgstr "Sahələri nəzərə alma - siyahı qoşmanın adından/arqumentindən alınır"
+
+#: Strings.rc:189
+msgid "Ignore leading line numbers (e.g., NC, BASIC)."
+msgstr "Əvvəldəki sətir nömrələrini nəzərə alma (məs., NC, BASIC)."
+
+#. IDS_PLUGIN_DESCRIPTION50
+#: Strings.rc:190
+msgid "Prediff Line Filter"
+msgstr "İlkin müqayisə sətir süzgəci"
+
+#. IDS_PLUGIN_DESCRIPTION51
+#: Strings.rc:191
+msgid "Date and time insertion"
+msgstr "Tarix və vaxtın daxil edilməsi"
+
+#: Strings.rc:193
+msgid "HTTP URL Scheme Handler (curl).\r\nArguments: curl command line options."
+msgstr "HTTP URL sxemi emalçısı (curl).\r\nArqumentlər: curl əmr sətri seçimləri."
+
+#: Strings.rc:199
+msgid "Windows Registry URL Scheme Handler.\r\nArguments: reg.exe command line options."
+msgstr "Windows reyestri URL sxemi emalçısı.\r\nArqumentlər: reg.exe əmr sətri seçimləri."
+
+#. IDS_PLUGIN_DESCRIPTION54
+#: Strings.rc:200
+msgid "Basic text functions"
+msgstr "Əsas mətn funksiyaları"
+
+#. IDS_PLUGIN_DESCRIPTION55
+#: Strings.rc:201
+msgid "AI-assisted text conversion"
+msgstr "Süni intellektlə mətn çevrilməsi"
+
+#. IDS_PLUGIN_DESCRIPTION56
+#: Strings.rc:202
+msgid "Text converter (OpenAI-compatible API).\r\nUsage: AIConvertText PROMPT"
+msgstr "Mətn çeviricisi (OpenAI ilə uyğun API).\r\nİstifadə: AIConvertText PROMPT"
+
+#. IDS_PLUGIN_DESCRIPTION57
+#: Strings.rc:203
+msgid "Unescape and display escaped Java properties files."
+msgstr "Java xassə fayllarındakı qaçış ardıcıllıqlarını aç və məzmunu göstər."
+
+#. IDS_PLUGIN_DESCRIPTION58
+#: Strings.rc:204
+msgid "Java decompiler (CFR).\r\nDecompiles .class files into readable Java source code.\r\nArguments: CFR command line options."
+msgstr "Java dekompilyatoru (CFR).\r\n.class fayllarını oxuna bilən Java mənbə koduna çevirir.\r\nArqumentlər: CFR əmr sətri seçimləri."
+
+#: Strings.rc:206
+msgid "Clipboard URL Scheme Handler (cliphcat).\r\nArguments: cliphcat command line options."
+msgstr "Mübadilə buferi URL sxemi emalçısı (cliphcat).\r\nArqumentlər: cliphcat əmr sətri seçimləri."
+
+#: Strings.rc:212
+msgid "CompareMSExcelFiles.sct WinMerge Plugin Options"
+msgstr "CompareMSExcelFiles.sct WinMerge qoşmasının seçimləri"
+
+#: Strings.rc:214
+msgid "Extract workbook data to multiple files"
+msgstr "İş kitabının məlumatlarını bir neçə fayla çıxar"
+
+#. IDS_PLUGIN_COMPAREMSEXCELFILES_STR3
+#: Strings.rc:215
+msgid "Update external references (links)"
+msgstr "Xarici istinadları (keçidləri) yenilə"
+
+#. IDS_PLUGIN_COMPAREMSPOWERPOINTFILES_STR3
+#: Strings.rc:216 Strings.rc:239 Strings.rc:256
+msgid "Compare document properties"
+msgstr "Sənəd xassələrini müqayisə et"
+
+#. IDS_PLUGIN_COMPAREMSEXCELFILES_STR5
+#: Strings.rc:217
+msgid "Compare names"
+msgstr "Adları müqayisə et"
+
+#. IDS_PLUGIN_COMPAREMSEXCELFILES_STR6
+#: Strings.rc:218
+msgid "Compare cell values"
+msgstr "Xanaların qiymətlərini müqayisə et"
+
+#: Strings.rc:220
+msgid "Compare worksheets as image (very slow)"
+msgstr "İş vərəqlərini şəkil kimi müqayisə et (çox yavaş)"
+
+#. IDS_PLUGIN_COMPAREMSEXCELFILES_STR8
+#: Strings.rc:221
+msgid " - Image split size: "
+msgstr " - Şəklin bölünmə ölçüsü: "
+
+#. IDS_PLUGIN_COMPAREMSEXCELFILES_STR9
+#: Strings.rc:222
+msgid "Compare worksheets as HTML"
+msgstr "İş vərəqlərini HTML kimi müqayisə et"
+
+#. IDS_PLUGIN_COMPAREMSEXCELFILES_STR10
+#: Strings.rc:223
+msgid "Compare formulas"
+msgstr "Düsturları müqayisə et"
+
+#. IDS_PLUGIN_COMPAREMSVISIOFILES_STR4
+#: Strings.rc:224 Strings.rc:244 Strings.rc:263 Strings.rc:276
+msgid "Compare texts in shapes"
+msgstr "Fiqurlardakı mətnləri müqayisə et"
+
+#. IDS_PLUGIN_COMPAREMSEXCELFILES_STR12
+#: Strings.rc:225
+msgid "Compare headers and footers"
+msgstr "Üst və alt kolontitulları müqayisə et"
+
+#: Strings.rc:227 Strings.rc:247 Strings.rc:267 Strings.rc:279
+msgid "Cannot get Macros.\r\nEnable 'Trust access to Visual Basic Project' in MS Office Macro Security."
+msgstr "Makrosları əldə etmək mümkün olmadı.\r\nMS Office makros təhlükəsizliyi bölməsində 'Visual Basic layihəsinə girişə etibar et' seçimini aktivləşdirin."
+
+#. IDS_PLUGIN_COMPAREMSEXCELFILES_STR14
+#: Strings.rc:228
+msgid "Replace line breaks in formulas with spaces"
+msgstr "Düsturlardakı sətir bölünmələrini boşluqlarla əvəz et"
+
+#. IDS_PLUGIN_COMPAREMSEXCELFILES_STR15
+#: Strings.rc:229
+msgid "Include sheet order number in filename"
+msgstr "Vərəqin sıra nömrəsini fayl adına daxil et"
+
+#. IDS_PLUGIN_COMPAREMSVISIOFILES_STR5
+#: Strings.rc:234 Strings.rc:245 Strings.rc:265 Strings.rc:277
+msgid "Compare VBA macros"
+msgstr "VBA makroslarını müqayisə et"
+
+#: Strings.rc:236
+msgid "CompareMSWordFiles.sct WinMerge Plugin Options"
+msgstr "CompareMSWordFiles.sct WinMerge qoşmasının seçimləri"
+
+#: Strings.rc:238
+msgid "Extract document data to multiple files"
+msgstr "Sənəd məlumatlarını bir neçə fayla çıxar"
+
+#. IDS_PLUGIN_COMPAREMSWORDFILES_STR4
+#: Strings.rc:240
+msgid "Compare bookmarks"
+msgstr "Əlfəcinləri müqayisə et"
+
+#. IDS_PLUGIN_COMPAREMSWORDFILES_STR5
+#: Strings.rc:241
+msgid "Compare text contents of documents"
+msgstr "Sənədlərin mətn məzmununu müqayisə et"
+
+#: Strings.rc:243
+msgid "Compare documents as HTML file (very slow)"
+msgstr "Sənədləri HTML faylı kimi müqayisə et (çox yavaş)"
+
+#: Strings.rc:253
+msgid "CompareMSPowerPointFiles.sct WinMerge Plugin Options"
+msgstr "CompareMSPowerPointFiles.sct WinMerge qoşmasının seçimləri"
+
+#: Strings.rc:255
+msgid "Extract slide data to multiple files"
+msgstr "Slayd məlumatlarını bir neçə fayla çıxar"
+
+#: Strings.rc:258
+msgid "Compare slides as image (very slow)"
+msgstr "Slaydları şəkil kimi müqayisə et (çox yavaş)"
+
+#. IDS_PLUGIN_COMPAREMSPOWERPOINTFILES_STR6
+#: Strings.rc:264
+msgid "Compare texts in notes page"
+msgstr "Qeyd səhifəsindəki mətnləri müqayisə et"
+
+#: Strings.rc:273
+msgid "CompareMSVisioFiles.sct WinMerge Plugin Options"
+msgstr "CompareMSVisioFiles.sct WinMerge qoşmasının seçimləri"
+
+#. IDS_PLUGIN_COMPAREMSVISIOFILES_STR2
+#: Strings.rc:274
+msgid "Extract page data to multiple files"
+msgstr "Səhifə məlumatlarını bir neçə fayla çıxar"
+
+#. IDS_PLUGIN_COMPAREMSVISIOFILES_STR3
+#: Strings.rc:275
+msgid "Compare pages as image (very slow)"
+msgstr "Səhifələri şəkil kimi müqayisə et (çox yavaş)"
+
+#: Strings.rc:285
+msgid "PrediffLineFilter.sct WinMerge Plugin Options"
+msgstr "PrediffLineFilter.sct WinMerge qoşmasının seçimləri"
+
+#. IDS_PLUGIN_PREDIFFLINEFILTER_STR3
+#: Strings.rc:287
+msgid "Delete"
+msgstr "Sil"
+
+#. IDS_PLUGIN_PREDIFFLINEFILTER_STR4
+#: Strings.rc:288
+msgid "Enabled"
+msgstr "Aktiv"
+
+#. IDS_PLUGIN_PREDIFFLINEFILTER_STR5
+#: Strings.rc:289
+msgid "Ignore Case"
+msgstr "Böyük-kiçik hərf fərqini nəzərə alma"
+
+#. IDS_PLUGIN_PREDIFFLINEFILTER_STR6
+#: Strings.rc:290
+msgid "Use RegExp"
+msgstr "Müntəzəm ifadədən istifadə et"
+
+#. IDS_PLUGIN_PREDIFFLINEFILTER_STR7
+#: Strings.rc:291
+msgid "Find what"
+msgstr "Axtarılan mətn"
+
+#. IDS_PLUGIN_PREDIFFLINEFILTER_STR8
+#: Strings.rc:292
+msgid "Replace with"
+msgstr "Əvəz edən mətn"
+
+#. IDS_PLUGIN_IGNORE_STR1
+#: Strings.rc:297
+msgid "Settings"
+msgstr "Parametrlər"
+
+#. IDS_PLUGIN_IGNORE_STR2
+#: Strings.rc:298
+msgid "Column Ranges to Ignore:\ne.g.) 3,10-20,32-33\n"
+msgstr "Nəzərə alınmayacaq sütun aralıqları:\nməs.) 3,10-20,32-33\n"
+
+#: Strings.rc:304
+#, c-format
+msgid "Enter filename for patch '%1'"
+msgstr "'%1' yamağı üçün fayl adı daxil edin"
+
+#. IDS_PLUGIN_APPLYPATCH_STR2
+#: Strings.rc:305
+#, c-format
+msgid "File '%1' does not exist"
+msgstr "'%1' faylı mövcud deyil"
+
+#: Strings.rc:307
+msgid "Enter command line arguments for patch"
+msgstr "Yamaq üçün əmr sətri arqumentlərini daxil edin"
+
+#: Strings.rc:309
+#, c-format
+msgid "Enter folder name for patch '%1'"
+msgstr "'%1' yamağı üçün qovluq adı daxil edin"
+
+#. IDS_PLUGIN_APPLYPATCH_STR5
+#: Strings.rc:314
+#, c-format
+msgid "Folder '%1' does not exist"
+msgstr "'%1' qovluğu mövcud deyil"
+
+#: Strings.rc:316
+msgid "Do not use '-p0' for patch files with absolute paths"
+msgstr "Mütləq yolları olan yamaq faylları üçün '-p0' istifadə etməyin"
+
+#: Strings.rc:322
+msgid "AI.sct WinMerge Plugin Options"
+msgstr "AI.sct WinMerge qoşmasının seçimləri"
+
+#: Strings.rc:324
+msgid "Enter prompt"
+msgstr "Təlimat daxil edin"
+
+#: Strings.rc:326
+#, c-format
+msgid "Enter API key.\r\n- Registration with the selected provider may be required (fees may apply).\r\n- Key stored in env var %1."
+msgstr "API açarını daxil edin.\r\n- Seçilmiş xidmət təminatçısında qeydiyyat tələb oluna bilər (ödəniş tutula bilər).\r\n- Açar %1 mühit dəyişənində saxlanılır."
+
+#: Strings.rc:328
+msgid "Environment variable name for API key"
+msgstr "API açarı üçün mühit dəyişəninin adı"
+
+#: Strings.rc:330
+msgid "API key"
+msgstr "API açarı"
+
+#: Strings.rc:332
+msgid "Temperature"
+msgstr "Temperatur"
+
+#: Strings.rc:334
+msgid "Maximum length"
+msgstr "Maksimum uzunluq"
+
+#: Strings.rc:336
+msgid "Model"
+msgstr "Model"
+
+#: Strings.rc:338
+msgid "API key changed. Restart to apply."
+msgstr "API açarı dəyişdirildi. Tətbiq etmək üçün yenidən başladın."
+
+#: Strings.rc:340
+msgid "Provider"
+msgstr "Xidmət təminatçısı"
+
+#: Strings.rc:342
+msgid "Base URL"
+msgstr "Əsas URL"
+
+#: Strings.rc:344
+msgid "(pick a preset to fill in the field above)"
+msgstr "(yuxarıdakı sahəni doldurmaq üçün hazır seçim edin)"


### PR DESCRIPTION
This PR adds an Azerbaijani (az) translation.

New file `Translations/WinMerge/Azerbaijani.po`: 1821 entries, every msgstr filled in, msgid order identical to `Translations/WinMerge/English.pot`.

The header sets `Language: az` and `Plural-Forms: nplurals=2; plural=(n != 1);`.

Bracketed UI labels keep their brackets and translate the word inside, the same way `Turkish.po` and `German.po` do it, for example `<None>` becomes `<Heç biri>`.
