### PR TITLE
Folder compare: optional side-by-side column layout (2-way)

### DIFF
--- a/Src/DirFrame.cpp
+++ b/Src/DirFrame.cpp
@@ -19,16 +19,8 @@
 #endif
 
 /**
- * @brief Statusbar pane indexes
+ * @brief Statusbar pane indexes (see CDirFrame::PANE_*)
  */
-enum
-{
-	PANE_FILTER = 1,
-	PANE_COMPMETHOD,
-	PANE_LEFT_RO,
-	PANE_MIDDLE_RO,
-	PANE_RIGHT_RO,
-};
 
 /**
  * @brief Width of compare method name pane in statusbar
@@ -44,7 +36,8 @@ const int FILTER_PANEL_WIDTH = 200;
  */
 static UINT indicators[] =
 {
-	ID_SEPARATOR,           // status line indicator
+	ID_SEPARATOR,           // left / classic status
+	ID_SEPARATOR,           // right status (hidden in classic layout)
 	ID_SEPARATOR,
 	ID_SEPARATOR,
 	ID_SEPARATOR,
@@ -115,7 +108,8 @@ int CDirFrame::OnCreate(LPCREATESTRUCT lpCreateStruct)
 	String sText = _("RO");
 	const int lpx = CClientDC(this).GetDeviceCaps(LOGPIXELSX);
 	auto pointToPixel = [lpx](int point) { return MulDiv(point, lpx, 72); };
-	m_wndStatusBar.SetPaneInfo(0, 0, SBPS_STRETCH | SBPS_NOBORDERS, 0);
+	m_wndStatusBar.SetPaneInfo(PANE_LEFT_STATUS, 0, SBPS_STRETCH | SBPS_NOBORDERS, 0);
+	m_wndStatusBar.SetPaneInfo(PANE_RIGHT_STATUS, 0, SBPS_DISABLED | SBPS_NOBORDERS, 0);
 	m_wndStatusBar.SetPaneInfo(PANE_FILTER, ID_STATUS_FILTER, SBPS_CLICKABLE, pointToPixel(FILTER_PANEL_WIDTH));
 	m_wndStatusBar.SetPaneInfo(PANE_COMPMETHOD, ID_STATUS_FILTER, SBPS_CLICKABLE, pointToPixel(COMPMETHOD_PANEL_WIDTH));
 	m_wndStatusBar.SetPaneInfo(PANE_LEFT_RO, ID_STATUS_LEFTDIR_RO, SBPS_CLICKABLE, pointToPixel(RO_PANEL_WIDTH));
@@ -138,7 +132,36 @@ int CDirFrame::OnCreate(LPCREATESTRUCT lpCreateStruct)
  */
 void CDirFrame::SetStatus(const tchar_t* szStatus)
 {
-	m_wndStatusBar.SetPaneText(0, szStatus);
+	m_wndStatusBar.SetPaneText(PANE_LEFT_STATUS, szStatus);
+}
+
+void CDirFrame::SetSideStatus(int side, const tchar_t* szStatus)
+{
+	const int pane = (side == 0) ? PANE_LEFT_STATUS : PANE_RIGHT_STATUS;
+	m_wndStatusBar.SetPaneText(pane, szStatus);
+}
+
+void CDirFrame::SetSplitPaneMode(bool split)
+{
+	const int lpx = CClientDC(this).GetDeviceCaps(LOGPIXELSX);
+	auto pointToPixel = [lpx](int point) { return MulDiv(point, lpx, 72); };
+	if (split)
+	{
+		m_wndStatusBar.SetPaneInfo(PANE_LEFT_STATUS, 0, SBPS_STRETCH | SBPS_NOBORDERS, 0);
+		m_wndStatusBar.SetPaneInfo(PANE_RIGHT_STATUS, 0, SBPS_STRETCH, 0);
+	}
+	else
+	{
+		m_wndStatusBar.SetPaneInfo(PANE_LEFT_STATUS, 0, SBPS_STRETCH | SBPS_NOBORDERS, 0);
+		m_wndStatusBar.SetPaneInfo(PANE_RIGHT_STATUS, 0, SBPS_DISABLED | SBPS_NOBORDERS, 0);
+		m_wndStatusBar.SetPaneText(PANE_RIGHT_STATUS, _T(""));
+	}
+	m_wndStatusBar.SetPaneInfo(PANE_FILTER, ID_STATUS_FILTER, SBPS_CLICKABLE, pointToPixel(FILTER_PANEL_WIDTH));
+	m_wndStatusBar.SetPaneInfo(PANE_COMPMETHOD, ID_STATUS_FILTER, SBPS_CLICKABLE, pointToPixel(COMPMETHOD_PANEL_WIDTH));
+	m_wndStatusBar.SetPaneInfo(PANE_LEFT_RO, ID_STATUS_LEFTDIR_RO, SBPS_CLICKABLE, pointToPixel(RO_PANEL_WIDTH));
+	m_wndStatusBar.SetPaneInfo(PANE_MIDDLE_RO, ID_STATUS_MIDDLEDIR_RO, SBPS_CLICKABLE, pointToPixel(RO_PANEL_WIDTH));
+	m_wndStatusBar.SetPaneInfo(PANE_RIGHT_RO, ID_STATUS_RIGHTDIR_RO, SBPS_CLICKABLE, pointToPixel(RO_PANEL_WIDTH));
+	RecalcLayout();
 }
 
 /**

--- a/Src/DirFrame.h
+++ b/Src/DirFrame.h
@@ -32,12 +32,22 @@ protected:
 
 // Attributes
 public:
-
-private:
+	enum
+	{
+		PANE_LEFT_STATUS = 0,
+		PANE_RIGHT_STATUS,
+		PANE_FILTER,
+		PANE_COMPMETHOD,
+		PANE_LEFT_RO,
+		PANE_MIDDLE_RO,
+		PANE_RIGHT_RO,
+	};
 
 // Operations
 public:
 	void SetStatus(const tchar_t* szStatus);
+	void SetSideStatus(int side, const tchar_t* szStatus);
+	void SetSplitPaneMode(bool split);
 	void SetCompareMethodStatusDisplay(int nCompMethod);
 	void SetFilterStatusDisplay(const tchar_t* szFilter);
 	CBasicFlatStatusBar m_wndStatusBar;

--- a/Src/DirView.cpp
+++ b/Src/DirView.cpp
@@ -57,6 +57,7 @@
 #include "PluginMenu.h"
 #include <numeric>
 #include <functional>
+#include <Shlwapi.h>
 
 #ifdef _DEBUG
 #define new DEBUG_NEW
@@ -193,11 +194,13 @@ BEGIN_MESSAGE_MAP(CDirView, CListView)
 	ON_COMMAND(ID_VIEW_SHOW_EMPTY_FOLDERS, OnViewShowEmptyFolders)
 	ON_UPDATE_COMMAND_UI(ID_VIEW_SHOW_EMPTY_FOLDERS, OnUpdateViewShowEmptyFolders)
 	ON_COMMAND(ID_VIEW_TREEMODE, OnViewTreeMode)
+	ON_COMMAND(ID_VIEW_SPLIT_PANE_LAYOUT, OnViewSplitPaneLayout)
 	ON_COMMAND(ID_VIEW_EXPAND_ALLSUBDIRS, OnViewExpandAllSubdirs)
 	ON_COMMAND(ID_VIEW_EXPAND_DIFFERENT_SUBDIRS, OnViewExpandDifferentSubdirs)
 	ON_COMMAND(ID_VIEW_EXPAND_IDENTICAL_SUBDIRS, OnViewExpandIdenticalSubdirs)
 	ON_COMMAND(ID_VIEW_COLLAPSE_ALLSUBDIRS, OnViewCollapseAllSubdirs)
 	ON_UPDATE_COMMAND_UI(ID_VIEW_TREEMODE, OnUpdateViewTreeMode)
+	ON_UPDATE_COMMAND_UI(ID_VIEW_SPLIT_PANE_LAYOUT, OnUpdateViewSplitPaneLayout)
 	ON_UPDATE_COMMAND_UI(ID_VIEW_EXPAND_ALLSUBDIRS, OnUpdateViewExpandSubdirs)
 	ON_UPDATE_COMMAND_UI(ID_VIEW_EXPAND_DIFFERENT_SUBDIRS, OnUpdateViewExpandSubdirs)
 	ON_UPDATE_COMMAND_UI(ID_VIEW_EXPAND_IDENTICAL_SUBDIRS, OnUpdateViewExpandSubdirs)
@@ -469,11 +472,11 @@ void CDirView::OnInitialUpdate()
 	}
 
 	// Restore column orders as they had them last time they ran
-	m_pColItems->LoadColumnOrders(
-		GetOptionsMgr()->GetString(pDoc->m_nDirs < 3 ? OPT_DIRVIEW_COLUMN_ORDERS : OPT_DIRVIEW3_COLUMN_ORDERS));
+	LoadColumnLayout();
 
 	// Display column headers (in appropriate order)
 	ReloadColumns();
+	GetParentFrame()->SetSplitPaneMode(UseSplitPaneLayout());
 
 	// Show selection across entire row.u
 	// Also allow user to rearrange columns via drag&drop of headers.
@@ -549,7 +552,7 @@ void CDirView::ReloadColumns()
 
 	UpdateColumnNames();
 	m_pColItems->LoadColumnWidths(
-		GetOptionsMgr()->GetString(GetDocument()->m_nDirs < 3 ? OPT_DIRVIEW_COLUMN_WIDTHS : OPT_DIRVIEW3_COLUMN_WIDTHS),
+		GetOptionsMgr()->GetString(GetColumnWidthsOption()),
 		std::bind(&CListCtrl::SetColumnWidth, m_pList, _1, _2), GetDefColumnWidth());
 	SetColAlignments();
 
@@ -708,6 +711,7 @@ void CDirView::Redisplay()
 	SetRedraw(TRUE);
 	m_pList->SetItemCount(static_cast<int>(m_listViewItems.size()));
 	m_pList->Invalidate();
+	UpdateSplitPaneFooters();
 }
 
 /**
@@ -1354,15 +1358,7 @@ void CDirView::OnDestroy()
 {
 	DeleteAllDisplayItems();
 
-	{
-		const String keyname = GetDocument()->m_nDirs < 3 ? OPT_DIRVIEW_COLUMN_ORDERS : OPT_DIRVIEW3_COLUMN_ORDERS;
-		GetOptionsMgr()->SaveOption(keyname, m_pColItems->SaveColumnOrders());
-	}
-	{
-		const String keyname = GetDocument()->m_nDirs < 3 ? OPT_DIRVIEW_COLUMN_WIDTHS : OPT_DIRVIEW3_COLUMN_WIDTHS;
-		GetOptionsMgr()->SaveOption(keyname,
-			m_pColItems->SaveColumnWidths(std::bind(&CListCtrl::GetColumnWidth, m_pList, _1)));
-	}
+	SaveColumnLayout();
 
 	__super::OnDestroy();
 }
@@ -1454,6 +1450,7 @@ void CDirView::CollapseSubdir(int sel)
 
 	m_pList->SetRedraw(TRUE);	// Turn updating back on
 	m_pList->Invalidate();
+	UpdateSplitPaneFooters();
 }
 
 /**
@@ -1495,6 +1492,7 @@ void CDirView::ExpandSubdir(int sel, bool bRecursive)
 
 	m_pList->SetRedraw(TRUE);	// Turn updating back on
 	m_pList->Invalidate();
+	UpdateSplitPaneFooters();
 }
 
 /**
@@ -2999,7 +2997,7 @@ bool CDirView::OnHeaderBeginDrag(LPNMHEADER hdr, LRESULT* pResult)
 {
 	// save column widths before user reorders them
 	// so we can reload them on the end drag
-	const String keyname = GetDocument()->m_nDirs < 3 ? OPT_DIRVIEW_COLUMN_WIDTHS : OPT_DIRVIEW3_COLUMN_WIDTHS;
+	const String keyname = GetColumnWidthsOption();
 	GetOptionsMgr()->SaveOption(keyname,
 		m_pColItems->SaveColumnWidths(std::bind(&CListCtrl::GetColumnWidth, m_pList, _1)).c_str());
 	return true;
@@ -3090,7 +3088,7 @@ void CDirView::OnTimer(UINT_PTR nIDEvent)
 		// Now redraw screen
 		UpdateColumnNames();
 		m_pColItems->LoadColumnWidths(
-			GetOptionsMgr()->GetString(GetDocument()->m_nDirs < 3 ? OPT_DIRVIEW_COLUMN_WIDTHS : OPT_DIRVIEW3_COLUMN_WIDTHS),
+			GetOptionsMgr()->GetString(GetColumnWidthsOption()),
 			std::bind(&CListCtrl::SetColumnWidth, m_pList, _1, _2), GetDefColumnWidth());
 		Redisplay();
 	}
@@ -3108,7 +3106,10 @@ void CDirView::OnTimer(UINT_PTR nIDEvent)
 		{
 			msg = (items == 1) ? _("1 item selected") : strutils::format_string1(_("%1 items selected"), strutils::to_str(items));
 		}
-		GetParentFrame()->SetStatus(msg.c_str());
+		if (UseSplitPaneLayout())
+			UpdateSplitPaneFooters();
+		else
+			GetParentFrame()->SetStatus(msg.c_str());
 	}
 	else if (nIDEvent == TIMER_ID_DBLCLICK_OPEN)
 	{
@@ -3201,8 +3202,7 @@ void CDirView::OnCustomizeColumns()
 {
 	// Located in DirViewColHandler.cpp
 	OnEditColumns();
-	const String keyname = GetDocument()->m_nDirs < 3 ? OPT_DIRVIEW_COLUMN_ORDERS : OPT_DIRVIEW3_COLUMN_ORDERS;
-	GetOptionsMgr()->SaveOption(keyname, m_pColItems->SaveColumnOrders());
+	GetOptionsMgr()->SaveOption(GetColumnOrdersOption(), m_pColItems->SaveColumnOrders());
 }
 
 void CDirView::OnOpenWithUnpacker()
@@ -4176,6 +4176,33 @@ void CDirView::OnUpdateViewTreeMode(CCmdUI* pCmdUI)
 }
 
 /**
+ * @brief Toggle split-pane (left/right block) folder compare layout.
+ */
+void CDirView::OnViewSplitPaneLayout()
+{
+	if (GetDocument()->m_nDirs >= 3)
+		return;
+	SaveColumnLayout();
+	const bool split = !GetOptionsMgr()->GetBool(OPT_DIRVIEW_SPLIT_LAYOUT);
+	GetOptionsMgr()->SaveOption(OPT_DIRVIEW_SPLIT_LAYOUT, split);
+	LoadColumnLayout();
+	ReloadColumns();
+	Redisplay();
+	GetParentFrame()->SetSplitPaneMode(UseSplitPaneLayout());
+	UpdateSplitPaneFooters();
+}
+
+/**
+ * @brief Check/Uncheck 'Split Pane Layout' menuitem.
+ */
+void CDirView::OnUpdateViewSplitPaneLayout(CCmdUI* pCmdUI)
+{
+	const bool enable = GetDocument()->m_nDirs < 3;
+	pCmdUI->Enable(enable);
+	pCmdUI->SetCheck(enable && UseSplitPaneLayout());
+}
+
+/**
  * @brief Toggle Show Empty Folders
  */
 void CDirView::OnViewShowEmptyFolders()
@@ -4886,34 +4913,36 @@ LRESULT CDirView::WindowProc(UINT message, WPARAM wParam, LPARAM lParam)
  */
 void CDirView::OnCustomDraw(NMHDR* pNMHDR, LRESULT* pResult) 
 {
-	if (!m_bUseColors) {
+	LPNMLVCUSTOMDRAW lpC = reinterpret_cast<LPNMLVCUSTOMDRAW>(pNMHDR);
+	*pResult = CDRF_DODEFAULT;
+
+	const bool split = UseSplitPaneLayout();
+	if (!m_bUseColors && !split)
+		return;
+
+	if (lpC->nmcd.dwDrawStage == CDDS_PREPAINT)
+	{
+		*pResult = CDRF_NOTIFYITEMDRAW;
 		return;
 	}
 
-	LPNMLISTVIEW pNM = (LPNMLISTVIEW)pNMHDR;
-	*pResult = CDRF_DODEFAULT;
-
-	if (pNM->hdr.code == NM_CUSTOMDRAW)
+	if (lpC->nmcd.dwDrawStage == CDDS_ITEMPREPAINT)
 	{
-		LPNMLVCUSTOMDRAW lpC = (LPNMLVCUSTOMDRAW)pNMHDR;
-
-		if (lpC->nmcd.dwDrawStage == CDDS_PREPAINT)
-		{
-			*pResult =  CDRF_NOTIFYITEMDRAW;
-			return;
-		}
-
-		if (lpC->nmcd.dwDrawStage == CDDS_ITEMPREPAINT)
-		{
-			*pResult = CDRF_NOTIFYITEMDRAW;
-			return;
-		}
-
-		if (lpC->nmcd.dwDrawStage == (CDDS_ITEMPREPAINT | CDDS_SUBITEM ))
-		{
-			GetColors (static_cast<int>(lpC->nmcd.dwItemSpec), lpC->iSubItem, lpC->clrTextBk, lpC->clrText);
-		}
+		*pResult = CDRF_NOTIFYSUBITEMDRAW;
+		if (split)
+			*pResult |= CDRF_NOTIFYPOSTPAINT;
+		return;
 	}
+
+	if (lpC->nmcd.dwDrawStage == (CDDS_ITEMPREPAINT | CDDS_SUBITEM))
+	{
+		if (m_bUseColors)
+			GetColors(static_cast<int>(lpC->nmcd.dwItemSpec), lpC->iSubItem, lpC->clrTextBk, lpC->clrText);
+		return;
+	}
+
+	if (split && lpC->nmcd.dwDrawStage == CDDS_ITEMPOSTPAINT)
+		DrawSplitPaneDivider(lpC);
 }
 
 /**
@@ -4985,14 +5014,15 @@ void CDirView::OnStatusBarClick(NMHDR* pNMHDR, LRESULT* pResult)
 	int index = static_cast<int>(pNMMouse->dwItemSpec);
 	switch (index)
 	{
-	case 0:
+	case CDirFrame::PANE_LEFT_STATUS:
+	case CDirFrame::PANE_RIGHT_STATUS:
 		break;
-	case 1:
+	case CDirFrame::PANE_FILTER:
 	{
 		GetMainFrame()->SelectFilter();
 		break;
 	}
-	case 2:
+	case CDirFrame::PANE_COMPMETHOD:
 	{
 		CPoint point;
 		::GetCursorPos(&point);
@@ -5011,11 +5041,11 @@ void CDirView::OnStatusBarClick(NMHDR* pNMHDR, LRESULT* pResult)
 		}
 		break;
 	}
-	case 3:
-	case 4:
-	case 5:
+	case CDirFrame::PANE_LEFT_RO:
+	case CDirFrame::PANE_MIDDLE_RO:
+	case CDirFrame::PANE_RIGHT_RO:
 	{
-		const int idx = std::clamp(index - 3, 0, GetDocument()->m_nDirs - 1);
+		const int idx = std::clamp(index - CDirFrame::PANE_LEFT_RO, 0, GetDocument()->m_nDirs - 1);
 		GetDocument()->SetReadOnly(idx, !GetDocument()->GetReadOnly(idx));
 		break;
 	}
@@ -5053,6 +5083,15 @@ void CDirView::NameColumn(const DirColInfo *col, int subitem)
 	if (phys>=0)
 	{
 		String s = col->GetDisplayName();
+		if (UseSplitPaneLayout() && col->regName != nullptr)
+		{
+			if (tc::tcscmp(col->regName, _T("Lname")) == 0 || tc::tcscmp(col->regName, _T("Rname")) == 0)
+				s = _("Name");
+			else if (tc::tcscmp(col->regName, _T("LsizeShort")) == 0 || tc::tcscmp(col->regName, _T("RsizeShort")) == 0)
+				s = _("Size");
+			else if (tc::tcscmp(col->regName, _T("Lmtime")) == 0 || tc::tcscmp(col->regName, _T("Rmtime")) == 0)
+				s = _("Modified");
+		}
 		LV_COLUMN lvc;
 		lvc.mask = LVCF_TEXT;
 		lvc.pszText = const_cast<tchar_t*>(s.c_str());
@@ -5261,6 +5300,27 @@ void CDirView::OnEditColumns()
 		for (l = 0; l < m_pColItems->GetColCount(); ++l)
 		{
 			int phy = m_pColItems->GetColDefaultOrder(l);
+			if (UseSplitPaneLayout())
+			{
+				phy = -1;
+				const DirColInfo* info = m_pColItems->GetDirColInfo(l);
+				if (info != nullptr && info->regName != nullptr)
+				{
+					static const tchar_t* splitNames[] =
+					{
+						_T("Lname"), _T("LsizeShort"), _T("Lmtime"), _T("StatusAbbr"),
+						_T("Rname"), _T("RsizeShort"), _T("Rmtime")
+					};
+					for (int i = 0; i < static_cast<int>(std::size(splitNames)); ++i)
+					{
+						if (tc::tcscmp(info->regName, splitNames[i]) == 0)
+						{
+							phy = i;
+							break;
+						}
+					}
+				}
+			}
 			dlg.AddDefColumn(m_pColItems->GetColDisplayName(l), l, phy);
 		}
 
@@ -5288,7 +5348,7 @@ void CDirView::OnEditColumns()
 		}
 	} 
 
-	const String keyname = GetDocument()->m_nDirs < 3 ? OPT_DIRVIEW_COLUMN_WIDTHS : OPT_DIRVIEW3_COLUMN_WIDTHS;
+	const String keyname = GetColumnWidthsOption();
 	GetOptionsMgr()->SaveOption(keyname,
 		(bReset ? m_pColItems->ResetColumnWidths(GetDefColumnWidth()) :
 		                m_pColItems->SaveColumnWidths(std::bind(&CListCtrl::GetColumnWidth, m_pList, _1))));
@@ -5318,10 +5378,139 @@ void CDirView::OnEditColumns()
 	{
 		// Set them back to default if they didn't leave a column showing
 		// (However, if none of the items are checked, this process will not be executed because the "OK" button in the "Display Columns" dialog cannot be pressed.)
-		m_pColItems->ResetColumnOrdering();
+		if (UseSplitPaneLayout())
+			m_pColItems->ApplySplitPaneColumnOrder();
+		else
+			m_pColItems->ResetColumnOrdering();
 	}
 	ReloadColumns();
 	Redisplay();
+}
+
+bool CDirView::UseSplitPaneLayout() const
+{
+	const CDirDoc *pDoc = GetDocument();
+	return pDoc != nullptr && pDoc->m_nDirs < 3 && GetOptionsMgr()->GetBool(OPT_DIRVIEW_SPLIT_LAYOUT);
+}
+
+const String& CDirView::GetColumnOrdersOption() const
+{
+	if (GetDocument()->m_nDirs >= 3)
+		return OPT_DIRVIEW3_COLUMN_ORDERS;
+	return UseSplitPaneLayout() ? OPT_DIRVIEW_SPLIT_COLUMN_ORDERS : OPT_DIRVIEW_COLUMN_ORDERS;
+}
+
+const String& CDirView::GetColumnWidthsOption() const
+{
+	if (GetDocument()->m_nDirs >= 3)
+		return OPT_DIRVIEW3_COLUMN_WIDTHS;
+	return UseSplitPaneLayout() ? OPT_DIRVIEW_SPLIT_COLUMN_WIDTHS : OPT_DIRVIEW_COLUMN_WIDTHS;
+}
+
+void CDirView::LoadColumnLayout()
+{
+	const String orders = GetOptionsMgr()->GetString(GetColumnOrdersOption());
+	m_pColItems->LoadColumnOrders(orders);
+	if (UseSplitPaneLayout() && orders.empty())
+		m_pColItems->ApplySplitPaneColumnOrder();
+}
+
+void CDirView::SaveColumnLayout()
+{
+	if (m_pColItems == nullptr || m_pList == nullptr)
+		return;
+	GetOptionsMgr()->SaveOption(GetColumnOrdersOption(), m_pColItems->SaveColumnOrders());
+	GetOptionsMgr()->SaveOption(GetColumnWidthsOption(),
+		m_pColItems->SaveColumnWidths(std::bind(&CListCtrl::GetColumnWidth, m_pList, _1)));
+}
+
+static String FormatDirViewByteSize(uint64_t size)
+{
+	tchar_t buffer[48]{};
+	StrFormatByteSize64(size, buffer, static_cast<unsigned>(std::size(buffer)));
+	return buffer;
+}
+
+static String FormatSplitPaneFooter(int nFiles, int nFolders, uint64_t nBytes, const String& path)
+{
+	const String sizeStr = FormatDirViewByteSize(nBytes);
+	String text;
+	if (nFolders > 0)
+		text = strutils::format(_("%d file(s), %d folder(s), %s"), nFiles, nFolders, sizeStr);
+	else
+		text = strutils::format(_("%d file(s), %s"), nFiles, sizeStr);
+
+	ULARGE_INTEGER avail{};
+	if (!path.empty() && GetDiskFreeSpaceEx(path.c_str(), &avail, nullptr, nullptr) != 0)
+	{
+		String root = path;
+		if (root.length() >= 2 && root[1] == ':')
+			root = root.substr(0, 2) + _T("\\");
+		text += _T("  ");
+		text += strutils::format(_("%s free on %s"), FormatDirViewByteSize(avail.QuadPart), root);
+	}
+	return text;
+}
+
+void CDirView::UpdateSplitPaneFooters()
+{
+	if (!UseSplitPaneLayout())
+		return;
+
+	int nFiles[2] = {};
+	int nFolders[2] = {};
+	uint64_t nBytes[2] = {};
+	const int nItems = m_pList->GetItemCount();
+	for (int i = 0; i < nItems; ++i)
+	{
+		DIFFITEM *key = GetItemKey(i);
+		if (key == nullptr || IsDiffItemSpecial(key))
+			continue;
+		const DIFFITEM& di = *key;
+		for (int pane = 0; pane < 2; ++pane)
+		{
+			if (!di.diffcode.exists(pane))
+				continue;
+			if (di.diffcode.isDirectory())
+				++nFolders[pane];
+			else
+			{
+				++nFiles[pane];
+				if (di.diffFileInfo[pane].size != DirItem::FILE_SIZE_NONE)
+					nBytes[pane] += static_cast<uint64_t>(di.diffFileInfo[pane].size);
+			}
+		}
+	}
+
+	const CDiffContext& ctxt = GetDiffContext();
+	GetParentFrame()->SetSideStatus(0, FormatSplitPaneFooter(nFiles[0], nFolders[0], nBytes[0], ctxt.GetPath(0)).c_str());
+	GetParentFrame()->SetSideStatus(1, FormatSplitPaneFooter(nFiles[1], nFolders[1], nBytes[1], ctxt.GetPath(1)).c_str());
+}
+
+void CDirView::DrawSplitPaneDivider(NMLVCUSTOMDRAW* lpC)
+{
+	if (m_pColItems == nullptr)
+		return;
+	const int log = m_pColItems->FindColByRegName(_T("Rname"));
+	if (log < 0)
+		return;
+	const int phys = m_pColItems->ColLogToPhys(log);
+	if (phys < 0)
+		return;
+
+	CRect rc;
+	if (!m_pList->GetSubItemRect(static_cast<int>(lpC->nmcd.dwItemSpec), phys, LVIR_BOUNDS, rc))
+		return;
+
+	CDC* pDC = CDC::FromHandle(lpC->nmcd.hdc);
+	if (pDC == nullptr)
+		return;
+	const COLORREF clr = GetSysColor(COLOR_3DSHADOW);
+	CPen pen(PS_SOLID, 1, clr);
+	CPen* pOld = pDC->SelectObject(&pen);
+	pDC->MoveTo(rc.left, rc.top);
+	pDC->LineTo(rc.left, rc.bottom);
+	pDC->SelectObject(pOld);
 }
 
 DirActions CDirView::MakeDirActions(DirActions::method_type func) const

--- a/Src/DirView.h
+++ b/Src/DirView.h
@@ -371,6 +371,8 @@ protected:
 	afx_msg void OnUpdateViewShowHiddenItems(CCmdUI* pCmdUI);
 	afx_msg void OnViewTreeMode();
 	afx_msg void OnUpdateViewTreeMode(CCmdUI* pCmdUI);
+	afx_msg void OnViewSplitPaneLayout();
+	afx_msg void OnUpdateViewSplitPaneLayout(CCmdUI* pCmdUI);
 	afx_msg void OnViewShowEmptyFolders();
 	afx_msg void OnUpdateViewShowEmptyFolders(CCmdUI* pCmdUI);
 	afx_msg void OnViewExpandAllSubdirs();
@@ -471,6 +473,13 @@ private:
 	void ShowShellContextMenu(UINT id);
 	CShellContextMenu* GetCorrespondingShellContextMenu(HMENU hMenu) const;
 	void ReloadColumns();
+	bool UseSplitPaneLayout() const;
+	const String& GetColumnOrdersOption() const;
+	const String& GetColumnWidthsOption() const;
+	void LoadColumnLayout();
+	void SaveColumnLayout();
+	void UpdateSplitPaneFooters();
+	void DrawSplitPaneDivider(NMLVCUSTOMDRAW* lpC);
 	bool IsLabelEdit() const;
 	void CollapseSubdir(int sel);
 	void ExpandSubdir(int sel, bool bRecursive = false);

--- a/Src/DirViewColItems.cpp
+++ b/Src/DirViewColItems.cpp
@@ -29,6 +29,8 @@ using std::swap;
 namespace
 {
 const char *COLHDR_FILENAME     = N_("Filename");
+const char *COLHDR_LFILENAME    = N_("Left Filename");
+const char *COLHDR_RFILENAME    = N_("Right Filename");
 const char *COLHDR_DIR          = NC_("DirView|ColumnHeader", "Folder");
 const char *COLHDR_RESULT       = N_("Comparison Result");
 const char *COLHDR_LTIMEM       = N_("Left Date");
@@ -74,6 +76,8 @@ const char *COLHDR_DEBUG_BLINK       = N_("[Debug]Blink");
 #endif // SHOW_DIFFITEM_DEBUG_INFO
 
 const char *COLDESC_FILENAME    = N_("Filename or folder name.");
+const char *COLDESC_LFILENAME   = N_("Left side filename or folder name.");
+const char *COLDESC_RFILENAME   = N_("Right side filename or folder name.");
 const char *COLDESC_DIR         = N_("Subfolder name when subfolders are included.");
 const char *COLDESC_RESULT      = N_("Comparison result, long form.");
 const char *COLDESC_LTIMEM      = N_("Left side modification date.");
@@ -234,6 +238,17 @@ static Type ColFileNameGet(const CDiffContext * pCtxt, const void *p, int) //sfi
 				+ (bExist[2] ? pDiffFileInfo[2].filename.get() : none));
 		}
 	}
+}
+
+/**
+ * @brief Filename for one compare side; empty if that side does not exist.
+ */
+static String ColSideFileNameGet(const CDiffContext *, const void *p, int pane)
+{
+	const DIFFITEM &di = *static_cast<const DIFFITEM *>(p);
+	if (pane < 0 || pane > 2 || !di.diffcode.exists(pane))
+		return _T("");
+	return di.diffFileInfo[pane].filename.get();
 }
 
 /**
@@ -1135,6 +1150,17 @@ static int ColFileNameSort(const CDiffContext *pCtxt, const void *p, const void 
 	return strutils::compare_logical(ColFileNameGet<boost::flyweight<String>>(pCtxt, p, 0), ColFileNameGet<boost::flyweight<String>>(pCtxt, q, 0));
 }
 
+static int ColSideFileNameSort(const CDiffContext *pCtxt, const void *p, const void *q, int pane)
+{
+	const DIFFITEM &ldi = *static_cast<const DIFFITEM *>(p);
+	const DIFFITEM &rdi = *static_cast<const DIFFITEM *>(q);
+	if (ldi.diffcode.isDirectory() && !rdi.diffcode.isDirectory())
+		return -1;
+	if (!ldi.diffcode.isDirectory() && rdi.diffcode.isDirectory())
+		return 1;
+	return strutils::compare_logical(ColSideFileNameGet(pCtxt, p, pane), ColSideFileNameGet(pCtxt, q, pane));
+}
+
 /**
  * @brief Compare file name extensions.
  * @param [in] pCtxt Pointer to compare context.
@@ -1463,6 +1489,8 @@ static DirColInfo f_cols[] =
 	{ _T("Reoltype"), nullptr, COLHDR_REOL_TYPE, COLDESC_REOL_TYPE, &ColEOLTypeGet, 0, 0, -1, true, DirColInfo::ALIGN_LEFT, 1 },
 	{ _T("Unpacker"), nullptr, COLHDR_UNPACKER, COLDESC_UNPACKER, &ColPluginPipelineGet, 0, 0, -1, true, DirColInfo::ALIGN_LEFT, 1 },
 	{ _T("Prediffer"), nullptr, COLHDR_PREDIFFER, COLDESC_PREDIFFER, &ColPluginPipelineGet, 0, 0, -1, true, DirColInfo::ALIGN_LEFT, 0 },
+	{ _T("Lname"), nullptr, COLHDR_LFILENAME, COLDESC_LFILENAME, &ColSideFileNameGet, &ColSideFileNameSort, 0, -1, true, DirColInfo::ALIGN_LEFT, 0 },
+	{ _T("Rname"), nullptr, COLHDR_RFILENAME, COLDESC_RFILENAME, &ColSideFileNameGet, &ColSideFileNameSort, 0, -1, true, DirColInfo::ALIGN_LEFT, 1 },
 #ifdef SHOW_DIFFITEM_DEBUG_INFO
 	{ _T("diffcode"), nullptr, COLHDR_DEBUG_DIFFCODE, COLDESC_DEBUG_DIFFCODE, &ColDebugDiffCodeGet, 0, 0, -1, true, DirColInfo::ALIGN_LEFT },
 	{ _T("customFlags"), nullptr, COLHDR_DEBUG_CUSTOMFLAGS, COLDESC_DEBUG_CUSTOMFLAGS, &ColDebugCustomFlagsGet, 0, 0, -1, true, DirColInfo::ALIGN_LEFT },
@@ -1774,7 +1802,13 @@ DirViewColItems::IsColById(int col, const char *idname) const
 bool
 DirViewColItems::IsColName(int col) const
 {
-	return IsColById(col, COLHDR_FILENAME);
+	return IsColById(col, COLHDR_FILENAME) || IsColSideName(col);
+}
+
+bool
+DirViewColItems::IsColSideName(int col) const
+{
+	return IsColById(col, COLHDR_LFILENAME) || IsColById(col, COLHDR_RFILENAME);
 }
 /**
  * @brief Is specified physical column the left modification time column?
@@ -1895,9 +1929,12 @@ DirViewColItems::ColGetTextToDisplay(const CDiffContext *pCtxt, int col,
 	size_t offset = pColInfo->offset;
 	String s = (*fnc)(pCtxt, reinterpret_cast<const char *>(&di) + offset, pColInfo->opt);
 
-	// Add '*' to newer time field
+	// Add '*' to newer time field (skip sides that do not exist)
 	if (IsColLmTime(col) || IsColMmTime(col) || IsColRmTime(col))
 	{
+		int pane = IsColLmTime(col) ? 0 : (IsColMmTime(col) ? 1 : (m_nDirs < 3 ? 1 : 2));
+		if (!di.diffcode.exists(pane))
+			return s;
 		if (m_nDirs < 3)
 		{
 			if (di.diffFileInfo[0].mtime != 0 || di.diffFileInfo[1].mtime != 0)
@@ -2152,4 +2189,37 @@ String DirViewColItems::SaveColumnOrders()
 	assert(static_cast<int>(m_colorder.size()) == m_numcols);
 	assert(static_cast<int>(m_invcolorder.size()) == m_numcols);
 	return strutils::join<String (*)(int)>(m_colorder.begin(), m_colorder.end(), _T(" "), strutils::to_str);
+}
+
+int DirViewColItems::FindColByRegName(const tchar_t* regName) const
+{
+	if (regName == nullptr)
+		return -1;
+	for (int i = 0; i < m_numcols; ++i)
+	{
+		if (m_cols[i].regName != nullptr && tc::tcscmp(m_cols[i].regName, regName) == 0)
+			return i;
+	}
+	return -1;
+}
+
+bool DirViewColItems::ApplySplitPaneColumnOrder()
+{
+	static const tchar_t* names[] =
+	{
+		_T("Lname"), _T("LsizeShort"), _T("Lmtime"), _T("StatusAbbr"),
+		_T("Rname"), _T("RsizeShort"), _T("Rmtime")
+	};
+	ClearColumnOrders();
+	m_dispcols = 0;
+	for (int phy = 0; phy < static_cast<int>(std::size(names)); ++phy)
+	{
+		const int log = FindColByRegName(names[phy]);
+		if (log < 0)
+			return false;
+		m_colorder[log] = phy;
+		m_invcolorder[phy] = log;
+		++m_dispcols;
+	}
+	return m_dispcols > 1;
 }

--- a/Src/DirViewColItems.h
+++ b/Src/DirViewColItems.h
@@ -81,6 +81,9 @@ public:
 	String ResetColumnWidths(int defcolwidth);
 	void LoadColumnOrders(const String& colOrders);
 	String SaveColumnOrders();
+	int FindColByRegName(const tchar_t* regName) const;
+	bool ApplySplitPaneColumnOrder();
+	bool IsColSideName(int col) const;
 	const std::vector<String>& GetAdditionalPropertyNames() const { return m_additionalPropertyNames; }
 	void SetAdditionalPropertyNames(const std::vector<String>& propertyNames);
 

--- a/Src/Merge.rc
+++ b/Src/Merge.rc
@@ -502,6 +502,7 @@ BEGIN
         MENUITEM "Show Hidd&en Items",          ID_VIEW_SHOWHIDDENITEMS
         MENUITEM SEPARATOR
         MENUITEM "Tree &Mode",                  ID_VIEW_TREEMODE
+        MENUITEM "S&plit Pane Layout",          ID_VIEW_SPLIT_PANE_LAYOUT
         POPUP "E&xpand Subfolders"
         BEGIN
             MENUITEM "&All Subfolders",             ID_VIEW_EXPAND_ALLSUBDIRS

--- a/Src/OptionsDef.h
+++ b/Src/OptionsDef.h
@@ -71,6 +71,9 @@ inline const String OPT_DIRVIEW_COLUMN_ORDERS {_T("DirView/ColumnOrders"s)};
 inline const String OPT_DIRVIEW_COLUMN_WIDTHS {_T("DirView/ColumnWidths"s)};
 inline const String OPT_DIRVIEW3_COLUMN_ORDERS {_T("DirView3/ColumnOrders"s)};
 inline const String OPT_DIRVIEW3_COLUMN_WIDTHS {_T("DirView3/ColumnWidths"s)};
+inline const String OPT_DIRVIEW_SPLIT_LAYOUT {_T("DirView/SplitPaneLayout"s)};
+inline const String OPT_DIRVIEW_SPLIT_COLUMN_ORDERS {_T("DirView/SplitColumnOrders"s)};
+inline const String OPT_DIRVIEW_SPLIT_COLUMN_WIDTHS {_T("DirView/SplitColumnWidths"s)};
 
 inline const String OPT_ADDITIONAL_PROPERTIES {_T("Settings/AdditionalProperties"s)};
 

--- a/Src/OptionsInit.cpp
+++ b/Src/OptionsInit.cpp
@@ -111,6 +111,9 @@ void Init(COptionsMgr *pOptions)
 	pOptions->InitOption(OPT_DIRVIEW_COLUMN_WIDTHS, _T(""));
 	pOptions->InitOption(OPT_DIRVIEW3_COLUMN_ORDERS, _T(""));
 	pOptions->InitOption(OPT_DIRVIEW3_COLUMN_WIDTHS, _T(""));
+	pOptions->InitOption(OPT_DIRVIEW_SPLIT_LAYOUT, true);
+	pOptions->InitOption(OPT_DIRVIEW_SPLIT_COLUMN_ORDERS, _T(""));
+	pOptions->InitOption(OPT_DIRVIEW_SPLIT_COLUMN_WIDTHS, _T(""));
 
 	pOptions->InitOption(OPT_ADDITIONAL_PROPERTIES, _T(""));
 

--- a/Src/resource.h
+++ b/Src/resource.h
@@ -952,6 +952,7 @@
 #define ID_FILE_OPEN_WITHEDITOR         32945
 #define ID_FILE_OPEN_WITH               32946
 #define ID_FILE_OPEN_PARENT_FOLDER      32947
+#define ID_VIEW_SPLIT_PANE_LAYOUT       32948
 #define ID_STATUS_MERGINGMODE           32960
 #define ID_STATUS_DIFFNUM               32961
 #define ID_STATUS_RIGHTDIR_RO           32962


### PR DESCRIPTION
## Summary
Adds an optional split-pane column layout for 2-way folder compare:
left name/size/time | status | right name/size/time, plus per-side status bar.

This is a view-only change. The compare engine and DIFFITEM model are unchanged.
3-way compare keeps the classic table.

Relates to #2535 and #2564.

## Why
WinMerge currently shows one merged table; users must read the result column
to tell left from right. File compare is already side-by-side; folder compare is not.

## How to test
1. Compare two folders with "Include subfolders".
2. View → Split Pane Layout: on/off.
3. Unique items: the missing side stays blank (no long "only on left/right" text).
4. Footer shows per-side counts and free disk space.
5. 3-way compare still uses the classic table.

## Notes
- Coding style: Allman, matching existing files.
- Default: split layout enabled for 2-way; can be turned off.
- Not in this PR: tree indent in Name columns, All/Diffs/Same display presets,
  true dual ListView, 3-pane layout.